### PR TITLE
Cherry pick locale fix from stabilization/2409 to development

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Serialization/Locale_WinAPI.h
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Serialization/Locale_WinAPI.h
@@ -14,7 +14,7 @@
 
 // Note that this is also the max defined in Windows.h but we'd like to avoid using windows.h
 // in headers if we can possibly avoid it.
-#define AZ_LOCALE_NAME_MAX_LENGTH 85 
+#define AZ_LOCALE_NAME_MAX_LENGTH 100 
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

This PR picks #18312 from stabilization/2409 to development.

I am having the same issue in development, in Chinese environment, the `getlocale` returns 

```
LC_COLLATE=C;LC_CTYPE=Chinese (Simplified)_China.utf8;LC_MONETARY=C;LC_NUMERIC=C;LC_TIME=C
```

It is longer than 85, then I am getting exactly the same assert. And I found that it's been fixed in stabilization/2409.

## How was this PR tested?

Tested in Chinese environment.
