### PR TITLE
Add missing include in PassData.h

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassData.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Limits.h>
 #include <AzCore/Name/Name.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/std/containers/vector.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassData.cpp
@@ -6,18 +6,18 @@
  *
  */
 
-#include <AzCore/Serialization/SerializeContext.h>
+#include <Atom/RPI.Reflect/Pass/PassData.h>
 
 #include <Atom/RPI.Reflect/Pass/ComputePassData.h>
 #include <Atom/RPI.Reflect/Pass/CopyPassData.h>
 #include <Atom/RPI.Reflect/Pass/DownsampleMipChainPassData.h>
 #include <Atom/RPI.Reflect/Pass/EnvironmentCubeMapPassData.h>
 #include <Atom/RPI.Reflect/Pass/FullscreenTrianglePassData.h>
-#include <Atom/RPI.Reflect/Pass/PassData.h>
 #include <Atom/RPI.Reflect/Pass/RasterPassData.h>
 #include <Atom/RPI.Reflect/Pass/RenderPassData.h>
 #include <Atom/RPI.Reflect/Pass/RenderToTexturePassData.h>
 #include <Atom/RPI.Reflect/Pass/SlowClearPassData.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

This PR adds the missing include file `<Atom/RHI.Reflect/Limits.h>` to `PassData.h`, since later the struct `PassData` uses `RHI::MultiDevice::InvalidDeviceIndex` to initialize a member variable, which is defined in `Limits.h`.
This error was not visible since the include order in `PassData.h` is not as it is commonly recommended, with the main header file (the corresponding .h file to a .cpp file) in the topmost position. Clang-format would not sort the includes correctly in this case, since it does not recognize a main include if it uses anglebrackets. Therefore, I added a blank line after the main include.
There is the rather new format option `MainIncludeChar: AngleBracket` which could be used to fix this, but I am not sure whether adoption of clang-format 19 is widespread enough to add this to the .clang-format file.

## How was this PR tested?

Compile with unity and nounity option on Windows.
