### PR TITLE
BUGFIX Cherrypick from stabilization to dev - Fixes an intermittent crash when working with actors.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1663,11 +1663,11 @@ namespace AZ
                 m_parent->QueueInit(model);
                 m_parent->m_modelChangedEvent.Signal(AZStd::move(model));
 
-                if (m_parent->m_flags.m_keepBufferAssetsInMemory)
-                {
-                    model->GetModelAsset()->AddRefBufferAssets();
-                }
-                else
+                // we always start out with a refcount of 1
+                model->GetModelAsset()->AddRefBufferAssets();
+
+                // if we don't want to keep them, this will drop the refcount to 0.
+                if (!m_parent->m_flags.m_keepBufferAssetsInMemory)
                 {
                     model->GetModelAsset()->ReleaseRefBufferAssets();
                 }


### PR DESCRIPTION
This is a cherry-pick of the already merged https://github.com/o3de/o3de/pull/18238 from stabilization to dev.

## What does this PR do?

Actors in the scene would cause a crash "randomly" when
* duplicated
* spawned new instances
* ctrl-g
* FBX Settings panel accesed and changed

see
https://github.com/o3de/o3de/issues/18027

The crash was caused by the mesh feature processor releasing the last reference to the actors stream buffers when the thumbnail previewer was asked to make a preview of it (which happens when you save the FBX settings, or view a thumbnail, or when the mesh changes on disk, browse to it in the asset browser for the first time this session, etc). 

Note that the crash would occur later (so not when you viewed a thumbnail or browsed or saved the settings) but was primed to occur later by viewing a thumbnail, hence it seeming like a random crash.

The main sequence of events leading to the crash is that the main actors in the scene using the asset were all pointed at the same atom model instance, which had an internal refcount for whether or not it should keep their stream buffers around.  Actors need those buffers to hang out, so they initialize and request it, which increments the refcount.

However, the mesh feature processor would either increase the refcount or decrease it whenever a model was registered to it.

This means it was possible for the actor to register a reference, (refcount to 1) but then the thumbnail previewer get the same model, and registers it without asking to keep the buffers, which causes the mesh feature processor to decrement the refcount.   This would cause the refcount to go to 0, unloading all the buffers the actor needed.

Instead, I change the code to always first capture a refcount, then release it if its not needed.

This causes it to go 0 ---> 1 ---> 0 in the case when the buffers are really not needed by anyone,

0 ---> 1 ---> 2 ---> 1 in the case where an actor asks for them to be kept, then the previewer gets and drops it.

this also means buffers that were not needed were not actually being dropped, so may save memory.

## How was this PR tested?

Reproing the bug turns out to be super easy
1. Spawn an actor into the scene
2. open the FBX settings panel for its fbx
3. hit "save" <-- this is where the thumbnailer regenerates the thumbnail and destroys the buffers
4. duplicate the actor.  (crash)

After this change, the crash no longer appeared.  I also tested some basic working such as loading a scene full of a mixture of actors, models, etc, and reprocessing FBXes and so on.

