### PR TITLE
remove an extraneous include

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerializationMetadata.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerializationMetadata.inl
@@ -59,5 +59,3 @@ namespace AZ
         return const_cast<JsonSerializationMetadata*>(this)->Find<MetadataT>();
     }
 } // namespace AZ
-
-#include <AzCore/Serialization/Json/JsonSerializationMetadata.inl>


### PR DESCRIPTION
## What does this PR do?

Removed an include of a file of itself.
The include didn't break anything so far because the file contains a `#pragma once`.

## How was this PR tested?

Compiled on Windows using clang.