### PR TITLE
Fixed depth attachment validation error:

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -422,8 +422,8 @@ namespace AZ
                 }
                 else if (RHI::CheckBitsAll(imageAspects, RHI::ImageAspectFlags::Depth))
                 {
-                    return RHI::CheckBitsAny(access, RHI::ScopeAttachmentAccess::Write) ? VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL
-                                                                                        : VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+                    return RHI::CheckBitsAny(access, RHI::ScopeAttachmentAccess::Write) ? VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL
+                                                                                        : VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
                 }
                 else
                 {


### PR DESCRIPTION
## What does this PR do?

Fixed depth attachment validation error:
```
<16:24:42> [Error] (vkDebugMessage) - [ERROR][Validation] Validation Error:
 [ VUID-VkRenderPassCreateInfo2-pAttachments-02523 ] Object 0: handle = 0x1b495c20070,
 type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x48599611 | vkCreateRenderPass2():
 Cannot clear attachment 1 with invalid first layout VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL.
 The Vulkan spec states: For any member of pAttachments with a stencilLoadOp equal to VK_ATTACHMENT_LOAD_OP_CLEAR,
 the first use of that attachment must not specify a layout equal to 
VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
 VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, or
 VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL
 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkRenderPassCreateInfo2-pAttachments-02523)
```

The error was caught while running
AtomSampleViewer sample "RHI/BindlessPrototype".

## How was this PR tested?

The validation error disappeared when running ASV  Sample "RHI/BindlessPrototype" with `-rhi=vulkan`
