### PR TITLE
CopyPass improvements (mainly for multi-device usage)

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshOutputStreamManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshOutputStreamManager.cpp
@@ -61,7 +61,8 @@ namespace AZ
             creator.SetPoolAsset(SkinnedMeshVertexStreamPropertyInterface::Get()->GetOutputStreamResourcePool());
 
             RHI::BufferDescriptor bufferDescriptor;
-            bufferDescriptor.m_bindFlags = RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::ShaderReadWrite;
+            bufferDescriptor.m_bindFlags = RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::ShaderReadWrite |
+                RHI::BufferBindFlags::CopyRead | RHI::BufferBindFlags::CopyWrite;
             bufferDescriptor.m_byteCount = m_sizeInBytes;
             bufferDescriptor.m_alignment = m_alignment;
             creator.SetBuffer(nullptr, 0, bufferDescriptor);

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
@@ -131,7 +131,8 @@ namespace AZ
             {
                 auto bufferPoolDesc = AZStd::make_unique<RHI::BufferPoolDescriptor>();
                 // Output buffers are both written to during skinning and used as input assembly buffers
-                bufferPoolDesc->m_bindFlags = RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::ShaderReadWrite;
+                bufferPoolDesc->m_bindFlags = RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::ShaderReadWrite |
+                    RHI::BufferBindFlags::CopyRead | RHI::BufferBindFlags::CopyWrite;
                 bufferPoolDesc->m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
 
                 RPI::ResourcePoolAssetCreator creator;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferProperty.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferProperty.h
@@ -10,6 +10,7 @@
 #include <Atom/RHI.Reflect/BufferDescriptor.h>
 #include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RHI/interval_map.h>
+#include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/sort.h>
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CopyItem.h
@@ -80,19 +80,21 @@ namespace AZ::RHI
             AZ_Assert(m_destinationImage, "Not initialized with destination Image\n");
 
             return DeviceCopyBufferToImageDescriptor{ m_sourceBuffer ? m_sourceBuffer->GetDeviceBuffer(deviceIndex).get() : nullptr,
-                                                m_sourceOffset,
-                                                m_sourceBytesPerRow,
-                                                m_sourceBytesPerImage,
-                                                m_sourceSize,
-                                                m_destinationImage ? m_destinationImage->GetDeviceImage(deviceIndex).get() : nullptr,
-                                                m_destinationSubresource,
-                                                m_destinationOrigin };
+                                                      m_sourceOffset,
+                                                      m_sourceBytesPerRow,
+                                                      m_sourceBytesPerImage,
+                                                      m_sourceFormat,
+                                                      m_sourceSize,
+                                                      m_destinationImage ? m_destinationImage->GetDeviceImage(deviceIndex).get() : nullptr,
+                                                      m_destinationSubresource,
+                                                      m_destinationOrigin };
         }
 
         const Buffer* m_sourceBuffer = nullptr;
         uint32_t m_sourceOffset = 0;
         uint32_t m_sourceBytesPerRow = 0;
         uint32_t m_sourceBytesPerImage = 0;
+        Format m_sourceFormat;
         Size m_sourceSize;
         const Image* m_destinationImage = nullptr;
         ImageSubresource m_destinationSubresource;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CopyItem.h
@@ -94,7 +94,9 @@ namespace AZ::RHI
         uint32_t m_sourceOffset = 0;
         uint32_t m_sourceBytesPerRow = 0;
         uint32_t m_sourceBytesPerImage = 0;
-        Format m_sourceFormat;
+        //! The source format is usually same as m_destinationImage's format. When destination image contains more than one aspect,
+        //! the format should be compatiable with the aspect of the destination image's subresource
+        Format m_sourceFormat = Format::Unknown;
         Size m_sourceSize;
         const Image* m_destinationImage = nullptr;
         ImageSubresource m_destinationSubresource;
@@ -133,7 +135,7 @@ namespace AZ::RHI
         uint32_t m_destinationBytesPerImage = 0;
         //! The destination format is usually same as m_sourceImage's format. When source image contains more than one aspect,
         //! the format should be compatiable with the aspect of the source image's subresource
-        Format m_destinationFormat;
+        Format m_destinationFormat = Format::Unknown;
     };
 
     //! A structure used to define a CopyItem, copying from a QueryPool to a Buffer

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceCopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceCopyItem.h
@@ -45,6 +45,9 @@ namespace AZ::RHI
         uint32_t m_sourceOffset = 0;
         uint32_t m_sourceBytesPerRow = 0;
         uint32_t m_sourceBytesPerImage = 0;
+        // The source format is usually same as m_destinationImage's format. When destination image contains more than one aspect,
+        // the format should be compatiable with the aspect of the destination image's subresource
+        Format m_sourceFormat;
         Size m_sourceSize;
         const DeviceImage* m_destinationImage = nullptr;
         ImageSubresource m_destinationSubresource;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceCopyItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceCopyItem.h
@@ -47,7 +47,7 @@ namespace AZ::RHI
         uint32_t m_sourceBytesPerImage = 0;
         // The source format is usually same as m_destinationImage's format. When destination image contains more than one aspect,
         // the format should be compatiable with the aspect of the destination image's subresource
-        Format m_sourceFormat;
+        Format m_sourceFormat = Format::Unknown;
         Size m_sourceSize;
         const DeviceImage* m_destinationImage = nullptr;
         ImageSubresource m_destinationSubresource;
@@ -68,7 +68,7 @@ namespace AZ::RHI
         uint32_t m_destinationBytesPerImage = 0;
         // The destination format is usually same as m_sourceImage's format. When source image contains more than one aspect,
         // the format should be compatiable with the aspect of the source image's subresource
-        Format m_destinationFormat; 
+        Format m_destinationFormat = Format::Unknown;
     };
 
     struct DeviceCopyQueryToBufferDescriptor

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/AttachmentEnums.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/AttachmentEnums.cpp
@@ -238,14 +238,8 @@ namespace AZ::RHI
             }
             return access;
 
-        // Disallow read/write access for Copy scope attachments as this is nonsensical, Copy operations
-        // have only sources and destinations. We remap read/write to write as a fallback.
+        // Read/write access for Copy scope attachments can happen when copying between two devices.
         case ScopeAttachmentUsage::Copy:
-            AZ_Error("ScopeAttachment", access != ScopeAttachmentAccess::ReadWrite, "ScopeAttachmentAccess cannot be 'ReadWrite' when usage is 'Copy'.");
-            if (access == ScopeAttachmentAccess::ReadWrite)
-            {
-                return ScopeAttachmentAccess::Write;
-            }
             return access;
 
         case ScopeAttachmentUsage::InputAssembly:

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferScopeAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferScopeAttachment.cpp
@@ -29,7 +29,10 @@ namespace AZ::RHI
 
         if (m_descriptor.m_loadStoreAction.m_loadAction == AttachmentLoadAction::Clear)
         {
-            AZ_Error("FrameScheduler", access == ScopeAttachmentAccess::ReadWrite, "Attempting to clear an attachment that is read-only");
+            AZ_Error(
+                "FrameScheduler",
+                CheckBitsAny(access, ScopeAttachmentAccess::Write),
+                "Attempting to clear an attachment that is read-only");
         }
     }
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -224,7 +224,7 @@ namespace AZ
                 footprint.Footprint.Width = descriptor.m_sourceSize.m_width;
                 footprint.Footprint.Height = descriptor.m_sourceSize.m_height;
                 footprint.Footprint.Depth = descriptor.m_sourceSize.m_depth;
-                footprint.Footprint.Format = ConvertFormat(destinationImage->GetDescriptor().m_format);
+                footprint.Footprint.Format = ConvertFormat(descriptor.m_sourceFormat);
                 footprint.Footprint.RowPitch = descriptor.m_sourceBytesPerRow;
 
                 const CD3DX12_TEXTURE_COPY_LOCATION sourceLocation(sourceBuffer->GetMemoryView().GetMemory(), footprint);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -128,7 +128,7 @@ namespace AZ
                                                      descriptor.m_sourceSize.m_height,
                                                      descriptor.m_sourceSize.m_depth);
 
-                    MTLBlitOption mtlBlitOption = GetBlitOption(destinationImage->GetDescriptor().m_format, descriptor.m_destinationSubresource.m_aspect);
+                    MTLBlitOption mtlBlitOption = GetBlitOption(descriptor.m_sourceFormat, descriptor.m_destinationSubresource.m_aspect);
                     [blitEncoder copyFromBuffer: sourceBuffer->GetMemoryView().GetGpuAddress<id<MTLBuffer>>()
                                    sourceOffset: sourceBuffer->GetMemoryView().GetOffset() + descriptor.m_sourceOffset
                               sourceBytesPerRow: descriptor.m_sourceBytesPerRow
@@ -157,7 +157,7 @@ namespace AZ
                                                      descriptor.m_sourceSize.m_height,
                                                      descriptor.m_sourceSize.m_depth);
 
-                    MTLBlitOption mtlBlitOption = GetBlitOption(sourceImage->GetDescriptor().m_format, descriptor.m_sourceSubresource.m_aspect);
+                    MTLBlitOption mtlBlitOption = GetBlitOption(descriptor.m_destinationFormat, descriptor.m_sourceSubresource.m_aspect);
                     [blitEncoder copyFromTexture: sourceImage->GetMemoryView().GetGpuAddress<id<MTLTexture>>()
                                      sourceSlice: descriptor.m_sourceSubresource.m_arraySlice
                                      sourceLevel: descriptor.m_sourceSubresource.m_mipSlice

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -293,6 +293,7 @@ namespace AZ
                                 copyDescriptor.m_sourceBytesPerImage = stagingSlicePitch;
                                 copyDescriptor.m_sourceSize = subresourceLayout.m_size;
                                 copyDescriptor.m_sourceSize.m_depth = 1;
+                                copyDescriptor.m_sourceFormat = image->GetDescriptor().m_format;
                                 copyDescriptor.m_destinationImage = image;
                                 copyDescriptor.m_destinationSubresource.m_mipSlice = curMip;
                                 copyDescriptor.m_destinationSubresource.m_arraySlice = static_cast<uint16_t>(arraySlice);
@@ -325,6 +326,7 @@ namespace AZ
                                 copyDescriptor.m_sourceBytesPerImage = stagingSlicePitch;
                                 copyDescriptor.m_sourceSize = subresourceLayout.m_size;
                                 copyDescriptor.m_sourceSize.m_depth = 1;
+                                copyDescriptor.m_sourceFormat = image->GetDescriptor().m_format;
                                 copyDescriptor.m_destinationImage = image;
                                 copyDescriptor.m_destinationSubresource.m_mipSlice = curMip;
                                 copyDescriptor.m_destinationSubresource.m_arraySlice = static_cast<uint16_t>(arraySlice);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -127,7 +127,7 @@ namespace AZ
                 const RHI::DeviceCopyBufferToImageDescriptor& descriptor = copyItem.m_bufferToImage;
                 const auto* sourceBufferMemoryView = static_cast<const Buffer*>(descriptor.m_sourceBuffer)->GetBufferMemoryView();
                 const auto* destinationImage = static_cast<const Image*>(descriptor.m_destinationImage);
-                const RHI::Format format = destinationImage->GetDescriptor().m_format;
+                const RHI::Format format = descriptor.m_sourceFormat;
                 RHI::Size formatDimensionAlignment = GetFormatDimensionAlignment(format);
 
                 // VkBufferImageCopy::bufferRowLength is specified in texels not in bytes. 
@@ -141,7 +141,8 @@ namespace AZ
                 copy.bufferOffset = sourceBufferMemoryView->GetOffset() + descriptor.m_sourceOffset;
                 copy.bufferRowLength = descriptor.m_sourceBytesPerRow / GetFormatSize(format) * formatDimensionAlignment.m_width;
                 copy.bufferImageHeight = RHI::AlignUp(descriptor.m_sourceSize.m_height, formatDimensionAlignment.m_height);
-                copy.imageSubresource.aspectMask = destinationImage->GetImageAspectFlags();
+                copy.imageSubresource.aspectMask = ConvertImageAspect(descriptor.m_destinationSubresource.m_aspect);
+
                 copy.imageSubresource.mipLevel = descriptor.m_destinationSubresource.m_mipSlice;
                 copy.imageSubresource.baseArrayLayer = descriptor.m_destinationSubresource.m_arraySlice;
                 copy.imageSubresource.layerCount = 1;
@@ -168,14 +169,14 @@ namespace AZ
                 const auto* destinationImage = static_cast<const Image*>(descriptor.m_destinationImage);
 
                 VkImageCopy copy{};
-                copy.srcSubresource.aspectMask = sourceImage->GetImageAspectFlags();
+                copy.srcSubresource.aspectMask = ConvertImageAspect(descriptor.m_sourceSubresource.m_aspect);
                 copy.srcSubresource.mipLevel = descriptor.m_sourceSubresource.m_mipSlice;
                 copy.srcSubresource.baseArrayLayer = descriptor.m_sourceSubresource.m_arraySlice;
                 copy.srcSubresource.layerCount = 1;
                 copy.srcOffset.x = descriptor.m_sourceOrigin.m_left;
                 copy.srcOffset.y = descriptor.m_sourceOrigin.m_top;
                 copy.srcOffset.z = descriptor.m_sourceOrigin.m_front;
-                copy.dstSubresource.aspectMask = destinationImage->GetImageAspectFlags();
+                copy.dstSubresource.aspectMask = ConvertImageAspect(descriptor.m_destinationSubresource.m_aspect);
                 copy.dstSubresource.mipLevel = descriptor.m_destinationSubresource.m_mipSlice;
                 copy.dstSubresource.baseArrayLayer = descriptor.m_destinationSubresource.m_arraySlice;
                 copy.dstSubresource.layerCount = 1;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -450,9 +450,18 @@ namespace AZ
 
                     if (RHI::CheckBitsAny(imageAspects, RHI::ImageAspectFlags::DepthStencil))
                     {
+                        if (imageAspects == RHI::ImageAspectFlags::Depth)
+                        {
+                            return VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
+                        }
+                        else if (imageAspects == RHI::ImageAspectFlags::Stencil)
+                        {
+                            return VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
+                        }
+
                         return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
                     }
-                        
+
                     return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
                 }
             case RHI::ScopeAttachmentUsage::Copy:

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImagePoolResolver.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImagePoolResolver.cpp
@@ -144,6 +144,7 @@ namespace AZ
                 copyDescriptor.m_sourceOffset = 0;
                 copyDescriptor.m_sourceBytesPerRow = stagingRowPitch;
                 copyDescriptor.m_sourceBytesPerImage = stagingSlicePitch;
+                copyDescriptor.m_sourceFormat = packet.m_destinationImage->GetDescriptor().m_format;
                 copyDescriptor.m_sourceSize = subresourceLayout.m_size;
                 copyDescriptor.m_destinationImage = packet.m_destinationImage;
                 copyDescriptor.m_destinationSubresource.m_mipSlice = packet.m_subresource.m_mipSlice;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -655,7 +655,7 @@ namespace AZ
             filteredBarrier.m_srcStageMask = RHI::FilterBits(unoptimizedBarrier.m_srcStageMask, m_deviceSupportedPipelineStageFlags);
 
             // a render pass can only automatically convert image layouts if a multi-aspect image has the same or compatible layouts for all
-            // aspects this workaround covers this case for depth/stencil images where one aspect is in a transfer state:
+            // aspects. This workaround covers the case for depth/stencil images where one aspect is in a transfer state:
             if (canOptimize && filteredBarrier.m_type == VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER && UsesRenderpass() &&
                 IsRenderAttachmentUsage(filteredBarrier.m_attachment->GetUsage()) &&
                 (filteredBarrier.m_imageBarrier.subresourceRange.aspectMask == VK_IMAGE_ASPECT_DEPTH_BIT ||

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.cpp
@@ -5,28 +5,29 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Atom_RHI_Vulkan_Platform.h>
-#include <algorithm>
-#include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/BufferProperty.h>
+#include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/FrameGraphExecuteContext.h>
-#include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ImageFrameAttachment.h>
+#include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
+#include <Atom_RHI_Vulkan_Platform.h>
+#include <AzCore/Math/MathIntrinsics.h>
+#include <RHI/BufferView.h>
 #include <RHI/CommandList.h>
+#include <RHI/Conversion.h>
+#include <RHI/Device.h>
+#include <RHI/Framebuffer.h>
 #include <RHI/GraphicsPipeline.h>
 #include <RHI/ImageView.h>
-#include <RHI/QueryPool.h>
 #include <RHI/PipelineState.h>
+#include <RHI/QueryPool.h>
 #include <RHI/RenderPass.h>
 #include <RHI/ResourcePoolResolver.h>
 #include <RHI/Scope.h>
 #include <RHI/SwapChain.h>
-#include <RHI/Framebuffer.h>
-#include <RHI/Device.h>
-#include <RHI/Conversion.h>
-#include <RHI/BufferView.h>
+#include <algorithm>
 
 namespace AZ
 {
@@ -611,11 +612,14 @@ namespace AZ
             case VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER:
                 if (barrier.m_imageBarrier.srcQueueFamilyIndex == barrier.m_imageBarrier.dstQueueFamilyIndex)
                 {
-                    // Barriers between subpasses have to be "optimized" as subpass dependencies and subpass layout transitions (for pipeline compatibilty)
-                    // Barriers to external scopes (outside of the group) can be optimized if we are using a renderpass and the optimization option is enabled.
+                    // Barriers between subpasses have to be "optimized" as subpass dependencies and subpass layout transitions (for
+                    // pipeline compatibilty) Barriers to external scopes (outside of the group) can be optimized if we are using a
+                    // renderpass and the optimization option is enabled.
                     bool useRenderpassBarrier = UsesRenderpass() && IsRenderAttachmentUsage(barrier.m_attachment->GetUsage());
-                    bool renderpassLayoutOptimizationEnabled = RHI::CheckBitsAll(optimizationFlags,BarrierOptimizationFlags::UseRenderpassLayout);
-                    useRenderpassBarrier &= renderpassLayoutOptimizationEnabled || !HasExternalConnection(barrier.m_attachment, slot);
+                    bool renderpassLayoutOptimizationEnabled =
+                        RHI::CheckBitsAll(optimizationFlags, BarrierOptimizationFlags::UseRenderpassLayout);
+                    useRenderpassBarrier &= (renderpassLayoutOptimizationEnabled || !HasExternalConnection(barrier.m_attachment, slot)) &&
+                        AreDepthStencilLayoutsCompatible(barrier, slot);
                     if (useRenderpassBarrier ||
                         (globalBarrierOptimizationEnabled &&
                          barrier.m_imageBarrier.oldLayout == barrier.m_imageBarrier.newLayout)) // If the layout doesn't change we can just
@@ -646,6 +650,68 @@ namespace AZ
             }
         }
 
+        bool Scope::AreDepthStencilLayoutsCompatible(const Barrier& barrier, BarrierSlot slot) const
+        {
+            // The two aspects of a depth stencil image could be in incompatible layouts so that an automatic layout transition
+            // by the renderpass doesn't work. In that case we will have two barriers each transitioning one aspect and we
+            // cannot optimize them. First we check if the usage is DepthStencil, there is only a single aspect and the layout
+            // changes.
+            if (barrier.m_attachment->GetUsage() == RHI::ScopeAttachmentUsage::DepthStencil &&
+                az_popcnt_u32(barrier.m_imageBarrier.subresourceRange.aspectMask) < 2 &&
+                barrier.m_imageBarrier.oldLayout != barrier.m_imageBarrier.newLayout)
+            {
+                const Image& image = static_cast<const Image&>(
+                    barrier.m_attachment->GetResourceView()->GetDeviceResourceView(GetDeviceIndex())->GetResource());
+
+                // Next, we check if the image actually has both a depth and a stencil aspect.
+                if (az_popcnt_u32(AZStd::to_underlying(image.GetAspectFlags())) == 2)
+                {
+                    VkImageLayout layout{ VK_IMAGE_LAYOUT_UNDEFINED };
+                    VkImageAspectFlags aspectFlags{ VK_IMAGE_ASPECT_NONE };
+
+                    // Finally, we need to go through all unoptimizedBarriers and for the barriers handling the same image, we
+                    // need to check if the layouts are compatible. E.g., DEPTH_READ_ONLY_OPTIMAL is compatible with
+                    // STENCIL_ATTACHMENT_OPTIMAL, but TRANSFER_DEST is not compatible with either of them.
+                    for (const Barrier& otherBarrier : m_unoptimizedBarriers[AZStd::to_underlying(slot)])
+                    {
+                        if (otherBarrier.m_type == VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER &&
+                            otherBarrier.m_imageBarrier.srcQueueFamilyIndex == otherBarrier.m_imageBarrier.dstQueueFamilyIndex &&
+                            otherBarrier.m_imageBarrier.image == barrier.m_imageBarrier.image &&
+                            otherBarrier.m_attachment->GetUsage() == RHI::ScopeAttachmentUsage::DepthStencil &&
+                            az_popcnt_u32(otherBarrier.m_imageBarrier.subresourceRange.aspectMask) == 1)
+                        {
+                            // First found barrier is used to initialize aspectFlags and layout
+                            if (aspectFlags == VK_IMAGE_ASPECT_NONE)
+                            {
+                                aspectFlags = otherBarrier.m_imageBarrier.subresourceRange.aspectMask;
+                                layout = FilterImageLayout(otherBarrier.m_imageBarrier.oldLayout, ConvertImageAspectFlags(aspectFlags));
+                            }
+                            // The second found barrier should not overlap with the aspects
+                            else if (!AZ::RHI::CheckBitsAll(aspectFlags, otherBarrier.m_imageBarrier.subresourceRange.aspectMask))
+                            {
+                                auto newLayout = CombineImageLayout(
+                                    FilterImageLayout(layout, ConvertImageAspectFlags(aspectFlags)),
+                                    FilterImageLayout(
+                                        otherBarrier.m_imageBarrier.oldLayout,
+                                        ConvertImageAspectFlags(otherBarrier.m_imageBarrier.subresourceRange.aspectMask)));
+
+                                // CombineImageLayout returns the first parameter if the layouts are incompatible
+                                if (newLayout == layout)
+                                {
+                                    return false;
+                                }
+
+                                layout = newLayout;
+                                aspectFlags |= otherBarrier.m_imageBarrier.subresourceRange.aspectMask;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
         void Scope::OptimizeBarrier(const Barrier& unoptimizedBarrier, BarrierSlot slot)
         {
             uint32_t slotIndex = aznumeric_caster(slot);
@@ -653,26 +719,6 @@ namespace AZ
             auto filteredBarrier = unoptimizedBarrier;
             filteredBarrier.m_dstStageMask = RHI::FilterBits(unoptimizedBarrier.m_dstStageMask, m_deviceSupportedPipelineStageFlags);
             filteredBarrier.m_srcStageMask = RHI::FilterBits(unoptimizedBarrier.m_srcStageMask, m_deviceSupportedPipelineStageFlags);
-
-            // a render pass can only automatically convert image layouts if a multi-aspect image has the same or compatible layouts for all
-            // aspects. This workaround covers the case for depth/stencil images where one aspect is in a transfer state:
-            if (canOptimize && filteredBarrier.m_type == VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER && UsesRenderpass() &&
-                IsRenderAttachmentUsage(filteredBarrier.m_attachment->GetUsage()) &&
-                (filteredBarrier.m_imageBarrier.subresourceRange.aspectMask == VK_IMAGE_ASPECT_DEPTH_BIT ||
-                 filteredBarrier.m_imageBarrier.subresourceRange.aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) &&
-                (filteredBarrier.m_imageBarrier.oldLayout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL ||
-                 filteredBarrier.m_imageBarrier.oldLayout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL))
-            {
-                auto oldLayout = filteredBarrier.m_imageBarrier.oldLayout;
-
-                // insert the newLayout as oldLayout into m_globalBarriers as the RenderPass uses oldLayout to determine the initial layout
-                filteredBarrier.m_imageBarrier.oldLayout = filteredBarrier.m_imageBarrier.newLayout;
-                OptimizeBarrier(filteredBarrier, slot);
-
-                // insert an actual barrier for transfer -> newLayout transition into m_scopeBarriers
-                filteredBarrier.m_imageBarrier.oldLayout = oldLayout;
-                canOptimize = false;
-            }
 
             AZStd::vector<Barrier>& barriers = canOptimize ? m_globalBarriers[slotIndex] : m_scopeBarriers[slotIndex];
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Scope.h
@@ -182,6 +182,10 @@ namespace AZ
             // Returns true if a barrier can be converted to an implicit subpass barrier.
             bool CanOptimizeBarrier(const Barrier& barrier, BarrierSlot slot) const;
 
+            // Returns true if the barriers in the scope have layout transitions that are incompatible with automatic layout transition of
+            // a renderpass and thus cannot be optimized.
+            bool AreDepthStencilLayoutsCompatible(const Barrier& barrier, BarrierSlot slot) const;
+
             template<class T>
             const Barrier QueueBarrierInternal(
                 RHI::ScopeAttachment* attachment,

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
@@ -62,8 +62,6 @@ namespace AZ
 
             // The copy item submitted to the command list
             RHI::CopyItem m_copyItemSameDevice;
-            AZStd::vector<RHI::CopyItem> m_copyItemDeviceToHost;
-            AZStd::vector<RHI::CopyItem> m_copyItemHostToDevice;
 
             AZStd::shared_ptr<AZ::RHI::ScopeProducer> m_copyScopeProducerSameDevice;
             AZStd::shared_ptr<AZ::RHI::ScopeProducer> m_copyScopeProducerDeviceToHost;
@@ -84,13 +82,22 @@ namespace AZ
             bool m_inputOutputCopy = false;
 
             constexpr static int MaxFrames = RHI::Limits::Device::FrameCountMax;
+
+            struct PerAspectCopyInfo
+            {
+                RHI::CopyItem m_copyItemDeviceToHost{};
+                RHI::CopyItem m_copyItemHostToDevice{};
+                AZStd::array<Data::Instance<Buffer>, MaxFrames> m_device1HostBuffer{};
+                AZStd::array<Data::Instance<Buffer>, MaxFrames> m_device2HostBuffer{};
+                AZStd::array<AZ::u64, MaxFrames> m_deviceHostBufferByteCount{};
+                RHI::DeviceImageSubresourceLayout m_inputImageLayout;
+            };
+
+            AZStd::vector<PerAspectCopyInfo> m_perAspectCopyInfos;
+
             int m_currentBufferIndex = 0;
-            AZStd::array<AZStd::array<Data::Instance<Buffer>, MaxFrames>, 2> m_device1HostBuffer;
-            AZStd::array<AZStd::array<Data::Instance<Buffer>, MaxFrames>, 2> m_device2HostBuffer;
-            AZStd::array<AZStd::array<AZ::u64, MaxFrames>, 2> m_deviceHostBufferByteCount{};
             AZStd::array<Ptr<RHI::Fence>, MaxFrames> m_device1SignalFence;
             AZStd::array<Ptr<RHI::Fence>, MaxFrames> m_device2WaitFence;
-            AZStd::array<RHI::DeviceImageSubresourceLayout, 2> m_inputImageLayouts;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
@@ -62,8 +62,9 @@ namespace AZ
 
             // The copy item submitted to the command list
             RHI::CopyItem m_copyItemSameDevice;
-            RHI::CopyItem m_copyItemDeviceToHost;
-            RHI::CopyItem m_copyItemHostToDevice;
+            AZStd::vector<RHI::CopyItem> m_copyItemDeviceToHost;
+            AZStd::vector<RHI::CopyItem> m_copyItemHostToDevice;
+
             AZStd::shared_ptr<AZ::RHI::ScopeProducer> m_copyScopeProducerSameDevice;
             AZStd::shared_ptr<AZ::RHI::ScopeProducer> m_copyScopeProducerDeviceToHost;
             AZStd::shared_ptr<AZ::RHI::ScopeProducer> m_copyScopeProducerHostToDevice;
@@ -80,15 +81,16 @@ namespace AZ
                 Invalid
             };
             CopyMode m_copyMode = CopyMode::Invalid;
+            bool m_inputOutputCopy = false;
 
             constexpr static int MaxFrames = RHI::Limits::Device::FrameCountMax;
             int m_currentBufferIndex = 0;
-            AZStd::array<Data::Instance<Buffer>, MaxFrames> m_device1HostBuffer;
-            AZStd::array<Data::Instance<Buffer>, MaxFrames> m_device2HostBuffer;
-            AZStd::array<AZ::u64, MaxFrames> m_deviceHostBufferByteCount{};
+            AZStd::array<AZStd::array<Data::Instance<Buffer>, MaxFrames>, 2> m_device1HostBuffer;
+            AZStd::array<AZStd::array<Data::Instance<Buffer>, MaxFrames>, 2> m_device2HostBuffer;
+            AZStd::array<AZStd::array<AZ::u64, MaxFrames>, 2> m_deviceHostBufferByteCount{};
             AZStd::array<Ptr<RHI::Fence>, MaxFrames> m_device1SignalFence;
             AZStd::array<Ptr<RHI::Fence>, MaxFrames> m_device2WaitFence;
-            RHI::DeviceImageSubresourceLayout m_inputImageLayout;
+            AZStd::array<RHI::DeviceImageSubresourceLayout, 2> m_inputImageLayouts;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/CopyPass.h
@@ -79,6 +79,7 @@ namespace AZ
                 Invalid
             };
             CopyMode m_copyMode = CopyMode::Invalid;
+            // Set to true for the MultiDeviceCopyPass, which uses one InputOutput slot instead of one Input and one Output slot.
             bool m_inputOutputCopy = false;
 
             constexpr static int MaxFrames = RHI::Limits::Device::FrameCountMax;
@@ -93,6 +94,8 @@ namespace AZ
                 RHI::DeviceImageSubresourceLayout m_inputImageLayout;
             };
 
+            // Multiple aspects cannot be copied at the same time, so we need a copy items (and corresponding other members)
+            // for each aspect. This is the case for example, when we want to copy a depth-stencil-image.
             AZStd::vector<PerAspectCopyInfo> m_perAspectCopyInfos;
 
             int m_currentBufferIndex = 0;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -207,8 +207,11 @@ namespace AZ
             //! Adds an attachment binding to the list of this Pass' attachment bindings
             void AddAttachmentBinding(PassAttachmentBinding attachmentBinding);
 
-            // Binds all attachments from the pass 
-            void DeclareAttachmentsToFrameGraph(RHI::FrameGraphInterface frameGraph, PassSlotType slotType = PassSlotType::Uninitialized) const;
+            // Binds all attachments from the pass
+            void DeclareAttachmentsToFrameGraph(
+                RHI::FrameGraphInterface frameGraph,
+                PassSlotType slotType = PassSlotType::Uninitialized,
+                RHI::ScopeAttachmentAccess accessMask = RHI::ScopeAttachmentAccess::ReadWrite) const;
 
             // Returns a reference to the N-th input binding, where N is the index passed to the function
             PassAttachmentBinding& GetInputBinding(uint32_t index);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -885,7 +885,8 @@ namespace AZ
             }
         }
 
-        void Pass::DeclareAttachmentsToFrameGraph(RHI::FrameGraphInterface frameGraph, PassSlotType slotType) const
+        void Pass::DeclareAttachmentsToFrameGraph(
+            RHI::FrameGraphInterface frameGraph, PassSlotType slotType, RHI::ScopeAttachmentAccess accessMask) const
         {
             for (size_t slotIndex = 0; slotIndex < m_attachmentBindings.size(); ++slotIndex)
             {
@@ -921,7 +922,7 @@ namespace AZ
                                 {
                                     frameGraph.UseAttachment(
                                         imageScopeAttachmentDescriptor,
-                                        attachmentBinding.GetAttachmentAccess(),
+                                        attachmentBinding.GetAttachmentAccess() & accessMask,
                                         attachmentBinding.m_scopeAttachmentUsage,
                                         attachmentBinding.m_scopeAttachmentStage);
                                 }
@@ -931,7 +932,7 @@ namespace AZ
                             {
                                 frameGraph.UseAttachment(
                                     attachmentBinding.m_unifiedScopeDesc.GetAsBuffer(),
-                                    attachmentBinding.GetAttachmentAccess(),
+                                    attachmentBinding.GetAttachmentAccess() & accessMask,
                                     attachmentBinding.m_scopeAttachmentUsage,
                                     attachmentBinding.m_scopeAttachmentStage);
                                 break;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
@@ -205,6 +205,19 @@ namespace AZ
             passTemplate->m_slots.emplace_back(outputSlot);
 
             AddPassTemplate(passTemplate->m_name, std::move(passTemplate));
+
+            passTemplate = AZStd::make_shared<PassTemplate>();
+            passTemplate->m_passClass = "CopyPass";
+            passTemplate->m_name = "MultiDeviceCopyPassTemplate";
+
+            PassSlot inputOutputSlot;
+            inputOutputSlot.m_name = "InputOutput";
+            inputOutputSlot.m_slotType = PassSlotType::InputOutput;
+            inputOutputSlot.m_scopeAttachmentUsage = RHI::ScopeAttachmentUsage::Copy;
+            inputOutputSlot.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Load;
+            passTemplate->m_slots.emplace_back(inputOutputSlot);
+
+            AddPassTemplate(passTemplate->m_name, std::move(passTemplate));
         }
 
         bool PassLibrary::AddPassTemplate(const Name& name, const AZStd::shared_ptr<PassTemplate>& passTemplate, bool hotReloading)


### PR DESCRIPTION
Major changes:

- CopyPass: add a MultiDeviceCopyPass with just one InputOutput slot to copy within a multi-device buffer/image
- CopyPass: add support to copy depth/stencil images
- Add m_sourceFormat to CopyBufferToImageDescriptor to give more control and stay consistent with CopyImageToBufferDescriptor which has m_destinationFormat

Minor changes:

- Fix for CopyPass to create a transient attachment when cloneInput is enabled and the input is not transient.
- Add copy flags to be able to copy some buffers between devices (SkinnedMeshOutputStreamManager.cpp and SkinnedMeshVertexStreamProperties.cpp)
- Allow RW access when the scope attachment usage is copy as this happens when copying multi-device resources between devices (AttachmentEnums.cpp)
- Fix for BufferScopeAttachment during clear action error to actually check the write flag rather than exactly read write in line with the error message (BufferScopeAttachment.cpp)
- Add support for just depth OR stencil read only image layouts for subpass inputs (Conversion.cpp)

The change in Scope.cpp is a workaround for a specific issue we encountered where for a multi-aspect (depth and stencil) image with differing layouts for the aspects the layout transition is not done correctly. The situation is as follows:

1. We copy a depth stencil image (final layout: transfer dest)
2. We run a compute pass that reads only the depth image (final layout: depth read only optimal for depth, while stencil is still in transfer dest)
3. We run a render pass where we use it as actual depth stencil attachment

The Vulkan render pass needs a working initial layout and that is determined by the global barriers which are not actually submitted, since the render pass does the necessary layout transition. It can only do so if the layout of the aspect masks is the same or at least can be combined to a valid one (eg. depth read only and stencil read only to depth stencil read only). However with the two layouts the image has at the time it wants to combine them and the combination doesn't work because the stencil aspect is still in transfer dest and not in a attachment optimal or read only optimal layout. Therefore it is necessary to insert a barrier that transitions the stencil aspect to one of these which in our workaround is done by directly going to the target layout that the render pass would transition to. The combination then works because the (recursive) OptimizeBarrier call in the if inserts the necessary global barrier that the render pass uses to determine the initial layout combination. We then set `canOptimize` to false to actually insert a barrier in the scope barriers that gets executed for the actual transition from transfer dest to the target layout. Of course this is a very specific use case and there are likely other instances where something like this can happen for depth/stencil images (or other currently unsupported multi-aspect images), e.g., the other way around where depth is still in a transfer state and stencil is correct. The way barriers and layout transitions are currently handled doesn't allow for a nice solution here really unfortunately.

## How was this PR tested?

With a local project that uses/tests multi-device features.
