### PR TITLE
Add interface to expose members that are not necessary to be kept private

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -59,6 +59,7 @@ namespace AZ
 
             using PostCullingInstanceDataList = AZStd::vector<PostCullingInstanceData>;
             const bool IsSkinnedMesh() { return m_descriptor.m_isSkinnedMesh; }
+            const AZ::Uuid GetRayTracingUuid() { return m_rayTracingUuid; }
 
             //! called when a DrawPacket used by this ModelDataInstance was updated. 
             void HandleDrawPacketUpdate();

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -59,7 +59,7 @@ namespace AZ
 
             using PostCullingInstanceDataList = AZStd::vector<PostCullingInstanceData>;
             const bool IsSkinnedMesh() { return m_descriptor.m_isSkinnedMesh; }
-            const AZ::Uuid GetRayTracingUuid() { return m_rayTracingUuid; }
+            const AZ::Uuid& GetRayTracingUuid() const { return m_rayTracingUuid; }
 
             //! called when a DrawPacket used by this ModelDataInstance was updated. 
             void HandleDrawPacketUpdate();

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -193,9 +193,6 @@ namespace AZ
 
                 ReflectionProbe m_reflectionProbe;
 
-            private:
-                friend RayTracingFeatureProcessor;
-
                 // indices of subMeshes in the subMesh list
                 IndexVector m_subMeshIndices;
             };
@@ -322,6 +319,11 @@ namespace AZ
             const SubMeshVector& GetSubMeshes() const { return m_subMeshes; }
             SubMeshVector& GetSubMeshes() { return m_subMeshes; }
 
+            // mesh data for meshes that should be included in ray tracing operations,
+            // this is a map of the mesh UUID to the ray tracing data for the sub-meshes
+            using MeshMap = AZStd::map<AZ::Uuid, Mesh>;
+            const MeshMap& GetMeshMap() const { return m_meshes; };
+
             //! Retrieves the RayTracingSceneSrg
             Data::Instance<RPI::ShaderResourceGroup> GetRayTracingSceneSrg() const { return m_rayTracingSceneSrg; }
 
@@ -420,9 +422,6 @@ namespace AZ
             // flag indicating if RayTracing is enabled, currently based on device support
             bool m_rayTracingEnabled = false;
 
-            // mesh data for meshes that should be included in ray tracing operations,
-            // this is a map of the mesh UUID to the ray tracing data for the sub-meshes
-            using MeshMap = AZStd::map<AZ::Uuid, Mesh>;
             MeshMap m_meshes;
             SubMeshVector m_subMeshes;
 


### PR DESCRIPTION
## What does this PR do?

This PR adds interface to `RayTracingFeatureProcessor` and `MeshFeatureProcessor` to access some of the members that are necessary for Gems to implement some features that need to scan over ray tracing meshes.

## How was this PR tested?

Tested in Windows
