### PR TITLE
Fix for missing gem.json in packaged Gems from the installer

### DIFF
--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -935,6 +935,8 @@ function(ly_setup_assets)
                     # it is not already in the list, so it is unique to this gem folder.
                     list(APPEND external_subdir_files ${check_file})
                 endif()
+            else()
+                list(APPEND external_subdir_files ${check_file})                
             endif()
         endforeach()
 


### PR DESCRIPTION
## What does this PR do?
This change fixes an issue with the SDK Installer where there are a lot of missing `gem.json` files for gems, making the code that uses it as a gem marker skip over the gem in various cases. 

fixes https://github.com/o3de/o3de/issues/18222 

## Root Cause
There was an [issue](https://github.com/o3de/o3de/issues/11207) related to not processing asset only gem files that was fixed with [PR-11213](https://github.com/o3de/o3de/pull/11213). However, another [PR](https://github.com/o3de/o3de/pull/18189) somewhat regressed this fix while attempting to fix a different [issue](https://github.com/o3de/o3de/issues/18054) related to no-script projects.

(from the ghi) the following error that occurs on new projects:
```
CMake Error at C:/O3DE/2.3.0/cmake/3rdParty.cmake:182 (message):
  Cannot find include path /External/glad/2.0.0-beta/include for
  3rdParty::glad_vulkan
Call Stack (most recent call first):
  C:/O3DE/2.3.0/cmake/3rdParty/Findglad_vulkan.cmake:10 (ly_add_external_target)
  C:/O3DE/2.3.0/cmake/LYWrappers.cmake:603 (find_package)
  C:/O3DE/2.3.0/cmake/LYWrappers.cmake:266 (ly_parse_third_party_dependencies)
  C:/O3DE/2.3.0/Gems/Atom/RHI/Vulkan/Code/Platform/Windows/Default/permutation.cmake:11 (ly_add_target)
  C:/O3DE/2.3.0/Gems/Atom/RHI/Vulkan/Code/Platform/Windows/platform_windows.cmake:12 (include)
  C:/O3DE/2.3.0/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt:9 (include)
```
Is caused by not being able to resolve `@GEMROOT:Atom_RHI_Vulkan@` in
```
get_property(atom_rhi_vulkan_gem_root GLOBAL PROPERTY "@GEMROOT:Atom_RHI_Vulkan@")
ly_add_external_target(
    NAME glad_vulkan
    VERSION 2.0.0-beta
    3RDPARTY_ROOT_DIRECTORY ${atom_rhi_vulkan_gem_root}/External/glad
    INCLUDE_DIRECTORIES include
)
```

`@GEMROOT:Atom_RHI_Vulkan` is never computed because its `gem.json` was not copied over to the installer layout, and this is was caused by the additional [f]ilter](https://github.com/o3de/o3de/blob/6c54f971bf354bbe2c46c4ea83bda889c03b6906/cmake/Platform/Common/Install_common.cmake#L931-L939)  that excludes folders that are themselves gem_candidate_dirs (for gems within gems).
The logic checks if the directory item is a folder before applying the filter, but does not account for the fact that the item could be a file, in which case, `gem.json` was being skipped completely, and it was needed further down the [code](https://github.com/o3de/o3de/blob/6c54f971bf354bbe2c46c4ea83bda889c03b6906/cmake/Platform/Common/Install_common.cmake#L979-L981).

## Fix
The fix is to add the missing file(s) to the `external_subdir_files`

## How was this PR tested?
Built the installer and installed the SDK, and followed the repro steps in the [GHI](https://github.com/o3de/o3de/issues/18222)
