### PR TITLE
Fix crash in test LevelEntityComponentCRUD

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -14,6 +14,7 @@
 #include <RPI.Private/RPISystemComponent.h>
 
 #include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHIUtils.h>
 
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/IO/IOUtils.h>
@@ -106,14 +107,15 @@ namespace AZ
             ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
             
             bool isNullRenderer = false;
-            if (appType.IsHeadless())
+            if ( (appType.IsHeadless()) || (RHI::IsNullRHI()) )
             {
-                // if the application is `headless`, merge `NullRenderer` attribute to the setting registry
+                // if the application is `headless` or the RHI is the null RHI, merge `NullRenderer` attribute to the setting registry
                 isNullRenderer = true;
             }
             else
             {
-                // Otherwise if the command line contains -NullRenderer merge it to setting registry
+                // The command-line switch "--NullRenderer=true" can also be used to switch to null renderer.  This is maintained
+                // for backwards compatibility.  Use "-rhi=null" instead.
                 const char* nullRendererOption = "NullRenderer"; // command line option name
                 const AzFramework::CommandLine* commandLine = nullptr;
                 AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetApplicationCommandLine);


### PR DESCRIPTION
## What does this PR do?
Fixes a crash in the test BasicEditorWorkflows_LevelEntityComponentCRUD

Issue # https://github.com/o3de/o3de/issues/18384

It was randomly crashing because the RHI was the null rhi thanks to the command line containing `-rhi=null`, but the RPI did not correctly detect this, instead, it was expecting a different command line option called `--NullRenderer=true`

So it was a combination of a null RHI and a not-null RPI that was trying to execute real commands and assert that things were working.

## How was this PR tested?

I ran the test suite locally.  Previously, the given test would crash on shutdown.  It no longer crashes.

Note that I confirmed this crash, by actually catching it trying to perform render actions during render tick, even though the RHI was null.  I was lucky and caught it in the debugger during shutdown.
