### PR TITLE
Harmonize ComputePassData and RayTracingPassData Field Names

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/BRDFTexture.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/BRDFTexture.pass
@@ -36,9 +36,9 @@
             ],
             "PassData": {
                 "$type": "ComputePassData",
-                "Target Thread Count X": "256",
-                "Target Thread Count Y": "256",
-                "Target Thread Count Z": "1",
+                "ThreadCountX": "256",
+                "ThreadCountY": "256",
+                "ThreadCountZ": "1",
                 "ShaderAsset": {
                     "FilePath": "Shaders/BRDFTexture/BRDFTextureCS.shader"
                 }

--- a/Gems/Atom/Feature/Common/Assets/Passes/BlendColorGradingLuts.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/BlendColorGradingLuts.pass
@@ -8,10 +8,10 @@
             "PassClass": "BlendColorGradingLutsPass",
             "PassData": {
                 "$type": "ComputePassData",
-                "Make Fullscreen Pass": false,
-                "Target Thread Count X": 32,
-                "Target Thread Count Y": 32,
-                "Target Thread Count Z": 32,
+                "FullscreenDispatch": false,
+                "ThreadCountX": 32,
+                "ThreadCountY": 32,
+                "ThreadCountZ": 32,
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/BlendColorGradingLuts.shader" 
                 }

--- a/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/BloomDownsample.pass
@@ -100,7 +100,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/BloomDownsampleCS.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveColor.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CheckerboardResolveColor.pass
@@ -220,7 +220,7 @@
                     "FilePath": "Shaders/Checkerboard/CheckerboardColorResolveCS.shader"
                 },
                 "BindViewSrg": true,
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ChromaticAberration.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ChromaticAberration.pass
@@ -63,7 +63,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/ChromaticAberration.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ContrastAdaptiveSharpening.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ContrastAdaptiveSharpening.pass
@@ -66,7 +66,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/ContrastAdaptiveSharpening.shader"
                 },
-                "Make Fullscreen Pass": true,
+                "FullscreenDispatch": true,
                 "ShaderDataMappings": {
                     "FloatMappings": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/DebugRayTracingPass.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DebugRayTracingPass.pass
@@ -50,7 +50,7 @@
                 "MissShaderName": "Miss",
                 "MaxPayloadSize": 16,
                 "MaxRecursionDepth": 1,
-                "Make Fullscreen Pass": true,
+                "FullscreenDispatch": true,
                 "BindViewSrg": true
             }
         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthDownsample.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthDownsample.pass
@@ -59,7 +59,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthDownsample.shader"
                 },
-                "Make Fullscreen Pass": true,
+                "FullscreenDispatch": true,
                 "BindViewSrg": true
             }
         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldWriteFocusDepthFromGpu.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthOfFieldWriteFocusDepthFromGpu.pass
@@ -25,9 +25,9 @@
             ],
             "PassData": {
                 "$type": "ComputePassData",
-                "Target Thread Count X": "1",
-                "Target Thread Count Y": "1",
-                "Target Thread Count Z": "1",
+                "ThreadCountX": "1",
+                "ThreadCountY": "1",
+                "ThreadCountZ": "1",
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DepthOfFieldWriteFocusDepthFromGpu.shader"
                 }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DownsampleLuminanceMinAvgMaxCS.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DownsampleLuminanceMinAvgMaxCS.pass
@@ -58,7 +58,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DownsampleLuminanceMinAvgMaxCS.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DownsampleMinAvgMaxCS.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DownsampleMinAvgMaxCS.pass
@@ -57,7 +57,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DownsampleMinAvgMaxCS.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/DownsampleSinglePassLuminance.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DownsampleSinglePassLuminance.pass
@@ -8,7 +8,7 @@
             "PassClass": "DownsampleSinglePassLuminancePass",
             "PassData": {
                 "$type": "ComputePassData",
-                "Make Fullscreen Pass": false,
+                "FullscreenDispatch": false,
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/DownsampleSinglePassLuminance.shader" 
                 }

--- a/Gems/Atom/Feature/Common/Assets/Passes/EyeAdaptation.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EyeAdaptation.pass
@@ -20,9 +20,9 @@
             ],
             "PassData": {
                 "$type": "ComputePassData",
-                "Target Thread Count X": "1",
-                "Target Thread Count Y": "1",
-                "Target Thread Count Z": "1",
+                "ThreadCountX": "1",
+                "ThreadCountY": "1",
+                "ThreadCountZ": "1",
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/EyeAdaptation.shader"
                 },

--- a/Gems/Atom/Feature/Common/Assets/Passes/FilmGrain.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FilmGrain.pass
@@ -63,7 +63,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/FilmGrain.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/FullscreenShadow.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FullscreenShadow.pass
@@ -106,7 +106,7 @@
             //     "ShaderAsset": {
             //         "FilePath": "Shaders/Shadow/FullscreenShadow.shader"
             //     },
-            //     "Make Fullscreen Pass": true,
+            //     "FullscreenDispatch": true,
             //     "BindViewSrg": true
             // }
         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/LuminanceHistogramGenerator.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LuminanceHistogramGenerator.pass
@@ -36,7 +36,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/LuminanceHistogramGenerator.shader"
                 },
-                "Make Fullscreen Pass": false
+                "FullscreenDispatch": false
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
@@ -518,7 +518,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.shader"
                         },
-                        "Make Fullscreen Pass": true,
+                        "FullscreenDispatch": true,
                         "BindViewSrg": true
                     }
                 },

--- a/Gems/Atom/Feature/Common/Assets/Passes/PaniniProjection.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PaniniProjection.pass
@@ -63,7 +63,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/PaniniProjection.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceRayTracing.pass
@@ -227,7 +227,7 @@
                 "MissShaderName": "Miss",
                 "MaxPayloadSize": 80,
                 "MaxRecursionDepth": 5,
-                "Make Fullscreen Pass": true,
+                "FullscreenDispatch": true,
                 "BindViewSrg": true
             }
         }

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyVolumeLUT.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyVolumeLUT.pass
@@ -23,9 +23,9 @@
             ],
             "PassData": {
                 "$type": "ComputePassData",
-                "Target Thread Count X": "32",
-                "Target Thread Count Y": "32",
-                "Target Thread Count Z": "32",
+                "ThreadCountX": "32",
+                "ThreadCountY": "32",
+                "ThreadCountZ": "32",
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyAtmosphere/SkyVolumeLUT.shader"
                 },

--- a/Gems/Atom/Feature/Common/Assets/Passes/SsaoCompute.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SsaoCompute.pass
@@ -49,7 +49,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/SsaoCompute.shader"
                 },
-                "Make Fullscreen Pass": true,
+                "FullscreenDispatch": true,
                 "BindViewSrg": true
             },
             "FallbackConnections": [

--- a/Gems/Atom/Feature/Common/Assets/Passes/SsaoParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SsaoParent.pass
@@ -129,7 +129,7 @@
                         "ShaderAsset": {
                             "FilePath": "Shaders/PostProcessing/ModulateTexture.shader"
                         },
-                        "Make Fullscreen Pass": true
+                        "FullscreenDispatch": true
                     }
                 }
             ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/Taa.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Taa.pass
@@ -94,7 +94,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/Taa.shader"
                 },
-                "Make Fullscreen Pass": true,
+                "FullscreenDispatch": true,
                 "ShaderDataMappings": {
                     "FloatMappings": [
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/Vignette.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Vignette.pass
@@ -63,7 +63,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/Vignette.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/WhiteBalance.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/WhiteBalance.pass
@@ -63,7 +63,7 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/PostProcessing/WhiteBalance.shader"
                 },
-                "Make Fullscreen Pass": true
+                "FullscreenDispatch": true
             }
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyVolumeLUT.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyVolumeLUT.azsl
@@ -92,7 +92,7 @@ float4 GetSkyVolumeAtPosition(uint3 position)
     return float4(ss.L, 1.0 - transmittance);
 }
 
-// total thread count is based on the "Target Thread Count X/Y/Z" in the SkyVolumeLUT.pass file
+// total thread count is based on the "ThreadCountX/Y/Z" in the SkyVolumeLUT.pass file
 // and the number of threads per group specified in numthreads() below.
 // given a volume texture size is 32x32x32, with 1 thread per froxel
 // the following values are based on intention to improve locality when accessing 

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPassData.h
@@ -44,14 +44,14 @@ namespace AZ
                         ->Field("MaxPayloadSize", &RayTracingPassData::m_maxPayloadSize)
                         ->Field("MaxAttributeSize", &RayTracingPassData::m_maxAttributeSize)
                         ->Field("MaxRecursionDepth", &RayTracingPassData::m_maxRecursionDepth)
-                        ->Field("Thread Count X", &RayTracingPassData::m_threadCountX)
-                        ->Field("Thread Count Y", &RayTracingPassData::m_threadCountY)
-                        ->Field("Thread Count Z", &RayTracingPassData::m_threadCountZ)
-                        ->Field("Make Fullscreen Pass", &RayTracingPassData::m_fullscreenDispatch)
+                        ->Field("ThreadCountX", &RayTracingPassData::m_threadCountX)
+                        ->Field("ThreadCountY", &RayTracingPassData::m_threadCountY)
+                        ->Field("ThreadCountZ", &RayTracingPassData::m_threadCountZ)
+                        ->Field("FullscreenDispatch", &RayTracingPassData::m_fullscreenDispatch)
                         ->Field("FullscreenSizeSourceSlotName", &RayTracingPassData::m_fullscreenSizeSourceSlotName)
                         ->Field("IndirectDispatch", &RayTracingPassData::m_indirectDispatch)
                         ->Field("IndirectDispatchBufferSlotName", &RayTracingPassData::m_indirectDispatchBufferSlotName)
-                        ->Field("Max Ray Length", &RayTracingPassData::m_maxRayLength);
+                        ->Field("MaxRayLength", &RayTracingPassData::m_maxRayLength);
                 }
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
@@ -168,14 +168,14 @@ namespace AZ
                 serializeContext->Class<ComputePassData, RenderPassData>()
                     ->Version(3)
                     ->Field("ShaderAsset", &ComputePassData::m_shaderReference)
-                    ->Field("Target Thread Count X", &ComputePassData::m_totalNumberOfThreadsX)
-                    ->Field("Target Thread Count Y", &ComputePassData::m_totalNumberOfThreadsY)
-                    ->Field("Target Thread Count Z", &ComputePassData::m_totalNumberOfThreadsZ)
-                    ->Field("Make Fullscreen Pass", &ComputePassData::m_fullscreenDispatch)
+                    ->Field("ThreadCountX", &ComputePassData::m_totalNumberOfThreadsX)
+                    ->Field("ThreadCountY", &ComputePassData::m_totalNumberOfThreadsY)
+                    ->Field("ThreadCountZ", &ComputePassData::m_totalNumberOfThreadsZ)
+                    ->Field("FullscreenDispatch", &ComputePassData::m_fullscreenDispatch)
                     ->Field("FullscreenSizeSourceSlotName", &ComputePassData::m_fullscreenSizeSourceSlotName)
                     ->Field("IndirectDispatch", &ComputePassData::m_indirectDispatch)
                     ->Field("IndirectDispatchBufferSlotName", &ComputePassData::m_indirectDispatchBufferSlotName)
-                    ->Field("Use Async Compute", &ComputePassData::m_useAsyncCompute);
+                    ->Field("UseAsyncCompute", &ComputePassData::m_useAsyncCompute);
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This is a followup to [!18255](https://github.com/o3de/o3de/pull/18255), and renames some of the existing fields of the `ComputePassData` and `RayTracingPassData` to remove spaces.

Note that this is a separate PR since these changes are entirely optional, but do introduce breaking changes.

There are several options on this, which are equally valid, which is why i would like to get reviewer feedback on this.

- Option A: Rename fields to conform to the style of other `PassData` fields. 
- Option B: Rename new fields from the other PR and add spaces, to at least make the `ComputePassData` somewhat consistent, if not the `RayTracingPassData`.
- Option C: Do nothing/close this PR, since the field names are not _that_ important.

## How was this PR tested?
Vulkan on Windows
