### PR TITLE
Bugfix for uninitialized variable.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
@@ -85,7 +85,7 @@ namespace AZ
             int m_currentBufferIndex = 0;
             AZStd::array<Data::Instance<Buffer>, MaxFrames> m_device1HostBuffer;
             AZStd::array<Data::Instance<Buffer>, MaxFrames> m_device2HostBuffer;
-            AZStd::array<AZ::u64, MaxFrames> m_deviceHostBufferByteCount;
+            AZStd::array<AZ::u64, MaxFrames> m_deviceHostBufferByteCount{};
             AZStd::array<Ptr<RHI::Fence>, MaxFrames> m_device1SignalFence;
             AZStd::array<Ptr<RHI::Fence>, MaxFrames> m_device2WaitFence;
             RHI::DeviceImageSubresourceLayout m_inputImageLayout;


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where a variable does not get 0 initialized resulting in other variables not being initialized when by random chance a specific value is already present.

## How was this PR tested?

Create, delete and recreate a copy pass so that the memory is initialized with the old copy pass's values.
