### PR TITLE
Asset Importer Now Builds Inside of SDKWrapper Module

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/CMakeLists.txt
+++ b/Code/Tools/SceneAPI/SDKWrapper/CMakeLists.txt
@@ -12,6 +12,62 @@ endif()
 
 set(sdkwrapper_dir ${CMAKE_CURRENT_LIST_DIR}/../SDKWrapper)
 
+# Add Assimp dependency using CMake's FetchContent
+# Note: Assimp requires lowering of the warning level to compile, due to a child dependency of TinyUSDZ
+include(FetchContent)
+FetchContent_Declare(
+    assimp
+    GIT_REPOSITORY "https://github.com/assimp/assimp"
+    GIT_TAG "d41b6b253d215a003ed6cfd7db197dbe7e7e8206"
+)
+
+message(WARNING "Gene ${CMAKE_MODULE_PATH}")
+
+set(ASSIMP_BUILD_ZLIB OFF)
+set(ASSIMP_BUILD_ASSIMP_TOOLS ON)
+set(ASSIMP_BUILD_USD_IMPORTER ON)
+set(ASSIMP_WARNINGS_AS_ERRORS OFF)
+set(ASSIMP_INSTALL OFF)  # Disable since we're using Assimp as a sub module
+
+get_property(
+    compile_options
+    DIRECTORY
+    PROPERTY COMPILE_OPTIONS
+)
+
+include(Platform/${PAL_PLATFORM_NAME}/PAL_assimp_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
+
+# Temporarily disable warnings as errors from TinyUSDZ (Assimp library dependency)
+#set(COMPILE_WARNING_AS_ERROR OFF CACHE BOOL "" FORCE)
+
+# Include compiler settings for Assimp libraries
+include(Platform/Common/${PAL_TRAIT_COMPILER_ID}/PAL_assimp_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake)
+
+#set_property(
+#    DIRECTORY
+#    APPEND
+#    PROPERTY COMPILE_DEFINITIONS DT_POLYREF64
+#)
+
+# Assimp requires ZLIB
+find_package(zlib REQUIRED)
+
+#target_link_libraries(assimp PRIVATE zlib)
+
+
+FetchContent_MakeAvailable(assimp)
+
+# Restore compile options
+set_property(
+    DIRECTORY
+    PROPERTY COMPILE_OPTIONS ${compile_options}
+)
+unset(compile_options)
+
+# Reenable warnings as errors
+#set(COMPILE_WARNING_AS_ERROR ON CACHE BOOL "" FORCE)
+
+
 ly_add_target(
     NAME SDKWrapper STATIC
     NAMESPACE AZ
@@ -26,5 +82,5 @@ ly_add_target(
             AZ::AzCore
             AZ::AzToolsFramework
         PUBLIC
-            3rdParty::assimplib
+            assimp
 )

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/PAL_android.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/PAL_android.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_RECASTNAVIGATION_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_EDITOR_TEST_SUPPORTED TRUE)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/PAL_recast_android.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/PAL_recast_android.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/recastnavigation_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/recastnavigation_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/recastnavigation_private_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/recastnavigation_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Android
+# i.e. ../Source/Android/RecastNavigationAndroid.cpp
+#      ../Source/Android/RecastNavigationAndroid.h
+#      ../Include/Android/RecastNavigationAndroid.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/recastnavigation_shared_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Android/recastnavigation_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Android
+# i.e. ../Source/Android/RecastNavigationAndroid.cpp
+#      ../Source/Android/RecastNavigationAndroid.h
+#      ../Include/Android/RecastNavigationAndroid.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/Clang/PAL_recast_clang.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/Clang/PAL_recast_clang.cmake
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Turn off warnings for RecastNavigation::Detour library
+set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY COMPILE_OPTIONS -Wno-everything
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/GCC/PAL_recast_gcc.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/GCC/PAL_recast_gcc.cmake
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Turn off warnings for RecastNavigation::Detour library
+set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY COMPILE_OPTIONS -w
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/MSVC/PAL_assimp_msvc.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/MSVC/PAL_assimp_msvc.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Set compiler options specific to this compiler
+message("Gene COMPILE_OPTIONS: ${COMPILE_OPTIONS}")
+ set_property(
+    DIRECTORY
+    APPEND_STRING
+    PROPERTY COMPILE_OPTIONS "/EHsc /wd4777"
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/PAL_linux.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/PAL_linux.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_RECASTNAVIGATION_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_EDITOR_TEST_SUPPORTED TRUE)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/PAL_recast_linux.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/PAL_recast_linux.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_editor_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_editor_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_private_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Linux
+# i.e. ../Source/Linux/RecastNavigationLinux.cpp
+#      ../Source/Linux/RecastNavigationLinux.h
+#      ../Include/Linux/RecastNavigationLinux.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_shared_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Linux/recastnavigation_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Linux
+# i.e. ../Source/Linux/RecastNavigationLinux.cpp
+#      ../Source/Linux/RecastNavigationLinux.h
+#      ../Include/Linux/RecastNavigationLinux.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/PAL_mac.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/PAL_mac.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_RECASTNAVIGATION_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_EDITOR_TEST_SUPPORTED TRUE)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/PAL_recast_mac.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/PAL_recast_mac.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_editor_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_editor_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_private_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Mac
+# i.e. ../Source/Mac/RecastNavigationMac.cpp
+#      ../Source/Mac/RecastNavigationMac.h
+#      ../Include/Mac/RecastNavigationMac.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_shared_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Mac/recastnavigation_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Mac
+# i.e. ../Source/Mac/RecastNavigationMac.cpp
+#      ../Source/Mac/RecastNavigationMac.h
+#      ../Include/Mac/RecastNavigationMac.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/PAL_assimp_windows.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/PAL_assimp_windows.cmake
@@ -1,0 +1,8 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/PAL_windows.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/PAL_windows.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+#set(PAL_TRAIT_RECASTNAVIGATION_SUPPORTED TRUE)
+#set(PAL_TRAIT_RECASTNAVIGATION_TEST_SUPPORTED TRUE)
+#set(PAL_TRAIT_RECASTNAVIGATION_EDITOR_TEST_SUPPORTED TRUE)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_editor_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_editor_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_private_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Windows
+# i.e. ../Source/Windows/RecastNavigationWindows.cpp
+#      ../Source/Windows/RecastNavigationWindows.h
+#      ../Include/Windows/RecastNavigationWindows.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_shared_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Windows/assimp_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for Windows
+# i.e. ../Source/Windows/RecastNavigationWindows.cpp
+#      ../Source/Windows/RecastNavigationWindows.h
+#      ../Include/Windows/RecastNavigationWindows.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/PAL_ios.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/PAL_ios.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_RECASTNAVIGATION_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_TEST_SUPPORTED TRUE)
+set(PAL_TRAIT_RECASTNAVIGATION_EDITOR_TEST_SUPPORTED TRUE)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/PAL_recast_ios.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/PAL_recast_ios.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/recastnavigation_api_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/recastnavigation_api_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/recastnavigation_private_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/recastnavigation_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for iOS
+# i.e. ../Source/iOS/RecastNavigationiOS.cpp
+#      ../Source/iOS/RecastNavigationiOS.h
+#      ../Include/iOS/RecastNavigationiOS.h
+
+set(FILES
+)

--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/recastnavigation_shared_files.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/iOS/recastnavigation_shared_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Platform specific files for iOS
+# i.e. ../Source/iOS/RecastNavigationiOS.cpp
+#      ../Source/iOS/RecastNavigationiOS.h
+#      ../Include/iOS/RecastNavigationiOS.h
+
+set(FILES
+)

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -99,7 +99,8 @@
                     "fbx.assetinfo": "fbx",
                     "stl.assetinfo": "stl",
                     "gltf.assetinfo": "gltf",
-                    "glb.assetinfo": "glb"
+                    "glb.assetinfo": "glb",
+                    "usd.assetinfo": "usd"
 
                 },
 

--- a/Registry/sceneassetimporter.setreg
+++ b/Registry/sceneassetimporter.setreg
@@ -13,7 +13,8 @@
                     ".glb",
                     ".usd",
                     ".usda",
-                    ".usdz"
+                    ".usdz",
+                    ".usdc"
                 ]
             },
             "MaterialConverter": 

--- a/Registry/sceneassetimporter.setreg
+++ b/Registry/sceneassetimporter.setreg
@@ -10,7 +10,10 @@
                     ".fbx",
                     ".stl",
                     ".gltf",
-                    ".glb"
+                    ".glb",
+                    ".usd",
+                    ".usda",
+                    ".usdz"
                 ]
             },
             "MaterialConverter": 

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
@@ -17,7 +17,6 @@ ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform               
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-linux-aarch64                             TARGETS expat                       PACKAGE_HASH 934a535c1492d11906789d7ddf105b1a530cf8d8fb126063ffde16c5caeb0179)
-ly_associate_package(PACKAGE_NAME assimp-5.2.5-rev1-linux-aarch64                            TARGETS assimplib                   PACKAGE_HASH 0e497e129f9868088c81891e87b778894c12486b039a5b7bd8a47267275b640f)
 ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.11.288-rev1-linux-aarch64                   TARGETS AWSNativeSDK                PACKAGE_HASH 55791343d3aaa07a4242190cc9d6f1f2448c55125839255bdec25efdbab46efa)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-rev1-linux-aarch64                            TARGETS cityhash                    PACKAGE_HASH c4fafa13add81c6ca03338462af78eabbdea917de68c599f11c4a36b0982cec2)
 ly_associate_package(PACKAGE_NAME tiff-4.2.0.15-rev3-linux-aarch64                           TARGETS TIFF                        PACKAGE_HASH 429461014b21a530dcad597c2d91072ae39d937a04b7bbbf5c34491c41767f7f)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
@@ -18,7 +18,6 @@ ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                    
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-linux                            TARGETS expat                       PACKAGE_HASH 755369a919e744b9b3f835d1acc684f02e43987832ad4a1c0b6bbf884e6cd45b)
-ly_associate_package(PACKAGE_NAME assimp-5.2.5-rev1-linux                           TARGETS assimplib                   PACKAGE_HASH 67bd3625078b63b40ae397ef7a3e589a6f77e95d3318c97dd7075e3e22a638cd)
 ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.11.288-rev1-linux                  TARGETS AWSNativeSDK                PACKAGE_HASH 20421c93a5d32feae636c6dc46323b10547f2c5e7e62b63db00319765bb45331)
 ly_associate_package(PACKAGE_NAME tiff-4.2.0.15-rev3-linux                          TARGETS TIFF                        PACKAGE_HASH 2377f48b2ebc2d1628d9f65186c881544c92891312abe478a20d10b85877409a)
 ly_associate_package(PACKAGE_NAME freetype-2.11.1-rev1-linux                        TARGETS Freetype                    PACKAGE_HASH 28bbb850590507eff85154604787881ead6780e6eeee9e71ed09cd1d48d85983)

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
@@ -19,7 +19,6 @@ ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform               
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-mac                              TARGETS expat                       PACKAGE_HASH 70f195977a17b08a4dc8687400fd7f2589e3b414d4961b562129166965b6f658)
-ly_associate_package(PACKAGE_NAME assimp-5.2.5-rev1-mac                             TARGETS assimplib                   PACKAGE_HASH 0c96f5bd230a6e8e432a3693a6bae540ad75665eb0187b8525cf63398673ca67)
 ly_associate_package(PACKAGE_NAME DirectXShaderCompilerDxc-1.7.2308-o3de-rev2-mac   TARGETS DirectXShaderCompilerDxc    PACKAGE_HASH bdbf069d5704cf16079e60421857bda150ba6eed69900d03ac7ffefc2335cda3)
 ly_associate_package(PACKAGE_NAME SPIRVCross-1.3.275.0-rev1-mac                     TARGETS SPIRVCross                  PACKAGE_HASH 5ad9629f677c42847daf8b097728323685d7018d3ac8af0508d1bd0727a81304)
 ly_associate_package(PACKAGE_NAME tiff-4.2.0.15-rev3-mac                            TARGETS TIFF                        PACKAGE_HASH c2615ccdadcc0e1d6c5ed61e5965c4d3a82193d206591b79b805c3b3ff35a4bf)

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -19,7 +19,6 @@ ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform               
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-windows                              TARGETS expat                       PACKAGE_HASH 748d08f21f5339757059a7887e72b52d15e954c549245c638b0b05bd5961e307)
-ly_associate_package(PACKAGE_NAME assimp-5.2.5-rev1-windows                             TARGETS assimplib                   PACKAGE_HASH a75ef3cdd0c880e990eee0afd1a40c1100ef34e757d0d5f59109be3439eb88c0)
 ly_associate_package(PACKAGE_NAME OpenEXR-3.1.3-rev5-windows                            TARGETS OpenEXR Imath               PACKAGE_HASH bff6dc78412bb1b04ded243753bee36e9229fdaf9a9e1fa85b1059238fba4c9b)
 ly_associate_package(PACKAGE_NAME DirectXShaderCompilerDxc-1.7.2308-o3de-rev2-windows   TARGETS DirectXShaderCompilerDxc    PACKAGE_HASH 1002eaef605abf2f5080f1edb7efbdad36c5c53e27ae17957b736ab3cdc61b36)
 ly_associate_package(PACKAGE_NAME SPIRVCross-1.3.275.0-rev1-windows                     TARGETS SPIRVCross                  PACKAGE_HASH 4c18c95834ebff103ff7f39fc814d65276668d2405d91376290f69723f2ab0f7)


### PR DESCRIPTION
- Removing AssImp out of 3rd Party and directly built by SDKWrapper using CMake's FetchContent. Pulling Assimp changes will be easier now that it doesn't require going through the [3rdParty pipeline](https://github.com/o3de/3p-package-source/tree/main/package-system/assimp)
- Adds ~2 minutes to build time
https://github.com/o3de/sig-simulation/pull/92