### PR TITLE
Fix asset browser freeze and crash when repeatedly searching.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -237,7 +237,7 @@ namespace AzToolsFramework
             }
             Q_EMIT filterChanged();
 
-            // Note that becuase the data we are filtering over is massive (all assets) its way faster
+            // Note that because the data we are filtering over is massive (all assets) its way faster
             // to reset the model than it is to try to incrementally apply filters here, which can cause many more
             // messages like "row added / row removed" to be sent to the view.
             beginResetModel();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -235,13 +235,13 @@ namespace AzToolsFramework
                     }
                 }
             }
-            Q_EMIT filterChanged();
-
             // Note that because the data we are filtering over is massive (all assets) its way faster
             // to reset the model than it is to try to incrementally apply filters here, which can cause many more
             // messages like "row added / row removed" to be sent to the view.
             beginResetModel();
             endResetModel();
+
+            Q_EMIT filterChanged();
         }
 
         void AssetBrowserFilterModel::filterUpdatedSlot()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -86,8 +86,9 @@ namespace AzToolsFramework
         {
             if (m_invalidateFilter)
             {
-                invalidateFilter();
+                beginResetModel();
                 m_invalidateFilter = false;
+                endResetModel();
             }
         }
 
@@ -98,7 +99,18 @@ namespace AzToolsFramework
 
         QVariant AssetBrowserFilterModel::data(const QModelIndex& index, int role) const
         {
-            auto assetBrowserEntry = mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+            if (!index.isValid())
+            {
+                return QVariant();
+            }
+            QModelIndex sourceIndex = mapToSource(index);
+
+            if (!sourceIndex.isValid())
+            {
+                return QVariant(); // the view may be in a state of repopulating.
+            }
+
+            auto assetBrowserEntry = sourceIndex.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
             AZ_Assert(assetBrowserEntry, "Couldn't fetch asset entry for the given index.");
             if (!assetBrowserEntry)
             {
@@ -223,9 +235,13 @@ namespace AzToolsFramework
                     }
                 }
             }
-
-            invalidateFilter();
             Q_EMIT filterChanged();
+
+            // Note that becuase the data we are filtering over is massive (all assets) its way faster
+            // to reset the model than it is to try to incrementally apply filters here, which can cause many more
+            // messages like "row added / row removed" to be sent to the view.
+            beginResetModel();
+            endResetModel();
         }
 
         void AssetBrowserFilterModel::filterUpdatedSlot()
@@ -234,7 +250,9 @@ namespace AzToolsFramework
             {
                 m_alreadyRecomputingFilters = true;
                 // de-bounce it, since we may get many filter updates all at once.
-                QTimer::singleShot(0, this, [this]()
+                // do not use a 0 here, as this puts the message directly in the message queue, and will interleave
+                // it with keypress events / referesh events, etc.
+                QTimer::singleShot(20, this, [this]()
                 {
                     m_alreadyRecomputingFilters = false;
                     FilterUpdatedSlotImmediate();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -597,7 +597,7 @@ namespace AzToolsFramework
                         if (GetEntryIndex(entry, index))
                         {
                             AZ_PUSH_DISABLE_WARNING(4127, "-Wunknown-warning-option") // conditional expression is constant
-                            Q_EMIT dataChanged(index, index, { Roles::EntryRole });
+                            Q_EMIT dataChanged(index, index, { Qt::DecorationRole });  // thumbnail image is the "decoration"
                             AZ_POP_DISABLE_WARNING
                         }
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
@@ -26,7 +26,24 @@ namespace AzToolsFramework
 
         QVariant AssetBrowserTableViewProxyModel::data(const QModelIndex& index, int role) const
         {
-            auto assetBrowserEntry = mapToSource(index).data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+            if (!index.isValid())
+            {
+                return QVariant();
+            }
+
+            QModelIndex currentIndex = mapToSource(index);
+            if (!currentIndex.isValid())
+            {
+                return QVariant(); 
+            }
+
+            QVariant entryVariant = currentIndex.data(AssetBrowserModel::Roles::EntryRole);
+            if (!entryVariant.isValid())
+            {
+                return QVariant(); // table might be temporarily empty or busy repopulating.
+            }
+
+            auto assetBrowserEntry = entryVariant.value<const AssetBrowserEntry*>();
             AZ_Assert(assetBrowserEntry, "Couldn't fetch asset entry for the given index.");
             if (!assetBrowserEntry)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTreeToTableProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTreeToTableProxyModel.cpp
@@ -107,7 +107,11 @@ namespace AzToolsFramework
         {
             Q_UNUSED(topLeft);
             Q_UNUSED(bottomRight);
-            Q_UNUSED(roles);
+            // we dont' need to consider refiltering or flattening if the role which changed is just the thumbnail icon.
+            if (roles.contains(Qt::DecorationRole))
+            {
+                return;
+            }
             FlattenTree();
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -603,10 +603,10 @@ namespace AzToolsFramework
                 clonedFilter->AddFilter(FilterConstType(customTypeFilter));
 
                 clonedFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
-                m_assetFilterModel->SetFilter(FilterConstType(clonedFilter));
                 m_tableViewWidget->expandAll();
                 m_tableViewProxyModel->setSourceModel(m_treeToTableProxyModel);
                 m_treeToTableProxyModel->ConnectSignals();
+                m_assetFilterModel->SetFilter(FilterConstType(clonedFilter));
             }
             else
             {


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/18051

This was caused by a number of asynchronous things happening when searches were being performed.  The main problem was actually a series of out of order operations where, for example, the search criteria changed before the view was ready to switch between search and non-search.

This also has a side effect of reducing the flicker when thumbnails are updating, and speeds up the search process significantly.

It also fixes an unreported bug where repeatedly searching then clearing the search would result in the table view not updating and being blank.

## How was this PR tested?

Tested each available view of Asset Browser (tree, table, thumbnail) while 
* searching for various terms rapidly
* clearing the search, adding new search terms
* incremental searches
* Switching views during searches
* thumbnails popping in and changing search term while thats happening
