### PR TITLE
Fixes a crash when you try to remove elements from unordered set.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -906,9 +906,17 @@ namespace AZ
             /// Get an element's address by its index (called before the element is loaded).
             void*   GetElementByIndex(void* instance, const SerializeContext::ClassElement* classElement, size_t index) override
             {
-                (void)instance;
                 (void)classElement;
-                (void)index;
+                // Linear iteration of the container.   If possible, use GetElementByKey, but this is implemented to be compatible
+                // with things that present the container as if it is a linear container (such as UIs)
+                T* containerPtr = reinterpret_cast<T*>(instance);
+                if (index < containerPtr->size())
+                {
+                    auto elementIterator = containerPtr->begin();
+                    AZStd::advance(elementIterator, index);
+                    
+                    return (elementIterator != containerPtr->end()) ? &(*elementIterator) : nullptr;
+                }
                 return nullptr;
             }
 


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/18348

NOTE: Pending approval for inclusion into stabilization. 

The function that it depended on was simply not implemented. While it is not ideal for it to walk the memory linearly when removing an element from a set, it's still worth implementing for cases where the set is being used in a way that relies on indices, which is the case for the UI.

## How was this PR tested?

It was a 100% repro before applying this.  If you look at the code, its implementing an unimplemented function.
Anything calling this code would have crashed or failed before, since the function was unimplemented.

After this, I can work on unordered sets in the UI without it crashing.  Its possible it fixes other containers with no index (such as sets).