### PR TITLE
Fix compile error on Mac

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
@@ -597,7 +597,7 @@ namespace UnitTests
     // To get around this we have to manually split the path here.
     static void MockAbsoluteSplit(const QString& absolutePath, AZStd::string& rootPath, AZStd::string& relPathFromRoot)
     {
-        qsizetype firstSlash = absolutePath.indexOf("/"); // we assume normalized forward slashes.
+        int firstSlash = absolutePath.indexOf("/"); // we assume normalized forward slashes.
         if (firstSlash == -1)
         {
             rootPath = AZStd::string();
@@ -605,8 +605,8 @@ namespace UnitTests
             return;
         }
 
-        rootPath = absolutePath.left(firstSlash + 1).toUtf8().constData();;
-        relPathFromRoot = absolutePath.mid(firstSlash + 1).toUtf8().constData();;
+        rootPath = absolutePath.left(firstSlash + 1).toUtf8().constData();
+        relPathFromRoot = absolutePath.mid(firstSlash + 1).toUtf8().constData();
     }
 
     bool MockFileStateCache::GetFileInfo(const QString& absolutePath, AssetProcessor::FileStateInfo* foundFileInfo) const


### PR DESCRIPTION
## What does this PR do?

The return value of `QString::indexOf` is `int`, and the `QString::left()` and `QString::mid()` functions expect `int` as a parameter, so it does not make sense to store it in `qsizetype`, which is a larger type, and leads to a compile error due to implicit downcast to a smaller integer type.

## How was this PR tested?

Compile with tests enabled on Mac.
