### PR TITLE
Only draw enabled shapes not based on if selected within the Editor.

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
@@ -135,7 +135,7 @@ namespace LmbrCentral
 
     bool EditorBaseShapeComponent::CanDraw() const
     {
-        return IsSelected() || m_visibleInEditor;
+        return m_visibleInEditor;
     }
 
     void EditorBaseShapeComponent::SetShapeComponentConfig(ShapeComponentConfig* shapeConfig)


### PR DESCRIPTION
## What does this PR do?

This pull request modifies how shapes are displayed in the viewport. As shown below, the 'Visible' property determines whether the shape remains visible in the editor viewport at all times. Currently it also seem to depend if the entity where this component resides is selected or not. Meaning even if I do set the 'Visible' property to false (not show) the shape will be shown when the entity with the component is selected.

![image](https://github.com/user-attachments/assets/f61c225a-b5bd-40cc-9296-efbefe23442d)

Deselecting the entity will then hide it, if 'Visible' property is disabled.
I do however expect the shape not being drawn no matter the entity is selected or not, if this property is set to false.
So I like to propose to change this behavior to honor the setting 'Visible', as the tooltip of this property says:

'Always display this shape in the editor viewport.'

## How was this PR tested?

Used only a Box Shape to render in the level. Set the property 'Visible' to false (un-checked).
