### PR TITLE
Fix optional dependencies in project.json not working correctly

### DIFF
--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -102,7 +102,12 @@ function(get_all_gem_dependencies gem_name output_resolved_gem_names)
         unset(gem_name_only)
         o3de_get_name_and_version_specifier(${gem_name} gem_name_only ignore_spec_op ignore_spec_version)
         get_property(gem_path GLOBAL PROPERTY "@GEMROOT:${gem_name_only}@")
-        if(NOT gem_path)
+        if (NOT gem_path)
+            unset(gem_optional)
+            get_property(gem_optional GLOBAL PROPERTY ${gem_name}_OPTIONAL)
+            if (gem_optional)
+                return()
+            endif()
             message(FATAL_ERROR "Unable to locate gem path for Gem \"${gem_name_only}\"."
                     " Is the gem registered in either the ~/.o3de/o3de_manifest.json, ${LY_ROOT_FOLDER}/engine.json,"
                     " any project.json or any gem.json which itself is registered?")


### PR DESCRIPTION
## What does this PR do?

This PR fixes a CMake error when an optional dependency, eg. from "gem_names" in project.json" is not present. This is most prominently used in AtomSampleViewer, which adds optional dependencies for `OpenXRVk` and `XR`.

Without this fix, I get the following error message when I try to bulid AtomSampleViewer:
```
CMake Error at cmake/Gems.cmake:111 (message):
  Unable to locate gem path for Gem "OpenXRVk".  Is the gem registered in
  either the ~/.o3de/o3de_manifest.json, D:/code/o3de/engine.json, any
  project.json or any gem.json which itself is registered?
```
After this fix, the optional dependencies are ignored correctly, and I can build AtomSampleViewer successfully.

@spham-amzn Since you touched this code most recently, is this the correct place to add the new check?

## How was this PR tested?

Add AtomSampleViewer to `LY_PROJECTS` in a engine-centric build, add a `message()` statement before the new `return()` statement and check if only the two optional dependencies are identified and return is called.
