### PR TITLE
Implement conversion from white box render data to visible geometry struct

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.cpp
@@ -53,7 +53,7 @@ namespace AzFramework
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Category, "Visibility")
                 ->Attribute(AZ::Script::Attributes::Module, "visibility")
-                ->Event("GetVisibleGeometry", &VisibleGeometryRequestBus::Events::GetVisibleGeometry)
+                ->Event("BuildVisibleGeometry", &VisibleGeometryRequestBus::Events::BuildVisibleGeometry, "GetVisibleGeometry")
                 ;
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/VisibleGeometryBus.h
@@ -57,7 +57,13 @@ namespace AzFramework
         //! multiple components on an entity an opportunity to add their geometry. It is the caller's responsibility to manage and clear the
         //! container between calls. The container should not be cleared within the function, which might destroy a prior components
         //! contribution.
-        virtual void GetVisibleGeometry(const AZ::Aabb& bounds, VisibleGeometryContainer& geometryContainer) const = 0;
+        virtual void BuildVisibleGeometry(const AZ::Aabb& bounds, VisibleGeometryContainer& geometryContainer) const = 0;
+
+        //! GetVisibleGeometry is being deprecated in favor of BuildVisibleGeometry.
+        virtual void GetVisibleGeometry(const AZ::Aabb& bounds, VisibleGeometryContainer& geometryContainer) const
+        {
+            BuildVisibleGeometry(bounds, geometryContainer);
+        }
 
     protected:
         ~VisibleGeometryRequests() = default;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -717,7 +717,7 @@ namespace AZ
             return Aabb::CreateNull();
         }
 
-        void MeshComponentController::GetVisibleGeometry(
+        void MeshComponentController::BuildVisibleGeometry(
             const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
         {
             // Only include data for this entity if it is within bounds. This could possibly be done per sub mesh.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -144,7 +144,7 @@ namespace AZ
             AZ::Aabb GetLocalBounds() const override;
 
             // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
-            void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
+            void BuildVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
             // Searches all shader items referenced by the material for one with a matching draw list tag.
             // Returns true if a matching tag was found. Otherwise, false.

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
@@ -806,7 +806,7 @@ namespace WhiteBox
         return m_localAabb.value();
     }
 
-    void EditorWhiteBoxComponent::GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
+    void EditorWhiteBoxComponent::BuildVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
     {
         // Only add the white box geometry if its bounds overlap the input bounds
         if (bounds.IsValid() && !bounds.Overlaps(GetWorldBounds()))

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
@@ -12,6 +12,7 @@
 #include "EditorWhiteBoxComponentMode.h"
 #include "EditorWhiteBoxComponentModeBus.h"
 #include "Rendering/WhiteBoxNullRenderMesh.h"
+#include "Rendering/WhiteBoxRenderDataUtil.h"
 #include "Rendering/WhiteBoxRenderMeshInterface.h"
 #include "Util/WhiteBoxEditorUtil.h"
 #include "WhiteBoxComponent.h"
@@ -309,6 +310,7 @@ namespace WhiteBox
         EditorWhiteBoxComponentNotificationBus::Handler::BusConnect(entityComponentIdPair);
         AZ::TransformNotificationBus::Handler::BusConnect(entityId);
         AzFramework::BoundsRequestBus::Handler::BusConnect(entityId);
+        AzFramework::VisibleGeometryRequestBus::Handler::BusConnect(entityId);
         AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(entityId);
         AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(entityId);
         AzToolsFramework::EditorVisibilityNotificationBus::Handler::BusConnect(entityId);
@@ -336,6 +338,7 @@ namespace WhiteBox
         AzToolsFramework::EditorVisibilityNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusDisconnect();
         AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect();
+        AzFramework::VisibleGeometryRequestBus::Handler::BusDisconnect();
         AzFramework::BoundsRequestBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect();
         EditorWhiteBoxComponentRequestBus::Handler::BusDisconnect();
@@ -801,6 +804,27 @@ namespace WhiteBox
         }
 
         return m_localAabb.value();
+    }
+
+    void EditorWhiteBoxComponent::GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
+    {
+        // Only add the white box geometry if its bounds overlap the input bounds
+        if (bounds.IsValid() && !bounds.Overlaps(GetWorldBounds()))
+        {
+            return;
+        }
+
+        // Extract white box geometry data to convert to visible geometry vertices and indices
+        const WhiteBoxRenderData renderData =
+            CreateWhiteBoxRenderData(*const_cast<EditorWhiteBoxComponent*>(this)->GetWhiteBoxMesh(), m_material);
+
+        // Convert the white box render data into visible geometry data
+        const AzFramework::VisibleGeometry geometry = BuildVisibleGeometryFromWhiteBoxRenderData(GetEntityId(), renderData);
+
+        if (!geometry.m_indices.empty() && !geometry.m_vertices.empty())
+        {
+            geometryContainer.push_back(geometry);
+        }
     }
 
     bool EditorWhiteBoxComponent::EditorSelectionIntersectRayViewport(

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
@@ -76,7 +76,7 @@ namespace WhiteBox
         AZ::Aabb GetLocalBounds() const override;
 
         // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
-        void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
+        void BuildVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
         //! Returns if the component currently has an instance of RenderMeshInterface.
         bool HasRenderMesh() const;

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.h
@@ -16,6 +16,7 @@
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/std/optional.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
+#include <AzFramework/Visibility/VisibleGeometryBus.h>
 #include <AzFramework/Visibility/BoundsBus.h>
 #include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <AzToolsFramework/ComponentMode/ComponentModeDelegate.h>
@@ -34,6 +35,7 @@ namespace WhiteBox
         : public AzToolsFramework::Components::EditorComponentBase
         , public AzToolsFramework::EditorComponentSelectionRequestsBus::Handler
         , public AzFramework::BoundsRequestBus::Handler
+        , public AzFramework::VisibleGeometryRequestBus::Handler
         , public EditorWhiteBoxComponentRequestBus::Handler
         , private EditorWhiteBoxComponentNotificationBus::Handler
         , private AZ::TransformNotificationBus::Handler
@@ -72,6 +74,9 @@ namespace WhiteBox
         // BoundsRequestBus overrides ...
         AZ::Aabb GetWorldBounds() const override;
         AZ::Aabb GetLocalBounds() const override;
+
+        // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
+        void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
         //! Returns if the component currently has an instance of RenderMeshInterface.
         bool HasRenderMesh() const;

--- a/Gems/WhiteBox/Code/Source/Rendering/WhiteBoxRenderDataUtil.cpp
+++ b/Gems/WhiteBox/Code/Source/Rendering/WhiteBoxRenderDataUtil.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "WhiteBoxRenderData.h"
+#include "WhiteBoxRenderDataUtil.h"
+#include <AzCore/Component/NonUniformScaleBus.h>
+#include <AzCore/Component/TransformBus.h>
+
+namespace WhiteBox
+{
+    AzFramework::VisibleGeometry BuildVisibleGeometryFromWhiteBoxRenderData(
+        const AZ::EntityId& entityId, const WhiteBoxRenderData& renderData)
+    {
+        // Calculate the world transform for the entity which will be used to transform the white box geometry
+        AZ::Transform transform = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(transform, entityId, &AZ::TransformBus::Events::GetWorldTM);
+
+        AZ::Vector3 nonUniformScale = AZ::Vector3::CreateOne();
+        AZ::NonUniformScaleRequestBus::EventResult(nonUniformScale, entityId, &AZ::NonUniformScaleRequests::GetScale);
+
+        // Initialize the visible geometry structure by reserving memory for mesh data and setting its world transform
+        const WhiteBoxFaces faceData = BuildCulledWhiteBoxFaces(renderData.m_faces);
+        const size_t faceCount = faceData.size();
+        const size_t vertCount = faceCount * 3;
+
+        AzFramework::VisibleGeometry geometry;
+        geometry.m_vertices.reserve(vertCount * 3);
+        geometry.m_indices.reserve(vertCount);
+        geometry.m_transform = AZ::Matrix4x4::CreateFromTransform(transform);
+        geometry.m_transform *= AZ::Matrix4x4::CreateScale(nonUniformScale);
+        geometry.m_transparent = false;
+
+        // Copy white box render data vertices and indices into visible geometry structure. This is not as efficient as it could be. The
+        // function that builds the white box data removes degenerate triangles but the format does not allow sharing vertices and edges.
+        uint32_t vertIndex = 0;
+        for (const auto& face : faceData)
+        {
+            geometry.m_vertices.push_back(face.m_v1.m_position.GetX());
+            geometry.m_vertices.push_back(face.m_v1.m_position.GetY());
+            geometry.m_vertices.push_back(face.m_v1.m_position.GetZ());
+            geometry.m_indices.push_back(vertIndex++);
+
+            geometry.m_vertices.push_back(face.m_v2.m_position.GetX());
+            geometry.m_vertices.push_back(face.m_v2.m_position.GetY());
+            geometry.m_vertices.push_back(face.m_v2.m_position.GetZ());
+            geometry.m_indices.push_back(vertIndex++);
+
+            geometry.m_vertices.push_back(face.m_v3.m_position.GetX());
+            geometry.m_vertices.push_back(face.m_v3.m_position.GetY());
+            geometry.m_vertices.push_back(face.m_v3.m_position.GetZ());
+            geometry.m_indices.push_back(vertIndex++);
+        }
+
+        return geometry;
+    }
+} // namespace WhiteBox

--- a/Gems/WhiteBox/Code/Source/Rendering/WhiteBoxRenderDataUtil.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/WhiteBoxRenderDataUtil.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/Visibility/VisibleGeometryBus.h>
+
+namespace AZ
+{
+    class EntityId;
+}
+
+namespace WhiteBox
+{
+    struct WhiteBoxRenderData;
+
+    //! @brief Convert white box render data into visible geometry mesh data used by other systems
+    //! @param entityId White box enter the id used to retrieve transform and bounds
+    //! @param renderData White box render data that will be converted into visible geometry data
+    //! @return Returns the populated visible geometry structure populated with the white box render mesh data.
+    AzFramework::VisibleGeometry BuildVisibleGeometryFromWhiteBoxRenderData(
+        const AZ::EntityId& entityId, const WhiteBoxRenderData& renderData);
+} // namespace WhiteBox

--- a/Gems/WhiteBox/Code/Source/WhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxComponent.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <Rendering/WhiteBoxMaterial.h>
 #include <Rendering/WhiteBoxRenderData.h>
+#include <Rendering/WhiteBoxRenderDataUtil.h>
 #include <Rendering/WhiteBoxRenderMeshInterface.h>
 #include <WhiteBox/WhiteBoxBus.h>
 
@@ -45,6 +46,7 @@ namespace WhiteBox
         m_renderMesh->UpdateMaterial(m_whiteBoxRenderData.m_material);
         m_renderMesh->SetVisiblity(m_whiteBoxRenderData.m_material.m_visible);
 
+        AzFramework::VisibleGeometryRequestBus::Handler::BusConnect(entityId);
         AZ::TransformNotificationBus::Handler::BusConnect(entityId);
         WhiteBoxComponentRequestBus::Handler::BusConnect(AZ::EntityComponentIdPair(entityId, GetId()));
     }
@@ -53,6 +55,7 @@ namespace WhiteBox
     {
         WhiteBoxComponentRequestBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect();
+        AzFramework::VisibleGeometryRequestBus::Handler::BusDisconnect();
 
         m_renderMesh.reset();
     }
@@ -65,6 +68,18 @@ namespace WhiteBox
     void WhiteBoxComponent::OnTransformChanged([[maybe_unused]] const AZ::Transform& local, const AZ::Transform& world)
     {
         m_renderMesh->UpdateTransform(world);
+    }
+
+    void WhiteBoxComponent::GetVisibleGeometry(
+        [[maybe_unused]] const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
+    {
+        // Convert the white box render data into visible geometry data
+        const AzFramework::VisibleGeometry geometry = BuildVisibleGeometryFromWhiteBoxRenderData(GetEntityId(), m_whiteBoxRenderData);
+
+        if (!geometry.m_indices.empty() && !geometry.m_vertices.empty())
+        {
+            geometryContainer.push_back(geometry);
+        }
     }
 
     bool WhiteBoxComponent::WhiteBoxIsVisible() const

--- a/Gems/WhiteBox/Code/Source/WhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxComponent.cpp
@@ -70,7 +70,7 @@ namespace WhiteBox
         m_renderMesh->UpdateTransform(world);
     }
 
-    void WhiteBoxComponent::GetVisibleGeometry(
+    void WhiteBoxComponent::BuildVisibleGeometry(
         [[maybe_unused]] const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const
     {
         // Convert the white box render data into visible geometry data

--- a/Gems/WhiteBox/Code/Source/WhiteBoxComponent.h
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxComponent.h
@@ -52,7 +52,7 @@ namespace WhiteBox
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
         // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
-        void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
+        void BuildVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
         WhiteBoxRenderData m_whiteBoxRenderData; //!< Intermediate format to store White Box render data.
         AZStd::unique_ptr<RenderMeshInterface> m_renderMesh; //!< The render mesh to use for White Box rendering.

--- a/Gems/WhiteBox/Code/Source/WhiteBoxComponent.h
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxComponent.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Math/Transform.h>
+#include <AzFramework/Visibility/VisibleGeometryBus.h>
 
 namespace WhiteBox
 {
@@ -24,6 +25,7 @@ namespace WhiteBox
         : public AZ::Component
         , public WhiteBoxComponentRequestBus::Handler
         , private AZ::TransformNotificationBus::Handler
+        , public AzFramework::VisibleGeometryRequestBus::Handler
     {
     public:
         AZ_COMPONENT(WhiteBoxComponent, "{6CFD4D82-FA68-4C18-BE67-43FC2B755B64}", AZ::Component)
@@ -48,6 +50,9 @@ namespace WhiteBox
 
         // TransformNotificationBus ...
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
+
+        // AzFramework::VisibleGeometryRequestBus::Handler overrides ...
+        void GetVisibleGeometry(const AZ::Aabb& bounds, AzFramework::VisibleGeometryContainer& geometryContainer) const override;
 
         WhiteBoxRenderData m_whiteBoxRenderData; //!< Intermediate format to store White Box render data.
         AZStd::unique_ptr<RenderMeshInterface> m_renderMesh; //!< The render mesh to use for White Box rendering.

--- a/Gems/WhiteBox/Code/whitebox_supported_files.cmake
+++ b/Gems/WhiteBox/Code/whitebox_supported_files.cmake
@@ -20,6 +20,8 @@ set(FILES
     Source/Rendering/WhiteBoxRenderMeshInterface.h
     Source/Rendering/WhiteBoxRenderData.cpp
     Source/Rendering/WhiteBoxRenderData.h
+    Source/Rendering/WhiteBoxRenderDataUtil.cpp
+    Source/Rendering/WhiteBoxRenderDataUtil.h
     Source/Rendering/WhiteBoxMaterial.cpp
     Source/Rendering/WhiteBoxMaterial.h
     Source/Rendering/WhiteBoxNullRenderMesh.cpp


### PR DESCRIPTION
## What does this PR do?

This implements the visible geometry request bus on the white box components. This allows other tools and systems, like occlusion culling, to mine geometric data from white box components using a general purpose bus and data structures.

## How was this PR tested?

Tested by exporting data in separate project