### PR TITLE
Adapt GpuCrashTracker to aftermath version 2024.2.0.24200

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
@@ -214,7 +214,7 @@ void GpuCrashTracker::OnShaderLookup(
 }
 
 void GpuCrashTracker::OnResolveMarker(
-    [[maybe_unused]] const void* pMarker, [[maybe_unused]] void** resolvedMarkerData, [[maybe_unused]] uint32_t* markerSize) const
+    [[maybe_unused]] const void* pMarker, [[maybe_unused]] const uint32_t markerDataSize, [[maybe_unused]] void** resolvedMarkerData, [[maybe_unused]] uint32_t* markerSize) const
 {
 }
 
@@ -271,12 +271,13 @@ void GpuCrashTracker::ShaderLookupCallback(
 
 void GpuCrashTracker::ResolveMarkerCallback(
     const void* pMarker,
+    const uint32_t markerDataSize,
     void* pUserData,
     void** resolvedMarkerData,
     uint32_t* markerSize)
 {
     GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnResolveMarker(pMarker, resolvedMarkerData, markerSize);
+    pGpuCrashTracker->OnResolveMarker(pMarker, markerDataSize, resolvedMarkerData, markerSize);
 }
 
 void GpuCrashTracker::ShaderSourceDebugInfoLookupCallback(

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
@@ -87,6 +87,7 @@ private:
     //! Marker resolve callback
     void OnResolveMarker(
         const void* pMarker,
+        const uint32_t markerDataSize,
         void** resolvedMarkerData,
         uint32_t* markerSize) const;
 
@@ -135,6 +136,7 @@ private:
     //! Marker resolve callback
     static void ResolveMarkerCallback(
         const void* pMarker,
+        const uint32_t markerDataSize,
         void* pUserData,
         void** resolvedMarkerData,
         uint32_t* markerSize);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
@@ -205,7 +205,7 @@ void GpuCrashTracker::OnShaderLookup(
 }
 
 void GpuCrashTracker::OnResolveMarker(
-    [[maybe_unused]] const void* pMarker, [[maybe_unused]] void** resolvedMarkerData, [[maybe_unused]] uint32_t* markerSize) const
+    [[maybe_unused]] const void* pMarker, [[maybe_unused]] const uint32_t markerDataSize,[[maybe_unused]] void** resolvedMarkerData, [[maybe_unused]] uint32_t* markerSize) const
 {
 }
 
@@ -262,12 +262,13 @@ void GpuCrashTracker::ShaderLookupCallback(
 
 void GpuCrashTracker::ResolveMarkerCallback(
     const void* pMarker,
+    const uint32_t markerDataSize,
     void* pUserData,
     void** resolvedMarkerData,
     uint32_t* markerSize)
 {
     GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnResolveMarker(pMarker, resolvedMarkerData, markerSize);
+    pGpuCrashTracker->OnResolveMarker(pMarker, markerDataSize, resolvedMarkerData, markerSize);
 }
 
 void GpuCrashTracker::ShaderSourceDebugInfoLookupCallback(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
@@ -77,9 +77,11 @@ private:
         const GFSDK_Aftermath_ShaderBinaryHash& shaderHash,
         PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
 
+
     //! Marker resolve callback
     void OnResolveMarker(
         const void* pMarker,
+        const uint32_t markerDataSize,
         void** resolvedMarkerData,
         uint32_t* markerSize) const;
 
@@ -128,6 +130,7 @@ private:
     //! Marker resolve callback
     static void ResolveMarkerCallback(
         const void* pMarker,
+        const uint32_t markerDataSize,
         void* pUserData,
         void** resolvedMarkerData,
         uint32_t* markerSize);


### PR DESCRIPTION
## What does this PR do?

Adapts to API changes for the NSight Aftermath GpuCrash Tracker, already introduced sometime in the beginning of 2023

## How was this PR tested?

Windows + Vulkan, set `LY_AFTERMATH_PATH` to `path/to/NVIDIA_Nsight_Aftermath_SDK_2024.2.0.24200` and compile the engine.
