### PR TITLE
Fix hyper-sensitve camera rotation remote clients

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -13,7 +13,6 @@
 #include <AzFramework/AzFramework_Traits_Platform.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
-#include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
 #include <AzFramework/Windowing/WindowBus.h>
 
 

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -36,7 +36,7 @@ namespace AzFramework
         AZ::ConsoleFunctorFlags::Null,
         "Disable the capture the mouse when it is used to freely rotate a camera view. Use this option if the camera rotation during free look movements with "
         "the mouse is hyper-sensitive, in which case may be an indication that the system is unable to trap the cursor location which is needed for normal mouse "
-        " movement calculations.");
+        "movement calculations.");
 #endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
 
     //! return -1.0f if inverted, 1.0f otherwise

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -30,11 +30,13 @@ namespace AzFramework
 #if AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
     AZ_CVAR(
         bool,
-        bg_capture_mouse_for_camera_rotation,
-        true,
+        ed_disable_capture_mouse_for_camera_rotation,
+        false,
         nullptr,
         AZ::ConsoleFunctorFlags::Null,
-        "Trap/Capture the mouse when it is used to freely rotate a camera view. If the system cannot capture the mouse, set this value to false to resolve movement calculation errors.");
+        "Disable the capture the mouse when it is used to freely rotate a camera view. Use this option if the camera rotation during free look movements with "
+        "the mouse is hyper-sensitive, in which case may be an indication that the system is unable to trap the cursor location which is needed for normal mouse "
+        " movement calculations.");
 #endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
 
     //! return -1.0f if inverted, 1.0f otherwise
@@ -1048,7 +1050,7 @@ namespace AzFramework
     bool IsMouseCaptureUsedForCameraRotation()
     {
 #if AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
-        return bg_capture_mouse_for_camera_rotation;
+        return !ed_disable_capture_mouse_for_camera_rotation;
 #else
         return true;
 #endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/numeric.h>
 #include <AzCore/Console/IConsole.h>
+#include <AzFramework/AzFramework_Traits_Platform.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
@@ -26,6 +27,7 @@ namespace AzFramework
         AZ::ConsoleFunctorFlags::Null,
         "Should the camera use cursor absolute positions or motion deltas");
 
+#if AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
     AZ_CVAR(
         bool,
         bg_capture_mouse_for_camera_rotation,
@@ -33,6 +35,7 @@ namespace AzFramework
         nullptr,
         AZ::ConsoleFunctorFlags::Null,
         "Trap/Capture the mouse when it is used to freely rotate a camera view. If the system cannot capture the mouse, set this value to false to resolve movement calculation errors.");
+#endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
 
     //! return -1.0f if inverted, 1.0f otherwise
     constexpr static float Invert(const bool invert)
@@ -1044,7 +1047,11 @@ namespace AzFramework
 
     bool IsMouseCaptureUsedForCameraRotation()
     {
+#if AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
         return bg_capture_mouse_for_camera_rotation;
+#else
+        return true;
+#endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
     }
 
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -171,14 +171,7 @@ namespace AzFramework
         if (const auto& cursor = AZStd::get_if<CursorEvent>(&state.m_inputEvent))
         {
             m_cursorState.SetCurrentPosition(cursor->m_position);
-            if (IsMouseCaptureUsedForCameraRotation())
-            {
-                m_cursorState.SetCaptured(cursor->m_captured);
-            }
-            else
-            {
-                m_cursorState.SetCaptured(false);
-            }
+            m_cursorState.SetCaptured(IsMouseCaptureUsedForCameraRotation() ? cursor->m_captured : false);
         }
         else if (const auto& horizontalMotion = AZStd::get_if<HorizontalMotionEvent>(&state.m_inputEvent))
         {

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -9,7 +9,6 @@
 #include "CameraInput.h"
 
 #include <AzCore/std/numeric.h>
-#include <AzCore/Console/IConsole.h>
 #include <AzFramework/AzFramework_Traits_Platform.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -32,7 +32,7 @@ namespace AzFramework
         false,
         nullptr,
         AZ::ConsoleFunctorFlags::Null,
-        "Disable the capture the mouse when it is used to freely rotate a camera view. Use this option if the camera rotation during free look movements with "
+        "Disable capturing the mouse position when it is used to freely rotate a camera view. Use this option if the camera rotation during free look movements with "
         "the mouse is hyper-sensitive, in which case may be an indication that the system is unable to trap the cursor location which is needed for normal mouse "
         "movement calculations.");
 #endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -759,4 +759,7 @@ namespace AzFramework
     //! Map from a generic InputChannel event to a camera specific InputEvent.
     InputState BuildInputEvent(
         const InputChannel& inputChannel, const AzFramework::ModifierKeyStates& modifiers, const WindowSize& windowSize);
+
+    //! Determine if we want to capture/trap the mouse cursor when using mouse movements for rotating the camera view
+    bool IsMouseCaptureUsedForCameraRotation();
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -568,8 +568,13 @@ namespace AzFramework
                         m_systemCursorPositionNormalized.SetX(movement_x);
                         m_systemCursorPositionNormalized.SetY(movement_y);
                     }
-                    QueueRawMovementEvent(InputDeviceMouse::Movement::X, movement_x - m_systemCursorPositionNormalized.GetX());
-                    QueueRawMovementEvent(InputDeviceMouse::Movement::Y, movement_y - m_systemCursorPositionNormalized.GetY());
+                    float movement_x_delta = movement_x - m_systemCursorPositionNormalized.GetX();
+                    float movement_y_delta = movement_y - m_systemCursorPositionNormalized.GetY();
+                    QueueRawMovementEvent(InputDeviceMouse::Movement::X, movement_x_delta);
+                    QueueRawMovementEvent(InputDeviceMouse::Movement::Y, movement_y_delta);
+
+                    AZ_Printf("Mouse", "(%f,%f) delta (%f,%f)", movement_x, movement_y, movement_x_delta, movement_y_delta);
+
                     m_systemCursorPositionNormalized.SetX(movement_x);
                     m_systemCursorPositionNormalized.SetY(movement_y);
                 }

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -81,8 +81,16 @@ namespace AzFramework
     xcb_screen_t* XcbInputDeviceMouse::s_xcbScreen = nullptr;
     bool XcbInputDeviceMouse::m_xfixesInitialized = false;
     bool XcbInputDeviceMouse::m_xInputInitialized = false;
-    static constexpr float s_movementThresholdDeltaLimit = 480.0f;
-    static constexpr int s_movementThresholdTriggerValue = 10;
+
+    // The mouse movement threshold value to detect possible absolute mouse positions versus actual incremental mouse movement
+    // deltas. This value represents a reasonable number where multiple deltas are not possible (ie its not possible to move
+    // a mouse by this number of pixels continously)
+    static constexpr const float s_movementThresholdDeltaLimit = 480.f;
+
+    // To prevent possible anomalies with the delta limit, set a value where X number of violations will trigger the mode where
+    // we internally calculate the mouse movements based on the assumption that the received mouse movement values are actually
+    // mouse coordinates.
+    static constexpr const int s_movementThresholdTriggerValue = 10;
 
     XcbInputDeviceMouse::XcbInputDeviceMouse(InputDeviceMouse& inputDevice)
         : InputDeviceMouse::Implementation(inputDevice)

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
@@ -178,5 +178,10 @@ namespace AzFramework
 
         //! Array that holds barrier information used to confine the cursor.
         std::vector<XFixesBarrierProperty> m_activeBarriers;
+
+        //! Tracks the number of mouse movement threshold violations so we can trigger
+        //! internal delta tracking on systems that report mouse movement deltas as absolute
+        //! screen positions.
+        size_t m_movementThresholdViolations;
     };
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
@@ -21,4 +21,6 @@
 // cursor when debugging Lua code.
 #define AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT 1
 
+// Enable the cvar 'ed_disable_capture_mouse_for_camera_rotation' to optionally disable mouse captures for 
+// mouse free-looks in the Editor
 #define AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION 1

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
@@ -20,3 +20,5 @@
 // the whole OS gets stuck with an invisible mouse
 // cursor when debugging Lua code.
 #define AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT 1
+
+#define AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION 1

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputMapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputMapper.cpp
@@ -23,6 +23,11 @@
 #include <QWheelEvent>
 #include <QWidget>
 
+namespace AzFramework
+{
+    // Forward declare the following function so we don't have to include the entire CameraInput.h file unnecessarily
+    bool IsMouseCaptureUsedForCameraRotation();
+}
 namespace AzToolsFramework
 {
     static bool HandleTextEvent(QEvent::Type eventType, Qt::Key key, QString keyText, bool isAutoRepeat)
@@ -264,8 +269,11 @@ namespace AzToolsFramework
             switch (m_cursorMode)
             {
             case CursorInputMode::CursorModeCaptured:
-                qApp->setOverrideCursor(Qt::BlankCursor);
-                m_mouseDevice->SetSystemCursorState(AzFramework::SystemCursorState::ConstrainedAndHidden);
+                if (AzFramework::IsMouseCaptureUsedForCameraRotation())
+                {
+                    qApp->setOverrideCursor(Qt::BlankCursor);
+                    m_mouseDevice->SetSystemCursorState(AzFramework::SystemCursorState::ConstrainedAndHidden);
+                }
                 break;
             case CursorInputMode::CursorModeWrapped:
                 qApp->restoreOverrideCursor();
@@ -523,7 +531,16 @@ namespace AzToolsFramework
         switch (m_cursorMode)
         {
         case CursorInputMode::CursorModeCaptured:
-            AzQtComponents::SetCursorPos(m_previousGlobalCursorPosition);
+            {
+                if (AzFramework::IsMouseCaptureUsedForCameraRotation())
+                {
+                    AzQtComponents::SetCursorPos(m_previousGlobalCursorPosition);
+                }
+                else
+                {
+                    m_previousGlobalCursorPosition = globalCursorPosition;
+                }
+            }
             break;
         case CursorInputMode::CursorModeWrappedX:
         case CursorInputMode::CursorModeWrappedY:


### PR DESCRIPTION
## What does this PR do?

When running O3DE on AWS EC2 using NiceDCV as the remote client viewer, O3DE is unable to trap/set the mouse cursor position when in camera 'free-look' mode. It may be caused by the remote client itself is setting the cursor position independently and not getting the set cursor messages that O3DE is setting through XCB. This PR adds a work-around that will at least make the Editor usable in this remote client scenario by not relying on the actual mouse position but instead tracking the 'expected' mouse position and calculating the delta from here. This scenario cannot be detected in the Editor so a cvar was created to enable this fix.

For game mode, its possible to detect this situation by evaluating what the mouse movement deltas are being received by O3DE. Game mode does not require the cvar to be enabled.

This fix has been isolated to Linux.

Fixes https://github.com/o3de/o3de/issues/18344

## How was this PR tested?
This is how the camera free look in the editor appears before the fix

https://github.com/user-attachments/assets/f524551b-8b62-492a-a2e1-7464de1b3d84

And the camera free look in game mode before the fix

https://github.com/user-attachments/assets/9d77612b-c03b-47b2-8798-2245a2dc6122

This is the camera free look in the editor after the fix when the cvar enabled

https://github.com/user-attachments/assets/d5cf86b8-7a52-4802-9f4f-c2f6d8ca7a41

And the camera free look in game mode after the fix

https://github.com/user-attachments/assets/30d066c4-9e71-45d6-bc81-1adabe2b8ed4

