### PR TITLE
Double-quote windows command calls to support spaces in paths

### DIFF
--- a/python/python.cmd
+++ b/python/python.cmd
@@ -50,7 +50,7 @@ IF [%1] EQU [debug] (
     SET PYTHON_VENV_PYTHON=%PYTHON_VENV%\Scripts\python.exe
     SET PYTHON_ARGS=%*
 )
-IF EXIST %PYTHON_VENV_PYTHON% GOTO PYTHON_VENV_EXISTS
+IF EXIST "%PYTHON_VENV_PYTHON%" GOTO PYTHON_VENV_EXISTS
 ECHO Python has not been setup completely for O3DE. Missing Python venv %PYTHON_VENV_PYTHON%
 ECHO Try running %CMD_DIR%\get_python.bat to setup Python for O3DE.
 exit /b 1
@@ -89,11 +89,11 @@ exit /b 1
 :PYTHON_VENV_MATCHES
 REM Execute the python call from the arguments within the python venv environment
 
-call %PYTHON_VENV_ACTIVATE%
+call "%PYTHON_VENV_ACTIVATE%"
 
 call "%PYTHON_VENV_PYTHON%" %PYTHON_ARGS%
 SET PYTHON_RESULT=%ERRORLEVEL%
 
-call %PYTHON_VENV_DEACTIVATE%
+call "%PYTHON_VENV_DEACTIVATE%"
 
 exit /B %PYTHON_RESULT%

--- a/python/python.cmd
+++ b/python/python.cmd
@@ -71,7 +71,7 @@ exit /b 1
 REM Make sure there a .hash file that serves as the marker for the source python package the venv is from
 SET PYTHON_VENV_HASH=%PYTHON_VENV%\.hash
 
-IF EXIST %PYTHON_VENV_HASH% GOTO PYTHON_VENV_HASH_EXISTS
+IF EXIST "%PYTHON_VENV_HASH%" GOTO PYTHON_VENV_HASH_EXISTS
 ECHO Python has not been setup completely for O3DE. Missing venv hash %PYTHON_VENV_HASH%
 ECHO Try running %CMD_DIR%\get_python.bat to setup Python for O3DE.
 exit /b 1
@@ -79,7 +79,7 @@ exit /b 1
 :PYTHON_VENV_HASH_EXISTS
 
 REM Read in the .hash from the venv to see if we need to update the version of python
-SET /p VENV_PACKAGE_HASH=<%PYTHON_VENV_HASH%
+SET /p VENV_PACKAGE_HASH=<"%PYTHON_VENV_HASH%"
 
 IF "%VENV_PACKAGE_HASH%" == "%CURRENT_PACKAGE_HASH%" GOTO PYTHON_VENV_MATCHES
 ECHO Python needs to be updated against the current version.


### PR DESCRIPTION
## What does this PR do?
This fixes O3DE command line python calls in windows environments where the %USERPROFILE% has spaces in the path (i.e. the user name has spaces) which is causing problems during the bootstrapping of Python on windows systems.

## Root Cause
The python virtual environment is stored under the %USERPROFILE%/Python/venv root path, and calls to python via `python.cmd` is routed to the python script in the created venv. But the system calls to python is not double-quoted, which causes problems with the batch interpreter. 

## Fix
While the actual python system call was double-quoted, the surrounding `activate` and `deactivate` calls were not. This addresses this issue.

## How was this PR tested?
Tested on a non-space %USERPROFILE% environment to ensure calls are still valid. 
Tested on a profile named "Test User" (whitespace in the %USERPROFILE% environment)

