### PR TITLE
Cherry pick two test crash fixes into the 2409.1 point release

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Main.py
@@ -37,11 +37,12 @@ def save_multiplayer_level_cache_folder_artifact(workspace, multiplayer_level):
 class TestAutomation(EditorTestSuite):
     class test_Multiplayer_BasicConnectivity_Connects(EditorSingleTest):
         from .tests import Multiplayer_BasicConnectivity_Connects as test_module
+        
+        timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup
 
         def __init__(self):
             super(test_Multiplayer_BasicConnectivity_Connects, self).__init__()
-            self.timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup
-        
+
         @classmethod
         def setup(cls, instance, request, workspace):
             save_multiplayer_level_cache_folder_artifact(workspace, "basicconnectivity_connects")
@@ -49,6 +50,7 @@ class TestAutomation(EditorTestSuite):
     class test_Multiplayer_BasicConnectivity_Connects_ClientServer(EditorSingleTest):
         from .tests import Multiplayer_BasicConnectivity_Connects_ClientServer as test_module
 
+        timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup
+
         def __init__(self):
             super(test_Multiplayer_BasicConnectivity_Connects_ClientServer, self).__init__()
-            self.timeout = 60.0 * 15.0 # increase timeout to ~15 minutes to accommodate for slow server startup

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -14,6 +14,7 @@
 #include <RPI.Private/RPISystemComponent.h>
 
 #include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHIUtils.h>
 
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/IO/IOUtils.h>
@@ -106,14 +107,15 @@ namespace AZ
             ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
             
             bool isNullRenderer = false;
-            if (appType.IsHeadless())
+            if ( (appType.IsHeadless()) || (RHI::IsNullRHI()) )
             {
-                // if the application is `headless`, merge `NullRenderer` attribute to the setting registry
+                // if the application is `headless` or the RHI is the null RHI, merge `NullRenderer` attribute to the setting registry
                 isNullRenderer = true;
             }
             else
             {
-                // Otherwise if the command line contains -NullRenderer merge it to setting registry
+                // The command-line switch "--NullRenderer=true" can also be used to switch to null renderer.  This is maintained
+                // for backwards compatibility.  Use "-rhi=null" instead.
                 const char* nullRendererOption = "NullRenderer"; // command line option name
                 const AzFramework::CommandLine* commandLine = nullptr;
                 AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetApplicationCommandLine);


### PR DESCRIPTION
## What does this PR do?

It cherry picks two existing test crash fixes from development into the 2409.1 point release

## How was this PR tested?

These PRs provide no conflicts and were already tested in dev. 
They fix the CRUD crash and the Multiplayer Timeout test failures.

See below - github shows the commits in this PR below this box.