### PR TITLE
Typo fix of MobileSubpass3ParentPassTemplate

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Subpass3Parent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Subpass3Parent.pass
@@ -4,7 +4,7 @@
     "ClassName": "PassAsset",
     "ClassData": {
         "PassTemplate": {
-            "Name": "MobileSubpass2ParentPassTemplate",
+            "Name": "MobileSubpass3ParentPassTemplate",
             "PassClass": "ParentPass",
             "Slots": [
                 // Outputs...


### PR DESCRIPTION
## What does this PR do?

Subpass3Parent.pass is having the same template name as Subpass2Parent.pass, which would cause some error in some of our scripts. I think it's a typo. This PR fixes it.

## How was this PR tested?

Tested on Windows