### PR TITLE
Fix editor crash when importing actor with only blendshapes but no skin weights

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
@@ -11,7 +11,7 @@
 #include <Atom/RPI/Math.azsli>
 
 
-option enum class SkinningMethod { LinearSkinning, DualQuaternion } o_skinningMethod = SkinningMethod::LinearSkinning;
+option enum class SkinningMethod { LinearSkinning, DualQuaternion, NoSkinning } o_skinningMethod = SkinningMethod::LinearSkinning;
 option bool o_applyMorphTargets = false;
 
 float3 ReadFloat3FromFloatBuffer(Buffer<float> buffer, uint index)
@@ -209,6 +209,9 @@ void MainCS(uint3 thread_id: SV_DispatchThreadID)
             break;
         case SkinningMethod::DualQuaternion:
             SkinVertexDualQuaternion(i, position, normal, tangent, bitangent);
+            break;
+        case SkinningMethod::NoSkinning:
+            // Do nothing
             break;
         }
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h
@@ -17,7 +17,8 @@ namespace AZ
         enum class SkinningMethod : uint8_t
         {
             DualQuaternion = 0,
-            LinearSkinning
+            LinearSkinning,
+            NoSkinning
         };
 
         struct SkinnedMeshShaderOptions

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
@@ -108,6 +108,13 @@ namespace AZ
             // Create a buffer view for each input stream in the current mesh
             for (; !streamIter.HasEnded(); ++streamIter, ++meshStreamIndex)
             {
+                // `IsValid` would return false for dummy buffers, since the index of those buffers equals the size of the buffer view.
+                // We shall skip dummy buffers to avoid empty pointers in the following code. 
+                if (!streamIter.IsValid())
+                {
+                    continue;
+                }
+
                 // Get the semantic from the input layout, and use that to get the SkinnedMeshStreamInfo
                 const SkinnedMeshVertexStreamInfo* streamInfo = SkinnedMeshVertexStreamPropertyInterface::Get()->GetInputStreamInfo(
                     inputLayout.GetStreamChannels()[meshStreamIndex].m_semantic);

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.cpp
@@ -23,6 +23,7 @@ namespace AZ
             m_skinningMethodOptionIndex = layout->FindShaderOptionIndex(AZ::Name("o_skinningMethod"));
             m_skinningMethodLinearSkinningValue = layout->FindValue(m_skinningMethodOptionIndex, AZ::Name("SkinningMethod::LinearSkinning"));
             m_skinningMethodDualQuaternionValue = layout->FindValue(m_skinningMethodOptionIndex, AZ::Name("SkinningMethod::DualQuaternion"));
+            m_skinningMethodNoSkinningValue = layout->FindValue(m_skinningMethodOptionIndex, AZ::Name("SkinningMethod::NoSkinning"));
 
             m_applyMorphTargetOptionIndex = layout->FindShaderOptionIndex(AZ::Name("o_applyMorphTargets"));
             m_applyMorphTargetFalseValue = layout->FindValue(m_applyMorphTargetOptionIndex, AZ::Name("false"));
@@ -43,6 +44,9 @@ namespace AZ
             {
             case SkinningMethod::DualQuaternion:
                 shaderOptionGroup.SetValue(m_skinningMethodOptionIndex, m_skinningMethodDualQuaternionValue);
+                break;
+            case SkinningMethod::NoSkinning:
+                shaderOptionGroup.SetValue(m_skinningMethodOptionIndex, m_skinningMethodNoSkinningValue);
                 break;
             case SkinningMethod::LinearSkinning:
             default:

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.h
@@ -51,6 +51,7 @@ namespace AZ
             RPI::ShaderOptionIndex m_skinningMethodOptionIndex;
             RPI::ShaderOptionValue m_skinningMethodLinearSkinningValue;
             RPI::ShaderOptionValue m_skinningMethodDualQuaternionValue;
+            RPI::ShaderOptionValue m_skinningMethodNoSkinningValue;
 
             RPI::ShaderOptionIndex m_applyMorphTargetOptionIndex;
             RPI::ShaderOptionValue m_applyMorphTargetFalseValue;

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
@@ -68,7 +68,7 @@ namespace AZ
                 Name{"SkinnedMeshInputBlendIndices"},
                 Name{"m_sourceBlendIndices"},
                 RHI::ShaderSemantic{Name{"SKIN_JOINTINDICES"}},
-                false, // isOptional
+                true, // isOptional
                 SkinnedMeshInputVertexStreams::BlendIndices
             };
 
@@ -78,7 +78,7 @@ namespace AZ
                 Name{"SkinnedMeshInputBlendWeights"},
                 Name{"m_sourceBlendWeights"},
                 RHI::ShaderSemantic{Name{"SKIN_WEIGHTS"}},
-                false, // isOptional
+                true, // isOptional
                 SkinnedMeshInputVertexStreams::BlendWeights
             };
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceGeometryView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceGeometryView.h
@@ -100,6 +100,12 @@ namespace AZ::RHI
         //! Can be used to reset the iterator if you want to use it for subsequent loops
         void Reset() { m_current = 0; }
 
+        //! Used to check if the current item is a valid buffer, useful when checking dummy buffers
+        bool IsValid()
+        {
+            return m_indices.GetIndex(m_current) < m_geometryView->GetStreamBufferViews().size();
+        }
+
         StreamIterator& operator++()
         {
             if (!HasEnded()) {

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -90,7 +90,9 @@ namespace AZ::RHI
                 return new_iterator->second;
             }
         }
-        else if (&iterator->second->GetBuffer() != m_buffer->GetDeviceBuffer(deviceIndex).get())
+        // TODO: Figure out why `iterator->second` is sometimes null given that `m_buffer` is non-null
+        // Add null check for `iterator->second` to avoid empty pointer
+        else if (!iterator->second || &iterator->second->GetBuffer() != m_buffer->GetDeviceBuffer(deviceIndex).get())
         {
             iterator->second = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor);
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -1071,7 +1071,8 @@ namespace AZ
                     // Align all the stream buffers to ensure they all padded to SkinnedMeshBufferAlignment byte boundary.
                     // This is done to ensure that we can respect Metal's requirement of having typed buffers aligned to 64.
                     // We also need to align to 16 and 12 byte boundary in order to respect RGB32 and RGBA32 buffer views.
-                    if (hasSkinData)
+                    // If a model only has morph targets, it is still recognized as an actor, so we still have to align it. 
+                    if (hasSkinData || sourceMesh.m_isMorphed)
                     {
                         if (AZ::SceneAPI::Utilities::IsDebugEnabled())
                         {
@@ -1088,24 +1089,31 @@ namespace AZ
                         RPI::ModelAssetHelpers::AlignStreamBuffer(normals, vertexCount, NormalFormat, SkinnedMeshBufferAlignment);
                         RPI::ModelAssetHelpers::AlignStreamBuffer(tangents, vertexCount, TangentFormat, SkinnedMeshBufferAlignment);
                         RPI::ModelAssetHelpers::AlignStreamBuffer(bitangents, vertexCount, BitangentFormat, SkinnedMeshBufferAlignment);
-                        
-                        const size_t totalVertexInfluences = productMesh.m_influencesPerVertex * vertexCount;
-                        RPI::ModelAssetHelpers::AlignStreamBuffer(
-                            skinJointIndices, totalVertexInfluences, SkinIndicesFormat, SkinnedMeshBufferAlignment);
-                        RPI::ModelAssetHelpers::AlignStreamBuffer(
-                            skinWeights, totalVertexInfluences, SkinWeightFormat, SkinnedMeshBufferAlignment);
 
-                        if (AZ::SceneAPI::Utilities::IsDebugEnabled())
+                        if (hasSkinData)
                         {
-                            AZ_Info(s_builderName, "  Aligning Buffers for mesh '%s' with vertexCount %zu\n", productMesh.m_name.GetCStr(), vertexCount);
-                            AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "  After:       %zu positions\n", positions.size());
-                            AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu normals\n", normals.size());
-                            AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu tangents\n", tangents.size());
-                            AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu bitangents\n", bitangents.size());
-                            AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu skinJointIndices\n", skinJointIndices.size());
-                            AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu skinWeights\n", skinWeights.size());
+                            const size_t totalVertexInfluences = productMesh.m_influencesPerVertex * vertexCount;
+                            RPI::ModelAssetHelpers::AlignStreamBuffer(
+                                skinJointIndices, totalVertexInfluences, SkinIndicesFormat, SkinnedMeshBufferAlignment);
+                            RPI::ModelAssetHelpers::AlignStreamBuffer(
+                                skinWeights, totalVertexInfluences, SkinWeightFormat, SkinnedMeshBufferAlignment);
+
+                            if (AZ::SceneAPI::Utilities::IsDebugEnabled())
+                            {
+                                AZ_Info(
+                                    s_builderName,
+                                    "  Aligning Buffers for mesh '%s' with vertexCount %zu\n",
+                                    productMesh.m_name.GetCStr(),
+                                    vertexCount);
+                                AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "  After:       %zu positions\n", positions.size());
+                                AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu normals\n", normals.size());
+                                AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu tangents\n", tangents.size());
+                                AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu bitangents\n", bitangents.size());
+                                AZ_Info(
+                                    AZ::SceneAPI::Utilities::LogWindow, "               %zu skinJointIndices\n", skinJointIndices.size());
+                                AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "               %zu skinWeights\n", skinWeights.size());
+                            }
                         }
-                        
                     }
 
                     // A morph target that only influenced one source mesh might be split over multiple product meshes

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -120,9 +120,17 @@ namespace AZ::Render
 
     void AtomActorInstance::SetSkinningMethod(EMotionFX::Integration::SkinningMethod emfxSkinningMethod)
     {
-        RenderActorInstance::SetSkinningMethod(emfxSkinningMethod);
+        // Check if the actor has skinning, otherwise fall back to `NoSkinning` regardless of `emfxSkinningMethod`
+        if (m_actorInstance->GetActor()->GetSkinMetaAsset().Get())
+        {
+            RenderActorInstance::SetSkinningMethod(emfxSkinningMethod);
+            m_boneTransforms = CreateBoneTransformBufferFromActorInstance(m_actorInstance, emfxSkinningMethod);
+        }
+        else
+        {
+            RenderActorInstance::SetSkinningMethod(EMotionFX::Integration::SkinningMethod::None);
+        }
 
-        m_boneTransforms = CreateBoneTransformBufferFromActorInstance(m_actorInstance, emfxSkinningMethod);
         // Release the Atom skinned mesh and acquire a new one to apply the new skinning method
         UnregisterActor();
         RegisterActor();
@@ -136,6 +144,8 @@ namespace AZ::Render
             return SkinningMethod::DualQuaternion;
         case EMotionFX::Integration::SkinningMethod::Linear:
             return SkinningMethod::LinearSkinning;
+        case EMotionFX::Integration::SkinningMethod::None:
+            return SkinningMethod::NoSkinning;
         default:
             AZ_Error("AtomActorInstance", false, "Unsupported skinning method. Defaulting to linear");
         }
@@ -457,8 +467,19 @@ namespace AZ::Render
         AZ_Warning("AtomActorInstance", m_skinnedMeshInputBuffers, "Failed to create SkinnedMeshInputBuffers from Actor. It is likely that this actor doesn't have any meshes");
         if (m_skinnedMeshInputBuffers)
         {
-            m_boneTransforms = CreateBoneTransformBufferFromActorInstance(m_actorInstance, GetSkinningMethod());
-            AZ_Error("AtomActorInstance", m_boneTransforms || AZ::RHI::IsNullRHI(), "Failed to create bone transform buffer.");
+            EMotionFX::Integration::SkinningMethod skinningMethod = GetSkinningMethod();
+            
+            // When skinning mode is none or there's no skin asset, skip creating bone transform buffer
+            if (skinningMethod != EMotionFX::Integration::SkinningMethod::None && m_actorAsset->GetActor()->GetSkinMetaAsset().Get())
+            {
+                m_boneTransforms = CreateBoneTransformBufferFromActorInstance(m_actorInstance, skinningMethod);
+                AZ_Error("AtomActorInstance", m_boneTransforms || AZ::RHI::IsNullRHI(), "Failed to create bone transform buffer.");
+            }
+            else if (!m_actorAsset->GetActor()->GetSkinMetaAsset().Get())
+            {
+                // Fallback to no skinning if skinning metaasset doesn't exist
+                RenderActorInstance::SetSkinningMethod(EMotionFX::Integration::SkinningMethod::None);
+            }
 
             // If the instance is created before the default materials on the model have finished loading, the mesh feature processor will ignore it.
             // Wait for them all to be ready before creating the instance
@@ -506,7 +527,10 @@ namespace AZ::Render
             UnregisterActor();
             m_skinnedMeshInputBuffers.reset();
             m_skinnedMeshInstance.reset();
-            m_boneTransforms.reset();
+            if (m_boneTransforms)
+            {
+                m_boneTransforms.reset();
+            }
         }
     }
 
@@ -628,7 +652,7 @@ namespace AZ::Render
             AZ_Error("AtomActorInstance", m_skinnedMeshInstance, "SkinnedMeshInstance must be created before register this actor.");
             return;
         }
-        
+
         MaterialAssignmentMap materials;
         MaterialComponentRequestBus::EventResult(materials, m_entityId, &MaterialComponentRequests::GetMaterialMap);
         CreateRenderProxy(materials);
@@ -713,7 +737,7 @@ namespace AZ::Render
             SkinnedMeshOutputStreamNotificationBus::Handler::BusConnect();
         }
     }
-    
+
     void AtomActorInstance::EnableSkinning(uint32_t lodIndex, uint32_t meshIndex)
     {
         if (m_skinnedMeshHandle.IsValid())

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -174,6 +174,7 @@ namespace EMotionFX
         AZ::u32 modelIndexCount = 0;
 
         // Find the maximum skin influences across all meshes to use when pre-allocating memory
+        bool hasSkinInfluence = false;
         AZ::u32 maxSkinInfluences = 0;
         for (const AZ::RPI::ModelLodAsset::Mesh& mesh : sourceModelLod->GetMeshes())
         {
@@ -184,9 +185,15 @@ namespace EMotionFX
             {
                 const AZ::u32 meshInfluenceCount = weightView->GetBufferViewDescriptor().m_elementCount / mesh.GetVertexCount();
                 maxSkinInfluences = AZStd::max(maxSkinInfluences, meshInfluenceCount);
+                hasSkinInfluence = true;
             }
         }
-        AZ_Assert(maxSkinInfluences > 0 && maxSkinInfluences < 100, "Expect max skin influences in a reasonable value range.");
+
+        // Assert the skin influence range only if the model has skin influence data
+        if (hasSkinInfluence)
+        {
+            AZ_Assert(maxSkinInfluences > 0 && maxSkinInfluences < 100, "Expect max skin influences in a reasonable value range.");
+        }
 
         // IndicesPerFace defined in atom is 3.
         const AZ::u32 numPolygons = modelIndexCount / 3;

--- a/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
@@ -44,7 +44,8 @@ namespace EMotionFX
         enum class SkinningMethod : AZ::u32
         {
             DualQuat = 0,       ///< Dual Quaternions will be used to blend joints during skinning.
-            Linear              ///< Matrices will be used to blend joints during skinning.
+            Linear,             ///< Matrices will be used to blend joints during skinning.
+            None                ///< No skinning will be applied, the model will be rendered as-is. 
         };
 
         /**

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -145,6 +145,7 @@ namespace EMotionFX
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnSkinningMethodChanged)
                         ->EnumAttribute(SkinningMethod::DualQuat, "Dual quat skinning")
                         ->EnumAttribute(SkinningMethod::Linear, "Linear skinning")
+                        ->EnumAttribute(SkinningMethod::None, "Disabled")
                         ->DataElement(AZ::Edit::UIHandlers::CheckBox, &EditorActorComponent::m_excludeFromReflectionCubeMaps, "Exclude from reflection cubemaps", "Actor will not be visible in baked reflection probe cubemaps")
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnExcludeFromReflectionCubeMapsChanged)


### PR DESCRIPTION
## What does this PR do?
A recreation of #18426. Fix crash when importing an Actor with only blendshape but without skinning. Closes #18381. 
The implementation is made in the following aspects: 
 - Mark `SKIN_JOINTINDICES` and `SKIN_WEIGHTS` as optional so that it won't trigger an error when these streams aren't found. 
 - Add some additional null check and make some asserts only active when there's skinning
 - Add a new skinning method call `NoSkinning` which skips the skinning calculation in the skinning shader. When an Actor doesn't have skin weights, then the skinning method falls back to `NoSkinning` automatically. 
 - Make Asset Builder still align buffers when the model has only blendshapes, to avoid alignment errors under vulkan

## How was this PR tested?
Tested on windows, both DX12 and Vulkan. It now works well with Actors with only blendshapes, and I suppose that the original functionality won't be affected. 
However, since I am new to O3DE source code, I am not fully aware of how the modules affect each other, so my changes might break other parts potentially. This has to be checked.  