### PR TITLE
Indirect Dispatch and updated Fullscreen Dispatch for RPI::ComputePass and RPI::RayTracingPass, 

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/IndirectRendering.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/IndirectRendering.azsli
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#pragma once
 
 // At the moment all RHI APIs share the same struct layout for the commands.
 // This could be become a per API header if needed in the future.

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
@@ -120,15 +120,6 @@ namespace AZ
                 }
             }
 
-            RHI::Size targetImageSize;
-            if (m_isFullscreenPass)
-            {
-                RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
-
-                targetImageSize = outputAttachment->m_descriptor.m_image.m_size;
-                SetTargetThreadCounts(targetImageSize.m_width, targetImageSize.m_height, targetImageSize.m_depth);
-            }
-
             RHI::Size sourceImageSize;
             RPI::PassAttachment* inputAttachment = GetInputBinding(0).GetAttachment().get();
             sourceImageSize = inputAttachment->m_descriptor.m_image.m_size;
@@ -136,7 +127,7 @@ namespace AZ
             // Update shader constant
             m_shaderResourceGroup->SetConstant(m_sourceImageTexelSizeInputIndex, AZ::Vector2(1.0f / static_cast<float>(sourceImageSize.m_width), 1.0f / static_cast<float>(sourceImageSize.m_height)));
 
-            RenderPass::FrameBeginInternal(params);
+            ComputePass::FrameBeginInternal(params);
         }
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FastDepthAwareBlurPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FastDepthAwareBlurPasses.cpp
@@ -50,7 +50,7 @@ namespace AZ
         {
             // Though this is a fullscreen pass, the algorithm used makes each thread output 3 blurred pixels, so
             // it's not a 1-to-1 ratio and requires custom calculation of target thread counts
-            m_isFullscreenPass = false;
+            m_fullscreenDispatch = false;
         }
 
         void FastDepthAwareBlurHorPass::SetConstants(float constFalloff, float depthFalloffThreshold, float depthFalloffStrength)
@@ -92,7 +92,7 @@ namespace AZ
         {
             // Though this is a fullscreen pass, the algorithm used makes each thread output 3 blurred pixels, so
             // it's not a 1-to-1 ratio and requires custom calculation of target thread counts
-            m_isFullscreenPass = false;
+            m_fullscreenDispatch = false;
         }
 
         void FastDepthAwareBlurVerPass::SetConstants(float constFalloff, float depthFalloffThreshold, float depthFalloffStrength)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
@@ -110,7 +110,7 @@ namespace AZ
         {
             // Though this is a fullscreen pass, the shader computes 16x16 tiles with groups of 8x8 threads,
             // each thread outputting to a single pixel in the tiled min/max texture
-            m_isFullscreenPass = false;
+            m_fullscreenDispatch = false;
         }
 
         void NewDepthOfFieldTileReducePass::FrameBeginInternal(FramePrepareParams params)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SubsurfaceScatteringPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SubsurfaceScatteringPass.h
@@ -33,7 +33,7 @@ namespace AZ
         protected:
             SubsurfaceScatteringPass(const PassDescriptor& descriptor);
 
-            void FrameBeginInternal(FramePrepareParams params) override;
+            void CompileResources(const RHI::FrameGraphCompileContext& context) override;
 
             // output texture vertical dimension required by compute shader
             AZ::RHI::ShaderInputNameIndex m_screenSizeInputIndex = "m_screenSize";

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -28,12 +28,9 @@
 #include <RayTracing/RayTracingPass.h>
 #include <RayTracing/RayTracingPassData.h>
 
-#ifndef INDIRECT_RENDERING_INCLUDE_GUARD
-#define INDIRECT_RENDERING_INCLUDE_GUARD
 using uint = uint32_t;
 using uint4 = uint[4];
 #include "../../../Feature/Common/Assets/ShaderLib/Atom/Features/IndirectRendering.azsli"
-#endif
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
@@ -7,12 +7,14 @@
  */
 #pragma once
 
-#include <AzCore/Memory/SystemAllocator.h>
+#include <Atom/RHI/DispatchRaysIndirectBuffer.h>
+#include <Atom/RHI/DispatchRaysItem.h>
 #include <Atom/RHI/RayTracingPipelineState.h>
 #include <Atom/RHI/RayTracingShaderTable.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
 {
@@ -42,6 +44,7 @@ namespace AZ
 
             // Pass overrides
             bool IsEnabled() const override;
+            void BuildInternal() override;
             void FrameBeginInternal(FramePrepareParams params) override;
 
             // Scope producer functions
@@ -64,6 +67,18 @@ namespace AZ
             RPI::PassDescriptor m_passDescriptor;
             const RayTracingPassData* m_passData = nullptr;
 
+            Name m_fullscreenSizeSourceSlot;
+            bool m_fullscreenDispatch = false;
+            RPI::PassAttachmentBinding* m_fullscreenSizeSourceBinding = nullptr;
+
+            bool m_indirectDispatch = false;
+            Name m_indirectDispatchBufferSlot;
+            RPI::PassAttachmentBinding* m_indirectDispatchRaysBufferBinding = nullptr;
+            RHI::Ptr<RHI::IndirectBufferSignature> m_indirectDispatchRaysBufferSignature;
+            RHI::IndirectBufferView m_indirectDispatchRaysBufferView;
+            RHI::Ptr<RHI::DispatchRaysIndirectBuffer> m_dispatchRaysIndirectBuffer;
+            uint32_t m_dispatchRaysShaderTableRevision{ std::numeric_limits<uint32_t>::max() };
+
             // revision number of the ray tracing TLAS when the shader table was built
             uint32_t m_rayTracingRevision = 0;
             uint32_t m_proceduralGeometryTypeRevision = 0;
@@ -82,6 +97,8 @@ namespace AZ
             bool m_requiresRayTracingMaterialSrg = false;
             bool m_requiresRayTracingSceneSrg = false;
             float m_maxRayLength = 1e27f;
+
+            AZ::RHI::DispatchRaysItem m_dispatchRaysItem{ AZ::RHI::MultiDevice::AllDevices };
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
@@ -46,6 +46,7 @@ namespace AZ
             bool IsEnabled() const override;
             void BuildInternal() override;
             void FrameBeginInternal(FramePrepareParams params) override;
+            void FrameEndInternal() override;
 
             // Scope producer functions
             void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
@@ -60,27 +61,24 @@ namespace AZ
             // load the raytracing shaders and setup pipeline states
             void CreatePipelineState();
 
-            // helper for loading a shader from a shader asset reference
-            Data::Instance<RPI::Shader> LoadShader(const RPI::AssetReference& shaderAssetReference);
-
             // pass data
             RPI::PassDescriptor m_passDescriptor;
             const RayTracingPassData* m_passData = nullptr;
 
-            Name m_fullscreenSizeSourceSlot;
+            Name m_fullscreenSizeSourceSlotName;
             bool m_fullscreenDispatch = false;
             RPI::PassAttachmentBinding* m_fullscreenSizeSourceBinding = nullptr;
 
             bool m_indirectDispatch = false;
-            Name m_indirectDispatchBufferSlot;
+            Name m_indirectDispatchBufferSlotName;
             RPI::PassAttachmentBinding* m_indirectDispatchRaysBufferBinding = nullptr;
             RHI::Ptr<RHI::IndirectBufferSignature> m_indirectDispatchRaysBufferSignature;
             RHI::IndirectBufferView m_indirectDispatchRaysBufferView;
             RHI::Ptr<RHI::DispatchRaysIndirectBuffer> m_dispatchRaysIndirectBuffer;
-            uint32_t m_dispatchRaysShaderTableRevision{ std::numeric_limits<uint32_t>::max() };
 
             // revision number of the ray tracing TLAS when the shader table was built
-            uint32_t m_rayTracingRevision = 0;
+            uint32_t m_rayTracingShaderTableRevision{ std::numeric_limits<uint32_t>::max() };
+            uint32_t m_dispatchRaysShaderTableRevision{ std::numeric_limits<uint32_t>::max() };
             uint32_t m_proceduralGeometryTypeRevision = 0;
 
             // raytracing shaders, pipeline states, and shader table
@@ -92,13 +90,20 @@ namespace AZ
             RHI::Ptr<RHI::RayTracingPipelineState> m_rayTracingPipelineState;
             RHI::ConstPtr<RHI::PipelineState> m_globalPipelineState;
             RHI::Ptr<RHI::RayTracingShaderTable> m_rayTracingShaderTable;
+
+            // [GFX TODO][ATOM-15610] Add RenderPass::SetSrgsForRayTracingDispatch
+            // Remove this as soon as we can use the RenderPass::BindSrg() for raytracing
+            AZStd::vector<RHI::ShaderResourceGroup*> m_rayTracingSRGsToBind;
+
             bool m_requiresViewSrg = false;
             bool m_requiresSceneSrg = false;
             bool m_requiresRayTracingMaterialSrg = false;
             bool m_requiresRayTracingSceneSrg = false;
             float m_maxRayLength = 1e27f;
 
-            AZ::RHI::DispatchRaysItem m_dispatchRaysItem{ AZ::RHI::MultiDevice::AllDevices };
+            RHI::ShaderInputNameIndex m_maxRayLengthInputIndex = "m_maxRayLength";
+
+            RHI::DispatchRaysItem m_dispatchRaysItem;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
@@ -48,9 +48,9 @@ namespace AZ
                         ->Field("Thread Count Y", &RayTracingPassData::m_threadCountY)
                         ->Field("Thread Count Z", &RayTracingPassData::m_threadCountZ)
                         ->Field("Make Fullscreen Pass", &RayTracingPassData::m_fullscreenDispatch)
-                        ->Field("FullscreenSizeSourceSlot", &RayTracingPassData::m_fullscreenSizeSourceSlot)
+                        ->Field("FullscreenSizeSourceSlotName", &RayTracingPassData::m_fullscreenSizeSourceSlotName)
                         ->Field("IndirectDispatch", &RayTracingPassData::m_indirectDispatch)
-                        ->Field("IndirectDispatchBufferSlot", &RayTracingPassData::m_indirectDispatchBufferSlot)
+                        ->Field("IndirectDispatchBufferSlotName", &RayTracingPassData::m_indirectDispatchBufferSlotName)
                         ->Field("Max Ray Length", &RayTracingPassData::m_maxRayLength);
                 }
             }
@@ -76,10 +76,10 @@ namespace AZ
             uint32_t m_threadCountZ = 1;
 
             bool m_fullscreenDispatch = false;
-            AZ::Name m_fullscreenSizeSourceSlot;
+            AZ::Name m_fullscreenSizeSourceSlotName;
 
             bool m_indirectDispatch = false;
-            AZ::Name m_indirectDispatchBufferSlot;
+            AZ::Name m_indirectDispatchBufferSlotName;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
@@ -47,9 +47,11 @@ namespace AZ
                         ->Field("Thread Count X", &RayTracingPassData::m_threadCountX)
                         ->Field("Thread Count Y", &RayTracingPassData::m_threadCountY)
                         ->Field("Thread Count Z", &RayTracingPassData::m_threadCountZ)
-                        ->Field("Make Fullscreen Pass", &RayTracingPassData::m_makeFullscreenPass)
-                        ->Field("Max Ray Length", &RayTracingPassData::m_maxRayLength)
-                        ;
+                        ->Field("Make Fullscreen Pass", &RayTracingPassData::m_fullscreenDispatch)
+                        ->Field("FullscreenSizeSourceSlot", &RayTracingPassData::m_fullscreenSizeSourceSlot)
+                        ->Field("IndirectDispatch", &RayTracingPassData::m_indirectDispatch)
+                        ->Field("IndirectDispatchBufferSlot", &RayTracingPassData::m_indirectDispatchBufferSlot)
+                        ->Field("Max Ray Length", &RayTracingPassData::m_maxRayLength);
                 }
             }
 
@@ -73,7 +75,11 @@ namespace AZ
             uint32_t m_threadCountY = 1;
             uint32_t m_threadCountZ = 1;
 
-            bool m_makeFullscreenPass = false;
+            bool m_fullscreenDispatch = false;
+            AZ::Name m_fullscreenSizeSourceSlot;
+
+            bool m_indirectDispatch = false;
+            AZ::Name m_indirectDispatchBufferSlot;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchRaysItem.h
@@ -9,6 +9,7 @@
 
 #include <Atom/RHI.Reflect/Limits.h>
 #include <Atom/RHI/DeviceDispatchRaysItem.h>
+#include <Atom/RHI/IndirectArguments.h>
 #include <Atom/RHI/DispatchRaysIndirectBuffer.h>
 #include <Atom/RHI/RayTracingAccelerationStructure.h>
 #include <Atom/RHI/RayTracingPipelineState.h>
@@ -182,7 +183,7 @@ namespace AZ::RHI
 
                 auto& [index, deviceShaderResourceGroup]{ *it };
 
-                for (int i = 0; i < shaderResourceGroupCount; ++i)
+                for (int i = 0; i < static_cast<int>(shaderResourceGroupCount); ++i)
                 {
                     deviceShaderResourceGroup[i] = shaderResourceGroups[i]->GetDeviceShaderResourceGroup(deviceIndex).get();
                 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
@@ -59,7 +59,7 @@ namespace AZ
             ComputePass(const PassDescriptor& descriptor, AZ::Name supervariant = AZ::Name(""));
 
             // Pass behavior overrides...
-            void FrameBeginInternal(FramePrepareParams params) override;
+            void BuildInternal() override;
 
             // Scope producer functions...
             void CompileResources(const RHI::FrameGraphCompileContext& context) override;
@@ -78,9 +78,18 @@ namespace AZ
             // The draw item submitted by this pass
             RHI::DispatchItem m_dispatchItem;
 
-            // Whether or not to make the pass a full-screen compute pass. If set to true, the dispatch group counts will
-            // be automatically calculated from the size of the first output attachment and the group size dimensions.
-            bool m_isFullscreenPass = false;
+            // Whether or not to make the pass a full-screen compute pass, and which slot to use as the size source
+            AZ::Name m_fullscreenSizeSourceSlotName;
+            bool m_fullscreenDispatch = false;
+            AZ::RPI::PassAttachmentBinding* m_fullscreenSizeSourceBinding = nullptr;
+
+            // Wheter or not to make the pass a indirect dispatch compute pass, and which slot to use as indirect dispatch
+            // command buffer
+            bool m_indirectDispatch = false;
+            AZ::Name m_indirectDispatchBufferSlotName;
+            AZ::RPI::PassAttachmentBinding* m_indirectDispatchBufferBinding = nullptr;
+            AZ::RHI::Ptr<AZ::RHI::IndirectBufferSignature> m_indirectDispatchBufferSignature;
+            AZ::RHI::IndirectBufferView m_indirectDispatchBufferView;
 
             // ShaderReloadNotificationBus::Handler overrides...
             void OnShaderReinitialized(const Shader& shader) override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/ComputePassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/ComputePassData.h
@@ -32,7 +32,11 @@ namespace AZ
             uint32_t m_totalNumberOfThreadsY = 0;
             uint32_t m_totalNumberOfThreadsZ = 0;
 
-            bool m_makeFullscreenPass = false;
+            bool m_fullscreenDispatch = false;
+            AZ::Name m_fullscreenSizeSourceSlotName;
+
+            bool m_indirectDispatch = false;
+            AZ::Name m_indirectDispatchBufferSlotName;
 
             // Whether the pass should use async compute and run on the compute hardware queue.
             bool m_useAsyncCompute = false;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -25,6 +25,13 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
+#ifndef INDIRECT_RENDERING_INCLUDE_GUARD
+#define INDIRECT_RENDERING_INCLUDE_GUARD
+using uint = uint32_t;
+using uint4 = uint[4];
+#include "../../../Feature/Common/Assets/ShaderLib/Atom/Features/IndirectRendering.azsli"
+#endif
+
 namespace AZ
 {
     namespace RPI
@@ -52,6 +59,17 @@ namespace AZ
                     "PassSystem", false, "[ComputePass '%s']: Trying to construct without valid ComputePassData!", GetPathName().GetCStr());
                 return;
             }
+
+            m_indirectDispatch = passData->m_indirectDispatch;
+            m_indirectDispatchBufferSlotName = passData->m_indirectDispatchBufferSlotName;
+
+            m_fullscreenDispatch = passData->m_fullscreenDispatch;
+            m_fullscreenSizeSourceSlotName = passData->m_fullscreenSizeSourceSlotName;
+
+            AZ_Assert(
+                !(m_indirectDispatch && m_fullscreenDispatch),
+                "[ComputePass '%s']: Only one of the dispatch options (indirect, fullscreen) can be active.",
+                GetPathName().GetCStr());
 
             RHI::DispatchDirect dispatchArgs;
             dispatchArgs.m_totalNumberOfThreadsX = passData->m_totalNumberOfThreadsX;
@@ -140,8 +158,6 @@ namespace AZ
                 m_dispatchItem.SetArguments(arguments);
             }
 
-            m_isFullscreenPass = passData->m_makeFullscreenPass;
-
             // Setup pipeline state...
             RHI::PipelineStateDescriptorForDispatch pipelineStateDescriptor;
             ShaderOptionGroup options = m_shader->GetDefaultShaderOptions();
@@ -173,6 +189,55 @@ namespace AZ
                 BindSrg(m_drawSrg->GetRHIShaderResourceGroup());
                 m_drawSrg->Compile();
             }
+
+            if (m_indirectDispatch && m_indirectDispatchBufferBinding)
+            {
+                auto& attachment = m_indirectDispatchBufferBinding->GetAttachment();
+                AZ_Assert(
+                    attachment,
+                    "[ComputePass '%s']: Indirect dispatch buffer slot %s has no attachment.",
+                    GetPathName().GetCStr(),
+                    m_indirectDispatchBufferBinding->m_name.GetCStr());
+
+                if (attachment)
+                {
+                    auto buffer = context.GetBuffer(attachment->GetAttachmentId());
+                    AZ_Assert(
+                        buffer,
+                        "[ComputePass '%s']: Attachment connected to Indirect dispatch buffer slot %s has no buffer",
+                        GetPathName().GetCStr(),
+                        m_indirectDispatchBufferBinding->m_name.GetCStr());
+                    m_indirectDispatchBufferView = {
+                        *buffer, *m_indirectDispatchBufferSignature, 0, sizeof(DispatchIndirectCommand), sizeof(DispatchIndirectCommand)
+                    };
+
+                    AZ::RHI::DispatchIndirect dispatchArgs(1, m_indirectDispatchBufferView, 0);
+                    m_dispatchItem.SetArguments(dispatchArgs);
+                }
+            }
+            else if (m_fullscreenDispatch && m_fullscreenSizeSourceBinding)
+            {
+                auto& attachment = m_fullscreenSizeSourceBinding->GetAttachment();
+                AZ_Assert(
+                    attachment,
+                    "[ComputePass '%s']: Slot %s has no attachment for fullscreen size source.",
+                    GetPathName().GetCStr(),
+                    m_fullscreenSizeSourceBinding->m_name.GetCStr());
+                if (attachment)
+                {
+                    AZ_Assert(
+                        attachment->GetAttachmentType() == AZ::RHI::AttachmentType::Image,
+                        "[ComputePass '%s']: Slot %s must be an image for fullscreen size source.",
+                        GetPathName().GetCStr(),
+                        m_fullscreenSizeSourceBinding->m_name.GetCStr());
+
+                    auto imageDescriptor = context.GetImageDescriptor(attachment->GetAttachmentId());
+                    // We are using the ArraySize or the image depth, whichever is bigger.
+                    // Note that this will fail for an array of 3d textures.
+                    auto depth = AZStd::max(imageDescriptor.m_size.m_depth, static_cast<uint32_t>(imageDescriptor.m_arraySize));
+                    SetTargetThreadCounts(imageDescriptor.m_size.m_width, imageDescriptor.m_size.m_height, depth);
+                }
+            }
         }
 
         void ComputePass::BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context)
@@ -182,31 +247,6 @@ namespace AZ
             SetSrgsForDispatch(context);
 
             commandList->Submit(m_dispatchItem.GetDeviceDispatchItem(context.GetDeviceIndex()));
-        }
-
-        void ComputePass::MatchDimensionsToOutput()
-        {
-            PassAttachment* outputAttachment = nullptr;
-
-            if (GetOutputCount() > 0)
-            {
-                outputAttachment = GetOutputBinding(0).GetAttachment().get();
-            }
-            else if (GetInputOutputCount() > 0)
-            {
-                outputAttachment = GetInputOutputBinding(0).GetAttachment().get();
-            }
-
-            AZ_Assert(outputAttachment != nullptr, "[ComputePass '%s']: A fullscreen compute pass must have a valid output or input/output.",
-                GetPathName().GetCStr());
-
-            AZ_Assert(outputAttachment->GetAttachmentType() == RHI::AttachmentType::Image,
-                "[ComputePass '%s']: The output of a fullscreen compute pass must be an image.",
-                GetPathName().GetCStr());
-
-            RHI::Size targetImageSize = outputAttachment->m_descriptor.m_image.m_size;
-
-            SetTargetThreadCounts(targetImageSize.m_width, targetImageSize.m_height, targetImageSize.m_depth);
         }
 
         void ComputePass::SetTargetThreadCounts(uint32_t targetThreadCountX, uint32_t targetThreadCountY, uint32_t targetThreadCountZ)
@@ -228,14 +268,92 @@ namespace AZ
             return m_shader;
         }
 
-        void ComputePass::FrameBeginInternal(FramePrepareParams params)
+        void ComputePass::BuildInternal()
         {
-            if (m_isFullscreenPass)
-            {
-                MatchDimensionsToOutput();
-            }
+            RenderPass::BuildInternal();
 
-            RenderPass::FrameBeginInternal(params);
+            if (m_indirectDispatch)
+            {
+                m_indirectDispatchBufferBinding = nullptr;
+                if (!m_indirectDispatchBufferSlotName.IsEmpty())
+                {
+                    m_indirectDispatchBufferBinding = FindAttachmentBinding(m_indirectDispatchBufferSlotName);
+                    AZ_Assert(m_indirectDispatchBufferBinding,
+                            "[ComputePass '%s']: Indirect dispatch buffer slot %s not found.",
+                            GetPathName().GetCStr(),
+                            m_indirectDispatchBufferSlotName.GetCStr());
+                    if (m_indirectDispatchBufferBinding)
+                    {
+                        AZ_Assert(
+                            m_indirectDispatchBufferBinding->m_scopeAttachmentUsage == AZ::RHI::ScopeAttachmentUsage::Indirect,
+                            "[ComputePass '%s']: Indirect dispatch buffer slot %s needs ScopeAttachmentUsage::Indirect.",
+                            GetPathName().GetCStr(),
+                            m_indirectDispatchBufferSlotName.GetCStr())
+                    }
+                }
+                else
+                {
+                    for (auto& binding : m_attachmentBindings)
+                    {
+                        if (binding.m_scopeAttachmentUsage == AZ::RHI::ScopeAttachmentUsage::Indirect)
+                        {
+                            m_indirectDispatchBufferBinding = &binding;
+                            break;
+                        }
+                    }
+                    AZ_Assert(
+                        m_indirectDispatchBufferBinding,
+                        "[ComputePass '%s']: No valid indirect dispatch buffer slot found.",
+                        GetPathName().GetCStr());
+                }
+
+                AZ::RHI::IndirectBufferLayout indirectDispatchBufferLayout;
+                indirectDispatchBufferLayout.AddIndirectCommand(AZ::RHI::IndirectCommandDescriptor(AZ::RHI::IndirectCommandType::Dispatch));
+
+                if (!indirectDispatchBufferLayout.Finalize())
+                {
+                    AZ_Assert(false, "[ComputePass '%s']: Failed to finalize Indirect Layout", GetPathName().GetCStr());
+                }
+
+                m_indirectDispatchBufferSignature = aznew AZ::RHI::IndirectBufferSignature;
+                AZ::RHI::IndirectBufferSignatureDescriptor signatureDescriptor{};
+                signatureDescriptor.m_layout = indirectDispatchBufferLayout;
+                [[maybe_unused]] auto result =
+                    m_indirectDispatchBufferSignature->Init(AZ::RHI::MultiDevice::AllDevices, signatureDescriptor);
+
+                AZ_Assert(
+                    result == AZ::RHI::ResultCode::Success,
+                    "[ComputePass '%s']: Failed to initialize Indirect Buffer Signature",
+                    GetPathName().GetCStr());
+            }
+            else if (m_fullscreenDispatch)
+            {
+                m_fullscreenSizeSourceBinding = nullptr;
+                if (!m_fullscreenSizeSourceSlotName.IsEmpty())
+                {
+                    m_fullscreenSizeSourceBinding = FindAttachmentBinding(m_fullscreenSizeSourceSlotName);
+                    AZ_Assert(
+                        m_fullscreenSizeSourceBinding,
+                        "[ComputePass '%s']: Fullscreen size source slot %s not found.",
+                        GetPathName().GetCStr(),
+                        m_fullscreenSizeSourceSlotName.GetCStr());
+                }
+                else
+                {
+                    if (GetOutputCount() > 0)
+                    {
+                        m_fullscreenSizeSourceBinding = &GetOutputBinding(0);
+                    }
+                    else if (!m_fullscreenSizeSourceBinding && GetInputOutputCount() > 0)
+                    {
+                        m_fullscreenSizeSourceBinding = &GetInputOutputBinding(0);
+                    }
+                    AZ_Assert(
+                        m_fullscreenSizeSourceBinding,
+                        "[ComputePass '%s']: No valid Output or InputOutput slot as a fullscreen size source found.",
+                        GetPathName().GetCStr());
+                }
+            }
         }
 
         void ComputePass::OnShaderReinitialized(const Shader& shader)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -25,12 +25,9 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#ifndef INDIRECT_RENDERING_INCLUDE_GUARD
-#define INDIRECT_RENDERING_INCLUDE_GUARD
 using uint = uint32_t;
 using uint4 = uint[4];
 #include "../../../Feature/Common/Assets/ShaderLib/Atom/Features/IndirectRendering.azsli"
-#endif
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
@@ -164,14 +164,16 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<ComputePassData, RenderPassData>()
-                    ->Version(2)
+                    ->Version(3)
                     ->Field("ShaderAsset", &ComputePassData::m_shaderReference)
                     ->Field("Target Thread Count X", &ComputePassData::m_totalNumberOfThreadsX)
                     ->Field("Target Thread Count Y", &ComputePassData::m_totalNumberOfThreadsY)
                     ->Field("Target Thread Count Z", &ComputePassData::m_totalNumberOfThreadsZ)
-                    ->Field("Make Fullscreen Pass", &ComputePassData::m_makeFullscreenPass)
-                    ->Field("Use Async Compute", &ComputePassData::m_useAsyncCompute)
-                    ;
+                    ->Field("Make Fullscreen Pass", &ComputePassData::m_fullscreenDispatch)
+                    ->Field("FullscreenSizeSourceSlotName", &ComputePassData::m_fullscreenSizeSourceSlotName)
+                    ->Field("IndirectDispatch", &ComputePassData::m_indirectDispatch)
+                    ->Field("IndirectDispatchBufferSlotName", &ComputePassData::m_indirectDispatchBufferSlotName)
+                    ->Field("Use Async Compute", &ComputePassData::m_useAsyncCompute);
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This adds a "IndirectDispatch" flag and a "IndirectDispatchBufferSlot", which assumes whatever buffer is attached to the slot uses the `DispatchIndirectCommand`  or the `DispatchRaysIndirectCommand` structure and contains the desired number of threads, to allow Indirect Dispatch of Compute and Raytracing - passes from the .pass file. 

Additionally, currently both the ComputePass and RayTracingPass have the flag "Make Fullscreen Pass", which selects the first input or inputOutput slot and uses it as source for the number of threads. This can be somewhat brittle, since the number of threads can then unintentionally change simply by re-orders the slots during development.

This PR now also adds a "FullscreenSizeSourceSlot" field that allows selecting the slot name that will be used to determine the number of threads. Note that this is not a breaking change; if the field is empty, the same behavior as before will be used.

To keep the logic of  IndirectDispatch and FullscreenDispatch the same for both ComputePass and RayTracingPass, i've modified the RayTracingPass to bring it closer in line with the ComputePass, mostly by creating a DispatchRaysItem as class member, and compiling / adding the SRGs in CompileInternal(), and submitting the prepared DispatchRaysItem in BuildCommandlistInternal(). Note that this isn't fully complete: There is no `RenderPass::BindSrgsForDispatchRays()` that is analoque to the `RenderPass::BindSrgsForDispatch()` used by the ComputePass, but i've tried to get close, and i've created the issue https://github.com/o3de/o3de/issues/18275 to keep a reminder of that. 

The logic for the IndirectDispatch and FullscreenDispatch is now:
- in `BuildInternal()` the pass checks the flags and selects a attachment-binding (aka slot) that will be used for the different dispatch calls. It will search for the slot-name if it is given, but will select the first Input/InputOutput slot otherwise, to replicate the previous behavior. For the IndirectDispatch the slot needs ScopeAttachmentUsage::Indirect. This will raise an assert if one of the flags is set, but no suitable slot was found.

- in  `CompileResources()` Pass then uses the slot and asks the FrameGraph for the actual size of the Attachment / creates a buffer-view for the indirect dispatch buffer, and modifies the dispatch-item accordingly. 

## How was this PR tested?

With DX12 and Vulkan on windows, making sure that the MainRenderPipeline still works, and using a custom Pipeline with several Indirect-Dispatch passes.