### PR TITLE
Move RaytracingAccelerationStructurePass back to Graphics Queue for 2409

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -42,7 +42,7 @@ namespace AZ
 
         void RayTracingAccelerationStructurePass::BuildInternal()
         {
-            InitScope(RHI::ScopeId(GetPathName()), AZ::RHI::HardwareQueueClass::Compute);
+            InitScope(RHI::ScopeId(GetPathName()), AZ::RHI::HardwareQueueClass::Graphics);
         }
 
         void RayTracingAccelerationStructurePass::FrameBeginInternal(FramePrepareParams params)
@@ -50,7 +50,7 @@ namespace AZ
             m_timestampResult = RPI::TimestampResult();
             if(GetScopeId().IsEmpty())
             {
-                InitScope(RHI::ScopeId(GetPathName()), RHI::HardwareQueueClass::Compute);
+                InitScope(RHI::ScopeId(GetPathName()), RHI::HardwareQueueClass::Graphics);
             }
 
             params.m_frameGraphBuilder->ImportScopeProducer(*this);


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/18305 by moving the `RaytracingAccelerationStructurePass` back to the Graphics queue

## How was this PR tested?

Opened a levelthat previously failed when changing the `r_displayInfo` to `1`