### PR TITLE
Bugfix: Pass::SetDeviceIndex not working.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -274,7 +274,7 @@ namespace AZ
             m_timestampResult = AZ::RPI::TimestampResult();
 
             // the pass may potentially migrate between devices dynamically at runtime so the deviceIndex is updated every frame.
-            if (GetScopeId().IsEmpty())
+            if (GetScopeId().IsEmpty() || (ScopeProducer::GetDeviceIndex() != Pass::GetDeviceIndex()))
             {
                 InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, Pass::GetDeviceIndex());
             }


### PR DESCRIPTION
## What does this PR do?

`Pass::SetDeviceIndex()` does not have any effect without this since the ScopeProducer needs to be updated after the pass's device index changed.

## How was this PR tested?

With a minor modification testing this in the ASV RPI MultiGPU sample.
