### PR TITLE
Fix project-export for ROS2 enabled projects on Linux

### DIFF
--- a/python/python.sh
+++ b/python/python.sh
@@ -16,7 +16,6 @@ while [[ -h "$SOURCE" ]]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-
 # Locate and make sure cmake is in the path
 if [[ "$OSTYPE" = *"darwin"* ]];
 then
@@ -39,6 +38,26 @@ if ! [ -x "$(command -v cmake)" ]; then
         echo "ERROR: Could not find cmake on the PATH or at the known location: $LY_CMAKE_PATH"
         echo "Please add cmake to the environment PATH or place it at the above known location."
         exit 1
+    fi
+fi
+
+# Special Case: If we are using the export-project script in a ROS2 enabled environment, then we cannot use the O3DE embedded python
+# for the export scripts because the ROS2 projects may require ros-specific python modules to exist for validation to build the project
+# which is installed as part of the ROS2 system packages. These packages are not available in the embedded O3DE python so in this
+# case we must call the system installed python3
+if [[ $ROS_DISTRO != ""  && $2 == "export-project" ]]
+then
+    which python3 > /dev/null 2>&1
+    if [ $? -eq 0 ]
+    then
+        # Make sure the required 'resolvelib' is installed which is required for project export
+        python3 -m pip install resolvelib || true
+
+        # Run the python command through the ROS-installed python3
+        python3 "$@"
+        exit $?
+    else
+        echo "Warning. Detected ROS but cannot locate python3 for ROS, this may cause issues with O3DE."
     fi
 fi
 

--- a/python/python.sh
+++ b/python/python.sh
@@ -45,7 +45,7 @@ fi
 # for the export scripts because the ROS2 projects may require ros-specific python modules to exist for validation to build the project
 # which is installed as part of the ROS2 system packages. These packages are not available in the embedded O3DE python so in this
 # case we must call the system installed python3
-if [[ $ROS_DISTRO != ""  && $2 == "export-project" ]]
+if [[ $ROS_DISTRO != ""  && ( $1 == "export-project" || $2 == "export-project" ) ]]
 then
     which python3 > /dev/null 2>&1
     if [ $? -eq 0 ]

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -1161,7 +1161,7 @@ SETTINGS_OPTION_FAIL_ON_ASSET_ERR = register_setting(key='option.fail.on.asset.e
 
 SETTINGS_SEED_LIST_PATHS          = register_setting(key='seedlist.paths',
                                                      description='List of seed list paths (relative to the project folder) used for asset bundling. Multiple paths are separated by semi-colon (;).',
-                                                     default='AssetBundling/SeedLists/DefaultLevel.seed')
+                                                     default='')
 SETTINGS_SEED_FILE_PATHS          = register_setting(key='seedfile.paths',
                                                      description='List of seed file paths (relative to the project folder) used for asset bundling. Multiple paths are separated by semi-colon (;).',
                                                      default='')


### PR DESCRIPTION
## What does this PR do?
This fixes the project export script on Linux with ROS2 enabled. Also removes the default seedlist path from the settings since not all of the templates will have this.

## Root Cause
The o3de export-project command will use a python venv from O3DE's embedded python rather that the system one. This causes problems when trying to export ROS2 enabled O3DE projects because the ROS2 gem performs ros2 system validation, which includes the detection of some python modules. 
```
Traceback (most recent call last):
[INFO] root:   File "/opt/ros/humble/share/ament_cmake_core/cmake/package_templates/templates_2_cmake.py", line 21, in <module>
[INFO] root:     from ament_package.templates import get_environment_hook_template_path
[INFO] root: ModuleNotFoundError: No module named 'ament_package'
```
When the o3de virtual environment is called, it intentionally clears out the 'PYTHONPATH' to prevent pollution of the o3de venv with the system python's modules :

https://github.com/o3de/o3de/blob/1b597ec1fb402811ce2fa2b511a6a89e1efd14a7/python/python.sh#L105 

## Fix
The `python.sh` script will detect 2 things: If ROS is enabled, and if the python script's 1st or 2nd argument is 'export-project'.
 If this is true, then use the system python3 instead.

## How was this PR tested?

Create a new project from the Robot Fleet template and exported it through Project Manager
