### PR TITLE
Fix: add if check to remove left project buttons when projects.isEmpty()

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -253,6 +253,11 @@ namespace O3DE::ProjectManager
     {
         PythonBindingsInterface::Get()->RemoveInvalidProjects();
 
+        if(projects.isEmpty() && !m_projectButtons.empty())
+        {
+            RemoveProjectButtonsFromFlowLayout(projects);
+        }
+
         if (!projects.isEmpty())
         {
             // Remove all existing buttons before adding them back in the correct order


### PR DESCRIPTION
## What does this PR do?

This PR aims to fix a bug with projects not been removed from the UI when they are deleted (when just 1 project is left)

### Old behaviour

This bug is is described [here](https://github.com/o3de/o3de/issues/18452#issue-2645272932) but essentially if only 1 project was left and the user deleted it. It 
1.  Was removed from the users files
2. but remained visible in the UI until the project manager was restarted or refreshed

### New behaviour

Now if just 1 project remains and the user deletes it, it is removed from the UI as expected.


https://github.com/user-attachments/assets/6fdc606f-54da-4680-aa95-bf3d4b443fe2


## How was this PR tested?

Tested locally (manually) in a profile build
OS: Debian 12 (bookworm)

