### PR TITLE
Fix DynamicDrawContext to use shader options properly

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h
@@ -45,7 +45,8 @@ namespace AZ
                 DepthState = AZ_BIT(1),
                 StencilState = AZ_BIT(2),
                 FaceCullMode = AZ_BIT(3),
-                BlendMode = AZ_BIT(4)
+                BlendMode = AZ_BIT(4),
+                ShaderVariant = AZ_BIT(5)
             };
 
             struct VertexChannel
@@ -208,6 +209,7 @@ namespace AZ
                 RHI::StencilState m_stencilState;
                 RHI::PrimitiveTopology m_topology;
                 RHI::TargetBlendState m_blendState0;
+                RPI::ShaderVariantId m_shaderVariantId;
 
                 HashValue64 m_hash = HashValue64{ 0 };
                 bool m_isDirty = false;
@@ -289,7 +291,6 @@ namespace AZ
 
             // Flags if this DynamicDrawContext can change shader variants
             bool m_supportShaderVariants = false;
-            ShaderVariantId m_currentShaderVariantId;
 
             Data::Instance<Shader> m_shader;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/PipelineState.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/PipelineState.h
@@ -68,6 +68,10 @@ namespace AZ
             //! Use ConstDescriptor() to access read-only InputStreamLayout
             RHI::InputStreamLayout& InputStreamLayout();
 
+            //! Updates the current shader variant id.
+            //! It sets this pipeline state to dirty whenever it's called.
+            void UpdateShaderVaraintId(const ShaderVariantId& shaderVariantId);
+
             const RHI::PipelineStateDescriptorForDraw& ConstDescriptor() const;
 
             //! Get the shader which is associated with this PipelineState

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
@@ -79,6 +79,12 @@ namespace AZ
                 seed = TypeHash64(m_blendState0.m_blendAlphaDest, seed);
             }
 
+            if (RHI::CheckBitsAny(drawStateOptions, DrawStateOptions::ShaderVariant))
+            {
+                seed = TypeHash64(m_shaderVariantId.m_key, seed);
+                seed = TypeHash64(m_shaderVariantId.m_mask, seed);
+            }
+
             m_hash = seed;
             m_isDirty = false;
         }
@@ -213,6 +219,7 @@ namespace AZ
             m_currentStates.m_depthState = m_pipelineState->ConstDescriptor().m_renderStates.m_depthStencilState.m_depth;
             m_currentStates.m_stencilState = m_pipelineState->ConstDescriptor().m_renderStates.m_depthStencilState.m_stencil;
             m_currentStates.m_blendState0 = m_pipelineState->ConstDescriptor().m_renderStates.m_blendState.m_targets[0];
+            m_currentStates.m_shaderVariantId = m_pipelineState->GetShaderVariantId();
             m_currentStates.UpdateHash(m_drawStateOptions);
 
             m_cachedRhiPipelineStates[m_currentStates.m_hash] = m_pipelineState->GetRHIPipelineState();
@@ -451,7 +458,19 @@ namespace AZ
                 return;
             }
 
-            m_currentShaderVariantId = shaderVariantId;
+            if (RHI::CheckBitsAny(m_drawStateOptions, DrawStateOptions::ShaderVariant))
+            {
+                if (m_currentStates.m_shaderVariantId != shaderVariantId)
+                {
+                    m_currentStates.m_shaderVariantId = shaderVariantId;
+                    m_currentStates.m_isDirty = true;
+                }
+            }
+            else
+            {
+                AZ_Warning("RHI", false, "Can't set SetShaderVariant if DrawVariation::ShaderVariant wasn't enabled");
+            }
+
         }
 
         void DynamicDrawContext::DrawIndexed(const void* vertexData, uint32_t vertexCount, const void* indexData, uint32_t indexCount, RHI::IndexFormat indexFormat, Data::Instance < ShaderResourceGroup> drawSrg)
@@ -659,7 +678,7 @@ namespace AZ
                 // If the dynamic draw context support multiple shader variants, it uses m_currentShaderVariantId to setup srg shader variant fallback key
                 if (m_supportShaderVariants)
                 {
-                    drawSrg->SetShaderVariantKeyFallbackValue(m_currentShaderVariantId.m_key);
+                    drawSrg->SetShaderVariantKeyFallbackValue(m_currentStates.m_shaderVariantId.m_key);
                 }
                 // otherwise use the m_pipelineState to config the fallback
                 else
@@ -809,6 +828,10 @@ namespace AZ
                 if (RHI::CheckBitsAny(m_drawStateOptions, DrawStateOptions::BlendMode))
                 {
                     m_pipelineState->RenderStatesOverlay().m_blendState.m_targets[0] = m_currentStates.m_blendState0;
+                }
+                if (RHI::CheckBitsAny(m_drawStateOptions, DrawStateOptions::ShaderVariant))
+                {
+                    m_pipelineState->UpdateShaderVaraintId(m_currentStates.m_shaderVariantId);
                 }
 
                 const RHI::PipelineState* pipelineState = m_pipelineState->Finalize();                

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/PipelineState.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/PipelineState.cpp
@@ -71,26 +71,16 @@ namespace AZ
             // Reset some variables
             m_pipelineState = nullptr;
 
-            // Reset some flags
-            m_dirty = true;
-            m_isShaderVariantReady = true;
+            // Cache shader so it can be used for create RHI::PipelineState later
+            m_shader = shader;
 
-            // Get shader variant from the shader
-            m_shaderVariantId = shaderVariantId;
-            ShaderVariant shaderVariant = shader->GetVariant(m_shaderVariantId);
-            m_isShaderVariantReady = !shaderVariant.UseKeyFallback();
-
-            // Fill the descriptor with data from shader variant
-            shaderVariant.ConfigurePipelineState(m_descriptor, m_shaderVariantId);
-
+            UpdateShaderVaraintId(shaderVariantId);
+            
             // Connect to shader reload notification bus to rebuilt pipeline state when shader or shader variant changed.
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
             ShaderReloadNotificationBus::MultiHandler::BusConnect(shader->GetAsset().GetId());
 
             m_initDataFromShader = true;
-
-            // Cache shader so it can be used for create RHI::PipelineState later
-            m_shader = shader;
         }
 
         void PipelineStateForDraw::RefreshShaderVariant()
@@ -203,6 +193,19 @@ namespace AZ
         {
             m_dirty = true;
             return m_descriptor.m_inputStreamLayout;
+        }
+
+        void PipelineStateForDraw::UpdateShaderVaraintId(const ShaderVariantId& shaderVariantId)
+        {
+            m_dirty = true;
+
+            // Get shader variant from the shader
+            m_shaderVariantId = shaderVariantId;
+            ShaderVariant shaderVariant = m_shader->GetVariant(m_shaderVariantId);
+            m_isShaderVariantReady = !shaderVariant.UseKeyFallback();
+
+            // Fill the descriptor with data from shader variant
+            shaderVariant.ConfigurePipelineState(m_descriptor, m_shaderVariantId);
         }
 
         const RHI::PipelineStateDescriptorForDraw& PipelineStateForDraw::ConstDescriptor() const

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -117,7 +117,8 @@ void CDraw2d::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
         {"TEXCOORD0", AZ::RHI::Format::R32G32_FLOAT} });
     m_dynamicDraw->AddDrawStateOptions(AZ::RPI::DynamicDrawContext::DrawStateOptions::PrimitiveType
         | AZ::RPI::DynamicDrawContext::DrawStateOptions::BlendMode
-        | AZ::RPI::DynamicDrawContext::DrawStateOptions::DepthState);
+        | AZ::RPI::DynamicDrawContext::DrawStateOptions::DepthState
+        | AZ::RPI::DynamicDrawContext::DrawStateOptions::ShaderVariant);
     // Use scene as output scope (will render to the UiCanvas child pass of the LyShine pass)
     m_dynamicDraw->SetOutputScope(scene);
     m_dynamicDraw->InitDrawListTag(uiCanvasPass->GetDrawListTag());

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -145,8 +145,8 @@ AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> UiRenderer::CreateDynamicDrawContext(
         { "TEXCOORD", AZ::RHI::Format::R32G32_FLOAT },
         { "BLENDINDICES", AZ::RHI::Format::R16G16_UINT } }
     );
-    dynamicDraw->AddDrawStateOptions(AZ::RPI::DynamicDrawContext::DrawStateOptions::StencilState
-        | AZ::RPI::DynamicDrawContext::DrawStateOptions::BlendMode);
+    dynamicDraw->AddDrawStateOptions(AZ::RPI::DynamicDrawContext::DrawStateOptions::StencilState | AZ::RPI::DynamicDrawContext::DrawStateOptions::BlendMode |
+        AZ::RPI::DynamicDrawContext::DrawStateOptions::ShaderVariant);
 
     dynamicDraw->SetOutputScope(m_scene);
     dynamicDraw->EndInit();
@@ -267,8 +267,8 @@ AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> UiRenderer::CreateDynamicDrawContextFo
         { "TEXCOORD", AZ::RHI::Format::R32G32_FLOAT },
         { "BLENDINDICES", AZ::RHI::Format::R16G16_UINT } }
     );
-    dynamicDraw->AddDrawStateOptions(AZ::RPI::DynamicDrawContext::DrawStateOptions::StencilState
-        | AZ::RPI::DynamicDrawContext::DrawStateOptions::BlendMode);
+    dynamicDraw->AddDrawStateOptions(AZ::RPI::DynamicDrawContext::DrawStateOptions::StencilState | AZ::RPI::DynamicDrawContext::DrawStateOptions::BlendMode |
+        AZ::RPI::DynamicDrawContext::DrawStateOptions::ShaderVariant);
 
     dynamicDraw->SetOutputScope(rttPass);
     dynamicDraw->InitDrawListTag(rttPass->GetDrawListTag());


### PR DESCRIPTION
## What does this PR do?

Fix DynamicDrawContext to use shader options when specialization constant are enabled.

## How was this PR tested?

Run PC DX12 and Vulkan