### PR TITLE
Add monolithic assets that were missing from the Linux installer

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -406,6 +406,7 @@
       "nightly-installer"
     ],
     "steps": [
+      "install_mono_22_release",
       "installer"
     ]
   },


### PR DESCRIPTION
## What does this PR do?
This fixes the missing monolithic assets that were missing from the Linux debian package. This uses the same steps to build the full default + monolithic support installs for the SDK as found in the windows install steps.

Fixes https://github.com/o3de/o3de/issues/18250

## How was this PR tested?
Built the installer locally and followed the steps described in https://github.com/o3de/o3de/issues/18250
