### PR TITLE
Added functions StoreToRow/ColumnMajorFloat11 for Matrix3x3 for GPU constant buffer packing

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
@@ -89,6 +89,22 @@ namespace AZ
         //! The floats need only be 4 byte aligned, 16 byte alignment is not required.
         void StoreToRowMajorFloat9(float* values) const;
 
+        //! Stores the matrix into to an array of 2 float4 and 1 float3.
+        //! Useful for GPU constant buffer packing rules, which pack a float3x3 as such:
+        //!    [0, 0], [0, 1], [0, 2], <padding>,
+        //!    [1, 0], [1, 1], [1, 2], <padding>,
+        //!    [2, 0], [2, 1], [2, 2]
+        //! Note that the last row is stored in 3 floats, not 4.
+        void StoreToRowMajorFloat11(float* values) const;
+
+        //! Stores the matrix into to an array of 2 float4 and 1 float3.
+        //! Useful for GPU constant buffer packing rules, which pack a float3x3 as such:
+        //!    [0, 0], [1, 0], [2, 0], <padding>,
+        //!    [0, 1], [1, 1], [2, 1], <padding>,
+        //!    [0, 2], [1, 2], [2, 2]
+        //! Note that the last row is stored in 3 floats, not 4.
+        void StoreToColumnMajorFloat11(float* values) const;
+
         //! Stores the matrix into to an array of 9 floats.
         //! The floats need only be 4 byte aligned, 16 byte alignment is not required.
         void StoreToColumnMajorFloat9(float* values) const;

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
@@ -160,16 +160,33 @@ namespace AZ
 
     AZ_MATH_INLINE void Matrix3x3::StoreToRowMajorFloat9(float* values) const
     {
+        // note: StoreToFloat4 is potentially faster, even if we overwrite the last value immediately
         GetRow(0).StoreToFloat4(values);
         GetRow(1).StoreToFloat4(values + 3);
         GetRow(2).StoreToFloat3(values + 6);
     }
 
+    AZ_MATH_INLINE void Matrix3x3::StoreToRowMajorFloat11(float* values) const
+    {
+        // for GPU constant - buffers each float3 is aligned on a 16 bit border
+        GetRow(0).StoreToFloat4(values);
+        GetRow(1).StoreToFloat4(values + 4);
+        GetRow(2).StoreToFloat3(values + 8);
+    }
+
     AZ_MATH_INLINE void Matrix3x3::StoreToColumnMajorFloat9(float* values) const
     {
+        // note: StoreToFloat4 is potentially faster, even if we overwrite the last value immediately
         GetColumn(0).StoreToFloat4(values);
         GetColumn(1).StoreToFloat4(values + 3);
         GetColumn(2).StoreToFloat3(values + 6);
+    }
+
+    AZ_MATH_INLINE void Matrix3x3::StoreToColumnMajorFloat11(float* values) const
+    {
+        GetColumn(0).StoreToFloat4(values);
+        GetColumn(1).StoreToFloat4(values + 4);
+        GetColumn(2).StoreToFloat3(values + 8);
     }
 
     AZ_MATH_INLINE float Matrix3x3::GetElement(int32_t row, int32_t col) const

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x3Tests.cpp
@@ -64,6 +64,46 @@ namespace UnitTest
         EXPECT_EQ(memcmp(testFloatsMtx, testFloats, sizeof(testFloatsMtx)), 0);
     }
 
+    TEST(MATH_Matrix3x3, TestStoreToRowMajorFloat11)
+    {
+        Matrix3x3 m1 = Matrix3x3::CreateFromRowMajorFloat9(testFloats);
+        float output[12];
+        output[11] = -1;
+        // we expect the first two rows to be written with 4 floats, with the last value as garbage,
+        // but the last row only with 3 floats, such that the final value remains untouched
+        // clang-format off
+        float expected[12] = {
+            testFloats[0], testFloats[1], testFloats[2], 0.0f,
+            testFloats[3], testFloats[4], testFloats[5], 0.0f,
+            testFloats[6], testFloats[7], testFloats[8], -1.0f};
+        // clang-format on
+        m1.StoreToRowMajorFloat11(output);
+        EXPECT_EQ(memcmp(&expected[0], &output[0], sizeof(float) * 3), 0);
+        EXPECT_EQ(memcmp(&expected[3], &output[3], sizeof(float) * 3), 0);
+        EXPECT_EQ(memcmp(&expected[6], &output[6], sizeof(float) * 3), 0);
+        EXPECT_EQ(output[11], -1);
+    }
+
+    TEST(MATH_Matrix3x3, TestStoreToColumnMajorFloat11)
+    {
+        Matrix3x3 m1 = Matrix3x3::CreateFromRowMajorFloat9(testFloats);
+        float output[12];
+        output[11] = -1;
+        // we expect the first two columns to be written with 4 floats, with the last value as garbage,
+        // but the last column only with 3 floats, such that the final value remains untouched
+        // clang-format off
+        float expected[12] = {
+            testFloats[0], testFloats[3], testFloats[6], 0.0f,
+            testFloats[1], testFloats[4], testFloats[7], 0.0f,
+            testFloats[2], testFloats[5], testFloats[8], -1.0f};
+        // clang-format on
+        m1.StoreToColumnMajorFloat11(output);
+        EXPECT_EQ(memcmp(&expected[0], &output[0], sizeof(float) * 3), 0);
+        EXPECT_EQ(memcmp(&expected[3], &output[3], sizeof(float) * 3), 0);
+        EXPECT_EQ(memcmp(&expected[6], &output[6], sizeof(float) * 3), 0);
+        EXPECT_EQ(output[11], -1);
+    }
+
     TEST(MATH_Matrix3x3, TestCreateRotationX)
     {
         Matrix3x3 m1 = Matrix3x3::CreateRotationX(DegToRad(30.0f));

--- a/Gems/Atom/RHI/Code/Source/RHI/ConstantsData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ConstantsData.cpp
@@ -171,13 +171,8 @@ namespace AZ::RHI
         // DirectX packing rules pack a float3x3 as such:
         //    [0, 0], [0, 1], [0, 2], <padding>,
         //    [1, 0], [1, 1], [1, 2], <padding>,
-        //    [1, 0], [2, 1], [2, 2]
+        //    [2, 0], [2, 1], [2, 2]
         // It's important to note that the last row is stored in 3 floats, not 4.
-
-        // For converting the data, we're using the Transform class as it's the only type that can store the data
-        // this way natively. Ideally Matrix3x3 would have a "StoreToRowMajorFloat11" method.
-
-        const Matrix3x4& transform = Matrix3x4::CreateFromMatrix3x3(value);
 
         // Packing rules put this at 11 floats (9 data, 2 padding).
         const size_t sizeInBytes = sizeof(float) * 11;
@@ -186,7 +181,7 @@ namespace AZ::RHI
             // Store the matrix into row major order
             const Interval interval = GetLayout()->GetInterval(inputIndex);
             float* matrixValue = reinterpret_cast<float*>(&m_constantData[interval.m_min]);
-            transform.StoreToRowMajorFloat12(matrixValue);
+            value.StoreToRowMajorFloat11(matrixValue);
 
             return true;
         }


### PR DESCRIPTION
## What does this PR do?

a `float3x3` takes up effectively 11 bytes in a GPU constant-buffer: Each float3 segment is aligned to 16 byte borders, with padding after the first and second segment, but no padding after the last segment, which means any 4-byte variable after a 3x3 matrix will be packed after the last float3 segment. Some Visualization [here](https://maraneshi.github.io/HLSL-ConstantBufferLayoutVisualizer/?visualizer=FAZwLgTgrgxmAEAVApueBvY9vwGYBsB7AQzAGYAPM+AWwH0CTyqBuLHR0+AB2JgGtkAEzoA3YhDYBfNsBgAjKLlzII8ZBWI1u+ZBnbYUaMKjDSWQA), though that link might be temporary.

`ConstantsData::SetConstant<Matrix3x3>` converted the Matrix3x3 into a Matrix3x4, and wrote 12 floats into the constant buffer, overwriting some variables following the float3x3.

This PR adds `Matrix3x3::StoreToRowMajorFloat11()` and `Matrix3x3::StoreToColumnMajorFloat11()`, and uses them in `ConstantsData::SetConstant<Matrix3x3>`.

~~I believe this is the source of the [GFX TODO][ATOM-14595] comments that appear several times in the shaders~~ 
As commented by @moudgils, that specific issue is not fixed by this PR, but the functionality should work for any platform regardless.

## How was this PR tested?

Ensured the new Matrix3x3 testcases run, and tested basic functionality with vulkan on Windows