### PR TITLE
Enable interoperability between rendering backends and other APIs

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasedAttachmentAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasedAttachmentAllocator.h
@@ -515,7 +515,7 @@ namespace AZ::RHI
     template<class Heap>
     AliasedHeap* AliasedAttachmentAllocator<Heap>::AddAliasedHeapPage(size_t sizeInBytes, uint32_t heapIndex)
     {
-        size_t newHeapSize = static_cast<size_t>(GetHeapPageScaleFactor() * sizeInBytes);
+        size_t newHeapSize = static_cast<size_t>(AlignUp(GetHeapPageScaleFactor() * sizeInBytes, m_descriptor.m_alignment));
 
         typename Heap::Descriptor heapDescriptor = m_descriptor;
         heapDescriptor.m_budgetInBytes = newHeapSize;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
@@ -49,6 +49,10 @@ namespace AZ::RHI
         /// is invoked when the fence completes.
         ResultCode WaitOnCpuAsync(SignalCallback callback);
 
+        /// BinaryFences in Vulkan need their dependent TimelineSemaphore Fences to be
+        /// signalled, only implemented in Vulkan
+        virtual void SetExternallySignalled(){};
+
     protected:
         bool ValidateIsInitialized() const;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
@@ -50,7 +50,7 @@ namespace AZ::RHI
         ResultCode WaitOnCpuAsync(SignalCallback callback);
 
         /// BinaryFences in Vulkan need their dependent TimelineSemaphore Fences to be
-        /// signalled, only implemented in Vulkan
+        /// signalled. This is currently only implemented in Vulkan
         virtual void SetExternallySignalled(){};
 
     protected:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIBus.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIBus.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/PhysicalDevice.h>
+#include <AzCore/EBus/EBus.h>
+
+namespace AZ::RHI
+{
+    class Device;
+    //! Ebus for collecting requirements for creating a PhysicalDevice.
+    class RHIRequirementsRequest : public AZ::EBusTraits
+    {
+    public:
+        virtual ~RHIRequirementsRequest() = default;
+
+        //! Removes PhysicalDevices that are not supported from a list of available devices.
+        virtual void FilterSupportedPhysicalDevices(
+            [[maybe_unused]] PhysicalDeviceList& supportedDevices, [[maybe_unused]] AZ::RHI::APIIndex apiIndex){};
+
+        virtual size_t GetRequiredAlignment([[maybe_unused]] const Device& device)
+        {
+            return 0;
+        };
+
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+    };
+
+    using RHIRequirementRequestBus = AZ::EBus<RHIRequirementsRequest>;
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIBus.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIBus.h
@@ -13,7 +13,7 @@
 namespace AZ::RHI
 {
     class Device;
-    //! Ebus for collecting requirements for creating a PhysicalDevice.
+    //! Ebus to collect requirements for creating a PhysicalDevice.
     class RHIRequirementsRequest : public AZ::EBusTraits
     {
     public:

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -280,8 +280,9 @@ namespace AZ::RHI
     {
         AZ_PROFILE_SCOPE(RHI, "FrameScheduler: CompileProducers");
 
-        for (ScopeProducer* scopeProducer : m_scopeProducers)
+        for (auto scope : m_frameGraph->GetScopes())
         {
+            auto scopeProducer = FindScopeProducer(scope->GetId());
             const FrameGraphCompileContext context(scopeProducer->GetScopeId(), m_frameGraph->GetAttachmentDatabase());
             scopeProducer->CompileResources(context);
         }

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -196,6 +196,7 @@ set(FILES
     Source/RHI/DeviceResourcePool.cpp
     Source/RHI/ResourcePool.cpp
     Source/RHI/ResourcePoolDatabase.cpp
+    Include/Atom/RHI/RHIBus.h
     Include/Atom/RHI/MemoryAllocation.h
     Include/Atom/RHI/MemorySubAllocator.h
     Include/Atom/RHI/MemoryLinearSubAllocator.h

--- a/Gems/Atom/RHI/DX12/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/DX12/Code/CMakeLists.txt
@@ -155,6 +155,22 @@ ly_add_target(
 )
 
 ly_add_target(
+    NAME ${gem_name}.Interface STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        atom_rhi_dx12_interface_common_files.cmake
+    INCLUDE_DIRECTORIES
+        PRIVATE
+            Source
+            ${pal_source_dir}
+        PUBLIC
+            Include
+    BUILD_DEPENDENCIES
+        PUBLIC
+            Gem::${gem_name}.Private.Static
+)
+
+ly_add_target(
     NAME ${gem_name}.Private ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/DeviceBuffer.h>
+#include <Atom/RHI/DeviceFence.h>
+#include <Atom/RHI/DeviceImage.h>
+#include <Atom/RHI/PhysicalDevice.h>
+
+#include <AzCore/PlatformIncl.h>
+#include <d3d12.h>
+#include <dxgi.h>
+#include <dxgi1_4.h>
+
+namespace AZ
+{
+    namespace DX12
+    {
+        //! Provide access to native device handles
+        ID3D12Device5* GetDeviceNativeHandle(RHI::Device& device);
+        IDXGIAdapter3* GetPhysicalDeviceNativeHandle(const RHI::PhysicalDevice& device);
+
+        //! Provide access to native fence handle and value
+        ID3D12Fence* GetFenceNativeHandle(RHI::DeviceFence& fence);
+        uint64_t GetFencePendingValue(RHI::DeviceFence& fence);
+
+        //! Provide access to native buffer resource, heap as well as size and offset
+        ID3D12Resource* GetBufferResource(RHI::DeviceBuffer& buffer);
+        ID3D12Heap* GetBufferHeap(RHI::DeviceBuffer& buffer);
+        size_t GetBufferMemoryViewSize(RHI::DeviceBuffer& buffer);
+        size_t GetBufferAllocationOffset(RHI::DeviceBuffer& buffer);
+        size_t GetBufferHeapOffset(RHI::DeviceBuffer& buffer);
+
+        //! Provide access to native image resource, heap as well as size and offset
+        ID3D12Resource* GetImageResource(RHI::DeviceImage& image);
+        ID3D12Heap* GetImageHeap(RHI::DeviceImage& image);
+        size_t GetImageMemoryViewSize(RHI::DeviceImage& image);
+        size_t GetImageAllocationOffset(RHI::DeviceImage& image);
+        size_t GetImageHeapOffset(RHI::DeviceImage& image);
+    } // namespace DX12
+} // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
@@ -22,6 +22,13 @@ namespace AZ
 {
     namespace DX12
     {
+        //! It is important to note that the usage of these functions requires care from the user.
+        //! This includes:
+        //! - Synchronizing with the renderer by waiting on a fence from the FrameGraph before
+        //!   starting execution as well as signaling the FrameGraph to continue execution
+        //! - Leaving the GPU in a valid state
+        //! - Returning resources in a valid state
+
         //! Provide access to native device handles
         ID3D12Device5* GetDeviceNativeHandle(RHI::Device& device);
         IDXGIAdapter3* GetPhysicalDeviceNativeHandle(const RHI::PhysicalDevice& device);

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/DX12Bus.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/DX12Bus.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+
+#include <AzCore/PlatformIncl.h>
+#include <d3d12.h>
+
+namespace AZ::DX12
+{
+    //! Ebus for collecting requirements external handle requirements for creating memory/semaphores
+    class DX12RequirementsRequest : public AZ::EBusTraits
+    {
+    public:
+        virtual ~DX12RequirementsRequest() = default;
+
+        //! Collects requirements for external memory when allocating memory
+        virtual void CollectTransientAttachmentPoolHeapFlags([[maybe_unused]] D3D12_HEAP_FLAGS& flags){};
+        virtual void CollectAllocatorExtraHeapFlags([[maybe_unused]] D3D12_HEAP_FLAGS& flags, [[maybe_unused]] D3D12_HEAP_TYPE heapType){};
+        virtual void CollectFenceFlags([[maybe_unused]] D3D12_FENCE_FLAGS& flags){};
+
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        using MutexType = AZStd::mutex;
+        static constexpr bool LocklessDispatch = true;
+    };
+
+    using DX12RequirementBus = AZ::EBus<DX12RequirementsRequest>;
+} // namespace AZ::DX12

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/DX12Bus.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/DX12Bus.h
@@ -14,7 +14,7 @@
 
 namespace AZ::DX12
 {
-    //! Ebus for collecting requirements external handle requirements for creating memory/semaphores
+    //! Ebus for collecting external handle requirements for creating memory/semaphores
     class DX12RequirementsRequest : public AZ::EBusTraits
     {
     public:

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/PhysicalDevice_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/PhysicalDevice_Windows.cpp
@@ -9,6 +9,8 @@
 #include <RHI/PhysicalDevice_Windows.h>
 #include <AzCore/std/string/conversions.h>
 
+#include <Atom/RHI/RHIBus.h>
+
 namespace AZ
 {
     namespace DX12
@@ -39,6 +41,9 @@ namespace AZ
                 physicalDevice->Init(dxgiFactory.Get(), dxgiAdapterX.Get());
                 physicalDeviceList.emplace_back(physicalDevice);
             }
+
+            RHI::RHIRequirementRequestBus::Broadcast(
+                &RHI::RHIRequirementsRequest::FilterSupportedPhysicalDevices, physicalDeviceList, RHI::APIIndex::DX12);
 
             return physicalDeviceList;
         }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI.Reflect/RHIDX12Interface.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI.Reflect/RHIDX12Interface.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Interface/DX12/RHIDX12Interface.h>
+#include <RHI/DX12.h>
+
+#include <RHI/Buffer.h>
+#include <RHI/Device.h>
+#include <RHI/Fence.h>
+#include <RHI/Image.h>
+#include <RHI/PhysicalDevice.h>
+
+namespace AZ
+{
+    namespace DX12
+    {
+        ID3D12Device5* GetDeviceNativeHandle(RHI::Device& device)
+        {
+            AZ_Assert(azrtti_cast<Device*>(&device), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            return static_cast<Device&>(device).GetDevice();
+        }
+
+        IDXGIAdapter3* GetPhysicalDeviceNativeHandle(const RHI::PhysicalDevice& device)
+        {
+            AZ_Assert(azrtti_cast<const PhysicalDevice*>(&device), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            return static_cast<const PhysicalDevice*>(&device)->GetAdapter();
+        }
+
+        ID3D12Fence* GetFenceNativeHandle(RHI::DeviceFence& fence)
+        {
+            AZ_Assert(azrtti_cast<FenceImpl*>(&fence), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            return static_cast<FenceImpl&>(fence).Get().Get();
+        }
+
+        uint64_t GetFencePendingValue(RHI::DeviceFence& fence)
+        {
+            AZ_Assert(azrtti_cast<FenceImpl*>(&fence), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            return static_cast<FenceImpl&>(fence).Get().GetPendingValue();
+        }
+
+        ID3D12Resource* GetBufferResource(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Buffer = static_cast<Buffer&>(buffer);
+            return dx12Buffer.GetMemoryView().GetMemory();
+        }
+
+        ID3D12Heap* GetBufferHeap(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Buffer = static_cast<Buffer&>(buffer);
+            return dx12Buffer.GetMemoryView().GetHeap();
+        }
+
+        size_t GetBufferMemoryViewSize(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Buffer = static_cast<Buffer&>(buffer);
+            return dx12Buffer.GetMemoryView().GetSize();
+        }
+
+        size_t GetBufferAllocationOffset(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Buffer = static_cast<Buffer&>(buffer);
+            return dx12Buffer.GetMemoryView().GetOffset();
+        }
+
+        size_t GetBufferHeapOffset(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Buffer = static_cast<Buffer&>(buffer);
+            return dx12Buffer.GetMemoryView().GetHeapOffset();
+        }
+
+        ID3D12Resource* GetImageResource(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Image = static_cast<Image&>(image);
+            return dx12Image.GetMemoryView().GetMemory();
+        }
+
+        ID3D12Heap* GetImageHeap(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Image = static_cast<Image&>(image);
+            return dx12Image.GetMemoryView().GetHeap();
+        }
+
+        size_t GetImageMemoryViewSize(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Image = static_cast<Image&>(image);
+            return dx12Image.GetMemoryView().GetSize();
+        }
+
+        size_t GetImageAllocationOffset(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Image = static_cast<Image&>(image);
+            return dx12Image.GetMemoryView().GetOffset();
+        }
+
+        size_t GetImageHeapOffset(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            auto& dx12Image = static_cast<Image&>(image);
+            return dx12Image.GetMemoryView().GetHeapOffset();
+        }
+    } // namespace DX12
+} // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/AliasedHeap.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/AliasedHeap.cpp
@@ -30,9 +30,10 @@ namespace AZ
             * across the whole frame is high, and the amount of internal fragmentation is low relative to the full
             * heap size.
             */
-            if (D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES == heapFlags ||
-                D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES == heapFlags ||
-                D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES == heapFlags)
+           auto maskedFlags = heapFlags & ~(D3D12_HEAP_FLAG_SHARED);
+            if (D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES == maskedFlags ||
+                D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES == maskedFlags ||
+                D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES == maskedFlags)
             {
                 return D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT;
             }
@@ -60,7 +61,7 @@ namespace AZ
             m_descriptor = static_cast<const Descriptor&>(descriptor);
             
             D3D12_HEAP_DESC heapDesc;
-            heapDesc.Alignment = CalculateHeapAlignment(m_descriptor.m_heapFlags);
+            heapDesc.Alignment = AZStd::max(CalculateHeapAlignment(m_descriptor.m_heapFlags), descriptor.m_alignment);
             // Even the dx12 document said 'but non-aligned SizeInBytes is also supported', but it may lead to TDR issue with some graphics cards
             // Such as nvidia 2070, 2080
             heapDesc.SizeInBytes = RHI::AlignUp<size_t>(descriptor.m_budgetInBytes, heapDesc.Alignment);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/AliasedHeap.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/AliasedHeap.cpp
@@ -23,14 +23,15 @@ namespace AZ
         static size_t CalculateHeapAlignment(D3D12_HEAP_FLAGS heapFlags)
         {
             /**
-            * Heap alignment is the alignment of the actual heap we are allocating, not the base alignment of
-            * of sub-allocations from the heap. That is confusing in the D3D12 docs. The heap itself is
-            * required to be 4MB aligned if it holds MSAA textures. Therefore, this simple metric just
-            * forces 4MB alignment of the heap for all textures, because our chances of having an MSAA target
-            * across the whole frame is high, and the amount of internal fragmentation is low relative to the full
-            * heap size.
-            */
-           auto maskedFlags = heapFlags & ~(D3D12_HEAP_FLAG_SHARED);
+             * Heap alignment is the alignment of the actual heap we are allocating, not the base alignment of
+             * of sub-allocations from the heap. That is confusing in the D3D12 docs. The heap itself is
+             * required to be 4MB aligned if it holds MSAA textures. Therefore, this simple metric just
+             * forces 4MB alignment of the heap for all textures, because our chances of having an MSAA target
+             * across the whole frame is high, and the amount of internal fragmentation is low relative to the full
+             * heap size.
+             * To simply test the flags for equality, we mask the D3D12_HEAP_FLAG_SHARED prior to testing.
+             */
+            auto maskedFlags = heapFlags & ~(D3D12_HEAP_FLAG_SHARED);
             if (D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES == maskedFlags ||
                 D3D12_HEAP_FLAG_ALLOW_ONLY_RT_DS_TEXTURES == maskedFlags ||
                 D3D12_HEAP_FLAG_ALLOW_ONLY_NON_RT_DS_TEXTURES == maskedFlags)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.cpp
@@ -8,6 +8,8 @@
 #include <RHI/Fence.h>
 #include <RHI/Device.h>
 
+#include <Atom/RHI.Reflect/DX12/DX12Bus.h>
+
 namespace AZ
 {
     namespace DX12
@@ -32,7 +34,9 @@ namespace AZ
         RHI::ResultCode Fence::Init(ID3D12DeviceX* dx12Device, RHI::FenceState initialState)
         {
             Microsoft::WRL::ComPtr<ID3D12Fence> fencePtr;
-            if (!AssertSuccess(dx12Device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_GRAPHICS_PPV_ARGS(fencePtr.GetAddressOf()))))
+            D3D12_FENCE_FLAGS flags = D3D12_FENCE_FLAG_NONE;
+            DX12RequirementBus::Broadcast(&DX12RequirementBus::Events::CollectFenceFlags, flags);
+            if (!AssertSuccess(dx12Device->CreateFence(0, flags, IID_GRAPHICS_PPV_ARGS(fencePtr.GetAddressOf()))))
             {
                 AZ_Error("Fence", false, "Failed to initialize ID3D12Fence.");
                 return RHI::ResultCode::Fail;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Fence.h
@@ -113,6 +113,7 @@ namespace AZ
         {
         public:
             AZ_CLASS_ALLOCATOR(FenceImpl, AZ::SystemAllocator);
+            AZ_RTTI(FenceImpl, "{6CD62A6F-FF00-4F6D-990B-59E220083939}", RHI::DeviceFence);
 
             static RHI::Ptr<FenceImpl> Create();
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.h
@@ -47,9 +47,17 @@ namespace AZ
 
         public:
             MemoryView() = default;
-            MemoryView(RHI::Ptr<Memory> memory, size_t offset, size_t size, size_t alignment, MemoryViewType viewType);
+            MemoryView(
+                RHI::Ptr<Memory> memory,
+                size_t offset,
+                size_t size,
+                size_t alignment,
+                MemoryViewType viewType,
+                ID3D12Heap* heap = nullptr,
+                size_t heapOffset = 0ull);
             MemoryView(D3D12MA::Allocation* allocation, RHI::Ptr<Memory> memory, size_t offset, size_t size, size_t alignment, MemoryViewType viewType);
-            MemoryView(const MemoryAllocation& memAllocation, MemoryViewType viewType);
+            MemoryView(
+                const MemoryAllocation& memAllocation, MemoryViewType viewType, ID3D12Heap* heap = nullptr, size_t heapOffset = 0ull);
 
             /// Supports copy and move construction / assignment.
             MemoryView(const MemoryView& rhs) = default;
@@ -89,6 +97,12 @@ namespace AZ
             /// Sets the name of the ID3D12Resource.
             void SetName(const AZStd::wstring_view& name);
 
+            // Heap the Memory was allocated in. Will be nullptr for committed resources
+            ID3D12Heap* GetHeap();
+
+            // Offset in the heap that the Memory is allocated in. Will be zero for committed resources
+            size_t GetHeapOffset();
+
         private:
             void Construct();
 
@@ -98,6 +112,9 @@ namespace AZ
             MemoryAllocation m_memoryAllocation;
 
             MemoryViewType m_viewType;
+
+            ID3D12Heap* m_heap = nullptr;
+            size_t m_heapOffset = 0;
 
             D3D12MA::Allocation* m_d3d12maAllocation = nullptr; //filled in for allocations created through D3D12MA
         };

--- a/Gems/Atom/RHI/DX12/Code/atom_rhi_dx12_interface_common_files.cmake
+++ b/Gems/Atom/RHI/DX12/Code/atom_rhi_dx12_interface_common_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
+    Source/RHI.Reflect/RHIDX12Interface.cpp
+)

--- a/Gems/Atom/RHI/Metal/Code/Source/Platform/Mac/RHI/Metal_RHI_Mac.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/Platform/Mac/RHI/Metal_RHI_Mac.cpp
@@ -41,6 +41,8 @@ namespace Platform
                 physicalDeviceList.emplace_back(physicalDevice);
             }
         }
+        RHI::RHIRequirementRequestBus::Broadcast(
+            &RHI::RHIRequirementsRequest::FilterSupportedPhysicalDevices, physicalDeviceList, RHI::APIIndex::Metal);
         return physicalDeviceList;
     }
     

--- a/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
@@ -158,6 +158,23 @@ ly_add_target(
 )
 
 ly_add_target(
+    NAME ${gem_name}.Interface STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        atom_rhi_vulkan_interface_files.cmake
+    INCLUDE_DIRECTORIES
+        PRIVATE
+            Source
+            ${pal_source_dir}
+        PUBLIC
+            Include
+            ${pal_include_dir}
+    BUILD_DEPENDENCIES
+        PUBLIC
+            Gem::${gem_name}.Private.Static
+)
+
+ly_add_target(
     NAME ${gem_name}.Private ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Interface/Vulkan/RHIVulkanInterface.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Interface/Vulkan/RHIVulkanInterface.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/DeviceBuffer.h>
+#include <Atom/RHI/DeviceFence.h>
+#include <Atom/RHI/DeviceImage.h>
+#include <Atom/RHI/PhysicalDevice.h>
+
+#include <vulkan/vulkan.h>
+
+namespace AZ
+{
+    namespace Vulkan
+    {
+        //! Provide access to native device handles
+        VkDevice GetDeviceNativeHandle(RHI::Device& device);
+        VkPhysicalDevice GetPhysicalDeviceNativeHandle(const RHI::PhysicalDevice& device);
+
+        //! Provide access to native fence handle and value
+        VkSemaphore GetFenceNativeHandle(RHI::DeviceFence& fence);
+        uint64_t GetFencePendingValue(RHI::DeviceFence& fence);
+
+        //! Provide access to native VkBuffer, VKDeviceMemory as well as size and offset
+        VkBuffer GetNativeBuffer(RHI::DeviceBuffer& buffer);
+        VkDeviceMemory GetBufferMemory(RHI::DeviceBuffer& buffer);
+        size_t GetBufferMemoryViewSize(RHI::DeviceBuffer& buffer);
+        size_t GetBufferAllocationSize(RHI::DeviceBuffer& buffer);
+        size_t GetBufferAllocationOffset(RHI::DeviceBuffer& buffer);
+
+        //! Provide access to native VkImage, VKDeviceMemory as well as size and offset
+        VkImage GetNativeImage(RHI::DeviceImage& image);
+        VkDeviceMemory GetImageMemory(RHI::DeviceImage& image);
+        size_t GetImageMemoryViewSize(RHI::DeviceImage& image);
+        size_t GetImageAllocationSize(RHI::DeviceImage& image);
+        size_t GetImageAllocationOffset(RHI::DeviceImage& image);
+    } // namespace Vulkan
+} // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Interface/Vulkan/RHIVulkanInterface.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Interface/Vulkan/RHIVulkanInterface.h
@@ -19,6 +19,13 @@ namespace AZ
 {
     namespace Vulkan
     {
+        //! It is important to note that the usage of these functions requires care from the user.
+        //! This includes:
+        //! - Synchronizing with the renderer by waiting on a fence from the FrameGraph before
+        //!   starting execution as well as signaling the FrameGraph to continue execution
+        //! - Leaving the GPU in a valid state
+        //! - Returning resources in a valid state
+
         //! Provide access to native device handles
         VkDevice GetDeviceNativeHandle(RHI::Device& device);
         VkPhysicalDevice GetPhysicalDeviceNativeHandle(const RHI::PhysicalDevice& device);

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/VulkanBus.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/VulkanBus.h
@@ -50,6 +50,24 @@ namespace AZ::Vulkan
 
     using DeviceRequirementBus = AZ::EBus<DeviceRequirementsRequest>;
 
+    //! Ebus for collecting requirements external handle requirements for creating memory/semaphores
+    class ExternalHandleRequirementsRequest : public AZ::EBusTraits
+    {
+    public:
+        virtual ~ExternalHandleRequirementsRequest() = default;
+
+        //! Collects requirements for external memory when allocating memory
+        virtual void CollectExternalMemoryRequirements([[maybe_unused]] VkExternalMemoryHandleTypeFlagsKHR& flags){};
+        //! Collect requirements for semaphore export when creating timeline semaphores
+        virtual void CollectSemaphoreExportHandleTypes([[maybe_unused]] VkExternalSemaphoreHandleTypeFlags& flags){};
+
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        using MutexType = AZStd::mutex;
+        static constexpr bool LocklessDispatch = true;
+    };
+
+    using ExternalHandleRequirementBus = AZ::EBus<ExternalHandleRequirementsRequest>;
+
     //! Notifications related to Vulkan instance operations.
     class InstanceNotification
         : public AZ::EBusTraits

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Interface/RHIVulkanInterface.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Interface/RHIVulkanInterface.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Interface/Vulkan/RHIVulkanInterface.h>
+
+#include <RHI/Buffer.h>
+#include <RHI/Device.h>
+#include <RHI/Fence.h>
+#include <RHI/Image.h>
+#include <RHI/PhysicalDevice.h>
+#include <RHI/TimelineSemaphoreFence.h>
+
+namespace AZ
+{
+    namespace Vulkan
+    {
+        VkDevice GetDeviceNativeHandle(RHI::Device& device)
+        {
+            AZ_Assert(azrtti_cast<Device*>(&device), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<Device&>(device).GetNativeDevice();
+        }
+
+        VkPhysicalDevice GetPhysicalDeviceNativeHandle(const RHI::PhysicalDevice& device)
+        {
+            AZ_Assert(azrtti_cast<const PhysicalDevice*>(&device), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<const PhysicalDevice&>(device).GetNativePhysicalDevice();
+        }
+
+        VkSemaphore GetFenceNativeHandle(RHI::DeviceFence& fence)
+        {
+            AZ_Assert(azrtti_cast<Fence*>(&fence), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            auto& vulkanFence = static_cast<Fence&>(fence);
+            auto timelineSemaphoreFence = azrtti_cast<TimelineSemaphoreFence*>(&vulkanFence.GetFenceBase());
+            AZ_Assert(timelineSemaphoreFence, "Cannot return a VkSemaphore from a binary fence");
+            return timelineSemaphoreFence->GetNativeSemaphore();
+        }
+
+        uint64_t GetFencePendingValue(RHI::DeviceFence& fence)
+        {
+            AZ_Assert(azrtti_cast<Fence*>(&fence), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            auto& vulkanFence = static_cast<Fence&>(fence);
+            auto timelineSemaphoreFence = azrtti_cast<TimelineSemaphoreFence*>(&vulkanFence.GetFenceBase());
+            AZ_Assert(timelineSemaphoreFence, "Cannot return a VkSemaphore from a binary fence");
+            return timelineSemaphoreFence->GetPendingValue();
+        }
+
+        VkBuffer GetNativeBuffer(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<Buffer&>(buffer).GetBufferMemoryView()->GetNativeBuffer();
+        }
+
+        VkDeviceMemory GetBufferMemory(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<Buffer&>(buffer).GetBufferMemoryView()->GetNativeDeviceMemory();
+        }
+
+        size_t GetBufferMemoryViewSize(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<Buffer&>(buffer).GetBufferMemoryView()->GetSize();
+        }
+
+        size_t GetBufferAllocationSize(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            auto& vulkanBuffer = static_cast<Buffer&>(buffer);
+            if (vulkanBuffer.GetBufferMemoryView()->GetAllocation()->GetMemoryView().GetAllocation()->GetVmaAllocation())
+            {
+                return vulkanBuffer.GetBufferMemoryView()->GetAllocation()->GetMemoryView().GetAllocation()->GetBlockSize();
+            }
+            else
+            {
+                return vulkanBuffer.GetBufferMemoryView()->GetAllocation()->GetAllocationSize();
+            }
+        }
+
+        size_t GetBufferAllocationOffset(RHI::DeviceBuffer& buffer)
+        {
+            AZ_Assert(azrtti_cast<Buffer*>(&buffer), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            auto& vulkanBuffer = static_cast<Buffer&>(buffer);
+            if (vulkanBuffer.GetBufferMemoryView()->GetAllocation()->GetMemoryView().GetAllocation()->GetVmaAllocation())
+            {
+                return vulkanBuffer.GetBufferMemoryView()->GetAllocation()->GetMemoryView().GetAllocation()->GetOffset() +
+                    vulkanBuffer.GetBufferMemoryView()->GetAllocation()->GetMemoryViewOffset() +
+                    vulkanBuffer.GetBufferMemoryView()->GetOffset();
+            }
+            else
+            {
+                return vulkanBuffer.GetBufferMemoryView()->GetAllocation()->GetMemoryViewOffset() +
+                    vulkanBuffer.GetBufferMemoryView()->GetOffset();
+            }
+        }
+
+        VkImage GetNativeImage(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<Image&>(image).GetNativeImage();
+        }
+
+        VkDeviceMemory GetImageMemory(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<Image&>(image).GetMemoryView().GetNativeDeviceMemory();
+        }
+
+        size_t GetImageMemoryViewSize(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            return static_cast<Image&>(image).GetMemoryView().GetSize();
+        }
+
+        size_t GetImageAllocationSize(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            auto& vulkanImage = static_cast<Image&>(image);
+            if (vulkanImage.GetMemoryView().GetAllocation()->GetVmaAllocation())
+            {
+                return vulkanImage.GetMemoryView().GetAllocation()->GetBlockSize();
+            }
+            else
+            {
+                return vulkanImage.GetMemoryView().GetAllocation()->GetSize();
+            }
+        }
+
+        size_t GetImageAllocationOffset(RHI::DeviceImage& image)
+        {
+            AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a Vulkan RHI object", __FUNCTION__);
+            auto& vulkanImage = static_cast<Image&>(image);
+            return vulkanImage.GetMemoryView().GetAllocation()->GetOffset() + vulkanImage.GetMemoryView().GetOffset();
+        }
+    } // namespace Vulkan
+} // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AliasedHeap.cpp
@@ -43,6 +43,7 @@ namespace AZ
 
             VmaAllocation vmaAllocation;
             VkMemoryRequirements memReq = m_descriptor.m_memoryRequirements;
+            memReq.alignment = AZStd::max(memReq.alignment, descriptor.m_alignment);
             memReq.size = descriptor.m_budgetInBytes;
             VkResult vkResult = vmaAllocateMemory(device.GetVmaAllocator(), &memReq, &allocInfo, &vmaAllocation, nullptr);
             AssertSuccess(vkResult);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemory.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemory.h
@@ -61,7 +61,11 @@ namespace AZ
             const Descriptor& GetDescriptor() const;
             VkSharingMode GetSharingMode() const;
 
+            VkDeviceMemory GetNativeDeviceMemory() const;
+            size_t GetMemoryViewOffset() const;
+            size_t GetAllocationSize() const;
             size_t GetSize() const;
+            const MemoryView& GetMemoryView() const;
 
         private:
             BufferMemory() = default;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemoryView.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferMemoryView.h
@@ -33,6 +33,11 @@ namespace AZ
             {
                 return GetAllocation()->GetNativeBuffer();
             }
+
+            VkDeviceMemory GetNativeDeviceMemory() const
+            {
+                return GetAllocation()->GetNativeDeviceMemory();
+            }
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
@@ -17,6 +17,7 @@
 #include <AtomCore/std/containers/lru_cache.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/base.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/list.h>
 #include <AzCore/std/containers/unordered_map.h>
@@ -54,17 +55,43 @@ namespace AZ
         //! Helper class to contain a vulkan create info structure
         //! Since the create info points into memory arrays, we need to keep the
         //! arrays alive when returning the create info from a function.
-        template<class T>
+        template<class T, class ExtT>
         struct CreateInfoContainer
         {
-            //! Vulkan create info structure
-            T m_vkCreateInfo = {};
+            CreateInfoContainer() = default;
+            AZ_DEFAULT_COPY_MOVE(CreateInfoContainer);
+
+            void SetCreateInfo(const T& createInfo)
+            {
+                m_vkCreateInfo = createInfo;
+            }
+            void SetExternalCreateInfo(const ExtT& createInfo)
+            {
+                m_vkExtCreateInfo = createInfo;
+            }
+
+            T* GetCreateInfo()
+            {
+                if (m_vkExtCreateInfo.sType != 0)
+                {
+                    // Add the external info to the createInfo if it exists
+                    // We do this here, so the pointer is always valid, even after copying this struct
+                    m_vkCreateInfo.pNext = &m_vkExtCreateInfo;
+                }
+                return &m_vkCreateInfo;
+            }
+
             //! Vector of queue families that the create info structure points to
             AZStd::vector<uint32_t> m_queueFamilyIndices;
+
+        private:
+            //! Vulkan create info structure
+            T m_vkCreateInfo = {};
+            ExtT m_vkExtCreateInfo = {};
         };
 
-        using BufferCreateInfo = CreateInfoContainer<VkBufferCreateInfo>;
-        using ImageCreateInfo = CreateInfoContainer<VkImageCreateInfo>;
+        using BufferCreateInfo = CreateInfoContainer<VkBufferCreateInfo, VkExternalMemoryBufferCreateInfo>;
+        using ImageCreateInfo = CreateInfoContainer<VkImageCreateInfo, VkExternalMemoryImageCreateInfo>;
 
         class Device final
             : public RHI::Device

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.cpp
@@ -91,5 +91,10 @@ namespace AZ
         {
             return m_fenceImpl->GetFenceStateInternal();
         }
+
+        void Fence::SetExternallySignalled()
+        {
+            m_fenceImpl->SignalEvent();
+        }
     } // namespace Vulkan
 } // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Fence.h
@@ -55,6 +55,7 @@ namespace AZ
             void WaitOnCpuInternal() const override;
             void ResetInternal() override;
             RHI::FenceState GetFenceStateInternal() const override;
+            void SetExternallySignalled() override;
             //////////////////////////////////////////////////////////////////////
 
             RHI::Ptr<FenceBase> m_fenceImpl;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.h
@@ -180,6 +180,8 @@ namespace AZ
                 TrySparse = AZ_BIT(0)  // Try to create a sparse image first
             };
 
+            const MemoryView& GetMemoryView();
+
         private:
             Image() = default;
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -5,16 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <RHI/Vulkan.h>
+#include <Atom/RHI.Reflect/VkAllocator.h>
+#include <Atom/RHI.Reflect/Vulkan/VulkanBus.h>
+#include <Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h>
+#include <Atom/RHI/RHIBus.h>
+#include <Atom/RHI/RHIUtils.h>
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/Utils/Utils.h>
 #include <RHI/Device.h>
 #include <RHI/Instance.h>
 #include <RHI/PhysicalDevice.h>
-#include <Atom/RHI/RHIUtils.h>
-#include <Atom/RHI.Reflect/Vulkan/VulkanBus.h>
-#include <Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h>
-#include <Atom/RHI.Reflect/VkAllocator.h>
-#include <AzCore/Debug/Trace.h>
-#include <AzCore/Utils/Utils.h>
+#include <RHI/Vulkan.h>
 
 namespace AZ
 {
@@ -333,6 +334,10 @@ namespace AZ
 
                 it = shouldIgnore ? supportedDevices.erase(it) : it + 1;
             }
+
+            RHI::RHIRequirementRequestBus::Broadcast(
+                &RHI::RHIRequirementsRequest::FilterSupportedPhysicalDevices, supportedDevices, RHI::APIIndex::Vulkan);
+
             return supportedDevices;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/MemoryView.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/MemoryView.h
@@ -34,6 +34,11 @@ namespace AZ
             {
                 return GetAllocation()->GetOffset() + GetOffset();
             }
+
+            VkDeviceMemory GetNativeDeviceMemory() const
+            {
+                return GetAllocation()->GetNativeDeviceMemory();
+            }
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TimelineSemaphoreFence.cpp
@@ -7,6 +7,7 @@
  */
 #include <Atom/RHI.Reflect/VkAllocator.h>
 #include <Atom/RHI.Reflect/Vulkan/Conversion.h>
+#include <Atom/RHI.Reflect/Vulkan/VulkanBus.h>
 #include <RHI/Device.h>
 #include <RHI/TimelineSemaphoreFence.h>
 
@@ -49,6 +50,17 @@ namespace AZ
             timelineCreateInfo.pNext = nullptr;
             timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
             timelineCreateInfo.initialValue = 0;
+
+            VkExternalSemaphoreHandleTypeFlags externalHandleTypeFlags = 0;
+            ExternalHandleRequirementBus::Broadcast(
+                &ExternalHandleRequirementBus::Events::CollectSemaphoreExportHandleTypes, externalHandleTypeFlags);
+            VkExportSemaphoreCreateInfoKHR createExport{};
+            if (externalHandleTypeFlags != 0)
+            {
+                createExport.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
+                createExport.handleTypes = externalHandleTypeFlags;
+                timelineCreateInfo.pNext = &createExport;
+            }
 
             VkSemaphoreCreateInfo createInfo{};
             createInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TransientAttachmentPool.cpp
@@ -7,6 +7,7 @@
  */
 #include <Atom/RHI.Reflect/TransientBufferDescriptor.h>
 #include <Atom/RHI.Reflect/TransientImageDescriptor.h>
+#include <Atom/RHI/RHIBus.h>
 #include <RHI/Buffer.h>
 #include <RHI/Device.h>
 #include <RHI/Image.h>
@@ -226,6 +227,16 @@ namespace AZ
             heapDesc.m_budgetInBytes = budgetInBytes;
             heapDesc.m_resourceTypeMask = resourceTypeMask;
             heapDesc.m_allocationParameters = heapParameters;
+            struct
+            {
+                size_t m_alignment = 0;
+                void operator=(size_t value)
+                {
+                    m_alignment = AZStd::max(m_alignment, value);
+                }
+            } alignment;
+            RHI::RHIRequirementRequestBus::BroadcastResult(alignment, &RHI::RHIRequirementsRequest::GetRequiredAlignment, device);
+            heapDesc.m_alignment = AZStd::max(alignment.m_alignment, heapDesc.m_alignment);
 
             auto result = allocator->Init(device, heapDesc);
             if (result != RHI::ResultCode::Success)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/VulkanMemoryAllocation.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/VulkanMemoryAllocation.cpp
@@ -36,6 +36,14 @@ namespace AZ
             return m_size;
         }
 
+        size_t VulkanMemoryAllocation::GetBlockSize() const
+        {
+            auto& device = static_cast<Device&>(GetDevice());
+            VmaAllocationInfo2 info;
+            vmaGetAllocationInfo2(device.GetVmaAllocator(), m_vmaAllocation, &info);
+            return info.blockSize;
+        }
+
         CpuVirtualAddress VulkanMemoryAllocation::Map(size_t offset, size_t size, RHI::HostMemoryAccess hostAccess)
         {
             Device& device = static_cast<Device&>(GetDevice());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/VulkanMemoryAllocation.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/VulkanMemoryAllocation.h
@@ -35,6 +35,9 @@ namespace AZ
             //! Returns the size of the memory region in bytes.
             size_t GetSize() const;
 
+            //! Returns the size of the memory block in bytes.
+            size_t GetBlockSize() const;
+
             //! A convenience method to map the resource region spanned by the view for CPU access.
             CpuVirtualAddress Map(size_t offset, size_t size, RHI::HostMemoryAccess hostAccess);
 

--- a/Gems/Atom/RHI/Vulkan/Code/atom_rhi_vulkan_interface_files.cmake
+++ b/Gems/Atom/RHI/Vulkan/Code/atom_rhi_vulkan_interface_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Source/RHI.Interface/RHIVulkanInterface.cpp
+    Include/Atom/RHI.Interface/Vulkan/RHIVulkanInterface.h
+)


### PR DESCRIPTION
## What does this PR do?

This PR introduces necessary functionality to allow for interoperability between `vulkan`/`dx12` and other "non-rendering" APIs.
In short, other APIs may specifiy certain requirements and need to be able to access memory and synchronize with the rendering APIs.
To allow for interoperability, this PR adds the ability to:
- query certain requirements from external APIs (i.e. alignment requirements for memory etc.) as well as 
- to export memory (`Buffer`s and `Image`s) and 
- to synchronize (exporting `Fence`).

The following functionality is added:
## Two new busses
  - `RHIRequirementsRequest`
    - `FilterSupportedPhysicalDevices`
      - Allows an external API to filter the device list for supported devices
    - `GetRequiredAlignment`
      - Let's an external API provide alignment requirements, which need to be followed to import memory
  - `APIRequirementsRequest`
    - `Dx12RequirementsRequest` (collect extra flags)
      - `CollectTransientAttachmentPoolHeapFlags`
      - `CollectAllocatorExtraHeapFlags`
      - `CollectFenceFlags`
    - `VulkanRequirementsRequest`
      - `CollectExternalMemoryRequirements`
      - `CollectSemaphoreExportHandleTypes`
## `RHIAPIInterface`
  - Provide access to
    - `Device`, `PhysicalDevice`, `Semaphore/Fence` (and pending value) as well as `Buffer` and `Image` information
## Smaller changes
  - `Dx12::MemoryView` get additional parameters (`heap` and `offset`) for non-`D3D12MAAllocations`
  - `FrameScheduler` needs to call the `CompileScopeProducers` in the order in which they are added to the queue such that external commands and sync points do net get reordered, which can lead to a deadlock in certain scenarios
  - `DeviceFence` needs the ability to be externally triggered in `vulkan`
    - This is due to a peculiarity of the `BinaryFence`, which needs to have all dependent Fences signalled before its submit call, this call hence is needed to allow a dependent `TimelineSemaphore Fence` to be signalled externally to allow the `BinaryFence` to be submitted
  - `Dx12::BufferD3D12MemoryAllocator`, `Vulkan::BufferMemory` as well as `TransientAttachmentPool` may need to align their allocations as specified by `RHIRequirementsRequest::GetRequiredAlignment`, such that the memory can be mapped 