### PR TITLE
Fixes the multiplayer connectivity test timeout

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
@@ -37,11 +37,12 @@ def save_multiplayer_level_cache_folder_artifact(workspace, multiplayer_level):
 class TestAutomation(EditorTestSuite):
     class test_Multiplayer_BasicConnectivity_Connects(EditorSingleTest):
         from .tests import Multiplayer_BasicConnectivity_Connects as test_module
+        
+        timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup
 
         def __init__(self):
             super(test_Multiplayer_BasicConnectivity_Connects, self).__init__()
-            self.timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup
-        
+
         @classmethod
         def setup(cls, instance, request, workspace):
             save_multiplayer_level_cache_folder_artifact(workspace, "basicconnectivity_connects")
@@ -49,6 +50,7 @@ class TestAutomation(EditorTestSuite):
     class test_Multiplayer_BasicConnectivity_Connects_ClientServer(EditorSingleTest):
         from .tests import Multiplayer_BasicConnectivity_Connects_ClientServer as test_module
 
+        timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup
+
         def __init__(self):
             super(test_Multiplayer_BasicConnectivity_Connects_ClientServer, self).__init__()
-            self.timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup


### PR DESCRIPTION
The variable needed to be a class variable, not an instance one.

## What does this PR do?
Actually properly increases the test timeout as expected.

## How was this PR tested?

This time I actually had a debugger break in python to actually inspect the timeout value.
Last time I was running the automated test suites and slowing it down to try to make it fail. 