### PR TITLE
Add option to set a default buffer/image view for transient buffer/image attachments

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedAttachmentDescriptor.h
@@ -9,7 +9,9 @@
 
 #include <Atom/RHI.Reflect/AttachmentEnums.h>
 #include <Atom/RHI.Reflect/BufferDescriptor.h>
+#include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
+#include <Atom/RHI.Reflect/ImageViewDescriptor.h>
 
 namespace AZ::RHI
 {
@@ -20,16 +22,25 @@ namespace AZ::RHI
         UnifiedAttachmentDescriptor();
         UnifiedAttachmentDescriptor(const BufferDescriptor& bufferDescriptor);
         UnifiedAttachmentDescriptor(const ImageDescriptor& imageDescriptor);
+        UnifiedAttachmentDescriptor(const BufferDescriptor& bufferDescriptor, const BufferViewDescriptor& bufferViewDescriptor);
+        UnifiedAttachmentDescriptor(const ImageDescriptor& imageDescriptor, const ImageViewDescriptor& imageViewDescriptor);
 
         HashValue64 GetHash(HashValue64 seed = HashValue64{ 0 }) const;
 
         /// Differentiates between an image, buffer and resolve attachment
         AttachmentType m_type = AttachmentType::Uninitialized;
 
-        union
-        {
-            BufferDescriptor m_buffer;
-            ImageDescriptor m_image;
+        union {
+            struct
+            {
+                BufferDescriptor m_buffer;
+                BufferViewDescriptor m_bufferView;
+            };
+            struct
+            {
+                ImageDescriptor m_image;
+                ImageViewDescriptor m_imageView;
+            };
         };
     };
-}
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/UnifiedAttachmentDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/UnifiedAttachmentDescriptor.cpp
@@ -13,20 +13,41 @@
 namespace AZ::RHI
 {
     UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor()
-    { }
+    {
+    }
 
     UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(const BufferDescriptor& bufferDescriptor)
         : m_buffer(bufferDescriptor)
+        , m_bufferView(BufferViewDescriptor{})
         , m_type(AttachmentType::Buffer)
-    { }
+    {
+    }
 
     UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(const ImageDescriptor& imageDescriptor)
         : m_image(imageDescriptor)
+        , m_imageView(ImageViewDescriptor{})
         , m_type(AttachmentType::Image)
-    { }
+    {
+    }
+
+    UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(
+        const BufferDescriptor& bufferDescriptor, const BufferViewDescriptor& bufferViewDescriptor)
+        : m_buffer(bufferDescriptor)
+        , m_bufferView(bufferViewDescriptor)
+        , m_type(AttachmentType::Buffer)
+    {
+    }
+
+    UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(
+        const ImageDescriptor& imageDescriptor, const ImageViewDescriptor& imageViewDescriptor)
+        : m_image(imageDescriptor)
+        , m_imageView(imageViewDescriptor)
+        , m_type(AttachmentType::Image)
+    {
+    }
 
     HashValue64 UnifiedAttachmentDescriptor::GetHash(HashValue64 seed /* = 0 */) const
     {
         return TypeHash64(*this, seed);
     }
-}
+} // namespace AZ::RHI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -66,7 +66,7 @@ namespace AZ
             //! This is the Id used to bind the attachment with the RHI
             RHI::AttachmentId m_path;
 
-            //! A descriptor of the attachment image
+            //! A descriptor of the attachment buffer or image
             RHI::UnifiedAttachmentDescriptor m_descriptor;
 
             //! Whether the attachment is transient or not

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAttachmentReflect.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAttachmentReflect.h
@@ -251,6 +251,9 @@ namespace AZ
             //! The image descriptor for the attachment
             RHI::ImageDescriptor m_imageDescriptor;
 
+            //! A image view descriptor which is used when no explicit descriptor is specified when using this image in a slot
+            RHI::ImageViewDescriptor m_imageViewDescriptor;
+
             //! Whether to auto generate the number of mips based on the attachment
             //! so that we get a full mip chain with the smallest mip being 1x1 in size
             bool m_generateFullMipChain = false;
@@ -271,6 +274,9 @@ namespace AZ
 
             //! The buffer descriptor for the transient buffer attachment
             RHI::BufferDescriptor m_bufferDescriptor;
+
+            //! A buffer view descriptor which is used when no explicit descriptor is specified when using this buffer in a slot
+            RHI::BufferViewDescriptor m_bufferViewDescriptor;
         };
 
         using PassBufferAttachmentDescList = AZStd::vector<PassBufferAttachmentDesc>;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -30,13 +30,13 @@ namespace AZ
             m_lifetime = attachmentDesc.m_lifetime;
             m_generateFullMipChain = attachmentDesc.m_generateFullMipChain;
 
-            m_descriptor = RHI::UnifiedAttachmentDescriptor(attachmentDesc.m_imageDescriptor);
+            m_descriptor = RHI::UnifiedAttachmentDescriptor(attachmentDesc.m_imageDescriptor, attachmentDesc.m_imageViewDescriptor);
             ValidateDeviceFormats(attachmentDesc.m_formatFallbacks);
         }
 
         PassAttachment::PassAttachment(const PassBufferAttachmentDesc& attachmentDesc)
         {
-            m_descriptor = RHI::UnifiedAttachmentDescriptor(attachmentDesc.m_bufferDescriptor);
+            m_descriptor = RHI::UnifiedAttachmentDescriptor(attachmentDesc.m_bufferDescriptor, attachmentDesc.m_bufferViewDescriptor);
             m_name = attachmentDesc.m_name;
             m_lifetime = attachmentDesc.m_lifetime;
         }
@@ -328,12 +328,11 @@ namespace AZ
                 {
                     if (attachment->GetAttachmentType() == RHI::AttachmentType::Buffer)
                     {
-                        // AZ_Assert(false, "Transient buffer's buffer view need to be set in slot");
-                        m_unifiedScopeDesc.SetAsBuffer(RHI::BufferViewDescriptor());
+                        m_unifiedScopeDesc.SetAsBuffer(attachment->m_descriptor.m_bufferView);
                     }
                     else if (attachment->GetAttachmentType() == RHI::AttachmentType::Image)
                     {
-                        m_unifiedScopeDesc.SetAsImage(RHI::ImageViewDescriptor());
+                        m_unifiedScopeDesc.SetAsImage(attachment->m_descriptor.m_imageView);
                     }
                 }
                 else if (attachment->m_lifetime == RHI::AttachmentLifetimeType::Imported)

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
@@ -180,6 +180,7 @@ namespace AZ
                 serializeContext->Class<PassImageAttachmentDesc, PassAttachmentDesc>()
                     ->Version(0)
                     ->Field("ImageDescriptor", &PassImageAttachmentDesc::m_imageDescriptor)
+                    ->Field("ImageViewDescriptor", &PassImageAttachmentDesc::m_imageViewDescriptor)
                     ->Field("GenerateFullMipChain", &PassImageAttachmentDesc::m_generateFullMipChain)
                     ->Field("FormatFallbacks", &PassImageAttachmentDesc::m_formatFallbacks)
                     ;
@@ -195,6 +196,7 @@ namespace AZ
                 serializeContext->Class<PassBufferAttachmentDesc, PassAttachmentDesc>()
                     ->Version(0)
                     ->Field("BufferDescriptor", &PassBufferAttachmentDesc::m_bufferDescriptor)
+                    ->Field("BufferViewDescriptor", &PassBufferAttachmentDesc::m_bufferViewDescriptor)
                     ;
             }
         }


### PR DESCRIPTION
## What does this PR do?

This PR adds the option to define a default buffer view for transient image and buffer attachments, such that a buffer/image view does not need to be defined when the attachment is used in a slot in a different pass and the default view is sufficient. This is especially useful when defining the size of a transient buffer in c++ in `BuildInternal()` (eg. when using a constant from c++ as the buffer size) of a pass class, and then using the same attachment in multiple different passes. Without this change, each pass who uses the attachment would need to update its buffer view separately. With this change, only the buffer declaration needs to be updated.
An alternative would of course be to use an imported buffer/image, but this would also require additional code to manage the resource and its lifetime.

For example, if I wanted to make a buffer of some structs of size 16 bytes I would use this code:
```
"PassRequests": [
	...
	"BufferAttachments": [
		{
			"Name": "Buffer1",
			"BufferDescriptor": {
				"m_bindFlags": "ShaderReadWrite",
				"m_byteCount": 1024,
				"m_alignment": 16
			},
			"BufferViewDescriptor": {
				"m_elementSize": 16,
				"m_elementCount": 64
			}
		}
	]

-- Somewhere else --

"PassTemplate": {
	...
	"Slots": [
		{
			"Name": "Buffer1",
			"ShaderInputName": "m_buffer1",
			"SlotType": "InputOutput",
			"ScopeAttachmentUsage": "Shader"
			// Dont need to add "BufferViewDesc" here
		}
	]
```

## How was this PR tested?

As far as I can tell there is no active code in a engine build with a default project template which uses the `"BufferViewDesc"` option when defining a slot, so I cannot submit any .pass-file changes together with this PR. I tested these changes with an internal gem which makes heavy use of compute shaders, and there I was able to remove various instances of defining the same `"BufferViewDesc"` for slots over and over again.
