### PR TITLE
Optimizations to Vulkan barriers

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/LookModificationComposite.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LookModificationComposite.pass
@@ -21,7 +21,10 @@
                 {
                     "Name": "Output",
                     "SlotType": "Output",
-                    "ScopeAttachmentUsage": "RenderTarget"
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
                 }
             ],
             "ImageAttachments": [

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasingBarrierTracker.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasingBarrierTracker.h
@@ -21,6 +21,7 @@ namespace AZ::RHI
     //! Describes the use of an Aliased Resource.
     struct AliasedResource
     {
+        AttachmentId m_attachmentId;    //< Id of the attachment being aliased.
         Scope* m_beginScope = nullptr;  ///< Scope when the resource begins being used.
         Scope* m_endScope = nullptr;    ///< Scope when the resource ends being used.
         DeviceResource* m_resource = nullptr; ///< DeviceResource being aliased.
@@ -54,6 +55,8 @@ namespace AZ::RHI
         //////////////////////////////////////////////////////////////////////////
         // Functions that must be implemented by each RHI.
 
+        //! Implementation specific AddResource. Optional.
+        virtual void AddResourceInternal(const AliasedResource& resourceNew);
         //! Implementation specific reset logic. Optional.
         virtual void ResetInternal();
         //! Implementation specific end logic. Optional.

--- a/Gems/Atom/RHI/Code/Source/RHI/AliasedHeap.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/AliasedHeap.cpp
@@ -212,6 +212,7 @@ namespace AZ::RHI
         {
             // Now that we have the begin and end scope we can add the resource to the tracker.
             AliasedResource aliasedResource;
+            aliasedResource.m_attachmentId = attachmentId;
             aliasedResource.m_beginScope = attachmentData.m_activateScope;
             aliasedResource.m_endScope = &scope;
             aliasedResource.m_resource = attachmentData.m_resource;

--- a/Gems/Atom/RHI/Code/Source/RHI/AliasingBarrierTracker.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/AliasingBarrierTracker.cpp
@@ -105,6 +105,7 @@ namespace AZ::RHI
         {
             m_resources.push_back(resourceNew);
         }
+        AddResourceInternal(resourceNew);
     }
 
     void AliasingBarrierTracker::End()
@@ -112,6 +113,7 @@ namespace AZ::RHI
         EndInternal();
     }
 
+    void AliasingBarrierTracker::AddResourceInternal([[maybe_unused]] const AliasedResource& resourceNew) {}
     void AliasingBarrierTracker::ResetInternal() {}
     void AliasingBarrierTracker::EndInternal() {}
 

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/Conversion.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/Conversion.h
@@ -37,6 +37,7 @@ namespace AZ
         VkFormat ConvertFormat(RHI::Format format, bool raiseAsserts = true);
         VkImageAspectFlagBits ConvertImageAspect(RHI::ImageAspect imageAspect);
         VkImageAspectFlags ConvertImageAspectFlags(RHI::ImageAspectFlags aspectFlagMask);
+        RHI::ImageAspectFlags ConvertImageAspectFlags(VkImageAspectFlags aspectFlagMask);
         VkPrimitiveTopology ConvertTopology(RHI::PrimitiveTopology topology);
         VkQueueFlags ConvertQueueClass(RHI::HardwareQueueClass queueClass);
         VkMemoryPropertyFlags ConvertHeapMemoryLevel(RHI::HeapMemoryLevel heapMemoryLevel);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
@@ -28,7 +28,7 @@ namespace AZ
 
         AZStd::unique_ptr<RHI::AliasingBarrierTracker> AliasedHeap::CreateBarrierTrackerInternal()
         {
-            return AZStd::make_unique<AliasingBarrierTracker>(GetVulkanRHIDevice());
+            return AZStd::make_unique<AliasingBarrierTracker>(GetVulkanRHIDevice(), GetDescriptor().m_budgetInBytes);
         }
 
         RHI::ResultCode AliasedHeap::InitInternal(RHI::Device& rhiDevice, const RHI::AliasedHeapDescriptor& descriptor)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasingBarrierTracker.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasingBarrierTracker.cpp
@@ -11,122 +11,166 @@
 #include <RHI/Scope.h>
 #include <RHI/Conversion.h>
 #include <RHI/Device.h>
+#include <Atom/RHI/ScopeAttachment.h>
+#include <Atom/RHI/FrameAttachment.h>
+#include <Atom/RHI/BufferScopeAttachment.h>
+#include <Atom/RHI/ImageScopeAttachment.h>
 
 namespace AZ
 {
     namespace Vulkan
     {
-        AliasingBarrierTracker::AliasingBarrierTracker(Device& device)
+        AliasingBarrierTracker::AliasingBarrierTracker(Device& device, uint64_t heapSize)
             :m_device(device)
         {
+            m_pipelineAccess.assign(0, heapSize + 1, PipelineAccessFlags{ VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_ACCESS_NONE });
         }
 
-        void AliasingBarrierTracker::AppendBarrierInternal(const RHI::AliasedResource& beforeResource, const RHI::AliasedResource& afterResource)
+        template<class T>
+        PipelineAccessFlags CollectPipelineAccess(const AZStd::vector<T>& propertyRanges)
         {
-            // We only need a barrier if the old or new resource writes to memory.
-            bool needsBarrier = false;
-            VkPipelineStageFlags srcPipelineFlags = {};
-            VkPipelineStageFlags dstPipelineFlags = {};
-            VkAccessFlags srcAccessFlags = {};
-            VkAccessFlags dstAccessFlags = {};
-            const RHI::ImageBindFlags writeImageFlags = RHI::ImageBindFlags::ShaderWrite | RHI::ImageBindFlags::Color | RHI::ImageBindFlags::DepthStencil | RHI::ImageBindFlags::CopyWrite;
-            const RHI::BufferBindFlags writeBufferFlags = RHI::BufferBindFlags::ShaderWrite | RHI::BufferBindFlags::CopyWrite;
-
-            // Get the srcPipeline and srcAccessFlags from the resource (image or buffer)
-            if (beforeResource.m_type == RHI::AliasedResourceType::Image)
+            PipelineAccessFlags flags = {};
+            for (const auto& range : propertyRanges)
             {
-                const Image* image = static_cast<const Image*>(beforeResource.m_resource);
-                const auto& bindFlags = image->GetDescriptor().m_bindFlags;
-                needsBarrier |= RHI::CheckBitsAny(bindFlags, writeImageFlags);
-                srcPipelineFlags = GetResourcePipelineStateFlags(bindFlags);
-                srcAccessFlags = GetResourceAccessFlags(bindFlags);
+                flags |= range.m_property;
             }
-            else  // Buffer
-            {
-                const Buffer* buffer = static_cast<const Buffer*>(beforeResource.m_resource);
-                const auto& bindFlags = buffer->GetDescriptor().m_bindFlags;
-                needsBarrier |= RHI::CheckBitsAny(bindFlags, writeBufferFlags);
-                srcPipelineFlags = GetResourcePipelineStateFlags(bindFlags);
-                srcAccessFlags = GetResourceAccessFlags(bindFlags);
-            }
+            return flags;
+        }
 
-            const auto& queueContext = m_device.GetCommandQueueContext();
-            QueueId oldQueueId = queueContext.GetCommandQueue(beforeResource.m_endScope->GetHardwareQueueClass()).GetId();
-            QueueId newQueueId = queueContext.GetCommandQueue(afterResource.m_beginScope->GetHardwareQueueClass()).GetId();
-
-            if (afterResource.m_type == RHI::AliasedResourceType::Image)
-            {
-                Image* image = static_cast<Image*>(afterResource.m_resource);
-                const auto& bindFlags = image->GetDescriptor().m_bindFlags;
-                needsBarrier |= RHI::CheckBitsAny(bindFlags, writeImageFlags);
-                dstPipelineFlags = GetResourcePipelineStateFlags(bindFlags);
-                dstAccessFlags = GetResourceAccessFlags(bindFlags);
-
-                if (!needsBarrier)
+        // Builds the pipeline and access flags needed when accessing the same memory that this aliased
+        // resource is using.
+        PipelineAccessFlags GetAliasedResourcePipelineAccessFlags(const RHI::AliasedResource& resource)
+        {
+            // First find the first usage of the resource
+            const auto& transientAttachments = resource.m_beginScope->GetTransientAttachments();
+            auto it = AZStd::find_if(
+                transientAttachments.begin(),
+                transientAttachments.end(),
+                [&](const RHI::ScopeAttachment* scopeAttachment)
                 {
-                    return;
+                    return scopeAttachment->GetFrameAttachment().GetId() == resource.m_attachmentId;
+                });
+
+            AZ_Assert(it != transientAttachments.end(), "Failed to find transient attachment %s", resource.m_attachmentId.GetCStr());
+
+            // Need to collect the pipeline and access of all the usages of the resource.
+            PipelineAccessFlags transientFlags;
+            if (resource.m_type == RHI::AliasedResourceType::Image)
+            {
+                Image* image = static_cast<Image*>(resource.m_resource);
+                // Use an interval map to keep track of the stage and accesses.
+                Image::ImagePipelineAccessProperty imagePipelineAccess;
+                imagePipelineAccess.Init(image->GetDescriptor());
+                for (const RHI::ScopeAttachment* scopeAttachment = *it; scopeAttachment != nullptr;
+                     scopeAttachment = scopeAttachment->GetNext())
+                {
+                    PipelineAccessFlags flags;
+                    flags.m_access = GetResourceAccessFlags(*scopeAttachment);
+                    flags.m_pipelineStage = GetResourcePipelineStateFlags(*scopeAttachment);
+                    const RHI::ImageScopeAttachment* imageScopeAttachment = static_cast<const RHI::ImageScopeAttachment*>(scopeAttachment);
+                    auto range = RHI::ImageSubresourceRange(imageScopeAttachment->GetDescriptor().GetViewDescriptor());
+                    // If it's a write or read after write access, we override the PipelineAccessFlags values (since we know that the scope will synchronize against it)
+                    // If it's a read after read access, the scope will not synchronize, so we combine the PipelineAccessFlags, so future accesses synchronize
+                    // against all read accesses.
+                    if (IsReadOnlyAccess(flags.m_access))
+                    {
+                        PipelineAccessFlags currentFlags = CollectPipelineAccess(imagePipelineAccess.Get(range));
+                        if (IsReadOnlyAccess(currentFlags.m_access))
+                        {
+                            flags |= currentFlags;
+                        }
+                    }
+                    imagePipelineAccess.Set(range, flags);
                 }
-
-                // If the old and new queues are different, we will add a semaphore that
-                // serves as the memory dependency.
-                if (oldQueueId == newQueueId)
+                // Now collect the final PipelineAccessFlags values.
+                auto overlap = imagePipelineAccess.Get(RHI::ImageSubresourceRange(image->GetDescriptor()));
+                for (auto overlapIt : overlap)
                 {
-                    VkImageMemoryBarrier barrier = {};
-                    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-                    barrier.pNext = nullptr;
-                    barrier.srcAccessMask = srcAccessFlags;
-                    barrier.dstAccessMask = dstAccessFlags;
-                    barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-                    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-                    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                    barrier.image = image->GetNativeImage();
-                    barrier.subresourceRange.aspectMask = image->GetImageAspectFlags();
-                    barrier.subresourceRange.baseMipLevel = 0;
-                    barrier.subresourceRange.levelCount = image->GetDescriptor().m_mipLevels;
-                    barrier.subresourceRange.baseArrayLayer = 0;
-                    barrier.subresourceRange.layerCount = image->GetDescriptor().m_arraySize;
-                    auto insertedBarrier = static_cast<Scope*>(afterResource.m_beginScope)->QueueBarrier(Scope::BarrierSlot::Aliasing, srcPipelineFlags, dstPipelineFlags, barrier);
-
-                    image->SetLayout(barrier.newLayout);
-                    image->SetOwnerQueue(newQueueId);
-                    image->SetPipelineAccess({ insertedBarrier.m_dstStageMask, insertedBarrier.m_imageBarrier.dstAccessMask});
+                    transientFlags |= overlapIt.m_property;
                 }
             }
             else // Buffer
             {
-                Buffer* buffer = static_cast<Buffer*>(afterResource.m_resource);
-                const auto& bindFlags = buffer->GetDescriptor().m_bindFlags;
-                needsBarrier |= RHI::CheckBitsAny(bindFlags, writeBufferFlags);
-                dstPipelineFlags = GetResourcePipelineStateFlags(bindFlags);
-                dstAccessFlags = GetResourceAccessFlags(bindFlags);
-
-                if (!needsBarrier)
+                Buffer* buffer = static_cast<Buffer*>(resource.m_resource);
+                // Use an interval map to keep track of the stage and accesses.
+                Buffer::BufferPipelineAccessProperty bufferPipelineAccess;
+                bufferPipelineAccess.Init(buffer->GetDescriptor());
+                for (const RHI::ScopeAttachment* scopeAttachment = *it; scopeAttachment != nullptr;
+                     scopeAttachment = scopeAttachment->GetNext())
                 {
-                    return;
+                    PipelineAccessFlags flags;
+                    flags.m_access = GetResourceAccessFlags(*scopeAttachment);
+                    flags.m_pipelineStage = GetResourcePipelineStateFlags(*scopeAttachment);
+                    const RHI::BufferScopeAttachment* bufferScopeAttachment =
+                        static_cast<const RHI::BufferScopeAttachment*>(scopeAttachment);
+                    auto range = RHI::BufferSubresourceRange(bufferScopeAttachment->GetDescriptor().GetViewDescriptor());
+                    // If it's a write or read after write access, we override the PipelineAccessFlags values (since we know that the scope
+                    // will synchronize against it) If it's a read after read access, the scope will not synchronize, so we combine the
+                    // PipelineAccessFlags, so future accesses synchronize against all read accesses.
+                    if (IsReadOnlyAccess(flags.m_access))
+                    {
+                        PipelineAccessFlags currentFlags = CollectPipelineAccess(bufferPipelineAccess.Get(range));
+                        if (IsReadOnlyAccess(currentFlags.m_access))
+                        {
+                            flags |= currentFlags;
+                        }
+                    }
+                    bufferPipelineAccess.Set(range, flags);
                 }
-
-                // If the old and new queues are different, we will add a semaphore that
-                // serves as the memory dependency.
-                if (oldQueueId == newQueueId)
+                // Now collect the final PipelineAccessFlags values.
+                auto overlap = bufferPipelineAccess.Get(RHI::BufferSubresourceRange(buffer->GetDescriptor()));
+                for (auto overlapIt : overlap)
                 {
-                    const auto* bufferMemory = buffer->GetBufferMemoryView();
-                    VkBufferMemoryBarrier barrier{};
-                    barrier.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
-                    barrier.pNext = nullptr;
-                    barrier.srcAccessMask = srcAccessFlags;
-                    barrier.dstAccessMask = dstAccessFlags;
-                    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                    barrier.buffer = bufferMemory->GetNativeBuffer();
-                    barrier.offset = bufferMemory->GetOffset() + afterResource.m_byteOffsetMin;
-                    barrier.size = afterResource.m_byteOffsetMax - afterResource.m_byteOffsetMin + 1;
-                    auto insertedBarrier = static_cast<Scope*>(afterResource.m_beginScope)->QueueBarrier(Scope::BarrierSlot::Aliasing, srcPipelineFlags, dstPipelineFlags, barrier);
-
-                    buffer->SetOwnerQueue(newQueueId);
-                    buffer->SetPipelineAccess({ insertedBarrier.m_dstStageMask, insertedBarrier.m_imageBarrier.dstAccessMask });
+                    transientFlags |= overlapIt.m_property;
                 }
             }
+
+            return transientFlags;
+        }
+
+        void AliasingBarrierTracker::AddResourceInternal(const RHI::AliasedResource& resourceNew)
+        {
+            // No need to emit an aliased barrier on first usage of the resource.
+            // We just need to set the proper pipeline and access flags so during first usage, the scope can synchronize properly.
+            // That first usage will provide the aliasing synchronization that is needed.
+            PipelineAccessFlags srcFlags{};
+
+            const auto& queueContext = m_device.GetCommandQueueContext();
+            QueueId newQueueId = queueContext.GetCommandQueue(resourceNew.m_beginScope->GetHardwareQueueClass()).GetId();
+
+            // Get the pipeline and access flags that the memory used by the aliased resource needs.
+            // These flags include previous usages of this memory by other resources.
+            auto overlap = m_pipelineAccess.overlap(resourceNew.m_byteOffsetMin, resourceNew.m_byteOffsetMax + 1);
+            for (auto it = overlap.first; it != overlap.second; ++it)
+            {
+                srcFlags |= it.value();
+            }
+
+            if (resourceNew.m_type == RHI::AliasedResourceType::Image)
+            {
+                Image* image = static_cast<Image*>(resourceNew.m_resource);
+                image->SetLayout(VK_IMAGE_LAYOUT_UNDEFINED);
+                image->SetOwnerQueue(newQueueId);
+                image->SetPipelineAccess(srcFlags);
+            }
+            else // Buffer
+            {
+                Buffer* buffer = static_cast<Buffer*>(resourceNew.m_resource);
+                buffer->SetOwnerQueue(newQueueId);
+                buffer->SetPipelineAccess(srcFlags);
+            }
+
+            // Set the aliased memory with the PipelineAccessFlags from using the aliased resource.
+            // This way future resources that use this same memory can synchronize properly.
+            PipelineAccessFlags dstFlags = GetAliasedResourcePipelineAccessFlags(resourceNew);
+            m_pipelineAccess.assign(resourceNew.m_byteOffsetMin, resourceNew.m_byteOffsetMax + 1, dstFlags);
+        }
+
+        void AliasingBarrierTracker::AppendBarrierInternal(const RHI::AliasedResource& beforeResource, const RHI::AliasedResource& afterResource)
+        {
+            const auto& queueContext = m_device.GetCommandQueueContext();
+            QueueId oldQueueId = queueContext.GetCommandQueue(beforeResource.m_endScope->GetHardwareQueueClass()).GetId();
+            QueueId newQueueId = queueContext.GetCommandQueue(afterResource.m_beginScope->GetHardwareQueueClass()).GetId();
 
             // If resources are in different queues then we need to add an execution dependency so
             // we don't start using the aliased resource in the new scope before the old scope finishes.
@@ -134,9 +178,10 @@ namespace AZ
             // these are two different resources that don't need a barrier/semaphore.
             if (oldQueueId != newQueueId)
             {
+                PipelineAccessFlags dstFlags = GetAliasedResourcePipelineAccessFlags(afterResource);
                 auto semaphore = m_device.GetSemaphoreAllocator().Allocate();
                 static_cast<Scope*>(beforeResource.m_endScope)->AddSignalSemaphore(semaphore);
-                static_cast<Scope*>(afterResource.m_beginScope)->AddWaitSemaphore(AZStd::make_pair(dstPipelineFlags, semaphore));
+                static_cast<Scope*>(afterResource.m_beginScope)->AddWaitSemaphore(AZStd::make_pair(dstFlags.m_pipelineStage, semaphore));
                 // This will not deallocate immediately.
                 m_barrierSemaphores.push_back(semaphore);
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasingBarrierTracker.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasingBarrierTracker.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI/AliasingBarrierTracker.h>
+#include <Atom/RHI/interval_map.h>
 
 namespace AZ
 {
@@ -16,6 +17,7 @@ namespace AZ
         class Device;
         class Scope;
         class Semaphore;
+        struct PipelineAccessFlags;
 
         // Tracks aliased resource and adds the proper barriers and synchronization semaphores when two resources that
         // overlap each other, partially or totally. It doesn't add any type of synchronization between resources
@@ -29,17 +31,20 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(AliasingBarrierTracker, AZ::SystemAllocator);
             AZ_RTTI(AliasingBarrierTracker, "{6BF3509E-D38A-4F55-B539-E9207C714CA7}", Base);
 
-            AliasingBarrierTracker(Device& device);
+            AliasingBarrierTracker(Device& device, uint64_t heapSize);
 
         private:
             //////////////////////////////////////////////////////////////////////////
             // RHI::AliasingBarrierTracker
+            void AddResourceInternal(const RHI::AliasedResource& resourceNew) override;
             void AppendBarrierInternal(const RHI::AliasedResource& resourceBefore, const RHI::AliasedResource& resourceAfter) override;
             void EndInternal() override;
             //////////////////////////////////////////////////////////////////////////
 
             Device& m_device;
             AZStd::vector<Semaphore*> m_barrierSemaphores;
+            // Keeps track of the PipelineAccessFlags of the heap memory.
+            RHI::interval_map<uint64_t, PipelineAccessFlags> m_pipelineAccess;
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.h
@@ -59,7 +59,7 @@ namespace AZ
             void SetOwnerQueue(const QueueId& queueId, const RHI::BufferSubresourceRange* range = nullptr);
             void SetOwnerQueue(const QueueId& queueId, const RHI::DeviceBufferView& bufferView);
 
-            using ImagePipelineAccessProperty = RHI::BufferProperty<PipelineAccessFlags>;
+            using BufferPipelineAccessProperty = RHI::BufferProperty<PipelineAccessFlags>;
 
             PipelineAccessFlags GetPipelineAccess(const RHI::BufferSubresourceRange* range = nullptr) const;
             void SetPipelineAccess(const PipelineAccessFlags& pipelineAccess, const RHI::BufferSubresourceRange* range = nullptr);
@@ -98,7 +98,7 @@ namespace AZ
             mutable AZStd::mutex m_ownerQueueMutex;
 
             // Last pipeline access to the image subresources
-            ImagePipelineAccessProperty m_pipelineAccess;
+            BufferPipelineAccessProperty m_pipelineAccess;
             mutable AZStd::mutex m_pipelineAccessMutex;
 
             RHI::AsyncWorkHandle m_uploadHandle;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupPrimary.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupPrimary.cpp
@@ -92,7 +92,6 @@ namespace AZ::Vulkan
         m_commandList->BeginDebugLabel(scope->GetMarkerLabel().data());
         context.SetCommandList(*m_commandList);
 
-        scope->EmitScopeBarriers(*m_commandList, Scope::BarrierSlot::Aliasing);
         scope->ProcessClearRequests(*m_commandList);
         scope->EmitScopeBarriers(*m_commandList, Scope::BarrierSlot::Prologue);
         scope->ResetQueryPools(*m_commandList);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupSecondaryHandler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupSecondaryHandler.cpp
@@ -90,7 +90,6 @@ namespace AZ::Vulkan
         commandList->BeginDebugLabel(scope->GetMarkerLabel().data());
 
         // First emit all scope barriers outside of the renderpass.
-        EmitScopeBarriers(*commandList, Scope::BarrierSlot::Aliasing);
         ProcessClearRequests(*commandList);
         EmitScopeBarriers(*commandList, Scope::BarrierSlot::Prologue);
         // Reset the RHI QueryPools.

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.cpp
@@ -208,6 +208,18 @@ namespace AZ
             }
         }
 
+        bool IsReadOnlyAccess(VkAccessFlags access)
+        {
+            return !RHI::CheckBitsAny(
+                access,
+                VkAccessFlags(VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                    VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+                    VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_HOST_WRITE_BIT | VK_ACCESS_MEMORY_WRITE_BIT |
+                    VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT | VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT |
+                    VK_ACCESS_CONDITIONAL_RENDERING_READ_BIT_EXT | VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR |
+                    VK_ACCESS_COMMAND_PREPROCESS_WRITE_BIT_NV | VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_NV));
+        }
+
         bool operator==(const VkImageSubresourceRange& lhs, const VkImageSubresourceRange& rhs)
         {
             return

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
@@ -50,6 +50,13 @@ namespace AZ
             {
                 return m_pipelineStage == other.m_pipelineStage && m_access == other.m_access;
             }
+
+            PipelineAccessFlags& operator|=(const PipelineAccessFlags& other)
+            {
+                m_pipelineStage |= other.m_pipelineStage;
+                m_access |= other.m_access;
+                return *this;
+            }
         };
 
         class Device;
@@ -137,6 +144,9 @@ namespace AZ
         bool SubresourceRangeOverlaps(const RHI::BufferSubresourceRange& lhs, const RHI::BufferSubresourceRange& rhs);
 
         bool IsRenderAttachmentUsage(RHI::ScopeAttachmentUsage usage);
+
+        /// Return true if the flags only included read accesses.
+        bool IsReadOnlyAccess(VkAccessFlags access);
 
         bool operator==(const VkImageSubresourceRange& lhs, const VkImageSubresourceRange& rhs);
 


### PR DESCRIPTION
## What does this PR do?
This PR includes optimizations to the usage of barriers for synchronization on Vulkan. Some of the improvements are:

-  Remove explicit aliased barriers. There's no longer an aliased stage for barriers. We just set the proper pipeline and access flags, so during first usage of the aliased resource, the resource is synchronize against those flags. For images, we set the layout to UNDEFINED before first usage since we don't need to keep the contents. Again, the first usage barrier will transition the image to the proper layout.
- Add narrower pipeline and access flags for aliased memory synchronization. We are now tracking the access to the aliased memory so we can synchronize against those accesses and not against the whole possible usage of a resource. This also fixes synchronization of aliased resources against accesses from the previous frame.
- Replace resource barriers for a global memory barrier. As part of the optimization we replace all the resource barriers in a scope for just one global memory barrier. Apparently this is more efficient (https://github.com/KhronosGroup/Vulkan-Docs/wiki/Synchronization-Examples). Added a CVAR too (r_vkOptimizeBarriers) to enable/disable this optimization because for debugging synchronization issues is easier to see all generated barriers.
- Ignore unnecessary barriers (e.g. read after read access). Some barriers are not needed because they are not doing layout transitions or owner transfer, and are not doing a hazardous access.
- Replace layout transition barriers with automatic renderpass layout transitions. When using a renderpass, we can take advantage of automatic layout transitions provided by the renderpass object. Because of compatibility issues with the renderpass used for generating a pipeline, we don't use external subpass dependencies. Instead we use a memory barrier before the begin of a renderpass (which is basically the same).

## How was this PR tested?

Run Vulkan PC and Android.