### PR TITLE
Fix crash after leaving picking mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -358,6 +358,11 @@ namespace AzToolsFramework
         ActionManagerInterface* m_actionManagerInterface = nullptr;
         HotKeyManagerInterface* m_hotKeyManagerInterface = nullptr;
         MenuManagerInterface* m_menuManagerInterface = nullptr;
+
+    private:
+        // static void in order to ensure that the 'this' pointer is not captured in any lamba functions
+        // as the actions are global.
+        static void RegisterActions();
     };
 
     //! Bundles viewport state that impacts how accents are added/removed in HandleAccents.


### PR DESCRIPTION
## What does this PR do?
fixes issue https://github.com/o3de/o3de/issues/18365

Note that Stabilization branch is locked, I will open an exception request.

The hook to register and unregister actions happens once during startup, and is not meant to have any connection to the lifetime of the objects.

The crash was happening because the EditorTransformComponentSelection object was being destroyed and recreated every time you enter pick mode, but its action registration captured its 'this' pointer.

usually, such action registration would be placed inside some kind of long lived singleton "manager" object, aka a system component, but in this case, it was put in an ephemeral object.  note that this is still a singleton object, there is only ever one of it, and it is essentially the "manager", its just special in that sometimes, it does not exist.

to fix this with as little "splash damage" as possible, I kept most of the code exactly as-is, without modifying any other classes, but I made the action registration happen in a static function with no "this" pointer, which means the compiler could find every illegal instance.

I added a simple AZ::Environment based singleton pattern in there to get the current instance when available.  This is also an attempt to keep the "Blast radius" of this change as small as possible, as this is a well-used pattern and bypasses any chance of there being weird dll-related issues.

## How was this PR tested?

Following the steps in the bug, as well as a bunch of other whitebox testing to make sure the operations still worked.
It is a 100% every time crash repro, so after this, it no longer crashes, and the operations work.
