### PR TITLE
Check count buffer of indirect draw arguments before accessing.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawArguments.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawArguments.h
@@ -54,7 +54,7 @@ namespace AZ::RHI
             case DrawType::Linear:
                 return DeviceDrawArguments(m_linear);
             case DrawType::Indirect:
-                return DeviceDrawArguments(DeviceDrawIndirect{ m_indirect.m_maxSequenceCount, m_indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_indirect.m_indirectBufferByteOffset, m_indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get(), m_indirect.m_countBufferByteOffset });
+                return DeviceDrawArguments(DeviceDrawIndirect{ m_indirect.m_maxSequenceCount, m_indirect.m_indirectBufferView->GetDeviceIndirectBufferView(deviceIndex), m_indirect.m_indirectBufferByteOffset, m_indirect.m_countBuffer ? m_indirect.m_countBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr, m_indirect.m_countBufferByteOffset });
             default:
                 return DeviceDrawArguments();
             }


### PR DESCRIPTION
## What does this PR do?

Indirect draw argument does not necessarily have `m_countBuffer` (the `m_maxSequenceCount` can also be used to specify the number of operations). Now the code doesn't check whether it's null before accessing it, if someone sends an indirect draw without count buffer, an access violation would happen.

This PR fix it by checking it before accessing, just like what it is usually done in `DispatchRaysArguments` and `DispatchArguments`

## How was this PR tested?

Tested in Windows
