### PR TITLE
Refactoring of multi-device code.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -195,12 +195,26 @@ namespace AZ
 
         RPI::TimestampResult RayTracingAccelerationStructurePass::GetTimestampResultInternal() const
         {
-            return m_timestampResults.at(RHI::MultiDevice::DefaultDeviceIndex);
+            RPI::TimestampResult result{};
+
+            for (auto& [deviceIndex, timestampResult] : m_timestampResults)
+            {
+                result.Add(timestampResult);
+            }
+
+            return result;
         }
 
         RPI::PipelineStatisticsResult RayTracingAccelerationStructurePass::GetPipelineStatisticsResultInternal() const
         {
-            return m_statisticsResults.at(RHI::MultiDevice::DefaultDeviceIndex);
+            RPI::PipelineStatisticsResult result{};
+
+            for (auto& [deviceIndex, statisticsResult] : m_statisticsResults)
+            {
+                result += statisticsResult;
+            }
+
+            return result;
         }
 
         void RayTracingAccelerationStructurePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -63,6 +63,7 @@ namespace AZ
                 {
                     m_meshBufferIndices[deviceIndex] = {};
                     m_materialTextureIndices[deviceIndex] = {};
+                    m_meshInfos[deviceIndex] = {};
                     m_materialInfos[deviceIndex] = {};
                     m_proceduralGeometryMaterialInfos[deviceIndex] = {};
                 }
@@ -104,7 +105,7 @@ namespace AZ
             const AZStd::string& name,
             const Data::Instance<RPI::Shader>& intersectionShader,
             const AZStd::string& intersectionShaderName,
-            uint32_t bindlessBufferIndex)
+            const AZStd::unordered_map<int, uint32_t>& bindlessBufferIndices)
         {
             ProceduralGeometryTypeHandle geometryTypeHandle;
 
@@ -113,7 +114,7 @@ namespace AZ
                 proceduralGeometryType.m_name = AZ::Name(name);
                 proceduralGeometryType.m_intersectionShader = intersectionShader;
                 proceduralGeometryType.m_intersectionShaderName = AZ::Name(intersectionShaderName);
-                proceduralGeometryType.m_bindlessBufferIndex = bindlessBufferIndex;
+                proceduralGeometryType.m_bindlessBufferIndices = bindlessBufferIndices;
 
                 AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
                 geometryTypeHandle = m_proceduralGeometryTypes.insert(proceduralGeometryType);
@@ -124,14 +125,14 @@ namespace AZ
         }
 
         void RayTracingFeatureProcessor::SetProceduralGeometryTypeBindlessBufferIndex(
-            ProceduralGeometryTypeWeakHandle geometryTypeHandle, uint32_t bindlessBufferIndex)
+            ProceduralGeometryTypeWeakHandle geometryTypeHandle, const AZStd::unordered_map<int, uint32_t>& bindlessBufferIndices)
         {
             if (!m_rayTracingEnabled)
             {
                 return;
             }
 
-            geometryTypeHandle->m_bindlessBufferIndex = bindlessBufferIndex;
+            geometryTypeHandle->m_bindlessBufferIndices = bindlessBufferIndices;
             m_proceduralGeometryInfoBufferNeedsUpdate = true;
         }
 
@@ -329,7 +330,10 @@ namespace AZ
                 subMeshIndices.push_back(subMeshGlobalIndex);
 
                 // add MeshInfo and MaterialInfo entries
-                m_meshInfos.emplace_back();
+                for (auto& [deviceIndex, meshInfos] : m_meshInfos)
+                {
+                    meshInfos.emplace_back();
+                }
                 for (auto& [deviceIndex, materialInfos] : m_materialInfos)
                 {
                     materialInfos.emplace_back();
@@ -414,24 +418,27 @@ namespace AZ
             for (uint32_t subMeshIndex : mesh.m_subMeshIndices)
             {
                 SubMesh& subMesh = m_subMeshes[subMeshIndex];
-                MeshInfo& meshInfo = m_meshInfos[subMesh.m_globalIndex];
-
-                worldInvTranspose3x4.StoreToRowMajorFloat12(meshInfo.m_worldInvTranspose.data());
-                meshInfo.m_bufferFlags = subMesh.m_bufferFlags;
-
                 AZ_Assert(subMesh.m_indexShaderBufferView.get(), "RayTracing Mesh IndexBuffer cannot be null");
                 AZ_Assert(subMesh.m_positionShaderBufferView.get(), "RayTracing Mesh PositionBuffer cannot be null");
                 AZ_Assert(subMesh.m_normalShaderBufferView.get(), "RayTracing Mesh NormalBuffer cannot be null");
 
-                meshInfo.m_indexByteOffset = subMesh.m_indexBufferView.GetByteOffset();
-                meshInfo.m_positionByteOffset = subMesh.m_positionVertexBufferView.GetByteOffset();
-                meshInfo.m_normalByteOffset = subMesh.m_normalVertexBufferView.GetByteOffset();
-                meshInfo.m_tangentByteOffset = subMesh.m_tangentShaderBufferView ? subMesh.m_tangentVertexBufferView.GetByteOffset() : 0;
-                meshInfo.m_bitangentByteOffset = subMesh.m_bitangentShaderBufferView ? subMesh.m_bitangentVertexBufferView.GetByteOffset() : 0;
-                meshInfo.m_uvByteOffset = subMesh.m_uvShaderBufferView ? subMesh.m_uvVertexBufferView.GetByteOffset() : 0;
-
-                for (auto& [deviceIndex, materialInfos] : m_materialInfos)
+                for (auto& [deviceIndex, meshInfos] : m_meshInfos)
                 {
+                    MeshInfo& meshInfo = meshInfos[subMesh.m_globalIndex];
+
+                    worldInvTranspose3x4.StoreToRowMajorFloat12(meshInfo.m_worldInvTranspose.data());
+                    meshInfo.m_bufferFlags = subMesh.m_bufferFlags;
+
+                    meshInfo.m_indexByteOffset = subMesh.m_indexBufferView.GetByteOffset();
+                    meshInfo.m_positionByteOffset = subMesh.m_positionVertexBufferView.GetByteOffset();
+                    meshInfo.m_normalByteOffset = subMesh.m_normalVertexBufferView.GetByteOffset();
+                    meshInfo.m_tangentByteOffset =
+                        subMesh.m_tangentShaderBufferView ? subMesh.m_tangentVertexBufferView.GetByteOffset() : 0;
+                    meshInfo.m_bitangentByteOffset =
+                        subMesh.m_bitangentShaderBufferView ? subMesh.m_bitangentVertexBufferView.GetByteOffset() : 0;
+                    meshInfo.m_uvByteOffset = subMesh.m_uvShaderBufferView ? subMesh.m_uvVertexBufferView.GetByteOffset() : 0;
+
+                    auto& materialInfos{ m_materialInfos[deviceIndex] };
                     MaterialInfo& materialInfo = materialInfos[subMesh.m_globalIndex];
                     ConvertMaterial(materialInfo, subMesh.m_material, deviceIndex);
 
@@ -519,10 +526,10 @@ namespace AZ
                     SubMesh& subMesh = m_subMeshes[subMeshIndex];
                     uint32_t globalIndex = subMesh.m_globalIndex;
 
-                    MeshInfo& meshInfo = m_meshInfos[globalIndex];
-
-                    for (auto& [deviceIndex, meshBufferIndices] : m_meshBufferIndices)
+                    for (auto& [deviceIndex, meshInfos] : m_meshInfos)
                     {
+                        MeshInfo& meshInfo = meshInfos[globalIndex];
+                        auto& meshBufferIndices = m_meshBufferIndices[deviceIndex];
                         meshBufferIndices.RemoveEntry(meshInfo.m_bufferStartIndex);
                     }
                     for (auto& [deviceIndex, materialTextureIndices] : m_materialTextureIndices)
@@ -539,20 +546,22 @@ namespace AZ
                     m_meshBuffers.RemoveResource(subMesh.m_bitangentShaderBufferView.get());
                     m_meshBuffers.RemoveResource(subMesh.m_uvShaderBufferView.get());
 
-                    m_materialTextures.RemoveResource(subMesh.m_baseColorImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
-                    m_materialTextures.RemoveResource(subMesh.m_normalImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
-                    m_materialTextures.RemoveResource(subMesh.m_metallicImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
-                    m_materialTextures.RemoveResource(subMesh.m_roughnessImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
-                    m_materialTextures.RemoveResource(subMesh.m_emissiveImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                    m_materialTextures.RemoveResource(subMesh.m_baseColorImageView.get());
+                    m_materialTextures.RemoveResource(subMesh.m_normalImageView.get());
+                    m_materialTextures.RemoveResource(subMesh.m_metallicImageView.get());
+                    m_materialTextures.RemoveResource(subMesh.m_roughnessImageView.get());
+                    m_materialTextures.RemoveResource(subMesh.m_emissiveImageView.get());
 #endif
 
                     if (globalIndex < m_subMeshes.size() - 1)
                     {
                         // the subMesh we're removing is in the middle of the global lists, remove by swapping the last element to its position in the list
                         m_subMeshes[globalIndex] = m_subMeshes.back();
-                        m_meshInfos[globalIndex] = m_meshInfos.back();
-                        for (auto& [deviceIndex, materialInfos] : m_materialInfos)
+
+                        for (auto& [deviceIndex, meshInfos] : m_meshInfos)
                         {
+                            auto& materialInfos{ m_materialInfos[deviceIndex] };
+                            meshInfos[globalIndex] = meshInfos.back();
                             materialInfos[globalIndex] = materialInfos.back();
                         }
 
@@ -566,9 +575,10 @@ namespace AZ
                     }
 
                     m_subMeshes.pop_back();
-                    m_meshInfos.pop_back();
-                    for (auto& [deviceIndex, materialInfos] : m_materialInfos)
+                    for (auto& [deviceIndex, meshInfos] : m_meshInfos)
                     {
+                        auto& materialInfos{ m_materialInfos[deviceIndex] };
+                        meshInfos.pop_back();
                         materialInfos.pop_back();
                     }
                 }
@@ -583,7 +593,11 @@ namespace AZ
                 {
                     m_meshes.clear();
                     m_subMeshes.clear();
-                    m_meshInfos.clear();
+
+                    for (auto& [deviceIndex, meshInfos] : m_meshInfos)
+                    {
+                        meshInfos.clear();
+                    }
                     for (auto& [deviceIndex, materialInfos] : m_materialInfos)
                     {
                         materialInfos.clear();
@@ -637,8 +651,11 @@ namespace AZ
                 // update all MeshInfos for this Mesh with the new transform
                 for (const auto& subMeshIndex : mesh.m_subMeshIndices)
                 {
-                    MeshInfo& meshInfo = m_meshInfos[subMeshIndex];
-                    worldInvTranspose3x4.StoreToRowMajorFloat12(meshInfo.m_worldInvTranspose.data());
+                    for (auto& [deviceIndex, meshInfos] : m_meshInfos)
+                    {
+                        MeshInfo& meshInfo = meshInfos[subMeshIndex];
+                        worldInvTranspose3x4.StoreToRowMajorFloat12(meshInfo.m_worldInvTranspose.data());
+                    }
                 }
 
                 m_meshInfoBufferNeedsUpdate = true;
@@ -664,7 +681,6 @@ namespace AZ
 
                 // update all of the subMeshes
                 const Data::Instance<RPI::Image>& reflectionProbeCubeMap = reflectionProbe.m_reflectionProbeCubeMap;
-                uint32_t reflectionProbeCubeMapIndex = reflectionProbeCubeMap.get() ? reflectionProbeCubeMap->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex() : InvalidIndex;
                 Matrix3x4 reflectionProbeModelToWorld3x4 = Matrix3x4::CreateFromTransform(mesh.m_reflectionProbe.m_modelToWorld);
 
                 for (auto& subMeshIndex : mesh.m_subMeshIndices)
@@ -676,7 +692,9 @@ namespace AZ
                     {
                         MaterialInfo& materialInfo = materialInfos[globalIndex];
 
-                        materialInfo.m_reflectionProbeCubeMapIndex = reflectionProbeCubeMapIndex;
+                        materialInfo.m_reflectionProbeCubeMapIndex = reflectionProbeCubeMap.get()
+                            ? reflectionProbeCubeMap->GetImageView()->GetDeviceImageView(deviceIndex)->GetBindlessReadIndex()
+                            : InvalidIndex;
                         if (materialInfo.m_reflectionProbeCubeMapIndex != InvalidIndex)
                         {
                             reflectionProbeModelToWorld3x4.StoreToRowMajorFloat12(materialInfo.m_reflectionProbeData.m_modelToWorld.data());
@@ -770,7 +788,15 @@ namespace AZ
         {
             if (m_meshInfoBufferNeedsUpdate)
             {
-                m_meshInfoGpuBuffer.AdvanceCurrentBufferAndUpdateData(m_meshInfos);
+                AZStd::unordered_map<int, const void*> rawMeshInfos;
+
+                for (auto& [deviceIndex, meshInfos] : m_meshInfos)
+                {
+                    rawMeshInfos[deviceIndex] = meshInfos.data();
+                }
+
+                size_t meshInfoByteCount = m_meshInfos.begin()->second.size() * sizeof(MeshInfo);
+                m_meshInfoGpuBuffer.AdvanceCurrentBufferAndUpdateData(rawMeshInfos, meshInfoByteCount);
                 m_meshInfoBufferNeedsUpdate = false;
             }
         }
@@ -782,15 +808,33 @@ namespace AZ
                 return;
             }
 
-            AZStd::vector<uint32_t> proceduralGeometryInfo;
-            proceduralGeometryInfo.reserve(m_proceduralGeometry.size() * 2);
+            AZStd::unordered_map<int, AZStd::vector<uint32_t>> proceduralGeometryInfos;
+
             for (const auto& proceduralGeometry : m_proceduralGeometry)
             {
-                proceduralGeometryInfo.push_back(proceduralGeometry.m_typeHandle->m_bindlessBufferIndex);
-                proceduralGeometryInfo.push_back(proceduralGeometry.m_localInstanceIndex);
+                for (auto& [deviceIndex, bindlessBufferIndex] : proceduralGeometry.m_typeHandle->m_bindlessBufferIndices)
+                {
+                    auto& proceduralGeometryInfo = proceduralGeometryInfos[deviceIndex];
+
+                    if (proceduralGeometryInfo.empty())
+                    {
+                        proceduralGeometryInfo.reserve(m_proceduralGeometry.size() * 2);
+                    }
+
+                    proceduralGeometryInfo.push_back(bindlessBufferIndex);
+                    proceduralGeometryInfo.push_back(proceduralGeometry.m_localInstanceIndex);
+                }
             }
 
-            m_proceduralGeometryInfoGpuBuffer.AdvanceCurrentBufferAndUpdateData(proceduralGeometryInfo);
+            AZStd::unordered_map<int, const void*> rawProceduralGeometryInfos;
+
+            for (auto& [deviceIndex, proceduralGeometryInfo] : proceduralGeometryInfos)
+            {
+                rawProceduralGeometryInfos[deviceIndex] = proceduralGeometryInfo.data();
+            }
+
+            m_proceduralGeometryInfoGpuBuffer.AdvanceCurrentBufferAndUpdateData(
+                rawProceduralGeometryInfos, m_proceduralGeometry.size() * 2 * sizeof(uint32_t));
             m_proceduralGeometryInfoBufferNeedsUpdate = false;
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -206,7 +206,7 @@ namespace AZ
                 Name m_name;
                 Data::Instance<RPI::Shader> m_intersectionShader;
                 Name m_intersectionShaderName;
-                uint32_t m_bindlessBufferIndex;
+                AZStd::unordered_map<int, uint32_t> m_bindlessBufferIndices;
                 int m_instanceCount = 0;
             };
             using ProceduralGeometryTypeHandle = StableDynamicArrayHandle<ProceduralGeometryType>;
@@ -244,16 +244,16 @@ namespace AZ
                 const AZStd::string& name,
                 const Data::Instance<RPI::Shader>& intersectionShader,
                 const AZStd::string& intersectionShaderName,
-                uint32_t bindlessBufferIndex = static_cast<uint32_t>(-1));
+                const AZStd::unordered_map<int, uint32_t>& bindlessBufferIndices = {});
 
-            //! Sets the bindlessBufferIndex of a procedural geometry type. This is necessary if the buffer, whose bindless read index was
+            //! Sets the bindlessBufferIndices of a procedural geometry type. This is necessary if the buffer, whose bindless read index was
             //! passed to `RegisterProceduralGeometryType`, is resized or recreated.
             //! \param geometryTypeHandle A weak handle of a procedural geometry type (obtained by calling `.GetWeakHandle()` on the handle
             //! returned by `RegisterProceduralGeometryType`.
-            //! \param bindlessBufferIndex A single 32-bit value which can be queried in the intersection shader with
+            //! \param bindlessBufferIndices A single 32-bit value which can be queried in the intersection shader with
             //! `GetBindlessBufferIndex()`.
             void SetProceduralGeometryTypeBindlessBufferIndex(
-                ProceduralGeometryTypeWeakHandle geometryTypeHandle, uint32_t bindlessBufferIndex);
+                ProceduralGeometryTypeWeakHandle geometryTypeHandle, const AZStd::unordered_map<int, uint32_t>& bindlessBufferIndices);
 
             //! Adds a procedural geometry to the ray tracing scene.
             //! \param geometryTypeHandle A weak handle of a procedural geometry type (obtained by calling `.GetWeakHandle()` on the handle
@@ -471,7 +471,7 @@ namespace AZ
 
             // vector of MeshInfo, transferred to the meshInfoGpuBuffer
             using MeshInfoVector = AZStd::vector<MeshInfo>;
-            MeshInfoVector m_meshInfos;
+            AZStd::unordered_map<int, MeshInfoVector> m_meshInfos;
             RPI::RingBuffer m_meshInfoGpuBuffer{ "RayTracingMeshInfo", RPI::CommonBufferPoolType::ReadOnly, sizeof(MeshInfo) };
             RPI::RingBuffer m_proceduralGeometryInfoGpuBuffer{ "ProceduralGeometryInfo", RPI::CommonBufferPoolType::ReadOnly, RHI::Format::R32G32_UINT };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
@@ -93,6 +93,8 @@ namespace AZ::RHI
             return m_descriptor;
         }
 
+        AZStd::unordered_map<int, uint32_t> GetBindlessReadIndex() const;
+
         const Resource* GetResource() const override
         {
             return m_buffer.get();

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchItem.h
@@ -12,7 +12,6 @@
 #include <Atom/RHI/IndirectArguments.h>
 #include <Atom/RHI/PipelineState.h>
 #include <Atom/RHI/ShaderResourceGroup.h>
-#include <Atom/RHI/RHISystemInterface.h>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/std/containers/array.h>
 
@@ -77,15 +76,13 @@ namespace AZ::RHI
         DispatchItem(MultiDevice::DeviceMask deviceMask)
             : m_deviceMask{ deviceMask }
         {
-            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
-
-            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
-            {
-                if (CheckBitsAll(AZStd::to_underlying(m_deviceMask), 1u << deviceIndex))
+            MultiDeviceObject::IterateDevices(
+                m_deviceMask,
+                [this](int deviceIndex)
                 {
                     m_deviceDispatchItems.emplace(deviceIndex, DeviceDispatchItem{});
-                }
-            }
+                    return true;
+                });
         }
 
         //! Returns the device-specific DeviceDispatchItem for the given index

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysIndirectBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysIndirectBuffer.h
@@ -11,7 +11,6 @@
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/RayTracingShaderTable.h>
-#include <Atom/RHI/RHISystemInterface.h>
 
 namespace AZ
 {
@@ -27,15 +26,13 @@ namespace AZ
             DispatchRaysIndirectBuffer(MultiDevice::DeviceMask deviceMask)
                 : m_deviceMask{ deviceMask }
             {
-                auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
-
-                for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
-                {
-                    if (CheckBitsAll(AZStd::to_underlying(m_deviceMask), 1u << deviceIndex))
+                MultiDeviceObject::IterateDevices(
+                    m_deviceMask,
+                    [this](int deviceIndex)
                     {
                         m_deviceDispatchRaysIndirectBuffers.emplace(deviceIndex, Factory::Get().CreateDispatchRaysIndirectBuffer());
-                    }
-                }
+                        return true;
+                    });
             }
 
             Ptr<DeviceDispatchRaysIndirectBuffer> GetDeviceDispatchRaysIndirectBuffer(int deviceIndex) const

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
@@ -14,7 +14,6 @@
 #include <Atom/RHI/RayTracingPipelineState.h>
 #include <Atom/RHI/RayTracingShaderTable.h>
 #include <Atom/RHI/ShaderResourceGroup.h>
-#include <Atom/RHI/RHISystemInterface.h>
 #include <AzCore/std/containers/array.h>
 
 namespace AZ::RHI
@@ -115,15 +114,13 @@ namespace AZ::RHI
         DispatchRaysItem(MultiDevice::DeviceMask deviceMask)
             : m_deviceMask{ deviceMask }
         {
-            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
-
-            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
-            {
-                if (CheckBitsAll(AZStd::to_underlying(m_deviceMask), 1u << deviceIndex))
+            MultiDeviceObject::IterateDevices(
+                m_deviceMask,
+                [this](int deviceIndex)
                 {
                     m_deviceDispatchRaysItems.emplace(deviceIndex, DeviceDispatchRaysItem{});
-                }
-            }
+                    return true;
+                });
         }
 
         //! Returns the device-specific DeviceDispatchRaysItem for the given index

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacketBuilder.h
@@ -12,7 +12,6 @@
 #include <Atom/RHI.Reflect/Viewport.h>
 #include <Atom/RHI/DeviceDrawPacketBuilder.h>
 #include <Atom/RHI/DrawPacket.h>
-#include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RHI/DeviceStreamBufferView.h>
 
 namespace AZ
@@ -64,16 +63,13 @@ namespace AZ::RHI
         explicit DrawPacketBuilder(RHI::MultiDevice::DeviceMask deviceMask)
             : m_deviceMask{ deviceMask }
         {
-            auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
-
-            for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
-            {
-                // cast to u8 to prevent warning
-                if (RHI::CheckBit(AZStd::to_underlying(m_deviceMask), static_cast<AZ::u8>(deviceIndex)))
+            MultiDeviceObject::IterateDevices(
+                m_deviceMask,
+                [this](int deviceIndex)
                 {
                     m_deviceDrawPacketBuilders.emplace(deviceIndex, DeviceDrawPacketBuilder());
-                }
-            }
+                    return true;
+                });
         }
 
         DrawPacketBuilder(const DrawPacketBuilder& other);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineLibrary.h
@@ -95,25 +95,6 @@ namespace AZ::RHI
         ResultCode MergeInto(AZStd::span<const PipelineLibrary* const> librariesToMerge);
 
         //! Serializes the platform-specific data and returns it as a new PipelineLibraryData instance
-        //! for a specific device 
-        //! @param deviceIndex Denotes from which device the serialized data should be retrieved
-        ConstPtr<PipelineLibraryData> GetSerializedData(int deviceIndex = RHI::MultiDevice::DefaultDeviceIndex) const
-        {
-            if (m_deviceObjects.contains(deviceIndex))
-            {
-                return GetDevicePipelineLibrary(deviceIndex)->GetSerializedData();
-            }
-            else
-            {
-                AZ_Error(
-                    "PipelineLibrary",
-                    false,
-                    "PipelineLibrary is not initialized. This operation is only permitted on an initialized library.");
-                return nullptr;
-            }
-        }
-
-        //! Serializes the platform-specific data and returns it as a new PipelineLibraryData instance
         //! for a specific device
         //! @param deviceIndex Denotes from which device the serialized data should be retrieved
         auto GetSerializedDataMap() const

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
-#include <Atom/RHI/Buffer.h>
 
 namespace AZ::RHI
 {
@@ -80,5 +80,20 @@ namespace AZ::RHI
         }
 
         return iterator->second;
+    }
+
+    AZStd::unordered_map<int, uint32_t> BufferView::GetBindlessReadIndex() const
+    {
+        AZStd::unordered_map<int, uint32_t> result;
+
+        MultiDeviceObject::IterateDevices(
+            m_buffer->GetDeviceMask(),
+            [this, &result](int deviceIndex)
+            {
+                result[deviceIndex] = GetDeviceBufferView(deviceIndex)->GetBindlessReadIndex();
+                return true;
+            });
+
+        return result;
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawItem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawItem.cpp
@@ -15,15 +15,13 @@ namespace AZ::RHI
     DrawItem::DrawItem(MultiDevice::DeviceMask deviceMask)
         : m_deviceMask{ deviceMask }
     {
-        auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
-
-        for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
-        {
-            if ((AZStd::to_underlying(m_deviceMask) >> deviceIndex) & 1)
+        MultiDeviceObject::IterateDevices(
+            m_deviceMask,
+            [this](int deviceIndex)
             {
                 m_deviceDrawItems.emplace(deviceIndex, DeviceDrawItem{});
-            }
-        }
+                return true;
+            });
 
         for(auto& [deviceIndex, drawItem] : m_deviceDrawItems)
         {

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
@@ -41,7 +41,7 @@ namespace AZ::RHI
         m_deviceMask = static_cast<MultiDevice::DeviceMask>(0u);
     }
 
-    int MultiDeviceObject::GetDeviceCount() const
+    int MultiDeviceObject::GetDeviceCount()
     {
         return RHI::RHISystemInterface::Get()->GetDeviceCount();
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineState.cpp
@@ -31,15 +31,13 @@ namespace AZ::RHI
 
     void PipelineState::PreInitialize(MultiDevice::DeviceMask deviceMask)
     {
-        const int deviceCount = RHI::RHISystemInterface::Get()->GetDeviceCount();
-
-        for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
-        {
-            if ((AZStd::to_underlying(deviceMask) >> deviceIndex) & 1)
+        MultiDeviceObject::IterateDevices(
+            deviceMask,
+            [this](int deviceIndex)
             {
                 m_deviceObjects[deviceIndex] = Factory::Get().CreatePipelineState();
-            }
-        }
+                return true;
+            });
     }
 
     ResultCode PipelineState::Init(

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
@@ -38,15 +38,13 @@ namespace AZ::RHI
         m_bufferViews.resize(layout->GetGroupSizeForBuffers());
         m_samplers.resize(layout->GetGroupSizeForSamplers());
 
-        auto deviceCount{ RHI::RHISystemInterface::Get()->GetDeviceCount() };
-
-        for (int deviceIndex = 0; deviceIndex < deviceCount; ++deviceIndex)
-        {
-            if (CheckBitsAll((AZStd::to_underlying(m_deviceMask) >> deviceIndex), 1u))
+        MultiDeviceObject::IterateDevices(
+            m_deviceMask,
+            [this, layout](int deviceIndex)
             {
                 m_deviceShaderResourceGroupDatas[deviceIndex] = DeviceShaderResourceGroupData(layout);
-            }
-        }
+                return true;
+            });
     }
 
     void ShaderResourceGroupData::ResetViews()

--- a/Gems/Atom/RHI/Code/Tests/MultiDevicePipelineStateTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDevicePipelineStateTests.cpp
@@ -179,8 +179,8 @@ namespace UnitTest
 
         AZ_TEST_START_ASSERTTEST;
         EXPECT_EQ(empty->MergeInto({}), RHI::ResultCode::InvalidOperation);
-        EXPECT_EQ(empty->GetSerializedData(), nullptr);
-        AZ_TEST_STOP_ASSERTTEST(2);
+        EXPECT_TRUE(empty->GetSerializedDataMap().empty());
+        AZ_TEST_STOP_ASSERTTEST(1);
     }
 
     TEST_F(MultiDevicePipelineStateTests, PipelineLibrary_Init_Test)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -586,7 +586,9 @@ namespace AZ
             if (!m_asyncUploadQueue)
             {
                 m_asyncUploadQueue = aznew AsyncUploadQueue();
-                AsyncUploadQueue::Descriptor asyncUploadQueueDescriptor(RHI::RHISystemInterface::Get()->GetPlatformLimitsDescriptor()->m_platformDefaultValues.m_asyncQueueStagingBufferSizeInBytes);
+                AsyncUploadQueue::Descriptor asyncUploadQueueDescriptor(RHI::RHISystemInterface::Get()
+                                                                            ->GetPlatformLimitsDescriptor(GetDeviceIndex())
+                                                                            ->m_platformDefaultValues.m_asyncQueueStagingBufferSizeInBytes);
                 asyncUploadQueueDescriptor.m_device = this;
                 m_asyncUploadQueue->Init(asyncUploadQueueDescriptor);
             }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -153,7 +153,7 @@ namespace AZ
             PipelineStatisticsResult m_statisticsResult;
 
             // The device index the pass ran on during the last frame, necessary to read the queries.
-            int m_lastDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
+            int m_lastDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
 
             // For each ScopeProducer an instance of the ScopeQuery is created, which consists
             // of an Timestamp and PipelineStatistic query.

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -1143,7 +1143,7 @@ namespace DebugDraw
                 "DebugDraw::Sphere",
                 rayTracingShader,
                 "SphereIntersection",
-                m_spheresRayTracingIndicesBuffer->GetBufferView()->GetDeviceBufferView(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex());
+                m_spheresRayTracingIndicesBuffer->GetBufferView()->GetBindlessReadIndex());
         }
 
         element.m_localInstanceIndex = m_spheresRayTracingIndices.AddEntry(0);
@@ -1153,7 +1153,7 @@ namespace DebugDraw
         {
             m_spheresRayTracingIndicesBuffer->Resize(requiredSizeInBytes);
             m_rayTracingFeatureProcessor->SetProceduralGeometryTypeBindlessBufferIndex(
-                m_sphereRayTracingTypeHandle.GetWeakHandle(), m_spheresRayTracingIndicesBuffer->GetBufferView()->GetDeviceBufferView(AZ::RHI::MultiDevice::DefaultDeviceIndex)->GetBindlessReadIndex());
+                m_sphereRayTracingTypeHandle.GetWeakHandle(), m_spheresRayTracingIndicesBuffer->GetBufferView()->GetBindlessReadIndex());
 
             // Need to copy all existing data to resized buffer
             AZStd::vector<float> radii(m_spheresRayTracingIndices.GetIndexList().size());

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -1053,7 +1053,6 @@ namespace AZ
                 ->IndexBuffer(m_visualizationIB)
             ;
 
-            RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
             m_visualizationBlas = aznew RHI::RayTracingBlas;
             auto deviceMask = RHI::RHISystemInterface::Get()->GetRayTracingSupport();
             if (deviceMask != RHI::MultiDevice::NoDevices)


### PR DESCRIPTION
## What does this PR do?

Mostly refactoring a bit and some minor bug fixes.

- Bugfix for RayTracingAccelerationStructurePass.
- meshInfos in RayTracingFeatureProcessor should be multi-device.
- Changed BindlessIndices to multi-device for RayTracingFeatureProcessor.
- Introduced a static MultiDeviceObject::IterateDevices method and use it wherever possible.
- Also added a static MultiDeviceObject::IsDeviceSet method.
- MultiDeviceObject::IterateObjects now supports callbacks with boolean return type.
- Removed unused GetSerializedData in the multi-device PipelineLibrary. GetSerializedDataMap fulfills that purpose.
- Added multi-device BufferView::GetBindlessReadIndex().
- RenderPass::m_lastDeviceIndex default initialization changed to InvalidDeviceIndex.
- Minor other changes.

## How was this PR tested?

Ran ASV Samples.
