### PR TITLE
Asset Import Universal Scene Description (USD) Files

### DIFF
--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -99,7 +99,8 @@
                     "fbx.assetinfo": "fbx",
                     "stl.assetinfo": "stl",
                     "gltf.assetinfo": "gltf",
-                    "glb.assetinfo": "glb"
+                    "glb.assetinfo": "glb",
+                    "usd.assetinfo": "usd"
 
                 },
 

--- a/Registry/sceneassetimporter.setreg
+++ b/Registry/sceneassetimporter.setreg
@@ -13,7 +13,8 @@
                     ".glb",
                     ".usd",
                     ".usda",
-                    ".usdz"
+                    ".usdz",
+                    ".usdc"
                 ]
             },
             "MaterialConverter": 

--- a/Registry/sceneassetimporter.setreg
+++ b/Registry/sceneassetimporter.setreg
@@ -10,7 +10,10 @@
                     ".fbx",
                     ".stl",
                     ".gltf",
-                    ".glb"
+                    ".glb",
+                    ".usd",
+                    ".usda",
+                    ".usdz"
                 ]
             },
             "MaterialConverter": 


### PR DESCRIPTION
Enables importing simple (non-reference) USD files

Tested by loading a USD
![image](https://github.com/user-attachments/assets/03315ec3-24c1-4e30-824d-3c8b54768428)
