### PR TITLE
Fix editor crash when importing actor with only blendshapes but no skin weights

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
@@ -11,7 +11,7 @@
 #include <Atom/RPI/Math.azsli>
 
 
-option enum class SkinningMethod { LinearSkinning, DualQuaternion } o_skinningMethod = SkinningMethod::LinearSkinning;
+option enum class SkinningMethod { LinearSkinning, DualQuaternion, NoSkinning } o_skinningMethod = SkinningMethod::LinearSkinning;
 option bool o_applyMorphTargets = false;
 
 float3 ReadFloat3FromFloatBuffer(Buffer<float> buffer, uint index)
@@ -209,6 +209,9 @@ void MainCS(uint3 thread_id: SV_DispatchThreadID)
             break;
         case SkinningMethod::DualQuaternion:
             SkinVertexDualQuaternion(i, position, normal, tangent, bitangent);
+            break;
+        case SkinningMethod::NoSkinning:
+            // Do nothing
             break;
         }
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h
@@ -17,7 +17,8 @@ namespace AZ
         enum class SkinningMethod : uint8_t
         {
             DualQuaternion = 0,
-            LinearSkinning
+            LinearSkinning,
+            NoSkinning
         };
 
         struct SkinnedMeshShaderOptions

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.cpp
@@ -120,6 +120,10 @@ namespace AZ
                     return false;
                 }
             }
+            else if (m_shaderOptions.m_skinningMethod == SkinningMethod::NoSkinning)
+            {
+                // Do nothing if no skinning
+            }
             else
             {
                 AZ_Assert(false, "Invalid skinning method for SkinnedMeshDispatchItem.");
@@ -158,7 +162,11 @@ namespace AZ
                 m_instanceSrg->SetConstant(outputOffsetIndex, m_positionHistoryBufferOffsetInBytes / 4);
             }
 
-            m_instanceSrg->SetBuffer(actorInstanceBoneTransformsIndex, m_boneTransforms);
+            // Ignore bone transform buffer for actors with skinning disabled
+            if (m_shaderOptions.m_skinningMethod != SkinningMethod::NoSkinning)
+            {
+                m_instanceSrg->SetBuffer(actorInstanceBoneTransformsIndex, m_boneTransforms);
+            }
 
             // Set the morph target related srg constants
             RHI::ShaderInputConstantIndex morphPositionOffsetIndex = m_instanceSrg->FindShaderInputConstantIndex(Name{ "m_morphTargetPositionDeltaOffset" });
@@ -176,14 +184,14 @@ namespace AZ
 
             RHI::ShaderInputConstantIndex morphDeltaIntegerEncodingIndex = m_instanceSrg->FindShaderInputConstantIndex(Name{ "m_morphTargetDeltaInverseIntegerEncoding" });
             m_instanceSrg->SetConstant(morphDeltaIntegerEncodingIndex, 1.0f / m_morphTargetDeltaIntegerEncoding);
-            
+
             // Set the vertex count
             const uint32_t vertexCount = GetVertexCount();
 
             RHI::ShaderInputConstantIndex numVerticesIndex = m_instanceSrg->FindShaderInputConstantIndex(Name{ "m_numVertices" });
             AZ_Error("SkinnedMeshInputBuffers", numVerticesIndex.IsValid(), "Failed to find shader input index for m_numVerticies in the skinning compute shader per-instance SRG.");
             m_instanceSrg->SetConstant(numVerticesIndex, vertexCount);
-            
+
             uint32_t xThreads = 0;
             uint32_t yThreads = 0;
             CalculateSkinnedMeshTotalThreadsPerDimension(vertexCount, xThreads, yThreads);
@@ -204,7 +212,7 @@ namespace AZ
             {
                 AZ_Error("SkinnedMeshInputBuffers", false, outcome.GetError().c_str());
             }
- 
+
             arguments.m_totalNumberOfThreadsX = xThreads;
             arguments.m_totalNumberOfThreadsY = yThreads;
             arguments.m_totalNumberOfThreadsZ = 1;
@@ -269,10 +277,10 @@ namespace AZ
                 yThreads = 0;
                 return;
             }
-            
+
             // Get the minimum number of threads in the y dimension needed to cover all the vertices in the mesh
             yThreads = vertexCount % maxVerticesPerDimension != 0 ? vertexCount / maxVerticesPerDimension + 1 : vertexCount / maxVerticesPerDimension;
-            
+
             // Divide the total number of threads across y dimensions, rounding the number of xThreads up to cover any remainder
             xThreads = 1 + ((vertexCount - 1) / yThreads);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.cpp
@@ -23,6 +23,7 @@ namespace AZ
             m_skinningMethodOptionIndex = layout->FindShaderOptionIndex(AZ::Name("o_skinningMethod"));
             m_skinningMethodLinearSkinningValue = layout->FindValue(m_skinningMethodOptionIndex, AZ::Name("SkinningMethod::LinearSkinning"));
             m_skinningMethodDualQuaternionValue = layout->FindValue(m_skinningMethodOptionIndex, AZ::Name("SkinningMethod::DualQuaternion"));
+            m_skinningMethodNoSkinningValue = layout->FindValue(m_skinningMethodOptionIndex, AZ::Name("SkinningMethod::NoSkinning"));
 
             m_applyMorphTargetOptionIndex = layout->FindShaderOptionIndex(AZ::Name("o_applyMorphTargets"));
             m_applyMorphTargetFalseValue = layout->FindValue(m_applyMorphTargetOptionIndex, AZ::Name("false"));
@@ -43,6 +44,9 @@ namespace AZ
             {
             case SkinningMethod::DualQuaternion:
                 shaderOptionGroup.SetValue(m_skinningMethodOptionIndex, m_skinningMethodDualQuaternionValue);
+                break;
+            case SkinningMethod::NoSkinning:
+                shaderOptionGroup.SetValue(m_skinningMethodOptionIndex, m_skinningMethodNoSkinningValue);
                 break;
             case SkinningMethod::LinearSkinning:
             default:

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.h
@@ -51,6 +51,7 @@ namespace AZ
             RPI::ShaderOptionIndex m_skinningMethodOptionIndex;
             RPI::ShaderOptionValue m_skinningMethodLinearSkinningValue;
             RPI::ShaderOptionValue m_skinningMethodDualQuaternionValue;
+            RPI::ShaderOptionValue m_skinningMethodNoSkinningValue;
 
             RPI::ShaderOptionIndex m_applyMorphTargetOptionIndex;
             RPI::ShaderOptionValue m_applyMorphTargetFalseValue;

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
@@ -68,7 +68,7 @@ namespace AZ
                 Name{"SkinnedMeshInputBlendIndices"},
                 Name{"m_sourceBlendIndices"},
                 RHI::ShaderSemantic{Name{"SKIN_JOINTINDICES"}},
-                false, // isOptional
+                true, // isOptional
                 SkinnedMeshInputVertexStreams::BlendIndices
             };
 
@@ -78,7 +78,7 @@ namespace AZ
                 Name{"SkinnedMeshInputBlendWeights"},
                 Name{"m_sourceBlendWeights"},
                 RHI::ShaderSemantic{Name{"SKIN_WEIGHTS"}},
-                false, // isOptional
+                true, // isOptional
                 SkinnedMeshInputVertexStreams::BlendWeights
             };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -308,7 +308,7 @@ namespace AZ
                     else
                     {
                         AZ_Warning("Mesh", false, "Mesh does not have all the required input streams. Missing '%s'.", contractStreamChannel.m_semantic.ToString().c_str());
-                        // success = false;
+                        success = false;
                     }
                 }
                 else
@@ -337,6 +337,7 @@ namespace AZ
             if (success)
             {
                 layoutOut = layoutBuilder.End();
+
                 success &= RHI::ValidateStreamBufferViews(layoutOut, streamBufferViewsOut);
             }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -308,7 +308,7 @@ namespace AZ
                     else
                     {
                         AZ_Warning("Mesh", false, "Mesh does not have all the required input streams. Missing '%s'.", contractStreamChannel.m_semantic.ToString().c_str());
-                        success = false;
+                        // success = false;
                     }
                 }
                 else
@@ -337,7 +337,6 @@ namespace AZ
             if (success)
             {
                 layoutOut = layoutBuilder.End();
-
                 success &= RHI::ValidateStreamBufferViews(layoutOut, streamBufferViewsOut);
             }
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -362,6 +362,7 @@ namespace AZ
             }
             else if (skinningMethod == EMotionFX::Integration::SkinningMethod::None)
             {
+                AZ_Warning("ActorAsset", false, "Create bone transform called with no skinning, will return nullptr.");
                 return nullptr;
             }
             else

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -211,92 +211,102 @@ namespace AZ
                 const RPI::BufferAssetView* weightsBuffAssetView =
                     modelLodAsset->GetSemanticBufferAssetView(Name(RPI::ShaderSemanticName_SkinWeights));
 
-                // Reserve enough memory for the default/common case. Use the element count from the main source buffer
-                blendIndexBufferData.reserve(indicesBuffAssetView->GetBufferAsset()->GetBufferViewDescriptor().m_elementCount);
-                blendWeightBufferData.reserve(weightsBuffAssetView->GetBufferAsset()->GetBufferViewDescriptor().m_elementCount);
-
-                // Now iterate over the actual data and populate the data for the per-actor buffers
-                uint32_t vertexBufferOffset = 0;
-                for (uint32_t jointIndex = 0; jointIndex < numJoints; ++jointIndex)
+                if(!indicesBuffAssetView || !weightsBuffAssetView)
                 {
-                    const EMotionFX::Mesh* mesh = actor->GetMesh(lodIndex, jointIndex);
-                    if (!mesh || mesh->GetIsCollisionMesh())
-                    {
-                        continue;
-                    }
-
-                    // For each sub-mesh within each mesh, we want to create a separate sub-piece.
-                    const uint32_t numSubMeshes = aznumeric_caster(mesh->GetNumSubMeshes());
-
-                    AZ_Assert(
-                        numSubMeshes == modelLodAsset->GetMeshes().size(),
-                        "Number of submeshes (%" PRIu32 ") in EMotionFX mesh (lod %d and joint index %d) "
-                        "doesn't match the number of meshes (%d) in model lod asset",
-                        numSubMeshes, lodIndex, jointIndex, modelLodAsset->GetMeshes().size());
-
-                    for (uint32_t subMeshIndex = 0; subMeshIndex < numSubMeshes; ++subMeshIndex)
-                    {
-                        const EMotionFX::SubMesh* subMesh = mesh->GetSubMesh(static_cast<uint32>(subMeshIndex));
-                        const uint32_t vertexCount = subMesh->GetNumVertices();
-
-                        // Skip empty sub-meshes and sub-meshes that would put the total vertex count beyond the supported range
-                        if (vertexCount > 0 && IsVertexCountWithinSupportedRange(vertexBufferOffset, vertexCount))
-                        {
-                            ProcessSkinInfluences(mesh, subMesh, skinnedMeshInputBuffers->GetInfluenceCountPerVertex(lodIndex, subMeshIndex), blendIndexBufferData, blendWeightBufferData);
-
-                            // Increment offsets so that the next sub-mesh can start at the right place
-                            vertexBufferOffset += vertexCount;
-                        }
-                    }   // for all submeshes
-                } // for all meshes
-
-                const RPI::BufferAssetView* jointIndicesBufferView = nullptr;
-                const RPI::BufferAssetView* skinWeightsBufferView = nullptr;
-
-                for (const auto& modelLodMesh : modelLodAsset->GetMeshes())
-                {
-                    // TODO: operate on a per-mesh basis
-
-                    // If the joint id/weight buffers haven't been found on a mesh yet, keep looking
-                    if (!jointIndicesBufferView)
-                    {
-                        jointIndicesBufferView = modelLodMesh.GetSemanticBufferAssetView(Name{ "SKIN_JOINTINDICES" });
-                        if (jointIndicesBufferView)
-                        {
-                            skinWeightsBufferView = modelLodMesh.GetSemanticBufferAssetView(Name{ "SKIN_WEIGHTS" });
-                            AZ_Error("CreateSkinnedMeshInputFromActor", skinWeightsBufferView, "Mesh '%s' on actor '%s' has joint indices but no joint weights", modelLodMesh.GetName().GetCStr(), fullFileName.c_str());
-                            break;
-                        }
-                    }
-                }
-
-                if (!jointIndicesBufferView || !skinWeightsBufferView)
-                {
-                    AZ_Error(
-                        "ProcessSkinInfluences", false,
-                        "Actor '%s' lod '%" PRIu32 "' has no skin influences, and will be stuck in bind pose.", fullFileName.c_str(),
-                        lodIndex);
+                    AZ_Warning(
+                            "ProcessSkinInfluences", false,
+                            "Actor '%s' lod '%" PRIu32 "' has no skin indice buffer, skinning would not be applicable on this mesh.", fullFileName.c_str(),
+                            lodIndex);
                 }
                 else
                 {
-                    Data::Asset<RPI::BufferAsset> jointIndicesBufferAsset = jointIndicesBufferView->GetBufferAsset();
-                    Data::Asset<RPI::BufferAsset> skinWeightsBufferAsset = skinWeightsBufferView->GetBufferAsset();
+                    // Reserve enough memory for the default/common case. Use the element count from the main source buffer
+                    blendIndexBufferData.reserve(indicesBuffAssetView->GetBufferAsset()->GetBufferViewDescriptor().m_elementCount);
+                    blendWeightBufferData.reserve(weightsBuffAssetView->GetBufferAsset()->GetBufferViewDescriptor().m_elementCount);
 
-                    // We're using the indices/weights buffers directly from the model.
-                    // However, EMFX has done some re-mapping of the id's, so we need to update the GPU buffer for it to have the correct data.
-                    size_t remappedJointIndexBufferSizeInBytes = blendIndexBufferData.size() * sizeof(blendIndexBufferData[0]);
-                    size_t remappedSkinWeightsBufferSizeInBytes = blendWeightBufferData.size() * sizeof(blendWeightBufferData[0]);
-
-                    AZ_Assert(jointIndicesBufferAsset->GetBufferDescriptor().m_byteCount == remappedJointIndexBufferSizeInBytes, "Joint indices data from EMotionFX is not the same size as the buffer from the model in '%s', lod '%d'", fullFileName.c_str(), lodIndex);
-                    AZ_Assert(skinWeightsBufferAsset->GetBufferDescriptor().m_byteCount == remappedSkinWeightsBufferSizeInBytes, "Skin weights data from EMotionFX is not the same size as the buffer from the model in '%s', lod '%d'", fullFileName.c_str(), lodIndex);
-
-                    if (Data::Instance<RPI::Buffer> jointIndicesBuffer = RPI::Buffer::FindOrCreate(jointIndicesBufferAsset))
+                    // Now iterate over the actual data and populate the data for the per-actor buffers
+                    uint32_t vertexBufferOffset = 0;
+                    for (uint32_t jointIndex = 0; jointIndex < numJoints; ++jointIndex)
                     {
-                        jointIndicesBuffer->UpdateData(blendIndexBufferData.data(), remappedJointIndexBufferSizeInBytes);
+                        const EMotionFX::Mesh* mesh = actor->GetMesh(lodIndex, jointIndex);
+                        if (!mesh || mesh->GetIsCollisionMesh())
+                        {
+                            continue;
+                        }
+
+                        // For each sub-mesh within each mesh, we want to create a separate sub-piece.
+                        const uint32_t numSubMeshes = aznumeric_caster(mesh->GetNumSubMeshes());
+
+                        AZ_Assert(
+                            numSubMeshes == modelLodAsset->GetMeshes().size(),
+                            "Number of submeshes (%" PRIu32 ") in EMotionFX mesh (lod %d and joint index %d) "
+                            "doesn't match the number of meshes (%d) in model lod asset",
+                            numSubMeshes, lodIndex, jointIndex, modelLodAsset->GetMeshes().size());
+
+                        for (uint32_t subMeshIndex = 0; subMeshIndex < numSubMeshes; ++subMeshIndex)
+                        {
+                            const EMotionFX::SubMesh* subMesh = mesh->GetSubMesh(static_cast<uint32>(subMeshIndex));
+                            const uint32_t vertexCount = subMesh->GetNumVertices();
+
+                            // Skip empty sub-meshes and sub-meshes that would put the total vertex count beyond the supported range
+                            if (vertexCount > 0 && IsVertexCountWithinSupportedRange(vertexBufferOffset, vertexCount))
+                            {
+                                ProcessSkinInfluences(mesh, subMesh, skinnedMeshInputBuffers->GetInfluenceCountPerVertex(lodIndex, subMeshIndex), blendIndexBufferData, blendWeightBufferData);
+
+                                // Increment offsets so that the next sub-mesh can start at the right place
+                                vertexBufferOffset += vertexCount;
+                            }
+                        }   // for all submeshes
+                    } // for all meshes
+
+                    const RPI::BufferAssetView* jointIndicesBufferView = nullptr;
+                    const RPI::BufferAssetView* skinWeightsBufferView = nullptr;
+
+                    for (const auto& modelLodMesh : modelLodAsset->GetMeshes())
+                    {
+                        // TODO: operate on a per-mesh basis
+
+                        // If the joint id/weight buffers haven't been found on a mesh yet, keep looking
+                        if (!jointIndicesBufferView)
+                        {
+                            jointIndicesBufferView = modelLodMesh.GetSemanticBufferAssetView(Name{ "SKIN_JOINTINDICES" });
+                            if (jointIndicesBufferView)
+                            {
+                                skinWeightsBufferView = modelLodMesh.GetSemanticBufferAssetView(Name{ "SKIN_WEIGHTS" });
+                                AZ_Error("CreateSkinnedMeshInputFromActor", skinWeightsBufferView, "Mesh '%s' on actor '%s' has joint indices but no joint weights", modelLodMesh.GetName().GetCStr(), fullFileName.c_str());
+                                break;
+                            }
+                        }
                     }
-                    if (Data::Instance<RPI::Buffer> skinWeightsBuffer = RPI::Buffer::FindOrCreate(skinWeightsBufferAsset))
+
+                    if (!jointIndicesBufferView || !skinWeightsBufferView)
                     {
-                        skinWeightsBuffer->UpdateData(blendWeightBufferData.data(), remappedSkinWeightsBufferSizeInBytes);
+                        AZ_Error(
+                            "ProcessSkinInfluences", false,
+                            "Actor '%s' lod '%" PRIu32 "' has no skin influences, and will be stuck in bind pose.", fullFileName.c_str(),
+                            lodIndex);
+                    }
+                    else
+                    {
+                        Data::Asset<RPI::BufferAsset> jointIndicesBufferAsset = jointIndicesBufferView->GetBufferAsset();
+                        Data::Asset<RPI::BufferAsset> skinWeightsBufferAsset = skinWeightsBufferView->GetBufferAsset();
+
+                        // We're using the indices/weights buffers directly from the model.
+                        // However, EMFX has done some re-mapping of the id's, so we need to update the GPU buffer for it to have the correct data.
+                        size_t remappedJointIndexBufferSizeInBytes = blendIndexBufferData.size() * sizeof(blendIndexBufferData[0]);
+                        size_t remappedSkinWeightsBufferSizeInBytes = blendWeightBufferData.size() * sizeof(blendWeightBufferData[0]);
+
+                        AZ_Assert(jointIndicesBufferAsset->GetBufferDescriptor().m_byteCount == remappedJointIndexBufferSizeInBytes, "Joint indices data from EMotionFX is not the same size as the buffer from the model in '%s', lod '%d'", fullFileName.c_str(), lodIndex);
+                        AZ_Assert(skinWeightsBufferAsset->GetBufferDescriptor().m_byteCount == remappedSkinWeightsBufferSizeInBytes, "Skin weights data from EMotionFX is not the same size as the buffer from the model in '%s', lod '%d'", fullFileName.c_str(), lodIndex);
+
+                        if (Data::Instance<RPI::Buffer> jointIndicesBuffer = RPI::Buffer::FindOrCreate(jointIndicesBufferAsset))
+                        {
+                            jointIndicesBuffer->UpdateData(blendIndexBufferData.data(), remappedJointIndexBufferSizeInBytes);
+                        }
+                        if (Data::Instance<RPI::Buffer> skinWeightsBuffer = RPI::Buffer::FindOrCreate(skinWeightsBufferAsset))
+                        {
+                            skinWeightsBuffer->UpdateData(blendWeightBufferData.data(), remappedSkinWeightsBufferSizeInBytes);
+                        }
                     }
                 }
 
@@ -349,6 +359,10 @@ namespace AZ
             else if (skinningMethod == EMotionFX::Integration::SkinningMethod::DualQuat)
             {
                 floatsPerBone = DualQuaternionSkinningFloatsPerBone;
+            }
+            else if (skinningMethod == EMotionFX::Integration::SkinningMethod::None)
+            {
+                return nullptr;
             }
             else
             {

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -130,12 +130,20 @@ namespace AZ::Render
 
     SkinningMethod AtomActorInstance::GetAtomSkinningMethod() const
     {
+        // No skeleton and skinning
+        if (m_boneTransforms->GetBufferSize() == 0)
+        {
+            return SkinningMethod::NoSkinning;
+        }
+
         switch (GetSkinningMethod())
         {
         case EMotionFX::Integration::SkinningMethod::DualQuat:
             return SkinningMethod::DualQuaternion;
         case EMotionFX::Integration::SkinningMethod::Linear:
             return SkinningMethod::LinearSkinning;
+        case EMotionFX::Integration::SkinningMethod::None:
+            return SkinningMethod::NoSkinning;
         default:
             AZ_Error("AtomActorInstance", false, "Unsupported skinning method. Defaulting to linear");
         }
@@ -457,8 +465,9 @@ namespace AZ::Render
         AZ_Warning("AtomActorInstance", m_skinnedMeshInputBuffers, "Failed to create SkinnedMeshInputBuffers from Actor. It is likely that this actor doesn't have any meshes");
         if (m_skinnedMeshInputBuffers)
         {
-            m_boneTransforms = CreateBoneTransformBufferFromActorInstance(m_actorInstance, GetSkinningMethod());
-            AZ_Error("AtomActorInstance", m_boneTransforms || AZ::RHI::IsNullRHI(), "Failed to create bone transform buffer.");
+            EMotionFX::Integration::SkinningMethod skinningMethod = GetSkinningMethod();
+            m_boneTransforms = CreateBoneTransformBufferFromActorInstance(m_actorInstance, skinningMethod);
+            AZ_Error("AtomActorInstance", m_boneTransforms || AZ::RHI::IsNullRHI() || skinningMethod == EMotionFX::Integration::SkinningMethod::None, "Failed to create bone transform buffer.");
 
             // If the instance is created before the default materials on the model have finished loading, the mesh feature processor will ignore it.
             // Wait for them all to be ready before creating the instance
@@ -506,7 +515,8 @@ namespace AZ::Render
             UnregisterActor();
             m_skinnedMeshInputBuffers.reset();
             m_skinnedMeshInstance.reset();
-            m_boneTransforms.reset();
+            if (m_boneTransforms)
+                m_boneTransforms.reset();
         }
     }
 
@@ -628,7 +638,7 @@ namespace AZ::Render
             AZ_Error("AtomActorInstance", m_skinnedMeshInstance, "SkinnedMeshInstance must be created before register this actor.");
             return;
         }
-        
+
         MaterialAssignmentMap materials;
         MaterialComponentRequestBus::EventResult(materials, m_entityId, &MaterialComponentRequests::GetMaterialMap);
         CreateRenderProxy(materials);
@@ -716,7 +726,7 @@ namespace AZ::Render
             SkinnedMeshOutputStreamNotificationBus::Handler::BusConnect();
         }
     }
-    
+
     void AtomActorInstance::EnableSkinning(uint32_t lodIndex, uint32_t meshIndex)
     {
         if (m_skinnedMeshHandle.IsValid())

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -174,6 +174,7 @@ namespace EMotionFX
         AZ::u32 modelIndexCount = 0;
 
         // Find the maximum skin influences across all meshes to use when pre-allocating memory
+        bool hasSkinInfluence = false;
         AZ::u32 maxSkinInfluences = 0;
         for (const AZ::RPI::ModelLodAsset::Mesh& mesh : sourceModelLod->GetMeshes())
         {
@@ -184,9 +185,15 @@ namespace EMotionFX
             {
                 const AZ::u32 meshInfluenceCount = weightView->GetBufferViewDescriptor().m_elementCount / mesh.GetVertexCount();
                 maxSkinInfluences = AZStd::max(maxSkinInfluences, meshInfluenceCount);
+                hasSkinInfluence = true;
             }
         }
-        AZ_Assert(maxSkinInfluences > 0 && maxSkinInfluences < 100, "Expect max skin influences in a reasonable value range.");
+
+        // Assert the skin influence range only if the model has skin influence data
+        if (hasSkinInfluence)
+        {
+            AZ_Assert(maxSkinInfluences > 0 && maxSkinInfluences < 100, "Expect max skin influences in a reasonable value range.");
+        }
 
         // IndicesPerFace defined in atom is 3.
         const AZ::u32 numPolygons = modelIndexCount / 3;

--- a/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
@@ -44,7 +44,8 @@ namespace EMotionFX
         enum class SkinningMethod : AZ::u32
         {
             DualQuat = 0,       ///< Dual Quaternions will be used to blend joints during skinning.
-            Linear              ///< Matrices will be used to blend joints during skinning.
+            Linear,             ///< Matrices will be used to blend joints during skinning.
+            None                ///< No skinning will be applied, the model will be rendered as-is. 
         };
 
         /**

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -145,7 +145,7 @@ namespace EMotionFX
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnSkinningMethodChanged)
                         ->EnumAttribute(SkinningMethod::DualQuat, "Dual quat skinning")
                         ->EnumAttribute(SkinningMethod::Linear, "Linear skinning")
-                        ->EnumAttribute(SkinningMethod::None, "No skinning")
+                        ->EnumAttribute(SkinningMethod::None, "Disabled")
                         ->DataElement(AZ::Edit::UIHandlers::CheckBox, &EditorActorComponent::m_excludeFromReflectionCubeMaps, "Exclude from reflection cubemaps", "Actor will not be visible in baked reflection probe cubemaps")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnExcludeFromReflectionCubeMapsChanged)

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -145,6 +145,7 @@ namespace EMotionFX
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnSkinningMethodChanged)
                         ->EnumAttribute(SkinningMethod::DualQuat, "Dual quat skinning")
                         ->EnumAttribute(SkinningMethod::Linear, "Linear skinning")
+                        ->EnumAttribute(SkinningMethod::None, "No skinning")
                         ->DataElement(AZ::Edit::UIHandlers::CheckBox, &EditorActorComponent::m_excludeFromReflectionCubeMaps, "Exclude from reflection cubemaps", "Actor will not be visible in baked reflection probe cubemaps")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnExcludeFromReflectionCubeMapsChanged)


### PR DESCRIPTION
## What does this PR do?
Fix crash when importing an Actor with only blendshape but without skinning. Closes #18381. 
The implementation is made in the following aspects: 
 - Mark `SKIN_JOINTINDICES` and `SKIN_WEIGHTS` as optional so that it won't trigger an error when these streams aren't found. 
 - Add some additional null check and make some asserts only active when there's skinning
 - Add a new skinning method call `NoSkinning` which skips the skinning calculation in the skinning shader. When an Actor doesn't have skin weights, then the skinning method falls back to `NoSkinning` automatically. 

## How was this PR tested?

_Please describe any testing performed._
Tested on windows, both DX12 and Vulkan. It now works well with Actors with only blendshapes, and I suppose that the original functionality won't be affected. 
However, since I am new to O3DE source code, I am not fully aware of how the modules affect each other, so my changes might break other parts potentially. This has to be checked.  