### PR TITLE
Fix Visual Studio Requirement in Project Manager when in script only mode

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -125,10 +125,16 @@ namespace O3DE::ProjectManager
 
             if (projectInfo.m_isScriptOnly)
             {
-                if (auto ninjaVersionQueryResult = FindSupportedNinja(); !ninjaVersionQueryResult.IsSuccess())
+                auto ninjaVersionQueryResult = FindSupportedNinja(); 
+                if (!ninjaVersionQueryResult.IsSuccess())
                 {
                     return ninjaVersionQueryResult;
                 }
+                else
+                {
+                    return AZ::Success("A Script Only Project only requires Ninja installation.");
+                }
+    
             }
 
             // Validate that the minimal version of visual studio is installed


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/18388

Turns out it would still look for Visual studio after the Ninja requirement was met.  This change makes it early out if its in a script only project, and build anyway, without trying to find visual studio.

## How was this PR tested?

Full installer testing (from locally built installer).
