### PR TITLE
Ignore imported object libraries as dependency when generating runtime dependencies

### DIFF
--- a/cmake/Platform/Common/RuntimeDependencies_common.cmake
+++ b/cmake/Platform/Common/RuntimeDependencies_common.cmake
@@ -179,7 +179,7 @@ function(o3de_get_dependencies_for_target)
     get_target_property(is_imported ${target} IMPORTED)
     if(is_imported)
         set(skip_imported FALSE)
-        if(target_type MATCHES "(STATIC_LIBRARY)")
+        if(target_type MATCHES "(STATIC_LIBRARY|OBJECT_LIBRARY)")
             # No need to copy these dependencies since the outputs are not used at runtime
             set(skip_imported TRUE)
         endif()


### PR DESCRIPTION
## What does this PR do?

When a gem contains an `OBJECT` cmake target (as is suggested for "private" targets in the [Gem public/private API RFC](https://github.com/o3de/sig-core/issues/37); but this specific part of the RFC was apparently never really adopted, neither for the gem template nor for existing gems), and this gem is then used by a project which uses a SDK build of the engine, there is the following cmake error (in this case I registered the o3de/install folder as an engine source):
```
CMake Error at D:/code/o3de/install/cmake/Platform/Common/RuntimeDependencies_common.cmake:233 (message):
  OBJECT_LIBRARY Library MyGem.Private.Object specified
  MAP_IMPORTED_CONFIG_PROFILE = PROFILE; but did not have any of
  IMPORTED_LOCATION_xxxx set
Call Stack (most recent call first):
  D:/code/o3de/install/cmake/Platform/Common/RuntimeDependencies_common.cmake:160 (o3de_get_dependencies_for_target)
  D:/code/o3de/install/cmake/Platform/Common/RuntimeDependencies_common.cmake:136 (o3de_get_dependencies_for_target)
  D:/code/o3de/install/cmake/Platform/Common/RuntimeDependencies_common.cmake:160 (o3de_get_dependencies_for_target)
  D:/code/o3de/install/cmake/Platform/Common/RuntimeDependencies_common.cmake:441 (o3de_get_dependencies_for_target)
  D:/code/o3de/install/CMakeLists.txt:129 (ly_delayed_generate_runtime_dependencies)
```
The same error does not occur if the `MyGem.Private.Object` library is of type `STATIC`.

@o3de/sig-core Is there a specific reason why the change of private targets from `STATIC` to `OBJECT` type as mentioned in the [RFC](https://github.com/o3de/sig-core/issues/37) (section "Why switch the STATIC library over to a OBJECT target?") was not adopted for existing gems in the engine and the gem template?

## How was this PR tested?

Build the engine SDK and use MyGem in a project that uses the SDK version of the engine.