### PR TITLE
AssetBuilder: Model Exporter: Add step after model asset creation

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Builders/Model/ModelExporterContexts.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Builders/Model/ModelExporterContexts.h
@@ -8,12 +8,12 @@
 
 #pragma once
 
+#include <Atom/RPI.Reflect/Buffer/BufferAsset.h>
+#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <Atom/RPI.Reflect/Model/ModelLodAsset.h>
 #include <Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h>
 #include <Atom/RPI.Reflect/Model/SkinMetaAsset.h>
-#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
-#include <Atom/RPI.Reflect/Buffer/BufferAsset.h>
 
 #include <AzCore/Asset/AssetCommon.h>
 
@@ -32,7 +32,7 @@ namespace AZ
         {
             class Scene;
         }
-    }
+    } // namespace SceneAPI
 
     namespace RPI
     {
@@ -45,10 +45,7 @@ namespace AZ
 
         struct ModelAssetBuilderContext : public AZ::SceneAPI::Events::ICallContext
         {
-            AZ_RTTI(
-                ModelAssetBuilderContext,
-                "{63FEFB4B-25DC-48DD-AC72-D27DA9A6D94A}",
-                AZ::SceneAPI::Events::ICallContext);
+            AZ_RTTI(ModelAssetBuilderContext, "{63FEFB4B-25DC-48DD-AC72-D27DA9A6D94A}", AZ::SceneAPI::Events::ICallContext);
 
             ModelAssetBuilderContext(
                 const AZ::SceneAPI::Containers::Scene& scene,
@@ -71,12 +68,37 @@ namespace AZ
             Data::Asset<MorphTargetMetaAsset>& m_outputMorphTargetMetaAsset;
         };
 
+        struct ModelAssetPostBuildContext : public AZ::SceneAPI::Events::ICallContext
+        {
+            AZ_RTTI(ModelAssetPostBuildContext, "{E0AA70B6-FA06-41E9-A137-60D7DCB85115}", AZ::SceneAPI::Events::ICallContext);
+
+            ModelAssetPostBuildContext(
+                const AZ::SceneAPI::Containers::Scene& scene,
+                AZStd::string outputDirectory,
+                SceneAPI::Events::ExportProductList& productList,
+                const AZ::SceneAPI::DataTypes::IMeshGroup& group,
+                const Data::Asset<ModelAsset>& modelAsset)
+                : m_scene(scene)
+                , m_outputDirectory(outputDirectory)
+                , m_productList(productList)
+                , m_group(group)
+                , m_modelAsset(modelAsset)
+            {
+            }
+            ~ModelAssetPostBuildContext() override = default;
+
+            ModelAssetPostBuildContext& operator=(const ModelAssetPostBuildContext& other) = delete;
+
+            const AZ::SceneAPI::Containers::Scene& m_scene;
+            AZStd::string m_outputDirectory;
+            SceneAPI::Events::ExportProductList& m_productList;
+            const AZ::SceneAPI::DataTypes::IMeshGroup& m_group;
+            const Data::Asset<ModelAsset>& m_modelAsset;
+        };
+
         struct MaterialAssetBuilderContext : public AZ::SceneAPI::Events::ICallContext
         {
-            AZ_RTTI(
-                MaterialAssetBuilderContext,
-                "{6451418A-453B-4646-A5B2-A5687FA2E97F}",
-                AZ::SceneAPI::Events::ICallContext);
+            AZ_RTTI(MaterialAssetBuilderContext, "{6451418A-453B-4646-A5B2-A5687FA2E97F}", AZ::SceneAPI::Events::ICallContext);
 
             MaterialAssetBuilderContext(const AZ::SceneAPI::Containers::Scene& scene, MaterialAssetsByUid& outputMaterialsByUid);
             ~MaterialAssetBuilderContext() override = default;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
+#include <Atom/RPI.Builders/Model/ModelExporterContexts.h>
 #include <AzCore/Serialization/Utils.h>
 #include <SceneAPI/SceneCore/Components/ExportingComponent.h>
 #include <SceneAPI/SceneCore/SceneBuilderDependencyBus.h>
-#include <Model/ModelExporterContexts.h>
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
@@ -25,7 +25,7 @@
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/SceneBuilderDependencyBus.h>
 
-#include <Model/ModelExporterContexts.h>
+#include <Atom/RPI.Builders/Model/ModelExporterContexts.h>
 
 #include <AzCore/std/containers/map.h>
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelExporterComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelExporterComponent.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <Model/ModelExporterComponent.h>
-#include <Model/ModelExporterContexts.h>
 
 #include <AzCore/Asset/AssetCommon.h>
 
@@ -30,6 +29,7 @@
 
 #include <cinttypes>
 
+#include <Atom/RPI.Builders/Model/ModelExporterContexts.h>
 #include <Atom/RPI.Reflect/Material/MaterialAsset.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 
@@ -147,6 +147,17 @@ namespace AZ
                 Data::Asset<MorphTargetMetaAsset> morphTargetMetaAsset;
                 ModelAssetBuilderContext modelContext(exportEventContext.GetScene(), meshGroup, coordSysConverter, materialsByUid, modelAsset, skinMetaAsset, morphTargetMetaAsset);
                 combinerResult = SceneAPI::Events::Process<ModelAssetBuilderContext>(modelContext);
+                if (combinerResult.GetResult() != SceneAPI::Events::ProcessingResult::Success)
+                {
+                    return combinerResult.GetResult();
+                }
+                ModelAssetPostBuildContext modelAssetPostBuildContext(
+                    exportEventContext.GetScene(),
+                    exportEventContext.GetOutputDirectory(),
+                    exportEventContext.GetProductList(),
+                    meshGroup,
+                    modelAsset);
+                combinerResult = SceneAPI::Events::Process<ModelAssetPostBuildContext>(modelAssetPostBuildContext);
                 if (combinerResult.GetResult() != SceneAPI::Events::ProcessingResult::Success)
                 {
                     return combinerResult.GetResult();

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelExporterContexts.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelExporterContexts.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <Model/ModelExporterContexts.h>
+#include <Atom/RPI.Builders/Model/ModelExporterContexts.h>
 
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/DataTypes/Groups/IMeshGroup.h>

--- a/Gems/Atom/RPI/Code/atom_rpi_builders_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_builders_files.cmake
@@ -26,7 +26,7 @@ set(FILES
     Source/RPI.Builders/Model/ModelExporterComponent.cpp
     Source/RPI.Builders/Model/ModelExporterComponent.h
     Source/RPI.Builders/Model/ModelExporterContexts.cpp
-    Source/RPI.Builders/Model/ModelExporterContexts.h
+    Include/Atom/RPI.Builders/Model/ModelExporterContexts.h
     Source/RPI.Builders/Model/MorphTargetExporter.cpp
     Source/RPI.Builders/Model/MorphTargetExporter.h
     Source/RPI.Builders/Pass/PassBuilder.cpp


### PR DESCRIPTION
## What does this PR do?

We have a Gem that adds additional data to every submesh of every created Model Asset file.
This PR adds a new build context that's executed after a Model Asset is finished building, where we generate this additional data.

I also needed to move the `ModelExporterContexts.h` file into an include directory so the new context can actually be used.

## How was this PR tested?

Tested on Windows with and without a Gem that uses the new processing step.
