### PR TITLE
feat: remove CreateQMimeData from IEditor

### DIFF
--- a/Code/Editor/IEditor.h
+++ b/Code/Editor/IEditor.h
@@ -456,15 +456,6 @@ struct IEditor
     virtual void SetActiveView(CViewport* viewport) = 0;
     virtual struct IEditorFileMonitor* GetFileMonitor() = 0;
 
-    //! QMimeData is used by the Qt clipboard.
-    //! IMPORTANT: Any QMimeData allocated for the clipboard will be deleted
-    //! when the editor exists. If a QMimeData is allocated by a different
-    //! memory allocator (for example, in a different DLL) than the one used
-    //! by the main editor, a crash will occur on exit, if data is left in
-    //! the clipboard. The solution is to enfore all allocations of QMimeData
-    //! using CreateQMimeData().
-    virtual QMimeData* CreateQMimeData() const = 0;
-    virtual void DestroyQMimeData(QMimeData* data) const = 0;
 
     //////////////////////////////////////////////////////////////////////////
     // Access for CLevelIndependentFileMan

--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -1237,12 +1237,3 @@ SEditorSettings* CEditorImpl::GetEditorSettings()
     return &gSettings;
 }
 
-QMimeData* CEditorImpl::CreateQMimeData() const
-{
-    return new QMimeData();
-}
-
-void CEditorImpl::DestroyQMimeData(QMimeData* data) const
-{
-    delete data;
-}

--- a/Code/Editor/IEditorImpl.h
+++ b/Code/Editor/IEditorImpl.h
@@ -248,9 +248,6 @@ public:
     void UnloadPlugins() override;
     void LoadPlugins() override;
 
-    QMimeData* CreateQMimeData() const override;
-    void DestroyQMimeData(QMimeData* data) const override;
-
 protected:
 
     AZStd::string LoadProjectIdFromProjectData();

--- a/Code/Editor/Lib/Tests/IEditorMock.h
+++ b/Code/Editor/Lib/Tests/IEditorMock.h
@@ -81,8 +81,6 @@ public:
     MOCK_METHOD0(GetActiveView, class CViewport* ());
     MOCK_METHOD1(SetActiveView, void(CViewport*));
     MOCK_METHOD0(GetFileMonitor, struct IEditorFileMonitor* ());
-    MOCK_CONST_METHOD0(CreateQMimeData, QMimeData* ());
-    MOCK_CONST_METHOD1(DestroyQMimeData, void(QMimeData*));
     MOCK_METHOD0(GetLevelIndependentFileMan, class CLevelIndependentFileMan* ());
     MOCK_METHOD2(UpdateViews, void(int , const AABB* ));
     MOCK_METHOD0(ResetViews, void());

--- a/Gems/LyShine/Code/Editor/HierarchyClipboard.cpp
+++ b/Gems/LyShine/Code/Editor/HierarchyClipboard.cpp
@@ -153,7 +153,7 @@ void HierarchyClipboard::CopySelectedItemsToClipboard(HierarchyWidget* widget,
         IEditor* pEditor = GetIEditor();
         AZ_Assert(pEditor, "Failed to get IEditor");
 
-        QMimeData* mimeData = pEditor->CreateQMimeData();
+        QMimeData* mimeData = new QMimeData();
         {
             // Concatenate all the data we need into a single QByteArray.
             QByteArray data(xml.c_str(), static_cast<int>(xml.size()));

--- a/Gems/LyShine/Code/Editor/HierarchyClipboard.cpp
+++ b/Gems/LyShine/Code/Editor/HierarchyClipboard.cpp
@@ -150,9 +150,6 @@ void HierarchyClipboard::CopySelectedItemsToClipboard(HierarchyWidget* widget,
     // XML -> Clipboard.
     if (!xml.empty())
     {
-        IEditor* pEditor = GetIEditor();
-        AZ_Assert(pEditor, "Failed to get IEditor");
-
         QMimeData* mimeData = new QMimeData();
         {
             // Concatenate all the data we need into a single QByteArray.


### PR DESCRIPTION
## What does this PR do?

This abstraction seems a bit unnecessary. I simply just inlined the implementation.
