### PR TITLE
Adjust DiffuseProbeGrid to prevent multiple SRG compilations

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
@@ -169,8 +169,10 @@ namespace AZ
                 // (see ValidateSetImageView() in ShaderResourceGroupData.cpp)
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
                 diffuseProbeGrid->UpdateBlendDistanceSrg(shader.m_shader, shader.m_srgLayout);
-
-                diffuseProbeGrid->GetBlendDistanceSrg()->Compile();
+                if (!diffuseProbeGrid->GetBlendDistanceSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetBlendDistanceSrg()->Compile();
+                }
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
@@ -160,7 +160,10 @@ namespace AZ
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
                 diffuseProbeGrid->UpdateBlendIrradianceSrg(shader.m_shader, shader.m_srgLayout);
 
-                diffuseProbeGrid->GetBlendIrradianceSrg()->Compile();
+                if (!diffuseProbeGrid->GetBlendIrradianceSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetBlendIrradianceSrg()->Compile();
+                }
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
@@ -160,11 +160,22 @@ namespace AZ
                 // (see line ValidateSetImageView() in ShaderResourceGroupData.cpp)
                 diffuseProbeGrid->UpdateBorderUpdateSrgs(m_rowShader, m_rowSrgLayout, m_columnShader, m_columnSrgLayout);
 
-                diffuseProbeGrid->GetBorderUpdateRowIrradianceSrg()->Compile();
-                diffuseProbeGrid->GetBorderUpdateColumnIrradianceSrg()->Compile();
-                diffuseProbeGrid->GetBorderUpdateRowDistanceSrg()->Compile();
-                diffuseProbeGrid->GetBorderUpdateColumnDistanceSrg()->Compile();
-
+                if (!diffuseProbeGrid->GetBorderUpdateRowIrradianceSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetBorderUpdateRowIrradianceSrg()->Compile();
+                }
+                if(!diffuseProbeGrid->GetBorderUpdateColumnIrradianceSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetBorderUpdateColumnIrradianceSrg()->Compile();
+                }
+                if (!diffuseProbeGrid->GetBorderUpdateRowDistanceSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetBorderUpdateRowDistanceSrg()->Compile();
+                }
+                if (!diffuseProbeGrid->GetBorderUpdateColumnDistanceSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetBorderUpdateColumnDistanceSrg()->Compile();
+                }
                 // setup the submit items now to properly handle submitting on multiple threads
                 uint32_t probeCountX;
                 uint32_t probeCountY;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
@@ -162,7 +162,10 @@ namespace AZ
                 // (see ValidateSetImageView() in ShaderResourceGroupData.cpp)
                 DiffuseProbeGridShader& shader = m_shaders[diffuseProbeGrid->GetNumRaysPerProbe().m_index];
                 diffuseProbeGrid->UpdateClassificationSrg(shader.m_shader, shader.m_srgLayout);
-                diffuseProbeGrid->GetClassificationSrg()->Compile();
+                if (!diffuseProbeGrid->GetClassificationSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetClassificationSrg()->Compile();
+                }
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
@@ -132,7 +132,10 @@ namespace AZ
                 // the diffuse probe grid Srg must be updated in the Compile phase in order to successfully bind the ReadWrite shader inputs
                 // (see ValidateSetImageView() in ShaderResourceGroupData.cpp)
                 diffuseProbeGrid->UpdatePrepareSrg(m_shader, m_srgLayout);
-                diffuseProbeGrid->GetPrepareSrg()->Compile();
+                if (!diffuseProbeGrid->GetPrepareSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetPrepareSrg()->Compile();
+                }
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -314,7 +314,10 @@ namespace AZ
                     diffuseProbeGrid->UpdateRayTraceSrg(m_rayTracingShader, m_globalSrgLayout);
 
                     diffuseProbeGrid->GetRayTraceSrg()->SetConstant(m_maxRecursionDepthNameIndex, MaxRecursionDepth);
-                    diffuseProbeGrid->GetRayTraceSrg()->Compile();
+                    if (!diffuseProbeGrid->GetRayTraceSrg()->IsQueuedForCompile())
+                    {
+                        diffuseProbeGrid->GetRayTraceSrg()->Compile();
+                    }
                 }
             }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
@@ -194,7 +194,10 @@ namespace AZ
                 // the diffuse probe grid Srg must be updated in the Compile phase in order to successfully bind the ReadWrite shader inputs
                 // (see ValidateSetImageView() in ShaderResourceGroupData.cpp)
                 diffuseProbeGrid->UpdateRelocationSrg(m_shader, m_srgLayout);
-                diffuseProbeGrid->GetRelocationSrg()->Compile();
+                if (!diffuseProbeGrid->GetRelocationSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetRelocationSrg()->Compile();
+                }
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
@@ -201,7 +201,10 @@ namespace AZ
                 // (see ValidateSetImageView() of ShaderResourceGroupData.cpp)
                 diffuseProbeGrid->UpdateRenderObjectSrg();
 
-                diffuseProbeGrid->GetRenderObjectSrg()->Compile();
+                if (!diffuseProbeGrid->GetRenderObjectSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetRenderObjectSrg()->Compile();
+                }
             }
 
             if (auto viewSRG = diffuseProbeGridFeatureProcessor->GetViewSrg(m_pipeline, GetPipelineViewTag()))

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -248,7 +248,10 @@ namespace AZ
                 // the DiffuseProbeGrid Srg must be updated in the Compile phase in order to successfully bind the ReadWrite shader inputs
                 // (see ValidateSetImageView() in ShaderResourceGroupData.cpp)
                 diffuseProbeGrid->UpdateVisualizationPrepareSrg(m_shader, m_srgLayout);
-                diffuseProbeGrid->GetVisualizationPrepareSrg()->Compile();
+                if (!diffuseProbeGrid->GetVisualizationPrepareSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetVisualizationPrepareSrg()->Compile();
+                }
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -268,7 +268,10 @@ namespace AZ
                 // the DiffuseProbeGridVisualization Srg must be updated in the Compile phase in order to successfully bind the ReadWrite shader
                 // inputs (see line ValidateSetImageView() in ShaderResourceGroupData.cpp)
                 diffuseProbeGrid->UpdateVisualizationRayTraceSrg(m_rayTracingShader, m_globalSrgLayout, outputImageView);
-                diffuseProbeGrid->GetVisualizationRayTraceSrg()->Compile();
+                if (!diffuseProbeGrid->GetVisualizationRayTraceSrg()->IsQueuedForCompile())
+                {
+                    diffuseProbeGrid->GetVisualizationRayTraceSrg()->Compile();
+                }
             }
 
             if (auto viewSRG = diffuseProbeGridFeatureProcessor->GetViewSrg(m_pipeline, GetPipelineViewTag()))


### PR DESCRIPTION
## What does this PR do?

There was spurious warning from SRG compilation when DiffuseProbe grid was used with more than one pipeline. 

It can be considered a minor bug fix to spurious warning message.
## How was this PR tested?

Run with ROS 2 camera using :
https://github.com/o3de/o3de/pull/18254