### PR TITLE
Fix for missing gem.json in packaged Gems from the installer (#18231)

### DIFF
--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -935,6 +935,8 @@ function(ly_setup_assets)
                     # it is not already in the list, so it is unique to this gem folder.
                     list(APPEND external_subdir_files ${check_file})
                 endif()
+            else()
+                list(APPEND external_subdir_files ${check_file})                
             endif()
         endforeach()
 


### PR DESCRIPTION
## What does this PR do?
Cherry picks https://github.com/o3de/o3de/pull/18231 which fixes an installer issues where gems cannot be resolved

## How was this PR tested?
Tested with locally built installer
