### PR TITLE
Fix of AddScopeQueryToFrameGraph being executed multiple times.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/Query.cpp
@@ -181,30 +181,12 @@ namespace AZ
 
         bool Query::AssignNewFrameIndexToSubQuery(uint64_t poolFrameIndex)
         {
-#if defined (AZ_RPI_ENABLE_VALIDATION)
-            // Check if the query is already added in this frame.
-            {
-                const auto predicate = [poolFrameIndex](SubQuery& queryIndices)
-                {
-                    return queryIndices.m_poolFrameIndex == poolFrameIndex;
-                };
-
-                if (AZStd::any_of(m_subQueryArray.begin(), m_subQueryArray.end(), predicate))
-                {
-                    AZ_Warning("RPI::Query", false, "Query is already added in this frame");
-                    return false;
-                }
-            }
-#else
-            // Check if the FrameIndex is already present for this query instance, meaning that
-            // the user is trying to use the same query multiple times to record within a single frame.
             if (m_cachedSubQueryArrayIndex != InvalidQueryIndex &&
                 m_subQueryArray[m_cachedSubQueryArrayIndex].m_poolFrameIndex == poolFrameIndex)
             {
-                AZ_Warning("RPI::Query", false, "Query is already added in this frame");
-                return false;
+                // It might run multiple times if a pass has multiple scopes run on multiple devices
+                return true;
             }
-#endif
 
             // Get the oldest query array index.
             const uint32_t availableQueryIndex = GetOldestOrAvailableSubQueryArrayIndex();

--- a/Gems/Atom/RPI/Code/Tests/System/GpuQueryTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/System/GpuQueryTests.cpp
@@ -75,7 +75,8 @@ namespace UnitTest
             QueryResultCode resultCode = query->AddToFrameGraph(frameGraph);
             EXPECT_EQ(resultCode, QueryResultCode::Success);
             resultCode = query->AddToFrameGraph(frameGraph);
-            EXPECT_EQ(resultCode, QueryResultCode::Fail);
+            // Adding query multiple times in a frame is allowed after introduced multi-device.
+            EXPECT_EQ(resultCode, QueryResultCode::Success);
 
             // Next frame
             queryPool->Update();


### PR DESCRIPTION
## What does this PR do?

Currently there is a warning every frame due to AssignNewFrameIndexToSubQuery is being executed multiple times if we have multiple devices.

This warning is unnecessary and running AssignNewFrameIndexToSubQuery multiple times in a frame is kind of expected after we introduce multi devices support, we might run a pass on multiple devices multiple times like we did in #18159 .

Therefore, this PR removes this warning.

## How was this PR tested?

Tested on Windows with 2 devices.
