### PR TITLE
Limit number of worker threads to capacity of m_workerThreads

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.cpp
@@ -61,7 +61,7 @@ namespace AZ::IO
     {
         JobManagerDesc jobDesc;
             jobDesc.m_jobManagerName = "Full File Decompressor";
-        u32 numThreads = AZ::GetMin(maxNumJobs, AZStd::thread::hardware_concurrency());
+        u32 numThreads = AZ::GetMin(maxNumJobs, jobDesc.GetWorkerThreadCount(AZStd::thread::hardware_concurrency()));
         for (u32 i = 0; i < numThreads; ++i)
         {
             jobDesc.m_workerThreads.push_back(JobManagerThreadDesc());

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
@@ -61,7 +61,7 @@ namespace AZ
             numberOfWorkerThreads = AZ_TRAIT_THREAD_NUM_JOB_MANAGER_WORKER_THREADS;
         #else
             uint32_t scaledHardwareThreads = Threading::CalcNumWorkerThreads(cl_jobThreadsConcurrencyRatio, cl_jobThreadsMinNumber, 0, cl_jobThreadsNumReserved);
-            numberOfWorkerThreads = AZ::GetMin(static_cast<unsigned int>(desc.m_workerThreads.capacity()), scaledHardwareThreads);
+            numberOfWorkerThreads = desc.GetWorkerThreadCount(scaledHardwareThreads);
         #endif // (AZ_TRAIT_THREAD_NUM_JOB_MANAGER_WORKER_THREADS)
         }
 

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerDesc.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerDesc.h
@@ -55,5 +55,13 @@ namespace AZ
 
         using DescList = AZStd::fixed_vector<JobManagerThreadDesc, 64>;
         DescList m_workerThreads; ///< List of worker threads to create
+
+        /**
+         *  Limits the number of worker threads to fit in m_workerThreads.
+         */
+        unsigned GetWorkerThreadCount(unsigned requestedWorkerThreadCount) const
+        {
+            return AZStd::min(requestedWorkerThreadCount, aznumeric_cast<unsigned>(m_workerThreads.capacity()));
+        }
     };
 }

--- a/Code/Framework/AzCore/Tests/Jobs.cpp
+++ b/Code/Framework/AzCore/Tests/Jobs.cpp
@@ -88,6 +88,7 @@ namespace UnitTest
             {
                 m_numWorkerThreads = AZStd::thread::hardware_concurrency();
             }
+            m_numWorkerThreads = desc.GetWorkerThreadCount(m_numWorkerThreads);
 
             for (unsigned int i = 0; i < m_numWorkerThreads; ++i)
             {
@@ -1608,7 +1609,7 @@ namespace Benchmark
             threadDesc.m_cpuId = 0; // Don't set processors IDs on windows
 #endif // AZ_TRAIT_SET_JOB_PROCESSOR_ID
 
-            const AZ::u32 numWorkerThreads = AZStd::thread::hardware_concurrency();
+            const AZ::u32 numWorkerThreads = desc.GetWorkerThreadCount(AZStd::thread::hardware_concurrency());
             for (AZ::u32 i = 0; i < numWorkerThreads; ++i)
             {
                 desc.m_workerThreads.push_back(threadDesc);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
@@ -173,7 +173,7 @@ namespace UnitTest
             threadDesc.m_cpuId = 0; // Don't set processors IDs on windows
 #endif 
 
-            uint32_t numWorkerThreads = AZStd::thread::hardware_concurrency();
+            uint32_t numWorkerThreads = jobManagerDesc.GetWorkerThreadCount(AZStd::thread::hardware_concurrency());
 
             for (unsigned int i = 0; i < numWorkerThreads; ++i)
             {

--- a/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
@@ -115,7 +115,7 @@ namespace UnitTest
         threadDesc.m_cpuId = 0; // Don't set processors IDs on windows
 #endif
 
-        uint32_t numWorkerThreads = AZStd::thread::hardware_concurrency();
+        uint32_t numWorkerThreads = desc.GetWorkerThreadCount(AZStd::thread::hardware_concurrency());
 
         for (unsigned int i = 0; i < numWorkerThreads; ++i)
         {


### PR DESCRIPTION
## What does this PR do?

This PR limits the number of worker threads that are generated for `JobManagerDesc` to the capacity of `m_workerThreads`. In many cases, the number of worker threads that are created is determined by the number of CPU cores (`AZStd::thread::hardware_concurrency()`), which leads to problems when running on a system with many cores (`m_workerThreads` is a `AZStd::fixed_vector` of capacity 64, and having more than 64 cores on a server or workstation is not that uncommon nowadays).

Another potential solution would be to change `m_workerThreads` to a normal vector.

## How was this PR tested?

Run the automated tests on a Linux system with 112 logical cores; without this change some tests fail due to the capacity of the fixed_vector being too small.
