### PR TITLE
Fix a spurious crash with AttachmentReadback

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -489,6 +489,15 @@ namespace AZ
         AttachmentReadback::ReadbackResult AttachmentReadback::GetReadbackResult() const
         {
             ReadbackResult result;
+
+            if (m_readbackItems.empty())
+            {
+                // the AttachmentReadback was reset before the readback was triggered from the GPU. Avoid 
+                // a crash by accessing a non-existend readback item
+                result.m_state = ReadbackState::Failed;
+                return result;
+            }
+
             result.m_state = m_state;
             result.m_attachmentType = m_attachmentType;
             result.m_dataBuffer = m_readbackItems[0].m_dataBuffer;


### PR DESCRIPTION
## What does this PR do?

Due to some race conditions (mostly caused by shader hot reload), an `AttachmentReadback` - Object is reset (e.g. from the destructor) before the readback was triggered by the GPU. During the readback later the callback function then tries to access non-existent readback items and crashes.

## How was this PR tested?

Have a continuous `AttachmentReadback` for various statistics running while causing shader hot reloads sometimes triggered an exception in that function. This seemingly doesn't happen anymore. 

Tested on Windows and Vulkan
