### PR TITLE
Multiplayer Component Registration: Compile Time Check for Duplicates 

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
@@ -11,11 +11,20 @@
 {% endif %}
 {% endfor %}
 
+{% set ComponentNames = dict() %}
 {% set Namespace = dataFiles[0].attrib['Namespace'] %}
 {% for Component in dataFiles %}
+{%     set ComponentName = Component.attrib['Name'] %}
+{%     set Duplicates = ComponentNames.get(ComponentName, 0) %}
+{%     set _dummy = ComponentNames.update({ComponentName : Duplicates + 1}) %}
 {%     if Component.attrib['Namespace'] != Namespace %}
 #error "mismatched component namespaces detected in declared multiplayer components, expected {{ Namespace }} but {{ Component.attrib['Name'] }} is using {{ Component.attrib['Namespace'] }} namespace."
 {%     endif %}
+{% endfor %}
+{% for componentName, duplicateCount in ComponentNames.items() %}
+{%      if duplicateCount > 1 %}
+#error "Duplicate multiplayer component! {{componentName}} was registered {{ duplicateCount }} times. Please update the cmake file lists so that {{componentName}} is only registered once."
+{%      endif %}
 {% endfor %}
 namespace {{ Namespace }}
 {


### PR DESCRIPTION
Catch, at compile time, if autogen registers the same Multiplayer auto-component multiple times.
Jinja logic creates a dictionary to track how many times each component is registered. It prints an error describing which auto-component and how many times it was registered (so users know how many instances they need to remove).

Fixes #18369

## How was this PR tested?
Purposely tried to register a multiplayer auto-component multiple times.
For example, by putting `Source/AutoGen/NetworkAnimationComponent.AutoComponent.xml` inside of both `multiplayersample_files.cmake` and `multiplayersample_autogen_files.cmake`
