### PR TITLE
feat: address compiling error for QualityCVarGroup

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp
@@ -216,7 +216,7 @@ namespace AzFramework
                 {
                     // the requested qualityLevel index wasn't found, use highest available 
                     PerformConsoleCommand(command, FixedValueString::format("%.*s/%d",
-                        AZ_STRING_ARG(visitArgs.m_jsonKeyPath), currentQualityLevel));
+                        AZ_STRING_ARG(visitArgs.m_jsonKeyPath), static_cast<int>(currentQualityLevel)));
                 }
             }
             else


### PR DESCRIPTION
## What does this PR do?

I've been running into a compiling error here. 
```
/home/michaelpollind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:219:65: error: format specifies type 'int' but the argument has type
 'QualityLevel' [-Werror,-Wformat]
  218 |                     PerformConsoleCommand(command, FixedValueString::format("%.*s/%d",
      |                                                                                   ~~
  219 |                         AZ_STRING_ARG(visitArgs.m_jsonKeyPath), currentQualityLevel));
      |                                                                 ^~~~~~~~~~~~~~~~~~~
      |                                                                 static_cast<int>(  )
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/typetraits/invoke_traits.h:206:67: note: in instantiation of function template specialization 'AzFram
ework::QualityCVarGroup::LoadQualityLevel(QualityLevel)::(anonymous class)::operator()<AZ::SettingsRegistryInterface::VisitArgs>' requested here
  206 |         constexpr auto INVOKE(Fn&& f, Args&&... args) -> decltype(InvokeTraits::forward<Fn>(f)(InvokeTraits::forward<Args>(args)...))
      |                                                                   ^
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/typetraits/invoke_traits.h:215:51: note: while substituting deduced template arguments into function 
template 'INVOKE' [with Fn = (lambda at /home/michaelpollind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25) &, Args = <const AZ:
:SettingsRegistryInterface::VisitArgs &>]
  215 |             static auto try_call(int) -> decltype(INVOKE(InvokeTraits::declval<Func>(), InvokeTraits::declval<Args>()...));
      |                                                   ^
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/typetraits/invoke_traits.h:219:42: note: while substituting deduced template arguments into function 
template 'try_call' [with Func = (lambda at /home/michaelpollind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25) &, Args = (no va
lue)]
  219 |             using result_type = decltype(try_call<Fn, ArgTypes...>(0));
      |                                          ^
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/function/invoke.h:45:38: note: in instantiation of template class 'AZStd::Internal::invocable_r<void,
 (lambda at /home/michaelpollind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25) &, const AZ::SettingsRegistryInterface::VisitArg
s &>' requested here
   45 |         : AZStd::enable_if<Internal::invocable<Fn, ArgTypes...>::value, typename Internal::invocable<Fn, ArgTypes...>::result_type>
      |                                      ^
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/function/invoke.h:49:5: note: in instantiation of template class 'AZStd::invoke_result<(lambda at /ho
me/michaelpollind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25) &, const AZ::SettingsRegistryInterface::VisitArgs &>' requested
 here
   49 |     using invoke_result_t = typename invoke_result<Fn, ArgTypes...>::type;
      |     ^
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/function/invoke.h:52:22: note: (skipping 3 contexts in backtrace; use -ftemplate-backtrace-limit=0 to
 see all)
   52 |     inline constexpr invoke_result_t<F, Args...> invoke(F&& f, Args&&... args)
      |                      ^
//projects/o3de/Code/Framework/AzCore/./AzCore/std/function/function_template.h:156:37: note: in instantiation of function template specialization 'AZSt
d::Internal::function_util::get_invoker<AZ::SettingsRegistryInterface::VisitResponse (const AZ::SettingsRegistryInterface::VisitArgs &), AZStd::Internal::function_util::fu
nction_obj_tag>::call<(lambda at /home/michaelpollind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25)>' requested here
  156 |                     auto funcPtr = &call<FunctionObj>;
      |                                     ^
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/function/function_template.h:538:70: note: in instantiation of function template specialization 'AZSt
d::Internal::function_util::get_invoker<AZ::SettingsRegistryInterface::VisitResponse (const AZ::SettingsRegistryInterface::VisitArgs &), AZStd::Internal::function_util::fu
nction_obj_tag>::create_vtable<(lambda at /home/michaelpollind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25)>' requested here
  538 |             static vtable_type stored_vtable = get_invoker::template create_vtable<decay_t<Functor>>();
      |                                                                      ^
/home/michaelpollind/projects/o3de/Code/Framework/AzCore/./AzCore/std/function/function_template.h:405:19: note: in instantiation of function template specialization 'AZSt
d::function_intermediate<AZ::SettingsRegistryInterface::VisitResponse, const AZ::SettingsRegistryInterface::VisitArgs &>::assign_to<(lambda at /home/michaelpollind/project
s/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25) &>' requested here
  405 |             this->assign_to(AZStd::forward<Functor>(f));
      |                   ^
//projects/o3de/Code/Framework/AzCore/./AzCore/std/function/function_template.h:629:15: note: in instantiation of function template specialization 'AZSt
d::function_intermediate<AZ::SettingsRegistryInterface::VisitResponse, const AZ::SettingsRegistryInterface::VisitArgs &>::function_intermediate<(lambda at /home/michaelpol
lind/projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25) &>' requested here
  629 |             : base_type(AZStd::forward<Functor>(f))
      |               ^
//projects/o3de/Code/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:230:66: note: in instantiation of function template specialization '
AZStd::function<AZ::SettingsRegistryInterface::VisitResponse (const AZ::SettingsRegistryInterface::VisitArgs &)>::function<(lambda at /home/michaelpollind/projects/o3de/Co
de/Framework/AzFramework/AzFramework/Quality/QualityCVarGroup.cpp:174:25) &>' requested here
  230 |         AZ::SettingsRegistryVisitorUtils::VisitObject(*registry, callback, key);
      |                                                                  ^
1 error generated.
```