### PR TITLE
Introduces Timestampresult::AddDuration

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -199,7 +199,7 @@ namespace AZ
 
             for (auto& [deviceIndex, timestampResult] : m_timestampResults)
             {
-                result.Add(timestampResult);
+                result.AddDuration(timestampResult);
             }
 
             return result;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/GpuQueryTypes.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/GpuQueryTypes.h
@@ -47,6 +47,7 @@ namespace AZ
             uint64_t GetTimestampBeginInTicks() const;
 
             void Add(const TimestampResult& extent);
+            void AddDuration(const TimestampResult& extent);
 
         private:
             // the timestamp of begin and duration in ticks.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuQueryTypes.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuQueryTypes.cpp
@@ -52,6 +52,17 @@ namespace AZ
             m_duration = (end1 > end2 ? end1 : end2) - m_begin;
         }
 
+        void TimestampResult::AddDuration(const TimestampResult& extent)
+        {
+            // Use the begin extent if our own begin is unset
+            if (m_begin == 0)
+            {
+                m_begin = extent.m_begin;
+            }
+
+            m_duration += extent.m_duration;
+        }
+
         // --- PipelineStatisticsResult ---
 
         PipelineStatisticsResult::PipelineStatisticsResult(AZStd::span<const PipelineStatisticsResult>&& statisticsResultArray)


### PR DESCRIPTION
… to simply add the duration independent of the beginning. This is necessary when Timestampresults of different devices are added since they can have different offsets (and actually also different scaling, which this doesn't fix).

A better solution would be to report timestampresults with a fixed time increment (e.g. nanoseconds) and offset (e.g. frame start time).

## How was this PR tested?

Using the GPU profiler IMGUI.
