### PR TITLE
[Cherry Pick] Allow for Entity creation and Prefab instantiation in place via viewport interactions

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -367,6 +367,17 @@ AZ::Vector3 SandboxIntegrationManager::GetWorldPositionAtViewportCenter()
     return AZ::Vector3::CreateZero();
 }
 
+AZ::Vector3 SandboxIntegrationManager::GetWorldPositionAtViewportInteraction() const
+{
+    const auto& iEditor = GetIEditor();
+    if (const auto& viewManager = (iEditor != nullptr) ? iEditor->GetViewManager() : nullptr)
+    {
+        return viewManager->GetClickPositionInViewportSpace();
+    }
+
+    return AZ::Vector3::CreateZero();
+}
+
 void SandboxIntegrationManager::ClearRedoStack()
 {
     // We have two separate undo systems that are assumed to be kept in sync,
@@ -524,6 +535,8 @@ void SandboxIntegrationManager::OnActionRegistrationHook()
             actionProperties,
             [this]()
             {
+                AZ::Vector3 worldPosition = GetWorldPositionAtViewportInteraction();
+
                 AzToolsFramework::EntityIdList selectedEntities;
                 AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
                     selectedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
@@ -531,7 +544,7 @@ void SandboxIntegrationManager::OnActionRegistrationHook()
                 // when nothing is selected, entity is created at root level.
                 if (selectedEntities.empty())
                 {
-                    ContextMenu_NewEntity();
+                    CreateNewEntityAtPosition(worldPosition);
                 }
                 // when a single entity is selected, entity is created as its child.
                 else if (selectedEntities.size() == 1)
@@ -542,8 +555,9 @@ void SandboxIntegrationManager::OnActionRegistrationHook()
 
                     if (containerEntityInterface && containerEntityInterface->IsContainerOpen(selectedEntityId) && !selectedEntityIsReadOnly)
                     {
-                        AzToolsFramework::EditorRequestBus::Broadcast(
-                            &AzToolsFramework::EditorRequestBus::Handler::CreateNewEntityAsChild, selectedEntityId);
+                        AZ::Transform entityTransform = AZ::Transform::CreateIdentity();
+                        AZ::TransformBus::EventResult(entityTransform, selectedEntityId, &AZ::TransformBus::Events::GetWorldTM);
+                        CreateNewEntityAtPosition(entityTransform.GetInverse().TransformPoint(worldPosition), selectedEntityId);
                     }
                 }
             }

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -134,6 +134,7 @@ private:
     void GoToSelectedEntitiesInViewports() override;
     bool CanGoToSelectedEntitiesInViewports() override;
     AZ::Vector3 GetWorldPositionAtViewportCenter() override;
+    AZ::Vector3 GetWorldPositionAtViewportInteraction() const override;
     void ClearRedoStack() override;
     //////////////////////////////////////////////////////////////////////////
 

--- a/Code/Editor/ViewManager.cpp
+++ b/Code/Editor/ViewManager.cpp
@@ -18,6 +18,8 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 
 // AzToolsFramework
+#include <AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h>
+#include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/Manipulators/ManipulatorManager.h>
 
 // Editor
@@ -210,8 +212,48 @@ void CViewManager::Cycle2DViewport()
 //////////////////////////////////////////////////////////////////////////
 CViewport* CViewManager::GetViewportAtPoint(const QPoint& point) const
 {
-    QWidget* widget = QApplication::widgetAt(point);
-    return qobject_cast<QtViewport*>(widget);
+    const auto viewportIter = AZStd::find_if(
+        m_viewports.begin(),
+        m_viewports.end(),
+        [&point](CViewport* viewport) -> bool
+        {
+            auto* widget = viewport->widget();
+            return widget && widget->rect().contains(widget->mapFromGlobal(point));
+        }
+    );
+
+    return (viewportIter == m_viewports.end()) ? nullptr : *viewportIter;
+}
+
+//////////////////////////////////////////////////////////////////////////
+AZ::Vector3 CViewManager::GetClickPositionInViewportSpace() const
+{
+    // Retrieve click position.
+    QPoint clickPos = QCursor::pos();
+
+    // If a context menu is active, get its position as the click position.
+    if (auto menuManagerInterface = AZ::Interface<AzToolsFramework::MenuManagerInterface>::Get())
+    {
+        auto outcome = menuManagerInterface->GetLastContextMenuPosition();
+        if (outcome.IsSuccess())
+        {
+            clickPos = outcome.GetValue();
+        }
+    }
+
+    // If the click position was on a viewport, retrieve the position in world coordinates.
+    AZ::Vector3 worldPosition = AZ::Vector3::CreateZero();
+    if (CViewport* view = GetViewportAtPoint(clickPos))
+    {
+        QPoint relativeCursor = view->widget()->mapFromGlobal(clickPos);
+        worldPosition = AzToolsFramework::FindClosestPickIntersection(
+            view->GetViewportId(),
+            AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(relativeCursor),
+            AzToolsFramework::EditorPickRayLength,
+            AzToolsFramework::GetDefaultEntityPlacementDistance());
+    }
+
+    return worldPosition;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/ViewManager.h
+++ b/Code/Editor/ViewManager.h
@@ -45,6 +45,10 @@ public:
     //! Find viewport at Screen point.
     CViewport* GetViewportAtPoint(const QPoint& point) const;
 
+    //! Retrieves the position in world space corresponding to the point clicked by the user.
+    //! Will take context menus and cursor position into account as appropriate.
+    AZ::Vector3 GetClickPositionInViewportSpace() const;
+
     void SelectViewport(CViewport* pViewport);
     CViewport* GetSelectedViewport() const { return m_pSelectedView; }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -871,6 +871,10 @@ namespace AzToolsFramework
         /// Returns the world-space position under the center of the render viewport.
         virtual AZ::Vector3 GetWorldPositionAtViewportCenter() { return AZ::Vector3::CreateZero(); }
 
+        //! Retrieves the position in world space corresponding to the point interacted with by the user.
+        //! Will take context menus and cursor position into account as appropriate.
+        virtual AZ::Vector3 GetWorldPositionAtViewportInteraction() const { return AZ::Vector3::CreateZero(); };
+
         /// Clears current redo stack
         virtual void ClearRedoStack() {}
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.cpp
@@ -186,6 +186,16 @@ namespace AzToolsFramework
         DisplayAtPosition(QCursor::pos());
     }
 
+    QPoint EditorMenu::GetMenuPosition() const
+    {
+        return m_menu->pos();
+    }
+
+    bool EditorMenu::IsMenuVisible() const
+    {
+        return m_menu->isVisible();
+    }
+
     void EditorMenu::RefreshMenu()
     {
         m_menu->clear();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.h
@@ -66,9 +66,15 @@ namespace AzToolsFramework
         QMenu* GetMenu();
         const QMenu* GetMenu() const;
 
-        // Displays the Menu
+        // Displays the menu.
         void DisplayAtPosition(QPoint screenPosition) const;
         void DisplayUnderCursor() const;
+
+        // Returns position of the menu.
+        QPoint GetMenuPosition() const;
+
+        // Returns whether the menu is currently visible.
+        bool IsMenuVisible() const;
 
         // Clears the menu and creates a new one from the EditorMenu information.
         void RefreshMenu();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManager.h
@@ -66,8 +66,9 @@ namespace AzToolsFramework
         MenuManagerIntegerResult GetSortKeyOfSubMenuInMenu(const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier) const override;
         MenuManagerIntegerResult GetSortKeyOfWidgetInMenu(const AZStd::string& menuIdentifier, const AZStd::string& widgetActionIdentifier) const override;
         MenuManagerIntegerResult GetSortKeyOfMenuInMenuBar(const AZStd::string& menuBarIdentifier, const AZStd::string& menuIdentifier) const override;
-        MenuManagerOperationResult DisplayMenuAtScreenPosition(const AZStd::string& menuIdentifier, const QPoint& screenPosition) const override;
-        MenuManagerOperationResult DisplayMenuUnderCursor(const AZStd::string& menuIdentifier) const override;
+        MenuManagerOperationResult DisplayMenuAtScreenPosition(const AZStd::string& menuIdentifier, const QPoint& screenPosition) override;
+        MenuManagerOperationResult DisplayMenuUnderCursor(const AZStd::string& menuIdentifier) override;
+        MenuManagerPositionResult GetLastContextMenuPosition() const override;
 
         // MenuManagerInternalInterface overrides ...
         QMenu* GetMenu(const AZStd::string& menuIdentifier) override;
@@ -89,6 +90,11 @@ namespace AzToolsFramework
 
         // Identifies whether adding a submenu to a menu would generate any circular dependencies.
         bool WouldGenerateCircularDependency(const AZStd::string& menuIdentifier, const AZStd::string& subMenuIdentifier);
+
+        // If the menu that was stored as the last displayed is no longer visible, clear the variable.
+        void RefreshLastDisplayedMenu();
+
+        AZStd::string m_lastDisplayedMenuIdentifier;
 
         AZStd::unordered_map<AZStd::string, EditorMenu> m_menus;
         AZStd::unordered_map<AZStd::string, EditorMenuBar> m_menuBars;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h
@@ -21,6 +21,7 @@ namespace AzToolsFramework
     using MenuManagerOperationResult = AZ::Outcome<void, AZStd::string>;
     using MenuManagerIntegerResult = AZ::Outcome<int, AZStd::string>;
     using MenuManagerStringResult = AZ::Outcome<AZStd::string, AZStd::string>;
+    using MenuManagerPositionResult = AZ::Outcome<QPoint, AZStd::string>;
 
     //! Provides additional properties to initialize a Menu upon registration.
     struct MenuProperties
@@ -166,12 +167,17 @@ namespace AzToolsFramework
         //! @param menuIdentifier The identifier for the menu to display.
         //! @param screenPosition The position where the menu should appear.
         //! @return A successful outcome object if the menu could be displayed, or a string with a message detailing the error in case of failure.
-        virtual MenuManagerOperationResult DisplayMenuAtScreenPosition(const AZStd::string& menuIdentifier, const QPoint& screenPosition) const = 0;
+        virtual MenuManagerOperationResult DisplayMenuAtScreenPosition(const AZStd::string& menuIdentifier, const QPoint& screenPosition) = 0;
 
         //! Show the menu under the mouse cursor.
         //! @param menuIdentifier The identifier for the menu to display.
         //! @return A successful outcome object if the menu could be displayed, or a string with a message detailing the error in case of failure.
-        virtual MenuManagerOperationResult DisplayMenuUnderCursor(const AZStd::string& menuIdentifier) const = 0;
+        virtual MenuManagerOperationResult DisplayMenuUnderCursor(const AZStd::string& menuIdentifier) = 0;
+
+        //! Returns the position of the last context menu displayed with the DisplayMenu functions.
+        //! Note that the menu must still be active.
+        //! @return A successful outcome object containing the position of the last context menu, or a string with a message detailing the error in case of failure.
+        virtual MenuManagerPositionResult GetLastContextMenuPosition() const = 0;
         
     };
 


### PR DESCRIPTION
## What does this PR do?
This cherry picks a [fix for placing entities/prefab](https://github.com/o3de/o3de/pull/17768) instantiation for viewport interactions to where the mouse is located, rather than at (0,0,0)

## How was this PR tested?

Verified fix on Windows and Linux