### PR TITLE
Fixing Depth of Field Assert

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.cpp
@@ -24,19 +24,6 @@ namespace AZ
         {
         }
 
-        void DepthOfFieldWriteFocusDepthFromGpuPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
-        {
-            AZ_Assert(m_bufferRef != nullptr, "%s has a null buffer when calling Prepare.", GetPathName().GetCStr());
-
-            ComputePass::SetupFrameGraphDependencies(frameGraph);
-
-            RHI::BufferScopeAttachmentDescriptor desc;
-            desc.m_attachmentId = m_bufferRef->GetAttachmentId();
-            desc.m_bufferViewDescriptor = m_bufferRef->GetBufferViewDescriptor();
-            desc.m_loadStoreAction.m_loadAction = AZ::RHI::AttachmentLoadAction::DontCare;
-            frameGraph.UseShaderAttachment(desc, AZ::RHI::ScopeAttachmentAccess::Write, RHI::ScopeAttachmentStage::ComputeShader);
-        }
-
         void DepthOfFieldWriteFocusDepthFromGpuPass::CompileResources(const RHI::FrameGraphCompileContext& context)
         {
             AZ_Assert(m_shaderResourceGroup != nullptr, "%s has a null shader resource group when calling Compile.", GetPathName().GetCStr());

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.h
@@ -43,7 +43,6 @@ namespace AZ
             AZ::Vector2 m_autoFocusScreenPosition{ 0.0f, 0.0f };
 
             // Scope producer functions...
-            void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
             void CompileResources(const RHI::FrameGraphCompileContext& context) override;
 
             // Pass overrides


### PR DESCRIPTION
Removing function override that erroneoulsy adds the same attachment twice in Depth of Field pass, triggering an assert every frame if Depth of Field is active.

Note: Not sure what happened with the diff view here, seems like it thinks the whole file has been changed. 
All that changed is the function DepthOfFieldWriteFocusDepthFromGpuPass::SetupFrameGraphDependencies has been removed.
