### PR TITLE
Fixes crash on close of Asset AssetEditor (#18216)

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.h
@@ -53,7 +53,6 @@ namespace AzToolsFramework
             , private AZ::Data::AssetBus::MultiHandler
             , private AzFramework::AssetCatalogEventBus::Handler
             , private AzToolsFramework::IPropertyEditorNotify
-            , private AZ::SystemTickBus::Handler
         {
             Q_OBJECT
 
@@ -89,6 +88,11 @@ namespace AzToolsFramework
             void ExpandAll();
             void CollapseAll();
 
+        private Q_SLOTS:
+            // note, intentionally not a reference to a QString - we want to make a copy of the string since this could be a queued thread call
+            // Also note, QStrings are reference counted copy-on-write, so this is not as expensive as it seems (++incref cost)
+            void ApplyStatusText(QString newStatus);
+
             // For subscribing to document property editor adapter property specific changes
             void OnDocumentPropertyChanged(const AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeInfo& changeInfo);
         Q_SIGNALS:
@@ -119,15 +123,9 @@ namespace AzToolsFramework
             void DirtyAsset();
 
             void SetStatusText(const QString& assetStatus);
-            void ApplyStatusText();
             void SetupHeader();
 
             void SaveAssetImpl(const AZStd::function<void()>& savedCallback);
-
-            QString m_queuedAssetStatus;
-
-            // AZ::SystemTickBus
-            void OnSystemTick() override;
 
             AZ::Data::AssetId m_sourceAssetId;
             AZ::Data::Asset<AZ::Data::AssetData> m_inMemoryAsset;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -218,7 +218,6 @@ namespace AzToolsFramework
 
         AssetEditorWidget::~AssetEditorWidget()
         {
-            AZ::SystemTickBus::Handler::BusDisconnect();
         }
 
         void AssetEditorWidget::SaveAll()
@@ -248,14 +247,6 @@ namespace AzToolsFramework
                     {
                         return;
                     }
-                }
-
-                // Close them.
-                for (int tabIndex = m_tabs->count() - 1; tabIndex >= 0; tabIndex--)
-                {
-                    AssetEditorTab* tab = qobject_cast<AssetEditorTab*>(m_tabs->widget(tabIndex));
-                    m_tabs->removeTab(tabIndex);
-                    delete tab;
                 }
 
                 CloseOnNextTick();
@@ -485,16 +476,21 @@ namespace AzToolsFramework
             }
         }
 
-        void AssetEditorWidget::OnSystemTick()
-        {
-            parentWidget()->parentWidget()->close();
-            AZ::SystemTickBus::Handler::BusDisconnect();
-        }
-
         void AssetEditorWidget::CloseOnNextTick()
         {
             // Close the window on the next tick so that the parent widgets finish processing any current event correctly.
-            AZ::SystemTickBus::Handler::BusConnect();
+            QTimer::singleShot(0, this, [this]()
+            {
+                    // Close tabs
+                for (int tabIndex = m_tabs->count() - 1; tabIndex >= 0; tabIndex--)
+                {
+                    AssetEditorTab* tab = qobject_cast<AssetEditorTab*>(m_tabs->widget(tabIndex));
+                    m_tabs->removeTab(tabIndex);
+                    tab->deleteLater();
+                }
+
+                parentWidget()->parentWidget()->close();
+            });
         }
 
         void AssetEditorWidget::CloseTabAndContainerIfEmpty(AssetEditorTab* tab)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -71,7 +71,6 @@ namespace AzToolsFramework
          */
         class AssetEditorWidget
             : public QWidget
-            , private AZ::SystemTickBus::Handler
         {
             Q_OBJECT
 
@@ -131,8 +130,6 @@ namespace AzToolsFramework
 
             void PopulateRecentMenu();
 
-            // AZ::SystemTickBus
-            void OnSystemTick() override;
             void CloseOnNextTick();
 
             AzQtComponents::TabWidget* m_tabs;


### PR DESCRIPTION
## What does this PR do?

This cherry-picks the changes already submitted from https://github.com/o3de/o3de/pull/18216 from stabilization into development.

Fixes issue: https://github.com/o3de/o3de/issues/14878

There were actually 2 issues here, both are fixed by this.

One is a use-after-free, it would attempt to talk to the tab after the tab was deleted, by deleting the tab prematurely in the save handler, instead of on close.

The other was the assumption that the source control "RequestEdit" operation was synchronous.  It is not - it exits immediately after queueing the event.  This caused the code to leave scope and clean up (including deleting the variables in lambda captures) before the operation was complete.

ust manual testing. This was a 100% crash and it even corrupted data files since it brought the app down during save-write.

Tested a few operations

    Closing with many unsaved tabs and saying "yes" to all
    Closing with many unsaved tabs and saying "yes" to some, no to others
    Closing with many unsaved tabs, and saying "yes" to some, no to others, and "cancel" to one
    Same test as above, closing and saying "yes", "no, "cancel" with just 1 tab unsaved
    Same as above, but with a mixture of saved and unsaved tabs.
