### PR TITLE
Fix assert on startup by extending a fixed string size

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Serialization/Locale_WinAPI.h
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Serialization/Locale_WinAPI.h
@@ -14,7 +14,7 @@
 
 // Note that this is also the max defined in Windows.h but we'd like to avoid using windows.h
 // in headers if we can possibly avoid it.
-#define AZ_LOCALE_NAME_MAX_LENGTH 85 
+#define AZ_LOCALE_NAME_MAX_LENGTH 100 
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

Prevent an assert on O3DE startup on my computer given that the locale is higher than the string size. Follow-up to https://github.com/o3de/o3de/pull/18171

(got  "LC_COLLATE=C;LC_CTYPE=English_United Kingdom.1252;LC_MONETARY=C;LC_NUMERIC=C;LC_TIME=C" in local on windows)

## How was this PR tested?

Local build and launch