### PR TITLE
Shading rate attachment format fix

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -422,8 +422,8 @@ namespace AZ
                 }
                 else if (RHI::CheckBitsAll(imageAspects, RHI::ImageAspectFlags::Depth))
                 {
-                    return RHI::CheckBitsAny(access, RHI::ScopeAttachmentAccess::Write) ? VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL
-                                                                                        : VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+                    return RHI::CheckBitsAny(access, RHI::ScopeAttachmentAccess::Write) ? VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL
+                                                                                        : VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
                 }
                 else
                 {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -422,8 +422,8 @@ namespace AZ
                 }
                 else if (RHI::CheckBitsAll(imageAspects, RHI::ImageAspectFlags::Depth))
                 {
-                    return RHI::CheckBitsAny(access, RHI::ScopeAttachmentAccess::Write) ? VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL
-                                                                                        : VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
+                    return RHI::CheckBitsAny(access, RHI::ScopeAttachmentAccess::Write) ? VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL
+                                                                                        : VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
                 }
                 else
                 {


### PR DESCRIPTION
## What does this PR do?

Fixed bug that occurs when a device supports both
"Fragment Shading Rate" and "Fragment Density Map".

The solution is to give exclusive priority to "Fragment Rate Shading" when
 defining the Format Capabilities for "RHI::FormatCapabilities::ShadingRate".
 By checking only one of them, we avoid color format selection errors when looking
 for color formats compatible with RHI::FormatCapabilities::ShadingRate.
 Otherwise the runtime may end up using color formats that are ONLY supported for "Fragment Density Map"
 when trying to use "Fragment Shading Rate" feature.

 This error was evident when enabling the XR Gem, because the
 FoveatedImagePass was using a color format for the Shading Rate
 attachment that was only compatible with a Density Map attachment.

## How was this PR tested?

The following validation error disappeared when running an OpenXR application on a Quest3 device:
```
[ERROR][Validation] Validation Error: [ VUID-VkRenderPassCreateInfo2-pAttachments-04586 ] |
MessageID = 0x594e9e6e | vkCreateRenderPass2: Attachment description 2 is used in subpass 0 as a fragment shading rate
 attachment, but specifies format VK_FORMAT_R8G8_UNORM, which does not support 
VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR.
 The Vulkan spec states: If any element of pAttachments is used as a fragment shading rate attachment in any subpass,
 it must have an image format whose potential format features contain
 VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR
 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkRenderPassCreateInfo2-pAttachments-04586)
```
