### PR TITLE
Remove static library targets from Atom_RPI

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
@@ -74,6 +74,8 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <ImageBuilderComponent.h>
 
+extern "C" void CleanUpRpiPublicGenericClassInfo();
+
 using namespace ImageProcessingAtom;
 
 namespace UnitTest
@@ -256,6 +258,8 @@ namespace UnitTest
 
             AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(this);
             ComponentApplicationBus::Handler::BusDisconnect();
+
+            CleanUpRpiPublicGenericClassInfo();
         }
 
         //enum names for Images with specific identification

--- a/Gems/Atom/RPI/Code/CMakeLists.txt
+++ b/Gems/Atom/RPI/Code/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 ly_add_target(
-    NAME ${gem_name}.Public STATIC
+    NAME ${gem_name}.Public ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         atom_rpi_reflect_files.cmake
@@ -26,6 +26,8 @@ ly_add_target(
         ../Assets/atom_rpi_asset_files.cmake
         ${pal_source_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
         ${MASKED_OCCLUSION_CULLING_FILES}
+    TARGET_PROPERTIES
+        WINDOWS_EXPORT_ALL_SYMBOLS TRUE
     PLATFORM_INCLUDE_FILES
         ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/Common/${PAL_TRAIT_COMPILER_ID}/atom_rpi_public_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
@@ -81,10 +83,12 @@ ly_add_source_properties(
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
 
     ly_add_target(
-        NAME ${gem_name}.Edit STATIC
+        NAME ${gem_name}.Edit ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
         NAMESPACE Gem
         FILES_CMAKE
             atom_rpi_edit_files.cmake
+        TARGET_PROPERTIES
+            WINDOWS_EXPORT_ALL_SYMBOLS TRUE
         INCLUDE_DIRECTORIES
             PRIVATE
                 Source
@@ -99,7 +103,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     ly_add_target(
-        NAME ${gem_name}.Editor.Static STATIC
+        NAME ${gem_name}.Editor.Private.Object OBJECT
         NAMESPACE Gem
         FILES_CMAKE
             atom_rpi_private_files.cmake
@@ -112,17 +116,16 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 RPI_EDITOR # Compile RPI Editor module
         BUILD_DEPENDENCIES
-            PRIVATE
+            PUBLIC
                 AZ::AtomCore
                 AZ::AzCore
                 AZ::AzFramework
-                Gem::${gem_name}.Public
                 Gem::Atom_RHI.Public
+                Gem::${gem_name}.Public
     )
 
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
-
         NAMESPACE Gem
         FILES_CMAKE
             atom_rpi_editor_files.cmake
@@ -133,12 +136,9 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Include
         BUILD_DEPENDENCIES
             PRIVATE
-                AZ::AtomCore
-                AZ::AzCore
                 AZ::AzToolsFramework
-                Gem::${gem_name}.Editor.Static
                 Gem::${gem_name}.Edit
-                Gem::${gem_name}.Public
+                Gem::${gem_name}.Editor.Private.Object
         RUNTIME_DEPENDENCIES
             Gem::Atom_RHI.Private
     )
@@ -159,10 +159,12 @@ endif()
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
 
     ly_add_target(
-        NAME ${gem_name}.TestUtils.Static STATIC
+        NAME ${gem_name}.TestUtils ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
         NAMESPACE Gem
         FILES_CMAKE
             atom_rpi_test_utils_files.cmake
+        TARGET_PROPERTIES
+            WINDOWS_EXPORT_ALL_SYMBOLS TRUE
         INCLUDE_DIRECTORIES
             PUBLIC
                 Tests
@@ -195,11 +197,11 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzFramework
                 AZ::AzToolsFramework
                 Legacy::CryCommon
-                Gem::${gem_name}.Public
                 Gem::Atom_RHI.Public
-                Gem::${gem_name}.Edit
-                Gem::${gem_name}.TestUtils.Static
                 Gem::Atom_Utils.TestUtils.Static
+                Gem::${gem_name}.Edit
+                Gem::${gem_name}.Public
+                Gem::${gem_name}.TestUtils
     )
     ly_add_googletest(
         NAME Gem::${gem_name}.Tests
@@ -224,7 +226,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         # Create a stub
         ly_add_target(
             NAME ${gem_name}.Builders GEM_MODULE
-
             NAMESPACE Gem
             FILES_CMAKE
                 atom_rpi_builders_stub_files.cmake
@@ -252,7 +253,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     endif()
     
     ly_add_target(
-        NAME ${gem_name}.Builders.Static STATIC
+        NAME ${gem_name}.Builders.Private.Object OBJECT
         NAMESPACE Gem
         FILES_CMAKE
             atom_rpi_builders_files.cmake
@@ -263,21 +264,20 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 Include
         BUILD_DEPENDENCIES
-            PRIVATE
+            PUBLIC
                 AZ::AtomCore
                 AZ::AzCore
                 AZ::AzFramework
                 AZ::SceneCore
                 AZ::SceneData
                 AZ::AssetBuilderSDK
+                Gem::Atom_RHI.Public
                 Gem::${gem_name}.Edit
                 Gem::${gem_name}.Public
-                Gem::Atom_RHI.Public
     )
 
     ly_add_target(
         NAME ${gem_name}.Builders GEM_MODULE
-
         NAMESPACE Gem
         FILES_CMAKE
             atom_rpi_builders_shared_files.cmake
@@ -289,15 +289,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Include
         BUILD_DEPENDENCIES
             PRIVATE
-                AZ::AtomCore
-                AZ::AzCore
-                AZ::AzFramework
-                AZ::SceneCore
-                AZ::AssetBuilderSDK
-                Gem::Atom_RHI.Public
-                Gem::${gem_name}.Edit
-                Gem::${gem_name}.Public
-                Gem::${gem_name}.Builders.Static
+                Gem::${gem_name}.Builders.Private.Object
     )
 
      # Inject the gem name into the Module source file
@@ -323,17 +315,9 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                     Source/RPI.Builders
             BUILD_DEPENDENCIES
                 PRIVATE
-                    AZ::AtomCore
                     AZ::AzTest
                     AZ::AzFramework
-                    AZ::AzToolsFramework
-                    AZ::AssetBuilderSDK
-                    AZ::SceneCore
-                    Legacy::CryCommon
-                    Gem::${gem_name}.Public
-                    Gem::Atom_RHI.Public
-                    Gem::${gem_name}.Edit
-                    Gem::${gem_name}.Builders.Static
+                    Gem::${gem_name}.Builders.Private.Object
         )
         ly_add_googletest(
             NAME Gem::${gem_name}.Builders.Tests

--- a/Gems/Atom/RPI/Code/CMakeLists.txt
+++ b/Gems/Atom/RPI/Code/CMakeLists.txt
@@ -20,14 +20,13 @@ endif()
 ly_add_target(
     NAME ${gem_name}.Public ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
     NAMESPACE Gem
+    EXPORT_ALL_SYMBOLS
     FILES_CMAKE
         atom_rpi_reflect_files.cmake
         atom_rpi_public_files.cmake
         ../Assets/atom_rpi_asset_files.cmake
         ${pal_source_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
         ${MASKED_OCCLUSION_CULLING_FILES}
-    TARGET_PROPERTIES
-        WINDOWS_EXPORT_ALL_SYMBOLS TRUE
     PLATFORM_INCLUDE_FILES
         ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/Common/${PAL_TRAIT_COMPILER_ID}/atom_rpi_public_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
@@ -85,10 +84,9 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Edit ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
         NAMESPACE Gem
+        EXPORT_ALL_SYMBOLS
         FILES_CMAKE
             atom_rpi_edit_files.cmake
-        TARGET_PROPERTIES
-            WINDOWS_EXPORT_ALL_SYMBOLS TRUE
         INCLUDE_DIRECTORIES
             PRIVATE
                 Source
@@ -161,10 +159,9 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     ly_add_target(
         NAME ${gem_name}.TestUtils ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
         NAMESPACE Gem
+        EXPORT_ALL_SYMBOLS
         FILES_CMAKE
             atom_rpi_test_utils_files.cmake
-        TARGET_PROPERTIES
-            WINDOWS_EXPORT_ALL_SYMBOLS TRUE
         INCLUDE_DIRECTORIES
             PUBLIC
                 Tests

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySourceData.h
@@ -45,9 +45,9 @@ namespace AZ
 
             using ConnectionList = AZStd::vector<Connection>;
 
-            static const float DefaultMin;
-            static const float DefaultMax;
-            static const float DefaultStep;
+            static constexpr float DefaultMin = AZStd::numeric_limits<float>::lowest();
+            static constexpr float DefaultMax = AZStd::numeric_limits<float>::max();
+            static constexpr float DefaultStep = 0.1f;
 
             static void Reflect(ReflectContext* context);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/GpuPassProfiler.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/GpuQuery/GpuPassProfiler.h
@@ -36,7 +36,7 @@ namespace AZ
             struct PassEntry
             {
                 //! Total number of attributes collected per  PipelineStatistics.
-                static const uint32_t PipelineStatisticsAttributeCount = 7u;
+                static constexpr uint32_t PipelineStatisticsAttributeCount = 7u;
 
                 using PipelineStatisticsArray = AZStd::array<uint64_t, PipelineStatisticsAttributeCount>;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -54,7 +54,7 @@ namespace AZ
             using ChangeId = size_t;
 
             //! GetCurrentChangeId() will never return this value, so client code can use this to initialize a ChangeId that is immediately dirty
-            static const ChangeId DEFAULT_CHANGE_ID = 0;
+            static constexpr ChangeId DEFAULT_CHANGE_ID = 0;
 
             static Data::Instance<Material> FindOrCreate(const Data::Asset<MaterialAsset>& materialAsset);
             static Data::Instance<Material> Create(const Data::Asset<MaterialAsset>& materialAsset);
@@ -195,7 +195,7 @@ namespace AZ
             // version of the function when a private overload is present, just based on a lambda signature.
             void ForAllShaderItemsWriteable(AZStd::function<bool(ShaderCollection::Item& shaderItem)> callback);
 
-            static const char* s_debugTraceName;
+            static constexpr const char* s_debugTraceName = "Material";
 
             //! The corresponding material asset that provides material type data and initial property values.
             Data::Asset<MaterialAsset> m_materialAsset;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -186,8 +186,8 @@ namespace AZ
             //! this is the fallback we will use when the pass is disabled.
             PassAttachmentBinding* m_fallbackBinding = nullptr;
 
-            static const int16_t ShaderInputAutoBind = -1;
-            static const int16_t ShaderInputNoBind = -2;
+            static constexpr int16_t ShaderInputAutoBind = -1;
+            static constexpr int16_t ShaderInputNoBind = -2;
 
             //! This tracks which SRG slot to bind the attachment to. This value gets applied in RenderPass::BindPassSrg
             //! after being converted to either an RHI::ShaderInputImageIndex or an RHI::ShaderInputBufferIndex using

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/EnvironmentCubeMapPass.h
@@ -37,8 +37,8 @@ namespace AZ
             void SetDefaultView();
 
             // cubemap face size is always 1024, it is downsampled during the asset build by the ImageProcessor
-            static const u32 CubeMapFaceSize = 1024;
-            static const u32 NumCubeMapFaces = 6;
+            static constexpr u32 CubeMapFaceSize = 1024;
+            static constexpr u32 NumCubeMapFaces = 6;
 
             // returns true if all faces of the cubemap have been rendered
             bool IsFinished() { return m_renderFace == NumCubeMapFaces; }
@@ -107,7 +107,7 @@ namespace AZ
             // tracks the number of frames elapsed before submitting the readback request
             // this is a work-around for a synchronization issue and will be removed after changing the readback mechanism
             // [ATOM-3844] Remove frame delay in EnvironmentCubeMapPass
-            static const u32 NumReadBackDelayFrames = 5;
+            static constexpr u32 NumReadBackDelayFrames = 5;
             u32 m_readBackDelayFrames = 0;
 
             // lock for managing state between this object and the callback

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -349,7 +349,7 @@ namespace AZ
             static AZ::Data::Instance<ShaderResourceGroup> CreateInternal(ShaderAsset& shaderAsset, const AZStd::any* srgInitParams);
 
             /// A name to be used in error messages
-            static const char* s_traceCategoryName;
+            static constexpr const char* s_traceCategoryName = "ShaderResourceGroup";
 
             /// Allows us to return const& to a null Image
             static const Data::Instance<Image> s_nullImage;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/XR/XRRenderingInterface.h
@@ -23,8 +23,8 @@ namespace AZ::RHI
 
 namespace AZ::RPI
 {
-    static const int XRMaxNumControllers = 2;
-    static const int XRMaxNumViews = 2;
+    static constexpr int XRMaxNumControllers = 2;
+    static constexpr int XRMaxNumViews = 2;
     class PassTemplate;
     class AttachmentImage;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Base.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Base.h
@@ -34,6 +34,8 @@ namespace AZ
                 return s_isEnabled;
             }
         private:
+            static void SetEnabled(bool enabled);
+
             static bool s_isEnabled;
         };
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Buffer/BufferAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Buffer/BufferAsset.h
@@ -34,9 +34,9 @@ namespace AZ
             friend class BufferAssetCreator;
 
         public:
-            static const char* DisplayName;
-            static const char* Extension;
-            static const char* Group;
+            static constexpr const char* DisplayName{ "BufferAsset" };
+            static constexpr const char* Group{ "Buffer" };
+            static constexpr const char* Extension{ "azbuffer" };
 
             AZ_RTTI(BufferAsset, "{F6C5EA8A-1DB3-456E-B970-B6E2AB262AED}", Data::AssetData);
             AZ_CLASS_ALLOCATOR(BufferAsset, AZ::SystemAllocator);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/AttachmentImageAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/AttachmentImageAsset.h
@@ -27,9 +27,9 @@ namespace AZ
             friend class AttachmentImageAssetCreator;
 
         public:
-            static const char* DisplayName;
-            static const char* Group;
-            static const char* Extension;
+            static constexpr const char* DisplayName{ "AttachmentImageAsset" };
+            static constexpr const char* Group{ "Image" };
+            static constexpr const char* Extension{ "attimage" };
 
             AZ_RTTI(AttachmentImageAsset, "{82CEA86B-E891-4969-8F35-D8017E8902C8}", ImageAsset);
             AZ_CLASS_ALLOCATOR(AttachmentImageAsset, AZ::SystemAllocator);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageAsset.h
@@ -28,9 +28,9 @@ namespace AZ
             : public Data::AssetData
         {
         public:
-            static const char* DisplayName;
-            static const char* Group;
-            static const char* Extension;
+            static constexpr const char* DisplayName{ "ImageAsset" };
+            static constexpr const char* Group{ "Image" };
+            static constexpr const char* Extension{ "image" };
 
             AZ_RTTI(ImageAsset, "{C53AB73A-5BC9-462D-805B-43BAFA8C8167}", Data::AssetData);
             AZ_CLASS_ALLOCATOR(ImageAsset, AZ::SystemAllocator);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageMipChainAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageMipChainAsset.h
@@ -42,10 +42,11 @@ namespace AZ
             friend class ImageMipChainAssetTester;
             friend class StreamingImageAssetCreator;
             friend class StreamingImageAssetHandler;
+
         public:
-            static const char* DisplayName;
-            static const char* Extension;
-            static const char* Group;
+            static constexpr const char* DisplayName{ "ImageMipChain" };
+            static constexpr const char* Group{ "Image" };
+            static constexpr const char* Extension{ "imagemipchain" };
 
             AZ_RTTI(ImageMipChainAsset, "{CB403C8A-6982-4C9F-8090-78C9C36FBEDB}", Data::AssetData);
             AZ_CLASS_ALLOCATOR(ImageMipChainAsset, AZ::SystemAllocator);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
@@ -53,9 +53,9 @@ namespace AZ
             friend class StreamingImageAssetHandler;
 
         public:
-            static const char* DisplayName;
-            static const char* Extension;
-            static const char* Group;
+            static constexpr const char* DisplayName{ "StreamingImage" };
+            static constexpr const char* Group{ "Image" };
+            static constexpr const char* Extension{ "streamingimage" };
 
             AZ_RTTI(StreamingImageAsset, "{3C96A826-9099-4308-A604-7B19ADBF8761}", ImageAsset);
             AZ_CLASS_ALLOCATOR(StreamingImageAsset , AZ::SystemAllocator)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImagePoolAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImagePoolAsset.h
@@ -43,9 +43,9 @@ namespace AZ
             AZ_RTTI(StreamingImagePoolAsset, "{877B2DA2-BBE7-42E7-AED3-F571929820FE}", Data::AssetData);
             AZ_CLASS_ALLOCATOR(StreamingImagePoolAsset, SystemAllocator);
 
-            static const char* DisplayName;
-            static const char* Extension;
-            static const char* Group;
+            static constexpr const char* DisplayName{ "StreamingImagePool" };
+            static constexpr const char* Group{ "Image" };
+            static constexpr const char* Extension{ "streamingimagepool" };
 
             static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
@@ -48,9 +48,9 @@ namespace AZ
             AZ_RTTI(MaterialAsset, "{522C7BE0-501D-463E-92C6-15184A2B7AD8}", AZ::Data::AssetData);
             AZ_CLASS_ALLOCATOR(MaterialAsset, SystemAllocator);
 
-            static const char* DisplayName;
-            static const char* Group;
-            static const char* Extension;
+            static constexpr const char* DisplayName{ "MaterialAsset" };
+            static constexpr const char* Group{ "Material" };
+            static constexpr const char* Extension{ "azmaterial" };
             
             static constexpr uint32_t UnspecifiedMaterialTypeVersion = static_cast<uint32_t>(-1);
 
@@ -132,7 +132,7 @@ namespace AZ
             //! Called by asset creators to assign the asset to a ready state.
             void SetReady();
 
-            static const char* s_debugTraceName;
+            static constexpr const char* s_debugTraceName{ "MaterialAsset" };
 
             Data::Asset<MaterialTypeAsset> m_materialTypeAsset = { AZ::Data::AssetLoadBehavior::PreLoad };
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
@@ -61,9 +61,9 @@ namespace AZ
             AZ_RTTI(MaterialTypeAsset, "{CD7803AB-9C4C-4A33-9A14-7412F1665464}", AZ::Data::AssetData);
             AZ_CLASS_ALLOCATOR(MaterialTypeAsset, SystemAllocator);
 
-            static const char* DisplayName;
-            static const char* Group;
-            static const char* Extension;
+            static constexpr const char* DisplayName{ "MaterialTypeAsset" };
+            static constexpr const char* Group{ "Material" };
+            static constexpr const char* Extension{ "azmaterialtype" };
 
             static constexpr AZ::u32 SubId = 0;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
@@ -34,9 +34,9 @@ namespace AZ
             friend class ModelAssetHelpers;
 
         public:
-            static const char* DisplayName;
-            static const char* Extension;
-            static const char* Group;
+            static constexpr const char* DisplayName{ "ModelAsset" };
+            static constexpr const char* Group{ "Model" };
+            static constexpr const char* Extension{ "azmodel" };
 
             AZ_RTTI(ModelAsset, "{2C7477B6-69C5-45BE-8163-BCD6A275B6D8}", AZ::Data::AssetData);
             AZ_CLASS_ALLOCATOR(ModelAsset, AZ::SystemAllocator);
@@ -146,7 +146,7 @@ namespace AZ
             // Various model information used in raycasting
             AZ::Name m_positionName{ "POSITION" };
             // there is a tradeoff between memory use and performance but anywhere under a few thousand triangles or so remains under a few milliseconds per ray cast
-            static const AZ::u32 s_minimumModelTriangleCountToOptimize = 100;
+            static constexpr AZ::u32 s_minimumModelTriangleCountToOptimize = 100;
             mutable AZStd::unique_ptr<ModelKdTree> m_kdTree;
             volatile mutable bool m_isKdTreeCalculationRunning = false;
             mutable AZStd::mutex m_kdTreeLock;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAssetHelpers.h
@@ -34,16 +34,16 @@ namespace AZ
             static constexpr AZ::RHI::Format SkinIndicesFormat = AZ::RHI::Format::R16_UINT; // Single-component, 16-bit int per weight
             static constexpr AZ::RHI::Format SkinWeightFormat = AZ::RHI::Format::R32_FLOAT; // Single-component, 32-bit floating point per weight
 
-            static const char* ShaderSemanticName_SkinJointIndices = "SKIN_JOINTINDICES";
-            static const char* ShaderSemanticName_SkinWeights = "SKIN_WEIGHTS";
+            static constexpr const char* ShaderSemanticName_SkinJointIndices = "SKIN_JOINTINDICES";
+            static constexpr const char* ShaderSemanticName_SkinWeights = "SKIN_WEIGHTS";
 
             // Morph targets
-            static const char* ShaderSemanticName_MorphTargetDeltas = "MORPHTARGET_VERTEXDELTAS";
+            static constexpr const char* ShaderSemanticName_MorphTargetDeltas = "MORPHTARGET_VERTEXDELTAS";
 
             // Cloth data
-            static const char* ShaderSemanticName_ClothData = "CLOTH_DATA";
+            static constexpr const char* ShaderSemanticName_ClothData = "CLOTH_DATA";
             static constexpr uint32_t ClothDataFloatsPerVert = 4;
-            static const AZ::RHI::Format ClothDataFormat = AZ::RHI::Format::R32G32B32A32_FLOAT;
+            static constexpr AZ::RHI::Format ClothDataFormat = AZ::RHI::Format::R32G32B32A32_FLOAT;
 
             // We align all the skinned mesh related stream buffers to 192 bytes for various reasons.
             // Metal has a restriction where each typed buffer needs to start at 64 byte boundary.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelKdTree.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelKdTree.h
@@ -67,7 +67,7 @@ namespace AZ
                 ModelKdTreeNode* pNode, const AZ::Vector3& raySrc, const AZ::Vector3& rayDir, AZStd::vector<AZ::Aabb>& outBoxes);
             void ConstructMeshList(const ModelAsset* model, const AZ::Transform& matParent);
 
-            static const int s_MinimumVertexSizeInLeafNode = 3 * 10;
+            static constexpr int s_MinimumVertexSizeInLeafNode = 3 * 10;
             // Stop splitting the tree if more than 10% of the triangles are straddling the split axis
             static constexpr float s_MaximumSplitAxisStraddlingTriangles = 1.1;
             AZStd::unique_ptr<ModelKdTreeNode> m_pRootNode;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
@@ -38,9 +38,9 @@ namespace AZ
         public:
             static constexpr size_t LodCountMax = 10;
 
-            static const char* DisplayName;
-            static const char* Extension;
-            static const char* Group;
+            static constexpr const char* DisplayName{ "ModelLodAsset" };
+            static constexpr const char* Group{ "Model" };
+            static constexpr const char* Extension{ "azlod" };
 
             AZ_RTTI(ModelLodAsset, "{65B5A801-B9B9-4160-9CB4-D40DAA50B15C}", Data::AssetData);
             AZ_CLASS_ALLOCATOR(ModelLodAsset, AZ::SystemAllocator);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelMaterialSlot.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelMaterialSlot.h
@@ -28,7 +28,7 @@ namespace AZ
             // Note that StableId is uint32_t for legacy reasons: we used to use AssetId::m_subId as the material slot ID. But actually the original MaterialUid
             // is 64 bit so we might want to switch this to be uint64_t at some point.
             using StableId = uint32_t;
-            static const StableId InvalidStableId;
+            static constexpr StableId InvalidStableId{ AZStd::numeric_limits<ModelMaterialSlot::StableId>::max() };
 
             //! This ID must have a consistent value when the asset is reprocessed by the asset pipeline, and must be unique within the ModelLodAsset.
             //! In practice, this set using the MaterialUid from SceneAPI. See ModelAssetBuilderComponent::CreateMesh.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAsset.h
@@ -38,9 +38,9 @@ namespace AZ
 
             static void Reflect(ReflectContext* context);
 
-            static const char* DisplayName;
-            static const char* Group;
-            static const char* Extension;
+            static constexpr const char* DisplayName{ "Pass" };
+            static constexpr const char* Group{ "RenderingPipeline" };
+            static constexpr const char* Extension{ "pass" };
 
             //! Retrieves the underlying PassTemplate
             const AZStd::unique_ptr<PassTemplate>& GetPassTemplate() const;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/ResourcePoolAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/ResourcePoolAsset.h
@@ -39,9 +39,9 @@ namespace AZ
             AZ_RTTI(ResourcePoolAsset, "{62A59999-66DA-467E-804A-0EA64A64299F}", AZ::Data::AssetData);
             AZ_CLASS_ALLOCATOR(ResourcePoolAsset, AZ::SystemAllocator);
 
-            static const char* DisplayName;
-            static const char* Group;
-            static const char* Extension;
+            static constexpr const char* DisplayName{ "ResourcePool" };
+            static constexpr const char* Group{ "RenderingPipeline" };
+            static constexpr const char* Extension{ "pool" };
 
             static void Reflect(ReflectContext* context);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
@@ -70,7 +70,7 @@ namespace AZ
             static constexpr char Group[] = "Shader";
 
             //! The default shader variant (i.e. the one without any options set).
-            static const ShaderVariantStableId RootShaderVariantStableId;
+            static constexpr ShaderVariantStableId RootShaderVariantStableId{ 0 };
 
             // @subProductType is one of ShaderAssetSubId, or ShaderAssetSubId::FirstByProduct+
             static uint32_t MakeProductAssetSubId(uint32_t rhiApiUniqueIndex, uint32_t supervariantIndex, uint32_t subProductType);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderCommonTypes.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderCommonTypes.h
@@ -42,7 +42,7 @@ namespace AZ
         //! The supervariant that supports subpass inputs.
         static constexpr const char* SubpassInputSupervariantName = "SubpassInput";
 
-        static const SupervariantIndex InvalidSupervariantIndex;
+        static constexpr SupervariantIndex InvalidSupervariantIndex;
 
         enum class ShaderStageType : uint32_t
         {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderOptionGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderOptionGroup.h
@@ -113,7 +113,7 @@ namespace AZ
             AZStd::string ToString() const;
 
         private:
-            static const char* DebugCategory;
+            static constexpr const char* DebugCategory = "ShaderOption";
 
             //! Returns the constructed key.
             ShaderVariantKey& GetShaderVariantKey();

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderOptionGroupLayout.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderOptionGroupLayout.h
@@ -179,7 +179,7 @@ namespace AZ
             uint32_t DecodeBits(ShaderVariantKey key) const;
 
         private:
-            static const char* DebugCategory;
+            static constexpr const char* DebugCategory = "ShaderOption";
 
             //! Adds a new option value to the (name, index) map. Only to use from the constructor.
             void AddValue(const Name& name, const ShaderOptionValue value);
@@ -283,7 +283,7 @@ namespace AZ
             template <typename, bool, bool>
             friend struct Serialize::InstanceFactory;
 
-            static const char* DebugCategory;
+            static constexpr const char* DebugCategory = "ShaderOption";
 
             bool ValidateIsFinalized() const;
             bool ValidateIsNotFinalized() const;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantKey.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantKey.h
@@ -72,7 +72,7 @@ namespace AZ
         //! Also the ShaderVariantStableId is used to make the Asset SubId of ShaderVariantAssets. See ShaderVariantAsset::GetAssetSubId()
         using ShaderVariantStableId = RHI::Handle<uint32_t, ShaderVariantId>;
 
-        extern const ShaderVariantStableId RootShaderVariantStableId;
+        static constexpr ShaderVariantStableId RootShaderVariantStableId{ 0 };
 
         //! Suggests the shader binary which best fits a requested variant
         //! The suggested binary is given as an index in the asset where the search was performed

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/System/AnyAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/System/AnyAsset.h
@@ -31,9 +31,9 @@ namespace AZ
             AZ_RTTI(AnyAsset, "{2643D686-3E7C-450C-BB61-427EDEBF13D5}", AZ::Data::AssetData);
             AZ_CLASS_ALLOCATOR(AnyAsset, SystemAllocator);
 
-            static const char* DisplayName;
-            static const char* Group;
-            static const char* Extension;
+            static constexpr const char* DisplayName{ "AnyAsset" };
+            static constexpr const char* Group{ "Common" };
+            static constexpr const char* Extension{ "azasset" };
             
             template <typename T>
             const T* GetDataAs() const

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/DllMain.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/DllMain.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#if !defined(AZ_MONOLITHIC_BUILD)
+
+#include <AzCore/PlatformDef.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+extern "C" AZ_DLL_EXPORT void CleanUpRpiEditGenericClassInfo()
+{
+    AZ::GetCurrentSerializeContextModule().Cleanup();
+}
+
+#endif

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertySourceData.cpp
@@ -49,10 +49,5 @@ namespace AZ
             , m_name(name)
         {
         }
-
-        const float MaterialPropertySourceData::DefaultMin = std::numeric_limits<float>::lowest();
-        const float MaterialPropertySourceData::DefaultMax = std::numeric_limits<float>::max();
-        const float MaterialPropertySourceData::DefaultStep = 0.1f;
-
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#if !defined(AZ_MONOLITHIC_BUILD)
+
+#include <AzCore/PlatformDef.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+extern "C" AZ_DLL_EXPORT void CleanUpRpiPublicGenericClassInfo()
+{
+    AZ::GetCurrentSerializeContextModule().Cleanup();
+}
+
+#endif

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -28,8 +28,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* Material::s_debugTraceName = "Material";
-
         Data::Instance<Material> Material::FindOrCreate(const Data::Asset<MaterialAsset>& materialAsset)
         {
             return Data::InstanceDatabase<Material>::Instance().FindOrCreate(materialAsset);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -16,7 +16,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ShaderResourceGroup::s_traceCategoryName = "ShaderResourceGroup";
         const Data::Instance<Image> ShaderResourceGroup::s_nullImage;
         const Data::Instance<Buffer> ShaderResourceGroup::s_nullBuffer;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Base.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Base.cpp
@@ -13,5 +13,10 @@ namespace AZ
     namespace RPI
     {
         bool Validation::s_isEnabled = RHI::BuildOptions::IsDebugBuild || RHI::BuildOptions::IsProfileBuild;
-    }
-}
+
+        void Validation::SetEnabled(bool enabled)
+        {
+            s_isEnabled = enabled;
+        }
+    } // namespace RPI
+} // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAsset.cpp
@@ -18,10 +18,6 @@ namespace AZ
 
     namespace RPI
     {
-        const char* BufferAsset::DisplayName = "BufferAsset";
-        const char* BufferAsset::Group = "Buffer";
-        const char* BufferAsset::Extension = "azbuffer";
-
         void BufferAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/AttachmentImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/AttachmentImageAsset.cpp
@@ -12,10 +12,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* AttachmentImageAsset::DisplayName = "AttachmentImageAsset";
-        const char* AttachmentImageAsset::Group = "Image";
-        const char* AttachmentImageAsset::Extension = "attimage";
-
         void AttachmentImageAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageAsset.cpp
@@ -14,10 +14,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ImageAsset::DisplayName = "ImageAsset";
-        const char* ImageAsset::Group = "Image";
-        const char* ImageAsset::Extension = "image";
-
         void ImageAsset::Reflect(AZ::ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
@@ -14,10 +14,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ImageMipChainAsset::DisplayName = "ImageMipChain";
-        const char* ImageMipChainAsset::Group = "Image";
-        const char* ImageMipChainAsset::Extension = "imagemipchain";
-
         void ImageMipChainAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
@@ -15,10 +15,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* StreamingImageAsset::DisplayName = "StreamingImage";
-        const char* StreamingImageAsset::Group = "Image";
-        const char* StreamingImageAsset::Extension = "streamingimage";
-
         void StreamingImageAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImagePoolAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImagePoolAsset.cpp
@@ -15,10 +15,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* StreamingImagePoolAsset::DisplayName = "StreamingImagePool";
-        const char* StreamingImagePoolAsset::Group = "Image";
-        const char* StreamingImagePoolAsset::Extension = "streamingimagepool";
-
         void StreamingImagePoolAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialAsset.cpp
@@ -22,12 +22,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* MaterialAsset::s_debugTraceName = "MaterialAsset";
-
-        const char* MaterialAsset::DisplayName = "MaterialAsset";
-        const char* MaterialAsset::Group = "Material";
-        const char* MaterialAsset::Extension = "azmaterial";
-
         void MaterialAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -19,10 +19,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* MaterialTypeAsset::DisplayName = "MaterialTypeAsset";
-        const char* MaterialTypeAsset::Group = "Material";
-        const char* MaterialTypeAsset::Extension = "azmaterialtype";
-
         void UvNamePair::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
@@ -24,10 +24,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ModelAsset::DisplayName = "ModelAsset";
-        const char* ModelAsset::Group = "Model";
-        const char* ModelAsset::Extension = "azmodel";
-
         void ModelAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAsset.cpp
@@ -14,10 +14,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ModelLodAsset::DisplayName = "ModelLodAsset";
-        const char* ModelLodAsset::Group = "Model";
-        const char* ModelLodAsset::Extension = "azlod";
-
         void ModelLodAsset::Reflect(AZ::ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelMaterialSlot.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelMaterialSlot.cpp
@@ -14,10 +14,6 @@ namespace AZ
 {
     namespace RPI
     {
-        // Normally this would be defined in the header file and substituted by the compiler, but for
-        // some reason clang doesn't accept it.
-        const ModelMaterialSlot::StableId ModelMaterialSlot::InvalidStableId = std::numeric_limits<ModelMaterialSlot::StableId>::max();
-
         void ModelMaterialSlot::Reflect(AZ::ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAsset.cpp
@@ -16,10 +16,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* PassAsset::DisplayName = "Pass";
-        const char* PassAsset::Group = "RenderingPipeline";
-        const char* PassAsset::Extension = "pass";
-
         void PassAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/ResourcePoolAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/ResourcePoolAsset.cpp
@@ -18,10 +18,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ResourcePoolAsset::DisplayName = "ResourcePool";
-        const char* ResourcePoolAsset::Group = "RenderingPipeline";
-        const char* ResourcePoolAsset::Extension = "pool";
-
         void ResourcePoolAsset::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
@@ -27,8 +27,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const ShaderVariantStableId ShaderAsset::RootShaderVariantStableId{0};
-
         static constexpr uint32_t SubProductTypeBitPosition = 0;
         static constexpr uint32_t SubProductTypeNumBits = SupervariantIndexBitPosition - SubProductTypeBitPosition;
         [[maybe_unused]] static constexpr uint32_t SubProductTypeMaxValue = (1 << SubProductTypeNumBits) - 1;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
@@ -14,8 +14,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ShaderOptionGroup::DebugCategory = "ShaderOption";
-
         ShaderOptionGroup::ShaderOptionGroup(const ShaderOptionGroup& rhs)
             : m_layout(rhs.m_layout)
             , m_id{rhs.m_id}

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
@@ -22,9 +22,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* ShaderOptionDescriptor::DebugCategory = "ShaderOption";
-        const char* ShaderOptionGroupLayout::DebugCategory = "ShaderOption";
-
         const char* ToString(ShaderOptionType shaderOptionType)
         {
             switch (shaderOptionType)

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantKey.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantKey.cpp
@@ -12,8 +12,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const ShaderVariantStableId RootShaderVariantStableId{0};
-
         void ShaderVariantId::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/System/AnyAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/System/AnyAsset.cpp
@@ -15,10 +15,6 @@ namespace AZ
 {
     namespace RPI
     {
-        const char* AnyAsset::DisplayName = "AnyAsset";
-        const char* AnyAsset::Group = "Common";
-        const char* AnyAsset::Extension = "azasset";
-
         void AnyAsset::SetReady()
         {
             m_status = AssetStatus::Ready;

--- a/Gems/Atom/RPI/Code/Tests.Builders/BuilderTestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/BuilderTestFixture.cpp
@@ -23,7 +23,9 @@
 #include <BuilderComponent.h>
 
 #include <Tests.Builders/BuilderTestFixture.h>
-  
+
+extern "C" void CleanUpRpiPublicGenericClassInfo();
+extern "C" void CleanUpRpiEditGenericClassInfo();
 
 namespace UnitTest
 {
@@ -118,6 +120,10 @@ namespace UnitTest
         NameDictionary::Destroy();
 
         m_context.reset();
+
+        CleanUpRpiPublicGenericClassInfo();
+        CleanUpRpiEditGenericClassInfo();
+
         LeakDetectionFixture::TearDown();
     }
 

--- a/Gems/Atom/RPI/Code/Tests/Common/AssetManagerTestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/AssetManagerTestFixture.cpp
@@ -14,6 +14,9 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
+extern "C" void CleanUpRpiPublicGenericClassInfo();
+extern "C" void CleanUpRpiEditGenericClassInfo();
+
 namespace UnitTest
 {
     void AssetManagerTestFixture::SetUp()
@@ -43,6 +46,9 @@ namespace UnitTest
 
         m_reflectionManager->Clear();
         m_reflectionManager.reset();
+
+        CleanUpRpiPublicGenericClassInfo();
+        CleanUpRpiEditGenericClassInfo();
 
         LeakDetectionFixture::TearDown();
     }

--- a/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
@@ -63,7 +63,7 @@ namespace UnitTest
     {
         AssetManagerTestFixture::SetUp();
 
-        AZ::RPI::Validation::s_isEnabled = true;
+        AZ::RPI::Validation::SetEnabled(true);
         AZ::RHI::Validation::s_isEnabled = true;
 
         m_priorFileIO = AZ::IO::FileIOBase::GetInstance();

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertySerializerTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertySerializerTests.cpp
@@ -15,6 +15,9 @@
 #include <Common/TestUtils.h>
 #include <Tests/Serialization/Json/JsonSerializerConformityTests.h>
 
+extern "C" void CleanUpRpiPublicGenericClassInfo();
+extern "C" void CleanUpRpiEditGenericClassInfo();
+
 namespace JsonSerializationTests
 {
     class MaterialPropertySerializerTestDescription :
@@ -137,6 +140,14 @@ namespace JsonSerializationTests
                 if (leftConnection.m_name!= rightConnection.m_name) { return false; }
             }
             return true;
+        }
+
+        void TearDown() override
+        {
+            CleanUpRpiPublicGenericClassInfo();
+            CleanUpRpiEditGenericClassInfo();
+
+            JsonSerializerConformityTestDescriptor::TearDown();
         }
     };
 

--- a/Gems/Atom/RPI/Code/atom_rpi_edit_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_edit_files.cmake
@@ -62,6 +62,7 @@ set(FILES
     Source/RPI.Edit/Common/AssetAliasesSourceData.cpp
     Source/RPI.Edit/Common/ColorUtils.cpp
     Source/RPI.Edit/Common/ConvertibleSource.cpp
+    Source/RPI.Edit/Common/DllMain.cpp
     Source/RPI.Edit/Common/JsonReportingHelper.cpp
     Source/RPI.Edit/Common/JsonUtils.cpp
 )

--- a/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
@@ -110,6 +110,7 @@ set(FILES
     Include/Atom/RPI.Public/XR/XRRenderingInterface.h
     Include/Atom/RPI.Public/XR/XRSpaceNotificationBus.h
     Source/RPI.Public/Culling.cpp
+    Source/RPI.Public/DllMain.cpp
     Source/RPI.Public/FeatureProcessor.cpp
     Source/RPI.Public/FeatureProcessorFactory.cpp
     Source/RPI.Public/MeshDrawPacket.cpp

--- a/Gems/GradientSignal/Code/CMakeLists.txt
+++ b/Gems/GradientSignal/Code/CMakeLists.txt
@@ -159,7 +159,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             PRIVATE
                 AZ::AzTest
                 AZ::AzTestShared
-                Gem::Atom_RPI.TestUtils.Static
+                Gem::Atom_RPI.TestUtils
                 Gem::${gem_name}.Static
                 Gem::LmbrCentral
                 Gem::LmbrCentral.Mocks

--- a/Gems/Terrain/Code/CMakeLists.txt
+++ b/Gems/Terrain/Code/CMakeLists.txt
@@ -131,7 +131,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzFrameworkTestShared
                 AZ::AzTestShared
                 AZ::AzFramework
-                Gem::Atom_RPI.TestUtils.Static
+                Gem::Atom_RPI.TestUtils
                 Gem::GradientSignal.Tests.Static
                 Gem::LmbrCentral.Mocks
                 Gem::GradientSignal.Mocks

--- a/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
@@ -39,6 +39,8 @@
 #include <MockAxisAlignedBoxShapeComponent.h>
 #include <Terrain/MockTerrainLayerSpawner.h>
 
+extern "C" void CleanUpRpiPublicGenericClassInfo();
+
 namespace UnitTest
 {
     void TerrainTestEnvironment::AddGemsAndComponents()
@@ -436,6 +438,8 @@ namespace UnitTest
         m_rhiFactory = nullptr;
 
         m_systemEntity.reset();
+
+        CleanUpRpiPublicGenericClassInfo();
 
         UnitTest::TerrainTestFixture::TearDown();
     }

--- a/cmake/LYWrappers.cmake
+++ b/cmake/LYWrappers.cmake
@@ -90,7 +90,7 @@ define_property(TARGET PROPERTY RUNTIME_DEPENDENCIES_DEPENDS
 # \arg:AUTOGEN_RULES a set of AutoGeneration rules to be passed to the AzAutoGen expansion system
 function(ly_add_target)
 
-    set(options STATIC SHARED MODULE GEM_STATIC GEM_MODULE OBJECT HEADERONLY EXECUTABLE APPLICATION IMPORTED AUTOMOC AUTOUIC AUTORCC NO_UNITY)
+    set(options STATIC SHARED MODULE GEM_STATIC GEM_MODULE OBJECT HEADERONLY EXECUTABLE APPLICATION IMPORTED AUTOMOC AUTOUIC AUTORCC NO_UNITY EXPORT_ALL_SYMBOLS)
     set(oneValueArgs NAME NAMESPACE OUTPUT_SUBDIRECTORY OUTPUT_NAME)
     set(multiValueArgs FILES_CMAKE GENERATED_FILES INCLUDE_DIRECTORIES COMPILE_DEFINITIONS BUILD_DEPENDENCIES RUNTIME_DEPENDENCIES PLATFORM_INCLUDE_FILES TARGET_PROPERTIES AUTOGEN_RULES)
 
@@ -272,6 +272,14 @@ function(ly_add_target)
         target_compile_definitions(${ly_add_target_NAME}
             ${ly_add_target_COMPILE_DEFINITIONS}
         )
+    endif()
+
+    if(ly_add_target_SHARED AND ly_add_target_EXPORT_ALL_SYMBOLS)
+        if(PAL_PLATFORM_NAME STREQUAL "Windows")
+            set_target_properties(${ly_add_target_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+        else()
+            target_compile_options(${ly_add_target_NAME} PRIVATE ${PAL_TRAIT_EXPORT_ALL_SYMBOLS_COMPILE_OPTIONS})
+        endif()
     endif()
 
     # For any target that depends on AzTest and is built as an executable, an additional 'AZ_TEST_EXECUTABLE' define will

--- a/cmake/Platform/Android/PAL_android.cmake
+++ b/cmake/Platform/Android/PAL_android.cmake
@@ -52,3 +52,6 @@ if(PAL_HOST_PLATFORM_NAME_LOWERCASE STREQUAL "windows")
 else()
     ly_set(LY_PYTHON_CMD ${CMAKE_CURRENT_SOURCE_DIR}/python/python.sh)
 endif()
+
+# Compiler flag to export all symbols from a library
+ly_set(PAL_TRAIT_EXPORT_ALL_SYMBOLS_COMPILE_OPTIONS -fvisibility=default)

--- a/cmake/Platform/Linux/PAL_linux.cmake
+++ b/cmake/Platform/Linux/PAL_linux.cmake
@@ -64,6 +64,9 @@ set(LY_ASSET_DEPLOY_ASSET_TYPE "linux" CACHE STRING "Set the asset type for depl
 # Set the python cmd tool
 ly_set(LY_PYTHON_CMD ${CMAKE_CURRENT_SOURCE_DIR}/python/python.sh)
 
+# Compiler flag to export all symbols from a library
+ly_set(PAL_TRAIT_EXPORT_ALL_SYMBOLS_COMPILE_OPTIONS -fvisibility=default)
+
 # Set the default window manager that applications should be using on Linux 
 # Note: Only ("xcb" or "wayland" should be considered)
 set(PAL_TRAIT_LINUX_WINDOW_MANAGER "xcb" CACHE STRING "Sets the Window Manager type to use when configuring Linux")  

--- a/cmake/Platform/Mac/PAL_mac.cmake
+++ b/cmake/Platform/Mac/PAL_mac.cmake
@@ -53,5 +53,8 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET ${LY_MAC_DEPLOYMENT_TARGET})
 # Set the python cmd tool
 ly_set(LY_PYTHON_CMD ${CMAKE_CURRENT_SOURCE_DIR}/python/python.sh)
 
+# Compiler flag to export all symbols from a library
+ly_set(PAL_TRAIT_EXPORT_ALL_SYMBOLS_COMPILE_OPTIONS -fvisibility=default)
+
 # Only x86_64 is currently supported on Mac
 ly_set(CMAKE_OSX_ARCHITECTURES "x86_64")

--- a/cmake/Platform/Windows/PAL_windows.cmake
+++ b/cmake/Platform/Windows/PAL_windows.cmake
@@ -51,3 +51,7 @@ set(LY_ASSET_DEPLOY_ASSET_TYPE "pc" CACHE STRING "Set the asset type for deploym
 
 # Set the python cmd tool
 ly_set(LY_PYTHON_CMD ${CMAKE_CURRENT_SOURCE_DIR}/python/python.cmd)
+
+# Compiler flag to export all symbols from a library
+# On Windows this is done directly with the WINDOWS_EXPORT_ALL_SYMBOLS cmake option instead
+ly_set(PAL_TRAIT_EXPORT_ALL_SYMBOLS_COMPILE_OPTIONS)

--- a/cmake/Platform/iOS/PAL_ios.cmake
+++ b/cmake/Platform/iOS/PAL_ios.cmake
@@ -49,3 +49,5 @@ set(LY_ASSET_DEPLOY_ASSET_TYPE "ios" CACHE STRING "Set the asset type for deploy
 # Set the python cmd tool
 ly_set(LY_PYTHON_CMD ${CMAKE_CURRENT_SOURCE_DIR}/python/python.sh)
 
+# Compiler flag to export all symbols from a library
+ly_set(PAL_TRAIT_EXPORT_ALL_SYMBOLS_COMPILE_OPTIONS -fvisibility=default)


### PR DESCRIPTION
## What does this PR do?

This PR removes static libraries from the Atom_RPI part of the Atom gem and uses object and shared libraries instead.

This has the following reasons:
* The ["Public/Private API split RFC"](https://github.com/o3de/sig-core/issues/37) recommends to use OBJECT libraries for internal targets, and since [PR18292](https://github.com/o3de/o3de/pull/18292) was merged this should no longer be a problem for the SDK build
* The ["Improve Developer iteration workflow RFC"](https://github.com/o3de/sig-core/issues/52) (not yet accepted) suggests to convert some core libraries from static to shared to decrease the number of build steps and link time for incremental builds, the same arguments apply here as well (eg. changing a single .cpp file leads to 2 targets needing to be rebuild instead of 75 with static ([details](https://github.com/o3de/sig-core/issues/37#issuecomment-2356027608))

Downsides of this change:
* Potentially slightly longer startup time due to shared library loading at runtime
* Symbol visibility: Ideally this would be achieved with adding an export/import macro to each public class or function (similar to the `SCENE_CORE_API` macro), but this would need to be added to all classes in all 225 include files, so I chose to do the following:
  * Add the option `EXPORT_ALL_SYMBOLS` to `ly_add_target`
  * On Windows this sets the `WINDOWS_EXPORT_ALL_SYMBOLS` CMake option
  * On other platforms this sets the `-fvisibility=default` compile option
* The `WINDOWS_EXPORT_ALL_SYMBOLS` option does not export static variables which are initialized in the cpp file. This would only be possible with an export/import macro, but for almost all cases this was circumvented by moving the initialization to the header file (mostly asset name/group/extension declarations, bot some other declarations as well). The only case where this was not possible is accessing `RPI::Validation::s_isEnabled` in a test fixture, there I had to add a new function.

If this PR is accepted I will also look at the other Atom libraries and potentially also other Gems and do the same refactoring there.

## How was this PR tested?

Compile the engine with unity and nounity option, run the editor with a small test level, test some ASV samples
