### PR TITLE
Revert "Remove python bootstrapping from post install steps on Windows"

### DIFF
--- a/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
+++ b/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
@@ -35,6 +35,7 @@
             <Directory Id="root.cmake" Name="cmake">
                 <Directory Id="root.cmake.runtime" Name="runtime"/>
             </Directory>
+            <Directory Id="root.python" Name="python"/>
             <Directory Id="root.scripts" Name="scripts"/>
             <Directory Id="root.tools" Name="Tools">
                 <Directory Id="root.tools.redist" Name="Redistributables">
@@ -51,6 +52,12 @@
 
         <CustomAction Id="MoveCMake"
             ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C move &quot;[root.tools.redist.cmake]$(var.CPACK_CMAKE_PACKAGE_NAME)&quot; &quot;[root.cmake]runtime&quot;"
+            Directory="INSTALL_ROOT"
+            Execute="deferred"
+            Impersonate="no"/>
+
+        <CustomAction Id="ConfigurePython"
+            ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C set &quot;LY_CMAKE_PATH=[root.cmake.runtime]bin&quot; &amp;&amp; &quot;[root.python]get_python.bat&quot;"
             Directory="INSTALL_ROOT"
             Execute="deferred"
             Impersonate="no"/>

--- a/cmake/Platform/Windows/Packaging/Template.wxs.in
+++ b/cmake/Platform/Windows/Packaging/Template.wxs.in
@@ -55,6 +55,9 @@
             <Custom Action="MoveCMake" After="ExtractCMake">
                 NOT Installed Or REINSTALL
             </Custom>
+            <Custom Action="ConfigurePython" After="MoveCMake">
+                NOT Installed Or REINSTALL
+            </Custom>
             <!-- limit the unregister action to full uninstall -->
             <Custom Action="UnRegisterEngine" After="InstallInitialize">
                 (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")


### PR DESCRIPTION
## What does this PR do?

This reverts commit 448d9a5bb7ce124bfbcf0c0d0b242476a1ddf39b to restore the windows python-bootstrapping during the install process
