### PR TITLE
Fix a potential deadlock with Vulkan Timeline Semaphores

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
@@ -96,7 +96,12 @@ namespace AZ
             waitInfo.flags = 0;
             waitInfo.semaphoreCount = 1;
             waitInfo.pSemaphores = &m_nativeSemaphore;
-            waitInfo.pValues = &m_pendingValue;
+
+            // If another thread resets this Semaphore while we are waiting, m_pendingValue is changed, which might interfere
+            // with the WaitSemaphore here, depending on how this is implemented in the driver.
+            // To avoid this, make a local copy of the pending value
+            auto pendingValue = m_pendingValue;
+            waitInfo.pValues = &pendingValue;
 
             auto& device = static_cast<Device&>(GetDevice());
             device.GetContext().WaitSemaphores(device.GetNativeDevice(), &waitInfo, AZStd::numeric_limits<uint64_t>::max());


### PR DESCRIPTION
## What does this PR do?

This fixes a potential issue where a CPU thread is waiting on a Timeline Semaphore Fence, and another thread calls reset() on the Fence, which increases the value of m_pendingValue.

Since `vkWaitSemaphores` uses a pointer to the pending value, this could mean, depending on how exactly the driver implements this, that the value the Fence is waiting for now changed, and will never be triggered.

This seemingly fixes a spurious deadlock issue with `AttachmentReadback`, if we use it to read some statistics values from the GPU each frame in combination with shader hot reloading. 

## How was this PR tested?

The `AttachmentReadback` deadlock doesn't occur anymore.
Windows and Vulkan, RTX 3090, driver version 560.70