### PR TITLE
Extend Pass functionality to improve inserting passes.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -1825,8 +1825,8 @@ namespace AZ
 
                 if(fullscreenBlurEnabled)
                 {
-                    RPI::Pass* child_0 = m_fullscreenShadowBlurPass->GetChildren()[0].get();
-                    RPI::Pass* child_1 = m_fullscreenShadowBlurPass->GetChildren()[1].get();
+                    RPI::Pass* child_0 = m_fullscreenShadowBlurPass->FindChildPass(Name("VerticalBlur")).get();
+                    RPI::Pass* child_1 = m_fullscreenShadowBlurPass->FindChildPass(Name("HorizontalBlur")).get();
 
                     FastDepthAwareBlurVerPass* verBlurPass = azrtti_cast<FastDepthAwareBlurVerPass*>(child_0);
                     FastDepthAwareBlurHorPass* horBlurPass = azrtti_cast<FastDepthAwareBlurHorPass*>(child_1);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -325,6 +325,9 @@ namespace AZ
             PassState GetPassState() const { return m_state; }
 
             //! Alter the connection of an Input or InputOutput attachment
+            void ChangeConnection(const Name& localSlot, const Name& passName, const Name& attachment, RenderPipeline* pipeline);
+
+            //! Alter the connection of an Input or InputOutput attachment
             void ChangeConnection(const Name& localSlot, Pass* pass, const Name& attachment);
 
             // Update all bindings on this pass that are connected to bindings on other passes
@@ -336,11 +339,11 @@ namespace AZ
             // Update output bindings on this pass that are connected to bindings on other passes
             void UpdateConnectedOutputBindings();
 
-        protected:
-            explicit Pass(const PassDescriptor& descriptor);
-
             // Creates a pass descriptor for creating a duplicate pass. Used for hot reloading.
             PassDescriptor GetPassDescriptor() const;
+
+        protected:
+            explicit Pass(const PassDescriptor& descriptor);
 
             // Imports owned imported attachments into the FrameGraph
             // Called in pass's frame prepare function

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1851,6 +1851,33 @@ namespace AZ
             }
         }
 
+        void Pass::ChangeConnection(const Name& localSlot, const Name& passName, const Name& attachment, RenderPipeline* pipeline)
+        {
+            Pass* otherPass{ nullptr };
+
+            if (passName == PassNameParent)
+            {
+                otherPass = GetParent();
+            }
+            else if (passName == PipelineGlobalKeyword)
+            {
+                const AZ::RPI::PipelineGlobalBinding* globalBinding = pipeline->GetPipelineGlobalConnection(attachment);
+                otherPass = globalBinding->m_pass;
+            }
+            else if (passName == PassNameThis)
+            {
+                otherPass = this;
+            }
+            else
+            {
+                otherPass = GetParent()->FindChildPass(passName).get();
+            }
+
+            AZ_Assert(otherPass, "Pass %s not found.", passName.GetCStr());
+
+            ChangeConnection(localSlot, otherPass, attachment);
+        }
+
         void Pass::ChangeConnection(const Name& localSlot, Pass* pass, const Name& attachment)
         {
             bool connectionFound(false);


### PR DESCRIPTION
## What does this PR do?

Adds functionality/access for the manipulation of passes which are especially useful when inserting passes and changing connections automatically.

- Make `GetPassDescriptor` public.
- Add an overload of `ChangeConnection` with a pass name (supporting keywords such as `PipelineGlobal`) instead of a `Pass*`.
- Fix `DirectionalLightFeatureProcessor` child pass retrieval in case passes are inserted.

## How was this PR tested?

With a sample code that inserts passes into the pipeline and changes connections.
