### PR TITLE
Added model change event listener to AtomActorInstance

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -204,6 +204,7 @@ namespace AZ
             void UpdateWrinkleMasks();
 
             void HandleObjectSrgCreate(const Data::Instance<RPI::ShaderResourceGroup>& objectSrg);
+            void HandleModelChange(const Data::Instance<RPI::Model>& model);
 
             void UpdateLightingChannelMask();
 
@@ -227,6 +228,11 @@ namespace AZ
 
             AZStd::vector<Data::Instance<RPI::Image>> m_wrinkleMasks;
             AZStd::vector<float> m_wrinkleMaskWeights;
+
+            MeshHandleDescriptor::ModelChangedEvent::Handler m_modelChangedEventHandler
+            {
+                 [&](const Data::Instance<RPI::Model>& model) { HandleModelChange(model); } 
+            };
 
             MeshHandleDescriptor::ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler
             {


### PR DESCRIPTION
## What does this PR do?

Adds a `m_modelChangedEventHandler` to the `meshDescriptor` of `AtomActorInstance`s.
The callback was introduced in https://github.com/o3de/o3de/pull/17309 but not added to actor meshes.
The `MeshComponentNotificationBus::Events::OnModelReady` and `MeshHandleStateNotificationBus::Events::OnMeshHandleSet` events thus always contained a null model.

I also added the entity id to the `meshDescriptor`. It was introduced in https://github.com/o3de/o3de/pull/18131
I'm not sure this is correct, but it doesn't seem to break anything. @gadams3 Does this make sense for actors?

## How was this PR tested?

Tested on Windows with an actor in the scene
Tested with the MainPipeline and a custom pipeline that relies on `MeshHandleStateNotificationBus::Events::OnMeshHandleSet` events
