### PR TITLE
Add missing alias for Atom_AtomBridge.HeadlessServers

### DIFF
--- a/Gems/AtomLyIntegration/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/CMakeLists.txt
@@ -9,6 +9,7 @@
 # The "AtomLyIntegration" Gem will alias the real Atom_AtomBridge target variants
 ly_create_alias(NAME AtomLyIntegration.Clients NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Clients)
 ly_create_alias(NAME AtomLyIntegration.Servers NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Servers)
+ly_create_alias(NAME AtomLyIntegration.HeadlessServers NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.HeadlessServers)
 ly_create_alias(NAME AtomLyIntegration.Unified NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Unified)
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME AtomLyIntegration.Builders NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Builders)


### PR DESCRIPTION
## What does this PR do?

This PR fixes a missing alias in `Gems/AtomLyIntegration/CMakeLists.txt` for the HeadlessServer target. Without this change I get the following linker error when trying to build the MyTestProject.HeadlessServerLauncher target (MyTestProject depends on an internal gem which depends on various Atom targets and the AtomLyIntegration.Common target):
```
Atom_AtomBridge.lib(AtomBridgeModule.cpp.obj) : error LNK2005: 
  "public: __cdecl AZ::AtomBridge::Module::Module(void)"
  (??0Module@AtomBridge@AZ@@QEAA@XZ) already defined in
  Atom_AtomBridge.Headless.lib(AtomBridgeModule.cpp.obj)
Atom_AtomBridge.lib(AtomBridgeModule.cpp.obj) : error LNK2005:
  "public: virtual class AZStd::vector<struct AZ::Uuid,class AZStd::allocator>
  __cdecl AZ::AtomBridge::Module::GetRequiredSystemComponents(void)const "
  (?GetRequiredSystemComponents@Module@AtomBridge@AZ@@UEBA?AV?$vector@UUuid@AZ@@Vallocator@AZStd@@@AZStd@@XZ)
  already defined in Atom_AtomBridge.Headless.lib(AtomBridgeModule.cpp.obj)
Creating library lib\profile\MyTestProject.HeadlessServerLauncher.lib and
  object lib\profile\MyTestProject.HeadlessServerLauncher.exp
bin\profile\MyTestProject.HeadlessServerLauncher.exe : fatal error LNK1169:
  one or more multiply defined symbols found
```

## How was this PR tested?

Build the MyTestProject.HeadlessServerLauncher target with the proposed change. Without the change, the target cannot be built successfully due to linker errors. I did not try to recreate the problem by building a minimal example from the default gem and project templates.