### PR TITLE
Fix epsilon of GetInverseTransform function being too large

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.cpp
@@ -514,8 +514,14 @@ namespace AZ
         // Calculate the determinant
         float det = (*this)(0, 0) * out(0, 0) + (*this)(1, 0) * out(0, 1) + (*this)(2, 0) * out(0, 2);
 
+        // Run singularity test
+        if (det == 0)
+        {
+            return CreateIdentity();
+        }
+
         // Divide cofactors by determinant
-        float f = (Abs(det) > Constants::Tolerance) ? 1.0f / det : 10000000.0f;
+        float f = 1.0f / det;
 
         out.SetRow(0, out.GetRow(0) * f);
         out.SetRow(1, out.GetRow(1) * f);

--- a/Code/Framework/AzCore/Tests/Math/Matrix4x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix4x4Tests.cpp
@@ -449,6 +449,7 @@ namespace UnitTest
         m1 = Matrix4x4::CreateRotationX(1.0f);
         m1.SetTranslation(Vector3(10.0f, -3.0f, 5.0f));
         m1.SetElement(0, 1, 23.1234f);
+        m1.MultiplyByScale(Vector3(0.1f, 0.07f, 0.09f));
         EXPECT_THAT((m1 * m1.GetInverseTransform()), IsCloseTolerance(Matrix4x4::CreateIdentity(), 0.01f));
     }
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MatrixUtility.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MatrixUtility.azsli
@@ -95,9 +95,14 @@ float4x4 Inverse(float4x4 m)
     /* Calculate the determinant */
     float det = m[0][0] * result[0][0] + m[1][0] * result[0][1] + m[2][0] * result[0][2];
 
+    /* Run singularity test */
+    if (det == 0)
+    {
+        return CreateIdentity4x4();
+    }
+
     /* divide cofactors by determinant */
-    bool isDetZero = step(-EPSILON, det) * (1 - step(EPSILON, det));
-    float f = (isDetZero? 10000000.0 : 1.0/det);
+    float f = 1.f / det;
 
     result[0][0] = result[0][0] * f;
     result[0][1] = result[0][1] * f;


### PR DESCRIPTION
## What does this PR do?

The funciton `Matrix4x4::GetInverseTransform` uses `Constants::Tolerance` (0.001) to determine if a given matrix can be inverted by checking if the determinant is smaller than this value. This is not sufficient for matrices which contain scales smaller than around 0.1, eg. the following matrix with uniform scale of 0.1 could not be inverted by this function, as its determinant is 0.001, which is exactly the epsilon value:
```
/ 0.1  0   0   0 \
|  0  0.1  0   0 |
|  0   0  0.1  0 |
\  0   0   0   1 /
```

The proposed solution removes the epsilon value, ie. sets it to 0, for the following reasons:
* One function further down in the function `GetInverseFull` an epsilon value of 0 is used
* Other libraries, such as [glm](https://github.com/g-truc/glm/blob/33b4a621a697a305bc3a7610d290677b96beb181/glm/detail/func_matrix.inl#L388) or [Eigen](https://github.com/libigl/eigen/blob/1f05f51517ec4fd91eed711e0f89e97a7c028c0e/Eigen/src/LU/InverseImpl.h#L229) don't apply a epsilon check for the determinant at all in the default invert function, but often provide a separate method instead (eg. `computeInverseWithCheck` in Eigen)
* The only reason for this check seems to be that there is no division by 0, which does not change. The inverted matrix is potentially wrong if there is a very small determinant != 0 due to floating point inaccuracy, but not more wrong than scaling the matrix by 10^7 if the determinant is smaller than epsilon, which would return a totally unrelated matrix anyway. `1.f / FLT_MIN` does not evaluate to infinity, so a valid matrix with (potentially) very large values would be returned in any way.

The only downside I see is that matrices with a very small determinant could potentially lead to infinity values in the matrix, which might happen when the determinant is close to `FLT_MIN`. A workaround for this would be to just use a smaller epsilon, but I am not sure how I would derive a suitable epsilon for the determinant that makes sense in all cases.

## How was this PR tested?

Update the `MATH_Matrix4x4.TestTransformInverse` test to include a smaller scale such that the test would fail initially but passes with the proposed changes.
