### PR TITLE
Model and geometry view changes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -126,7 +126,7 @@ namespace AZ
             CustomMaterialInfo GetCustomMaterialWithFallback(const CustomMaterialId& id) const;
 
             // When instancing is disabled, draw packets are owned by the ModelDataInstance
-            RPI::MeshDrawPacketLods m_drawPacketListsByLod;
+            RPI::MeshDrawPacketLods m_meshDrawPacketListsByLod;
             
             // When instancing is enabled, draw packets are owned by the MeshInstanceManager,
             // and the ModelDataInstance refers to those draw packets via InstanceGroupHandles,

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
@@ -752,7 +752,7 @@ namespace AZ
                     isSkinningEnabledPerMesh.push_back(lod.m_meshes[i].m_skinInfluenceCountPerVertex > 0);
 
                     Aabb localAabb = inputMesh.GetAabb();
-                    modelLodCreator.SetMeshAabb(AZStd::move(localAabb));
+                    modelLodCreator.SetMeshAabb(localAabb);
 
                     modelCreator.AddMaterialSlot(m_modelAsset->FindMaterialSlot(inputMesh.GetMaterialSlotId()));
                     modelLodCreator.SetMeshMaterialSlot(inputMesh.GetMaterialSlotId());

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceGeometryView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceGeometryView.h
@@ -176,6 +176,7 @@ namespace AZ::RHI
             m_dummyStreamBufferIndex = InvalidStreamBufferIndex;
         }
         void AddStreamBufferView(DeviceStreamBufferView streamBufferView) { m_streamBufferViews.emplace_back(streamBufferView); }
+        void SetStreamBufferView(u8 idx, DeviceStreamBufferView streamBufferView) { m_streamBufferViews[idx] = streamBufferView; }
         const DeviceStreamBufferView& GetStreamBufferView(u8 idx) const { return m_streamBufferViews[idx]; }
 
         AZStd::vector<DeviceStreamBufferView>& GetStreamBufferViews() { return m_streamBufferViews; }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
@@ -106,6 +106,15 @@ namespace AZ::RHI
         AZStd::vector<StreamBufferView>& GetStreamBufferViews() { return m_streamBufferViews; }
         const AZStd::vector<StreamBufferView>& GetStreamBufferViews() const { return m_streamBufferViews; }
 
+        inline void SetStreamBufferView(u8 idx, StreamBufferView streamBufferView)
+        {
+            m_streamBufferViews[idx] = streamBufferView;
+            for (auto& [deviceIndex, geometryView] : m_geometryViews)
+            {
+                geometryView.SetStreamBufferView(idx, streamBufferView.GetDeviceStreamBufferView(deviceIndex));
+            }
+        }
+
         inline void SetStreamBufferViews(const AZStd::vector<StreamBufferView>& streamBufferViews)
         {
             m_streamBufferViews = streamBufferViews;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
@@ -116,6 +116,9 @@ namespace AZ
                 const MaterialModelUvOverrideMap& materialModelUvMap = {},
                 const MaterialUvNameMap& materialUvNameMap = {});
 
+            // Releases all the buffer dependencies that were added through TrackBuffer
+            void ReleaseTrackedBuffers();
+
         private:
             ModelLod() = default;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAssetCreator.h
@@ -44,7 +44,7 @@ namespace AZ
 
             //! Sets the Aabb of the current SubMesh.
             //! Begin and BeginMesh must be called first.
-            void SetMeshAabb(AZ::Aabb&& aabb);
+            void SetMeshAabb(AZ::Aabb aabb);
 
             //! Sets the ID of the model's material slot that this mesh uses.
             //! Begin and BeginMesh must be called first

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAssetCreator.h
@@ -44,7 +44,7 @@ namespace AZ
 
             //! Sets the Aabb of the current SubMesh.
             //! Begin and BeginMesh must be called first.
-            void SetMeshAabb(AZ::Aabb aabb);
+            void SetMeshAabb(const AZ::Aabb& aabb);
 
             //! Sets the ID of the model's material slot that this mesh uses.
             //! Begin and BeginMesh must be called first

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -2293,7 +2293,7 @@ namespace AZ
                 AZ::Aabb subMeshAabb = AZ::Aabb::CreateNull();
                 if (CalculateAABB(positionBufferViewDescriptor, *positionStreamBufferInfo.m_bufferAssetView.GetBufferAsset().Get(), subMeshAabb))
                 {
-                    lodAssetCreator.SetMeshAabb(AZStd::move(subMeshAabb));
+                    lodAssetCreator.SetMeshAabb(subMeshAabb);
                 }
                 else
                 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -432,5 +432,11 @@ namespace AZ
             m_buffers.emplace_back(buffer);
             return static_cast<uint32_t>(m_buffers.size() - 1);
         }
+
+        void ModelLod::ReleaseTrackedBuffers()
+        {
+            m_buffers.clear();
+        }
+
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAssetHelpers.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAssetHelpers.cpp
@@ -101,7 +101,7 @@ namespace AZ
 
             // Set up a single-mesh asset with only position data.
             creator.BeginMesh();
-            creator.SetMeshAabb(AZStd::move(aabb));
+            creator.SetMeshAabb(aabb);
             creator.SetMeshMaterialSlot(0);
             creator.SetMeshIndexBuffer({ CreateBufferAsset(indices.data(), indexElementCount, IndexElementSize),
                                          AZ::RHI::BufferViewDescriptor::CreateTyped(0, indexElementCount, AZ::RHI::Format::R32_UINT) });

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAssetCreator.cpp
@@ -53,7 +53,7 @@ namespace AZ
             }
         }
 
-        void ModelLodAssetCreator::SetMeshAabb(AZ::Aabb aabb)
+        void ModelLodAssetCreator::SetMeshAabb(const AZ::Aabb& aabb)
         {
             if (ValidateIsMeshReady())
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAssetCreator.cpp
@@ -53,14 +53,14 @@ namespace AZ
             }
         }
 
-        void ModelLodAssetCreator::SetMeshAabb(AZ::Aabb&& aabb)
+        void ModelLodAssetCreator::SetMeshAabb(AZ::Aabb aabb)
         {
             if (ValidateIsMeshReady())
             {
-                m_currentMesh.m_aabb = AZStd::move(aabb);
+                m_currentMesh.m_aabb = aabb;
             }
         }
-        
+                
         void ModelLodAssetCreator::SetMeshMaterialSlot(ModelMaterialSlot::StableId id)
         {
             if (!ValidateIsMeshReady())
@@ -289,7 +289,7 @@ namespace AZ
                 creator.BeginMesh();
                 creator.SetMeshName(sourceMesh.GetName());
                 AZ::Aabb aabb = sourceMesh.GetAabb();
-                creator.SetMeshAabb(AZStd::move(aabb));
+                creator.SetMeshAabb(aabb);
 
                 creator.SetMeshMaterialSlot(sourceMesh.GetMaterialSlotId());
 


### PR DESCRIPTION
1. Made some naming more explicit so the code is easier to follow (for example m_drawPacketListsByLod -> m_meshDrawPacketListsByLod  and  meshDataIter -> modelDataIter)
2. Added SetStreamBufferView to GeometryView to allow setting an individual stream buffer view without having to clear and set all the stream buffer views.
3. Added ReleaseTrackedBuffers() so custom components could release tracked buffer references from ModelLod
4. Changed SetMeshAabb(AZ::Aabb&& aabb) to SetMeshAabb(AZ::Aabb aabb) to make it useable in more scenarios (if there's a good reason this should use move semantics please let me know).