### PR TITLE
Bump engine.json version for point-release 24091

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.2.1",
@@ -12,7 +12,7 @@
         "tools": "1.1.0"
     },
     "file_version": 2,
-    "copyright_year": 2023,
+    "copyright_year": 2024,
     "build": 0,
     "external_subdirectories": [
         "Gems/Achievements",


### PR DESCRIPTION
## What does this PR do?

Updates the engine version to `2.3.1` and copyright year to `2024`

## How was this PR tested?

Local testing on compiled installer