### PR TITLE
Cherrypick stab to dev 03

### DIFF
--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:079c6d28fab15dfe624307d2be81d7008cc582de496f486a604186404ca818ab
-size 903037
+oid sha256:5d543f9bfef1a186b2f68c6144320c369ca155a40c6ed81023b14ee1d3e0bfe0
+size 1800167

--- a/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/AZStdContainers.inl
@@ -906,9 +906,17 @@ namespace AZ
             /// Get an element's address by its index (called before the element is loaded).
             void*   GetElementByIndex(void* instance, const SerializeContext::ClassElement* classElement, size_t index) override
             {
-                (void)instance;
                 (void)classElement;
-                (void)index;
+                // Linear iteration of the container.   If possible, use GetElementByKey, but this is implemented to be compatible
+                // with things that present the container as if it is a linear container (such as UIs)
+                T* containerPtr = reinterpret_cast<T*>(instance);
+                if (index < containerPtr->size())
+                {
+                    auto elementIterator = containerPtr->begin();
+                    AZStd::advance(elementIterator, index);
+                    
+                    return (elementIterator != containerPtr->end()) ? &(*elementIterator) : nullptr;
+                }
                 return nullptr;
             }
 

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -9,11 +9,9 @@
 #include "CameraInput.h"
 
 #include <AzCore/std/numeric.h>
-#include <AzFramework/AzFramework_Traits_Platform.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Windowing/WindowBus.h>
-
 
 namespace AzFramework
 {
@@ -24,18 +22,6 @@ namespace AzFramework
         nullptr,
         AZ::ConsoleFunctorFlags::Null,
         "Should the camera use cursor absolute positions or motion deltas");
-
-#if AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
-    AZ_CVAR(
-        bool,
-        ed_disable_capture_mouse_for_camera_rotation,
-        false,
-        nullptr,
-        AZ::ConsoleFunctorFlags::Null,
-        "Disable capturing the mouse position when it is used to freely rotate a camera view. Use this option if the camera rotation during free look movements with "
-        "the mouse is hyper-sensitive, in which case may be an indication that the system is unable to trap the cursor location which is needed for normal mouse "
-        "movement calculations.");
-#endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
 
     //! return -1.0f if inverted, 1.0f otherwise
     constexpr static float Invert(const bool invert)
@@ -169,7 +155,7 @@ namespace AzFramework
         if (const auto& cursor = AZStd::get_if<CursorEvent>(&state.m_inputEvent))
         {
             m_cursorState.SetCurrentPosition(cursor->m_position);
-            m_cursorState.SetCaptured(IsMouseCaptureUsedForCameraRotation() ? cursor->m_captured : false);
+            m_cursorState.SetCaptured(cursor->m_captured);
         }
         else if (const auto& horizontalMotion = AZStd::get_if<HorizontalMotionEvent>(&state.m_inputEvent))
         {
@@ -1037,14 +1023,4 @@ namespace AzFramework
 
         return { AZStd::monostate{}, ModifierKeyStates{} };
     }
-
-    bool IsMouseCaptureUsedForCameraRotation()
-    {
-#if AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
-        return !ed_disable_capture_mouse_for_camera_rotation;
-#else
-        return true;
-#endif // AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION
-    }
-
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -759,7 +759,4 @@ namespace AzFramework
     //! Map from a generic InputChannel event to a camera specific InputEvent.
     InputState BuildInputEvent(
         const InputChannel& inputChannel, const AzFramework::ModifierKeyStates& modifiers, const WindowSize& windowSize);
-
-    //! Determine if we want to capture/trap the mouse cursor when using mouse movements for rotating the camera view
-    bool IsMouseCaptureUsedForCameraRotation();
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -82,23 +82,12 @@ namespace AzFramework
     bool XcbInputDeviceMouse::m_xfixesInitialized = false;
     bool XcbInputDeviceMouse::m_xInputInitialized = false;
 
-    // The mouse movement threshold value to detect possible absolute mouse positions versus actual incremental mouse movement
-    // deltas. This value represents a reasonable number where multiple deltas are not possible (ie its not possible to move
-    // a mouse by this number of pixels continously)
-    static constexpr const float s_movementThresholdDeltaLimit = 480.f;
-
-    // To prevent possible anomalies with the delta limit, set a value where X number of violations will trigger the mode where
-    // we internally calculate the mouse movements based on the assumption that the received mouse movement values are actually
-    // mouse coordinates.
-    static constexpr const int s_movementThresholdTriggerValue = 10;
-
     XcbInputDeviceMouse::XcbInputDeviceMouse(InputDeviceMouse& inputDevice)
         : InputDeviceMouse::Implementation(inputDevice)
         , m_systemCursorState(SystemCursorState::Unknown)
-        , m_systemCursorPositionNormalized(0.0f, 0.0f)
+        , m_systemCursorPositionNormalized(0.5f, 0.5f)
         , m_focusWindow(XCB_WINDOW_NONE)
         , m_cursorShown(true)
-        , m_movementThresholdViolations(0)
     {
         XcbEventHandlerBus::Handler::BusConnect();
 
@@ -547,8 +536,6 @@ namespace AzFramework
 
                 int axisLen = xcb_input_raw_button_press_axisvalues_length(mouseMotionEvent);
                 const xcb_input_fp3232_t* axisvalues = xcb_input_raw_button_press_axisvalues_raw(mouseMotionEvent);
-                float movement_x = 0.0f;
-                float movement_y = 0.0f;
                 for (int i = 0; i < axisLen; ++i)
                 {
                     const float axisValue = fp3232ToFloat(axisvalues[i]);
@@ -556,48 +543,12 @@ namespace AzFramework
                     switch (i)
                     {
                     case 0:
-                        movement_x = axisValue;
+                        QueueRawMovementEvent(InputDeviceMouse::Movement::X, axisValue);
                         break;
                     case 1:
-                        movement_y = axisValue;
+                        QueueRawMovementEvent(InputDeviceMouse::Movement::Y, axisValue);
                         break;
                     }
-                }
-
-                if (m_movementThresholdViolations < s_movementThresholdTriggerValue)
-                {
-                    // Treat values as movement (delta) values
-                    QueueRawMovementEvent(InputDeviceMouse::Movement::X, movement_x);
-                    QueueRawMovementEvent(InputDeviceMouse::Movement::Y, movement_y);
-
-                    // If we detect a movement greater than whats considered a possible normal mouse movement, it is
-                    // possible that we are unable to track mouse movement deltas, but are instead tracking absolute
-                    // screen positions. Track the number of times this threshold is crossed to determine if we need
-                    // to instead keep track of the last position internally and use that to calculate the delta.
-                    if (movement_x > s_movementThresholdDeltaLimit || movement_y > s_movementThresholdDeltaLimit)
-                    {
-                        m_movementThresholdViolations += 1;
-                    }
-                }
-                else
-                {
-                    // Treat values as absolute mouse coordinates.
-                    if ((m_systemCursorPositionNormalized.GetX() == 0.0f) &&
-                        (m_systemCursorPositionNormalized.GetY() == 0.0f))
-                    {
-                        // Initialize the last tracked position if this is the first time being set to avoid a initial large
-                        // jump
-                        m_systemCursorPositionNormalized.SetX(movement_x);
-                        m_systemCursorPositionNormalized.SetY(movement_y);
-                    }
-
-                    // Calculate movement deltas from the mouse coordinates based on the last internally tracked mouse position
-                    QueueRawMovementEvent(InputDeviceMouse::Movement::X, movement_x - m_systemCursorPositionNormalized.GetX());
-                    QueueRawMovementEvent(InputDeviceMouse::Movement::Y, movement_y - m_systemCursorPositionNormalized.GetY());
-
-                    // Internally track the last position
-                    m_systemCursorPositionNormalized.SetX(movement_x);
-                    m_systemCursorPositionNormalized.SetY(movement_y);
                 }
             }
             break;

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
@@ -178,10 +178,5 @@ namespace AzFramework
 
         //! Array that holds barrier information used to confine the cursor.
         std::vector<XFixesBarrierProperty> m_activeBarriers;
-
-        //! Tracks the number of mouse movement threshold violations so we can trigger
-        //! internal delta tracking on systems that report mouse movement deltas as absolute
-        //! screen positions.
-        size_t m_movementThresholdViolations;
     };
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/AzFramework_Traits_Linux.h
@@ -20,7 +20,3 @@
 // the whole OS gets stuck with an invisible mouse
 // cursor when debugging Lua code.
 #define AZ_TRAIT_AZFRAMEWORK_SHOW_MOUSE_ON_LUA_BREAKPOINT 1
-
-// Enable the cvar 'ed_disable_capture_mouse_for_camera_rotation' to optionally disable mouse captures for 
-// mouse free-looks in the Editor
-#define AZ_TRAIT_AZFRAMEWORK_ENABLE_DISABLE_MOUSE_CAPTURE_FOR_CAMERA_CVAR_OPTION 1

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputMapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputMapper.cpp
@@ -23,11 +23,6 @@
 #include <QWheelEvent>
 #include <QWidget>
 
-namespace AzFramework
-{
-    // Forward declare the following function so we don't have to include the entire CameraInput.h file unnecessarily
-    bool IsMouseCaptureUsedForCameraRotation();
-}
 namespace AzToolsFramework
 {
     static bool HandleTextEvent(QEvent::Type eventType, Qt::Key key, QString keyText, bool isAutoRepeat)
@@ -269,11 +264,8 @@ namespace AzToolsFramework
             switch (m_cursorMode)
             {
             case CursorInputMode::CursorModeCaptured:
-                if (AzFramework::IsMouseCaptureUsedForCameraRotation())
-                {
-                    qApp->setOverrideCursor(Qt::BlankCursor);
-                    m_mouseDevice->SetSystemCursorState(AzFramework::SystemCursorState::ConstrainedAndHidden);
-                }
+                qApp->setOverrideCursor(Qt::BlankCursor);
+                m_mouseDevice->SetSystemCursorState(AzFramework::SystemCursorState::ConstrainedAndHidden);
                 break;
             case CursorInputMode::CursorModeWrapped:
                 qApp->restoreOverrideCursor();
@@ -531,16 +523,7 @@ namespace AzToolsFramework
         switch (m_cursorMode)
         {
         case CursorInputMode::CursorModeCaptured:
-            {
-                if (AzFramework::IsMouseCaptureUsedForCameraRotation())
-                {
-                    AzQtComponents::SetCursorPos(m_previousGlobalCursorPosition);
-                }
-                else
-                {
-                    m_previousGlobalCursorPosition = globalCursorPosition;
-                }
-            }
+            AzQtComponents::SetCursorPos(m_previousGlobalCursorPosition);
             break;
         case CursorInputMode::CursorModeWrappedX:
         case CursorInputMode::CursorModeWrappedY:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -358,6 +358,11 @@ namespace AzToolsFramework
         ActionManagerInterface* m_actionManagerInterface = nullptr;
         HotKeyManagerInterface* m_hotKeyManagerInterface = nullptr;
         MenuManagerInterface* m_menuManagerInterface = nullptr;
+
+    private:
+        // static void in order to ensure that the 'this' pointer is not captured in any lamba functions
+        // as the actions are global.
+        static void RegisterActions();
     };
 
     //! Bundles viewport state that impacts how accents are added/removed in HandleAccents.

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
@@ -353,7 +353,6 @@ namespace ScriptCanvasEditor
     {
         GraphCanvas::FocusConfig focusConfig;
 
-        // TODO https://github.com/o3de/o3de/issues/9192 focus broken because both scriptCanvasNodeId and graphCanvasNodeId are invalid (broken by #6394)
         AZ::EntityId scriptCanvasNodeId;
         AssetGraphSceneBus::BroadcastResult(scriptCanvasNodeId, &AssetGraphScene::FindEditorNodeIdByAssetNodeId, SourceHandle(nullptr, assetId.m_guid), assetNodeId);
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
@@ -353,6 +353,7 @@ namespace ScriptCanvasEditor
     {
         GraphCanvas::FocusConfig focusConfig;
 
+        // TODO https://github.com/o3de/o3de/issues/9192 focus broken because both scriptCanvasNodeId and graphCanvasNodeId are invalid (broken by #6394)
         AZ::EntityId scriptCanvasNodeId;
         AssetGraphSceneBus::BroadcastResult(scriptCanvasNodeId, &AssetGraphScene::FindEditorNodeIdByAssetNodeId, SourceHandle(nullptr, assetId.m_guid), assetNodeId);
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -3557,20 +3557,18 @@ namespace ScriptCanvasEditor
 
     AZ::EntityId MainWindow::FindEditorNodeIdByAssetNodeId([[maybe_unused]] const SourceHandle& assetId, [[maybe_unused]] AZ::EntityId assetNodeId) const
     {
-        AZ::EntityId editorEntityId{};
-//         AssetTrackerRequestBus::BroadcastResult
-//             ( editorEntityId, &AssetTrackerRequests::GetEditorEntityIdFromSceneEntityId, assetId.Id(), assetNodeId);
-        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
-        return editorEntityId;
+        const ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
+        AZ::EntityId newNodeId;
+        EditorGraphRequestBus::EventResult(newNodeId, scriptId, &EditorGraphRequests::FindNewIdFromOriginal, assetNodeId);
+        return newNodeId;
     }
 
     AZ::EntityId MainWindow::FindAssetNodeIdByEditorNodeId([[maybe_unused]] const SourceHandle& assetId, [[maybe_unused]] AZ::EntityId editorNodeId) const
     {
-        AZ::EntityId sceneEntityId{};
-        // AssetTrackerRequestBus::BroadcastResult
-        // ( sceneEntityId, &AssetTrackerRequests::GetSceneEntityIdFromEditorEntityId, assetId.Id(), editorNodeId);
-        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
-        return sceneEntityId;
+        const ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
+        AZ::EntityId originalNodeId;
+        EditorGraphRequestBus::EventResult(originalNodeId, scriptId, &EditorGraphRequests::FindOriginalIdFromNew, editorNodeId);
+        return originalNodeId;
     }
 
     GraphCanvas::Endpoint MainWindow::CreateNodeForProposalWithGroup(const AZ::EntityId& connectionId

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -3555,20 +3555,22 @@ namespace ScriptCanvasEditor
         return findChild<QObject*>(elementName);
     }
 
-    AZ::EntityId MainWindow::FindEditorNodeIdByAssetNodeId([[maybe_unused]] const SourceHandle& assetId, AZ::EntityId assetNodeId) const
+    AZ::EntityId MainWindow::FindEditorNodeIdByAssetNodeId([[maybe_unused]] const SourceHandle& assetId, [[maybe_unused]] AZ::EntityId assetNodeId) const
     {
-        const ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
-        AZ::EntityId newNodeId;
-        EditorGraphRequestBus::EventResult(newNodeId, scriptId, &EditorGraphRequests::FindNewIdFromOriginal, assetNodeId);
-        return newNodeId;
+        AZ::EntityId editorEntityId{};
+//         AssetTrackerRequestBus::BroadcastResult
+//             ( editorEntityId, &AssetTrackerRequests::GetEditorEntityIdFromSceneEntityId, assetId.Id(), assetNodeId);
+        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
+        return editorEntityId;
     }
 
-    AZ::EntityId MainWindow::FindAssetNodeIdByEditorNodeId([[maybe_unused]] const SourceHandle& assetId, AZ::EntityId editorNodeId) const
+    AZ::EntityId MainWindow::FindAssetNodeIdByEditorNodeId([[maybe_unused]] const SourceHandle& assetId, [[maybe_unused]] AZ::EntityId editorNodeId) const
     {
-        const ScriptCanvas::ScriptCanvasId scriptId = GetActiveScriptCanvasId();
-        AZ::EntityId originalNodeId;
-        EditorGraphRequestBus::EventResult(originalNodeId, scriptId, &EditorGraphRequests::FindOriginalIdFromNew, editorNodeId);
-        return originalNodeId;
+        AZ::EntityId sceneEntityId{};
+        // AssetTrackerRequestBus::BroadcastResult
+        // ( sceneEntityId, &AssetTrackerRequests::GetSceneEntityIdFromEditorEntityId, assetId.Id(), editorNodeId);
+        // TODO https://github.com/o3de/o3de/issues/9192 broken by https://github.com/o3de/o3de/issues/6394
+        return sceneEntityId;
     }
 
     GraphCanvas::Endpoint MainWindow::CreateNodeForProposalWithGroup(const AZ::EntityId& connectionId

--- a/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
@@ -29,8 +29,7 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
             AZ::AzFramework
-            Gem::ImGui.imguilib
-            Gem::ImGui            
+            Gem::ImGui.imguilib           
 )
 
 ly_add_target(
@@ -95,7 +94,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::${gem_name}.Static
                 Gem::ScriptCanvas.Editor.Static
                 Gem::GraphCanvasWidgets
-                Gem::ImGui  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
+                Gem::ImGui.Tools  # note that this includes the ImGui bus interfaces, but not necessarily the static lib 
         RUNTIME_DEPENDENCIES
             Gem::ScriptCanvas.Editor
             Gem::GraphCanvasWidgets


### PR DESCRIPTION
## What does this PR do?

Cherry-picks missed PRs from stabilization (`main` is the same) to development so they are not missed.

## How was this PR tested?
CI Build script and manual testing:
```
[ci_build] ctest -j12 -C profile --output-on-failure -L "(SUITE_smoke|SUITE_main)" -LE "(REQUIRES_gpu|REQUIRES_tiaf)" -T Test --no-tests=error
   Build name: Win32-MSBuild
Create new tag: 20241015-2027 - Experimental
Test project D:/o3de-repos/o3de/build/windows
      Start   7: AZ::AzFramework.NativeUI.Tests.main::TEST_RUN
      Start  10: AZ::AzManipulatorTestFramework.Tests.main::TEST_RUN
      Start  28: AZ::SerializeContextTools.Tests.main::TEST_RUN
      Start  29: AZ::AssetBundler.Tests.main::TEST_RUN
      Start  33: test_commit_validation.smoke::TEST_RUN
      Start  46: cli_test_driver.main::TEST_RUN
      Start  47: test_detect_file_changes.main::TEST_RUN
      Start  48: o3de_register.smoke::TEST_RUN
      Start  49: o3de_cmake.smoke::TEST_RUN
      Start  50: o3de_disable_gem.smoke::TEST_RUN
      Start  51: o3de_download.smoke::TEST_RUN
      Start  52: o3de_enable_gem.smoke::TEST_RUN
 1/49 Test   #7: AZ::AzFramework.NativeUI.Tests.main::TEST_RUN ..............   Passed    0.54 sec
      Start  53: o3de_global_project.smoke::TEST_RUN
 2/49 Test  #28: AZ::SerializeContextTools.Tests.main::TEST_RUN .............   Passed    1.19 sec
      Start  54: o3de_manifest.smoke::TEST_RUN
 3/49 Test  #47: test_detect_file_changes.main::TEST_RUN ....................   Passed    2.77 sec
      Start  55: o3de_engine_properties.smoke::TEST_RUN
 4/49 Test  #53: o3de_global_project.smoke::TEST_RUN ........................   Passed    2.84 sec
      Start  56: o3de_project_properties.smoke::TEST_RUN
 5/49 Test  #50: o3de_disable_gem.smoke::TEST_RUN ...........................   Passed    3.07 sec
      Start  57: o3de_repo.smoke::TEST_RUN
 6/49 Test  #49: o3de_cmake.smoke::TEST_RUN .................................   Passed    3.16 sec
      Start  58: o3de_gem_properties.smoke::TEST_RUN
 7/49 Test  #29: AZ::AssetBundler.Tests.main::TEST_RUN ......................   Passed    3.49 sec
      Start  59: o3de_template.smoke::TEST_RUN
 8/49 Test  #52: o3de_enable_gem.smoke::TEST_RUN ............................   Passed    3.65 sec
      Start  60: o3de_register_show.smoke::TEST_RUN
 9/49 Test  #48: o3de_register.smoke::TEST_RUN ..............................   Passed    3.76 sec
      Start  61: o3de_export_project.smoke::TEST_RUN
10/49 Test  #33: test_commit_validation.smoke::TEST_RUN .....................   Passed    4.03 sec
      Start  62: o3de_utils.smoke::TEST_RUN
11/49 Test  #51: o3de_download.smoke::TEST_RUN ..............................   Passed    4.05 sec
      Start  63: o3de_export_source_built_project.smoke::TEST_RUN
12/49 Test  #54: o3de_manifest.smoke::TEST_RUN ..............................   Passed    3.91 sec
      Start  64: o3de_export_source_ios_xcode.smoke::TEST_RUN
13/49 Test  #55: o3de_engine_properties.smoke::TEST_RUN .....................   Passed    2.98 sec
      Start  65: o3de_export_source_android.smoke::TEST_RUN
14/49 Test  #56: o3de_project_properties.smoke::TEST_RUN ....................   Passed    3.00 sec
      Start  66: LyTestTools_Unit.smoke::TEST_RUN
15/49 Test  #58: o3de_gem_properties.smoke::TEST_RUN ........................   Passed    3.03 sec
      Start  68: LyTestTools_Integ_Codeowners.smoke::TEST_RUN
16/49 Test  #57: o3de_repo.smoke::TEST_RUN ..................................   Passed    3.77 sec
      Start  95: Gem::Compression.Tests.main::TEST_RUN
17/49 Test  #95: Gem::Compression.Tests.main::TEST_RUN ......................   Passed    0.08 sec
      Start  96: Gem::Compression.Editor.Tests.main::TEST_RUN
18/49 Test  #96: Gem::Compression.Editor.Tests.main::TEST_RUN ...............   Passed    0.08 sec
      Start  97: Gem::Archive.Editor.Tests.main::TEST_RUN
19/49 Test  #59: o3de_template.smoke::TEST_RUN ..............................   Passed    3.99 sec
      Start 104: Gem::AudioSystem.Tests.main::TEST_RUN
20/49 Test  #62: o3de_utils.smoke::TEST_RUN .................................   Passed    3.36 sec
      Start 130: Gem::ScriptCanvas.Tests.main::TEST_RUN
21/49 Test #104: Gem::AudioSystem.Tests.main::TEST_RUN ......................   Passed    0.30 sec
      Start 131: Gem::ScriptCanvas.Editor.Tests.main::TEST_RUN
22/49 Test #130: Gem::ScriptCanvas.Tests.main::TEST_RUN .....................   Passed    0.39 sec
      Start 144: Gem::ScriptCanvasPhysics.Tests.main::TEST_RUN
23/49 Test #131: Gem::ScriptCanvas.Editor.Tests.main::TEST_RUN ..............   Passed    0.45 sec
      Start 145: Gem::ScriptCanvasTesting.Editor.Tests.main::TEST_RUN
24/49 Test  #97: Gem::Archive.Editor.Tests.main::TEST_RUN ...................   Passed    1.08 sec
      Start 146: Gem::StartingPointInput.Tests.main::TEST_RUN
25/49 Test #146: Gem::StartingPointInput.Tests.main::TEST_RUN ...............   Passed    0.23 sec
      Start 152: Gem::WhiteBox.Editor.Tests.main::TEST_RUN
26/49 Test #144: Gem::ScriptCanvasPhysics.Tests.main::TEST_RUN ..............   Passed    0.71 sec
      Start 156: APTests.Batch_2_Main.main::TEST_RUN
27/49 Test  #68: LyTestTools_Integ_Codeowners.smoke::TEST_RUN ...............   Passed    2.27 sec
      Start 157: APTests.ScriptCanvas_Main.main::TEST_RUN
28/49 Test  #61: o3de_export_project.smoke::TEST_RUN ........................   Passed    7.70 sec
      Start 224: AutomatedTesting::SmokeTest.smoke::TEST_RUN
29/49 Test  #60: o3de_register_show.smoke::TEST_RUN .........................   Passed    8.67 sec
30/49 Test  #64: o3de_export_source_ios_xcode.smoke::TEST_RUN ...............   Passed    7.86 sec
31/49 Test  #46: cli_test_driver.main::TEST_RUN .............................   Passed   13.03 sec
32/49 Test  #10: AZ::AzManipulatorTestFramework.Tests.main::TEST_RUN ........   Passed   14.16 sec
33/49 Test #224: AutomatedTesting::SmokeTest.smoke::TEST_RUN ................   Passed    2.38 sec
34/49 Test  #65: o3de_export_source_android.smoke::TEST_RUN .................   Passed   10.99 sec
35/49 Test #152: Gem::WhiteBox.Editor.Tests.main::TEST_RUN ..................   Passed    9.74 sec
36/49 Test  #66: LyTestTools_Unit.smoke::TEST_RUN ...........................   Passed   14.34 sec
37/49 Test #156: APTests.Batch_2_Main.main::TEST_RUN ........................   Passed   13.83 sec
38/49 Test #145: Gem::ScriptCanvasTesting.Editor.Tests.main::TEST_RUN .......   Passed   24.77 sec
39/49 Test #157: APTests.ScriptCanvas_Main.main::TEST_RUN ...................   Passed   30.24 sec
40/49 Test  #63: o3de_export_source_built_project.smoke::TEST_RUN ...........   Passed   46.89 sec
      Start  34: pytest_sanity_smoke_no_gpu.smoke::TEST_RUN
41/49 Test  #34: pytest_sanity_smoke_no_gpu.smoke::TEST_RUN .................   Passed    1.27 sec
      Start  36: pytest_sanity_main_no_gpu.main::TEST_RUN
42/49 Test  #36: pytest_sanity_main_no_gpu.main::TEST_RUN ...................   Passed    1.28 sec
      Start  67: LyTestTools_Integ_Sanity.smoke::TEST_RUN
43/49 Test  #67: LyTestTools_Integ_Sanity.smoke::TEST_RUN ...................   Passed   54.41 sec
      Start  69: LyTestTools_Integ_ProcessUtils.smoke::TEST_RUN
44/49 Test  #69: LyTestTools_Integ_ProcessUtils.smoke::TEST_RUN .............   Passed    1.96 sec
      Start  70: LyTestTools_Integ_ProcessUtilsLinux.smoke::TEST_RUN
45/49 Test  #70: LyTestTools_Integ_ProcessUtilsLinux.smoke::TEST_RUN ........   Passed    1.39 sec
      Start 186: AutomatedTesting::MetadataRelocation.Main.main::TEST_RUN
46/49 Test #186: AutomatedTesting::MetadataRelocation.Main.main::TEST_RUN ...   Passed   59.15 sec
      Start 203: AutomatedTesting::PhysicsTests_Main.main::TEST_RUN
47/49 Test #203: AutomatedTesting::PhysicsTests_Main.main::TEST_RUN .........   Passed   46.20 sec
      Start 221: AutomatedTesting::EditorTests_Main.main::TEST_RUN
48/49 Test #221: AutomatedTesting::EditorTests_Main.main::TEST_RUN ..........   Passed  594.39 sec
      Start 222: AutomatedTesting::EditorTests_DPE_Main.main::TEST_RUN
49/49 Test #222: AutomatedTesting::EditorTests_DPE_Main.main::TEST_RUN ......   Passed  228.93 sec

100% tests passed, 0 tests failed out of 49

Label Time Summary:
COMPONENT_Editor                = 823.32 sec*proc (2 tests)
COMPONENT_MetadataRelocation    =  59.15 sec*proc (1 test)
COMPONENT_Physics               =  46.20 sec*proc (1 test)
COMPONENT_ScriptCanvas          =  30.24 sec*proc (1 test)
COMPONENT_Smoke                 =   2.38 sec*proc (1 test)
COMPONENT_TestTools             =  74.37 sec*proc (5 tests)
FRAMEWORK_googletest            =  57.22 sec*proc (14 tests)
FRAMEWORK_pytest                = 1185.51 sec*proc (34 tests)
SUITE_main                      = 1047.04 sec*proc (23 tests)
SUITE_smoke                     = 208.72 sec*proc (26 tests)

Total Test time (real) = 1042.63 sec
--------------------------------------------------------------------------------
[ci_build] OK
```