### PR TITLE
GameLift Server Gem: AZ_TRAIT_SERVER 1, AZ_TRAIT_CLIENT 0 

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
@@ -36,7 +36,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AzCore
-            Gem::Multiplayer.Unified.Static
+            Gem::Multiplayer.Server.Static
             3rdParty::AWSGameLiftServerSDK
     )
 
@@ -83,7 +83,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             PRIVATE
                 AZ::AzCore
                 AZ::AzTest
-                Gem::Multiplayer.Unified.Static
+                Gem::Multiplayer.Server.Static
                 Gem::${gem_name}.Server.Static
                 3rdParty::AWSGameLiftServerSDK
     )


### PR DESCRIPTION
GameLift server should only bring in Multiplayer gem server, not unified. Otherwise, this causes servers to enable AZ_TRAIT_CLIENT, breaking an important multiplayer paradigm

Fixes #18444 

## How was this PR tested?
Created a small GameLift demo using Multiplayer Template. GameLauncher was able to connect to cloud. 
GameLauncher: AZ_TRAIT_CLIENT 1 AZ_TRAIT_SERVER 0
ServerLauncher: AZ_TRAIT_CLIENT 0 AZ_TRAIT_SERVER 1
UnifiedLauncher: AZ_TRAIT_CLIENT 1 AZ_TRAIT_SERVER 1
Editor: AZ_TRAIT_CLIENT 1 AZ_TRAIT_SERVER 1