### PR TITLE
Bugfix for the device index of root pass.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -604,6 +604,7 @@ namespace AZ
                 Ptr<ParentPass> newRoot = azrtti_cast<ParentPass*>(m_passTree.m_rootPass->Recreate().get());
                 newRoot->SetRenderPipeline(this);
                 newRoot->m_flags.m_isPipelineRoot = true;
+                newRoot->SetDeviceIndex(m_passTree.m_rootPass->GetDeviceIndex());
                 newRoot->ManualPipelineBuildAndInitialize();
 
                 // Validate the new root


### PR DESCRIPTION
This is necessary for the BRDFTexturePipeline to run on all devices when the root pass gets recreated.
