### PR TITLE
Adjusment to error message with incompatible components activation

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Entity.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Entity.cpp
@@ -1048,8 +1048,12 @@ namespace AZ
             // different error message for multiple components of the same type
             if (componentProvidingService->m_underlyingTypeId == componentIncompatibleWithService->m_underlyingTypeId)
             {
-                return AZStd::string::format("Multiple '%s' found, but this component is incompatible with others of the same type.",
-                    componentProvidingService->m_component->RTTI_GetTypeName());
+                return AZStd::string::format(
+                    "Multiple '%s' found, but this component is incompatible with others of the same type. Components with UUID %s "
+                    "and %s are incompatible with each other.",
+                    componentProvidingService->m_component->RTTI_GetTypeName(),
+                    componentProvidingService->m_component->RTTI_GetType().ToString<AZStd::string>().c_str(),
+                    componentIncompatibleWithService->m_component->RTTI_GetType().ToString<AZStd::string>().c_str());
             }
 
             return AZStd::string::format("Components '%s' and '%s' are incompatible.",


### PR DESCRIPTION
## What does this PR do?

This PR make an error message when multiple, conflicting components are being activated. It can help to navigate issues like:
https://github.com/o3de/o3de/issues/18234

It can be considered as partial bugfix, and its impact on existing stabilized codebase is minimal.
I am asking reviewers to accept this contribution as bugfix to stabilization/2409.
## How was this PR tested?

Run with PhysX and PhysX5 gem activated together.