### PR TITLE
Address various mobile fixes in the 24.09 release

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/AZSL/Platform/Android/Vulkan/AzslcHeader.azsli
+++ b/Gems/Atom/Asset/Shader/Code/AZSL/Platform/Android/Vulkan/AzslcHeader.azsli
@@ -24,8 +24,8 @@ static const float4 s_AzslDebugColor = float4(165.0 / 255.0, 30.0 / 255.0, 36.0 
 //Assuming unbounded array suport for Android
 #define UNBOUNDED_SIZE
 
-#define USE_HALF_FLOATS_FOR_ANDROID 1
-#if USE_HALF_FLOATS_FOR_ANDROID
+#define USE_HALF_FLOATS 1
+#if USE_HALF_FLOATS
 
 // use half float for android
 #define real half

--- a/Gems/Atom/Asset/Shader/Code/AZSL/Platform/Android/Vulkan/AzslcHeader.azsli
+++ b/Gems/Atom/Asset/Shader/Code/AZSL/Platform/Android/Vulkan/AzslcHeader.azsli
@@ -24,26 +24,23 @@ static const float4 s_AzslDebugColor = float4(165.0 / 255.0, 30.0 / 255.0, 36.0 
 //Assuming unbounded array suport for Android
 #define UNBOUNDED_SIZE
 
-#define USE_HALF_FLOATS 1
-#if USE_HALF_FLOATS
-
 // use half float for android
-#define real half
-#define real2 half2
-#define real3 half3
-#define real4 half4
-#define real3x3 half3x3
-#define real3x4 half3x4
-#define real4x4 half4x4
+#define USE_HALF_FLOATS 1
 
+#if USE_HALF_FLOATS
+    #define real half
+    #define real2 half2
+    #define real3 half3
+    #define real4 half4
+    #define real3x3 half3x3
+    #define real3x4 half3x4
+    #define real4x4 half4x4
 #else
-
-#define real float
-#define real2 float2
-#define real3 float3
-#define real4 float4
-#define real3x3 float3x3
-#define real3x4 float3x4
-#define real4x4 float4x4
-
+    #define real float
+    #define real2 float2
+    #define real3 float3
+    #define real4 float4
+    #define real3x3 float3x3
+    #define real3x4 float3x4
+    #define real4x4 float4x4
 #endif

--- a/Gems/Atom/Asset/Shader/Code/AZSL/Platform/iOS/Metal/AzslcHeader.azsli
+++ b/Gems/Atom/Asset/Shader/Code/AZSL/Platform/iOS/Metal/AzslcHeader.azsli
@@ -22,7 +22,10 @@
 
 static const float4 s_AzslDebugColor = float4(85.0 / 255.0, 85.0 / 255.0, 85.0 / 255.0, 1);
 
-// use half float for ios
+#define USE_HALF_FLOATS 1
+#if USE_HALF_FLOATS
+
+// use half float for android
 #define real half
 #define real2 half2
 #define real3 half3
@@ -30,3 +33,15 @@ static const float4 s_AzslDebugColor = float4(85.0 / 255.0, 85.0 / 255.0, 85.0 /
 #define real3x3 half3x3
 #define real3x4 half3x4
 #define real4x4 half4x4
+
+#else
+
+#define real float
+#define real2 float2
+#define real3 float3
+#define real4 float4
+#define real3x3 float3x3
+#define real3x4 float3x4
+#define real4x4 float4x4
+
+#endif

--- a/Gems/Atom/Asset/Shader/Code/AZSL/Platform/iOS/Metal/AzslcHeader.azsli
+++ b/Gems/Atom/Asset/Shader/Code/AZSL/Platform/iOS/Metal/AzslcHeader.azsli
@@ -22,26 +22,24 @@
 
 static const float4 s_AzslDebugColor = float4(85.0 / 255.0, 85.0 / 255.0, 85.0 / 255.0, 1);
 
+// use half float for iOS
 #define USE_HALF_FLOATS 1
+
+
 #if USE_HALF_FLOATS
-
-// use half float for android
-#define real half
-#define real2 half2
-#define real3 half3
-#define real4 half4
-#define real3x3 half3x3
-#define real3x4 half3x4
-#define real4x4 half4x4
-
+    #define real half
+    #define real2 half2
+    #define real3 half3
+    #define real4 half4
+    #define real3x3 half3x3
+    #define real3x4 half3x4
+    #define real4x4 half4x4
 #else
-
-#define real float
-#define real2 float2
-#define real3 float3
-#define real4 float4
-#define real3x3 float3x3
-#define real3x4 float3x4
-#define real4x4 float4x4
-
+    #define real float
+    #define real2 float2
+    #define real3 float3
+    #define real4 float4
+    #define real3x3 float3x3
+    #define real3x4 float3x4
+    #define real4x4 float4x4
 #endif

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/BicubicPcfFilters.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/BicubicPcfFilters.azsli
@@ -32,7 +32,7 @@ struct SampleShadowMapBicubicParameters
     real shadowMapSize;
     real invShadowMapSize;
     SamplerComparisonState samplerState;
-    real comparisonValue;
+    float comparisonValue;
 
     // Optionally pass in a non-zero value into the receiverPlaneDepthBias to reduce shadow acne with large Pcf kernels
     float2 receiverPlaneDepthBias;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -71,7 +71,7 @@ class DirectionalShadowCalculator
     float GetThickness();
 
     real GetVisibilityFromLightNoFilter();
-    real SamplePcfBicubic(const real3 shadowCoord, const int indexOfCascade);
+    real SamplePcfBicubic(const float3 shadowCoord, const int indexOfCascade);
     real GetVisibilityFromLightPcf();
     float GetVisibilityFromLightEsm();
     float GetVisibilityFromLightEsmPcf();
@@ -287,7 +287,7 @@ real DirectionalShadowCalculator::GetVisibilityFromLightNoFilter()
     return 1.0;
 }
 
-real DirectionalShadowCalculator::SamplePcfBicubic(const real3 shadowCoord, const int indexOfCascade)
+real DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, const int indexOfCascade)
 {
     const ShadowFilterSampleCount filteringSampleCountMode = m_filteringSampleCountMode;
     const uint size = ViewSrg::m_directionalLightShadows[m_lightIndex].m_shadowmapSize;
@@ -327,10 +327,10 @@ real DirectionalShadowCalculator::GetVisibilityFromLightPcf()
     
     for (int indexOfCascade = m_minCascade; indexOfCascade <= m_maxCascade && lit > 0.01; ++indexOfCascade)
     {
-        lit = min(lit, SamplePcfBicubic(real3(m_shadowCoords[indexOfCascade]), indexOfCascade));
+        lit = min(lit, SamplePcfBicubic(m_shadowCoords[indexOfCascade], indexOfCascade));
     }
 
-    if(m_blendBetweenCascadesEnable) 
+    if(m_blendBetweenCascadesEnable)
     {
         const real blendBetweenCascadesAmount = CalculateCascadeBlendAmount(real3(m_shadowCoords[m_maxCascade].xyz));
 
@@ -338,7 +338,7 @@ real DirectionalShadowCalculator::GetVisibilityFromLightPcf()
         [branch]
         if (blendBetweenCascadesAmount < 1.0f && nextCascadeIndex < m_cascadeCount)
         {
-            const real nextLit = SamplePcfBicubic(real3(m_shadowCoords[nextCascadeIndex]), nextCascadeIndex);
+            const real nextLit = SamplePcfBicubic(m_shadowCoords[nextCascadeIndex], nextCascadeIndex);
             lit = lerp(nextLit, lit, blendBetweenCascadesAmount);
         }
     } 
@@ -394,7 +394,7 @@ float DirectionalShadowCalculator::GetVisibilityFromLightEsmPcf()
                 static const real pcfFallbackThreshold = 1.04;
                 if (ratio > pcfFallbackThreshold)
                 {
-                    ratio = SamplePcfBicubic(real3(shadowCoord), indexOfCascade);
+                    ratio = SamplePcfBicubic(shadowCoord, indexOfCascade);
                 }
                 return saturate(ratio);
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -521,7 +521,7 @@ namespace AZ
             }
 
             //spirv-cross introduced the keyword [[clang::optnone]] across shader functions which cancels all optimizations
-            //for the tagged method. This is suppose to be tied to the keyword 'precise' but is contaminating areas outside it's usage.
+            //for the tagged method. This is suppose to be tied to the keyword 'precise' but is contaminating areas outside its usage.
             //Removing this manually until a better solution is established.
             //GHI for ref - https://github.com/KhronosGroup/SPIRV-Cross/issues/1999
             finalMetalSLStr = AZStd::regex_replace(finalMetalSLStr, AZStd::regex("\\[\\[clang::optnone\\]\\]"), "");

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -14,6 +14,7 @@
 #include <Atom/RHI.Reflect/Metal/PipelineLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/Metal/ShaderStageFunction.h>
 #include <Atom/RHI/RHIUtils.h>
+#include <AzCore/std/string/regex.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
 namespace AZ
@@ -518,6 +519,12 @@ namespace AZ
                 finalMetalSLStr.insert(startOfShaderPos + startOfShaderTag.length() + 1, constantBufferTempStructs);
                 finalMetalSLStr.insert(startOfShaderPos + startOfShaderTag.length() + 1, structuredBufferTempStructs);
             }
+
+            //spirv-cross introduces the keyword [[clang::optnone]] across shader functions which will cancel all optimizations
+            //for that method. This is suppose to be tied to the keyword 'precise' but is contaminating areas outside it's usage.
+            //Removing this manually until a better solution is established.
+            //GHI for ref - https://github.com/KhronosGroup/SPIRV-Cross/issues/1999
+            finalMetalSLStr = AZStd::regex_replace(finalMetalSLStr, AZStd::regex("\\[\\[clang::optnone\\]\\]"), "");
 
             compiledShader = AZStd::vector<char>(finalMetalSLStr.begin(), finalMetalSLStr.end());
             return true;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -520,8 +520,8 @@ namespace AZ
                 finalMetalSLStr.insert(startOfShaderPos + startOfShaderTag.length() + 1, structuredBufferTempStructs);
             }
 
-            //spirv-cross introduces the keyword [[clang::optnone]] across shader functions which will cancel all optimizations
-            //for that method. This is suppose to be tied to the keyword 'precise' but is contaminating areas outside it's usage.
+            //spirv-cross introduced the keyword [[clang::optnone]] across shader functions which cancels all optimizations
+            //for the tagged method. This is suppose to be tied to the keyword 'precise' but is contaminating areas outside it's usage.
             //Removing this manually until a better solution is established.
             //GHI for ref - https://github.com/KhronosGroup/SPIRV-Cross/issues/1999
             finalMetalSLStr = AZStd::regex_replace(finalMetalSLStr, AZStd::regex("\\[\\[clang::optnone\\]\\]"), "");


### PR DESCRIPTION
## What does this PR do?

1. Fix ios/Mac performance issues (20x drop) introduced via the introduction of [[clang::optnone]]
2. Address shadow banding issues due to half precision
3. Minor cleanup

## How was this PR tested?

Tested AutomatedTesting on iOS
