### PR TITLE
Allow to disable mouse capture in Editor

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
@@ -231,7 +231,7 @@ namespace AzFramework
             AZ::ApplicationTypeQuery appType;
             AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
 
-            m_captureMouseCursor = (captureMouseCursor && (!appType.IsHeadless() && !appType.IsConsoleMode()) || appType.IsEditor());
+            m_captureMouseCursor = captureMouseCursor && (!appType.IsHeadless() && !appType.IsConsoleMode());
         }
 
         // Create all enabled input devices


### PR DESCRIPTION
## What does this PR do?

It is bugfix to #18208 
## How was this PR tested?
I used following setreg file:
```
{
    "O3DE":
    {
        "InputSystem":
        {
            "Mouse":
            {
                "CaptureMouseCursor": false
            }
        }
    }
}
```
I've run following configurations:
- Editor with CaptureMouseCursor set to false - OK 
- Editor with CaptureMouseCursor set to false - OK
- GameLauncher (ap before) with CaptureMouseCursor set to false OK
- GameLauncher (ap before) with CaptureMouseCursor set to true OK
- GameLauncher(ap before), headless with CaptureMouseCursor set to true OK
- GameLauncher(ap before), headless with CaptureMouseCursor set to false OK


  
