### PR TITLE
Extend pass attachment binding count

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -444,8 +444,8 @@ namespace AZ
             const Name PipelineGlobalKeyword{"PipelineGlobal"};
 
             // List of input, output and input/output attachment bindings
-            // Fixed size for performance and so we can hold pointers to the bindings for connections
-            AZStd::fixed_vector<PassAttachmentBinding, PassAttachmentBindingCountMax> m_attachmentBindings;
+            // The size is reserved to PassAttachmentBindingCountMax in the constructor for performance
+            AZStd::vector<PassAttachmentBinding> m_attachmentBindings;
             
             // List of attachments owned by this pass.
             // It includes both transient attachments and imported attachments
@@ -659,13 +659,13 @@ namespace AZ
             // --- Private Members ---
 
             // List of attachment binding indices for all the input bindings
-            AZStd::fixed_vector<uint8_t, PassInputBindingCountMax> m_inputBindingIndices;
+            AZStd::vector<uint8_t> m_inputBindingIndices;
 
             // List of attachment binding indices for all the input/output bindings
-            AZStd::fixed_vector<uint8_t, PassInputOutputBindingCountMax> m_inputOutputBindingIndices;
+            AZStd::vector<uint8_t> m_inputOutputBindingIndices;
 
             // List of attachment binding indices for all the output bindings
-            AZStd::fixed_vector<uint8_t, PassOutputBindingCountMax> m_outputBindingIndices;
+            AZStd::vector<uint8_t> m_outputBindingIndices;
 
             // Used to maintain references to imported attachments so they're underlying
             // buffers and images don't get deleted during attachment build phase

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -93,6 +93,12 @@ namespace AZ
             // Skip reset since the pass just got created
             m_state = PassState::Reset;
             m_flags.m_lastFrameEnabled = m_flags.m_enabled;
+
+            // Reserve memory for performance concern.
+            m_attachmentBindings.reserve(PassAttachmentBindingCountMax);
+            m_inputBindingIndices.reserve(PassInputBindingCountMax);
+            m_inputOutputBindingIndices.reserve(PassInputOutputBindingCountMax);
+            m_outputBindingIndices.reserve(PassOutputBindingCountMax);
         }
 
         Pass::~Pass()


### PR DESCRIPTION
## What does this PR do?

The current pass attachment binding count is set to 32, for some parent pass that has multiple complex children, this limit can be easily exceeded.

This PR increase this limit further to 48,  not adding too much performance loss but might be sufficient for most of the use cases.

## How was this PR tested?

Tested in windows
