### PR TITLE
Update O3DE Splash Screen background

### DIFF
--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:079c6d28fab15dfe624307d2be81d7008cc582de496f486a604186404ca818ab
-size 903037
+oid sha256:5d543f9bfef1a186b2f68c6144320c369ca155a40c6ed81023b14ee1d3e0bfe0
+size 1800167


### PR DESCRIPTION
## What does this PR do?

Updates the splash screen for version 2409 to

![splashscreen_background](https://github.com/user-attachments/assets/c911b6a1-c877-477b-9c3a-d547ca75715c)


## How was this PR tested?
Launched the Editor and verified the updated splash screen
