### PR TITLE
Add Pass::ChangeConnection.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -316,6 +316,9 @@ namespace AZ
 
             PassState GetPassState() const { return m_state; }
 
+            //! Alter the connection of an Input or InputOutput attachment
+            void ChangeConnection(const Name& localSlot, Pass* pass, const Name& attachment);
+
             // Update all bindings on this pass that are connected to bindings on other passes
             virtual void UpdateConnectedBindings();
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -19,18 +19,18 @@
 
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
-#include <Atom/RPI.Reflect/Image/Image.h>
+#include <Atom/RPI.Public/Image/AttachmentImagePool.h>
+#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
 #include <Atom/RPI.Public/Pass/AttachmentReadback.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
-#include <Atom/RPI.Public/Pass/PassLibrary.h>
 #include <Atom/RPI.Public/Pass/PassDefines.h>
+#include <Atom/RPI.Public/Pass/PassLibrary.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassUtils.h>
 #include <Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
-#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
-#include <Atom/RPI.Public/Image/AttachmentImagePool.h>
+#include <Atom/RPI.Reflect/Image/Image.h>
 
 #include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
 #include <Atom/RPI.Reflect/Pass/PassRequest.h>
@@ -1788,6 +1788,48 @@ namespace AZ
                     }
                 }
                 AZ_Printf("PassSystem", stringOutput.c_str());
+            }
+        }
+
+        void Pass::ChangeConnection(const Name& localSlot, Pass* pass, const Name& attachment)
+        {
+            bool connectionFound(false);
+
+            for (auto& connection : m_request.m_connections)
+            {
+                if (connection.m_localSlot == localSlot)
+                {
+                    connection.m_attachmentRef.m_pass = pass->GetName();
+                    connection.m_attachmentRef.m_attachment = attachment;
+                    connectionFound = true;
+                    break;
+                }
+            }
+
+            // if the connection is not yet present, we add it to the request so that it will be recreated
+            // when the pass system updates
+            if (!connectionFound)
+            {
+                m_request.m_connections.emplace_back(PassConnection{ localSlot, { pass->GetName(), attachment } });
+            }
+
+            auto attachmentBinding = FindAttachmentBinding(localSlot);
+
+            if (attachmentBinding)
+            {
+                auto otherAttachmentBinding = pass->FindAttachmentBinding(attachment);
+
+                if (otherAttachmentBinding)
+                {
+                    attachmentBinding->m_connectedBinding = otherAttachmentBinding;
+                    attachmentBinding->UpdateConnection(false);
+                }
+                else
+                {
+                    // if the pass we should attach to has been newly created and not yet built,
+                    // we can queue ourself to build as well to establish the connection in the next frame
+                    QueueForBuildAndInitialization();
+                }
             }
         }
 

--- a/Gems/Atom/RPI/Code/Tests/Pass/PassTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Pass/PassTests.cpp
@@ -510,6 +510,27 @@ namespace UnitTest
             EXPECT_TRUE(pass != nullptr);
         }
 
+        void TestChangeConnection()
+        {
+            m_data->AddPassTemplatesToLibrary();
+
+            // create a pass tree
+
+            Ptr<Pass> pass, parent1, parent2, parent3;
+            CreatePassTestTree(pass, parent1, parent2, parent3);
+
+            EXPECT_TRUE(pass->m_request.m_connections.size() == 0);
+
+            pass->ChangeConnection(Name("Input"), parent1.get(), Name("Input1"));
+            EXPECT_TRUE(pass->m_request.m_connections.size() == 1);
+
+            pass->ChangeConnection(Name("Input"), parent1.get(), Name("Input2"));
+            EXPECT_TRUE(pass->m_request.m_connections.size() == 1);
+
+            parent1->ChangeConnection(Name("Output"), pass.get(), Name("Output"));
+            EXPECT_TRUE(pass->m_request.m_connections.size() == 1);
+        }
+
         void TestPassFilter_PassHierarchy()
         {
             m_data->AddPassTemplatesToLibrary();
@@ -697,7 +718,6 @@ namespace UnitTest
             // only the ParentPass in the render pipeline was found
             EXPECT_TRUE(count == 1);
         }
-
     };
 
     TEST_F(PassTests, ConstructionAndValidation)
@@ -743,6 +763,11 @@ namespace UnitTest
     TEST_F(PassTests, CreationMethodsSuccess)
     {
         TestCreationMethodsSuccess();
+    }
+
+    TEST_F(PassTests, ChangeConnection)
+    {
+        TestChangeConnection();
     }
 
     TEST_F(PassTests, PassFilter_PassHierarchy)


### PR DESCRIPTION
## What does this PR do?

Adds a new method: `Pass::ChangeConnection`. Used to change how an Input or InputOutput slot is connected to a slot from a different pass.

## How was this PR tested?

ASV: https://github.com/o3de/o3de-atom-sampleviewer/pull/688
