### PR TITLE
Cherry Pick: Unified Launcher Stream Error Fix

### DIFF
--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -236,7 +236,7 @@ namespace Multiplayer
 
     void NetworkEntityManager::HandleLocalRpcMessage(NetworkEntityRpcMessage& message)
     {
-        m_localDeferredRpcMessages.emplace_back(AZStd::move(message));
+        m_localDeferredRpcMessages.emplace_back(message);
     }
 
     void NetworkEntityManager::HandleEntitiesExitDomain(const NetEntityIdSet& entitiesNotInDomain)
@@ -245,7 +245,7 @@ namespace Multiplayer
         {
             NetworkEntityHandle entityHandle = m_networkEntityTracker.Get(exitingId);
 
-            bool safeToExit = IsHierarchySafeToExit(entityHandle, entitiesNotInDomain);;
+            bool safeToExit = IsHierarchySafeToExit(entityHandle, entitiesNotInDomain);
 
             // Validate that we aren't already planning to remove this entity
             if (safeToExit)

--- a/Gems/Multiplayer/Code/Tests/LocalRpcTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/LocalRpcTests.cpp
@@ -73,7 +73,7 @@ namespace Multiplayer
         EXPECT_EQ(component->GetTestController()->m_serverToAuthorityCalls, 1);
     }
 
-    TEST_F(LocalRpcTests, LocalRpcAuthorityToClients)
+    TEST_F(LocalRpcTests, LocalRpcAuthorityToClient)
     {
         const auto component = m_root->m_entity->FindComponent<MultiplayerTest::RpcUnitTesterComponent>();
         component->GetTestController()->RPC_AuthorityToClient();
@@ -92,6 +92,21 @@ namespace Multiplayer
         m_networkEntityManager->DispatchLocalDeferredRpcMessages();        
 
         EXPECT_EQ(component->GetTestController()->m_authorityToAutonomousCalls, 1);
+    }
+
+    TEST_F(LocalRpcTests, LocalRpcAuthorityToRemoteAutonomous)
+    {
+        // Turn off player host autonomy.
+        // This simulates a host machine (authority) sending an RPC to a remote autonomous client
+        // For example, a local prediction player input correction RPC
+        m_root->m_entity->FindComponent<NetBindComponent>()->EnablePlayerHostAutonomy(false);
+
+        const auto component = m_root->m_entity->FindComponent<MultiplayerTest::RpcUnitTesterComponent>();
+        component->GetTestController()->RPC_AuthorityToAutonomous();
+
+        m_networkEntityManager->DispatchLocalDeferredRpcMessages();
+
+        EXPECT_EQ(component->GetTestController()->m_authorityToAutonomousCalls, 0);
     }
 
     TEST_F(LocalRpcTests, LocalRpcAutonomousToAuthority)


### PR DESCRIPTION
Cherry pick https://github.com/o3de/o3de/pull/18294 from 2409

## What does this PR do?
Fix for network packet being corrupted on the host causing the packet that's received by client to end up having no data attached.

GetNetBindComponent()->GetSendAuthorityToAutonomousRpcEvent().Signal(rpcMessage) ends up calling 2 callbacks
1. NetworkEntityManager::HandleLocalRpcMessage. This is the one that ends up leaving rpcMessage in a bad state
2. EntityReplicator::OnSendRpcEvent

HandleLocalRpcMessage would store the packet to a list via std::move and cause the packet to become invalid for anyone trying to use the packet in a later callback.

Also ensures that the client-server only tries to locally handle Authority->Autonomous RPCs if it's indeed the player. Otherwise you'll rightly receive an asset on the client-server "Entity proxy does not have autonomy", because it's the remote client, not the client-server host, which owns the player.
Note: It may be worth entirely removing the callback to handle all Authority->Autonomous RPCs locally on the client-server. The authority logic controls the network state, so there's no need to run the autonomous code as well when the authority and autonomous are the same application. For example, the only RPC using this currently is for the authority host to tell the player when they need to run client input correction. LocalPredictionPlayerInputComponentController::SendClientInputCorrection already (correctly) asserts if it tries to reprocess the corrections.

Fixes https://github.com/o3de/o3de-multiplayersample/issues/487
Fixes #18297 

## How was this PR tested?
- Ran 2 Unified Launchers in MultiplayerSample and see that the games no longer disconnect due to packet stream error.
- Added another unit test to ensure that the client-server only tries to locally handle Authority->Autonomous RPCs if it's the player.