### PR TITLE
Expose more functions to feature processor interfaces

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/CapsuleLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/CapsuleLightFeatureProcessorInterface.h
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
 
 namespace AZ
 {
@@ -70,6 +71,11 @@ namespace AZ
 
             //! Sets all of the the capsule data for the provided LightHandle.
             virtual void SetCapsuleData(LightHandle handle, const CapsuleLightData& data) = 0;
+
+            //! Returns the buffer containing the light data for all capsule lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+            //! Returns the number of capsule lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
@@ -10,6 +10,7 @@
 
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 #include <Atom/Feature/CoreLights/ShadowConstants.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <AzCore/Math/Color.h>
 #include <AzFramework/Components/CameraBus.h>
@@ -186,6 +187,12 @@ namespace AZ
 
             //! Sets the lighting channel mask
             virtual void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) = 0;
+
+            //! Returns the buffer containing the light data for all directional lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+
+            //! Returns the number of directional lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 #include <Atom/Feature/CoreLights/ShadowConstants.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
 
 namespace AZ
 {
@@ -118,6 +119,11 @@ namespace AZ
 
             //! Get a read only copy of a disk lights data, useful for debug rendering
             virtual const DiskLightData& GetDiskData(LightHandle handle) const = 0;
+
+            //! Returns the buffer containing the light data for all disk lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+            //! Returns the number of disk lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PointLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PointLightFeatureProcessorInterface.h
@@ -10,6 +10,7 @@
 
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 #include <Atom/Feature/CoreLights/ShadowConstants.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 
 namespace AZ
@@ -91,6 +92,10 @@ namespace AZ
             virtual void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) = 0;
             //! Sets all of the the point data for the provided LightHandle.
             virtual void SetPointData(LightHandle handle, const PointLightData& data) = 0;
+            //! Returns the buffer containing the light data for all point lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+            //! Returns the number of point lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PolygonLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PolygonLightFeatureProcessorInterface.h
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/std/containers/vector.h>
 
@@ -92,6 +93,13 @@ namespace AZ
             virtual void SetAttenuationRadius(LightHandle handle, float attenuationRadius) = 0;
             //! Sets the lighting channel mask
             virtual void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) = 0;
+
+            //! Returns the buffer containing the light data for all polygon lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+            //! Returns the buffer containing the points of all polygon lights
+            virtual const Data::Instance<RPI::Buffer> GetLightPointBuffer() const = 0;
+            //! Returns the number of directional lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/QuadLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/QuadLightFeatureProcessorInterface.h
@@ -8,9 +8,10 @@
 
 #pragma once
 
+#include <Atom/Feature/CoreLights/PhotometricValue.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <AzCore/Math/Quaternion.h>
-#include <Atom/Feature/CoreLights/PhotometricValue.h>
 
 namespace AZ
 {
@@ -99,6 +100,11 @@ namespace AZ
 
             //! Sets all of the the quad data for the provided LightHandle.
             virtual void SetQuadData(LightHandle handle, const QuadLightData& data) = 0;
+
+            //! Returns the buffer containing the light data for all quad lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+            //! Returns the number of quad lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimplePointLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimplePointLightFeatureProcessorInterface.h
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
 
 namespace AZ
 {
@@ -46,6 +47,10 @@ namespace AZ
             virtual void SetAffectsGIFactor(LightHandle handle, float affectsGIFactor) = 0;
             //! Sets the lighting channel mask
             virtual void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) = 0;
+            //! Returns the buffer containing the light data for all simple point lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+            //! Returns the number of simple point lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
-#include <Atom/RPI.Public/FeatureProcessor.h>
-#include <Atom/RPI.Reflect/Image/Image.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 #include <Atom/Feature/CoreLights/ShadowConstants.h>
+#include <Atom/RPI.Public/Buffer/Buffer.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
+#include <Atom/RPI.Reflect/Image/Image.h>
 
 namespace AZ
 {
@@ -71,6 +72,11 @@ namespace AZ
             virtual void SetEsmExponent(LightHandle handle, float exponent) = 0;
             //! Sets if this shadow should be rendered every frame (not cached) or only when it detects a change (cached).
             virtual void SetUseCachedShadows(LightHandle handle, bool useCachedShadows) = 0;
+
+            //! Returns the buffer containing the light data for all simple spot lights
+            virtual const Data::Instance<RPI::Buffer> GetLightBuffer() const = 0;
+            //! Returns the number of simple spot lights
+            virtual uint32_t GetLightCount() const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ImageBasedLights/ImageBasedLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ImageBasedLights/ImageBasedLightFeatureProcessorInterface.h
@@ -31,6 +31,14 @@ namespace AZ
             virtual void SetExposure(float exposure) = 0;
             //! Sets the orientation of the global IBL.
             virtual void SetOrientation(const Quaternion& orientation) = 0;
+            //! Returns the global specular IBL image for this scene
+            virtual const Data::Instance<RPI::Image>& GetSpecularImage() const = 0;
+            //! Returns the global diffuse IBL image for this scene
+            virtual const Data::Instance<RPI::Image>& GetDiffuseImage() const = 0;
+            //! Returns the exposure value in stops for the global IBL
+            virtual float GetExposure() const = 0;
+            //! Returns the orientation of the global IBL.
+            virtual const Quaternion& GetOrientation() const = 0;
             //! Resets the images and exposure back to default (unset) values.
             virtual void Reset() = 0;
         };

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -68,6 +68,10 @@ namespace AZ
             "This is helpful for simulating the worst case scenario for instancing for profiling performance.");
 
         struct MeshInstanceGroupData;
+
+        // ModelDataInstanceInterface provides an interface to ModelDataInstance
+        // It provides information about an instance of a model in the scene
+        // The class can be accessed through MeshHandles from the MeshFeatureProcessor
         class ModelDataInstanceInterface
         {
             friend class MeshFeatureProcessor;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -67,7 +67,50 @@ namespace AZ
             "Enable instanced draw calls in the MeshFeatureProcessor, but force one object per draw call. "
             "This is helpful for simulating the worst case scenario for instancing for profiling performance.");
 
-        class ModelDataInstance;
+        struct MeshInstanceGroupData;
+        class ModelDataInstanceInterface
+        {
+            friend class MeshFeatureProcessor;
+            friend class MeshLoader;
+
+        public:
+            AZ_RTTI(AZ::Render::ModelDataInstanceInterface, "{0B990760-AB5C-4357-A983-AD066EC9AC2E}");
+            virtual ~ModelDataInstanceInterface() = default;
+
+            virtual const Data::Instance<RPI::Model>& GetModel() = 0;
+            virtual const RPI::Cullable& GetCullable() = 0;
+
+            virtual const uint32_t GetLightingChannelMask() = 0;
+
+            using InstanceGroupHandle = StableDynamicArrayWeakHandle<MeshInstanceGroupData>;
+
+            //! PostCullingInstanceData represents the data the MeshFeatureProcessor needs after culling
+            //! in order to generate instanced draw calls
+            struct PostCullingInstanceData
+            {
+                InstanceGroupHandle m_instanceGroupHandle;
+                uint32_t m_instanceGroupPageIndex;
+                TransformServiceFeatureProcessorInterface::ObjectId m_objectId;
+            };
+
+            using PostCullingInstanceDataList = AZStd::vector<PostCullingInstanceData>;
+            virtual const bool IsSkinnedMesh() = 0;
+            virtual const AZ::Uuid& GetRayTracingUuid() const = 0;
+
+            //! Internally called when a DrawPacket used by this ModelDataInstance was updated.
+            virtual void HandleDrawPacketUpdate(RPI::MeshDrawPacket& meshDrawPacket) = 0;
+
+            //! Event that let's us know whenever one of the MeshDrawPackets has been updated.
+            //! This event can occur on multiple threads.
+            //! Provides the ModelDataInstance parent object that owns the MeshDrawPacket.
+            using MeshDrawPacketUpdatedEvent = Event<const ModelDataInstanceInterface&, const AZ::RPI::MeshDrawPacket&>;
+            //! Connects @handler to the MeshDrawPacketUpdatedEvent.
+            //! One of the most common reasons a MeshDrawPacket gets updated is
+            //! when a RenderPipeline is instantiated at runtime and it happens to contain
+            //! a RasterPass with a DrawListTag that matches one of the Shaders of one of the Materials in
+            //! a Mesh.
+            virtual void ConnectMeshDrawPacketUpdatedHandler(MeshDrawPacketUpdatedEvent::Handler& handler) = 0;
+        };
 
         //! Mesh feature processor data types for customizing model materials
         using CustomMaterialLodIndex = AZ::u64;
@@ -141,7 +184,7 @@ namespace AZ
         public:
             AZ_RTTI(AZ::Render::MeshFeatureProcessorInterface, "{975D7F0C-2E7E-4819-94D0-D3C4E2024721}", AZ::RPI::FeatureProcessor);
 
-            using MeshHandle = StableDynamicArrayHandle<ModelDataInstance>;
+            using MeshHandle = StableDynamicArrayHandle<ModelDataInstanceInterface>;
 
             //! Returns the object id for a mesh handle.
             virtual TransformServiceFeatureProcessorInterface::ObjectId GetObjectId(const MeshHandle& meshHandle) const = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CapsuleLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CapsuleLightFeatureProcessor.h
@@ -52,8 +52,8 @@ namespace AZ
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
             void SetCapsuleData(LightHandle handle, const CapsuleLightData& data) override;
 
-            const Data::Instance<RPI::Buffer> GetLightBuffer()const;
-            uint32_t GetLightCount()const;
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override;
+            uint32_t GetLightCount() const override;
 
         private:
             CapsuleLightFeatureProcessor(const CapsuleLightFeatureProcessor&) = delete;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -252,8 +252,8 @@ namespace AZ
             void SetAffectsGIFactor(LightHandle handle, float affectsGIFactor) override;
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
 
-            const Data::Instance<RPI::Buffer> GetLightBuffer() const { return m_lightBufferHandler.GetBuffer(); }
-            uint32_t GetLightCount() const { return m_lightBufferHandler.GetElementCount(); }
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override { return m_lightBufferHandler.GetBuffer(); }
+            uint32_t GetLightCount() const override { return m_lightBufferHandler.GetElementCount(); }
             ShadowProperty& GetShadowProperty(LightHandle handle) { return m_shadowProperties.GetData(handle.GetIndex()); }
 
         private:

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.h
@@ -67,8 +67,8 @@ namespace AZ
             void SetDiskData(LightHandle handle, const DiskLightData& data) override;
             const DiskLightData& GetDiskData(LightHandle handle) const override;
 
-            const Data::Instance<RPI::Buffer> GetLightBuffer()const;
-            uint32_t GetLightCount()const;
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override;
+            uint32_t GetLightCount() const override;
 
         private:
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.h
@@ -61,8 +61,8 @@ namespace AZ
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
             void SetPointData(LightHandle handle, const PointLightData& data) override;
 
-            const Data::Instance<RPI::Buffer>  GetLightBuffer() const;
-            uint32_t GetLightCount()const;
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override;
+            uint32_t GetLightCount() const override;
 
         private:
             PointLightFeatureProcessor(const PointLightFeatureProcessor&) = delete;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.h
@@ -51,9 +51,9 @@ namespace AZ
             void SetAttenuationRadius(LightHandle handle, float attenuationRadius) override;
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
 
-            const Data::Instance<RPI::Buffer> GetLightBuffer()const;
-            const Data::Instance<RPI::Buffer> GetLightPointBuffer()const;
-            uint32_t GetLightCount()const;
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override;
+            const Data::Instance<RPI::Buffer> GetLightPointBuffer() const override;
+            uint32_t GetLightCount() const override;
 
         private:
             PolygonLightFeatureProcessor(const PolygonLightFeatureProcessor&) = delete;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/QuadLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/QuadLightFeatureProcessor.h
@@ -55,8 +55,8 @@ namespace AZ
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
             void SetQuadData(LightHandle handle, const QuadLightData& data) override;
 
-            const Data::Instance<RPI::Buffer> GetLightBuffer()const;
-            uint32_t GetLightCount()const;
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override;
+            uint32_t GetLightCount() const override;
 
         private:
             QuadLightFeatureProcessor(const QuadLightFeatureProcessor&) = delete;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.h
@@ -65,8 +65,8 @@ namespace AZ
             void SetAffectsGIFactor(LightHandle handle, float affectsGIFactor) override;
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
 
-            const Data::Instance<RPI::Buffer> GetLightBuffer() const;
-            uint32_t GetLightCount()const;
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override;
+            uint32_t GetLightCount() const override;
 
             // SceneNotificationBus::Handler overrides...
             void OnRenderPipelinePersistentViewChanged(

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
@@ -83,8 +83,8 @@ namespace AZ
             void SetUseCachedShadows(LightHandle handle, bool useCachedShadows) override;
             void SetGoboTexture(LightHandle handle, AZ::Data::Instance<AZ::RPI::Image> goboTexture) override;
 
-            const Data::Instance<RPI::Buffer>  GetLightBuffer() const;
-            uint32_t GetLightCount()const;
+            const Data::Instance<RPI::Buffer> GetLightBuffer() const override;
+            uint32_t GetLightCount() const override;
 
             // SceneNotificationBus::Handler overrides...
             void OnRenderPipelinePersistentViewChanged(

--- a/Gems/Atom/Feature/Common/Code/Source/ImageBasedLights/ImageBasedLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImageBasedLights/ImageBasedLightFeatureProcessor.h
@@ -40,16 +40,16 @@ namespace AZ
             void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
 
             void SetSpecularImage(const Data::Asset<RPI::StreamingImageAsset>& imageAsset) override;
-            const Data::Instance<RPI::Image>& GetSpecularImage() const { return m_specular; }
+            const Data::Instance<RPI::Image>& GetSpecularImage() const override { return m_specular; }
 
             void SetDiffuseImage(const Data::Asset<RPI::StreamingImageAsset>& imageAsset) override;
-            const Data::Instance<RPI::Image>& GetDiffuseImage() const { return m_diffuse; }
+            const Data::Instance<RPI::Image>& GetDiffuseImage() const override { return m_diffuse; }
 
             void SetExposure(float exposure) override;
-            float GetExposure() const { return m_exposure; }
+            float GetExposure() const override { return m_exposure; }
 
             void SetOrientation(const Quaternion& orientation) override;
-            const Quaternion& GetOrientation() const { return m_orientation; }
+            const Quaternion& GetOrientation() const override { return m_orientation; }
 
             void Reset() override;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -95,6 +95,11 @@ namespace AZ
         static AZ::Name s_transparent_Name = AZ::Name::FromStringLiteral("transparent", AZ::Interface<AZ::NameDictionary>::Get());
         static AZ::Name s_block_silhouette_Name = AZ::Name::FromStringLiteral("silhouette.blockSilhouette", AZ::Interface<AZ::NameDictionary>::Get());
 
+        static ModelDataInstance& ToModelDataInstance(const MeshFeatureProcessorInterface::MeshHandle& meshHandle)
+        {
+            return *azrtti_cast<ModelDataInstance*>(&*meshHandle);
+        }
+
         static void CacheRootConstantInterval(MeshInstanceGroupData& meshInstanceGroupData)
         {
             meshInstanceGroupData.m_drawRootConstantOffset = 0;
@@ -202,7 +207,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->m_objectId;
+                return ToModelDataInstance(meshHandle).m_objectId;
             }
 
             return TransformServiceFeatureProcessorInterface::ObjectId::Null;
@@ -626,7 +631,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->SetLightingChannelMask(lightingChannelMask);
+                ToModelDataInstance(meshHandle).SetLightingChannelMask(lightingChannelMask);
             }
         }
 
@@ -996,7 +1001,7 @@ namespace AZ
 
             // don't need to check the concurrency during emplace() because the StableDynamicArray won't move the other elements during
             // insertion
-            MeshHandle meshDataHandle = m_modelData.emplace();
+            StableDynamicArrayHandle<ModelDataInstance> meshDataHandle = m_modelData.emplace();
 
             meshDataHandle->m_descriptor = descriptor;
             meshDataHandle->m_descriptor.m_modelChangedEventHandler.Connect(meshDataHandle->m_modelChangedEvent);
@@ -1022,12 +1027,13 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_meshLoader.reset();
-                meshHandle->DeInit(this);
-                m_transformService->ReleaseObjectId(meshHandle->m_objectId);
+                auto converted = StableDynamicArrayHandle<ModelDataInstance>(std::move(meshHandle));
+                converted->m_meshLoader.reset();
+                converted->DeInit(this);
+                m_transformService->ReleaseObjectId(converted->m_objectId);
 
                 AZStd::concurrency_check_scope scopeCheck(m_meshDataChecker);
-                m_modelData.erase(meshHandle);
+                m_modelData.erase(converted);
 
                 return true;
             }
@@ -1036,7 +1042,9 @@ namespace AZ
 
         void MeshFeatureProcessor::SetDrawItemEnabled(const MeshHandle& meshHandle, RHI::DrawListTag drawListTag, bool enabled)
         {
-            AZ::RPI::MeshDrawPacketLods& drawPacketListByLod = meshHandle.IsValid() && !r_meshInstancingEnabled ? meshHandle->m_meshDrawPacketListsByLod : m_emptyDrawPacketLods;
+            AZ::RPI::MeshDrawPacketLods& drawPacketListByLod = meshHandle.IsValid() && !r_meshInstancingEnabled
+                ? ToModelDataInstance(meshHandle).m_meshDrawPacketListsByLod
+                : m_emptyDrawPacketLods;
 
             for (AZ::RPI::MeshDrawPacketList& drawPacketList : drawPacketListByLod)
             {
@@ -1065,7 +1073,9 @@ namespace AZ
         {
             AZStd::string stringOutput = "\n------- MESH INFO -------\n";
 
-            AZ::RPI::MeshDrawPacketLods& drawPacketListByLod = meshHandle.IsValid() && !r_meshInstancingEnabled ? meshHandle->m_meshDrawPacketListsByLod : m_emptyDrawPacketLods;
+            AZ::RPI::MeshDrawPacketLods& drawPacketListByLod = meshHandle.IsValid() && !r_meshInstancingEnabled
+                ? ToModelDataInstance(meshHandle).m_meshDrawPacketListsByLod
+                : m_emptyDrawPacketLods;
 
             u32 lodCounter = 0;
             for (AZ::RPI::MeshDrawPacketList& drawPacketList : drawPacketListByLod)
@@ -1100,21 +1110,21 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return AcquireMesh(meshHandle->m_descriptor);
+                return AcquireMesh(ToModelDataInstance(meshHandle).m_descriptor);
             }
             return MeshFeatureProcessor::MeshHandle();
         }
 
         Data::Instance<RPI::Model> MeshFeatureProcessor::GetModel(const MeshHandle& meshHandle) const
         {
-            return meshHandle.IsValid() ? meshHandle->m_model : nullptr;
+            return meshHandle.IsValid() ? ToModelDataInstance(meshHandle).m_model : nullptr;
         }
 
         Data::Asset<RPI::ModelAsset> MeshFeatureProcessor::GetModelAsset(const MeshHandle& meshHandle) const
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->m_originalModelAsset;
+                return ToModelDataInstance(meshHandle).m_originalModelAsset;
             }
 
             return {};
@@ -1126,20 +1136,21 @@ namespace AZ
             // debug information about the draw packets in an imgui menu. But the ownership model for draw packets is changing.
             // We can no longer assume a meshHandle directly keeps a copy of all of its draw packets.
 
-            return meshHandle.IsValid() && !r_meshInstancingEnabled ? meshHandle->m_meshDrawPacketListsByLod : m_emptyDrawPacketLods;
+            return meshHandle.IsValid() && !r_meshInstancingEnabled ? ToModelDataInstance(meshHandle).m_meshDrawPacketListsByLod
+                                                                    : m_emptyDrawPacketLods;
         }
 
         const AZStd::vector<Data::Instance<RPI::ShaderResourceGroup>>& MeshFeatureProcessor::GetObjectSrgs(const MeshHandle& meshHandle) const
         {
             static AZStd::vector<Data::Instance<RPI::ShaderResourceGroup>> staticEmptyList;
-            return meshHandle.IsValid() ? meshHandle->m_objectSrgList : staticEmptyList;
+            return meshHandle.IsValid() ? ToModelDataInstance(meshHandle).m_objectSrgList : staticEmptyList;
         }
 
         void MeshFeatureProcessor::QueueObjectSrgForCompile(const MeshHandle& meshHandle) const
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_flags.m_objectSrgNeedsUpdate = true;
+                ToModelDataInstance(meshHandle).m_flags.m_objectSrgNeedsUpdate = true;
             }
         }
 
@@ -1154,26 +1165,27 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_descriptor.m_customMaterials = materials;
-                if (meshHandle->m_model)
+                auto& modelData = ToModelDataInstance(meshHandle);
+                modelData.m_descriptor.m_customMaterials = materials;
+                if (modelData.m_model)
                 {
-                    meshHandle->ReInit(this);
+                    modelData.ReInit(this);
                 }
 
-                meshHandle->m_flags.m_objectSrgNeedsUpdate = true;
+                modelData.m_flags.m_objectSrgNeedsUpdate = true;
             }
         }
 
         const CustomMaterialMap& MeshFeatureProcessor::GetCustomMaterials(const MeshHandle& meshHandle) const
         {
-            return meshHandle.IsValid() ? meshHandle->m_descriptor.m_customMaterials : DefaultCustomMaterialMap;
+            return meshHandle.IsValid() ? ToModelDataInstance(meshHandle).m_descriptor.m_customMaterials : DefaultCustomMaterialMap;
         }
 
         void MeshFeatureProcessor::SetTransform(const MeshHandle& meshHandle, const AZ::Transform& transform, const AZ::Vector3& nonUniformScale)
         {
             if (meshHandle.IsValid())
             {
-                ModelDataInstance& modelData = *meshHandle;
+                auto& modelData = ToModelDataInstance(meshHandle);
                 modelData.m_flags.m_cullBoundsNeedsUpdate = true;
                 modelData.m_flags.m_objectSrgNeedsUpdate = true;
                 modelData.m_cullable.m_flags = modelData.m_cullable.m_flags | m_meshMovedFlag.GetIndex();
@@ -1203,12 +1215,12 @@ namespace AZ
                     }
                 }
 
-                m_transformService->SetTransformForId(meshHandle->m_objectId, transform, nonUniformScale);
+                m_transformService->SetTransformForId(modelData.m_objectId, transform, nonUniformScale);
 
                 // ray tracing data needs to be updated with the new transform
                 if (m_rayTracingFeatureProcessor)
                 {
-                    m_rayTracingFeatureProcessor->SetMeshTransform(meshHandle->m_rayTracingUuid, transform, nonUniformScale);
+                    m_rayTracingFeatureProcessor->SetMeshTransform(modelData.m_rayTracingUuid, transform, nonUniformScale);
                 }
             }
         }
@@ -1217,7 +1229,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                ModelDataInstance& modelData = *meshHandle;
+                ModelDataInstance& modelData = ToModelDataInstance(meshHandle);
                 modelData.m_aabb = localAabb;
                 modelData.m_flags.m_cullBoundsNeedsUpdate = true;
                 modelData.m_flags.m_objectSrgNeedsUpdate = true;
@@ -1228,7 +1240,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->m_aabb;
+                return ToModelDataInstance(meshHandle).m_aabb;
             }
             else
             {
@@ -1241,7 +1253,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return m_transformService->GetTransformForId(meshHandle->m_objectId);
+                return m_transformService->GetTransformForId(ToModelDataInstance(meshHandle).m_objectId);
             }
             else
             {
@@ -1254,7 +1266,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return m_transformService->GetNonUniformScaleForId(meshHandle->m_objectId);
+                return m_transformService->GetNonUniformScaleForId(ToModelDataInstance(meshHandle).m_objectId);
             }
             else
             {
@@ -1267,7 +1279,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->SetSortKey(this, sortKey);
+                ToModelDataInstance(meshHandle).SetSortKey(this, sortKey);
             }
         }
 
@@ -1275,7 +1287,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->GetSortKey();
+                return ToModelDataInstance(meshHandle).GetSortKey();
             }
             else
             {
@@ -1293,7 +1305,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->SetMeshLodConfiguration(meshLodConfig);
+                ToModelDataInstance(meshHandle).SetMeshLodConfiguration(meshLodConfig);
             }
         }
 
@@ -1301,7 +1313,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->GetMeshLodConfiguration();
+                return ToModelDataInstance(meshHandle).GetMeshLodConfiguration();
             }
             else
             {
@@ -1314,7 +1326,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_flags.m_isAlwaysDynamic = isAlwaysDynamic;
+                ToModelDataInstance(meshHandle).m_flags.m_isAlwaysDynamic = isAlwaysDynamic;
             }
         }
 
@@ -1325,21 +1337,22 @@ namespace AZ
                 AZ_Assert(false, "Invalid mesh handle");
                 return false;
             }
-            return meshHandle->m_flags.m_isAlwaysDynamic;
+            return ToModelDataInstance(meshHandle).m_flags.m_isAlwaysDynamic;
         }
 
         void MeshFeatureProcessor::SetExcludeFromReflectionCubeMaps(const MeshHandle& meshHandle, bool excludeFromReflectionCubeMaps)
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_descriptor.m_excludeFromReflectionCubeMaps = excludeFromReflectionCubeMaps;
+                auto& modelData = ToModelDataInstance(meshHandle);
+                modelData.m_descriptor.m_excludeFromReflectionCubeMaps = excludeFromReflectionCubeMaps;
                 if (excludeFromReflectionCubeMaps)
                 {
-                    meshHandle->m_cullable.m_cullData.m_hideFlags |= RPI::View::UsageReflectiveCubeMap;
+                    modelData.m_cullable.m_cullData.m_hideFlags |= RPI::View::UsageReflectiveCubeMap;
                 }
                 else
                 {
-                    meshHandle->m_cullable.m_cullData.m_hideFlags &= ~RPI::View::UsageReflectiveCubeMap;
+                    modelData.m_cullable.m_cullData.m_hideFlags &= ~RPI::View::UsageReflectiveCubeMap;
                 }
             }
         }
@@ -1348,7 +1361,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->m_descriptor.m_excludeFromReflectionCubeMaps;
+                return ToModelDataInstance(meshHandle).m_descriptor.m_excludeFromReflectionCubeMaps;
             }
             return false;
         }
@@ -1357,23 +1370,24 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
+                auto& modelData = ToModelDataInstance(meshHandle);
                 // update the ray tracing data based on the current state and the new state
-                if (enabled && !meshHandle->m_descriptor.m_isRayTracingEnabled)
+                if (enabled && !modelData.m_descriptor.m_isRayTracingEnabled)
                 {
                     // add to ray tracing
-                    meshHandle->m_flags.m_needsSetRayTracingData = true;
+                    modelData.m_flags.m_needsSetRayTracingData = true;
                 }
-                else if (!enabled && meshHandle->m_descriptor.m_isRayTracingEnabled)
+                else if (!enabled && modelData.m_descriptor.m_isRayTracingEnabled)
                 {
                     // remove from ray tracing
                     if (m_rayTracingFeatureProcessor)
                     {
-                        m_rayTracingFeatureProcessor->RemoveMesh(meshHandle->m_rayTracingUuid);
+                        m_rayTracingFeatureProcessor->RemoveMesh(modelData.m_rayTracingUuid);
                     }
                 }
 
                 // set new state
-                meshHandle->m_descriptor.m_isRayTracingEnabled = enabled;
+                modelData.m_descriptor.m_isRayTracingEnabled = enabled;
             }
         }
 
@@ -1381,7 +1395,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->m_descriptor.m_isRayTracingEnabled;
+                return ToModelDataInstance(meshHandle).m_descriptor.m_isRayTracingEnabled;
             }
             else
             {
@@ -1394,7 +1408,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                return meshHandle->m_flags.m_visible;
+                return ToModelDataInstance(meshHandle).m_flags.m_visible;
             }
             return false;
         }
@@ -1403,17 +1417,18 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->SetVisible(visible);
+                auto& modelData = ToModelDataInstance(meshHandle);
+                modelData.SetVisible(visible);
 
-                if (m_rayTracingFeatureProcessor && meshHandle->m_descriptor.m_isRayTracingEnabled)
+                if (m_rayTracingFeatureProcessor && modelData.m_descriptor.m_isRayTracingEnabled)
                 {
                     // always remove from ray tracing first
-                    m_rayTracingFeatureProcessor->RemoveMesh(meshHandle->m_rayTracingUuid);
+                    m_rayTracingFeatureProcessor->RemoveMesh(modelData.m_rayTracingUuid);
 
                     // now add if it's visible
                     if (visible)
                     {
-                        meshHandle->m_flags.m_needsSetRayTracingData = true;
+                        modelData.m_flags.m_needsSetRayTracingData = true;
                     }
                 }
             }
@@ -1423,15 +1438,16 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_descriptor.m_useForwardPassIblSpecular = useForwardPassIblSpecular;
-                meshHandle->m_flags.m_objectSrgNeedsUpdate = true;
+                auto& modelData = ToModelDataInstance(meshHandle);
+                modelData.m_descriptor.m_useForwardPassIblSpecular = useForwardPassIblSpecular;
+                modelData.m_flags.m_objectSrgNeedsUpdate = true;
 
-                if (meshHandle->m_model)
+                if (modelData.m_model)
                 {
-                    const size_t modelLodCount = meshHandle->m_model->GetLodCount();
+                    const size_t modelLodCount = modelData.m_model->GetLodCount();
                     for (size_t modelLodIndex = 0; modelLodIndex < modelLodCount; ++modelLodIndex)
                     {
-                        meshHandle->BuildDrawPacketList(this, modelLodIndex);
+                        modelData.BuildDrawPacketList(this, modelLodIndex);
                     }
                 }
             }
@@ -1441,7 +1457,7 @@ namespace AZ
         {
             if (meshHandle.IsValid())
             {
-                meshHandle->m_flags.m_needsSetRayTracingData = true;
+                ToModelDataInstance(meshHandle).m_flags.m_needsSetRayTracingData = true;
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
@@ -33,47 +33,43 @@ namespace AZ
         class MeshFeatureProcessor;
         class GpuBufferHandler;
 
-        class ModelDataInstance
+        class ModelDataInstance : ModelDataInstanceInterface
         {
             friend class MeshFeatureProcessor;
             friend class MeshLoader;
 
         public:
+            AZ_RTTI(AZ::Render::ModelDataInstance, "{AF38DCED-9692-4B88-8738-9710BA70F49C}", AZ::Render::ModelDataInstanceInterface);
             ModelDataInstance();
 
-            const Data::Instance<RPI::Model>& GetModel() { return m_model; }
-            const RPI::Cullable& GetCullable() { return m_cullable; }
+            const Data::Instance<RPI::Model>& GetModel() override
+            {
+                return m_model;
+            }
+            const RPI::Cullable& GetCullable() override
+            {
+                return m_cullable;
+            }
 
-            const uint32_t GetLightingChannelMask() { return m_lightingChannelMask; }
+            const uint32_t GetLightingChannelMask() override
+            {
+                return m_lightingChannelMask;
+            }
 
             using InstanceGroupHandle = StableDynamicArrayWeakHandle<MeshInstanceGroupData>;
 
-            //! PostCullingInstanceData represents the data the MeshFeatureProcessor needs after culling
-            //! in order to generate instanced draw calls
-            struct PostCullingInstanceData
-            {
-                InstanceGroupHandle m_instanceGroupHandle;
-                uint32_t m_instanceGroupPageIndex;
-                TransformServiceFeatureProcessorInterface::ObjectId m_objectId;
-            };
-
             using PostCullingInstanceDataList = AZStd::vector<PostCullingInstanceData>;
-            const bool IsSkinnedMesh() { return m_descriptor.m_isSkinnedMesh; }
-            const AZ::Uuid& GetRayTracingUuid() const { return m_rayTracingUuid; }
+            const bool IsSkinnedMesh() override
+            {
+                return m_descriptor.m_isSkinnedMesh;
+            }
+            const AZ::Uuid& GetRayTracingUuid() const override
+            {
+                return m_rayTracingUuid;
+            }
 
-            //! Internally called when a DrawPacket used by this ModelDataInstance was updated. 
             void HandleDrawPacketUpdate(RPI::MeshDrawPacket& meshDrawPacket);
-
-            //! Event that let's us know whenever one of the MeshDrawPackets has been updated.
-            //! This event can occur on multiple threads.
-            //! Provides the ModelDataInstance parent object that owns the MeshDrawPacket.
-            using MeshDrawPacketUpdatedEvent = Event<const ModelDataInstance&, const AZ::RPI::MeshDrawPacket&>;
-            //! Connects @handler to the MeshDrawPacketUpdatedEvent.
-            //! One of the most common reasons a MeshDrawPacket gets updated is
-            //! when a RenderPipeline is instantiated at runtime and it happens to contain
-            //! a RasterPass with a DrawListTag that matches one of the Shaders of one of the Materials in
-            //! a Mesh.
-            void ConnectMeshDrawPacketUpdatedHandler(MeshDrawPacketUpdatedEvent::Handler& handler);
+            void ConnectMeshDrawPacketUpdatedHandler(MeshDrawPacketUpdatedEvent::Handler& handler) override;
 
         private:
             class MeshLoader

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -192,8 +192,7 @@ namespace AZ
                     renderProxy.m_instance->m_model->WaitForUpload();
                 }
 
-                ModelDataInstance& modelDataInstance = **renderProxy.m_meshHandle;
-                const RPI::Cullable& cullable = modelDataInstance.GetCullable();
+                const RPI::Cullable& cullable = (*renderProxy.m_meshHandle)->GetCullable();
 
                 for (const RPI::ViewPtr& viewPtr : packet.m_views)
                 {


### PR DESCRIPTION
## What does this PR do?

Exposes more functions to various feature processor interfaces.

- `GetLightBuffer`, `GetLightCount` in all light feature processors
-  `GetSpecularImage`, `GetDiffuseImage`, `GetExposure`, `GetOrientation` in the image based light feature processor
- Added a `ModelDataInstanceInterface` in the mesh feature processor. This one needs a bit more changes, as the `MeshHandle` needs to be cast to the implementation of `ModelDataInstance` when it is used.

## How was this PR tested?

On Windows with the MainPipeline and a custom one that relies on these functions
