### PR TITLE
Improve messaging for missing Tix package

### DIFF
--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -19,11 +19,30 @@ import shutil
 import subprocess
 
 from o3de import command_utils, manifest, utils
+
+# Check if tkinter is installed or not
 tkinter_installed = True
 try:
     from o3de.ui import export_project as export_project_ui
 except:
     tkinter_installed = False
+
+# Check if tix is installed or not
+tkinter_tix_installed = True
+try:
+    import tkinter.tix as tkp
+
+    class CheckTix(tkp.Tk):
+
+        def __init__(self):
+            super().__init__()
+
+    CheckTix().destroy()
+
+except Exception as e:
+    print(e)
+    tkinter_tix_installed = False
+
 from typing import List
 from enum import IntEnum
 
@@ -395,14 +414,17 @@ def _run_export_script(args: argparse, passthru_args: list) -> int:
         export_script = args.export_script
     
     if args.configure:
-        if tkinter_installed:
+        if tkinter_installed and tkinter_tix_installed:
             export_config = get_export_project_config(args.project_path)
             project_info = manifest.get_project_json_data(project_path=args.project_path)
             is_o3de_sdk = project_info.get('engine') == 'o3de-sdk'
             export_project_ui.MainWindow(export_config, is_o3de_sdk).configure_settings()
             return 0
         else:
-            print("Unable to open configure window. Tk is not installed on this system")
+            if not tkinter_installed:
+                print("Unable to open the configure window. Required package 'tk' is not installed on this system.")
+            else:
+                print("Unable to open the configure window. Required package 'tix' is not installed on this system.")
             return 1
     
     return _export_script(export_script, args.project_path, passthru_args)

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -30,6 +30,8 @@ except:
 # Check if tix is installed or not
 tkinter_tix_installed = True
 try:
+    # `tix` won't be detected with a simple import, it won't raise an exception until
+    # tk attempts to create an object
     import tkinter.tix as tkp
 
     class CheckTix(tkp.Tk):
@@ -40,7 +42,6 @@ try:
     CheckTix().destroy()
 
 except Exception as e:
-    print(e)
     tkinter_tix_installed = False
 
 from typing import List


### PR DESCRIPTION
## What does this PR do?
Add check for the require 'tix' package needed for tkinter configuration of the project export screen. The `tix` package is required along with the `tk` package if you want to use the configuration ui for project export with the following command
`o3de.sh export-project --configure` . 

This fix, in conjunction with https://github.com/o3de/o3de.org/pull/2580 will provide better messaging and instructions to resolve the system dependency.

Fixes https://github.com/o3de/o3de/issues/18246 

## How was this PR tested?
Followed the step of `o3de.sh export-project --configure`  with and without the `tix` package installed on Ubuntu

