### PR TITLE
Multiple Bugfixes mostly based on validation layer errors

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
@@ -85,7 +85,6 @@ namespace AZ
                         for (const auto& attachmentName : attachmentNames)
                         {
                             RPI::PassAttachmentBinding* attachmentBinding = pass->FindAttachmentBinding(attachmentName);
-                            AZ_Assert(attachmentBinding, "Failed to retrieve attachment binding [%s] on ReflectionScreenSpacePass", attachmentName.GetCStr());
 
                             if (attachmentBinding)
                             {
@@ -141,7 +140,6 @@ namespace AZ
                             for (const auto& attachmentName : attachmentNames)
                             {
                                 RPI::PassAttachmentBinding* attachmentBinding = pass->FindAttachmentBinding(attachmentName);
-                                AZ_Assert(attachmentBinding, "Failed to retrieve attachment binding [%s] on ReflectionScreenSpaceRayTracingPass", attachmentName.GetCStr());
 
                                 if (attachmentBinding)
                                 {
@@ -171,7 +169,6 @@ namespace AZ
                         for (const auto& attachmentName : attachmentNames)
                         {
                             RPI::PassAttachmentBinding* attachmentBinding = pass->FindAttachmentBinding(attachmentName);
-                            AZ_Assert(attachmentBinding, "Failed to retrieve attachment binding [%s] on ReflectionScreenSpaceTracePass", attachmentName.GetCStr());
 
                             if (attachmentBinding)
                             {
@@ -197,8 +194,7 @@ namespace AZ
                     {
                         // size multiplier
                         RPI::PassAttachmentBinding* attachmentBinding = pass->FindAttachmentBinding(AZ::Name("DownsampledDepthLinearInputOutput"));
-                        AZ_Assert(attachmentBinding, "Failed to retrieve attachment binding [DownsampledDepthLinearInputOutput] on ReflectionScreenSpaceDownsampleDepthLinearPass");
-            
+
                         if (attachmentBinding)
                         {
                             RPI::Ptr<RPI::PassAttachment> attachment = attachmentBinding->GetAttachment();
@@ -225,7 +221,6 @@ namespace AZ
                         for (const auto& attachmentName : attachmentNames)
                         {
                             RPI::PassAttachmentBinding* attachmentBinding = pass->FindAttachmentBinding(attachmentName);
-                            AZ_Assert(attachmentBinding, "Failed to retrieve attachment binding [%s] on ReflectionScreenSpaceFilterPass", attachmentName.GetCStr());
 
                             if (attachmentBinding)
                             {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
@@ -25,7 +25,8 @@ namespace AZ::RHI
         virtual ~DeviceFence() = 0;
 
         /// Initializes the fence using the provided device and initial state.
-        ResultCode Init(Device& device, FenceState initialState);
+        /// Set usedForWaitingOnDevice to true if the Fence shoud be signaled on the CPU and waited for on the device.
+        ResultCode Init(Device& device, FenceState initialState, bool usedForWaitingOnDevice = false);
 
         /// Shuts down the fence.
         void Shutdown() override final;
@@ -55,7 +56,7 @@ namespace AZ::RHI
         // Platform API
 
         /// Called when the fence is being initialized.
-        virtual ResultCode InitInternal(Device& device, FenceState initialState) = 0;
+        virtual ResultCode InitInternal(Device& device, FenceState initialState, bool usedForWaitingOnDevice) = 0;
 
         /// Called when the PSO is being shutdown.
         virtual void ShutdownInternal() = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Fence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Fence.h
@@ -26,8 +26,9 @@ namespace AZ::RHI
 
         //! Initializes the multi-device fence using the provided deviceMask.
         //! It creates on device-specific fence for each bit set in the deviceMask and
-        //! passes on the initial FenceState to each DeviceFence
-        ResultCode Init(MultiDevice::DeviceMask deviceMask, FenceState initialState);
+        //! passes on the initial FenceState to each DeviceFence.
+        //! Set usedForWaitingOnDevice to true if the Fence shoud be signaled on the CPU and waited for on the device.
+        ResultCode Init(MultiDevice::DeviceMask deviceMask, FenceState initialState, bool usedForWaitingOnDevice = false);
 
         //! Shuts down all device-specific fences.
         void Shutdown() override final;

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -45,11 +45,6 @@ namespace AZ::RHI
 
     void Buffer::Shutdown()
     {
-        IterateObjects<DeviceBuffer>([]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
-        {
-            deviceBuffer->Shutdown();
-        });
-
         Resource::Shutdown();
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -345,10 +345,6 @@ namespace AZ::RHI
 
     void BufferPool::Shutdown()
     {
-        IterateObjects<DeviceBufferPool>([]([[maybe_unused]] auto deviceIndex, auto deviceBufferPool)
-        {
-            deviceBufferPool->Shutdown();
-        });
         ResourcePool::Shutdown();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceFence.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceFence.cpp
@@ -28,7 +28,7 @@ namespace AZ::RHI
         return true;
     }
 
-    ResultCode DeviceFence::Init(Device& device, FenceState initialState)
+    ResultCode DeviceFence::Init(Device& device, FenceState initialState, bool usedForWaitingOnDevice)
     {
         if (Validation::IsEnabled())
         {
@@ -39,7 +39,7 @@ namespace AZ::RHI
             }
         }
 
-        const ResultCode resultCode = InitInternal(device, initialState);
+        const ResultCode resultCode = InitInternal(device, initialState, usedForWaitingOnDevice);
 
         if (resultCode == ResultCode::Success)
         {

--- a/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
@@ -84,11 +84,6 @@ namespace AZ::RHI
 
     void Image::Shutdown()
     {
-        IterateObjects<DeviceImage>([]([[maybe_unused]] auto deviceIndex, auto deviceImage)
-        {
-            deviceImage->Shutdown();
-        });
-
         Resource::Shutdown();
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImagePool.cpp
@@ -178,11 +178,6 @@ namespace AZ::RHI
 
     void ImagePool::Shutdown()
     {
-        IterateObjects<DeviceImagePool>([]([[maybe_unused]] auto deviceIndex, auto deviceImagePool)
-        {
-            deviceImagePool->Shutdown();
-        });
-
         ResourcePool::Shutdown();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/MultiDeviceObject.cpp
@@ -39,6 +39,7 @@ namespace AZ::RHI
     void MultiDeviceObject::Shutdown()
     {
         m_deviceMask = static_cast<MultiDevice::DeviceMask>(0u);
+        m_deviceObjects.clear();
     }
 
     int MultiDeviceObject::GetDeviceCount()

--- a/Gems/Atom/RHI/Code/Source/RHI/Query.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Query.cpp
@@ -22,11 +22,6 @@ namespace AZ::RHI
 
     void Query::Shutdown()
     {
-        IterateObjects<DeviceQuery>([]([[maybe_unused]] auto deviceIndex, auto deviceQuery)
-        {
-            deviceQuery->Shutdown();
-        });
-
         Resource::Shutdown();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/QueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/QueryPool.cpp
@@ -258,11 +258,6 @@ namespace AZ::RHI
 
     void QueryPool::Shutdown()
     {
-        IterateObjects<DeviceQueryPool>([]([[maybe_unused]] auto deviceIndex, auto deviceQueryPool)
-        {
-            deviceQueryPool->Shutdown();
-        });
-
         ResourcePool::Shutdown();
     }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroup.cpp
@@ -58,11 +58,6 @@ namespace AZ::RHI
 
     void ShaderResourceGroup::Shutdown()
     {
-        IterateObjects<DeviceShaderResourceGroup>([]([[maybe_unused]] auto deviceIndex, auto deviceShaderResourceGroup)
-        {
-            deviceShaderResourceGroup->Shutdown();
-        });
-
         Resource::Shutdown();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -188,11 +188,6 @@ namespace AZ::RHI
 
     void ShaderResourceGroupPool::Shutdown()
     {
-        IterateObjects<DeviceShaderResourceGroupPool>([]([[maybe_unused]] auto deviceIndex, auto deviceShaderResourceGroupPool)
-        {
-            deviceShaderResourceGroupPool->Shutdown();
-        });
-
         ResourcePool::Shutdown();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -303,11 +303,6 @@ namespace AZ::RHI
 
     void StreamingImagePool::Shutdown()
     {
-        IterateObjects<DeviceStreamingImagePool>([]([[maybe_unused]] auto deviceIndex, auto deviceStreamingImagePool)
-        {
-            deviceStreamingImagePool->Shutdown();
-        });
-
         ResourcePool::Shutdown();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
@@ -300,10 +300,6 @@ namespace AZ::RHI
 
     void SwapChain::Shutdown()
     {
-        IterateObjects<DeviceSwapChain>([]([[maybe_unused]] auto deviceIndex, auto deviceSwapChain)
-        {
-            deviceSwapChain->Shutdown();
-        });
         ResourcePool::Shutdown();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
@@ -66,12 +66,6 @@ namespace AZ::RHI
     {
         if (IsInitialized())
         {
-            IterateObjects<DeviceTransientAttachmentPool>(
-                [](auto /*deviceIndex*/, auto deviceTransientAttachmentPool)
-                {
-                    deviceTransientAttachmentPool->Shutdown();
-                });
-            m_deviceObjects.clear();
             MultiDeviceObject::Shutdown();
             m_cache.Clear();
             m_reverseLookupHash.clear();

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceQueryTests.cpp
@@ -195,6 +195,10 @@ namespace UnitTest
         EXPECT_EQ(result, RHI::ResultCode::Success);
         checkSlotsFunc(queriesToShutdown);
 
+        // Since we are recreating queries it adds a refcount and invalidates the (non-existing) views.
+        // We need to ensure to release the refcount and avoid leaks by running the invalidate bus.
+        RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
+
         queriesIndicesToShutdown = { 2, 5, 9 };
         queriesToShutdown.clear();
         for (auto& index : queriesIndicesToShutdown)
@@ -207,8 +211,8 @@ namespace UnitTest
 
         result = queryPool->InitQuery(queriesToShutdown.data(), static_cast<uint32_t>(queriesToShutdown.size()));
 
-        // Since we are switching queryPools for some queries it adds a refcount and invalidates the views.
-        // We need to ensure the views are fully invalidated in order to release the refcount and avoid leaks.
+        // Since we are recreating queries it adds a refcount and invalidates the (non-existing) views.
+        // We need to ensure to release the refcount and avoid leaks by running the invalidate bus.
         RHI::ResourceInvalidateBus::ExecuteQueuedEvents();
 
         checkSlotsFunc(queriesToInitialize);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
@@ -142,7 +142,7 @@ namespace AZ
             return aznew FenceImpl();
         }
 
-        RHI::ResultCode FenceImpl::InitInternal(RHI::Device& deviceBase, RHI::FenceState initialState)
+        RHI::ResultCode FenceImpl::InitInternal(RHI::Device& deviceBase, RHI::FenceState initialState, [[maybe_unused]] bool usedForWaitingOnDevice)
         {
             return m_fence.Init(static_cast<Device&>(deviceBase).GetDevice(), initialState);
         }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.h
@@ -126,7 +126,7 @@ namespace AZ
 
             //////////////////////////////////////////////////////////////////////////
             // RHI::DeviceFence
-            RHI::ResultCode InitInternal(RHI::Device& device, RHI::FenceState initialState) override;
+            RHI::ResultCode InitInternal(RHI::Device& device, RHI::FenceState initialState, bool usedForWaitingOnDevice) override;
             void ShutdownInternal() override;
             void SignalOnCpuInternal() override;
             void WaitOnCpuInternal() const override;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Fence.cpp
@@ -116,7 +116,7 @@ namespace AZ
             return aznew FenceImpl();
         }
 
-        RHI::ResultCode FenceImpl::InitInternal(RHI::Device& deviceBase, RHI::FenceState initialState)
+        RHI::ResultCode FenceImpl::InitInternal(RHI::Device& deviceBase, RHI::FenceState initialState, [[maybe_unused]] bool usedForWaitingOnDevice)
         {
             return m_fence.Init(&static_cast<Device&>(deviceBase), initialState);
         }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Fence.h
@@ -103,7 +103,7 @@ namespace AZ
 
             //////////////////////////////////////////////////////////////////////////
             // RHI::DeviceFence overrides ...
-            RHI::ResultCode InitInternal(RHI::Device& device, RHI::FenceState initialState) override;
+            RHI::ResultCode InitInternal(RHI::Device& device, RHI::FenceState initialState, bool usedForWaitingOnDevice) override;
             void ShutdownInternal() override;
             void SignalOnCpuInternal() override;
             void WaitOnCpuInternal() const override;

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/Fence.h
@@ -28,7 +28,13 @@ namespace AZ
             
             //////////////////////////////////////////////////////////////////////////
             // RHI::DeviceFence
-            RHI::ResultCode InitInternal([[maybe_unused]] RHI::Device& device, [[maybe_unused]] RHI::FenceState initialState) override { return RHI::ResultCode::Success;}
+            RHI::ResultCode InitInternal(
+                [[maybe_unused]] RHI::Device& device,
+                [[maybe_unused]] RHI::FenceState initialState,
+                [[maybe_unused]] bool usedForWaitingOnDevice) override
+            {
+                return RHI::ResultCode::Success;
+            }
             void ShutdownInternal() override {}
             void SignalOnCpuInternal() override {}
             void WaitOnCpuInternal() const override {}

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinaryFence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BinaryFence.cpp
@@ -71,7 +71,6 @@ namespace AZ
                 device.GetContext().DestroyFence(device.GetNativeDevice(), m_nativeFence, VkSystemAllocator::Get());
                 m_nativeFence = VK_NULL_HANDLE;
             }
-            Base::ShutdownInternal();
         }
 
         void BinaryFence::SignalOnCpuInternal()

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.cpp
@@ -5,18 +5,19 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Atom/RHI.Reflect/BufferDescriptor.h>
+#include <Atom/RHI.Reflect/Vulkan/Conversion.h>
+#include <Atom/RHI/DeviceBufferView.h>
+#include <Atom/RHI/MemoryStatisticsBuilder.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/sort.h>
-#include <Atom/RHI/DeviceBufferView.h>
-#include <Atom/RHI/MemoryStatisticsBuilder.h>
-#include <Atom/RHI.Reflect/BufferDescriptor.h>
 #include <RHI/Buffer.h>
 #include <RHI/BufferPool.h>
-#include <Atom/RHI.Reflect/Vulkan/Conversion.h>
-#include <RHI/MemoryView.h>
 #include <RHI/Device.h>
+#include <RHI/MemoryView.h>
 #include <RHI/Queue.h>
+#include <RHI/RayTracingAccelerationStructure.h>
 #include <RHI/ReleaseContainer.h>
 
 namespace AZ
@@ -157,10 +158,10 @@ namespace AZ
             AZ_Assert(RHI::CheckBitsAll(GetDescriptor().m_bindFlags, RHI::BufferBindFlags::RayTracingAccelerationStructure),
                 "GetNativeAccelerationStructure() is only valid for buffers with the RayTracingAccelerationStructure bind flag");
 
-            return m_nativeAccelerationStructure;
+            return m_nativeAccelerationStructure->GetNativeAccelerationStructure();
         }
 
-        void Buffer::SetNativeAccelerationStructure(const VkAccelerationStructureKHR& accelerationStructure)
+        void Buffer::SetNativeAccelerationStructure(const RHI::Ptr<RayTracingAccelerationStructure>& accelerationStructure)
         {
             AZ_Assert(RHI::CheckBitsAll(GetDescriptor().m_bindFlags, RHI::BufferBindFlags::RayTracingAccelerationStructure),
                 "SetNativeAccelerationStructure() is only valid for buffers with the RayTracingAccelerationStructure bind flag");

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.h
@@ -7,15 +7,16 @@
  */
 #pragma once
 
-#include <Atom/RHI/DeviceBuffer.h>
-#include <Atom/RHI/BufferProperty.h>
 #include <Atom/RHI.Reflect/AttachmentEnums.h>
+#include <Atom/RHI/AsyncWorkQueue.h>
+#include <Atom/RHI/BufferProperty.h>
+#include <Atom/RHI/DeviceBuffer.h>
 #include <AzCore/Memory/PoolAllocator.h>
 #include <AzCore/std/containers/list.h>
 #include <AzCore/std/parallel/mutex.h>
-#include <Atom/RHI/AsyncWorkQueue.h>
 #include <RHI/BufferMemoryView.h>
 #include <RHI/Queue.h>
+#include <RHI/RayTracingAccelerationStructure.h>
 
 namespace AZ
 {
@@ -69,7 +70,7 @@ namespace AZ
 
             /// Only valid for buffers with the RayTracingAccelerationStructure bind flag
             VkAccelerationStructureKHR GetNativeAccelerationStructure() const;
-            void SetNativeAccelerationStructure(const VkAccelerationStructureKHR& accelerationStructure);
+            void SetNativeAccelerationStructure(const RHI::Ptr<RayTracingAccelerationStructure>& accelerationStructure);
 
             VkSharingMode GetSharingMode() const;
 
@@ -105,7 +106,7 @@ namespace AZ
 
             // native raytracing acceleration structure handle, necessary to bind the descriptor for
             // this buffer if it is of type VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR
-            VkAccelerationStructureKHR m_nativeAccelerationStructure = VK_NULL_HANDLE;
+            RHI::Ptr<RayTracingAccelerationStructure> m_nativeAccelerationStructure = VK_NULL_HANDLE;
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -5,8 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <AzCore/std/containers/vector.h>
+#include <Atom/RHI.Reflect/IndirectBufferLayout.h>
+#include <Atom/RHI/DeviceDispatchRaysItem.h>
+#include <Atom/RHI/DeviceIndirectBufferSignature.h>
 #include <AzCore/std/containers/fixed_vector.h>
+#include <AzCore/std/containers/vector.h>
 #include <AzCore/std/parallel/lock.h>
 #include <RHI/Buffer.h>
 #include <RHI/BufferView.h>
@@ -23,18 +26,16 @@
 #include <RHI/PipelineLayout.h>
 #include <RHI/PipelineLibrary.h>
 #include <RHI/PipelineState.h>
-#include <RHI/RayTracingBlas.h>
-#include <RHI/RayTracingTlas.h>
-#include <RHI/RayTracingPipelineState.h>
-#include <RHI/RayTracingShaderTable.h>
 #include <RHI/Query.h>
 #include <RHI/QueryPool.h>
+#include <RHI/RayTracingAccelerationStructure.h>
+#include <RHI/RayTracingBlas.h>
+#include <RHI/RayTracingPipelineState.h>
+#include <RHI/RayTracingShaderTable.h>
+#include <RHI/RayTracingTlas.h>
 #include <RHI/RenderPass.h>
 #include <RHI/ShaderResourceGroup.h>
 #include <RHI/SwapChain.h>
-#include <Atom/RHI/DeviceIndirectBufferSignature.h>
-#include <Atom/RHI.Reflect/IndirectBufferLayout.h>
-#include <Atom/RHI/DeviceDispatchRaysItem.h>
 
 namespace AZ
 {
@@ -1161,7 +1162,7 @@ namespace AZ
             // Set the build mode to update the acceleration structure
             VkAccelerationStructureBuildGeometryInfoKHR tempBuildInfo = blasBuffers.m_buildInfo;
             tempBuildInfo.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR;
-            tempBuildInfo.srcAccelerationStructure = blasBuffers.m_accelerationStructure;
+            tempBuildInfo.srcAccelerationStructure = blasBuffers.m_accelerationStructure->GetNativeAccelerationStructure();
 
             const auto& context = dynamic_cast<Device&>(GetDevice()).GetContext();
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -419,7 +419,7 @@ namespace AZ
             SwapChainSemaphoreAllocator::Descriptor swapChainSemaphoreAllocDescriptor;
             swapChainSemaphoreAllocDescriptor.m_device = this;
             swapChainSemaphoreAllocDescriptor.m_collectLatency = RHI::Limits::Device::FrameCountMax;
-            m_swapChaiSemaphoreAllocator.Init(swapChainSemaphoreAllocDescriptor);
+            m_swapChainSemaphoreAllocator.Init(swapChainSemaphoreAllocDescriptor);
 
             m_imageMemoryRequirementsCache.SetInitFunction([](auto& cache) { cache.set_capacity(MemoryRequirementsCacheSize); });
             m_bufferMemoryRequirementsCache.SetInitFunction([](auto& cache) { cache.set_capacity(MemoryRequirementsCacheSize); });
@@ -573,7 +573,7 @@ namespace AZ
 
         SwapChainSemaphoreAllocator& Device::GetSwapChainSemaphoreAllocator()
         {
-            return m_swapChaiSemaphoreAllocator;
+            return m_swapChainSemaphoreAllocator;
         }
 
         const AZStd::vector<VkQueueFamilyProperties>& Device::GetQueueFamilyProperties() const
@@ -680,15 +680,16 @@ namespace AZ
             m_descriptorSetLayoutCache.first.Clear();
             m_samplerCache.first.Clear();
             m_pipelineLayoutCache.first.Clear();
-            m_semaphoreAllocator.Shutdown();
 
-            // Make sure this is last to flush any objects released in the above calls.
-            m_releaseQueue.Shutdown();
-
-            // The Objects in the release-queue need the command / upload queues for shutting down
             m_asyncUploadQueue.reset();
-            m_commandListAllocator.Shutdown();
             m_commandQueueContext.Shutdown();
+            m_commandListAllocator.Shutdown();
+
+            m_semaphoreAllocator.Shutdown();
+            m_swapChainSemaphoreAllocator.Shutdown();
+
+            // Flush any objects released in the above calls.
+            m_releaseQueue.Shutdown();
         }
 
         void Device::ShutdownInternal()
@@ -759,6 +760,7 @@ namespace AZ
             m_commandQueueContext.End();
             m_commandListAllocator.Collect();
             m_semaphoreAllocator.Collect();
+            m_swapChainSemaphoreAllocator.Collect();
             m_bindlessDescriptorPool.GarbageCollect();
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
@@ -214,7 +214,7 @@ namespace AZ
             RHI::Ptr<AsyncUploadQueue> m_asyncUploadQueue;
             CommandListAllocator m_commandListAllocator;
             SemaphoreAllocator m_semaphoreAllocator;
-            SwapChainSemaphoreAllocator m_swapChaiSemaphoreAllocator;
+            SwapChainSemaphoreAllocator m_swapChainSemaphoreAllocator;
 
             // New VkImageUsageFlags are inserted in the map in a lazy way.
             // Because of this, the map containing the usages per formar is mutable to keep the

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
@@ -52,10 +52,11 @@ namespace AZ
             m_fenceImpl->SetNameInternal(name);
         }
 
-        RHI::ResultCode Fence::InitInternal(RHI::Device& baseDevice, RHI::FenceState initialState)
+        RHI::ResultCode Fence::InitInternal(RHI::Device& baseDevice, RHI::FenceState initialState, bool usedForWaitingOnDevice)
         {
-            if (baseDevice.GetFeatures().m_signalFenceFromCPU)
+            if (usedForWaitingOnDevice)
             {
+                AZ_Assert(baseDevice.GetFeatures().m_signalFenceFromCPU, "Fences cannot be waited for on the GPU.");
                 m_fenceImpl = TimelineSemaphoreFence::Create();
             }
             else

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.h
@@ -49,7 +49,7 @@ namespace AZ
 
             //////////////////////////////////////////////////////////////////////
             // RHI::DeviceFence
-            RHI::ResultCode InitInternal(RHI::Device& device, RHI::FenceState initialState) override;
+            RHI::ResultCode InitInternal(RHI::Device& device, RHI::FenceState initialState, bool usedForWaitingOnDevice) override;
             void ShutdownInternal() override;
             void SignalOnCpuInternal() override;
             void WaitOnCpuInternal() const override;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FenceBase.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FenceBase.cpp
@@ -61,9 +61,10 @@ namespace AZ
             return RHI::ResultCode::Success;
         }
 
-        void FenceBase::ShutdownInternal()
+        void FenceBase::Shutdown()
         {
-            SignalEvent();
+            ShutdownInternal();
+            Base::Shutdown();
         }
     } // namespace Vulkan
 } // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FenceBase.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FenceBase.h
@@ -27,8 +27,6 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(FenceBase, AZ::ThreadPoolAllocator);
             AZ_RTTI(FenceBase, "{AAAD0A37-5F85-4A68-9464-06EDAC6D62B0}", RHI::DeviceObject);
 
-            ~FenceBase() = default;
-
             void SetSignalEvent(const AZStd::shared_ptr<AZ::Vulkan::SignalEvent>& signalEvent);
             void SetSignalEventBitToSignal(int bitToSignal);
             void SetSignalEventDependencies(AZ::Vulkan::SignalEvent::BitSet dependencies);
@@ -46,7 +44,8 @@ namespace AZ
             //////////////////////////////////////////////////////////////////////
             // Interface
             virtual RHI::ResultCode InitInternal(RHI::Device& device, RHI::FenceState initialState);
-            virtual void ShutdownInternal();
+            virtual void ShutdownInternal() = 0;
+            virtual void Shutdown();
             virtual void SignalOnCpuInternal() = 0;
             virtual void WaitOnCpuInternal() const = 0;
             virtual void ResetInternal() = 0;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "Atom_RHI_Vulkan_Platform.h"
+#include <Atom/RHI.Reflect/VkAllocator.h>
+#include <RHI/Device.h>
+#include <RHI/RayTracingAccelerationStructure.h>
+
+namespace AZ::Vulkan
+{
+    RHI::Ptr<RayTracingAccelerationStructure> RayTracingAccelerationStructure::Create()
+    {
+        return new RayTracingAccelerationStructure;
+    }
+
+    void RayTracingAccelerationStructure::Init(Device& device, const VkAccelerationStructureCreateInfoKHR& createInfo)
+    {
+        VkResult vkResult = device.GetContext().CreateAccelerationStructureKHR(
+            device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_accelerationStructure);
+        AssertSuccess(vkResult);
+        DeviceObject::Init(device);
+    }
+
+    void RayTracingAccelerationStructure::Shutdown()
+    {
+        m_blasBuffers.clear();
+        auto& device = static_cast<Device&>(GetDevice());
+        device.GetContext().DestroyAccelerationStructureKHR(device.GetNativeDevice(), m_accelerationStructure, VkSystemAllocator::Get());
+        m_accelerationStructure = VK_NULL_HANDLE;
+        RHI::DeviceObject::Shutdown();
+    }
+
+    void RayTracingAccelerationStructure::SetBlasBuffers(AZStd::vector<RHI::Ptr<RHI::DeviceBuffer>>&& buffers)
+    {
+        m_blasBuffers = buffers;
+    }
+} // namespace AZ::Vulkan

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingAccelerationStructure.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/DeviceBuffer.h>
+#include <Atom_RHI_Vulkan_Platform.h>
+#include <AzCore/Memory/SystemAllocator.h>
+
+namespace AZ
+{
+    namespace Vulkan
+    {
+        //! This class builds and contains the Vulkan RayTracing BLAS buffers.
+        class RayTracingAccelerationStructure final : public RHI::DeviceObject
+        {
+        public:
+            AZ_CLASS_ALLOCATOR(RayTracingAccelerationStructure, AZ::SystemAllocator);
+
+            static RHI::Ptr<RayTracingAccelerationStructure> Create();
+
+            void Init(Device& device, const VkAccelerationStructureCreateInfoKHR& createInfo);
+
+            void Shutdown() override;
+
+            bool IsValid() const
+            {
+                return m_accelerationStructure != VK_NULL_HANDLE;
+            }
+
+            VkAccelerationStructureKHR GetNativeAccelerationStructure()
+            {
+                return m_accelerationStructure;
+            }
+
+            void SetBlasBuffers(AZStd::vector<RHI::Ptr<RHI::DeviceBuffer>>&& buffers);
+
+        private:
+            RayTracingAccelerationStructure() = default;
+
+            VkAccelerationStructureKHR m_accelerationStructure = VK_NULL_HANDLE;
+
+            // need to keep a reference to the BLAS buffers to keep them alive as long as this AS is alive if this AS is a TLAS
+            AZStd::vector<RHI::Ptr<RHI::DeviceBuffer>> m_blasBuffers;
+        };
+    } // namespace Vulkan
+} // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.cpp
@@ -6,14 +6,15 @@
  *
  */
 
-#include <RHI/RayTracingBlas.h>
-#include <RHI/Buffer.h>
+#include <Atom/RHI.Reflect/VkAllocator.h>
 #include <Atom/RHI.Reflect/Vulkan/Conversion.h>
-#include <RHI/Device.h>
-#include <Atom/RHI/Factory.h>
 #include <Atom/RHI/DeviceBufferPool.h>
 #include <Atom/RHI/DeviceRayTracingBufferPools.h>
-#include <Atom/RHI.Reflect/VkAllocator.h>
+#include <Atom/RHI/Factory.h>
+#include <RHI/Buffer.h>
+#include <RHI/Device.h>
+#include <RHI/RayTracingAccelerationStructure.h>
+#include <RHI/RayTracingBlas.h>
 
 namespace AZ
 {
@@ -35,8 +36,6 @@ namespace AZ
 
             if (buffers.m_accelerationStructure)
             {
-                device.GetContext().DestroyAccelerationStructureKHR(
-                    device.GetNativeDevice(), buffers.m_accelerationStructure, VkSystemAllocator::Get());
                 buffers.m_accelerationStructure = nullptr;
             }
 
@@ -218,16 +217,19 @@ namespace AZ
             addressInfo.buffer = static_cast<Buffer*>(buffers.m_blasBuffer.get())->GetBufferMemoryView()->GetNativeBuffer();
             createInfo.buffer = blasMemoryView->GetNativeBuffer();
 
-            VkResult vkResult = device.GetContext().CreateAccelerationStructureKHR(
-                device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &buffers.m_accelerationStructure);
-            AssertSuccess(vkResult);
+            buffers.m_accelerationStructure = RayTracingAccelerationStructure::Create();
+            buffers.m_accelerationStructure->Init(device, createInfo);
 
-            buffers.m_buildInfo.dstAccelerationStructure = buffers.m_accelerationStructure;
+            buffers.m_buildInfo.dstAccelerationStructure = buffers.m_accelerationStructure->GetNativeAccelerationStructure();
 
             addressInfo.sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO;
             addressInfo.buffer = scratchMemoryView->GetNativeBuffer();
             buffers.m_buildInfo.scratchData.deviceAddress =
                 device.GetContext().GetBufferDeviceAddress(device.GetNativeDevice(), &addressInfo);
+
+            // store the VkAccelerationStructureKHR in the BLAS Buffer, this is necessary since we need it to
+            // stay alive as long as it is used
+            static_cast<Buffer*>(buffers.m_blasBuffer.get())->SetNativeAccelerationStructure(buffers.m_accelerationStructure);
 
             return RHI::ResultCode::Success;
         }
@@ -252,5 +254,5 @@ namespace AZ
 
             return vkBuildFlags;
         }
-    }
+    } // namespace Vulkan
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.h
@@ -18,6 +18,7 @@ namespace AZ
     namespace Vulkan
     {
         class Buffer;
+        class RayTracingAccelerationStructure;
 
         //! This class builds and contains the Vulkan RayTracing BLAS buffers.
         class RayTracingBlas final
@@ -33,7 +34,7 @@ namespace AZ
                 RHI::Ptr<RHI::DeviceBuffer> m_blasBuffer;
                 RHI::Ptr<RHI::DeviceBuffer> m_scratchBuffer;
                 RHI::Ptr<RHI::DeviceBuffer> m_aabbBuffer;
-                VkAccelerationStructureKHR m_accelerationStructure = VK_NULL_HANDLE;
+                RHI::Ptr<RayTracingAccelerationStructure> m_accelerationStructure;
 
                 AZStd::vector<VkAccelerationStructureGeometryKHR> m_geometryDescs;
                 AZStd::vector<VkAccelerationStructureBuildRangeInfoKHR> m_rangeInfos;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -247,6 +247,9 @@ namespace AZ
         void RayTracingPipelineState::ShutdownInternal()
         {
             Device& device = static_cast<Device&>(GetDevice());
+
+            device.GetContext().DestroyPipeline(device.GetNativeDevice(), m_pipeline, VkSystemAllocator::Get());
+
             for (auto& shaderModule : m_shaderModules)
             {
                 device.GetContext().DestroyShaderModule(device.GetNativeDevice(), shaderModule, VkSystemAllocator::Get());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingTlas.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingTlas.h
@@ -18,6 +18,7 @@ namespace AZ
     namespace Vulkan
     {
         class Buffer;
+        class RayTracingAccelerationStructure;
 
         //! This class builds and contains the Vulkan RayTracing TLAS buffers.
         class RayTracingTlas final
@@ -33,7 +34,7 @@ namespace AZ
                 RHI::Ptr<RHI::DeviceBuffer> m_tlasBuffer;
                 RHI::Ptr<RHI::DeviceBuffer> m_scratchBuffer;
                 RHI::Ptr<RHI::DeviceBuffer> m_tlasInstancesBuffer;
-                VkAccelerationStructureKHR m_accelerationStructure = VK_NULL_HANDLE;
+                RHI::Ptr<RayTracingAccelerationStructure> m_accelerationStructure;
 
                 VkAccelerationStructureGeometryKHR m_geometry = {};
                 VkAccelerationStructureBuildRangeInfoKHR m_offsetInfo = {};

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Semaphore.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Semaphore.cpp
@@ -89,8 +89,6 @@ namespace AZ
                 device.GetContext().DestroySemaphore(device.GetNativeDevice(), m_nativeSemaphore, VkSystemAllocator::Get());
                 m_nativeSemaphore = VK_NULL_HANDLE;
             }
-            // Signal any pending threads.
-            SignalEvent();
             Base::Shutdown();
         }
     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -544,7 +544,6 @@ namespace AZ
             RHI::ResultCode result = ConvertResult(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
-            imageAvailableSemaphore->SignalEvent();
             if (m_currentFrameContext.m_imageAvailableSemaphore)
             {
                 semaphoreAllocator.DeAllocate(m_currentFrameContext.m_imageAvailableSemaphore);
@@ -569,7 +568,7 @@ namespace AZ
             auto& device = static_cast<Device&>(GetDevice());
             auto presentCommand = [&device, swapchain]([[maybe_unused]] void* queue)
             {
-                device.GetContext().DeviceWaitIdle(device.GetNativeDevice());
+                device.GetCommandQueueContext().GetCommandQueue(RHI::HardwareQueueClass::Graphics).WaitForIdle();
                 if (swapchain != VK_NULL_HANDLE)
                 {
                     device.GetContext().DestroySwapchainKHR(device.GetNativeDevice(), swapchain, VkSystemAllocator::Get());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
@@ -73,7 +73,6 @@ namespace AZ
                 device.GetContext().DestroySemaphore(device.GetNativeDevice(), m_nativeSemaphore, VkSystemAllocator::Get());
                 m_nativeSemaphore = VK_NULL_HANDLE;
             }
-            Base::ShutdownInternal();
         }
 
         void TimelineSemaphoreFence::SignalOnCpuInternal()

--- a/Gems/Atom/RHI/Vulkan/Code/atom_rhi_vulkan_private_common_files.cmake
+++ b/Gems/Atom/RHI/Vulkan/Code/atom_rhi_vulkan_private_common_files.cmake
@@ -157,6 +157,8 @@ set(FILES
     Source/RHI/BufferMemory.cpp
     Source/RHI/BufferMemory.h
     Source/RHI/BufferMemoryView.h
+    Source/RHI/RayTracingAccelerationStructure.cpp
+    Source/RHI/RayTracingAccelerationStructure.h
     Source/RHI/RayTracingBufferPools.h
     Source/RHI/RayTracingBlas.cpp
     Source/RHI/RayTracingBlas.h

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -137,7 +137,7 @@ namespace AZ
                 {
                     fence = new RHI::Fence();
                     AZ_Assert(fence != nullptr, "CopyPass failed to create a fence");
-                    [[maybe_unused]] auto result = fence->Init(RHI::MultiDevice::AllDevices, RHI::FenceState::Signaled);
+                    [[maybe_unused]] auto result = fence->Init(RHI::MultiDevice::AllDevices, RHI::FenceState::Signaled, true);
                     AZ_Assert(result == RHI::ResultCode::Success, "CopyPass failed to init fence");
                 }
 

--- a/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
@@ -242,7 +242,10 @@ namespace UnitTest
             AZ_CLASS_ALLOCATOR(Fence, AZ::SystemAllocator);
 
         private:
-            AZ::RHI::ResultCode InitInternal(AZ::RHI::Device&, AZ::RHI::FenceState) override { return AZ::RHI::ResultCode::Success; }
+            AZ::RHI::ResultCode InitInternal(AZ::RHI::Device&, AZ::RHI::FenceState, [[maybe_unused]] bool usedForWaitingOnDevice) override
+            {
+                return AZ::RHI::ResultCode::Success;
+            }
             void ShutdownInternal() override {}
             void SignalOnCpuInternal() override {}
             void WaitOnCpuInternal() const override {};


### PR DESCRIPTION
- SpecularReflectionsFeatureProcessor.cpp: remove asserts that unnecessarily trigger when UpdatePasses is called before AttachmentBindings are created.
- MultiDeviceObject derived classes: Clear map of DeviceObjects on Shutdown and do not forward the Shutdown call as the DeviceObjects may still be in use.
- Fence: only use timeline semaphores in Vulkan when waiting for a Fence on the GPU. Fixes the bug that you cannot immediately free a timeline semaphore when it is signaled as is done with the Fence in the AsyncUploadQueue.
- Vulkan FenceBase/BinaryFence/TimelineSemaphoreFence: fixed wrong Shutdown chain
- VkAccelerationStructure: fix leak by implementing a RayTracingAccelerationStructure class with a Shutdown method that properly releases the Vulkan object. To keep it around long enough it is referenced in the Buffer class that stores the corresponding acceleration structure.
- Vulkan RayTracingAccelerationStructure: keep a vector of references to BLAS buffers to keep them alive as long as the TLAS exists.
- Vulkan Device: m_swapChaiSemaphoreAllocator name spelling fixed to m_swapChainSemaphoreAllocator (chaiN).
- Vulkan Device: properly call m_swapChainSemaphoreAllocator's Collect() and Shutdown() methods to stop leaking semaphores.
- Vulkan Device: fixed release order in Device::PreShutdown.
- Vulkan RayTracingPipelineState: m_pipeline was leaking.
- Vulkan Semaphore: removed unnecessary SignalEvent call.
- Vulkan SwapChain: removed unnecessary SignalEvent call that triggered an assert.
- Vulkan SwapChain: wait for the graphics queue only instead of the whole device which causes an issue if another thread works on the AsyncUploadQueue at the same time.

## What does this PR do?

I got a lot of validation layer errors in the atom-sampleviewer especially when closing it on shutdown. This PR fixes many (but not all) of these.

## How was this PR tested?

Run the atom-sampleviewer with `--rhi-device-validation enable` and the Vulkan backend (default on Linux).
