### PR TITLE
Clang compile fix for (UI)SplineCtrlEx on Windows

### DIFF
--- a/Code/Editor/Controls/SplineCtrlEx.cpp
+++ b/Code/Editor/Controls/SplineCtrlEx.cpp
@@ -2667,7 +2667,7 @@ void AbstractSplineWidget::SelectAll()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void SplineWidget::SendNotifyEvent(int nEvent)
+void SplineWidget::SendNotifyEvent(unsigned int nEvent)
 {
     if (nEvent == SPLN_BEFORE_CHANGE)
     {

--- a/Code/Editor/Controls/SplineCtrlEx.h
+++ b/Code/Editor/Controls/SplineCtrlEx.h
@@ -37,8 +37,10 @@
 #define SPLN_KEY_SELECTION_CHANGE (0x0005)
 
 #ifndef NM_CLICK
-#define NM_CLICK (-2)
-#define NM_RCLICK (-5)
+// from commctrl.h
+#define NM_FIRST (0U - 0U)
+#define NM_CLICK (NM_FIRST - 2)
+#define NM_RCLICK (NM_FIRST - 5)
 #endif
 
 #ifdef LoadCursor
@@ -233,7 +235,7 @@ protected:
 
     void SetHorizontalExtent(int min, int max);
 
-    virtual void SendNotifyEvent(int nEvent) = 0;
+    virtual void SendNotifyEvent(unsigned int nEvent) = 0;
 
     virtual void SelectRectangle(const QRect& rc, bool bSelect);
     //////////////////////////////////////////////////////////////////////////
@@ -403,7 +405,7 @@ protected:
 
     void DrawTangentHandle(QPainter* pDC, int nSpline, int nKey, int nDimension);
 
-    void SendNotifyEvent(int nEvent) override;
+    void SendNotifyEvent(unsigned int nEvent) override;
 
     void captureMouseImpl() override { grabMouse(); }
     void releaseMouseImpl() override { releaseMouse(); }

--- a/Gems/LyShine/Code/Editor/Animation/Controls/UiSplineCtrlEx.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/Controls/UiSplineCtrlEx.cpp
@@ -40,8 +40,10 @@
 #define LEFT_BORDER_OFFSET 40
 
 #ifndef NM_CLICK
-#define NM_CLICK (-2)
-#define NM_RCLICK (-5)
+// from commctrl.h
+#define NM_FIRST (0U - 0U)
+#define NM_CLICK (NM_FIRST - 2)
+#define NM_RCLICK (NM_FIRST - 5)
 #endif
 
 const float AbstractSplineWidget::threshold = 0.015f;
@@ -2607,7 +2609,7 @@ void AbstractSplineWidget::SelectAll()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void SplineWidget::SendNotifyEvent(int nEvent)
+void SplineWidget::SendNotifyEvent(unsigned int nEvent)
 {
     if (nEvent == SPLN_BEFORE_CHANGE)
     {

--- a/Gems/LyShine/Code/Editor/Animation/Controls/UiSplineCtrlEx.h
+++ b/Gems/LyShine/Code/Editor/Animation/Controls/UiSplineCtrlEx.h
@@ -219,7 +219,7 @@ protected:
 
     void SetHorizontalExtent(int min, int max);
 
-    virtual void SendNotifyEvent(int nEvent) = 0;
+    virtual void SendNotifyEvent(unsigned int nEvent) = 0;
 
     virtual void SelectRectangle(const QRect& rc, bool bSelect);
     //////////////////////////////////////////////////////////////////////////
@@ -384,7 +384,7 @@ protected:
 
     void DrawTangentHandle(QPainter* pDC, int nSpline, int nKey, int nDimension);
 
-    void SendNotifyEvent(int nEvent) override;
+    void SendNotifyEvent(unsigned int nEvent) override;
 
     void captureMouseImpl() override { grabMouse(); }
     void releaseMouseImpl() override { releaseMouse(); }


### PR DESCRIPTION
## What does this PR do?

Fixes a compile error with Clang on Windows when Nvidia Aftermath is enabled.
The macros `NM_CLICK` and `NM_RCLICK` are defined as signed `-1` and `-5` in O3DE.
In the header `commctrl.h` they are defined as unsigned instead.

When aftermath is enabled, the `commctrl.h` is included somewhere, and the macros are defined as unsigned.
This leads to a compiler error in the switch statements of the `SendNotifyEvent` in `SplineCtrlExe` and `UiSplineCtrlEx` because `-1u` is greater than the max value of a signed integer.

This PR defines the macros the same way they are defined in the `commctrl.h` header.

## How was this PR tested?

Windows and Clang
