### PR TITLE
DiffuseProbeGridVisualizationAccelerationStructurePass header missing forward declaration

### DIFF
--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.h
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.h
@@ -16,6 +16,8 @@ namespace AZ
 {
     namespace Render
     {
+        class DiffuseProbeGrid;
+
         //! This pass builds the DiffuseProbeGrid visualization acceleration structure
         class DiffuseProbeGridVisualizationAccelerationStructurePass final
             : public RPI::Pass


### PR DESCRIPTION
## What does this PR do?

Introduces a forward declaration for `DiffuseProbeGrid` in the `DiffuseProbeGridVisualizationAccelerationStructurePass .h` header file, which currently worked only in the right include order and not stand-alone.

