### PR TITLE
Fix compile error for Mac

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #ifdef __APPLE__
-# include <xlocale.h>
+#include <xlocale.h>
 #else
 #include <locale.h>
 #endif

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
@@ -7,7 +7,11 @@
  */
 #pragma once
 
+#ifdef __APPLE__
+# include <xlocale.h>
+#else
 #include <locale.h>
+#endif
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

Fixes the following compilation error on Mac:

```
    In file included from /Users/o3de/github/o3de/Code/Framework/AzCore/Platform/Mac/AzCore/Serialization/Locale_Platform.h:10:
    /Users/o3de/github/o3de/Code/Framework/AzCore/Platform/Mac/AzCore/Serialization/../../../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h:22:17: error: unknown type name 'locale_t'
                    locale_t m_createdLocale;
                    ^
    1 error generated.
```

## How was this PR tested?
Built on Mac locally
