### PR TITLE
[Cherry-pick] Fix parameter order in calls to EvaluateVertexGeometry_BasePBR (#18302)

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
@@ -83,7 +83,7 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         uint instanceId,
         bool useVertexBlendMask)
     {
-        VsOutput output = EvaluateVertexGeometry_BasePBR(position, normal, tangent, uv0, uv1, float4(1.0f, 1.0f, 1.0f, 1.0f), instanceId, false);
+        VsOutput output = EvaluateVertexGeometry_BasePBR(position, normal, tangent, uv0, uv1, instanceId, false, float4(1.0f, 1.0f, 1.0f, 1.0f));
 
         if(useVertexBlendMask)
         {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
@@ -108,6 +108,6 @@ VsOutput EvaluateVertexGeometry_BasePBR(
         uv0,
         uv1,
         instanceId,
-        float4(1.0f, 1.0f, 1.0f, 1.0f),
-        false);
+        false,
+        float4(1.0f, 1.0f, 1.0f, 1.0f));
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_LightingBrdf.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_LightingBrdf.azsli
@@ -71,6 +71,7 @@ real3 GetSpecularLighting_EnhancedPBR(Surface surface, LightingData lightingData
         specular = SpecularGGXMobile(lightingData.dirToCamera, dirToLight, surface.GetSpecularNormal(), surface.GetSpecularF0(), surface.roughnessA2, surface.roughnessA, surface.roughnessLinear);
 #else
         specular = SpecularGGX(lightingData.dirToCamera, dirToLight, surface.GetSpecularNormal(), surface.GetSpecularF0(), lightingData.GetSpecularNdotV(), surface.roughnessA2, lightingData.multiScatterCompensation);
+#endif
     }
 
 #if ENABLE_CLEAR_COAT


### PR DESCRIPTION
## What does this PR do?

Cherry pick from dev to stab/2409

Fix parameter order in calls to EvaluateVertexGeometry_BasePBR

## How was this PR tested?

Run PC

