### PR TITLE
View: Expose matrices with offsets applied

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -136,8 +136,8 @@ namespace AZ
             const AZ::Matrix4x4& GetClipToViewMatrix() const;
 
             //! Functions for getting the matrices that are used in the view srg
-            //! These are different from the matrices returned above if a clip space offset is applied
-            //! They updated in the UpdateSrg function
+            //! These are different from the matrices returned above as they take clip space offset into account
+            //! They are updated in the UpdateSrg function
             //! Calling these functions before UpdateSrg will return the last frames values
             const Matrix4x4& GetWorldToClipPrevMatrixWithOffset() const;
             const Matrix4x4& GetWorldToClipMatrixWithOffset() const;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -133,6 +133,17 @@ namespace AZ
             const AZ::Matrix4x4& GetWorldToClipMatrix() const;
             const AZ::Matrix4x4* GetWorldToClipExcludeMatrix() const;
             const AZ::Matrix4x4& GetClipToWorldMatrix() const;
+            const AZ::Matrix4x4& GetClipToViewMatrix() const;
+
+            //! Functions for getting the matrices that are used in the view srg
+            //! These are different from the matrices returned above if a clip space offset is applied
+            //! They updated in the UpdateSrg function
+            //! Calling these functions before UpdateSrg will return the last frames values
+            const Matrix4x4& GetWorldToClipPrevMatrixWithOffset() const;
+            const Matrix4x4& GetWorldToClipMatrixWithOffset() const;
+            const Matrix4x4& GetViewToClipMatrixWithOffset() const;
+            const Matrix4x4& GetClipToWorldMatrixWithOffset() const;
+            const Matrix4x4& GetClipToViewMatrixWithOffset() const;
 
             AZ::Matrix3x4 GetWorldToViewMatrixAsMatrix3x4() const;
             AZ::Matrix3x4 GetViewToWorldMatrixAsMatrix3x4() const;
@@ -240,6 +251,12 @@ namespace AZ
             Matrix4x4 m_clipToViewMatrix;
             Matrix4x4 m_clipToWorldMatrix;
             AZStd::optional<Matrix4x4> m_worldToClipExcludeMatrix;
+
+            Matrix4x4 m_worldToClipPrevMatrixWithOffset;
+            Matrix4x4 m_worldToClipMatrixWithOffset;
+            Matrix4x4 m_viewToClipMatrixWithOffset;
+            Matrix4x4 m_clipToWorldMatrixWithOffset;
+            Matrix4x4 m_clipToViewMatrixWithOffset;
 
             // Cached View transform from ViewToWorld matrix 
             AZ::Transform m_viewTransform;


### PR DESCRIPTION
## What does this PR do?

Added functions to the view that return the matrices with the clip space offset applied.

## How was this PR tested?

Tested with the MainPipeline and a custom pipeline that needs the clipToView matrix in a separate buffer
