### PR TITLE
Fixes a crash / nullptr dereference in MoveProject_MovesExpectedFiles

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -462,21 +462,36 @@ namespace O3DE::ProjectManager
             if (projectDirectory.exists())
             {
                 // Check if there is an actual project here or just force it
-                AZ::Outcome<ProjectInfo> pInfo = PythonBindingsInterface::Get()->GetProject(path);
-                if (force || pInfo.IsSuccess())
+                auto pythonBindingsPtr = PythonBindingsInterface::Get();
+                if (pythonBindingsPtr)
                 {
-                    //determine if we have a restricted directory to worry about
-                    if (!pInfo.GetValue().m_restricted.isEmpty())
+                    // if we can obtain the python interface, then we will ONLY delete the folder
+                    // if its a real project, unless force is specified.
+
+                    AZ::Outcome<ProjectInfo> pInfo = pythonBindingsPtr->GetProject(path);
+                    if (force || pInfo.IsSuccess())
                     {
-                        QDir restrictedDirectory(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
-                        
-                        if (restrictedDirectory.cd("O3DE/Restricted/Projects") &&
-                            restrictedDirectory.cd(pInfo.GetValue().m_restricted) &&
-                            !restrictedDirectory.isEmpty())
+                        if (pInfo.IsSuccess())
                         {
-                            restrictedDirectory.removeRecursively();
+                            //determine if we have a restricted directory to worry about
+                            if (!pInfo.GetValue().m_restricted.isEmpty())
+                            {
+                                QDir restrictedDirectory(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
+                        
+                                if (restrictedDirectory.cd("O3DE/Restricted/Projects") &&
+                                    restrictedDirectory.cd(pInfo.GetValue().m_restricted) &&
+                                    !restrictedDirectory.isEmpty())
+                                {
+                                    restrictedDirectory.removeRecursively();
+                                }
+                            }
                         }
+                        return projectDirectory.removeRecursively();
                     }
+                }
+                else
+                {
+                    // we don't have any python bindings available, we're likely in test mode.
                     return projectDirectory.removeRecursively();
                 }
             }

--- a/Code/Tools/ProjectManager/tests/UtilsTests.cpp
+++ b/Code/Tools/ProjectManager/tests/UtilsTests.cpp
@@ -27,27 +27,22 @@ namespace O3DE::ProjectManager
             : public ::UnitTest::LeakDetectionFixture
         {
         public:
-            static inline QString ReplaceFirstAWithB(const QString& originalString)
-            {
-                QString bString(originalString);
-                return bString.replace(bString.indexOf('A'), 1, 'B');
-            }
 
             ProjectManagerUtilsTests()
             {
-                m_projectAPath = "ProjectA";
+                m_projectAPath = QDir(m_testFolder.GetDirectory()).path() + QDir::separator() + "ProjectA";
+                m_projectBPath = QDir(m_testFolder.GetDirectory()).path() + QDir::separator() + "ProjectB";
 
                 // Replaces first 'A' with 'B'
-                m_projectBPath = ReplaceFirstAWithB(m_projectAPath);
                 m_projectABuildPath = QString("%1%2%3").arg(m_projectAPath, QDir::separator(), ProjectBuildDirectoryName);
-                m_projectBBuildPath = ReplaceFirstAWithB(m_projectABuildPath);
+                m_projectBBuildPath = QString("%1%2%3").arg(m_projectBPath, QDir::separator(), ProjectBuildDirectoryName);
 
                 QDir dir;
                 dir.mkpath(m_projectABuildPath);
                 dir.mkdir(m_projectBPath);
 
                 m_projectAOrigFilePath = QString("%1%2%3").arg(m_projectAPath, QDir::separator(), "origFile.txt");
-                m_projectBOrigFilePath = ReplaceFirstAWithB(m_projectAOrigFilePath);
+                m_projectBOrigFilePath = QString("%1%2%3").arg(m_projectBPath, QDir::separator(), "origFile.txt");
                 QFile origFile(m_projectAOrigFilePath);
                 if (origFile.open(QIODevice::ReadWrite))
                 {
@@ -57,7 +52,7 @@ namespace O3DE::ProjectManager
                 }
 
                 m_projectAReplaceFilePath = QString("%1%2%3").arg(m_projectAPath, QDir::separator(), "replaceFile.txt");
-                m_projectBReplaceFilePath = ReplaceFirstAWithB(m_projectAReplaceFilePath);
+                m_projectBReplaceFilePath = QString("%1%2%3").arg(m_projectBPath, QDir::separator(), "replaceFile.txt");
                 QFile replaceFile(m_projectAReplaceFilePath);
                 if (replaceFile.open(QIODevice::ReadWrite))
                 {
@@ -67,7 +62,7 @@ namespace O3DE::ProjectManager
                 }
 
                 m_projectABuildFilePath = QString("%1%2%3").arg(m_projectABuildPath, QDir::separator(), "build.obj");
-                m_projectBBuildFilePath = ReplaceFirstAWithB(m_projectABuildFilePath);
+                m_projectBBuildFilePath = QString("%1%2%3").arg(m_projectBBuildPath, QDir::separator(), "build.obj");
                 QFile buildFile(m_projectABuildFilePath);
                 if (buildFile.open(QIODevice::ReadWrite))
                 {
@@ -96,6 +91,7 @@ namespace O3DE::ProjectManager
             QString m_projectBReplaceFilePath;
             QString m_projectBBuildPath;
             QString m_projectBBuildFilePath;
+            AZ::Test::ScopedAutoTempDirectory m_testFolder;
 
         };
 
@@ -106,8 +102,8 @@ namespace O3DE::ProjectManager
 #endif // !AZ_TRAIT_DISABLE_FAILED_PROJECT_MANAGER_TESTS
         {
             EXPECT_TRUE(MoveProject(
-                QDir::currentPath() + QDir::separator() + m_projectAPath,
-                QDir::currentPath() + QDir::separator() + m_projectBPath, nullptr,
+                m_projectAPath,
+                m_projectBPath, nullptr,
                 true, /*displayProgress=*/ false));
 
             QFileInfo origFile(m_projectAOrigFilePath);
@@ -130,8 +126,8 @@ namespace O3DE::ProjectManager
 #endif // !AZ_TRAIT_DISABLE_FAILED_PROJECT_MANAGER_TESTS
         {
             EXPECT_TRUE(MoveProject(
-                QDir::currentPath() + QDir::separator() + m_projectAPath,
-                QDir::currentPath() + QDir::separator() + m_projectBPath, nullptr,
+                m_projectAPath,
+                m_projectBPath, nullptr,
                 true, /*displayProgress=*/ false));
 
             QFileInfo origFile(m_projectAOrigFilePath);
@@ -151,8 +147,8 @@ namespace O3DE::ProjectManager
 #endif // !AZ_TRAIT_DISABLE_FAILED_PROJECT_MANAGER_TESTS
         {
             EXPECT_TRUE(CopyProject(
-                QDir::currentPath() + QDir::separator() + m_projectAPath,
-                QDir::currentPath() + QDir::separator() + m_projectBPath, nullptr,
+                m_projectAPath,
+                m_projectBPath, nullptr,
                 true, /*displayProgress=*/ false));
 
             QFileInfo origFile(m_projectAOrigFilePath);
@@ -175,8 +171,8 @@ namespace O3DE::ProjectManager
 #endif // !AZ_TRAIT_DISABLE_FAILED_PROJECT_MANAGER_TESTS
         {
             EXPECT_TRUE(CopyProject(
-                QDir::currentPath() + QDir::separator() + m_projectAPath,
-                QDir::currentPath() + QDir::separator() + m_projectBPath, nullptr,
+                m_projectAPath,
+                m_projectBPath, nullptr,
                 true, /*displayProgress=*/ false));
 
             QFileInfo origFile(m_projectAOrigFilePath);


### PR DESCRIPTION

## What does this PR do?
The python layer is not available while testing these functions.
Code was added in commit # c9c732b5d94 from https://github.com/o3de/o3de/pull/18037 that made it hit the python interface when deleting folders but that interface isn't available and nullptr when unit testing.

Also makes it work in parallel by using temp folders instead of real ones.

## How was this PR tested?

running the actual aztest module across this, in debug, on windows, with the crt heap checker enabled + leak detection enabled and whiteboxing every path.