### PR TITLE
Fixes a crash if you enable Script canvas developer Gem

### DIFF
--- a/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
@@ -29,8 +29,7 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
             AZ::AzFramework
-            Gem::ImGui.imguilib
-            Gem::ImGui            
+            Gem::ImGui.imguilib           
 )
 
 ly_add_target(
@@ -95,7 +94,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::${gem_name}.Static
                 Gem::ScriptCanvas.Editor.Static
                 Gem::GraphCanvasWidgets
-                Gem::ImGui  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
+                Gem::ImGui.Tools  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
         RUNTIME_DEPENDENCIES
             Gem::ScriptCanvas.Editor
             Gem::GraphCanvasWidgets


### PR DESCRIPTION
## What does this PR do?

Fix issue https://github.com/o3de/o3de/issues/17572

Sig-Release has decided that this should be APPROVED for stabilization 2409

Tools modules should depend on the Tools modules of other dependencies.  SCD was depending on the runtime version of ImGUi, which was in turn depending on the runtime version of LmbrCentral.

## How was this PR tested?

1. Built an install version of O3DE from latest stabilization
2. Created a default game project with no changes
3. Verified that it works fine
4. used the project manager to add just Script canvas Developer to it
5. Verified that the problem occurs, and editor fails to start up
6. Made this one line change to the scripts
7. Rebuilt the installer
8. rebuilt the project based on this new installer with the fix
9. Problem is gone and SCD works.
