### PR TITLE
Remove android options from installed sdk

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -298,6 +298,10 @@ namespace O3DE::ProjectManager
         m_projectImageLabel->setAlignment(Qt::AlignCenter);
         vLayout->addWidget(m_projectImageLabel);
 
+        // Determine if the project's engine is the installed SDK or a source engine.
+        // Certain features may be only supported in the source engine.
+        m_isEngineSDK = projectInfo.m_engineName.compare("o3de-sdk") == 0;
+
         QString projectPreviewPath = QDir(m_projectInfo.m_path).filePath(m_projectInfo.m_iconPath);
         QFileInfo doesPreviewExist(projectPreviewPath);
         if (!doesPreviewExist.exists() || !doesPreviewExist.isFile())
@@ -366,11 +370,19 @@ namespace O3DE::ProjectManager
         menu->addSeparator();
         QMenu* exportMenu = menu->addMenu(tr("Export Launcher"));
         exportMenu->addAction(AZ_TRAIT_PROJECT_MANAGER_HOST_PLATFORM_NAME , this, [this](){ emit ExportProject(m_projectInfo, "export_source_built_project.py");});
-        exportMenu->addAction(tr("Android"), this, [this](){ emit ExportProject(m_projectInfo, "export_source_android.py"); });
+        if (!m_isEngineSDK)
+        {
+            exportMenu->addAction(tr("Android"), this, [this](){ emit ExportProject(m_projectInfo, "export_source_android.py"); });
+        }
+
         menu->addAction(tr("Open Export Settings..."), this, [this]() { emit OpenProjectExportSettings(m_projectInfo.m_path); });
         menu->addSeparator();
         menu->addAction(tr("Open CMake GUI..."), this, [this]() { emit OpenCMakeGUI(m_projectInfo); });
-        menu->addAction(tr("Open Android Project Generator..."), this, [this]() { emit OpenAndroidProjectGenerator(m_projectInfo.m_path); });
+        if (!m_isEngineSDK)
+        {
+            menu->addAction(tr("Open Android Project Generator..."), this, [this]() { emit OpenAndroidProjectGenerator(m_projectInfo.m_path); });
+        }
+
         menu->addSeparator();
         menu->addAction(tr("Open Project folder..."), this, [this]()
         { 

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
@@ -186,6 +186,7 @@ namespace O3DE::ProjectManager
         bool m_isProjectBuilding = false;
         bool m_isProjectExporting = false;
         bool m_canLaunch = true;
+        bool m_isEngineSDK = false;
 
         ProjectButtonState m_currentState = ProjectButtonState::ReadyToLaunch;
     };

--- a/scripts/o3de/ExportScripts/export_source_android.py
+++ b/scripts/o3de/ExportScripts/export_source_android.py
@@ -46,6 +46,8 @@ def export_source_android_project(ctx: exp.O3DEScriptExportContext,
         logger.setLevel(logging.ERROR)
 
     is_installer_sdk = manifest.is_sdk_engine(engine_path=ctx.engine_path)
+    if is_installer_sdk:
+        raise exp.ExportProjectError("Exporting Android projects is not supported in from the SDK version of O3DE")
 
     android_arg_parser = argparse.ArgumentParser()
     android_subparser = android_arg_parser.add_subparsers(title="Android sub-commands")

--- a/scripts/o3de/o3de/android.py
+++ b/scripts/o3de/o3de/android.py
@@ -291,6 +291,10 @@ def generate_android_project(args: argparse) -> int:
             raise android_support.AndroidToolError(f"Project '{project_name}' is not registered with O3DE.")
         project_settings, android_settings = android_support.read_android_settings_for_project(resolved_project_path)
 
+        # Generating android projects from an install O3DE SDK is not supported yet
+        if manifest.is_sdk_engine():
+            raise android_support.AndroidToolError("Exporting Android projects is not supported in from the SDK version of O3DE")
+
         # Perform validation on the config and the environment
         android_env = validate_android_config(android_config)
 

--- a/scripts/o3de/o3de/android.py
+++ b/scripts/o3de/o3de/android.py
@@ -292,7 +292,7 @@ def generate_android_project(args: argparse) -> int:
         project_settings, android_settings = android_support.read_android_settings_for_project(resolved_project_path)
 
         # Generating android projects from an install O3DE SDK is not supported yet
-        if manifest.is_sdk_engine():
+        if manifest.is_sdk_engine(engine_path=ENGINE_PATH):
             raise android_support.AndroidToolError("Exporting Android projects is not supported in from the SDK version of O3DE")
 
         # Perform validation on the config and the environment


### PR DESCRIPTION
## What does this PR do?
Android support is a missing feature from the installed SDK version of O3DE. The functionality is only supported for the source build of O3DE. This PR is to disable the android functionality from the SDK builds for the time being until Android is supported fully in both the source and SDK version of O3DE.

Fixes https://github.com/o3de/o3de/issues/18242
Fixes https://github.com/o3de/o3de/issues/18243 

## How was this PR tested?
Built the SDK installer locally and confirmed the Android options from the project manager is no longer present and the android-export command ran from the sdk scripts will fail with the proper not supported message. 
