### PR TITLE
Fix various Mac related issues.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
@@ -21,7 +21,7 @@
 #include "../MaterialInputs/TransmissionInput.azsli"
 
 [[range(0,4)]]
-option uint o_wrinkleLayers_count = 0;
+option int o_wrinkleLayers_count = 0;
 option bool o_wrinkleLayers_enabled;
 
 option bool o_wrinkleLayers_baseColor_enabled;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BlendColorGradingLuts.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BlendColorGradingLuts.azsl
@@ -61,7 +61,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 
 // Option shader variable to select number of source LUTs.
 [[range(0, 4)]]
-option uint o_numSourceLuts = 0;
+option int o_numSourceLuts = 0;
 
 float3 GetSourceLutLinearColor(float3 baseColor, Texture3D<float4> sourceLut, ShaperType shaperType, float shaperBias, float shaperScale)
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LookModificationTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LookModificationTransform.azsl
@@ -48,7 +48,7 @@ option bool o_enableColorGradingLut = false;
 // 1 - 7 tap b-spline
 // 2 - 19 tap b-spline
 [[range(0, 2)]]
-option uint o_lutSampleQuality = 0;
+option int o_lutSampleQuality = 0;
 
 // Sample a 3dtexture with a 7 or 19 tap B-Spline. Consider ripping this out and putting in a more general location.
 // This function samples a 4x4x4 neighborhood around the uv. Normally this would take 64 samples, but by taking

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -764,15 +764,14 @@ namespace AZ
                 AZ_Assert(count <= METAL_MAX_ENTRIES_BUFFER_ARG_TABLE , "Slots needed cannot exceed METAL_MAX_ENTRIES_BUFFER_ARG_TABLE");
 
                 NSRange range = {METAL_MAX_ENTRIES_BUFFER_ARG_TABLE - count, count};
-                for (u8 i = 0; !streamIter.HasEnded(); ++streamIter, ++i)
+                //The stream buffers are populated from bottom to top as the top slots are taken by argument buffers
+                for (int i = count-1; i >= 0; --i)
                 {
-                    //The stream buffers are populated from bottom to top as the top slots are taken by argument buffers
-                    uint16_t index = count - i - 1;
-                    if (streamIter[index].GetBuffer())
+                    if (streamIter[i].GetBuffer())
                     {
-                        const Buffer * buff = static_cast<const Buffer*>(streamIter[index].GetBuffer());
+                        const Buffer * buff = static_cast<const Buffer*>(streamIter[i].GetBuffer());
                         id<MTLBuffer> mtlBuff = buff->GetMemoryView().GetGpuAddress<id<MTLBuffer>>();
-                        uint32_t offset = static_cast<uint32_t>(streamIter[index].GetByteOffset() + buff->GetMemoryView().GetOffset());
+                        uint32_t offset = static_cast<uint32_t>(streamIter[i].GetByteOffset() + buff->GetMemoryView().GetOffset());
                         mtlStreamBuffers[bufferArrayLen] = mtlBuff;
                         mtlStreamBufferOffsets[bufferArrayLen] = offset;
                         bufferArrayLen++;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -621,17 +621,17 @@ namespace AZ
                 return;
             }
 
-            SetStreamBuffers(drawItem.m_streamBufferViews, drawItem.m_streamBufferViewCount);
+            SetStreamBuffers(*drawItem.m_geometryView, drawItem.m_streamIndices);
             SetStencilRef(drawItem.m_stencilRef);
 
             MTLPrimitiveType mtlPrimType = pipelineState->GetPipelineTopology();
 
-            switch (drawItem.m_arguments.m_type)
+            switch (drawItem.m_geometryView->GetDrawArguments().m_type)
             {
                 case RHI::DrawType::Indexed:
                 {
-                    const RHI::DrawIndexed& indexed = drawItem.m_arguments.m_indexed;
-                    const RHI::DeviceIndexBufferView& indexBuffDescriptor = *drawItem.m_indexBufferView;
+                    const RHI::DrawIndexed& indexed = drawItem.m_geometryView->GetDrawArguments().m_indexed;
+                    const RHI::DeviceIndexBufferView& indexBuffDescriptor = drawItem.m_geometryView->GetIndexBufferView();
                     const Buffer * buff = static_cast<const Buffer*>(indexBuffDescriptor.GetBuffer());
                     id<MTLBuffer> mtlBuff = buff->GetMemoryView().GetGpuAddress<id<MTLBuffer>>();
                     MTLIndexType mtlIndexType = (indexBuffDescriptor.GetIndexFormat() == RHI::IndexFormat::Uint16) ?
@@ -645,20 +645,20 @@ namespace AZ
                                                indexType: mtlIndexType
                                              indexBuffer: mtlBuff
                                        indexBufferOffset: indexOffset
-                                           instanceCount: indexed.m_instanceCount
+                                           instanceCount: drawItem.m_drawInstanceArgs.m_instanceCount
                                               baseVertex: indexed.m_vertexOffset
-                                            baseInstance: indexed.m_instanceOffset];
+                                            baseInstance: drawItem.m_drawInstanceArgs.m_instanceOffset];
                     break;
                 }
 
                 case RHI::DrawType::Linear:
                 {
-                    const RHI::DrawLinear& linear = drawItem.m_arguments.m_linear;
+                    const RHI::DrawLinear& linear = drawItem.m_geometryView->GetDrawArguments().m_linear;
                     [renderEncoder drawPrimitives: mtlPrimType
                                       vertexStart: linear.m_vertexOffset
                                       vertexCount: linear.m_vertexCount
-                                    instanceCount: linear.m_instanceCount
-                                     baseInstance: linear.m_instanceOffset];
+                                    instanceCount: drawItem.m_drawInstanceArgs.m_instanceCount
+                                     baseInstance: drawItem.m_drawInstanceArgs.m_instanceOffset];
                     break;
                 }
             }
@@ -741,14 +741,15 @@ namespace AZ
             }
         }
 
-        void CommandList::SetStreamBuffers(const RHI::DeviceStreamBufferView* streams, uint32_t count)
+        void CommandList::SetStreamBuffers(const RHI::DeviceGeometryView& geometryBufferViews, const RHI::StreamBufferIndices& streamIndices)
         {
+            auto streamIter = geometryBufferViews.CreateStreamIterator(streamIndices);
             bool needsBinding = false;
-            for (uint32_t i = 0; i < count; ++i)
+            for (u8 index = 0; !streamIter.HasEnded(); ++streamIter, ++index)
             {
-                if (m_state.m_streamsHashes[i] != streams[i].GetHash())
+                if (m_state.m_streamsHashes[index] != streamIter->GetHash())
                 {
-                    m_state.m_streamsHashes[i] = streams[i].GetHash();
+                    m_state.m_streamsHashes[index] = streamIter->GetHash();
                     needsBinding = true;
                 }
             }
@@ -758,17 +759,23 @@ namespace AZ
             if (needsBinding)
             {
                 uint16_t bufferArrayLen = 0;
+                streamIter.Reset();
+                //u8 count = geometryBufferViews.GetStreamBufferViews().size();
+                u8 count = streamIndices.Size();
                 AZ_Assert(count <= METAL_MAX_ENTRIES_BUFFER_ARG_TABLE , "Slots needed cannot exceed METAL_MAX_ENTRIES_BUFFER_ARG_TABLE");
 
+                
                 NSRange range = {METAL_MAX_ENTRIES_BUFFER_ARG_TABLE - count, count};
                 //The stream buffers are populated from bottom to top as the top slots are taken by argument buffers
-                for (int i = count-1; i >= 0; --i)
+                //for (uint16_t i = count-1; i >= 0; --i)
+                for (u8 i = 0; !streamIter.HasEnded(); ++streamIter, ++i)
                 {
-                    if (streams[i].GetBuffer())
+                    uint16_t index = count - i - 1;
+                    if (streamIter[index].GetBuffer())
                     {
-                        const Buffer * buff = static_cast<const Buffer*>(streams[i].GetBuffer());
+                        const Buffer * buff = static_cast<const Buffer*>(streamIter[index].GetBuffer());
                         id<MTLBuffer> mtlBuff = buff->GetMemoryView().GetGpuAddress<id<MTLBuffer>>();
-                        uint32_t offset = static_cast<uint32_t>(streams[i].GetByteOffset() + buff->GetMemoryView().GetOffset());
+                        uint32_t offset = static_cast<uint32_t>(streamIter[index].GetByteOffset() + buff->GetMemoryView().GetOffset());
                         mtlStreamBuffers[bufferArrayLen] = mtlBuff;
                         mtlStreamBufferOffsets[bufferArrayLen] = offset;
                         bufferArrayLen++;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -760,16 +760,13 @@ namespace AZ
             {
                 uint16_t bufferArrayLen = 0;
                 streamIter.Reset();
-                //u8 count = geometryBufferViews.GetStreamBufferViews().size();
                 u8 count = streamIndices.Size();
                 AZ_Assert(count <= METAL_MAX_ENTRIES_BUFFER_ARG_TABLE , "Slots needed cannot exceed METAL_MAX_ENTRIES_BUFFER_ARG_TABLE");
 
-                
                 NSRange range = {METAL_MAX_ENTRIES_BUFFER_ARG_TABLE - count, count};
-                //The stream buffers are populated from bottom to top as the top slots are taken by argument buffers
-                //for (uint16_t i = count-1; i >= 0; --i)
                 for (u8 i = 0; !streamIter.HasEnded(); ++streamIter, ++i)
                 {
+                    //The stream buffers are populated from bottom to top as the top slots are taken by argument buffers
                     uint16_t index = count - i - 1;
                     if (streamIter[index].GetBuffer())
                     {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
@@ -10,6 +10,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/CommandListStates.h>
+#include <Atom/RHI/DeviceGeometryView.h>
 #include <Atom/RHI/ObjectPool.h>
 #include <Atom/RHI/PipelineStateDescriptor.h>
 #include <Atom/RHI/ScopeAttachment.h>
@@ -80,7 +81,7 @@ namespace AZ
         private:
             
             void SetPipelineState(const PipelineState* pipelineState);
-            void SetStreamBuffers(const RHI::DeviceStreamBufferView* descriptors, AZ::u32 count);
+            void SetStreamBuffers(const RHI::DeviceGeometryView& geometryView, const RHI::StreamBufferIndices& streamIndices);
             void SetIndexBuffer(const RHI::DeviceIndexBufferView& descriptor);
             void SetStencilRef(AZ::u8 stencilRef);
             void SetRasterizerState(const RasterizerState& rastState);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -241,13 +241,13 @@ namespace AZ
             return usageFlags;
         }
         
-        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap)
+        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap, bool isViewArray)
         {
             if(isCubeMap)
             {
                 AZ_Assert(arraySize % RHI::ImageDescriptor::NumCubeMapSlices == 0, "Incorrect array layers for Cube or CubeArray.");
                 int numCubeMaps = arraySize / RHI::ImageDescriptor::NumCubeMapSlices;
-                if(numCubeMaps>1)
+                if(numCubeMaps>1 || isViewArray)
                 {
                     return MTLTextureTypeCubeArray;
                 }
@@ -260,7 +260,7 @@ namespace AZ
             {
                 case RHI::ImageDimension::Image1D:
                 {
-                    if(arraySize>1)
+                    if(arraySize>1 || isViewArray)
                     {
                         return MTLTextureType1DArray;
                     }
@@ -271,7 +271,7 @@ namespace AZ
                 }
                 case RHI::ImageDimension::Image2D:
                 {
-                    if(arraySize>1)
+                    if(arraySize>1 || isViewArray)
                     {
                         return MTLTextureType2DArray;
                     }
@@ -293,6 +293,14 @@ namespace AZ
             }
         }
         
+        bool IsTextureTypeAnArray(MTLTextureType textureType)
+        {
+            return textureType == MTLTextureType1DArray ||
+                    textureType == MTLTextureType2DArray ||
+                    textureType == MTLTextureTypeCubeArray ||
+                    textureType == MTLTextureType2DMultisampleArray;
+        }
+    
         uint32_t GetArrayLength(int arraySize, bool isCubeMap)
         {            
             if(arraySize>1)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
@@ -48,7 +48,7 @@ namespace AZ
 
         MTLPixelFormat ConvertPixelFormat(RHI::Format format);
         MTLTextureUsage ConvertTextureUsageFlags(RHI::BufferBindFlags flags, RHI::Format format);
-        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap);
+        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap, bool isViewArray=false);
         MTLPixelFormat ConvertImageViewFormat( const Image& image, const RHI::ImageViewDescriptor& imageViewDescriptor);
         MTLBlendOperation ConvertBlendOp(RHI::BlendOp op);
         MTLBlendFactor ConvertBlendFactor(RHI::BlendFactor factor);
@@ -94,6 +94,7 @@ namespace AZ
         bool IsDepthStencilMerged(MTLPixelFormat mtlFormat);
         bool GetVertexFormatSizeInBytes(const MTLVertexFormat vertexFormat, uint32_t& size);
         bool GetIndexTypeSizeInBytes(const MTLIndexType indexType, uint32_t& size);
+        bool IsTextureTypeAnArray(MTLTextureType textureType);
         uint32_t GetArrayLength(int arraySize, bool isCubeMap);
         
         ResourceDescriptor ConvertBufferDescriptor(const RHI::BufferDescriptor& descriptor, RHI::HeapMemoryLevel heapMemoryLevel = RHI::HeapMemoryLevel::Device);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
@@ -53,6 +53,15 @@ namespace AZ
                 textureLength = textureLength * RHI::ImageDescriptor::NumCubeMapSlices;
             }
             
+            MTLTextureType imgTextureType = mtlTexture.textureType;
+            //Recreate the texture if the existing texture is not flagged as an array but the view is of an array.
+            //Essentially this will tag a 2d texture as 2darray texture to ensure that sampling works correctly.
+            if(!IsTextureTypeAnArray(imgTextureType) && viewDescriptor.m_isArray)
+            {
+                isViewFormatDifferent = true;
+                imgTextureType = ConvertTextureType(imgDesc.m_dimension, imgDesc.m_arraySize, imgDesc.m_isCubemap, viewDescriptor.m_isArray);
+            }
+            
             //Create a new view if the format, mip range or slice range has changed
             if( isViewFormatDifferent ||
                 levelRange.location != 0 || levelRange.length != mtlTexture.mipmapLevelCount ||
@@ -66,7 +75,7 @@ namespace AZ
                 }
 
                 textureView = [mtlTexture newTextureViewWithPixelFormat : textureViewFormat
-                                                            textureType : mtlTexture.textureType
+                                                            textureType : imgTextureType
                                                                  levels : levelRange
                                                                  slices : sliceRange];
             }


### PR DESCRIPTION
## What does this PR do?

- Cherry pick the shadow fix from stab - https://github.com/o3de/o3de/pull/18326
- Fix compile errors from Geometryview change 
- Fix runtime errors due to function constants change. O3DE can not track type uint for function constants and hence the drivers complain during PSO compilation - 
```
Constant o_numSourceLuts_tmp (0) is of type MTLDataTypeUInt but value found has type MTLDataTypeInt
## How was this PR tested?
```

Tested Editor on AutomatedTesting.
