### PR TITLE
Added MeshDrawPacket Update Event.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2699,7 +2699,7 @@ namespace AZ
                     }
                     if (meshDrawPacket.Update(*m_scene, forceUpdate))
                     {
-                        m_flags.m_cullableNeedsRebuild = true;
+                        HandleDrawPacketUpdate(meshDrawPacket);
                     }
                 }
             }
@@ -2977,10 +2977,20 @@ namespace AZ
             return CustomMaterialInfo{};
         }
 
-        void ModelDataInstance::HandleDrawPacketUpdate()
+        void ModelDataInstance::HandleDrawPacketUpdate(RPI::MeshDrawPacket& meshDrawPacket)
         {
             // When the drawpacket is updated, the cullable must be rebuilt to use the latest draw packet
             m_flags.m_cullableNeedsRebuild = true;
+            m_meshDrawPacketUpdatedEvent.Signal(*this, meshDrawPacket);
+        }
+
+        void ModelDataInstance::ConnectMeshDrawPacketUpdatedHandler(MeshDrawPacketUpdatedEvent::Handler& handler)
+        {
+            if (handler.IsConnected())
+            {
+                handler.Disconnect();
+            }
+            handler.Connect(m_meshDrawPacketUpdatedEvent);
         }
 
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.cpp
@@ -21,7 +21,7 @@ namespace AZ::Render
             m_perViewDrawPackets.clear();
             for (auto modelDataInstance : m_associatedInstances)
             {
-                modelDataInstance->HandleDrawPacketUpdate();
+                modelDataInstance->HandleDrawPacketUpdate(m_drawPacket);
             }
             return true;
         }


### PR DESCRIPTION
## What does this PR do?

The MeshModelInstance class, typically accesible from a MeshHandle, now offers a mechanism to report whenever a MeshDrawPacket within the MeshModelInstance has been updated via an AZ::Event of type:  
```cpp
using MeshDrawPacketUpdatedEvent =
      Event<const ModelDataInstance&, const AZ::RPI::MeshDrawPacket&>;
```
This is important for FeatureProcessors that leverage the MeshFeatureProcessor to work with MeshHandles. Each time a MeshDrawPacket inside a MeshModelInstance changes, all the DrawItems get their DrawListTag enabled/disabled state reset.

If such reset occurs, a FeatureProcessor can now react to such event and force updating the ObjectSrg or DrawListTag Enable state as needed.

## How was this PR tested?

Tested on a game project where my FeatureProcessor now gets notified whenever there's a change in a MeshDrawPacket.
Tested on both Windows & Android (Quest3). 
