### PR TITLE
Change Atom_RPI shared libraries back to static libraries

### DIFF
--- a/Gems/Atom/RPI/Code/CMakeLists.txt
+++ b/Gems/Atom/RPI/Code/CMakeLists.txt
@@ -18,9 +18,8 @@ else()
 endif()
 
 ly_add_target(
-    NAME ${gem_name}.Public ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
+    NAME ${gem_name}.Public STATIC
     NAMESPACE Gem
-    EXPORT_ALL_SYMBOLS
     FILES_CMAKE
         atom_rpi_reflect_files.cmake
         atom_rpi_public_files.cmake
@@ -82,9 +81,8 @@ ly_add_source_properties(
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
 
     ly_add_target(
-        NAME ${gem_name}.Edit ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
+        NAME ${gem_name}.Edit STATIC
         NAMESPACE Gem
-        EXPORT_ALL_SYMBOLS
         FILES_CMAKE
             atom_rpi_edit_files.cmake
         INCLUDE_DIRECTORIES
@@ -157,9 +155,8 @@ endif()
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
 
     ly_add_target(
-        NAME ${gem_name}.TestUtils ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
+        NAME ${gem_name}.TestUtils STATIC
         NAMESPACE Gem
-        EXPORT_ALL_SYMBOLS
         FILES_CMAKE
             atom_rpi_test_utils_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/DllMain.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/DllMain.cpp
@@ -13,7 +13,8 @@
 
 extern "C" AZ_DLL_EXPORT void CleanUpRpiEditGenericClassInfo()
 {
-    AZ::GetCurrentSerializeContextModule().Cleanup();
+    // TODO(Atom_RPI-sharedlib): Uncomment this when Atom_RPI.Edit is converted to a shared library
+    // AZ::GetCurrentSerializeContextModule().Cleanup();
 }
 
 #endif

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
@@ -13,7 +13,8 @@
 
 extern "C" AZ_DLL_EXPORT void CleanUpRpiPublicGenericClassInfo()
 {
-    AZ::GetCurrentSerializeContextModule().Cleanup();
+    // TODO(Atom_RPI-sharedlib): Uncomment this when Atom_RPI.Public is converted to a shared library
+    // AZ::GetCurrentSerializeContextModule().Cleanup();
 }
 
 #endif


### PR DESCRIPTION
## What does this PR do?

This PR partially reverts [PR18315](https://github.com/o3de/o3de/pull/18315) because too many symbols are exported on Windows with a debug build (Windows dlls cannot export more than 2^16 symbols, which is exceeded in the `Atom_RPI.Public` target).

I want to keep the other changes of the original PR (mostly change `static const char*` in header files (+ definition in cpp file) to  `static constexpr char*`), which will be needed eventually if I want to properly convert these targets to shared libraries.

A proper solution is certainly possible, but not straight-forward:
* Add export macros to all classes (easy)
* Add additional macros to disable warnings about base classes not having a dll interface (`AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING`, easy)
* Add additional macros to disable warnings about members of non-exported classes (`AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING`, easy)
* Fix linker errors (hard): After implementing the previous steps, there are many linker errors which suggest that this is not possible without also converting AzCore to a shared library (or at least add some dll macros); after some digging around in the code that is where I gave up and fell back to the `EXPORT_ALL_SYMBOLS` version

So I will further pursue the goal of properly converting these targets to shared libraries, but for now a revert to static libraries is inevitable.

## How was this PR tested?

Compile on Windows and Linux, run tests on Linux, AR