### PR TITLE
Fix FulllScreenCopy pass

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/FullscreenCopy.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FullscreenCopy.pass
@@ -10,7 +10,7 @@
                 {
                     "Name": "Input",
                     "SlotType": "Input",
-                    "ScopeAttachmentUsage": "SubpassInput",
+                    "ScopeAttachmentUsage": "Shader",
                     "ImageViewDesc": {
                         "MipSliceMin": "0",
                         "MipSliceMax": "0",

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
@@ -115,7 +115,28 @@
                             }
                         }
                     ]
-                }
+                },
+                {
+                    "Name": "CopyToSwapChain",
+                    "TemplateName": "FullscreenCopyTemplate",
+                    "Enabled": false,
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "Subpasses",
+                                "Attachment": "Output"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                }          
             ]
         }
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Subpass3Parent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Subpass3Parent.pass
@@ -20,6 +20,19 @@
                 {
                     "Name": "DepthStencilInputOutput",
                     "SlotType": "InputOutput"
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output"
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "Output",
+                    "AttachmentRef": {
+                        "Pass": "DisplayMapperPass",
+                        "Attachment": "Output"
+                    }
                 }
             ],
             "PassRequests": [
@@ -106,28 +119,7 @@
                             }
                         }
                     ]
-                },
-                {
-                    "Name": "CopyToSwapChain",
-                    "TemplateName": "FullscreenCopyTemplate",
-                    "Enabled": false,
-                    "Connections": [
-                        {
-                            "LocalSlot": "Input",
-                            "AttachmentRef": {
-                                "Pass": "DisplayMapperPass",
-                                "Attachment": "Output"
-                            }
-                        },
-                        {
-                            "LocalSlot": "Output",
-                            "AttachmentRef": {
-                                "Pass": "Parent",
-                                "Attachment": "PipelineOutput"
-                            }
-                        }
-                    ]
-                }          
+                }               
             ],
             "PassData": {
                 "MergeChildrenAsSubpasses": true

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/SubpassesParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/SubpassesParent.pass
@@ -20,6 +20,19 @@
                 {
                     "Name": "PipelineOutput",
                     "SlotType": "InputOutput"
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output"
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "Output",
+                    "AttachmentRef": {
+                        "Pass": "Subpass3",
+                        "Attachment": "Output"
+                    }
                 }
             ],
             "PassRequests": [

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FullscreenCopy.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FullscreenCopy.azsl
@@ -14,13 +14,21 @@
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {
-    [[input_attachment_index(0)]]
-    SubpassInput m_framebuffer;
+    Texture2D<float4> m_framebuffer;
+    Sampler LinearSampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
 }
 
 PSOutput MainPS(VSOutput IN)
 {
     PSOutput OUT;
-    OUT.m_color = PassSrg::m_framebuffer.SubpassLoad(int3(IN.m_position.x, IN.m_position.y, 0));
+    OUT.m_color = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord);
     return OUT;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FullscreenCopy.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FullscreenCopy.shader
@@ -18,20 +18,5 @@
           "type": "Fragment"
         }
       ]
-    },
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "azslc": ["--no-subpass-input"]
-            }
-        },
-        {
-            "Name": "SubpassInput",
-            "RemoveBuildArguments": {
-                "azslc": ["--no-subpass-input"]
-            }
-        }
-    ]
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Fix FullScreenCopy pass to use a shader input rather than a subpass input. Since the FullScreenCopy is also doing resizing, it cannot use subpass inputs. Updated the Mobile pipeline to not merge the CopyToSwapchainPass. Fortunately mobile (android/ios) do not use the pass, so it's not going to impact the performance.

## How was this PR tested?

Run PC Vulkan, DX12 and Android.