### PR TITLE
Use uint32_t for DispatchDirect group count

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDispatchItem.h
@@ -37,19 +37,19 @@ namespace AZ::RHI
             , m_threadsPerGroupZ(threadsPerGroupZ)
         {}
 
-        uint16_t GetNumberOfGroupsX() const
+        uint32_t GetNumberOfGroupsX() const
         {
-            return aznumeric_cast<uint16_t>(DivideAndRoundUp(m_totalNumberOfThreadsX, aznumeric_cast<uint32_t>(m_threadsPerGroupX)));
+            return DivideAndRoundUp(m_totalNumberOfThreadsX, aznumeric_cast<uint32_t>(m_threadsPerGroupX));
         }
 
-        uint16_t GetNumberOfGroupsY() const
+        uint32_t GetNumberOfGroupsY() const
         {
-            return aznumeric_cast<uint16_t>(DivideAndRoundUp(m_totalNumberOfThreadsY, aznumeric_cast<uint32_t>(m_threadsPerGroupY)));
+            return DivideAndRoundUp(m_totalNumberOfThreadsY, aznumeric_cast<uint32_t>(m_threadsPerGroupY));
         }
 
-        uint16_t GetNumberOfGroupsZ() const
+        uint32_t GetNumberOfGroupsZ() const
         {
-            return aznumeric_cast<uint16_t>(DivideAndRoundUp(m_totalNumberOfThreadsZ, aznumeric_cast<uint32_t>(m_threadsPerGroupZ)));
+            return DivideAndRoundUp(m_totalNumberOfThreadsZ, aznumeric_cast<uint32_t>(m_threadsPerGroupZ));
         }
 
         // Different platforms require number of groups or number of threads or both in their Dispatch() call


### PR DESCRIPTION
## What does this PR do?

Increases the size of group count variable for compute launches from 16-bit to 32-bit. Vulkan, DX12 and Metal all support 32-bit compute dispatches.

## How was this PR tested?

Tested on Windows with Vulkan and DX12
