### PR TITLE
Fix TransformServiceFeatureProcessor Set/Get transform functions for negative scales

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
@@ -574,7 +574,8 @@ namespace AZ
 
     AZ_MATH_INLINE Vector3 Matrix3x4::RetrieveScale() const
     {
-        return Vector3(GetColumn(0).GetLength(), GetColumn(1).GetLength(), GetColumn(2).GetLength());
+        return Vector3(GetColumn(0).GetLength(), GetColumn(1).GetLength(), GetColumn(2).GetLength()) *
+            (GetDeterminant3x3() >= 0.f ? 1.f : -1.f);
     }
 
     AZ_MATH_INLINE Vector3 Matrix3x4::RetrieveScaleSq() const

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
@@ -575,7 +575,7 @@ namespace AZ
     AZ_MATH_INLINE Vector3 Matrix3x4::RetrieveScale() const
     {
         return Vector3(GetColumn(0).GetLength(), GetColumn(1).GetLength(), GetColumn(2).GetLength()) *
-            (GetDeterminant3x3() >= 0.f ? 1.f : -1.f);
+            AZ::GetSign(GetDeterminant3x3());
     }
 
     AZ_MATH_INLINE Vector3 Matrix3x4::RetrieveScaleSq() const

--- a/Code/Framework/AzCore/Tests/Math/MathTestData.h
+++ b/Code/Framework/AzCore/Tests/Math/MathTestData.h
@@ -54,6 +54,9 @@ namespace MathTestData
 
     static const AZ::Matrix3x4 NonOrthogonalMatrix3x4s[] = {
         AZ::Matrix3x4::CreateScale(AZ::Vector3(2.4f, 0.3f, 1.7f)),
+        AZ::Matrix3x4::CreateScale(AZ::Vector3(-2.4f, 0.3f, 1.7f)),
+        AZ::Matrix3x4::CreateScale(AZ::Vector3(-2.4f, -0.3f, -1.7f)),
+        AZ::Matrix3x4::CreateRotationX(2.2f) * AZ::Matrix3x4::CreateScale(AZ::Vector3(-2.4f, -0.3f, -1.7f)),
         AZ::Matrix3x4::CreateRotationX(2.2f) * AZ::Matrix3x4::CreateDiagonal(AZ::Vector3(0.2f, 0.8f, 1.4f))
     };
 

--- a/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
@@ -186,6 +186,23 @@ namespace UnitTest
 
     INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformCreateLookAtFixture, ::testing::ValuesIn(MathTestData::Axes));
 
+    using TransformFromMatrixFixture = ::testing::TestWithParam<AZ::Matrix3x4>;
+
+    TEST_P(TransformFromMatrixFixture, ReconstructMatrixFromRetrievedTransformScale)
+    {
+        AZ::Matrix3x4 matrix = GetParam();
+        AZ::Transform retrievedTransform = AZ::Transform::CreateFromMatrix3x4(matrix);
+        retrievedTransform.ExtractUniformScale();
+        AZ::Vector3 retrievedNonUniformScale = matrix.RetrieveScale();
+
+        AZ::Matrix3x4 reconstructedMatrix = AZ::Matrix3x4::CreateFromTransform(retrievedTransform);
+        reconstructedMatrix.MultiplyByScale(retrievedNonUniformScale);
+
+        EXPECT_THAT(matrix, IsClose(reconstructedMatrix));
+    }
+
+    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformFromMatrixFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
+
     TEST(MATH_Transform, CreateLookAtDegenerateCases)
     {
         const AZ::Vector3 from(2.5f, 0.2f, 3.6f);


### PR DESCRIPTION
## What does this PR do?

This PR fixes a wrong behavior about the `TransformServiceFeatureProcessor` when a transform with negative scale is passed to `SetTransformForId`, it is not correctly returned when calling `GetTransformForId`/`GetNonUniformScaleForId`.

In the following code the values of `matrix` and `retrievedMatrix` are not the same:
```c++
Transform transform{ Vector3::CreateZero(), AZ::Quaternion::CreateIdentity(), -1.f };
Vector3 nonUniformScale{ 2.f, 3.f, 4.f };
m_transformServiceFeatureProcessor->SetTransformForId(m_transformObjectId, transform, nonUniformScale);
Matrix3x4 matrix{ Matrix3x4::CreateFromTransform(transform));
matrix.MultiplyByScale(nonUniformScale);

Transform retrievedTransform{ m_transformServiceFeatureProcessor->GetTransformForId(m_transformObjectId) };
Vector3 retrievedNonUniformScale{ m_transformServiceFeatureProcessor->GetTransformForId(m_transformObjectId) };
Matrix3x4 retrievedMatrix{ Matrix3x4::CreateFromTransform(retrievedTransform)) };
retrievedMatrix.MultiplyByScale(retrievedNonUniformScale);
```

This is problematic when eg. using a negative scale in the transform component and then querying the `TransformServiceFeatureProcessor` for the transform of an object, which yields a wrong combined transform.

## How was this PR tested?

Added a new automated test which checks the above code for some matrices with negative scale
