### PR TITLE
Cherry Pick: Fix hyper-sensitive camera rotation remote clients (#18354)

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -759,4 +759,7 @@ namespace AzFramework
     //! Map from a generic InputChannel event to a camera specific InputEvent.
     InputState BuildInputEvent(
         const InputChannel& inputChannel, const AzFramework::ModifierKeyStates& modifiers, const WindowSize& windowSize);
+
+    //! Determine if we want to capture/trap the mouse cursor when using mouse movements for rotating the camera view
+    bool IsMouseCaptureUsedForCameraRotation();
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
@@ -178,5 +178,10 @@ namespace AzFramework
 
         //! Array that holds barrier information used to confine the cursor.
         std::vector<XFixesBarrierProperty> m_activeBarriers;
+
+        //! Tracks the number of mouse movement threshold violations so we can trigger
+        //! internal delta tracking on systems that report mouse movement deltas as absolute
+        //! screen positions.
+        size_t m_movementThresholdViolations;
     };
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
@@ -20,3 +20,7 @@
 // the whole OS gets stuck with an invisible mouse
 // cursor when debugging Lua code.
 #define AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT 1
+
+// Enable the cvar 'ed_disable_capture_mouse_for_camera_rotation' to optionally disable mouse captures for 
+// mouse free-looks in the Editor
+#define AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION 1

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputMapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputMapper.cpp
@@ -23,6 +23,11 @@
 #include <QWheelEvent>
 #include <QWidget>
 
+namespace AzFramework
+{
+    // Forward declare the following function so we don't have to include the entire CameraInput.h file unnecessarily
+    bool IsMouseCaptureUsedForCameraRotation();
+}
 namespace AzToolsFramework
 {
     static bool HandleTextEvent(QEvent::Type eventType, Qt::Key key, QString keyText, bool isAutoRepeat)
@@ -264,8 +269,11 @@ namespace AzToolsFramework
             switch (m_cursorMode)
             {
             case CursorInputMode::CursorModeCaptured:
-                qApp->setOverrideCursor(Qt::BlankCursor);
-                m_mouseDevice->SetSystemCursorState(AzFramework::SystemCursorState::ConstrainedAndHidden);
+                if (AzFramework::IsMouseCaptureUsedForCameraRotation())
+                {
+                    qApp->setOverrideCursor(Qt::BlankCursor);
+                    m_mouseDevice->SetSystemCursorState(AzFramework::SystemCursorState::ConstrainedAndHidden);
+                }
                 break;
             case CursorInputMode::CursorModeWrapped:
                 qApp->restoreOverrideCursor();
@@ -523,7 +531,16 @@ namespace AzToolsFramework
         switch (m_cursorMode)
         {
         case CursorInputMode::CursorModeCaptured:
-            AzQtComponents::SetCursorPos(m_previousGlobalCursorPosition);
+            {
+                if (AzFramework::IsMouseCaptureUsedForCameraRotation())
+                {
+                    AzQtComponents::SetCursorPos(m_previousGlobalCursorPosition);
+                }
+                else
+                {
+                    m_previousGlobalCursorPosition = globalCursorPosition;
+                }
+            }
             break;
         case CursorInputMode::CursorModeWrappedX:
         case CursorInputMode::CursorModeWrappedY:


### PR DESCRIPTION
## What does this PR do?

Cherry picks the fix for hyper-sensitive camera rotations on remote clients:

* Add CVAR to control whether or not to capture mouse movements to calculate mouse-controlled camera rotations
* Make the mouse capture cvar option Linux only through PAL traits
* Change xcb client to detect if the mouse position capture does not work on the system instead of relying on the cvar

