### PR TITLE
Fix validation error of ray-tracing pipeline still in use.

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -6,12 +6,13 @@
  *
  */
 
-#include <RHI/RayTracingPipelineState.h>
-#include <RHI/Device.h>
-#include <RHI/SpecializationConstantData.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
-#include <Atom/RHI.Reflect/Vulkan/ShaderStageFunction.h>
 #include <Atom/RHI.Reflect/VkAllocator.h>
+#include <Atom/RHI.Reflect/Vulkan/ShaderStageFunction.h>
+#include <RHI/Device.h>
+#include <RHI/RayTracingPipelineState.h>
+#include <RHI/ReleaseContainer.h>
+#include <RHI/SpecializationConstantData.h>
 
 namespace AZ
 {
@@ -248,7 +249,8 @@ namespace AZ
         {
             Device& device = static_cast<Device&>(GetDevice());
 
-            device.GetContext().DestroyPipeline(device.GetNativeDevice(), m_pipeline, VkSystemAllocator::Get());
+            device.QueueForRelease(
+                new ReleaseContainer<VkPipeline>(device.GetNativeDevice(), m_pipeline, device.GetContext().DestroyPipeline));
 
             for (auto& shaderModule : m_shaderModules)
             {


### PR DESCRIPTION
## What does this PR do?

Fixes the Vulkan validation error

```
vkDebugMessage: [ERROR][Validation] Validation Error: [ VUID-vkDestroyPipeline-pipeline-00765 ] Object 0: handle = 0x5555581e0070, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x6bdce5fd | Cannot call vkDestroyPipeline on VkPipeline 0x65908900000009ac[] that is currently in use by a command buffer. The Vulkan spec states: All submitted commands that refer to pipeline must have completed execution (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-vkDestroyPipeline-pipeline-00765)
```

which appears when a RayTracingPipelineState is freed while a frame using it is still in flight.

## How was this PR tested?

Running the ASV RHI Ray Tracing sample switching to another sample.
