### PR TITLE
fix: viewport camera grab mouse first time opening a level

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
@@ -13,7 +13,7 @@
 
 namespace AzFramework
 {
-    ClickDetector::ClickDetector() : m_detectionState(DetectionState::Nil)
+    ClickDetector::ClickDetector()
     {
         m_timeNowFn = []
         {

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
@@ -13,7 +13,7 @@
 
 namespace AzFramework
 {
-    ClickDetector::ClickDetector()
+    ClickDetector::ClickDetector() : m_detectionState(DetectionState::Nil)
     {
         m_timeNowFn = []
         {

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.h
@@ -73,7 +73,7 @@ namespace AzFramework
         float m_moveAccumulator = 0.0f; //!< How far the mouse has moved after mouse down.
         float m_deadZone = DefaultMouseMoveDeadZone; //!< How far to move before a click is cancelled (when Move will fire).
         float m_doubleClickInterval = 0.4f; //!< Default double click interval, can be overridden.
-        DetectionState m_detectionState; //!< Internal state of ClickDetector.
+        DetectionState m_detectionState = DetectionState::Nil; //!< Internal state of ClickDetector.
         //! Mouse down time (happens each mouse down, helps with double click handling).
         AZStd::optional<AZStd::chrono::milliseconds> m_tryBeginTime;
         AZStd::function<AZStd::chrono::milliseconds()> m_timeNowFn; //!< Interface to query the current time.


### PR DESCRIPTION
## What does this PR do?

`ClickDetector::m_detectionState` is not initialized in construction. On Windows, it's fine. But on Linux it would cause the viewport camera grabbing mouse first time opening a level. (m_detectionState is initialized with DetectionState::WaitingForMove)

## How was this PR tested?

Manually tested. 
