### PR TITLE
Cherry Pick : Fix project-export for ROS2 enabled projects on Linux

### DIFF
--- a/python/python.sh
+++ b/python/python.sh
@@ -16,7 +16,6 @@ while [[ -h "$SOURCE" ]]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-
 # Locate and make sure cmake is in the path
 if [[ "$OSTYPE" = *"darwin"* ]];
 then
@@ -43,6 +42,26 @@ if ! [ -x "$(command -v cmake)" ]; then
         echo "ERROR: Could not find cmake on the PATH or at the known location: $LY_CMAKE_PATH"
         echo "Please add cmake to the environment PATH or place it at the above known location."
         exit 1
+    fi
+fi
+
+# Special Case: If we are using the export-project script in a ROS2 enabled environment, then we cannot use the O3DE embedded python
+# for the export scripts because the ROS2 projects may require ros-specific python modules to exist for validation to build the project
+# which is installed as part of the ROS2 system packages. These packages are not available in the embedded O3DE python so in this
+# case we must call the system installed python3
+if [[ $ROS_DISTRO != ""  && ( $1 == "export-project" || $2 == "export-project" ) ]]
+then
+    which python3 > /dev/null 2>&1
+    if [ $? -eq 0 ]
+    then
+        # Make sure the required 'resolvelib' is installed which is required for project export
+        python3 -m pip install resolvelib || true
+
+        # Run the python command through the ROS-installed python3
+        python3 "$@"
+        exit $?
+    else
+        echo "Warning. Detected ROS but cannot locate python3 for ROS, this may cause issues with O3DE."
     fi
 fi
 

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -1161,7 +1161,7 @@ SETTINGS_OPTION_FAIL_ON_ASSET_ERR = register_setting(key='option.fail.on.asset.e
 
 SETTINGS_SEED_LIST_PATHS          = register_setting(key='seedlist.paths',
                                                      description='List of seed list paths (relative to the project folder) used for asset bundling. Multiple paths are separated by semi-colon (;).',
-                                                     default='AssetBundling/SeedLists/DefaultLevel.seed')
+                                                     default='')
 SETTINGS_SEED_FILE_PATHS          = register_setting(key='seedfile.paths',
                                                      description='List of seed file paths (relative to the project folder) used for asset bundling. Multiple paths are separated by semi-colon (;).',
                                                      default='')


### PR DESCRIPTION
## What does this PR do?

Cherry picks https://github.com/o3de/o3de/pull/18293

* Update python.sh to use system python when running o3de export-project in a ROS2 enabled environment