### PR TITLE
fixing export button to not affect build indicator, and to show exported files in the end

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
@@ -158,6 +158,10 @@ namespace O3DE::ProjectManager
                     }
                 }
             }
+            else
+            {
+                qDebug() << "Failed to retrieve output path from recent export task:\n" << expectedOutputPathQuery.GetError() << "\n";
+            }
         }
         emit Done(success);
     }

--- a/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
@@ -138,7 +138,7 @@ namespace O3DE::ProjectManager
         }
         else
         {
-            AZ::Outcome<QString> expectedOutputPathQuery = m_worker->GetExpectedOutputPath();
+            AZ::Outcome<QString, QString> expectedOutputPathQuery = m_worker->GetExpectedOutputPath();
 
             if (expectedOutputPathQuery.IsSuccess())
             {

--- a/Code/Tools/ProjectManager/Source/ProjectExportWorker.h
+++ b/Code/Tools/ProjectManager/Source/ProjectExportWorker.h
@@ -30,6 +30,8 @@ namespace O3DE::ProjectManager
         ~ProjectExportWorker() = default;
 
         AZ::Outcome<QString, QString> GetLogFilePath() const;
+        AZ::Outcome<QString> GetExpectedOutputPath() const;
+
 
     public slots:
         void ExportProject();
@@ -46,5 +48,6 @@ namespace O3DE::ProjectManager
         QProcess* m_exportProjectProcess = nullptr;
         const ProjectInfo& m_projectInfo;
         QString exportScript;
+        QString m_expectedOutputDir;
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectExportWorker.h
+++ b/Code/Tools/ProjectManager/Source/ProjectExportWorker.h
@@ -30,7 +30,7 @@ namespace O3DE::ProjectManager
         ~ProjectExportWorker() = default;
 
         AZ::Outcome<QString, QString> GetLogFilePath() const;
-        AZ::Outcome<QString> GetExpectedOutputPath() const;
+        AZ::Outcome<QString, QString> GetExpectedOutputPath() const;
 
 
     public slots:

--- a/Code/Tools/ProjectManager/Source/ProjectInfo.h
+++ b/Code/Tools/ProjectManager/Source/ProjectInfo.h
@@ -65,6 +65,7 @@ namespace O3DE::ProjectManager
         QString m_newPreviewImagePath;
         QString m_newBackgroundImagePath;
         QString m_currentExportScript;
+        QString m_expectedOutputDir;
         bool m_remote = false;
 
         //! Used in project creation

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -813,12 +813,6 @@ namespace O3DE::ProjectManager
 
     void ProjectsScreen::QueueExportProject(const ProjectInfo& projectInfo, const QString& exportScript, bool skipDialogBox)
     {
-        auto requiredIter = RequiresBuildProjectIterator(projectInfo.m_path);
-        if (requiredIter != m_requiresBuild.end())
-        {
-            m_requiresBuild.erase(requiredIter);
-        }
-
         if (!ExportQueueContainsProject(projectInfo.m_path))
         {
             if (m_exportQueue.empty() && !m_currentExporter)

--- a/scripts/o3de/ExportScripts/export_source_android.py
+++ b/scripts/o3de/ExportScripts/export_source_android.py
@@ -124,7 +124,7 @@ def export_source_android_project(ctx: exp.O3DEScriptExportContext,
         except FileNotFoundError:
             logger.error("Unable to open build.gradle file. Aborting deployment...")
     
-    logger.info(f"Exporting finished. Output Android Project generated at {target_android_project_path}")
+    logger.info(f"Exporting finished. Output Android Project generated at '{target_android_project_path}'")
         
 
 def export_source_android_parse_args(o3de_context: exp.O3DEScriptExportContext,
@@ -252,5 +252,5 @@ if "o3de_context" in globals():
     args = export_source_android_parse_args(o3de_context, export_config)
 
     export_source_android_run_command(o3de_context, args, export_config, o3de_logger)
-    o3de_logger.info(f"Finished exporting android project to {args.android_build_path}")
+    o3de_logger.info(f"Finished exporting android project to '{args.android_build_path}'")
     sys.exit(0)

--- a/scripts/o3de/ExportScripts/export_source_android.py
+++ b/scripts/o3de/ExportScripts/export_source_android.py
@@ -124,7 +124,8 @@ def export_source_android_project(ctx: exp.O3DEScriptExportContext,
         except FileNotFoundError:
             logger.error("Unable to open build.gradle file. Aborting deployment...")
     
-    logger.info(f"Exporting finished. Output Android Project generated at '{target_android_project_path}'")
+    logger.info(f"Project exported to '{target_android_project_path}'.")
+    
         
 
 def export_source_android_parse_args(o3de_context: exp.O3DEScriptExportContext,
@@ -252,5 +253,5 @@ if "o3de_context" in globals():
     args = export_source_android_parse_args(o3de_context, export_config)
 
     export_source_android_run_command(o3de_context, args, export_config, o3de_logger)
-    o3de_logger.info(f"Finished exporting android project to '{args.android_build_path}'")
+    o3de_logger.info(f"Finished exporting.")
     sys.exit(0)

--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -222,7 +222,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                                             archive_output_format=archive_output_format,
                                             logger=logger)
     
-    logger.info(f"Exporting finished. Output Launchers were generated at '{output_path}'")
+    logger.info(f"Project exported to '{output_path}'.")
 
 def export_standalone_parse_args(o3de_context: exp.O3DEScriptExportContext, export_config: command_utils.O3DEConfig):
 
@@ -461,5 +461,5 @@ if "o3de_context" in globals():
     args = export_standalone_parse_args(o3de_context, export_config)
 
     export_standalone_run_command(o3de_context, args, export_config, o3de_logger)
-    o3de_logger.info(f"Finished exporting project to '{args.output_path}'")
+    o3de_logger.info(f"Finished exporting.")
     sys.exit(0)

--- a/scripts/o3de/ExportScripts/export_source_built_project.py
+++ b/scripts/o3de/ExportScripts/export_source_built_project.py
@@ -222,7 +222,7 @@ def export_standalone_project(ctx: exp.O3DEScriptExportContext,
                                             archive_output_format=archive_output_format,
                                             logger=logger)
     
-    logger.info(f"Exporting finished. Output Launchers were generated at {output_path}")
+    logger.info(f"Exporting finished. Output Launchers were generated at '{output_path}'")
 
 def export_standalone_parse_args(o3de_context: exp.O3DEScriptExportContext, export_config: command_utils.O3DEConfig):
 
@@ -461,5 +461,5 @@ if "o3de_context" in globals():
     args = export_standalone_parse_args(o3de_context, export_config)
 
     export_standalone_run_command(o3de_context, args, export_config, o3de_logger)
-    o3de_logger.info(f"Finished exporting project to {args.output_path}")
+    o3de_logger.info(f"Finished exporting project to '{args.output_path}'")
     sys.exit(0)


### PR DESCRIPTION
## What does this PR do?

This PR fixes https://github.com/o3de/o3de/issues/18226.

At the end of export, a new dialog window appears for all standardized export platforms, where clicking "Yes" opens the folder containing the exported contents of the project.

## How was this PR tested?

Testing was performed manually on a Windows machine. The export processes for PC and Android was tested and verified to correctly show the exported files in the OS file explorer, and also to not affect the Project Card's build indicator. Error cases in exporting also confirmed that the build indicator was not affected.
