### PR TITLE
Fixing two issues with the frame graph when multi-device features are used.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameAttachment.h
@@ -96,6 +96,8 @@ namespace AZ::RHI
         AttachmentLifetimeType m_lifetimeType;
         HardwareQueueClassMask m_usedQueueMask = HardwareQueueClassMask::None;
         HardwareQueueClassMask m_supportedQueueMask = HardwareQueueClassMask::None;
+        // we need to store the first device this frame attachment is used on to initialize the clear value
+        int m_firstDeviceIndex{ MultiDevice::InvalidDeviceIndex };
         AZStd::unordered_map<int, ScopeInfo> m_scopeInfos;
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentDatabase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentDatabase.h
@@ -193,6 +193,11 @@ namespace AZ::RHI
             // First element in the linked list. Trivial assignment.
             attachment.m_scopeInfos[deviceIndex].m_firstScopeAttachment = scopeAttachment;
             attachment.m_scopeInfos[deviceIndex].m_firstScope = &scope;
+
+            if (attachment.m_firstDeviceIndex == MultiDevice::InvalidDeviceIndex)
+            {
+                attachment.m_firstDeviceIndex = deviceIndex;
+            }
         }
         else
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
@@ -79,6 +79,12 @@ namespace AZ::RHI
         //! is used, after all allocations for that scope have been processed. It will also be removed from the cache.
         void DeactivateImage(const AttachmentId& attachmentId);
 
+        //! Called when a buffer is not used on a specific device this frame
+        void RemoveDeviceBuffer(int deviceIndex, Buffer* buffer);
+
+        //! Called when an image is not used on a specific device this frame
+        void RemoveDeviceImage(int deviceIndex, Image* image);
+
         //! Called when all allocations for the current scope have completed.
         void EndScope();
 

--- a/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/TransientAttachmentPool.cpp
@@ -246,6 +246,18 @@ namespace AZ::RHI
         GetDeviceTransientAttachmentPool(m_currentScope->GetDeviceIndex())->DeactivateImage(attachmentId);
     }
 
+    void TransientAttachmentPool::RemoveDeviceBuffer(int deviceIndex, Buffer* buffer)
+    {
+        buffer->Init(ResetBit(buffer->GetDeviceMask(), deviceIndex));
+        buffer->m_deviceObjects.erase(deviceIndex);
+    }
+
+    void TransientAttachmentPool::RemoveDeviceImage(int deviceIndex, Image* image)
+    {
+        image->Init(ResetBit(image->GetDeviceMask(), deviceIndex));
+        image->m_deviceObjects.erase(deviceIndex);
+    }
+
     AZStd::unordered_map<int, TransientAttachmentStatistics> TransientAttachmentPool::GetStatistics() const
     {
         AZStd::unordered_map<int, TransientAttachmentStatistics> statistics;


### PR DESCRIPTION
## What does this PR do?

1. When MD transient attachments are not used on one device after they have been before, they were not removed properly and triggered asserts that attachments have been added to the frame graph that are not used.

2. The clear value needs to be set to the clear value from the first scope, so it needs to be retrieved from the device the first scope runs on. Therefore, we store that device index and use it to retrieve the optimized clear value.

## How was this PR tested?

With a sample that runs a pass on one device and then moves it to another device.
