### PR TITLE
[Cherry-pick] Fix interval_map continuous overlap (#18195)

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/interval_map.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/interval_map.h
@@ -218,33 +218,33 @@ namespace AZ::RHI
                 return pair<const_iterator, const_iterator>(end(), end());
             }
 
-            auto lower_bound = m_container.upper_bound(lower);
-            auto upper_bound = m_container.upper_bound(upper);
-            if (lower_bound == m_container.end() || upper_bound == m_container.begin())
+            auto lower_limit = m_container.upper_bound(lower);
+            auto upper_limit = m_container.lower_bound(upper);
+            if (lower_limit == m_container.end() || upper_limit == m_container.begin())
             {
                 return pair<const_iterator, const_iterator>(end(), end());
             }
 
             const_iterator begin_range;
             const_iterator end_range;
-            if (lower_bound == m_container.begin())
+            if (lower_limit == m_container.begin())
             {
-                begin_range = const_iterator(m_container, lower_bound);
+                begin_range = const_iterator(m_container, lower_limit);
             }
             else
             {
-                auto prev = AZStd::prev(lower_bound);
-                begin_range = const_iterator(m_container, has_value(prev) ? prev : lower_bound);
+                auto prev = AZStd::prev(lower_limit);
+                begin_range = const_iterator(m_container, has_value(prev) ? prev : lower_limit);
             }
 
-            if (upper_bound == m_container.end())
+            if (upper_limit == m_container.end())
             {
-                end_range = const_iterator(m_container, upper_bound);
+                end_range = const_iterator(m_container, upper_limit);
             }
             else
             {
-                auto next = AZStd::next(upper_bound);
-                end_range = const_iterator(m_container, has_value(upper_bound) ? upper_bound : next);
+                auto next = AZStd::next(upper_limit);
+                end_range = const_iterator(m_container, has_value(upper_limit) ? upper_limit : next);
             }
 
             return pair<const_iterator, const_iterator>(begin_range, end_range);

--- a/Gems/Atom/RHI/Code/Tests/IntervalMapTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/IntervalMapTests.cpp
@@ -136,15 +136,56 @@ namespace UnitTest
         EXPECT_EQ(iter.interval_end(), interval2.m_max);
         iter++;
         EXPECT_EQ(iter, m_intervalMap.end());
+        overlap = m_intervalMap.overlap(interval1.m_min, interval2.m_min);
+        iter = overlap.first;
+        EXPECT_EQ(iter.value(), 1337);
+        EXPECT_EQ(iter.interval_begin(), interval1.m_min);
+        EXPECT_EQ(iter.interval_end(), interval1.m_max);
+        iter++;
+        EXPECT_EQ(iter, overlap.second);
+        overlap = m_intervalMap.overlap(interval1.m_min, interval2.m_min + 1);
+        iter = overlap.first;
+        EXPECT_EQ(iter.value(), 1337);
+        EXPECT_EQ(iter.interval_begin(), interval1.m_min);
+        EXPECT_EQ(iter.interval_end(), interval1.m_max);
+        iter++;
+        EXPECT_EQ(iter.value(), 1338);
+        EXPECT_EQ(iter.interval_begin(), interval2.m_min);
+        EXPECT_EQ(iter.interval_end(), interval2.m_max);
+        iter++;
+        EXPECT_EQ(iter, m_intervalMap.end());
     }
 
     TEST_F(IntervalMapTests, TestNoOverlap)
     {
         RHI::Interval interval(0, 500);
         m_intervalMap.assign(interval.m_min, interval.m_max, 1337);
-        auto overlap = m_intervalMap.overlap(interval.m_max, interval.m_max + 1);
+        auto overlap = m_intervalMap.overlap(interval.m_max, interval.m_max);
         EXPECT_EQ(overlap.first, m_intervalMap.end());
         EXPECT_EQ(overlap.second, m_intervalMap.end());
+    }
+
+    TEST_F(IntervalMapTests, TestOverlapContinuousIntervals)
+    {
+        RHI::Interval interval1(0, 500);
+        RHI::Interval interval2(500, 1000);
+        m_intervalMap.assign(interval1.m_min, interval1.m_max, 1337);
+        m_intervalMap.assign(interval2.m_min, interval2.m_max, 1338);
+        auto overlap = m_intervalMap.overlap(interval1.m_min, interval1.m_max);
+        auto iter = overlap.first;
+        EXPECT_EQ(iter.value(), 1337);
+        EXPECT_EQ(iter.interval_begin(), interval1.m_min);
+        EXPECT_EQ(iter.interval_end(), interval1.m_max);
+        iter++;
+        EXPECT_EQ(iter, overlap.second);
+
+        overlap = m_intervalMap.overlap(interval2.m_min, interval2.m_max);
+        iter = overlap.first;
+        EXPECT_EQ(iter.value(), 1338);
+        EXPECT_EQ(iter.interval_begin(), interval2.m_min);
+        EXPECT_EQ(iter.interval_end(), interval2.m_max);
+        iter++;
+        EXPECT_EQ(iter, overlap.second);
     }
 
     TEST_F(IntervalMapTests, TestErase)


### PR DESCRIPTION
## What does this PR do?

Cherry-pick from dev to stab https://github.com/o3de/o3de/pull/18195

## How was this PR tested?

Run PC Vulkan