### PR TITLE
Fix leaking of Decal textures when reloading levels

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexableList.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexableList.h
@@ -120,6 +120,7 @@ namespace AZ
 
                 m_data[positionToRemove].m_next = m_freeListHead;
                 m_freeListHead = positionToRemove;
+                m_data[positionToRemove].m_value.~T();
             }
 
             void clear()

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexableList.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexableList.h
@@ -120,7 +120,7 @@ namespace AZ
 
                 m_data[positionToRemove].m_next = m_freeListHead;
                 m_freeListHead = positionToRemove;
-                m_data[positionToRemove].m_value.~T();
+                m_data[positionToRemove].m_value = {};
             }
 
             void clear()

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -123,7 +123,6 @@ namespace AZ
 
         void DecalTextureArray::RemoveMaterial(const int index)
         {
-            m_materials[index] = {};
             m_materials.erase(index);
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -526,15 +526,27 @@ namespace AZ
 
         void DecalTextureArrayFeatureProcessor::SetPackedTexturesToSrg(const RPI::ViewPtr& view)
         {
-            int iter = m_textureArrayList.begin();
-            while (iter != -1)
+            for (int mapType = 0; mapType < DecalMapType_Num; ++mapType)
             {
-                for (int mapType = 0 ; mapType < DecalMapType_Num ; ++mapType)
+                AZStd::bitset<NumTextureArrays> usedTextureArrayIndices;
+                int iter = m_textureArrayList.begin();
+                while (iter != -1)
                 {
                     const auto& packedTexture = m_textureArrayList[iter].second.GetPackedTexture(aznumeric_cast<DecalMapType>(mapType));
                     view->GetShaderResourceGroup()->SetImage(m_decalTextureArrayIndices[iter][mapType], packedTexture);
+                    usedTextureArrayIndices.set(iter);
+                    iter = m_textureArrayList.next(iter);
                 }
-                iter = m_textureArrayList.next(iter);
+
+                // Need to set to null all the not used texture shader inputs in case the texture array was destroyed
+                // but the SRG cached a copy of it.
+                for (uint32_t i = 0; i < usedTextureArrayIndices.size(); ++i)
+                {
+                    if (!usedTextureArrayIndices[i])
+                    {
+                        view->GetShaderResourceGroup()->SetImage(m_decalTextureArrayIndices[i][mapType], nullptr);
+                    }
+                }
             }
         }
 
@@ -573,6 +585,8 @@ namespace AZ
 
                 if (textureArray.NumMaterials() == 0)
                 {
+                    // Need to "destroy" the DecalTextureArray since erase only free up the space to be reused
+                    m_textureArrayList[decalLocation.textureArrayIndex] = {};
                     m_textureArrayList.erase(decalLocation.textureArrayIndex);
                 }
             }

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -585,8 +585,6 @@ namespace AZ
 
                 if (textureArray.NumMaterials() == 0)
                 {
-                    // Need to "destroy" the DecalTextureArray since erase only free up the space to be reused
-                    m_textureArrayList[decalLocation.textureArrayIndex] = {};
                     m_textureArrayList.erase(decalLocation.textureArrayIndex);
                 }
             }

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -670,9 +670,10 @@ namespace AZ
 
                     addVisibleObjectsToBucketsTG.AddTask(
                         addVisibleObjectsToBucketsTaskDescriptor,
-                        [this, view, viewIndex, batchStart, currentBatchCount]()
+                        // Don't capture the shared_ptr because that causes incorrect ref counting when copying/moving the lambda
+                        [this, viewPtr = view.get(), viewIndex, batchStart, currentBatchCount]()
                         {
-                            RPI::VisibleObjectListView visibilityList = view->GetVisibleObjectList();
+                            RPI::VisibleObjectListView visibilityList = viewPtr->GetVisibleObjectList();
                             AZStd::vector<InstanceGroupBucket>& currentViewInstanceGroupBuckets = m_perViewInstanceGroupBuckets[viewIndex];
                             for (size_t i = batchStart; i < batchStart + currentBatchCount; ++i)
                             {


### PR DESCRIPTION
## What does this PR do?

Fix leaking of decal textures when reloading levels due to incorrect ref counting of RPI::View objects (which contains the View SRG that holds strong references to images) when copying/moving lambdas that captured a RPI::ViewPtr

## How was this PR tested?

Run PC and reload the level multiple times