### PR TITLE
Upgrade google test

### DIFF
--- a/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
+++ b/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
@@ -311,7 +311,7 @@ namespace UnitTest
         HaltCollaborators();
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All, ModularViewportCameraControllerDeltaTimeParamFixture, testing::Values(1.0f / 60.0f, 1.0f / 50.0f, 1.0f / 30.0f));
 
     TEST_F(ModularViewportCameraControllerFixture, MouseMovementOrientatesCameraWhenCursorIsCaptured)

--- a/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
+++ b/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
@@ -297,7 +297,7 @@ namespace UnitTest
 
         // When
         RepeatDiagonalMouseMovements(
-            [this]
+            []
             {
                 return GetParam();
             });

--- a/Code/Framework/AzCore/Tests/AZStd/Any.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Any.cpp
@@ -78,7 +78,7 @@ namespace UnitTest
         }
     };
     using AnySizedTestTypes = ::testing::Types<Small0, Large0, Align0>;
-    TYPED_TEST_CASE(AnySizedTest, AnySizedTestTypes);
+    TYPED_TEST_SUITE(AnySizedTest, AnySizedTestTypes);
 
     // Fixture for tests with 2 types (for converting between types)
     template <typename StructPair>
@@ -108,7 +108,7 @@ namespace UnitTest
         AZStd::pair<Align0, Small0>, // Align -> Small
         AZStd::pair<Align0, Large0>  // Align -> Large
     >;
-    TYPED_TEST_CASE(AnyConversionTest, AnyConversionTestTypes);
+    TYPED_TEST_SUITE(AnyConversionTest, AnyConversionTestTypes);
 
     //////////////////////////////////////////////////////////////////////////
     // Tests for constructors

--- a/Code/Framework/AzCore/Tests/AZStd/Atomics.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Atomics.cpp
@@ -135,9 +135,9 @@ namespace UnitTest
     template <class T>
     struct AtomicOpsPointer : public Atomics {};
 
-    TYPED_TEST_CASE(AtomicOps, AllAtomicTypes);
-    TYPED_TEST_CASE(AtomicOpsIntegral, IntegralAtomicTypes);
-    TYPED_TEST_CASE(AtomicOpsPointer, PointerAtomicTypes);
+    TYPED_TEST_SUITE(AtomicOps, AllAtomicTypes);
+    TYPED_TEST_SUITE(AtomicOpsIntegral, IntegralAtomicTypes);
+    TYPED_TEST_SUITE(AtomicOpsPointer, PointerAtomicTypes);
 
     TYPED_TEST(AtomicOps, CompareExchangeStrong)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/Bitset.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Bitset.cpp
@@ -336,11 +336,11 @@ namespace UnitTest
         return bitset1.to_string() + 'x' + bitset2.to_string();
     }
 
-    INSTANTIATE_TEST_CASE_P(Bitset, BitsetUnsignedLongTests, ::testing::ValuesIn(GenerateBitsetUnsignedLongTestCases()), GenerateBitsetUnsignedLongTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(Bitset, BitsetUnsignedLongTests, ::testing::ValuesIn(GenerateBitsetUnsignedLongTestCases()), GenerateBitsetUnsignedLongTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(Bitset, BitsetUnsignedLongPairTests, ::testing::ValuesIn(GenerateBitsetUnsignedLongPairTestCases()), GenerateBitsetUnsignedLongPairTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(Bitset, BitsetUnsignedLongPairTests, ::testing::ValuesIn(GenerateBitsetUnsignedLongPairTestCases()), GenerateBitsetUnsignedLongPairTestCaseName);
 
-    INSTANTIATE_TEST_CASE_P(Bitset, BitsetStdComparisonTests, ::testing::ValuesIn(GenerateBitsetUnsignedLongTestCases()), GenerateBitsetUnsignedLongTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(Bitset, BitsetStdComparisonTests, ::testing::ValuesIn(GenerateBitsetUnsignedLongTestCases()), GenerateBitsetUnsignedLongTestCaseName);
 
     class BitsetTests
         : public LeakDetectionFixture

--- a/Code/Framework/AzCore/Tests/AZStd/ChronoTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/ChronoTests.cpp
@@ -52,7 +52,7 @@ namespace UnitTest
         DurationExpectation<AZStd::chrono::seconds, 44, AZStd::ratio<1>>,
         DurationExpectation<AZStd::chrono::minutes, 28, AZStd::ratio<60>>,
         DurationExpectation<AZStd::chrono::hours, 22, AZStd::ratio<3600>>>;
-    TYPED_TEST_CASE(DurationTypedTest, ChronoTestTypes);
+    TYPED_TEST_SUITE(DurationTypedTest, ChronoTestTypes);
 
     //////////////////////////////////////////////////////////////////////////
     // Tests for std::duration  compile time requirements

--- a/Code/Framework/AzCore/Tests/AZStd/ConcurrentAllocators.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/ConcurrentAllocators.cpp
@@ -38,7 +38,7 @@ namespace UnitTest
     using AllocatorTypes = ::testing::Types<
         AZStd::static_pool_concurrent_allocator<NodeType, s_allocatorCapacity>
     >;
-    TYPED_TEST_CASE(ConcurrentAllocatorTestFixture, AllocatorTypes);
+    TYPED_TEST_SUITE(ConcurrentAllocatorTestFixture, AllocatorTypes);
 
     TYPED_TEST(ConcurrentAllocatorTestFixture, Name)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/FunctorsBind.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/FunctorsBind.cpp
@@ -1028,7 +1028,7 @@ namespace UnitTest
         FunctionTestInternal::Functor<1>,
         FunctionTestInternal::Functor<sizeof(AZStd::Internal::function_util::function_buffer) + 8>
     >;
-    TYPED_TEST_CASE(FunctionFunctorTestFixture, FunctionFunctorTypes);
+    TYPED_TEST_SUITE(FunctionFunctorTestFixture, FunctionFunctorTypes);
 
 
 

--- a/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
@@ -1234,7 +1234,7 @@ namespace UnitTest
         , HashedSetConfig<AZStd::unordered_set<MoveOnlyIntType, MoveOnlyIntTypeHasher>>
         , HashedSetConfig<AZStd::unordered_multiset<MoveOnlyIntType, MoveOnlyIntTypeHasher>>
     >;
-    TYPED_TEST_CASE(HashedSetContainers, SetContainerConfigs);
+    TYPED_TEST_SUITE(HashedSetContainers, SetContainerConfigs);
 
     TYPED_TEST(HashedSetContainers, ExtractNodeHandleByKeySucceeds)
     {
@@ -1416,7 +1416,7 @@ namespace UnitTest
         HashedSetWithCustomAllocatorConfig<AZStd::unordered_set>
         , HashedSetWithCustomAllocatorConfig<AZStd::unordered_multiset>
     >;
-    TYPED_TEST_CASE(HashedSetDifferentAllocatorFixture, SetTemplateConfigs);
+    TYPED_TEST_SUITE(HashedSetDifferentAllocatorFixture, SetTemplateConfigs);
 
 #if GTEST_HAS_DEATH_TEST
 #if AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
@@ -1477,7 +1477,7 @@ namespace UnitTest
         , HashedMapConfig<AZStd::unordered_map<MoveOnlyIntType, int32_t, MoveOnlyIntTypeHasher>>
         , HashedMapConfig<AZStd::unordered_multimap<MoveOnlyIntType, int32_t, MoveOnlyIntTypeHasher>>
     >;
-    TYPED_TEST_CASE(HashedMapContainers, MapContainerConfigs);
+    TYPED_TEST_SUITE(HashedMapContainers, MapContainerConfigs);
 
     TYPED_TEST(HashedMapContainers, ExtractNodeHandleByKeySucceeds)
     {
@@ -1916,7 +1916,7 @@ namespace UnitTest
         HashedMapWithCustomAllocatorConfig<AZStd::unordered_map>
         , HashedMapWithCustomAllocatorConfig<AZStd::unordered_multimap>
     >;
-    TYPED_TEST_CASE(HashedMapDifferentAllocatorFixture, MapTemplateConfigs);
+    TYPED_TEST_SUITE(HashedMapDifferentAllocatorFixture, MapTemplateConfigs);
 
 #if GTEST_HAS_DEATH_TEST
 #if AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
@@ -2050,7 +2050,7 @@ namespace UnitTest
         >
     >;
 
-    TYPED_TEST_CASE(HashedContainerTransparentFixture, HashedContainerConfigs);
+    TYPED_TEST_SUITE(HashedContainerTransparentFixture, HashedContainerConfigs);
 
     TYPED_TEST(HashedContainerTransparentFixture, FindDoesNotConstructKeyForTransparentHashEqual_NoKeyConstructed_Succeeds)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/Math.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Math.cpp
@@ -17,7 +17,7 @@ namespace UnitTest
     };
 
     using MathTestConfigs = ::testing::Types<float, double, long double>;
-    TYPED_TEST_CASE(StdMathTest, MathTestConfigs);
+    TYPED_TEST_SUITE(StdMathTest, MathTestConfigs);
 
     TYPED_TEST(StdMathTest, LerpOperations)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/Ordered.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Ordered.cpp
@@ -905,7 +905,7 @@ namespace UnitTest
         , TreeSetConfig<AZStd::set<MoveOnlyIntType, MoveOnlyIntTypeCompare>>
         , TreeSetConfig<AZStd::multiset<MoveOnlyIntType, MoveOnlyIntTypeCompare>>
     >;
-    TYPED_TEST_CASE(TreeSetContainers, SetContainerConfigs);
+    TYPED_TEST_SUITE(TreeSetContainers, SetContainerConfigs);
 
     TYPED_TEST(TreeSetContainers, ExtractNodeHandleByKeySucceeds)
     {
@@ -1162,7 +1162,7 @@ namespace UnitTest
         TreeSetWithCustomAllocatorConfig<AZStd::set>
         , TreeSetWithCustomAllocatorConfig<AZStd::multiset>
     >;
-    TYPED_TEST_CASE(TreeSetDifferentAllocatorFixture, SetTemplateConfigs);
+    TYPED_TEST_SUITE(TreeSetDifferentAllocatorFixture, SetTemplateConfigs);
 
 #if GTEST_HAS_DEATH_TEST
 #if AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
@@ -1243,7 +1243,7 @@ namespace UnitTest
         , TreeMapConfig<AZStd::map<MoveOnlyIntType, int32_t, MoveOnlyIntTypeCompare>>
         , TreeMapConfig<AZStd::multimap<MoveOnlyIntType, int32_t, MoveOnlyIntTypeCompare>>
     >;
-    TYPED_TEST_CASE(TreeMapContainers, MapContainerConfigs);
+    TYPED_TEST_SUITE(TreeMapContainers, MapContainerConfigs);
 
     TYPED_TEST(TreeMapContainers, ExtractNodeHandleByKeySucceeds)
     {
@@ -1643,7 +1643,7 @@ namespace UnitTest
         TreeMapWithCustomAllocatorConfig<AZStd::map>
         , TreeMapWithCustomAllocatorConfig<AZStd::multimap>
     >;
-    TYPED_TEST_CASE(TreeMapDifferentAllocatorFixture, MapTemplateConfigs);
+    TYPED_TEST_SUITE(TreeMapDifferentAllocatorFixture, MapTemplateConfigs);
 
 #if GTEST_HAS_DEATH_TEST
 #if AZ_TRAIT_DISABLE_FAILED_DEATH_TESTS
@@ -1773,7 +1773,7 @@ namespace UnitTest
         , TreeContainerTransparentConfig<AZStd::multimap<TreeContainerTransparentTestInternal::TrackConstructorCalls, int, AZStd::less<>>>
     >;
 
-    TYPED_TEST_CASE(TreeContainerTransparentFixture, TreeContainerConfigs);
+    TYPED_TEST_SUITE(TreeContainerTransparentFixture, TreeContainerConfigs);
 
     TYPED_TEST(TreeContainerTransparentFixture, FindDoesNotConstructKeyForTransparentHashEqual_NoKeyConstructed_Succeeds)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/Pair.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Pair.cpp
@@ -65,7 +65,7 @@ namespace UnitTest
         , CompressedPairTestConfig<int32_t, CompressedPairInternal::EmptyStruct, 4>
         , CompressedPairTestConfig<int32_t, int32_t, 8>
     >;
-    TYPED_TEST_CASE(CompressedPairTest, CompressedPairTestConfigs);
+    TYPED_TEST_SUITE(CompressedPairTest, CompressedPairTestConfigs);
 
     using CompressedPairSizeTestConfigs = ::testing::Types<
         CompressedPairTestConfig<CompressedPairInternal::EmptyStruct, CompressedPairInternal::FinalEmptyStruct, 1>
@@ -80,7 +80,7 @@ namespace UnitTest
         , CompressedPairTestConfig<CompressedPairInternal::DerivedWithDataFromEmptyStruct, CompressedPairInternal::DerivedWithDataFromEmptyStruct, 8>
         , CompressedPairTestConfig<int32_t, int32_t, 8>
     >;
-    TYPED_TEST_CASE(CompressedPairSizeTest, CompressedPairSizeTestConfigs);
+    TYPED_TEST_SUITE(CompressedPairSizeTest, CompressedPairSizeTestConfigs);
 
     TYPED_TEST(CompressedPairTest, CompressedPairDefaultConstructorSucceeds)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/String.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/String.cpp
@@ -1559,7 +1559,7 @@ namespace UnitTest
     {};
 
     using StringViewElementTypes = ::testing::Types<char, wchar_t>;
-    TYPED_TEST_CASE(BasicStringViewConstexprFixture, StringViewElementTypes);
+    TYPED_TEST_SUITE(BasicStringViewConstexprFixture, StringViewElementTypes);
     TYPED_TEST(BasicStringViewConstexprFixture, StringView_DefaultConstructorsIsConstexpr)
     {
         constexpr AZStd::basic_string_view<TypeParam> defaultView1;
@@ -2518,7 +2518,7 @@ namespace UnitTest
         : public LeakDetectionFixture
     {};
     using StringTypesToTest = ::testing::Types<AZStd::string_view, AZStd::string, AZStd::fixed_string<1024>>;
-    TYPED_TEST_CASE(ImmutableStringFunctionsFixture, StringTypesToTest);
+    TYPED_TEST_SUITE(ImmutableStringFunctionsFixture, StringTypesToTest);
 
     TYPED_TEST(ImmutableStringFunctionsFixture, Contains_Succeeds)
     {
@@ -2553,7 +2553,7 @@ namespace UnitTest
     };
 
     using StringFormatTypesToTest = ::testing::Types<AZStd::string>; //, AZStd::wstring>;
-    TYPED_TEST_CASE(StringFormatFixture, StringFormatTypesToTest);
+    TYPED_TEST_SUITE(StringFormatFixture, StringFormatTypesToTest);
 
     TYPED_TEST(StringFormatFixture, CanFormatStringLongerThan2048Chars)
     {
@@ -2568,7 +2568,7 @@ namespace UnitTest
     {};
 
     using StringTypeWithRangeFunctions = ::testing::Types<AZStd::string, AZStd::fixed_string<32>>;
-    TYPED_TEST_CASE(StringTypeFixture, StringTypeWithRangeFunctions);
+    TYPED_TEST_SUITE(StringTypeFixture, StringTypeWithRangeFunctions);
 
     TYPED_TEST(StringTypeFixture, RangeConstructor_Succeeds)
     {

--- a/Code/Framework/AzCore/Tests/AZStd/Tuple.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Tuple.cpp
@@ -65,7 +65,7 @@ namespace UnitTest
         AZStd::tuple<int, float, int>,
         AZStd::tuple<bool, bool, bool, bool>
     >;
-    TYPED_TEST_CASE(TupleTypedTest, TupleTestTypes);
+    TYPED_TEST_SUITE(TupleTypedTest, TupleTestTypes);
 
 
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzCore/Tests/AZStd/Variant.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Variant.cpp
@@ -37,7 +37,7 @@ namespace UnitTest
         , VariantSizeTestConfig<AZStd::variant<void*, const void*>, 2>
         , VariantSizeTestConfig<AZStd::variant<uint64_t, AZStd::string, uint64_t, double>, 4>
     >;
-    TYPED_TEST_CASE(VariantSizeTest, VariantSizeTestConfigs);
+    TYPED_TEST_SUITE(VariantSizeTest, VariantSizeTestConfigs);
 
     template<typename TestConfig>
     class VariantAlternativeTest
@@ -61,7 +61,7 @@ namespace UnitTest
         , VariantAlternativeTestConfig<Variant6AltType, 4, int32_t>
         , VariantAlternativeTestConfig<Variant6AltType, 5, uintptr_t>
     >;
-    TYPED_TEST_CASE(VariantAlternativeTest, VariantAlternativeTestConfigs);
+    TYPED_TEST_SUITE(VariantAlternativeTest, VariantAlternativeTestConfigs);
 
     namespace VariantTestInternal
     {

--- a/Code/Framework/AzCore/Tests/AZTestShared/Math/MathTestHelpers.cpp
+++ b/Code/Framework/AzCore/Tests/AZTestShared/Math/MathTestHelpers.cpp
@@ -19,6 +19,8 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Color.h>
 
+#include <iomanip>
+
 // make gtest/gmock aware of these types so when a failure occurs we get more useful output
 namespace AZ
 {

--- a/Code/Framework/AzCore/Tests/AssetJsonSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/AssetJsonSerializerTests.cpp
@@ -260,5 +260,5 @@ namespace JsonSerializationTests
     };
 
     using AssetConformityTestTypes = ::testing::Types<AssetSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(Asset, JsonSerializerConformityTests, AssetConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(Asset, JsonSerializerConformityTests, AssetConformityTestTypes));
 } // namespace JsonSerializationTests

--- a/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
+++ b/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
@@ -646,7 +646,7 @@ namespace ConsoleSettingsRegistryTests
             ]
         )";
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         ExecuteCommandFromSettingsFile,
         ConsoleSettingsRegistryFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/EBus.cpp
+++ b/Code/Framework/AzCore/Tests/EBus.cpp
@@ -553,14 +553,14 @@ namespace UnitTest
         AZStd::unordered_map<int, AZStd::vector<BusHandler*>> m_handlers;
         int m_numHandlers = 0;
     };
-    TYPED_TEST_CASE(EBusTestAll, BusTypesAll);
+    TYPED_TEST_SUITE(EBusTestAll, BusTypesAll);
 
     template <typename Bus>
     class EBusTestId
         : public EBusTestAll<Bus>
     {
     };
-    TYPED_TEST_CASE(EBusTestId, BusTypesId);
+    TYPED_TEST_SUITE(EBusTestId, BusTypesId);
 
     using BusTypesIdMultiHandlers = ::testing::Types<
         ManyToMany, ManyToManyOrdered,
@@ -570,7 +570,7 @@ namespace UnitTest
         : public EBusTestAll<Bus>
     {
     };
-    TYPED_TEST_CASE(EBusTestIdMultiHandlers, BusTypesIdMultiHandlers);
+    TYPED_TEST_SUITE(EBusTestIdMultiHandlers, BusTypesIdMultiHandlers);
 
     //////////////////////////////////////////////////////////////////////////
     // Non-event functions
@@ -4130,7 +4130,7 @@ namespace UnitTest
 
     using ThreadDispatchParamFixture = EBusParamFixture<ThreadDispatchParams>;
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         ThreadDispatch,
         ThreadDispatchParamFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/FixedWidthIntegers.cpp
+++ b/Code/Framework/AzCore/Tests/FixedWidthIntegers.cpp
@@ -445,7 +445,7 @@ namespace UnitTest
         AZ::s8, AZ::u8, AZ::s16, AZ::u16, AZ::s32, AZ::u32, AZ::s64, AZ::u64
     >;
 
-    TYPED_TEST_CASE(IntegralTypeTestFixture, IntegralTypeTestConfigs);
+    TYPED_TEST_SUITE(IntegralTypeTestFixture, IntegralTypeTestConfigs);
 
     ///////////////////////////////////////////////////////////////////////////
 

--- a/Code/Framework/AzCore/Tests/IO/FileReaderTests.cpp
+++ b/Code/Framework/AzCore/Tests/IO/FileReaderTests.cpp
@@ -35,7 +35,7 @@ namespace UnitTest
 
     using FileIOTypes = ::testing::Types<void, TestFileIOBase>;
 
-    TYPED_TEST_CASE(FileReaderTestFixture, FileIOTypes);
+    TYPED_TEST_SUITE(FileReaderTestFixture, FileIOTypes);
 
     TYPED_TEST(FileReaderTestFixture, ConstructorWithFilePath_OpensFileSuccessfully)
     {

--- a/Code/Framework/AzCore/Tests/IO/Path/PathReflectTests.cpp
+++ b/Code/Framework/AzCore/Tests/IO/Path/PathReflectTests.cpp
@@ -85,7 +85,7 @@ namespace UnitTest
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathSerialization,
         PathSerializationFixture,
         ::testing::Values(
@@ -216,7 +216,7 @@ namespace UnitTest
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathScripting,
         PathScriptingParamFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/IO/Path/PathTests.cpp
+++ b/Code/Framework/AzCore/Tests/IO/Path/PathTests.cpp
@@ -186,7 +186,7 @@ namespace UnitTest
         EXPECT_EQ(path2, pathView2);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         ComparePaths,
         PathParamFixture,
         ::testing::Values(
@@ -233,7 +233,7 @@ namespace UnitTest
         EXPECT_EQ(path1, path2);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         CompareWindowsPaths,
         WindowsPathCompareParamFixture,
         ::testing::Values(
@@ -282,7 +282,7 @@ namespace UnitTest
             path1.c_str(), path2.c_str()).c_str();
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         HashPaths,
         PathHashParamFixture,
         ::testing::Values(
@@ -318,7 +318,7 @@ AZ_PUSH_DISABLE_WARNING(4296, "-Wunknown-warning-option")
 AZ_POP_DISABLE_WARNING
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         HashPathCompareValidation,
         PathHashCompareFixture,
         ::testing::Values(
@@ -380,7 +380,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_TRUE(testPath.IsRelative());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         RelativePaths,
         WindowsPathRelativeParamFixture,
         ::testing::Values(
@@ -409,7 +409,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_TRUE(testPath.IsAbsolute());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AbsolutePaths,
         WindowsPathAbsoluteParamFixture,
         ::testing::Values(
@@ -438,7 +438,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_TRUE(testPath.IsRelative());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         RelativePaths,
         PosixPathRelativeParamFixture,
         ::testing::Values(
@@ -468,7 +468,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_TRUE(testPath.IsAbsolute());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AbsolutePaths,
         PosixPathAbsoluteParamFixture,
         ::testing::Values(
@@ -510,7 +510,7 @@ AZ_POP_DISABLE_WARNING
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AppendPaths,
         PathAppendTest,
         ::testing::Values(
@@ -541,7 +541,7 @@ AZ_POP_DISABLE_WARNING
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AppendPaths,
         WindowsPathAppendTest,
         ::testing::Values(
@@ -593,7 +593,7 @@ AZ_POP_DISABLE_WARNING
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AppendPaths,
         PosixPathAppendTest,
         ::testing::Values(
@@ -663,7 +663,7 @@ AZ_POP_DISABLE_WARNING
 
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathIterator,
         PathIteratorFixture,
         ::testing::Values(
@@ -720,7 +720,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_STREQ(testParams.m_expectedResult, resultPath.c_str());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathLexicallyNormal,
         PathLexicallyNormalFixture,
         ::testing::Values(
@@ -750,7 +750,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_STREQ(testParams.m_expectedResult, testPath.c_str());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathLexicallyRelative,
         PathLexicallyRelativeFixture,
         ::testing::Values(
@@ -790,7 +790,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_EQ(testParams.m_expectedIsRelativeTo, testPath.IsRelativeTo(AZ::IO::PathView{ testParams.m_testBasePath, testParams.m_preferredSeparator }));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathLexicallyProximate,
         PathViewLexicallyProximateFixture,
         ::testing::Values(
@@ -829,7 +829,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_EQ(testParams.m_expectedMatch, testPath.Match(testParams.m_testPattern));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathMatch,
         PathViewMatchFixture,
         ::testing::Values(
@@ -857,7 +857,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_STREQ(testParams.m_expectedResult, testPath.c_str());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathMakePreferred,
         PathMakePreferredFixture,
         ::testing::Values(
@@ -887,7 +887,7 @@ AZ_POP_DISABLE_WARNING
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         ReplaceFilenames,
         PathReplaceFilenameTest,
         ::testing::Values(
@@ -914,7 +914,7 @@ AZ_POP_DISABLE_WARNING
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         RemoveFilenames,
         PathRemoveFilenameTest,
         ::testing::Values(
@@ -939,7 +939,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_EQ(testParams.m_expectedResult, prefixIter == testPath.end());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathPrefix,
         PathPrefixFixture,
         ::testing::Values(
@@ -989,7 +989,7 @@ AZ_POP_DISABLE_WARNING
         EXPECT_EQ(AZ::IO::PathView(testParams.m_expectedExtension, testParams.m_preferredSeparator), testPath.Extension());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathExtractComponents,
         PathDecompositionFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/FrustumTests.cpp
@@ -653,7 +653,7 @@ namespace UnitTest
         return testCaseName;
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Frustum, Tests, ::testing::ValuesIn(GenerateFrustumIntersectionTestCases()),
         GenerateFrustumIntersectionTestCaseName);
 

--- a/Code/Framework/AzCore/Tests/Math/Geometry3DUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Geometry3DUtilsTests.cpp
@@ -33,5 +33,5 @@ namespace UnitTest
         EXPECT_NEAR(maxRadius, 1.0f, 1e-3f);
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Geometry3DUtilsTests, Geometry3DUtilsFixture, ::testing::Values(0u, 1u, 2u, 3u));
+    INSTANTIATE_TEST_SUITE_P(MATH_Geometry3DUtilsTests, Geometry3DUtilsFixture, ::testing::Values(0u, 1u, 2u, 3u));
 } // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/IntersectionTests.cpp
@@ -597,7 +597,7 @@ namespace UnitTest
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_IntersectSegmentTriangleTest, RayTriangleTests, ::testing::ValuesIn(RayTriangleTestParams));
+    INSTANTIATE_TEST_SUITE_P(MATH_IntersectSegmentTriangleTest, RayTriangleTests, ::testing::ValuesIn(RayTriangleTestParams));
 
     class MATH_IntersectRayCappedCylinderTest
         : public LeakDetectionFixture

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -47,7 +47,7 @@ namespace UnitTest
         EXPECT_THAT(matrix * vector, IsClose(vector + translation));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateFixture, ::testing::ValuesIn(MathTestData::Vector3s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4CreateFixture, ::testing::ValuesIn(MathTestData::Vector3s));
 
     TEST(MATH_Matrix3x4, CreateFromValue)
     {
@@ -172,7 +172,7 @@ namespace UnitTest
         EXPECT_NEAR(projectedDotProduct, projectedMagnitudeSq * cosf(angle), 1e-3f);
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateRotationFixture, ::testing::ValuesIn(MathTestData::Angles));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4CreateRotationFixture, ::testing::ValuesIn(MathTestData::Angles));
 
     TEST(MATH_Matrix3x4, CreateFromRows)
     {
@@ -368,7 +368,7 @@ namespace UnitTest
         EXPECT_THAT(matrix * vector, IsClose(quaternion.TransformVector(vector)));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateFromQuaternionFixture, ::testing::ValuesIn(MathTestData::UnitQuaternions));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4CreateFromQuaternionFixture, ::testing::ValuesIn(MathTestData::UnitQuaternions));
 
     using Matrix3x4CreateFromMatrix3x3Fixture = ::testing::TestWithParam<AZ::Matrix3x3>;
 
@@ -391,7 +391,7 @@ namespace UnitTest
         EXPECT_THAT(matrix3x4 * vector, IsClose(matrix3x3 * vector + translation));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateFromMatrix3x3Fixture, ::testing::ValuesIn(MathTestData::Matrix3x3s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4CreateFromMatrix3x3Fixture, ::testing::ValuesIn(MathTestData::Matrix3x3s));
 
     using Matrix3x4CreateFromMatrix4x4Fixture = ::testing::TestWithParam<AZ::Matrix4x4>;
 
@@ -406,7 +406,7 @@ namespace UnitTest
         EXPECT_THAT(matrix3x4.TransformPoint(point), IsClose((matrix4x4 * AZ::Vector4(point, 1.0f)).GetAsVector3()));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateFromMatrix4x4Fixture, ::testing::ValuesIn(MathTestData::Matrix4x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4CreateFromMatrix4x4Fixture, ::testing::ValuesIn(MathTestData::Matrix4x4s));
 
     TEST(MATH_Matrix3x4, TransformPoint)
     {
@@ -467,7 +467,7 @@ namespace UnitTest
         EXPECT_THAT(forward, IsClose(expectedForward.GetNormalized()));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4CreateLookAtFixture, ::testing::ValuesIn(MathTestData::Axes));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4CreateLookAtFixture, ::testing::ValuesIn(MathTestData::Axes));
 
     TEST(MATH_Matrix3x4, CreateLookAtDegenerateCases)
     {
@@ -702,7 +702,7 @@ namespace UnitTest
         EXPECT_THAT(transpose.GetColumn(2), IsClose(matrix.GetRowAsVector3(2)));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4TransposeFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4TransposeFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
 
     using Matrix3x4InvertFullFixture = ::testing::TestWithParam<AZ::Matrix3x4>;
 
@@ -727,7 +727,7 @@ namespace UnitTest
         EXPECT_THAT((inverse * matrix), IsClose(AZ::Matrix3x4::Identity()));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4InvertFullFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4InvertFullFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
 
     TEST(MATH_Matrix3x4, GetInverseFullSingularMatrix)
     {
@@ -782,7 +782,7 @@ namespace UnitTest
         EXPECT_THAT(inverseFast, IsClose(inverseFull));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4InvertFastFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4InvertFastFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
 
     using Matrix3x4ScaleFixture = ::testing::TestWithParam<AZ::Matrix3x4>;
 
@@ -829,7 +829,7 @@ namespace UnitTest
         EXPECT_THAT(scaledMatrix.GetReciprocalScaled(), IsClose(reciprocalScaledMatrix));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4ScaleFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4ScaleFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
 
     TEST(MATH_Matrix3x4, IsOrthogonal)
     {
@@ -944,7 +944,7 @@ namespace UnitTest
         EXPECT_THAT(matrix, IsClose(rotX * rotY * rotZ));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4SetFromEulerDegreesFixture, ::testing::ValuesIn(MathTestData::EulerAnglesDegrees));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4SetFromEulerDegreesFixture, ::testing::ValuesIn(MathTestData::EulerAnglesDegrees));
 
     using Matrix3x4SetFromEulerRadiansFixture = ::testing::TestWithParam<AZ::Vector3>;
 
@@ -959,7 +959,7 @@ namespace UnitTest
         EXPECT_THAT(matrix, IsClose(rotX * rotY * rotZ));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4SetFromEulerRadiansFixture, ::testing::ValuesIn(MathTestData::EulerAnglesRadians));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4SetFromEulerRadiansFixture, ::testing::ValuesIn(MathTestData::EulerAnglesRadians));
 
     using Matrix3x4GetEulerFixture = ::testing::TestWithParam<AZ::Matrix3x4>;
 
@@ -980,7 +980,7 @@ namespace UnitTest
         EXPECT_THAT(eulerMatrix, IsClose(matrix));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4GetEulerFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4GetEulerFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
 
     using Matrix3x4GetDeterminantFixture = ::testing::TestWithParam<AZ::Matrix3x4>;
 
@@ -990,7 +990,7 @@ namespace UnitTest
         EXPECT_NEAR(matrix.GetDeterminant3x3(), 1.0f, 1e-3f);
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Matrix3x4, Matrix3x4GetDeterminantFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Matrix3x4, Matrix3x4GetDeterminantFixture, ::testing::ValuesIn(MathTestData::OrthogonalMatrix3x4s));
 
     TEST(MATH_Matrix3x4, GetDeterminantOfArbitraryMatrices)
     {

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -360,7 +360,7 @@ namespace UnitTest
         EXPECT_TRUE(recoveredQuaternion1.IsClose(recoveredQuaternion2) || recoveredQuaternion1.IsClose(-recoveredQuaternion2));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Quaternion, QuaternionEulerFixture, ::testing::ValuesIn(TestUnitQuaternions));
+    INSTANTIATE_TEST_SUITE_P(MATH_Quaternion, QuaternionEulerFixture, ::testing::ValuesIn(TestUnitQuaternions));
 
     TEST(MATH_Quaternion, FromEulerDegrees)
     {
@@ -515,7 +515,7 @@ namespace UnitTest
         EXPECT_THAT(testQuat, IsCloseTolerance(backFromAxisAngle, 1e-6f));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Quaternion, QuaternionScaledAxisAngleConversionFixture, ::testing::ValuesIn(RotationRepresentationConversionTestQuats));
+    INSTANTIATE_TEST_SUITE_P(MATH_Quaternion, QuaternionScaledAxisAngleConversionFixture, ::testing::ValuesIn(RotationRepresentationConversionTestQuats));
 
     TEST(MATH_Quaternion, ShortestEquivalent)
     {
@@ -549,7 +549,7 @@ namespace UnitTest
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Quaternion,
         AngleRadianTestFixtureXYZ,
         ::testing::Values(
@@ -595,7 +595,7 @@ namespace UnitTest
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesYXZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Quaternion,
         AngleRadianTestFixtureYXZ,
         ::testing::Values(
@@ -642,7 +642,7 @@ namespace UnitTest
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesZYX(Vector3RadToDeg(param.euler)), IsClose(param.result));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Quaternion,
         AngleRadianTestFixtureZYX,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
@@ -201,7 +201,7 @@ namespace UnitTest
         EXPECT_THAT(matrix, IsClose(reconstructedMatrix));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformFromMatrixFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformFromMatrixFixture, ::testing::ValuesIn(MathTestData::NonOrthogonalMatrix3x4s));
 
     TEST(MATH_Transform, CreateLookAtDegenerateCases)
     {

--- a/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/TransformTests.cpp
@@ -41,7 +41,7 @@ namespace UnitTest
         EXPECT_THAT(transform.TransformPoint(vector), IsClose(vector + translation));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformCreateFixture, ::testing::ValuesIn(MathTestData::Vector3s));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformCreateFixture, ::testing::ValuesIn(MathTestData::Vector3s));
 
     using TransformCreateRotationFixture = ::testing::TestWithParam<float>;
 
@@ -108,7 +108,7 @@ namespace UnitTest
         EXPECT_NEAR(projectedDotProduct, projectedMagnitudeSq * cosf(angle), 1e-2f * projectedMagnitudeSq);
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformCreateRotationFixture, ::testing::ValuesIn(MathTestData::Angles));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformCreateRotationFixture, ::testing::ValuesIn(MathTestData::Angles));
 
     TEST(MATH_Transform, GetSetTranslation)
     {
@@ -153,7 +153,7 @@ namespace UnitTest
         EXPECT_THAT(transform.TransformPoint(vector), IsClose(quaternion.TransformVector(vector)));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformCreateFromQuaternionFixture, ::testing::ValuesIn(MathTestData::UnitQuaternions));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformCreateFromQuaternionFixture, ::testing::ValuesIn(MathTestData::UnitQuaternions));
 
     TEST(MATH_Transform, CreateUniformScale)
     {
@@ -184,7 +184,7 @@ namespace UnitTest
         EXPECT_THAT(forward, IsClose(expectedForward.GetNormalized()));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformCreateLookAtFixture, ::testing::ValuesIn(MathTestData::Axes));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformCreateLookAtFixture, ::testing::ValuesIn(MathTestData::Axes));
 
     using TransformFromMatrixFixture = ::testing::TestWithParam<AZ::Matrix3x4>;
 
@@ -320,7 +320,7 @@ namespace UnitTest
         EXPECT_THAT((inverse * transform), IsClose(AZ::Transform::Identity()));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformInvertFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformInvertFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));
 
     using TransformScaleFixture = ::testing::TestWithParam<AZ::Transform>;
 
@@ -337,7 +337,7 @@ namespace UnitTest
         EXPECT_NEAR(scaledTransform.GetUniformScale(), scale, AZ::Constants::Tolerance);
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformScaleFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformScaleFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));
 
     TEST(MATH_Transform, IsOrthogonal)
     {
@@ -366,7 +366,7 @@ namespace UnitTest
         EXPECT_THAT(transform, IsClose(rotX * rotY * rotZ));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformSetFromEulerDegreesFixture, ::testing::ValuesIn(MathTestData::EulerAnglesDegrees));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformSetFromEulerDegreesFixture, ::testing::ValuesIn(MathTestData::EulerAnglesDegrees));
 
     using TransformSetFromEulerRadiansFixture = ::testing::TestWithParam<AZ::Vector3>;
 
@@ -381,7 +381,7 @@ namespace UnitTest
         EXPECT_THAT(transform, IsClose(rotX * rotY * rotZ));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformSetFromEulerRadiansFixture, ::testing::ValuesIn(MathTestData::EulerAnglesRadians));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformSetFromEulerRadiansFixture, ::testing::ValuesIn(MathTestData::EulerAnglesRadians));
 
     using TransformGetEulerFixture = ::testing::TestWithParam<AZ::Transform>;
 
@@ -402,7 +402,7 @@ namespace UnitTest
         EXPECT_THAT(eulerTransform, IsClose(transform));
     }
 
-    INSTANTIATE_TEST_CASE_P(MATH_Transform, TransformGetEulerFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));
+    INSTANTIATE_TEST_SUITE_P(MATH_Transform, TransformGetEulerFixture, ::testing::ValuesIn(MathTestData::OrthogonalTransforms));
 
     class MATH_TransformApplicationFixture
         : public LeakDetectionFixture

--- a/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector2Tests.cpp
@@ -459,7 +459,7 @@ namespace UnitTest
         EXPECT_NEAR(param.current.AngleSafe(param.target), param.angle, Constants::SimdTolerance);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector2,
         Vector2AngleTestFixture,
         ::testing::Values(
@@ -484,7 +484,7 @@ namespace UnitTest
         EXPECT_NEAR(param.current.AngleSafeDeg(param.target), param.angle, Constants::SimdToleranceAngleDeg);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector2,
         Vector2AngleDegTestFixture,
         ::testing::Values(
@@ -509,7 +509,7 @@ namespace UnitTest
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector2,
         AngleSafeInvalidVector2AngleTestFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector3Tests.cpp
@@ -482,7 +482,7 @@ namespace UnitTest
         EXPECT_NEAR(param.current.AngleSafe(param.target), param.angle, Constants::SimdTolerance);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector3,
         Vector3AngleTestFixture,
         ::testing::Values(
@@ -507,7 +507,7 @@ namespace UnitTest
         EXPECT_NEAR(param.current.AngleSafeDeg(param.target), param.angle, Constants::SimdToleranceAngleDeg);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector3,
         Vector3AngleDegTestFixture,
         ::testing::Values(
@@ -532,7 +532,7 @@ namespace UnitTest
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector3,
         AngleSafeInvalidVector3AngleTestFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Vector4Tests.cpp
@@ -436,7 +436,7 @@ namespace UnitTest
         EXPECT_NEAR(param.current.AngleSafe(param.target), param.angle, Constants::SimdTolerance);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector4,
         Vector4AngleTestFixture,
         ::testing::Values(
@@ -460,7 +460,7 @@ namespace UnitTest
         auto& param = GetParam();
         EXPECT_NEAR(param.current.AngleSafeDeg(param.target), param.angle, Constants::SimdToleranceAngleDeg);
     }
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector4,
         Vector4AngleDegTestFixture,
         ::testing::Values(
@@ -484,7 +484,7 @@ namespace UnitTest
         EXPECT_FLOAT_EQ(param.current.AngleSafeDeg(param.target), param.angle);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_Vector4,
         AngleSafeInvalidVector4AngleTestFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/Memory/HphaAllocator.cpp
+++ b/Code/Framework/AzCore/Tests/Memory/HphaAllocator.cpp
@@ -83,7 +83,7 @@ namespace UnitTest
          HphaSchemaTestParameters(s_smallAllocationSizes, 2),
          HphaSchemaTestParameters(s_smallAllocationSizes, 100)
     };
-    INSTANTIATE_TEST_CASE_P(Small,
+    INSTANTIATE_TEST_SUITE_P(Small,
         HphaSchemaTestFixture,
         ::testing::ValuesIn(s_smallInstancesParameters));
 
@@ -91,7 +91,7 @@ namespace UnitTest
          HphaSchemaTestParameters(s_bigAllocationSizes, 2),
          HphaSchemaTestParameters(s_bigAllocationSizes, 100)
     };
-    INSTANTIATE_TEST_CASE_P(Big,
+    INSTANTIATE_TEST_SUITE_P(Big,
         HphaSchemaTestFixture,
         ::testing::ValuesIn(s_bigInstancesParameters));
 
@@ -99,7 +99,7 @@ namespace UnitTest
          HphaSchemaTestParameters(s_mixedAllocationSizes, 2),
          HphaSchemaTestParameters(s_mixedAllocationSizes, 100)
     };
-    INSTANTIATE_TEST_CASE_P(Mixed,
+    INSTANTIATE_TEST_SUITE_P(Mixed,
         HphaSchemaTestFixture,
         ::testing::ValuesIn(s_mixedInstancesParameters));
 }

--- a/Code/Framework/AzCore/Tests/Memory/LeakDetection.cpp
+++ b/Code/Framework/AzCore/Tests/Memory/LeakDetection.cpp
@@ -246,7 +246,7 @@ namespace UnitTest
         AZ::PoolAllocator,
         AZ::ThreadPoolAllocator
     >;
-    TYPED_TEST_CASE(AllocatorTypeLeakDetectionTest, AllocatorTypes);
+    TYPED_TEST_SUITE(AllocatorTypeLeakDetectionTest, AllocatorTypes);
 
 #if AZ_TRAIT_DISABLE_FAILED_ALLOCATOR_LEAK_DETECTION_TESTS
     TYPED_TEST(AllocatorTypeLeakDetectionTest, DISABLED_Leak)

--- a/Code/Framework/AzCore/Tests/Name/NameJsonSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Name/NameJsonSerializerTests.cpp
@@ -75,7 +75,7 @@ namespace JsonSerializationTests
     };
 
     using NameJsonSerializerTestTypes = ::testing::Types<NameJsonSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(NameJsonSerializer, JsonSerializerConformityTests, NameJsonSerializerTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(NameJsonSerializer, JsonSerializerConformityTests, NameJsonSerializerTestTypes));
 
     class NameJsonSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
@@ -49,7 +49,7 @@ namespace AZ::IO
         }
     };
 
-    INSTANTIATE_TYPED_TEST_CASE_P(
+    INSTANTIATE_TYPED_TEST_SUITE_P(
         Streamer_StorageDriveWindowsConformityTests, StreamStackEntryConformityTests, StorageDriveWindowsTestDescription);
 
 

--- a/Code/Framework/AzCore/Tests/RTTI/TypeSafeIntegralTests.cpp
+++ b/Code/Framework/AzCore/Tests/RTTI/TypeSafeIntegralTests.cpp
@@ -29,7 +29,7 @@ namespace UnitTest
     };
 
     using IntegralTypes = ::testing::Types<TestInt8, TestInt16, TestInt32, TestInt64, TestUInt8, TestUInt16, TestUInt32, TestUInt64>;
-    TYPED_TEST_CASE(TypeSafeIntegralTests, IntegralTypes);
+    TYPED_TEST_SUITE(TypeSafeIntegralTests, IntegralTypes);
 
     TYPED_TEST(TypeSafeIntegralTests, TestSum)
     {

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -7816,7 +7816,7 @@ namespace UnitTest
         GenericsLoadInPlaceHolder<T> m_holder;
     };
 
-    TYPED_TEST_CASE_P(GenericsLoadInPlaceFixture);
+    TYPED_TEST_SUITE_P(GenericsLoadInPlaceFixture);
 
     TYPED_TEST_P(GenericsLoadInPlaceFixture, ClearsOnLoadInPlace)
     {
@@ -7879,7 +7879,7 @@ namespace UnitTest
         EXPECT_THAT(got.m_data, ::testing::ContainerEq(this->m_holder.m_data));
     }
 
-    REGISTER_TYPED_TEST_CASE_P(GenericsLoadInPlaceFixture, ClearsOnLoadInPlace);
+    REGISTER_TYPED_TEST_SUITE_P(GenericsLoadInPlaceFixture, ClearsOnLoadInPlace);
 
     // The test ClearsOnLoadInPlace is run once for each type in this list
     typedef ::testing::Types<
@@ -7890,7 +7890,7 @@ namespace UnitTest
         AZStd::unordered_set<int>,
         AZStd::unordered_multiset<int>
     > TypesThatShouldBeClearedWhenLoadedInPlace;
-    INSTANTIATE_TYPED_TEST_CASE_P(Clears, GenericsLoadInPlaceFixture, TypesThatShouldBeClearedWhenLoadedInPlace);
+    INSTANTIATE_TYPED_TEST_SUITE_P(Clears, GenericsLoadInPlaceFixture, TypesThatShouldBeClearedWhenLoadedInPlace);
 
     enum TestUnscopedSerializationEnum : int32_t
     {

--- a/Code/Framework/AzCore/Tests/Serialization/Json/AnySerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/AnySerializerTests.cpp
@@ -227,5 +227,5 @@ namespace JsonSerializationTests
          , AnySerializerTestDescription<InheritedPointerInContainer>
          , AnySerializerTestDescription<PrimitivePointerInContainer>
          >;
-     IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(Any, JsonSerializerConformityTests, AnyConformityTestTypes));
+     IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(Any, JsonSerializerConformityTests, AnyConformityTestTypes));
 }

--- a/Code/Framework/AzCore/Tests/Serialization/Json/ArraySerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/ArraySerializerTests.cpp
@@ -291,7 +291,7 @@ namespace JsonSerializationTests
     };
 
     using ArraySerializerConformityTestTypes = ::testing::Types<SimpleArraySerializerTestDescription, ComplexArraySerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonArraySerializer, JsonSerializerConformityTests, ArraySerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonArraySerializer, JsonSerializerConformityTests, ArraySerializerConformityTestTypes));
 
     class JsonArraySerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/BasicContainerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/BasicContainerSerializerTests.cpp
@@ -263,7 +263,7 @@ namespace JsonSerializationTests
         ComplextTestDescription<AZStd::vector<SimpleClass>>,
         ComplextTestDescription<AZStd::fixed_vector<SimpleClass, 256>>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonBasicContainers, JsonSerializerConformityTests, BasicContainerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonBasicContainers, JsonSerializerConformityTests, BasicContainerConformityTestTypes));
 
     class JsonBasicContainerSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/BoolSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/BoolSerializerTests.cpp
@@ -53,7 +53,7 @@ namespace JsonSerializationTests
     };
 
     using BoolSerializerConformityTestTypes = ::testing::Types<BoolSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonBoolSerializer, JsonSerializerConformityTests, BoolSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonBoolSerializer, JsonSerializerConformityTests, BoolSerializerConformityTestTypes));
 
     class JsonBoolSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/ByteStreamSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/ByteStreamSerializerTests.cpp
@@ -51,5 +51,5 @@ namespace JsonSerializationTests
     };
 
     using ByteStreamConformityTestTypes = ::testing::Types<ByteStreamSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonByteStreamSerialzier, JsonSerializerConformityTests, ByteStreamConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonByteStreamSerialzier, JsonSerializerConformityTests, ByteStreamConformityTestTypes));
 } // namespace JsonSerializationTests

--- a/Code/Framework/AzCore/Tests/Serialization/Json/ColorSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/ColorSerializerTests.cpp
@@ -64,7 +64,7 @@ namespace JsonSerializationTests
     };
 
     using ColorSerializerConformityTestTypes = ::testing::Types<ColorSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonColorSerializer, JsonSerializerConformityTests, ColorSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonColorSerializer, JsonSerializerConformityTests, ColorSerializerConformityTestTypes));
 
     class JsonColorSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/DoubleSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/DoubleSerializerTests.cpp
@@ -61,7 +61,7 @@ namespace JsonSerializationTests
         DoubleSerializerTestDescription<double, AZ::JsonDoubleSerializer>,
         DoubleSerializerTestDescription<float, AZ::JsonFloatSerializer>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonDoubleSerializer, JsonSerializerConformityTests, DoubleSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonDoubleSerializer, JsonSerializerConformityTests, DoubleSerializerConformityTestTypes));
 
     class JsonDoubleSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/IntSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/IntSerializerTests.cpp
@@ -73,7 +73,7 @@ namespace JsonSerializationTests
         IntegerSerializerTestDescription<unsigned long, AZ::JsonUnsignedLongSerializer>,
         IntegerSerializerTestDescription<unsigned long long, AZ::JsonUnsignedLongLongSerializer>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonIntSerializer, JsonSerializerConformityTests, IntegerSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonIntSerializer, JsonSerializerConformityTests, IntegerSerializerConformityTestTypes));
 
 
     template<typename> struct SerializerInfo {};
@@ -301,7 +301,7 @@ namespace JsonSerializationTests
         AZ::JsonUnsignedIntSerializer,
         AZ::JsonUnsignedLongSerializer,
         AZ::JsonUnsignedLongLongSerializer >;
-    TYPED_TEST_CASE(TypedJsonIntSerializerTests, IntSerializationTypes);
+    TYPED_TEST_SUITE(TypedJsonIntSerializerTests, IntSerializationTypes);
 
     TYPED_TEST(TypedJsonIntSerializerTests, Load_FalseBoolean_ValueIsZero)
     {

--- a/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializationTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializationTests.cpp
@@ -37,7 +37,7 @@ namespace JsonSerializationTests
         bool m_fullyReflected = true;
     };
 
-    TYPED_TEST_CASE(TypedJsonSerializationTests, JsonSerializationTestCases);
+    TYPED_TEST_SUITE(TypedJsonSerializationTests, JsonSerializationTestCases);
 
     TYPED_TEST(TypedJsonSerializationTests, Store_SerializedDefaultInstance_EmptyJsonReturned)
     {

--- a/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
@@ -331,7 +331,7 @@ namespace JsonSerializationTests
         AZ_RTTI(IncorrectClass, "{E201252B-D653-4753-93AD-4F13C5FA2246}");
     };
 
-    TYPED_TEST_CASE_P(JsonSerializerConformityTests);
+    TYPED_TEST_SUITE_P(JsonSerializerConformityTests);
 
     TYPED_TEST_P(JsonSerializerConformityTests, Registration_SerializerIsRegisteredWithContext_SerializerFound)
     {
@@ -1344,7 +1344,7 @@ namespace JsonSerializationTests
         }
     }
 
-    REGISTER_TYPED_TEST_CASE_P(JsonSerializerConformityTests,
+    REGISTER_TYPED_TEST_SUITE_P(JsonSerializerConformityTests,
         Registration_SerializerIsRegisteredWithContext_SerializerFound,
 
         Load_InvalidTypeOfNullType_ReturnsUnsupported,

--- a/Code/Framework/AzCore/Tests/Serialization/Json/MapSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/MapSerializerTests.cpp
@@ -336,7 +336,7 @@ namespace JsonSerializationTests
         MapPointerTestDescription<AZStd::unordered_map, AZ::JsonUnorderedMapSerializer, false>,
         MapPointerTestDescription<AZStd::unordered_multimap, AZ::JsonUnorderedMultiMapSerializer, true>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonMapSerializer, JsonSerializerConformityTests, MapSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonMapSerializer, JsonSerializerConformityTests, MapSerializerConformityTestTypes));
 
 
     struct TestString

--- a/Code/Framework/AzCore/Tests/Serialization/Json/MathMatrixSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/MathMatrixSerializerTests.cpp
@@ -223,7 +223,7 @@ namespace JsonSerializationTests
         MathMatrixSerializerTestDescription<AZ::Matrix3x4, 3, 4, AZ::JsonMatrix3x4Serializer>,
         MathMatrixSerializerTestDescription<AZ::Matrix4x4, 4, 4, AZ::JsonMatrix4x4Serializer>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonMathMatrixSerializer, JsonSerializerConformityTests, MathMatrixSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonMathMatrixSerializer, JsonSerializerConformityTests, MathMatrixSerializerConformityTestTypes));
 
     template<typename T>
     class JsonMathMatrixSerializerTests
@@ -280,7 +280,7 @@ namespace JsonSerializationTests
 
     using JsonMathMatrixSerializerTypes = ::testing::Types <
         Matrix3x3Descriptor, Matrix3x4Descriptor, Matrix4x4Descriptor>;
-    TYPED_TEST_CASE(JsonMathMatrixSerializerTests, JsonMathMatrixSerializerTypes);
+    TYPED_TEST_SUITE(JsonMathMatrixSerializerTests, JsonMathMatrixSerializerTypes);
 
     // Load array tests
 

--- a/Code/Framework/AzCore/Tests/Serialization/Json/MathVectorSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/MathVectorSerializerTests.cpp
@@ -90,7 +90,7 @@ namespace JsonSerializationTests
         MathVectorSerializerTestDescription<AZ::Vector3, 3, AZ::JsonVector3Serializer>,
         MathVectorSerializerTestDescription<AZ::Vector4, 4, AZ::JsonVector4Serializer>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonMathVectorSerializer, JsonSerializerConformityTests, MathVectorSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonMathVectorSerializer, JsonSerializerConformityTests, MathVectorSerializerConformityTestTypes));
     
     template<typename T>
     class JsonMathVectorSerializerTests
@@ -148,7 +148,7 @@ namespace JsonSerializationTests
 
     using JsonMathVectorSerializerTypes = ::testing::Types <
         Vector2Descriptor, Vector3Descriptor, Vector4Descriptor>;
-    TYPED_TEST_CASE(JsonMathVectorSerializerTests, JsonMathVectorSerializerTypes);
+    TYPED_TEST_SUITE(JsonMathVectorSerializerTests, JsonMathVectorSerializerTypes);
 
     // Load array tests
 

--- a/Code/Framework/AzCore/Tests/Serialization/Json/PathSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/PathSerializerTests.cpp
@@ -65,7 +65,7 @@ namespace JsonSerializationTests
         PathTestDescription<AZ::IO::Path>,
         PathTestDescription<AZ::IO::FixedMaxPath>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(Path, JsonSerializerConformityTests, PathConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(Path, JsonSerializerConformityTests, PathConformityTestTypes));
 
 
     class PathSerializerTests

--- a/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/PointerSerializerTests.cpp
@@ -69,5 +69,5 @@ namespace JsonSerializationTests
     };
 
     using PointerConformityTestTypes = ::testing::Types<PointerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(Pointer, JsonSerializerConformityTests, PointerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(Pointer, JsonSerializerConformityTests, PointerConformityTestTypes));
 } // namespace JsonSerializationTests

--- a/Code/Framework/AzCore/Tests/Serialization/Json/SmartPointerSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/SmartPointerSerializerTests.cpp
@@ -464,7 +464,7 @@ namespace JsonSerializationTests
         SmartPointerComplexDerivedClassWithDerivedInstanceTestDescription<AZStd::intrusive_ptr>
     >;
 
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(SmartPointerSerializer, JsonSerializerConformityTests, SmartPointerSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(SmartPointerSerializer, JsonSerializerConformityTests, SmartPointerSerializerConformityTestTypes));
 
     struct SimpleInheritenceAlt : BaseClass
     {

--- a/Code/Framework/AzCore/Tests/Serialization/Json/StringSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/StringSerializerTests.cpp
@@ -58,7 +58,7 @@ namespace JsonSerializationTests
         StringTestDescription<AZStd::string, AZ::JsonStringSerializer>,
         StringTestDescription<AZ::OSString, AZ::JsonOSStringSerializer>
     >;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(String, JsonSerializerConformityTests, StringConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(String, JsonSerializerConformityTests, StringConformityTestTypes));
 
     template<typename> struct SerializerInfo {};
 
@@ -98,7 +98,7 @@ namespace JsonSerializationTests
     using StringSerializationTypes = ::testing::Types<
         AZ::JsonStringSerializer,
         AZ::JsonOSStringSerializer >;
-    TYPED_TEST_CASE(TypedJsonStringSerializerTests, StringSerializationTypes);
+    TYPED_TEST_SUITE(TypedJsonStringSerializerTests, StringSerializationTypes);
 
     TYPED_TEST(TypedJsonStringSerializerTests, Load_FalseBoolean_FalseAsString)
     {

--- a/Code/Framework/AzCore/Tests/Serialization/Json/TestCases_Enum.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/TestCases_Enum.cpp
@@ -158,7 +158,7 @@ namespace JsonSerializationTests
         ScopedEnumBitFlagsU64,
         ScopedEnumBitFlagsNoZero
     >;
-    TYPED_TEST_CASE(TypedJsonEnumSerializationTests, EnumTypes);
+    TYPED_TEST_SUITE(TypedJsonEnumSerializationTests, EnumTypes);
 
     TYPED_TEST(TypedJsonEnumSerializationTests, Load_EmptyInstanceOfArrayType_ReturnsDefault)
     {

--- a/Code/Framework/AzCore/Tests/Serialization/Json/TransformSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/TransformSerializerTests.cpp
@@ -63,7 +63,7 @@ namespace JsonSerializationTests
     };
 
     using JsonTransformSerializerConformityTestTypes = ::testing::Types<JsonTransformSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonTransformSerializer, JsonSerializerConformityTests, JsonTransformSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonTransformSerializer, JsonSerializerConformityTests, JsonTransformSerializerConformityTestTypes));
 
     class JsonTransformSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/TupleSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/TupleSerializerTests.cpp
@@ -519,7 +519,7 @@ namespace JsonSerializationTests
         TupleTestDescription,
         ComplexTupleTestDescription,
         NestedTupleTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(Tuple, JsonSerializerConformityTests, TupleConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(Tuple, JsonSerializerConformityTests, TupleConformityTestTypes));
 
     class JsonTupleSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/UnorderedSetSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/UnorderedSetSerializerTests.cpp
@@ -121,7 +121,7 @@ namespace JsonSerializationTests
     };
 
     using UnorderedSetSerializerConformityTestTypes = ::testing::Types< UnorderedSetTestDescription, UnorderedMultiSetTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(UnorderedSetSerializer, JsonSerializerConformityTests, UnorderedSetSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(UnorderedSetSerializer, JsonSerializerConformityTests, UnorderedSetSerializerConformityTestTypes));
 
     class JsonUnorderedSetSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Serialization/Json/UnsupportedTypesSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/UnsupportedTypesSerializerTests.cpp
@@ -51,7 +51,7 @@ namespace JsonSerializationTests
     };
 
     using UnsupportedTypesTestTypes = ::testing::Types<VariantInfo, OptionalInfo>;
-    TYPED_TEST_CASE(JsonUnsupportedTypesSerializerTests, UnsupportedTypesTestTypes);
+    TYPED_TEST_SUITE(JsonUnsupportedTypesSerializerTests, UnsupportedTypesTestTypes);
 
     TYPED_TEST(JsonUnsupportedTypesSerializerTests, Load_CallDirectly_ReportsIssueAndHalts)
     {

--- a/Code/Framework/AzCore/Tests/Serialization/Json/UuidSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/UuidSerializerTests.cpp
@@ -50,7 +50,7 @@ namespace JsonSerializationTests
     };
 
     using UuidSerializerConformityTestTypes = ::testing::Types<UuidSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(JsonUuidSerializer, JsonSerializerConformityTests, UuidSerializerConformityTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonUuidSerializer, JsonSerializerConformityTests, UuidSerializerConformityTestTypes));
     
     class JsonUuidSerializerTests
         : public BaseJsonSerializerFixture

--- a/Code/Framework/AzCore/Tests/Settings/ConfigParserTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/ConfigParserTests.cpp
@@ -196,7 +196,7 @@ namespace UnitTest
         }
     }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ReadConfigFile,
     ConfigParserParamFixture,
     ::testing::Values(

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryMergeUtilsTests.cpp
@@ -76,7 +76,7 @@ namespace SettingsRegistryMergeUtilsTests
             param.m_dumperSettings));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         DumpSettings,
         SettingsRegistryMergeUtilsParamFixture,
         ::testing::Values(
@@ -295,7 +295,7 @@ namespace SettingsRegistryMergeUtilsTests
         }
     }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ReadConfigFile,
     SettingsRegistryMergeUtilsConfigFileFixture,
     ::testing::Values(
@@ -654,7 +654,7 @@ tags=tools,renderer,metal)"
             } };
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MergeManifestJson,
         SettingsRegistryGemVisitFixture,
         ::testing::ValuesIn(MakeGemVisitTestingValues()));
@@ -1043,7 +1043,7 @@ tags=tools,renderer,metal)"
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         FindEngineRoot,
         SettingsRegistryMergeUtilsFindEngineRootFixture,
         ::testing::ValuesIn(MakeFindEngineRootTestingValues()));

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryScriptUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryScriptUtilsTests.cpp
@@ -553,7 +553,7 @@ namespace SettingsRegistryScriptUtilsTests
         EXPECT_TRUE(updateNotifySent);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         SettingsRegistryBehaviorContextGetFunctions,
         SettingsRegistryBehaviorContextParamFixture,
         testing::Values(

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryTests.cpp
@@ -228,7 +228,7 @@ namespace SettingsRegistryTests
 
     using SettingsTypes = ::testing::Types<
         BoolTrue, BoolFalse, AZ::s64, double, AZStd::string, AZ::SettingsRegistryInterface::FixedValueString>;
-    TYPED_TEST_CASE(TypedSettingsRegistryTest, SettingsTypes);
+    TYPED_TEST_SUITE(TypedSettingsRegistryTest, SettingsTypes);
 
     TYPED_TEST(TypedSettingsRegistryTest, GetSet_SetAndGetValue_Success)
     {

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryVisitorUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryVisitorUtilsTests.cpp
@@ -178,7 +178,7 @@ namespace SettingsRegistryVisitorUtilsTests
     }
 
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         VisitField,
         SettingsRegistryVisitCallbackFixture,
         ::testing::Values(

--- a/Code/Framework/AzCore/Tests/Settings/TextParserTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/TextParserTests.cpp
@@ -134,7 +134,7 @@ namespace UnitTest
         EXPECT_THAT(parseSettingsVector, ::testing::ContainerEq(textFileParam.m_expectedLines));
     }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ReadTextFile,
     TextParserParamFixture,
     ::testing::Values(

--- a/Code/Framework/AzCore/Tests/StatisticalProfilerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StatisticalProfilerTests.cpp
@@ -107,7 +107,7 @@ namespace UnitTest
         StatisticalProfilerTestTraits<AZ::HashValue32, AZStd::shared_mutex>,
         StatisticalProfilerTestTraits<AZ::HashValue64, AZStd::shared_mutex>
     >;
-    TYPED_TEST_CASE(StatisticalProfilerFixture, StatisticalProfilerTestTypes);
+    TYPED_TEST_SUITE(StatisticalProfilerFixture, StatisticalProfilerTestTypes);
 
     TYPED_TEST(StatisticalProfilerFixture, ProfileCode_SingleThread_ValidateStatistics)
     {
@@ -159,7 +159,7 @@ namespace UnitTest
         StatisticalProfilerTestTraits<AZ::HashValue32, AZStd::shared_mutex>,
         StatisticalProfilerTestTraits<AZ::HashValue64, AZStd::shared_mutex>
     >;
-    TYPED_TEST_CASE(ThreadedStatisticalProfilerFixture, ThreadedStatisticalProfilerTestTypes);
+    TYPED_TEST_SUITE(ThreadedStatisticalProfilerFixture, ThreadedStatisticalProfilerTestTypes);
 
     TYPED_TEST(ThreadedStatisticalProfilerFixture, ProfileCode_4Threads_ValidateStatistics)
     {

--- a/Code/Framework/AzCore/Tests/Streamer/BlockCacheTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/BlockCacheTests.cpp
@@ -32,7 +32,7 @@ namespace AZ::IO
         }
     };
 
-    INSTANTIATE_TYPED_TEST_CASE_P(Streamer_BlockCacheConformityTests, StreamStackEntryConformityTests, BlockCacheTestDescription);
+    INSTANTIATE_TYPED_TEST_SUITE_P(Streamer_BlockCacheConformityTests, StreamStackEntryConformityTests, BlockCacheTestDescription);
 
     class BlockCacheTest
         : public UnitTest::LeakDetectionFixture

--- a/Code/Framework/AzCore/Tests/Streamer/DedicatedCacheTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/DedicatedCacheTests.cpp
@@ -27,5 +27,5 @@ namespace AZ::IO
         }
     };
 
-    INSTANTIATE_TYPED_TEST_CASE_P(Streamer_DedicatedCacheConformityTests, StreamStackEntryConformityTests, DedicatedCacheTestDescription);
+    INSTANTIATE_TYPED_TEST_SUITE_P(Streamer_DedicatedCacheConformityTests, StreamStackEntryConformityTests, DedicatedCacheTestDescription);
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/Tests/Streamer/FullDecompressorTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/FullDecompressorTests.cpp
@@ -33,7 +33,7 @@ namespace AZ::IO
         }
     };
 
-    INSTANTIATE_TYPED_TEST_CASE_P(
+    INSTANTIATE_TYPED_TEST_SUITE_P(
         Streamer_FullFileDecompressorConformityTests, StreamStackEntryConformityTests, FullFileDecompressorTestDescription);
 
     class Streamer_FullDecompressorTest

--- a/Code/Framework/AzCore/Tests/Streamer/ReadSplitterTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/ReadSplitterTests.cpp
@@ -47,7 +47,7 @@ namespace AZ::IO
     };
 
     using ReadSplitterTestTypes = ::testing::Types<ReadSplitterTestDescription, ReadSplitterWithBufferTestDescription>;
-    INSTANTIATE_TYPED_TEST_CASE_P(Streamer_ReadSplitterConformityTests, StreamStackEntryConformityTests, ReadSplitterTestTypes);
+    INSTANTIATE_TYPED_TEST_SUITE_P(Streamer_ReadSplitterConformityTests, StreamStackEntryConformityTests, ReadSplitterTestTypes);
 
     class Streamer_ReadSplitterTest
         : public UnitTest::LeakDetectionFixture

--- a/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
@@ -77,7 +77,7 @@ namespace AZ::IO
         AZStd::unique_ptr<StreamerContext> m_context;
     };
 
-    TYPED_TEST_CASE_P(StreamStackEntryConformityTests);
+    TYPED_TEST_SUITE_P(StreamStackEntryConformityTests);
 
     TYPED_TEST_P(StreamStackEntryConformityTests, GetName_RetrieveNameSetOnConstruction_NameIsNotEmpty)
     {
@@ -317,7 +317,7 @@ namespace AZ::IO
         entry.CollectStatistics(statistics);
     }
 
-    REGISTER_TYPED_TEST_CASE_P(StreamStackEntryConformityTests,
+    REGISTER_TYPED_TEST_SUITE_P(StreamStackEntryConformityTests,
         GetName_RetrieveNameSetOnConstruction_NameIsNotEmpty,
         Next_SetAndGetNext_NextIsSetAndCanBeRetrieved,
         SetContext_ContextIsForwardedToNext_SetContextOnMockIsCalled,

--- a/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryTests.cpp
@@ -25,5 +25,5 @@ namespace AZ::IO
         }
     };
 
-    INSTANTIATE_TYPED_TEST_CASE_P(Streamer_StreamStackEntryConformityTests, StreamStackEntryConformityTests, StreamStackEntryTestDescription);
+    INSTANTIATE_TYPED_TEST_SUITE_P(Streamer_StreamStackEntryConformityTests, StreamStackEntryConformityTests, StreamStackEntryTestDescription);
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/Tests/StreamerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StreamerTests.cpp
@@ -434,7 +434,7 @@ namespace AZ::IO
 
 #if !AZ_TRAIT_DISABLE_FAILED_STREAMER_TESTS
 
-    TYPED_TEST_CASE_P(StreamerTest);
+    TYPED_TEST_SUITE_P(StreamerTest);
 
     // Read a file that's smaller than the cache.
     TYPED_TEST_P(StreamerTest, Read_ReadSmallFileEntirely_FileFullyRead)
@@ -653,7 +653,7 @@ namespace AZ::IO
         EXPECT_TRUE(readSuccessful);
     }
 
-    REGISTER_TYPED_TEST_CASE_P(StreamerTest,
+    REGISTER_TYPED_TEST_SUITE_P(StreamerTest,
         Read_ReadSmallFileEntirely_FileFullyRead,
         Read_ReadLargeFileEntirely_FileFullyRead,
         Read_ReadMultiplePieces_AllReadRequestWereSuccessful,
@@ -663,7 +663,7 @@ namespace AZ::IO
 
     using StreamerTestCases = ::testing::Types<GlobalCache_Uncompressed, DedicatedCache_Uncompressed, GlobalCache_Compressed, DedicatedCache_Compressed>;
 
-    INSTANTIATE_TYPED_TEST_CASE_P(StreamerTests, StreamerTest, StreamerTestCases);
+    INSTANTIATE_TYPED_TEST_SUITE_P(StreamerTests, StreamerTest, StreamerTestCases);
 #endif // AZ_TRAIT_DISABLE_FAILED_STREAMER_TESTS
 
 } // namespace AZ::IO

--- a/Code/Framework/AzCore/Tests/StringFunc.cpp
+++ b/Code/Framework/AzCore/Tests/StringFunc.cpp
@@ -1031,14 +1031,14 @@ namespace AZ
 
 #if AZ_TRAIT_OS_USE_WINDOWS_FILE_PATHS
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathWithSingleDotSubFolders,
         StringPathFuncTest, 
         ::testing::Values(
             TestPathStringArgs("F:\\test\\to\\get\\.\\drive\\", "F:\\test\\to\\get\\drive\\")
         ));
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathWithDoubleDotSubFolders,
         StringPathFuncTest, 
         ::testing::Values(
@@ -1053,13 +1053,13 @@ namespace AZ
             TestPathStringArgs("F:\\..\\",                                                           "F:\\")
    ));
 #else
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathWithSingleDotSubFolders,
         StringPathFuncTest, ::testing::Values(
             TestPathStringArgs("/test/to/get/./drive/", "/test/to/get/drive/")
         ));
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PathWithDoubleDotSubFolders,
         StringPathFuncTest, 
         ::testing::Values(

--- a/Code/Framework/AzFramework/Tests/ArchiveCompressionTests.cpp
+++ b/Code/Framework/AzFramework/Tests/ArchiveCompressionTests.cpp
@@ -424,7 +424,7 @@ namespace UnitTest
         EXPECT_TRUE(IsPackValid(testArchivePath.c_str()));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         ArchiveCompression,
         ArchiveCompressionTestFixture,
         ::testing::Values(

--- a/Code/Framework/AzFramework/Tests/CameraState.cpp
+++ b/Code/Framework/AzFramework/Tests/CameraState.cpp
@@ -70,7 +70,7 @@ namespace UnitTest
         EXPECT_THAT(m_cameraState.m_side, IsCloseTolerance(AZ::Vector3::CreateAxisX(), 0.01f));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         CameraState,
         Translation,
         testing::Combine(
@@ -120,7 +120,7 @@ namespace UnitTest
         AZ_TEST_STOP_TRACE_SUPPRESSION(expectedErrors);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         CameraState,
         Rotation,
         testing::Combine(
@@ -148,7 +148,7 @@ namespace UnitTest
         EXPECT_NEAR(rotationDelta, 0.f, 0.01f);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         CameraState,
         WorldFromViewMatrix,
         testing::Combine(
@@ -172,7 +172,7 @@ namespace UnitTest
         EXPECT_NEAR(m_cameraState.m_fovOrZoom, fovY, 0.01f);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         CameraState,
         PerspectiveMatrix,
         testing::Combine(

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceKeyboardTests.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceKeyboardTests.cpp
@@ -21,6 +21,8 @@
 #include "XcbBaseTestFixture.h"
 #include "XcbTestApplication.h"
 
+using ::testing::DoAll;
+
 namespace AzFramework
 {
     // Sets up default behavior for mock keyboard responses to xcb methods

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceMouseTests.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceMouseTests.cpp
@@ -342,7 +342,7 @@ namespace AzFramework
         EXPECT_THAT(inactiveButtonChannels, Each(Property(&InputChannel::GetState, Eq(InputChannel::State::Idle))));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AllButtons,
         XcbInputDeviceMouseButtonTests,
         testing::Values(
@@ -634,7 +634,7 @@ namespace AzFramework
         ));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AllPointerPositions,
         XcbGetSystemCursorPositionTests,
         testing::Values(

--- a/Code/Framework/AzTest/CMakeLists.txt
+++ b/Code/Framework/AzTest/CMakeLists.txt
@@ -8,8 +8,8 @@
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     set(GOOGLETEST_GIT_REPOSITORY "https://github.com/google/googletest.git")
-    set(GOOGLETEST_GIT_TAG 2fe3bd994b3189899d93f1d5a881e725e046fdc2) # release-1.8.1
-    set(GOOGLETEST_VERSION_STRING "release-1.8.1")
+    set(GOOGLETEST_GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59) # release-1.15.2
+    set(GOOGLETEST_VERSION_STRING "release-1.15.2")
 
     o3de_pal_dir(pal_aztest_dir ${CMAKE_CURRENT_LIST_DIR}/AzTest/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
 

--- a/Code/Framework/AzToolsFramework/Tests/AzToolsFrameworkTestHelpersTest.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/AzToolsFrameworkTestHelpersTest.cpp
@@ -78,7 +78,7 @@ namespace UnitTest
         EXPECT_THAT(mouseLocalPositionFromGlobal.y(), Eq(expectedPosition.y()));
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         MouseMoveAzToolsFrameworkTestHelperFixture,
         testing::Values(

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -1101,7 +1101,7 @@ namespace UnitTest
         EXPECT_THAT(manipulatorTransform->GetTranslation(), IsClose(Entity2WorldTranslation));
     }
 
-    INSTANTIATE_TEST_CASE_P(All, EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam, testing::Values(true, false));
+    INSTANTIATE_TEST_SUITE_P(All, EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam, testing::Values(true, false));
 
     // create alias for EditorTransformComponentSelectionViewportPickingManipulatorTestFixture to help group tests
     using EditorTransformComponentSelectionManipulatorInteractionTestFixture =
@@ -1169,7 +1169,7 @@ namespace UnitTest
         AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f)),
         EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation);
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam,
         testing::Values(
@@ -1280,7 +1280,7 @@ namespace UnitTest
         AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation) *
         AZ::Transform::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f)));
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam,
         testing::Values(
@@ -1391,7 +1391,7 @@ namespace UnitTest
         AggregateManipulatorPositionWithEntity2and3Selected +
         AZ::Vector3(0.0f, LinearManipulatorYAxisMovement, LinearManipulatorZAxisMovement));
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam,
         testing::Values(
@@ -1516,7 +1516,7 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation +
         AZ::Vector3(0.0f, LinearManipulatorYAxisMovement, LinearManipulatorZAxisMovement));
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam,
         testing::Values(
@@ -1623,7 +1623,7 @@ namespace UnitTest
         AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation) *
         AZ::Transform::CreateUniformScale(LinearManipulatorZAxisMovement);
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam,
         testing::Values(
@@ -1708,7 +1708,7 @@ namespace UnitTest
                     -ManipulatorPickBoxHalfSize + ManipulatorPickOffsetTolerance,
                     -ManipulatorPickBoxHalfSize + ManipulatorPickOffsetTolerance);
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionTranslationManipulatorPickingEntityTestFixtureParam,
         testing::Values(
@@ -2046,7 +2046,7 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionSingleEntityPivotFixture,
         testing::Values(
@@ -2095,7 +2095,7 @@ namespace UnitTest
     }
 
     // with a single entity selected with a parent the orientation reference frames follow as you'd expect
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionSingleEntityWithParentPivotFixture,
         testing::Values(
@@ -2152,7 +2152,7 @@ namespace UnitTest
 
     // with a group selection, when the entities are not in a hierarchy, no matter what reference frame,
     // we will always get an orientation aligned to the world
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionMultipleEntitiesPivotFixture,
         testing::Values(
@@ -2215,7 +2215,7 @@ namespace UnitTest
 
     // here two entities are selected with the same parent - local and parent will match parent space, with world
     // giving the identity (aligned to world axes)
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture,
         testing::Values(
@@ -2278,7 +2278,7 @@ namespace UnitTest
     }
 
     // if multiple entities are selected without a parent in common, orientation will always be world again
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture,
         testing::Values(
@@ -2328,7 +2328,7 @@ namespace UnitTest
 
     // local reference frame will still return local orientation for entity, but pivot override will trump parent
     // space (world will still give identity alignment for axes)
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture,
         testing::Values(
@@ -2388,7 +2388,7 @@ namespace UnitTest
     }
 
     // with multiple entities selected, override frame wins in both local and parent reference frames
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture,
         testing::Values(
@@ -2446,7 +2446,7 @@ namespace UnitTest
     }
 
     // multiple entities selected (no hierarchy) always get world aligned axes (identity)
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture,
         testing::Values(
@@ -2509,7 +2509,7 @@ namespace UnitTest
 
     // no optional frame, same parent, local and parent both get parent alignment (world reference frame
     // gives world alignment (identity))
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture,
         testing::Values(

--- a/Code/Framework/AzToolsFramework/Tests/Input/QtEventToAzInputMapperTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Input/QtEventToAzInputMapperTests.cpp
@@ -369,7 +369,7 @@ namespace UnitTest
         AzFramework::InputChannelNotificationBus::Handler::BusDisconnect();
     }
 
-    INSTANTIATE_TEST_CASE_P(All, MouseButtonParamQtEventToAzInputMapperFixture,
+    INSTANTIATE_TEST_SUITE_P(All, MouseButtonParamQtEventToAzInputMapperFixture,
         testing::Values(
             MouseButtonIdsParam{ Qt::MouseButton::LeftButton, AzFramework::InputDeviceMouse::Button::Left },
             MouseButtonIdsParam{ Qt::MouseButton::RightButton, AzFramework::InputDeviceMouse::Button::Right },
@@ -462,7 +462,7 @@ namespace UnitTest
         AzFramework::InputChannelNotificationBus::Handler::BusDisconnect();
     }
 
-    INSTANTIATE_TEST_CASE_P(All, PrintableKeyEventParamQtEventToAzInputMapperFixture,
+    INSTANTIATE_TEST_SUITE_P(All, PrintableKeyEventParamQtEventToAzInputMapperFixture,
         testing::Values(
             KeyEventIdsParam{ Qt::Key_0, AzFramework::InputDeviceKeyboard::Key::Alphanumeric0 },
             KeyEventIdsParam{ Qt::Key_1, AzFramework::InputDeviceKeyboard::Key::Alphanumeric1 },
@@ -526,9 +526,9 @@ namespace UnitTest
 
     // Note that this class is identical to the previous fixture class.
     // This is intentional - the test framework appears to gather all TEST_P bodies and execute them for all
-    // fixtures that use the same class, even if they have different names in INSTANTIATE_TEST_CASE_P.
-    // By making a different class here, we can separate them so the above INSTANTIATE_TEST_CASE_P params
-    // do not get fed into the below TEST_P.  (This happens even if you give the INSTANTIATE_TEST_CASE_P calls different names.)
+    // fixtures that use the same class, even if they have different names in INSTANTIATE_TEST_SUITE_P.
+    // By making a different class here, we can separate them so the above INSTANTIATE_TEST_SUITE_P params
+    // do not get fed into the below TEST_P.  (This happens even if you give the INSTANTIATE_TEST_SUITE_P calls different names.)
     class ModifierKeyEventFixture
         : public QtEventToAzInputMapperFixture
         , public ::testing::WithParamInterface<KeyEventIdsParam>
@@ -606,7 +606,7 @@ namespace UnitTest
 
     // Test case exercises each modifier key and makes sure it doesn't "stick" when the application
     // is deactivated.
-    INSTANTIATE_TEST_CASE_P(All, ModifierKeyEventFixture,
+    INSTANTIATE_TEST_SUITE_P(All, ModifierKeyEventFixture,
         testing::Values(
             KeyEventIdsParam{ Qt::Key_Alt, AzFramework::InputDeviceKeyboard::Key::ModifierAltL },
             KeyEventIdsParam{ Qt::Key_Shift, AzFramework::InputDeviceKeyboard::Key::ModifierShiftL },
@@ -676,7 +676,7 @@ namespace UnitTest
         AzFramework::InputChannelNotificationBus::Handler::BusDisconnect();
     }
 
-    INSTANTIATE_TEST_CASE_P(All, MoveMoveWrapParamQtEventToAzInputMapperFixture,
+    INSTANTIATE_TEST_SUITE_P(All, MoveMoveWrapParamQtEventToAzInputMapperFixture,
         testing::Values(
             // verify CursorModeWrappedX wrapping
             MouseMoveParam {AzToolsFramework::CursorInputMode::CursorModeWrappedX, 

--- a/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
@@ -1647,7 +1647,7 @@ namespace UnitTest
     {
     };
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         InstanceDataHierarchyGroupTestFixture,
         InstanceDataHierarchyGroupTestFixtureParameterized,
         ::testing::Values("GroupFloat", "GroupToggle", "ToggleGroupInt", "SubInt", "SubToggle", "SubFloat"));

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableMetaDataTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableMetaDataTests.cpp
@@ -86,7 +86,7 @@ namespace UnitTest
         }
     };
 
-    TYPED_TEST_CASE_P(TypedSpawnableMetaDataTests);
+    TYPED_TEST_SUITE_P(TypedSpawnableMetaDataTests);
 
     TYPED_TEST_P(TypedSpawnableMetaDataTests, Add_AddValueToMetaData_NoCrash)
     {
@@ -228,7 +228,7 @@ namespace UnitTest
         }
     }
 
-    REGISTER_TYPED_TEST_CASE_P(TypedSpawnableMetaDataTests,
+    REGISTER_TYPED_TEST_SUITE_P(TypedSpawnableMetaDataTests,
         Add_AddValueToMetaData_NoCrash,
         Add_ChainAdds_NoCrash,
         Add_AddThenRetrieveValue_StoredIsSameAsRetrieved,
@@ -242,7 +242,7 @@ namespace UnitTest
         Get_WrongType_ReturnsFalse);
 
     using SpawnableMetaDataTestTypes = ::testing::Types<bool, AZ::u64, AZ::s64, double, AZStd::string>;
-    INSTANTIATE_TYPED_TEST_CASE_P(SpawnableMetaDataTests, TypedSpawnableMetaDataTests, SpawnableMetaDataTestTypes);
+    INSTANTIATE_TYPED_TEST_SUITE_P(SpawnableMetaDataTests, TypedSpawnableMetaDataTests, SpawnableMetaDataTestTypes);
 
 
     TEST_F(SpawnableMetaDataTests, Get_UnknownKey_ReturnsFalse)

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.cpp
@@ -21,7 +21,7 @@ namespace UnitTest
 
     };
 
-    TYPED_TEST_CASE(PropertyIntCtrlCommonFixture, IntegerPrimtitiveTestConfigs);
+    TYPED_TEST_SUITE(PropertyIntCtrlCommonFixture, IntegerPrimtitiveTestConfigs);
 
     TYPED_TEST(PropertyIntCtrlCommonFixture, ValidMinValue_ExpectSafeValueEqualToOriginalValue)
     {

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntSliderCtrlTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntSliderCtrlTests.cpp
@@ -16,7 +16,7 @@ namespace UnitTest
     template <typename ValueType>
     using PropertySliderCtrlFixture = PropertyCtrlFixture<ValueType, PropertyIntSliderCtrl, IntSliderHandler>;
 
-    TYPED_TEST_CASE(PropertySliderCtrlFixture, IntegerPrimtitiveTestConfigs);
+    TYPED_TEST_SUITE(PropertySliderCtrlFixture, IntegerPrimtitiveTestConfigs);
 
     TYPED_TEST(PropertySliderCtrlFixture, PropertySliderCtrlHandlersCreated)
     {

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntSpinCtrlTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntSpinCtrlTests.cpp
@@ -16,7 +16,7 @@ namespace UnitTest
     template <typename ValueType>
     using PropertySpinCtrlFixture = PropertyCtrlFixture<ValueType, PropertyIntSpinCtrl, IntSpinBoxHandler>;
 
-    TYPED_TEST_CASE(PropertySpinCtrlFixture, IntegerPrimtitiveTestConfigs);
+    TYPED_TEST_SUITE(PropertySpinCtrlFixture, IntegerPrimtitiveTestConfigs);
 
     TYPED_TEST(PropertySpinCtrlFixture, PropertySpinCtrlHandlersCreated)
     {

--- a/Code/Framework/AzToolsFramework/Tests/QtWidgetLimitsTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/QtWidgetLimitsTests.cpp
@@ -20,7 +20,7 @@ namespace UnitTest
 
     };
 
-    TYPED_TEST_CASE(QtWidgetLimitsFixture, IntegerPrimtitiveTestConfigs);
+    TYPED_TEST_SUITE(QtWidgetLimitsFixture, IntegerPrimtitiveTestConfigs);
 
     TYPED_TEST(QtWidgetLimitsFixture, MinRange)
     {

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
@@ -293,7 +293,7 @@ namespace UnitTest
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         AllEditorModes,
         ViewportEditorModesTestsFixtureWithParams,
         ::testing::Values(

--- a/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/FileWatcherUnitTests.cpp
@@ -524,7 +524,7 @@ namespace FileWatcherTests
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(FileWatcherUnitTest, FileWatcherUnitTest_FloodTests, ::testing::Bool());
+    INSTANTIATE_TEST_SUITE_P(FileWatcherUnitTest, FileWatcherUnitTest_FloodTests, ::testing::Bool());
     
     TEST_F(FileWatcherUnitTest, DirectoryRemoves_ShowUp)
     {
@@ -788,6 +788,6 @@ namespace FileWatcherTests
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(FileWatcherUnitTest, FileWatcherUnitTest_DefaultExclusions, ::testing::Bool());
+    INSTANTIATE_TEST_SUITE_P(FileWatcherUnitTest, FileWatcherUnitTest_DefaultExclusions, ::testing::Bool());
 
 } // namespace File Watcher Tests.

--- a/Code/Tools/AzTestRunner/test/RunnerTest.cpp
+++ b/Code/Tools/AzTestRunner/test/RunnerTest.cpp
@@ -45,7 +45,7 @@ TEST_P(EndsWithTest, CallEndsWith)
     ASSERT_EQ(p.m_expected, b);
 }
 
-INSTANTIATE_TEST_CASE_P(All, EndsWithTest, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(All, EndsWithTest, ::testing::Values(
     EndsWithParam("foo.dll", ".dll", true),
     EndsWithParam("foo.dll", ".dxx", false),
     EndsWithParam("abcdef", "bcd", false), // value found in middle
@@ -127,7 +127,7 @@ TEST_P(RemoveParametersTest, Foo)
     delete[] argv;
 }
 
-INSTANTIATE_TEST_CASE_P(All, RemoveParametersTest, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(All, RemoveParametersTest, ::testing::Values(
     RemoveParam { { "a", "b" }, 0, 0, { "b" } } // remove from start
     ,RemoveParam { { "a", "b" }, 1, 1, { "a" } } // remove from end
     ,RemoveParam { { "a", "b", "c" }, 1, 1, { "a", "c" } } // remove from middle

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/ConvertIteratorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/ConvertIteratorTests.cpp
@@ -84,7 +84,7 @@ namespace AZ
                     ~ConvertIteratorTests() override = default;
                 };
 
-                TYPED_TEST_CASE_P(ConvertIteratorTests);
+                TYPED_TEST_SUITE_P(ConvertIteratorTests);
 
                 // MakeConvertIterator
                 TYPED_TEST_P(ConvertIteratorTests, MakeConvertIterator_FunctionComparedWithExplicitlyDeclaredIterator_IteratorsAreEqual)
@@ -120,13 +120,13 @@ namespace AZ
                     EXPECT_EQ(view.end(), end);
                 }
 
-                REGISTER_TYPED_TEST_CASE_P(ConvertIteratorTests,
+                REGISTER_TYPED_TEST_SUITE_P(ConvertIteratorTests,
                     MakeConvertIterator_FunctionComparedWithExplicitlyDeclaredIterator_IteratorsAreEqual,
                     MakeConvertView_IteratorVersionComparedWithExplicitlyDeclaredIterators_ViewHasEquivalentBeginAndEnd,
                     MakeConvertView_ViewVersionComparedWithExplicitlyDeclaredIterators_ViewHasEquivalentBeginAndEnd
                     );
 
-                INSTANTIATE_TYPED_TEST_CASE_P(CommonTests, ConvertIteratorTests, BasicCollectionTypes);
+                INSTANTIATE_TYPED_TEST_SUITE_P(CommonTests, ConvertIteratorTests, BasicCollectionTypes);
 
                 // Casting
                 TEST(ConvertIterator, Casting_CanBetweenValueTypes_GetCastedValueAsInt)

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/FilterIteratorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/FilterIteratorTests.cpp
@@ -59,7 +59,7 @@ namespace AZ
                     AZStd::function<bool(const BaseIteratorReference)> m_testPredicate;
                 };
 
-                TYPED_TEST_CASE_P(FilterIteratorBasicTests);
+                TYPED_TEST_SUITE_P(FilterIteratorBasicTests);
 
                 TYPED_TEST_P(FilterIteratorBasicTests,
                     Constructor_InputIsEmptyValidBaseIterator_NoCrash)
@@ -502,7 +502,7 @@ namespace AZ
                     }
                 }
 
-                REGISTER_TYPED_TEST_CASE_P(FilterIteratorBasicTests,
+                REGISTER_TYPED_TEST_SUITE_P(FilterIteratorBasicTests,
                     Constructor_InputIsEmptyValidBaseIterator_NoCrash,
                     OperatorStar_GetValueByDereferencingIterator_ExpectFirstValueInArray,
                     Constructor_MovesForwardBasedOnPredicate_ExpectSkipFirstEntryAndReturnSecond,
@@ -525,7 +525,7 @@ namespace AZ
                     Algorithms_PartialSortCopyFilteredContainer_AllValuesLargerOrEqualThan10AreCopiedAndSorted
                     );
 
-                INSTANTIATE_TYPED_TEST_CASE_P(CommonTests,
+                INSTANTIATE_TYPED_TEST_SUITE_P(CommonTests,
                     FilterIteratorBasicTests,
                     BasicCollectionTypes);
 
@@ -554,7 +554,7 @@ namespace AZ
                     AZStd::function<bool(const BaseIteratorReference)> m_testPredicate;
                 };
 
-                TYPED_TEST_CASE_P(FilterIteratorMapTests);
+                TYPED_TEST_SUITE_P(FilterIteratorMapTests);
 
                 TYPED_TEST_P(FilterIteratorMapTests,
                     MakeFilterView_InputIsIterator_CorrectFilteredElements)
@@ -578,11 +578,11 @@ namespace AZ
                     EXPECT_TRUE(expectedElements.empty());
                 }
 
-                REGISTER_TYPED_TEST_CASE_P(FilterIteratorMapTests,
+                REGISTER_TYPED_TEST_SUITE_P(FilterIteratorMapTests,
                     MakeFilterView_InputIsIterator_CorrectFilteredElements
                     );
 
-                INSTANTIATE_TYPED_TEST_CASE_P(CommonTests,
+                INSTANTIATE_TYPED_TEST_SUITE_P(CommonTests,
                     FilterIteratorMapTests,
                     MapCollectionTypes);
 

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/IteratorConformityTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/IteratorConformityTests.cpp
@@ -262,7 +262,7 @@ namespace AZ
                         ~AllContext() override = default;
                     };
 
-                    TYPED_TEST_CASE_P(AllContext);
+                    TYPED_TEST_SUITE_P(AllContext);
 
                     // Constructor
                     TYPED_TEST_P(AllContext, Constructor_CanBeConstructedAndDestructed_DoesNotCrash)
@@ -343,7 +343,7 @@ namespace AZ
                         ++iterator;
                     }
 
-                    REGISTER_TYPED_TEST_CASE_P(AllContext,
+                    REGISTER_TYPED_TEST_SUITE_P(AllContext,
                         Constructor_CanBeConstructedAndDestructed_DoesNotCrash,
                         CopyConstructor_CanBeCopyConstructedExplicit_DoesNotCrash,
                         CopyConstructor_CanBeCopyConstructedImplicit_DoesNotCrash,
@@ -370,7 +370,7 @@ namespace AZ
                         ~InputContext() override = default;
                     };
 
-                    TYPED_TEST_CASE_P(InputContext);
+                    TYPED_TEST_SUITE_P(InputContext);
 
                     // Equal operator
                     TYPED_TEST_P(InputContext, EqualsOperator_IteratorComparedWithSelf_SameIteratorObject)
@@ -580,7 +580,7 @@ namespace AZ
                         EXPECT_EQ(iteratorFirst, iteratorThird);
                     }
 
-                    REGISTER_TYPED_TEST_CASE_P(InputContext,
+                    REGISTER_TYPED_TEST_SUITE_P(InputContext,
                         EqualsOperator_IteratorComparedWithSelf_SameIteratorObject,
                         EqualsOperator_IdenticallyConstructedIterators_IteratorsAreEqual,
                         EqualsOperator_DifferentIterators_IteratorsAreNotEqual,
@@ -617,7 +617,7 @@ namespace AZ
                         ~ForwardContext() override = default;
                     };
 
-                    TYPED_TEST_CASE_P(ForwardContext);
+                    TYPED_TEST_SUITE_P(ForwardContext);
 
                     // Default constructor
                     TYPED_TEST_P(ForwardContext, DefaultConstructor_CanExplicityConstructed_DoesNotCrash)
@@ -648,7 +648,7 @@ namespace AZ
                         EXPECT_EQ(aValue, bValue);
                     }
 
-                    REGISTER_TYPED_TEST_CASE_P(ForwardContext,
+                    REGISTER_TYPED_TEST_SUITE_P(ForwardContext,
                         DefaultConstructor_CanExplicityConstructed_DoesNotCrash,
                         DefaultConstructor_CanImplicityConstructed_DoesNotCrash,
                         MultiPass_DereferencingMultipleTimes_ValueBeforeAndAfterIncrementingIsTheSame
@@ -669,7 +669,7 @@ namespace AZ
                         ~BidirectionalContext() override = default;
                     };
 
-                    TYPED_TEST_CASE_P(BidirectionalContext);
+                    TYPED_TEST_SUITE_P(BidirectionalContext);
 
                     // Post Decrement Operator
                     TYPED_TEST_P(BidirectionalContext, PostDecrementOperator_IterateOneStep_DoesNotCrash)
@@ -757,7 +757,7 @@ namespace AZ
                         EXPECT_EQ(*copy, *original);
                     }
 
-                    REGISTER_TYPED_TEST_CASE_P(BidirectionalContext,
+                    REGISTER_TYPED_TEST_SUITE_P(BidirectionalContext,
                         PostDecrementOperator_IterateOneStep_DoesNotCrash,
                         PostDecrementOperator_ReturnsIterator_DoesNotCrash,
                         PostDecrementOperator_IteratorReturnsOriginalIterator_OriginalIteratorMatchesCopiedValueAndNotMoveIterator,
@@ -783,7 +783,7 @@ namespace AZ
                         ~RandomAccessContext() override = default;
                     };
 
-                    TYPED_TEST_CASE_P(RandomAccessContext);
+                    TYPED_TEST_SUITE_P(RandomAccessContext);
 
                     // Difference subtract operator
                     TYPED_TEST_P(RandomAccessContext, DifferenceSubtractOperator_DifferenceWithItself_DifferenceIsZero)
@@ -995,7 +995,7 @@ namespace AZ
                         EXPECT_EQ(*moved, original[1]);
                     }
 
-                    REGISTER_TYPED_TEST_CASE_P(RandomAccessContext,
+                    REGISTER_TYPED_TEST_SUITE_P(RandomAccessContext,
                         DifferenceSubtractOperator_DifferenceWithItself_DifferenceIsZero,
                         DifferenceSubtractOperator_DifferenceBetweenIteratorsAtSamePosition_DifferenceIsZero,
                         DifferenceSubtractOperator_DifferenceBetweenIteratorsAtDifferentPositions_DifferenceIsOne,
@@ -1030,9 +1030,9 @@ namespace AZ
                     using GraphGroup = ::testing::Types<
                         SceneGraphUpwardsIteratorContext, SceneGraphChildIteratorContext,
                         SceneGraphDownwardsIteratorContext_DepthFirst, SceneGraphDownwardsIteratorContext_BreadthFirst>;
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Base, AllContext, BaseGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_BaseExt, AllContext, BaseExtGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Graph, AllContext, GraphGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Base, AllContext, BaseGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_BaseExt, AllContext, BaseExtGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Graph, AllContext, GraphGroup);
                 }
                 namespace InputIterators
                 {
@@ -1044,9 +1044,9 @@ namespace AZ
                     using GraphGroup = ::testing::Types<
                         SceneGraphUpwardsIteratorContext, SceneGraphChildIteratorContext,
                         SceneGraphDownwardsIteratorContext_DepthFirst, SceneGraphDownwardsIteratorContext_BreadthFirst>;
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Base, InputContext, BaseGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_BaseExt, InputContext, BaseExtGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Graph, InputContext, GraphGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Base, InputContext, BaseGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_BaseExt, InputContext, BaseExtGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Graph, InputContext, GraphGroup);
                 }
                 namespace ForwardIterators
                 {
@@ -1058,9 +1058,9 @@ namespace AZ
                     using GraphGroup = ::testing::Types<
                         SceneGraphUpwardsIteratorContext, SceneGraphChildIteratorContext,
                         SceneGraphDownwardsIteratorContext_DepthFirst, SceneGraphDownwardsIteratorContext_BreadthFirst>;
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Base, ForwardContext, BaseGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_BaseExt, ForwardContext, BaseExtGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Graph, ForwardContext, GraphGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Base, ForwardContext, BaseGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_BaseExt, ForwardContext, BaseExtGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Graph, ForwardContext, GraphGroup);
                 }
                 namespace BidirectionalIterators
                 {
@@ -1069,15 +1069,15 @@ namespace AZ
                             ConvertIteratorContext<VectorIteratorContext>, ConvertIteratorContext<ListIteratorContext>,
                             FilterIteratorContext<VectorIteratorContext>, FilterIteratorContext<ListIteratorContext>,
                             PairIteratorContext<VectorIteratorContext>, PairIteratorContext<ListIteratorContext>>;
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Base, BidirectionalContext, BaseGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_BaseExt, BidirectionalContext, BaseExtGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Base, BidirectionalContext, BaseGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_BaseExt, BidirectionalContext, BaseExtGroup);
                 }
                 namespace RandomAccessIterators
                 {
                     using BaseGroup = ::testing::Types<VectorIteratorContext>;
                     using BaseExtGroup = ::testing::Types<ConvertIteratorContext<VectorIteratorContext>, PairIteratorContext<VectorIteratorContext>>;
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_Base, RandomAccessContext, BaseGroup);
-                    INSTANTIATE_TYPED_TEST_CASE_P(IteratorConformityTests_BaseExt, RandomAccessContext, BaseExtGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_Base, RandomAccessContext, BaseGroup);
+                    INSTANTIATE_TYPED_TEST_SUITE_P(IteratorConformityTests_BaseExt, RandomAccessContext, BaseExtGroup);
                 }
             } // Views
         } // Containers

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/PairIteratorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/PairIteratorTests.cpp
@@ -88,7 +88,7 @@ namespace AZ::SceneAPI::Containers::Views
         CollectionType m_secondContainer;
     };
 
-    TYPED_TEST_CASE_P(PairIteratorTests);
+    TYPED_TEST_SUITE_P(PairIteratorTests);
 
     TYPED_TEST_P(PairIteratorTests, MakePairIterator_BuildFromTwoSeparateIterators_StoredIteratorsMatchTheGivenIterators)
     {
@@ -214,7 +214,7 @@ namespace AZ::SceneAPI::Containers::Views
         }
     }
 
-    REGISTER_TYPED_TEST_CASE_P(PairIteratorTests,
+    REGISTER_TYPED_TEST_SUITE_P(PairIteratorTests,
         MakePairIterator_BuildFromTwoSeparateIterators_StoredIteratorsMatchTheGivenIterators,
         MakePairIterator_BuildFromTwoSeparateIterators_FirstAndSecondInContainersCanBeAccessedThroughIterator,
         MakePairView_CreateFromIterators_IteratorsInViewMatchExplicitlyCreatedIterators,
@@ -227,7 +227,7 @@ namespace AZ::SceneAPI::Containers::Views
         PostIncrementOperator_IncrementingMovesBothIterators_BothStoredIteratorsMoved,
         Algorithms_Generate_FirstContainerFilledWithTheFirstAndSecondContainerFilledWithSecondInGivenPair);
 
-    INSTANTIATE_TYPED_TEST_CASE_P(CommonTests, PairIteratorTests, BasicCollectionTypes);
+    INSTANTIATE_TYPED_TEST_SUITE_P(CommonTests, PairIteratorTests, BasicCollectionTypes);
 
     // The following tests are done as standalone tests as not all iterators support this functionality
     TEST(PairIteratorTest, PreDecrementIterator_DecrementingMovesBothIterators_BothStoredIteratorsMoved)

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/SceneGraphDownwardsIteratorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/Views/SceneGraphDownwardsIteratorTests.cpp
@@ -84,7 +84,7 @@ namespace AZ
                     using Traversal = T;
                 };
 
-                TYPED_TEST_CASE_P(SceneGraphDownwardsIteratorContext);
+                TYPED_TEST_SUITE_P(SceneGraphDownwardsIteratorContext);
 
                 TYPED_TEST_P(SceneGraphDownwardsIteratorContext, MakeSceneGraphDownwardsIterator_FunctionComparedWithExplicitlyDeclaredIterator_IteratorsAreEqual)
                 {
@@ -317,7 +317,7 @@ namespace AZ
                     EXPECT_EQ(3, value->m_id);
                 }
 
-                REGISTER_TYPED_TEST_CASE_P(SceneGraphDownwardsIteratorContext,
+                REGISTER_TYPED_TEST_SUITE_P(SceneGraphDownwardsIteratorContext,
                     MakeSceneGraphDownwardsIterator_FunctionComparedWithExplicitlyDeclaredIterator_IteratorsAreEqual,
                     MakeSceneGraphDownwardsIterator_ExtendedFunctionComparedWithExplicitlyDeclaredIterator_IteratorsAreEqual,
                     MakeSceneGraphDownwardsIterator_NodeAndHierarchyVersions_IteratorsAreEqual,
@@ -341,7 +341,7 @@ namespace AZ
                     );
 
                 using Group = ::testing::Types<DepthFirst, BreadthFirst>;
-                INSTANTIATE_TYPED_TEST_CASE_P(SceneGraphDownwardsIteratorTests, SceneGraphDownwardsIteratorContext, Group);
+                INSTANTIATE_TYPED_TEST_SUITE_P(SceneGraphDownwardsIteratorTests, SceneGraphDownwardsIteratorContext, Group);
 
                 TEST_F(SceneGraphDownwardsIteratorTest, DepthFirst_IncrementOperator_MoveDownTheTree_IteratorReturnsParentOfPreviousIteration)
                 {

--- a/Gems/Atom/RHI/Code/Tests/BufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/BufferTests.cpp
@@ -396,8 +396,8 @@ namespace UnitTest
         return BufferBindFlagsToString(info.param.bufferBindFlags) + "BufferWith" + BufferBindFlagsToString(info.param.viewBindFlags) + "BufferView";
     }
 
-    INSTANTIATE_TEST_CASE_P(BufferView, BufferBindFlagTests, ::testing::ValuesIn(GenerateCompatibleBufferBindFlagCombinations()), GenerateBufferBindFlagTestCaseName);
-    INSTANTIATE_TEST_CASE_P(BufferView, BufferBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleBufferBindFlagCombinations()), GenerateBufferBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(BufferView, BufferBindFlagTests, ::testing::ValuesIn(GenerateCompatibleBufferBindFlagCombinations()), GenerateBufferBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(BufferView, BufferBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleBufferBindFlagCombinations()), GenerateBufferBindFlagTestCaseName);
 
 
     enum class ParallelGetBufferViewTestCases

--- a/Gems/Atom/RHI/Code/Tests/ImageTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/ImageTests.cpp
@@ -396,6 +396,6 @@ namespace UnitTest
         return ImageBindFlagsToString(info.param.imageBindFlags) + "ImageWith" + ImageBindFlagsToString(info.param.viewBindFlags) + "ImageView";
     }
 
-    INSTANTIATE_TEST_CASE_P(ImageView, ImageBindFlagTests, ::testing::ValuesIn(GenerateCompatibleImageBindFlagCombinations()), GenerateImageBindFlagTestCaseName);
-    INSTANTIATE_TEST_CASE_P(ImageView, ImageBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleImageBindFlagCombinations()), GenerateImageBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(ImageView, ImageBindFlagTests, ::testing::ValuesIn(GenerateCompatibleImageBindFlagCombinations()), GenerateImageBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(ImageView, ImageBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleImageBindFlagCombinations()), GenerateImageBindFlagTestCaseName);
 }

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceBufferTests.cpp
@@ -427,8 +427,8 @@ namespace UnitTest
         return MultiDeviceBufferBindFlagsToString(info.param.bufferBindFlags) + "BufferWith" + MultiDeviceBufferBindFlagsToString(info.param.viewBindFlags) + "BufferView";
     }
 
-    INSTANTIATE_TEST_CASE_P(BufferView, MultiDeviceBufferBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
-    INSTANTIATE_TEST_CASE_P(BufferView, MultiDeviceBufferBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(BufferView, MultiDeviceBufferBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(BufferView, MultiDeviceBufferBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceBufferBindFlagCombinations()), GenerateMultiDeviceBufferBindFlagTestCaseName);
 
     enum class MultiDeviceParallelGetBufferViewTestCases
     {

--- a/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/MultiDeviceImageTests.cpp
@@ -428,6 +428,6 @@ namespace UnitTest
         return MultiDeviceImageBindFlagsToString(info.param.imageBindFlags) + "ImageWith" + MultiDeviceImageBindFlagsToString(info.param.viewBindFlags) + "ImageView";
     }
 
-    INSTANTIATE_TEST_CASE_P(ImageView, MultiDeviceImageBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
-    INSTANTIATE_TEST_CASE_P(ImageView, MultiDeviceImageBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(ImageView, MultiDeviceImageBindFlagTests, ::testing::ValuesIn(GenerateCompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
+    INSTANTIATE_TEST_SUITE_P(ImageView, MultiDeviceImageBindFlagFailureCases, ::testing::ValuesIn(GenerateIncompatibleMultiDeviceImageBindFlagCombinations()), GenerateMultiDeviceImageBindFlagTestCaseName);
 }

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorSourceDataSerializerTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialFunctorSourceDataSerializerTests.cpp
@@ -123,5 +123,5 @@ namespace JsonSerializationTests
     };
 
     using MaterialFunctorSourceDataSerializerTestTypes = ::testing::Types<MaterialFunctorSourceDataSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(MaterialFunctorSourceDataTests, JsonSerializerConformityTests, MaterialFunctorSourceDataSerializerTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(MaterialFunctorSourceDataTests, JsonSerializerConformityTests, MaterialFunctorSourceDataSerializerTestTypes));
 } // namespace JsonSerializationTests

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertySerializerTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertySerializerTests.cpp
@@ -152,7 +152,7 @@ namespace JsonSerializationTests
     };
 
     using MaterialPropertySerializerTestTypes = ::testing::Types<MaterialPropertySerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(MaterialPropertySerializerTests, JsonSerializerConformityTests, MaterialPropertySerializerTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(MaterialPropertySerializerTests, JsonSerializerConformityTests, MaterialPropertySerializerTestTypes));
 } // namespace JsonSerializationTests
 
 namespace UnitTest

--- a/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertyValueSourceDataTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Material/MaterialPropertyValueSourceDataTests.cpp
@@ -80,7 +80,7 @@ namespace JsonSerializationTests
     };
 
     using MaterialPropertyValueSourceDataSerializerTestTypes = ::testing::Types<MaterialPropertyValueSourceDataSerializerTestDescription>;
-    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_CASE_P(MaterialPropertyValueSourceDataTests, JsonSerializerConformityTests, MaterialPropertyValueSourceDataSerializerTestTypes));
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(MaterialPropertyValueSourceDataTests, JsonSerializerConformityTests, MaterialPropertyValueSourceDataSerializerTestTypes));
 } // namespace JsonSerializationTests
 
 namespace UnitTest

--- a/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
@@ -1206,7 +1206,7 @@ namespace UnitTest
         IntersectParams{ 0.778f, 0.778f, 1.0f, 0.0f, 0.0f, -1.0f, 0.5f, true },
     };
 
-    INSTANTIATE_TEST_CASE_P(KdTreeIntersectsPlane, KdTreeIntersectsParameterizedFixture, ::testing::ValuesIn(KdTreeIntersectTestData));
+    INSTANTIATE_TEST_SUITE_P(KdTreeIntersectsPlane, KdTreeIntersectsParameterizedFixture, ::testing::ValuesIn(KdTreeIntersectTestData));
 
     class KdTreeIntersectsFixture
         : public ModelTests
@@ -1300,7 +1300,7 @@ namespace UnitTest
         IntersectParams{ 0.0f,  20.0f, 0.0f, 0.0f, -19.0f, 0.0f, 1.0f, true },
     };
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         BruteForceIntersects, BruteForceIntersectsParameterizedFixture, ::testing::ValuesIn(BruteForceIntersectTestData));
 
     class BruteForceModelIntersectsFixture

--- a/Gems/EMotionFX/Code/Tests/ActorBuilderTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/ActorBuilderTests.cpp
@@ -237,5 +237,5 @@ namespace EMotionFX
         EXPECT_TRUE(emfxLocal.IsClose(builderLocal));
     }
 
-    INSTANTIATE_TEST_CASE_P(ActorBuilder_Transforms, ActorBuilderPipelineTransformTestFixture, ::testing::ValuesIn(EMotionFX::Matrix3x4s));
+    INSTANTIATE_TEST_SUITE_P(ActorBuilder_Transforms, ActorBuilderPipelineTransformTestFixture, ::testing::ValuesIn(EMotionFX::Matrix3x4s));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/AnimGraphCommandTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphCommandTests.cpp
@@ -135,7 +135,7 @@ namespace EMotionFX
         , public ::testing::WithParamInterface<bool>
     {
     };
-    INSTANTIATE_TEST_CASE_P(LoadAnimGraphCommandTests, LoadAnimGraphCommandTestsBoolParam, ::testing::Bool());
+    INSTANTIATE_TEST_SUITE_P(LoadAnimGraphCommandTests, LoadAnimGraphCommandTestsBoolParam, ::testing::Bool());
 
     TEST_F(LoadAnimGraphCommandTests, DISABLED_LoadAnimGraph)
     {

--- a/Gems/EMotionFX/Code/Tests/AnimGraphCopyPasteTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphCopyPasteTests.cpp
@@ -284,7 +284,7 @@ namespace EMotionFX
         VerifyAfterOperation();
     }
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphCopyPasteTests,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphCopyPasteTests,
         AnimGraphTransitionConditionCopyPasteFixture,
         ::testing::Bool());
 
@@ -503,7 +503,7 @@ namespace EMotionFX
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphCopyPasteTests,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphCopyPasteTests,
         AnimGraphSimpleCopyPasteFixture,
         ::testing::Bool());
 
@@ -628,7 +628,7 @@ namespace EMotionFX
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(CopyPasteTests,
+    INSTANTIATE_TEST_SUITE_P(CopyPasteTests,
         AnimGraphCopyPasteFixture_CanBeInterruptedBy,
         ::testing::Bool());
 
@@ -793,7 +793,7 @@ namespace EMotionFX
             "New connection's parameter weight should be the weight value of 1.";
     }
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphCopyPasteTests,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphCopyPasteTests,
         AnimGraphCopyPasteFixture_NodeTriggerValue,
         ::testing::Bool());
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/AnimGraphEventTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphEventTests.cpp
@@ -195,7 +195,7 @@ namespace EMotionFX
         SimulateTest(params.m_simulationTime, params.m_expectedFps, params.m_fpsVariance);
     }
 
-    INSTANTIATE_TEST_CASE_P(TestAnimGraphEvents,
+    INSTANTIATE_TEST_SUITE_P(TestAnimGraphEvents,
          AnimGraphEventTestFixture,
          ::testing::ValuesIn(animGraphEventTestData));
 } // EMotionFX

--- a/Gems/EMotionFX/Code/Tests/AnimGraphFuzzTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphFuzzTests.cpp
@@ -130,7 +130,7 @@ namespace EMotionFX
 
     const std::vector<Seed> randomSeeds = GetSeedsForTest(s_AnimGraphFuzzTestLoad);
 
-    INSTANTIATE_TEST_CASE_P(InstantiationName,
+    INSTANTIATE_TEST_SUITE_P(InstantiationName,
         AnimGraphFuzzTest,
         ::testing::ValuesIn(randomSeeds),
         ::testing::PrintToStringParamName()

--- a/Gems/EMotionFX/Code/Tests/AnimGraphNodeEventFilterTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphNodeEventFilterTests.cpp
@@ -283,7 +283,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(EventFilterTests,
+    INSTANTIATE_TEST_SUITE_P(EventFilterTests,
         AnimGraphNodeEventFilterTestFixture,
         ::testing::ValuesIn(EventFilteringTestData));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/AnimGraphNodeProcessingTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphNodeProcessingTests.cpp
@@ -195,7 +195,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphNodeProcessingTests,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphNodeProcessingTests,
         AnimGraphNodeProcessingTestFixture,
         ::testing::ValuesIn(AnimGraphNodeProcessingTestTestData));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/AnimGraphRefCountTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphRefCountTests.cpp
@@ -132,7 +132,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphRefCountTest_SimpleChain,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphRefCountTest_SimpleChain,
          AnimGraphRefCountTest_SimpleChain,
          ::testing::ValuesIn(animGraphRefCountTest_SimpleChainTestData)
     );

--- a/Gems/EMotionFX/Code/Tests/AnimGraphStateMachineInterruptionTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphStateMachineInterruptionTests.cpp
@@ -380,7 +380,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphStateMachine_InterruptionTest,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphStateMachine_InterruptionTest,
         AnimGraphStateMachine_InterruptionFixture,
             ::testing::ValuesIn(animGraphStateMachineInterruptionTestData)
         );
@@ -558,7 +558,7 @@ namespace EMotionFX
         },
     };
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphStateMachine_InterruptionPropertiesTest,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphStateMachine_InterruptionPropertiesTest,
         AnimGraphStateMachine_InterruptionPropertiesFixture,
             ::testing::ValuesIn(animGraphStateMachineInterruptionPropertiesTestData)
         );

--- a/Gems/EMotionFX/Code/Tests/AnimGraphStateMachineSyncTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphStateMachineSyncTests.cpp
@@ -222,7 +222,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(AnimGraphStateMachineSyncTests,
+    INSTANTIATE_TEST_SUITE_P(AnimGraphStateMachineSyncTests,
         AnimGraphStateMachineSyncFixture,
         ::testing::ValuesIn(animGraphStateMachineSyncTestData)
     );

--- a/Gems/EMotionFX/Code/Tests/AnimGraphStateMachineTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphStateMachineTests.cpp
@@ -80,7 +80,7 @@ namespace EMotionFX
         static_cast<int>(AnimGraphStateMachine::GetMaxNumPasses())
     };
 
-    INSTANTIATE_TEST_CASE_P(TestAnimGraphStateMachine_MultiplePassesSingleFrameTest,
+    INSTANTIATE_TEST_SUITE_P(TestAnimGraphStateMachine_MultiplePassesSingleFrameTest,
          AnimGraphStateMachine_MultiplePassesSingleFrameFixture,
          ::testing::ValuesIn(animGraphStateMachinePassesTestData)
      );

--- a/Gems/EMotionFX/Code/Tests/AnimGraphSyncTrackTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphSyncTrackTests.cpp
@@ -162,7 +162,7 @@ namespace EMotionFX
                 1,
                 2
             },
-        });
+        })
     );
 
     struct FindMatchingEventsParams

--- a/Gems/EMotionFX/Code/Tests/AnimGraphSyncTrackTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphSyncTrackTests.cpp
@@ -90,7 +90,7 @@ namespace EMotionFX
         EXPECT_EQ(indexRight, params.m_expectedRight);
     }
 
-    INSTANTIATE_TEST_CASE_P(TestFindEventIndices, TestFindEventIndicesFixture,
+    INSTANTIATE_TEST_SUITE_P(TestFindEventIndices, TestFindEventIndicesFixture,
         ::testing::ValuesIn(std::vector<FindEventIndicesParams> {
             {
                 MakeNoEvents,
@@ -258,7 +258,7 @@ namespace EMotionFX
         EXPECT_EQ(outRight, params.m_expectedEventB);
     }
 
-    INSTANTIATE_TEST_CASE_P(TestFindMatchingEvents, TestFindMatchingEventsFixture,
+    INSTANTIATE_TEST_SUITE_P(TestFindMatchingEvents, TestFindMatchingEventsFixture,
         ::testing::ValuesIn(std::vector<FindMatchingEventsParams> {
             // With no events, it shouldn't matter what we put in, we'll get
             // back invalid indices

--- a/Gems/EMotionFX/Code/Tests/AnimGraphTransitionConditionTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphTransitionConditionTests.cpp
@@ -1292,7 +1292,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestMotionCondition, MotionConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestMotionCondition, MotionConditionFixture,
         ::testing::ValuesIn(motionTransitionConditionData)
     );
 
@@ -1300,7 +1300,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestRangedMotionCondition, RangedMotionEventConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestRangedMotionCondition, RangedMotionEventConditionFixture,
         ::testing::ValuesIn(rangedMotionTransitionConditionData)
     );
 
@@ -1309,7 +1309,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestParameterCondition, ParameterConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestParameterCondition, ParameterConditionFixture,
         ::testing::ValuesIn(parameterTransitionConditionData)
     );
 
@@ -1318,7 +1318,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestPlayTimeCondition, PlayTimeConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestPlayTimeCondition, PlayTimeConditionFixture,
         ::testing::ValuesIn(playTimeTransitionConditionData)
     );
 
@@ -1326,7 +1326,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestStateCondition, StateConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestStateCondition, StateConditionFixture,
         ::testing::ValuesIn(stateTransitionConditionData)
     );
 
@@ -1335,7 +1335,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestTagCondition, TagConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestTagCondition, TagConditionFixture,
         ::testing::ValuesIn(tagTransitionConditionData)
     );
 
@@ -1345,7 +1345,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestTimeCondition, TimeConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestTimeCondition, TimeConditionFixture,
         ::testing::ValuesIn(timeTransitionConditionData)
     );
 
@@ -1354,7 +1354,7 @@ namespace EMotionFX
     {
         RunEMotionFXUpdateLoop();
     }
-    INSTANTIATE_TEST_CASE_P(TestVector2Condition, Vector2ConditionFixture,
+    INSTANTIATE_TEST_SUITE_P(TestVector2Condition, Vector2ConditionFixture,
         ::testing::ValuesIn(vector2TransitionConditionData)
     );
 

--- a/Gems/EMotionFX/Code/Tests/AnimGraphTransitionTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphTransitionTests.cpp
@@ -52,7 +52,7 @@ namespace EMotionFX
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(TestAnimGraphTransitionWeights, AnimGraphTransitionFixtureParams,
+    INSTANTIATE_TEST_SUITE_P(TestAnimGraphTransitionWeights, AnimGraphTransitionFixtureParams,
         ::testing::Values(
             &AnimGraphNodeData::GetLocalWeight,
             &AnimGraphNodeData::GetGlobalWeight

--- a/Gems/EMotionFX/Code/Tests/AutoSkeletonLODTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AutoSkeletonLODTests.cpp
@@ -244,7 +244,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(AutoSkeletonLOD_Tests,
+    INSTANTIATE_TEST_SUITE_P(AutoSkeletonLOD_Tests,
         AutoSkeletonLODFixture,
             ::testing::ValuesIn(testParams)
         );

--- a/Gems/EMotionFX/Code/Tests/BlendTreeBlendNNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeBlendNNodeTests.cpp
@@ -396,7 +396,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(BlendTreeBlendNNode,
+    INSTANTIATE_TEST_SUITE_P(BlendTreeBlendNNode,
         BlendTreeBlendNNodeSyncTestFixture,
         ::testing::ValuesIn(blendNNodeSyncTestData));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/BlendTreeFloatConditionNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeFloatConditionNodeTests.cpp
@@ -196,7 +196,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(BlendTreeFloatConditionNode_ConditionTest,
+    INSTANTIATE_TEST_SUITE_P(BlendTreeFloatConditionNode_ConditionTest,
         BlendTreeFloatConditionNodeFixture,
         ::testing::Combine(
             ::testing::Bool(),

--- a/Gems/EMotionFX/Code/Tests/BlendTreeFloatMath1NodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeFloatMath1NodeTests.cpp
@@ -374,7 +374,7 @@ namespace EMotionFX
         TestInput<MCore::AttributeBool, bool>("BoolParam", m_param.m_xInputBool);
     };
 
-    INSTANTIATE_TEST_CASE_P(BlendTreeFloatMath1Node_ValidOutputTests,
+    INSTANTIATE_TEST_SUITE_P(BlendTreeFloatMath1Node_ValidOutputTests,
         BlendTreeFloatMath1NodeFixture,
             ::testing::ValuesIn(blendTreeFloatMath1NodeTestData)
     );

--- a/Gems/EMotionFX/Code/Tests/BlendTreeMaskNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeMaskNodeTests.cpp
@@ -309,7 +309,7 @@ namespace EMotionFX
         },
     };
 
-    INSTANTIATE_TEST_CASE_P(BlendTreeMaskNode,
+    INSTANTIATE_TEST_SUITE_P(BlendTreeMaskNode,
         BlendTreeMaskNodeTestFixture,
             ::testing::ValuesIn(maskNodeTestData));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/BlendTreeRagdollNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeRagdollNodeTests.cpp
@@ -75,7 +75,7 @@ namespace EMotionFX
             << "Activation expected in case const float value is not zero.";
     }
 
-    INSTANTIATE_TEST_CASE_P(BlendTreeRagdollNode_ConstFloatActivateInputTest,
+    INSTANTIATE_TEST_SUITE_P(BlendTreeRagdollNode_ConstFloatActivateInputTest,
         BlendTreeRagdollNode_ConstFloatActivateInputTest,
         ::testing::ValuesIn({ -1.0f, 0.0f, 0.1f, 1.0f }));
 
@@ -207,7 +207,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(RagdollRootNodeIsSimulatedTests,
+    INSTANTIATE_TEST_SUITE_P(RagdollRootNodeIsSimulatedTests,
         RagdollRootNodeFixture,
         ::testing::ValuesIn(ragdollRootNodeIsSimulatedTestValues));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/BlendTreeRangeRemapperNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeRangeRemapperNodeTests.cpp
@@ -144,7 +144,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(BlendTreeRangeRemapperNode_ValidOutputTests,
+    INSTANTIATE_TEST_SUITE_P(BlendTreeRangeRemapperNode_ValidOutputTests,
         BlendTreeRangeRemapperNodeFixture,
         ::testing::ValuesIn(blendTreeRangeRemapperNodeTestData)
     );

--- a/Gems/EMotionFX/Code/Tests/BlendTreeTwoLinkIKNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeTwoLinkIKNodeTests.cpp
@@ -537,7 +537,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(BlendTreeTwoLinkIKNode_OutputTests,
+    INSTANTIATE_TEST_SUITE_P(BlendTreeTwoLinkIKNode_OutputTests,
         BlendTreeTwoLinkIKNodeFixture,
         ::testing::Combine(
             ::testing::Bool(),

--- a/Gems/EMotionFX/Code/Tests/Bugs/CanUndoParameterDeletionAndRestoreBlendTreeConnections.cpp
+++ b/Gems/EMotionFX/Code/Tests/Bugs/CanUndoParameterDeletionAndRestoreBlendTreeConnections.cpp
@@ -184,5 +184,5 @@ namespace EMotionFX
         Run();
     };
 
-    INSTANTIATE_TEST_CASE_P(UndoParameterDeletionTests, UndoParameterDeletionTests, ::testing::Values(prepareLY92860Commands));
+    INSTANTIATE_TEST_SUITE_P(UndoParameterDeletionTests, UndoParameterDeletionTests, ::testing::Values(prepareLY92860Commands));
 } // EMotionFX

--- a/Gems/EMotionFX/Code/Tests/ColliderCommandTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/ColliderCommandTests.cpp
@@ -317,7 +317,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(EditColliderCommandTests,
+    INSTANTIATE_TEST_SUITE_P(EditColliderCommandTests,
         EditColliderCommandFixture,
         ::testing::ValuesIn(editColliderCommandTestParameters)
     );

--- a/Gems/EMotionFX/Code/Tests/CommandAdjustSimulatedObjectTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/CommandAdjustSimulatedObjectTests.cpp
@@ -254,7 +254,7 @@ namespace EMotionFX
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(TestCommandAdjustSimulatedObject, CommandAdjustSimulatedObjectTestsFixture,
+    INSTANTIATE_TEST_SUITE_P(TestCommandAdjustSimulatedObject, CommandAdjustSimulatedObjectTestsFixture,
         ::testing::Combine(
             ::testing::Bool(), // Test execute or test undo
             ::testing::Bool(), // Use command strings or not
@@ -618,7 +618,7 @@ namespace EMotionFX
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(TestCommandAdjustSimulatedJoint, CommandAdjustSimulatedJointTestsFixture,
+    INSTANTIATE_TEST_SUITE_P(TestCommandAdjustSimulatedJoint, CommandAdjustSimulatedJointTestsFixture,
         ::testing::Combine(
             ::testing::Bool(), // Test execute or test undo
             ::testing::Bool(), // Use command strings or not

--- a/Gems/EMotionFX/Code/Tests/Editor/ParametersGroupDefaultValues.cpp
+++ b/Gems/EMotionFX/Code/Tests/Editor/ParametersGroupDefaultValues.cpp
@@ -122,7 +122,7 @@ namespace EMotionFX
         Vector4ParameterT
     >;
 
-    TYPED_TEST_CASE(CanSetParameterToDefaultValueWhenInGroupFixture, TypesToTest);
+    TYPED_TEST_SUITE(CanSetParameterToDefaultValueWhenInGroupFixture, TypesToTest);
 
     TYPED_TEST(CanSetParameterToDefaultValueWhenInGroupFixture, CanSetParameterToDefaultValueWhenInGroup)
     {

--- a/Gems/EMotionFX/Code/Tests/Game/SamplePerformanceTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/Game/SamplePerformanceTests.cpp
@@ -700,7 +700,7 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(PerformanceTests,
+    INSTANTIATE_TEST_SUITE_P(PerformanceTests,
         PerformanceTestFixture,
         ::testing::ValuesIn(performanceTestData));
 

--- a/Gems/EMotionFX/Code/Tests/Integration/PoseComparisonTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/Integration/PoseComparisonTests.cpp
@@ -294,7 +294,7 @@ namespace EMotionFX
         recording->Destroy();
     }
 
-    INSTANTIATE_TEST_CASE_P(DISABLED_TestPoses, PoseComparisonFixture,
+    INSTANTIATE_TEST_SUITE_P(DISABLED_TestPoses, PoseComparisonFixture,
         ::testing::Values(
             PoseComparisonFixtureParams (
                 "@exefolder@/Test.Assets/Gems/EMotionFX/Code/Tests/TestAssets/Rin/rin.actor",
@@ -311,7 +311,7 @@ namespace EMotionFX
         )
     );
 
-    INSTANTIATE_TEST_CASE_P(DISABLED_TestPoseComparison, TestPoseComparisonFixture,
+    INSTANTIATE_TEST_SUITE_P(DISABLED_TestPoseComparison, TestPoseComparisonFixture,
         ::testing::Values(
             PoseComparisonFixtureParams (
                 "@exefolder@/Test.Assets/Gems/EMotionFX/Code/Tests/TestAssets/Rin/rin.actor",

--- a/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
+++ b/Gems/EMotionFX/Code/Tests/MCore/AZCoreConversionsTest.cpp
@@ -27,7 +27,7 @@ namespace MCore
     }
 
     // same test cases in QuaternionTests.cpp AngleRadianTestFixtureZYX
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         MATH_AZCoreConversions,
         AngleRadianTestFixtureXYZ,
         ::testing::Values(

--- a/Gems/EMotionFX/Code/Tests/MCore/CommandLineTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MCore/CommandLineTests.cpp
@@ -108,5 +108,5 @@ namespace EMotionFX
         },
     };
 
-    INSTANTIATE_TEST_CASE_P(TestCommandLine, CommandLineFixture, ::testing::ValuesIn(commandLineTestData));
+    INSTANTIATE_TEST_SUITE_P(TestCommandLine, CommandLineFixture, ::testing::ValuesIn(commandLineTestData));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/MCore/CommandManagerTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MCore/CommandManagerTests.cpp
@@ -260,7 +260,7 @@ namespace EMotionFX
         tester.TestCommandGroup(commandGroup, 4, 0.0f, 4.0f, GetParam());
     }
 
-    INSTANTIATE_TEST_CASE_P(CommandGroupTests,
+    INSTANTIATE_TEST_SUITE_P(CommandGroupTests,
         CommandGroupFixture,
         ::testing::ValuesIn({ TestCommandExecutionMethod::Execute, TestCommandExecutionMethod::Undo, TestCommandExecutionMethod::Redo}));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/MorphTargetPipelineTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MorphTargetPipelineTests.cpp
@@ -292,7 +292,7 @@ namespace EMotionFX
 
     // Note that these values are instantiated before the SystemAllocator is
     // created, so we can't use AZStd::vector
-    INSTANTIATE_TEST_CASE_P(TestMorphTargetCreation, MorphTargetCreationTestFixture,
+    INSTANTIATE_TEST_SUITE_P(TestMorphTargetCreation, MorphTargetCreationTestFixture,
         ::testing::Values(
             std::vector<std::string> {},
             std::vector<std::string> {"testMorphTarget0"},

--- a/Gems/EMotionFX/Code/Tests/MotionEventTrackTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MotionEventTrackTests.cpp
@@ -884,6 +884,6 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(TestExtractProcessEvents, TestExtractProcessEventsFixture,
+    INSTANTIATE_TEST_SUITE_P(TestExtractProcessEvents, TestExtractProcessEventsFixture,
         ::testing::ValuesIn(extractEventTestData));
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/MotionExtractionTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MotionExtractionTests.cpp
@@ -339,7 +339,7 @@ namespace EMotionFX
         EXPECT_EQ(m_animGraphInstance->GetEventBuffer().GetNumEvents(), 0);
     }
     
-    INSTANTIATE_TEST_CASE_P(MotionExtraction_OutputTests,
+    INSTANTIATE_TEST_SUITE_P(MotionExtraction_OutputTests,
         MotionExtractionFixture,
         ::testing::Combine(
             ::testing::Bool(),

--- a/Gems/EMotionFX/Code/Tests/MotionInstanceTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MotionInstanceTests.cpp
@@ -747,5 +747,5 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(MotionInstanceTests, MotionInstanceFixture, ::testing::ValuesIn(motionInstanceTestParams));
+    INSTANTIATE_TEST_SUITE_P(MotionInstanceTests, MotionInstanceFixture, ::testing::ValuesIn(motionInstanceTestParams));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/PoseTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/PoseTests.cpp
@@ -151,7 +151,7 @@ namespace EMotionFX
         , public ::testing::WithParamInterface<bool>
     {
     };
-    INSTANTIATE_TEST_CASE_P(PoseTests, PoseTestsBoolParam, ::testing::Bool());
+    INSTANTIATE_TEST_SUITE_P(PoseTests, PoseTestsBoolParam, ::testing::Bool());
 
     TEST_F(PoseTests, Clear)
     {
@@ -787,7 +787,7 @@ namespace EMotionFX
         , public ::testing::WithParamInterface<float>
     {
     };
-    INSTANTIATE_TEST_CASE_P(PoseTests, PoseTestsBlendWeightParam, ::testing::ValuesIn({0.0f, 0.1f, 0.25f, 0.33f, 0.5f, 0.77f, 1.0f}));
+    INSTANTIATE_TEST_SUITE_P(PoseTests, PoseTestsBlendWeightParam, ::testing::ValuesIn({0.0f, 0.1f, 0.25f, 0.33f, 0.5f, 0.77f, 1.0f}));
 
     TEST_P(PoseTestsBlendWeightParam, Blend)
     {
@@ -903,7 +903,7 @@ namespace EMotionFX
         , public ::testing::WithParamInterface<PoseTestsMultiplyFunction>
     {
     };
-    INSTANTIATE_TEST_CASE_P(PoseTests, PoseTestsMultiply, ::testing::ValuesIn({
+    INSTANTIATE_TEST_SUITE_P(PoseTests, PoseTestsMultiply, ::testing::ValuesIn({
         PreMultiply, Multiply, MultiplyInverse}));
 
     TEST_P(PoseTestsMultiply, Multiply)
@@ -965,7 +965,7 @@ namespace EMotionFX
         , public ::testing::WithParamInterface<float>
     {
     };
-    INSTANTIATE_TEST_CASE_P(PoseTests, PoseTestsSum, ::testing::ValuesIn({0.0f, 0.1f, 0.25f, 0.33f, 0.5f, 0.77f, 1.0f}));
+    INSTANTIATE_TEST_SUITE_P(PoseTests, PoseTestsSum, ::testing::ValuesIn({0.0f, 0.1f, 0.25f, 0.33f, 0.5f, 0.77f, 1.0f}));
 
     TEST_P(PoseTestsSum, Sum)
     {
@@ -1084,7 +1084,7 @@ namespace EMotionFX
         {true, ApplyAdditiveWeight, 0.0f}, {true, ApplyAdditiveWeight, 0.25f}, {true, ApplyAdditiveWeight, 0.5f}, {true, ApplyAdditiveWeight, 1.0f}
     };
 
-    INSTANTIATE_TEST_CASE_P(PoseTests, PoseTestsAdditive, ::testing::ValuesIn(poseTestsAdditiveData));
+    INSTANTIATE_TEST_SUITE_P(PoseTests, PoseTestsAdditive, ::testing::ValuesIn(poseTestsAdditiveData));
 
     TEST_P(PoseTestsAdditive, Additive)
     {

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Parameters/AddParameter.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Parameters/AddParameter.cpp
@@ -107,7 +107,7 @@ namespace EMotionFX
         return result;
     }
 
-    INSTANTIATE_TEST_CASE_P(AddParameters,
+    INSTANTIATE_TEST_SUITE_P(AddParameters,
         AddParametersFixture,
         ::testing::ValuesIn(GetValueParameterTypeIndices()));
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/QuaternionParameterTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/QuaternionParameterTests.cpp
@@ -133,7 +133,7 @@ namespace EMotionFX
         AZ::Quaternion(AZ::Constants::FloatMax, -AZ::Constants::FloatMax, AZ::Constants::FloatEpsilon, 1.0f)
     };
 
-    INSTANTIATE_TEST_CASE_P(QuaternionParameter_ValidOutputTests,
+    INSTANTIATE_TEST_SUITE_P(QuaternionParameter_ValidOutputTests,
         QuaternionParameterFixture,
         ::testing::ValuesIn(quaternionParameterTestData)
     );

--- a/Gems/EMotionFX/Code/Tests/SimulatedObjectSetupTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/SimulatedObjectSetupTests.cpp
@@ -161,7 +161,7 @@ namespace SimulatedObjectSetupTests
         EXPECT_EQ(object->GetSimulatedJoints().size(), GetParam().m_expectedSimulatedJointCount);
     }
 
-    INSTANTIATE_TEST_CASE_P(Test, AddSimulatedJointAndChildrenFixture,
+    INSTANTIATE_TEST_SUITE_P(Test, AddSimulatedJointAndChildrenFixture,
         testing::ValuesIn(std::vector<AddSimulatedJointAndChildrenParams>
         {
             {PrefabLeftArmSkeleton::leftShoulderIndex, 13}, // leftShoulder is a root joint
@@ -280,7 +280,7 @@ namespace SimulatedObjectSetupTests
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(Test, GetSimulatedRootJointFixture,
+    INSTANTIATE_TEST_SUITE_P(Test, GetSimulatedRootJointFixture,
         ::testing::Combine(
             ::testing::Values(
                 PrefabLeftArmSkeleton::leftShoulderIndex,

--- a/Gems/EMotionFX/Code/Tests/SyncingSystemTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/SyncingSystemTests.cpp
@@ -262,6 +262,6 @@ namespace EMotionFX
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(SyncingSystem, SyncingSystemFixture,
+    INSTANTIATE_TEST_SUITE_P(SyncingSystem, SyncingSystemFixture,
         ::testing::ValuesIn(SyncTestData));
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/TransformUnitTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/TransformUnitTests.cpp
@@ -167,7 +167,7 @@ namespace EMotionFX
         )
     }
 
-    INSTANTIATE_TEST_CASE_P(Test, TransformConstructFromVec3QuatVec3Fixture,
+    INSTANTIATE_TEST_SUITE_P(Test, TransformConstructFromVec3QuatVec3Fixture,
         ::testing::Combine(
             ::testing::Values(
                 AZ::Vector3::CreateZero(),
@@ -347,7 +347,7 @@ namespace EMotionFX
         );
     }
 
-    INSTANTIATE_TEST_CASE_P(Test, TransformMultiplyFixture,
+    INSTANTIATE_TEST_SUITE_P(Test, TransformMultiplyFixture,
         ::testing::Values(
             TransformMultiplyParams {
                 /* input a */{Transform::CreateIdentity()},
@@ -712,7 +712,7 @@ namespace EMotionFX
         );
     }
 
-    INSTANTIATE_TEST_CASE_P(Test, TransformApplyDeltaFixture,
+    INSTANTIATE_TEST_SUITE_P(Test, TransformApplyDeltaFixture,
         ::testing::ValuesIn(std::vector<ApplyDeltaParams>{
             {
                 {Transform::CreateIdentity()},
@@ -953,7 +953,7 @@ namespace EMotionFX
         AZ::Constants::QuarterPi,
         AZ::Constants::HalfPi
     );
-    INSTANTIATE_TEST_CASE_P(Test, TransformProjectedToGroundPlaneFixture,
+    INSTANTIATE_TEST_SUITE_P(Test, TransformProjectedToGroundPlaneFixture,
         ::testing::Combine(
             ::testing::Values(
                 AZ::Vector3::CreateZero(),

--- a/Gems/EMotionFX/Code/Tests/UI/CanAdjustGroupParameter.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAdjustGroupParameter.cpp
@@ -10,7 +10,7 @@
 
 namespace EMotionFX
 {
-    INSTANTIATE_TEST_CASE_P(CanAdjustGroupParameter, CommandRunnerFixture,
+    INSTANTIATE_TEST_SUITE_P(CanAdjustGroupParameter, CommandRunnerFixture,
         ::testing::Values(std::vector<std::string> {
             R"str(CreateAnimGraph -animGraphID 100)str",
             R"str(AnimGraphAddGroupParameter -animGraphID 100 -name Group0)str",

--- a/Gems/EMotionFX/Code/Tests/UI/CanDeleteAnimGraphNode_AnimGraphModelUpdates.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanDeleteAnimGraphNode_AnimGraphModelUpdates.cpp
@@ -64,7 +64,7 @@ namespace EMotionFX
 
     }
 
-    INSTANTIATE_TEST_CASE_P(CanDeleteAnimGraphNode_AnimGraphModelUpdates, CanDeleteAnimGraphNode,
+    INSTANTIATE_TEST_SUITE_P(CanDeleteAnimGraphNode_AnimGraphModelUpdates, CanDeleteAnimGraphNode,
         ::testing::Values(std::vector<std::string> {
             R"str(CreateAnimGraph -animGraphID 100)str",
             R"str(Select -animGraphID 100)str",

--- a/Gems/EMotionFX/Code/Tests/UI/CanRenameParameter_ParameterNodeUpdates.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanRenameParameter_ParameterNodeUpdates.cpp
@@ -10,7 +10,7 @@
 
 namespace EMotionFX
 {
-    INSTANTIATE_TEST_CASE_P(CanRenameParameter_ParameterNodeUpdates, CommandRunnerFixture,
+    INSTANTIATE_TEST_SUITE_P(CanRenameParameter_ParameterNodeUpdates, CommandRunnerFixture,
         ::testing::Values(std::vector<std::string> {
             R"str(CreateAnimGraph -animGraphID 100)str",
             R"str(AnimGraphCreateNode -animGraphID 100 -type {A8B5BB1E-5BA9-4B0A-88E9-21BB7A199ED2} -parentName Root -xPos 240 -yPos 230 -name GENERATE -namePrefix BlendTree)str",

--- a/Gems/EMotionFX/Code/Tests/UI/LODSkinnedMeshTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/LODSkinnedMeshTests.cpp
@@ -104,7 +104,7 @@ namespace EMotionFX
         QLabel* GetDefaultLabel() { return m_defaultLabel; }
     };
 
-    INSTANTIATE_TEST_CASE_P(LODSkinnedMeshFixtureTests, LODSkinnedMeshFixture, ::testing::Range<int>(1, 7));
+    INSTANTIATE_TEST_SUITE_P(LODSkinnedMeshFixtureTests, LODSkinnedMeshFixture, ::testing::Range<int>(1, 7));
 
     // TODO: Re-enabled the test when we can access viewport context in the SimpleLODComponent.
     TEST_F(LODSkinnedMeshColorFixture, DISABLED_CheckLODDistanceChange)

--- a/Gems/EMotionFX/Code/Tests/Vector3ParameterTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/Vector3ParameterTests.cpp
@@ -131,7 +131,7 @@ namespace EMotionFX
         AZ::Vector3(AZ::Constants::FloatMax, -AZ::Constants::FloatMax, AZ::Constants::FloatEpsilon)
     };
 
-    INSTANTIATE_TEST_CASE_P(Vector3Parameter_ValidOutputTests,
+    INSTANTIATE_TEST_SUITE_P(Vector3Parameter_ValidOutputTests,
         Vector3ParameterFixture,
         ::testing::ValuesIn(Vector3ParameterTestData)
     );

--- a/Gems/LmbrCentral/Code/Tests/CylinderShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/CylinderShapeTest.cpp
@@ -442,12 +442,12 @@ namespace UnitTest
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(ValidIntersections,
+    INSTANTIATE_TEST_SUITE_P(ValidIntersections,
         CylinderShapeRayIntersectTest,
         ::testing::ValuesIn(CylinderShapeRayIntersectTest::ShouldPass)
     );
 
-    INSTANTIATE_TEST_CASE_P(InvalidIntersections,
+    INSTANTIATE_TEST_SUITE_P(InvalidIntersections,
         CylinderShapeRayIntersectTest,
         ::testing::ValuesIn(CylinderShapeRayIntersectTest::ShouldFail)
     );
@@ -469,7 +469,7 @@ namespace UnitTest
         EXPECT_TRUE(aabb.GetMax().IsClose(maxExtent));
     }
 
-    INSTANTIATE_TEST_CASE_P(AABB,
+    INSTANTIATE_TEST_SUITE_P(AABB,
         CylinderShapeAABBTest,
         ::testing::ValuesIn(CylinderShapeAABBTest::ShouldPass)
     );
@@ -492,7 +492,7 @@ namespace UnitTest
         EXPECT_TRUE(aabb.GetMax().IsClose(maxExtent));
     }
 
-    INSTANTIATE_TEST_CASE_P(TransformAndLocalBounds,
+    INSTANTIATE_TEST_SUITE_P(TransformAndLocalBounds,
         CylinderShapeTransformAndLocalBoundsTest,
         ::testing::ValuesIn(CylinderShapeTransformAndLocalBoundsTest::ShouldPass)
     );
@@ -513,13 +513,13 @@ namespace UnitTest
         EXPECT_EQ(inside, expectedInside);
     }
 
-    INSTANTIATE_TEST_CASE_P(ValidIsPointInside,
+    INSTANTIATE_TEST_SUITE_P(ValidIsPointInside,
         CylinderShapeIsPointInsideTest,
         ::testing::ValuesIn(CylinderShapeIsPointInsideTest::ShouldPass)
     );
 
 
-    INSTANTIATE_TEST_CASE_P(InvalidIsPointInside,
+    INSTANTIATE_TEST_SUITE_P(InvalidIsPointInside,
         CylinderShapeIsPointInsideTest,
         ::testing::ValuesIn(CylinderShapeIsPointInsideTest::ShouldFail)
     );
@@ -541,7 +541,7 @@ namespace UnitTest
         EXPECT_NEAR(distance, expectedDistance, epsilon);
     }
 
-    INSTANTIATE_TEST_CASE_P(ValidIsDistanceFromPoint,
+    INSTANTIATE_TEST_SUITE_P(ValidIsDistanceFromPoint,
         CylinderShapeDistanceFromPointTest,
         ::testing::ValuesIn(CylinderShapeDistanceFromPointTest::ShouldPass)
     );

--- a/Gems/LmbrCentral/Code/Tests/EditorComponentIntersectionTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/EditorComponentIntersectionTests.cpp
@@ -152,7 +152,7 @@ namespace LmbrCentral
         VerifySelectionIntersection();
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         ShapeEditorComponentIndirectCallManipulatorViewportInteractionFixtureParam,
         testing::Values(IntersectionQueryOutcome{ true, true }, IntersectionQueryOutcome{ false, false }));
@@ -162,7 +162,7 @@ namespace LmbrCentral
         VerifySelectionIntersection();
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         SplineEditorComponentIndirectCallManipulatorViewportInteractionFixtureParam,
         testing::Values(IntersectionQueryOutcome{ true, true }, IntersectionQueryOutcome{ false, false }));

--- a/Gems/LmbrCentral/Code/Tests/EditorTubeShapeComponentTests.cpp
+++ b/Gems/LmbrCentral/Code/Tests/EditorTubeShapeComponentTests.cpp
@@ -28,7 +28,7 @@ namespace UnitTest
     };
 
     // test both open and closed versions of the spline
-    INSTANTIATE_TEST_CASE_P(GenerateTubeManipulatorStates, EditorTubeShapeFixture, ::testing::Values(true, false));
+    INSTANTIATE_TEST_SUITE_P(GenerateTubeManipulatorStates, EditorTubeShapeFixture, ::testing::Values(true, false));
 
     TEST_P(EditorTubeShapeFixture, GenerateTubeManipulatorStates_returns_no_TubeManipulatorStates_when_spline_is_empty)
     {

--- a/Gems/PhysX/Common/Code/NumericalMethods/Tests/EigenanalysisTest.cpp
+++ b/Gems/PhysX/Common/Code/NumericalMethods/Tests/EigenanalysisTest.cpp
@@ -311,7 +311,7 @@ namespace NumericalMethods::Eigenanalysis
         EXPECT_NEAR(v3.Norm(), 1.0, 1e-6);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         OrthogonalComplementParams,
         ::testing::Values(
@@ -352,7 +352,7 @@ namespace NumericalMethods::Eigenanalysis
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(All, ComputeEigenvector0Params, ::testing::ValuesIn(testCasesUniqueEigenvalues));
+    INSTANTIATE_TEST_SUITE_P(All, ComputeEigenvector0Params, ::testing::ValuesIn(testCasesUniqueEigenvalues));
 
 
     class ComputeEigenvector1UniqueEigenvalueParams
@@ -394,7 +394,7 @@ namespace NumericalMethods::Eigenanalysis
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         ComputeEigenvector1UniqueEigenvalueParams,
         ::testing::ValuesIn(testCasesUniqueEigenvalues)
@@ -430,7 +430,7 @@ namespace NumericalMethods::Eigenanalysis
         );
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         ComputeEigenvector1RepeatedEigenvalueParams,
         ::testing::ValuesIn(testCasesRepeatedEigenvalues)
@@ -467,8 +467,8 @@ namespace NumericalMethods::Eigenanalysis
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(Unique, ComputeEigenvector2Params, ::testing::ValuesIn(testCasesUniqueEigenvalues));
-    INSTANTIATE_TEST_CASE_P(Repeated, ComputeEigenvector2Params, ::testing::ValuesIn(testCasesRepeatedEigenvalues));
+    INSTANTIATE_TEST_SUITE_P(Unique, ComputeEigenvector2Params, ::testing::ValuesIn(testCasesUniqueEigenvalues));
+    INSTANTIATE_TEST_SUITE_P(Repeated, ComputeEigenvector2Params, ::testing::ValuesIn(testCasesRepeatedEigenvalues));
 
 
     class NonIterativeSymmetricEigensolver3x3UniqueEigenvalueParams
@@ -509,7 +509,7 @@ namespace NumericalMethods::Eigenanalysis
         );
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         NonIterativeSymmetricEigensolver3x3UniqueEigenvalueParams,
         ::testing::ValuesIn(testCasesUniqueEigenvalues)
@@ -574,7 +574,7 @@ namespace NumericalMethods::Eigenanalysis
         );
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         NonIterativeSymmetricEigensolver3x3RepeatedEigenvalueParams,
         ::testing::ValuesIn(testCasesRepeatedEigenvalues)
@@ -612,7 +612,7 @@ namespace NumericalMethods::Eigenanalysis
         ExpectParallelUnitVector(ArrayToVector(result.m_eigenpairs[2].m_vector), { 0.0, 0.0, 1.0 }, 1e-6);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         NonIterativeSymmetricEigensolver3x3DiagonalMatrixParams,
         ::testing::Values(

--- a/Gems/PhysX/Core/Code/Tests/CharacterControllerTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/CharacterControllerTests.cpp
@@ -356,7 +356,7 @@ namespace PhysX
         EXPECT_EQ(errorHandler.GetErrorCount(), 1);
     }
 
-    INSTANTIATE_TEST_CASE_P(PhysXCharacters, CharacterControllerFixture, ::testing::ValuesIn(controllerShapeTypes));
+    INSTANTIATE_TEST_SUITE_P(PhysXCharacters, CharacterControllerFixture, ::testing::ValuesIn(controllerShapeTypes));
 
     TEST_F(PhysXDefaultWorldTest, CharacterController_ResizingCapsuleControllerBelowTwiceRadius_EmitsError)
     {

--- a/Gems/PhysX/Core/Code/Tests/CharacterGameplayControllerTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/CharacterGameplayControllerTests.cpp
@@ -261,6 +261,6 @@ namespace PhysX
         EXPECT_THAT(endPosition.GetZ(), testing::FloatNear((startPosition.GetZ() + calculatedDistanceFell), 0.001f));
     }
 
-    INSTANTIATE_TEST_CASE_P(PhysXDefaultWorldTest, PhysXDefaultWorldTestWithParamFixture, ::testing::Values(10, 30, 60, 90, 120, 136, 180));
+    INSTANTIATE_TEST_SUITE_P(PhysXDefaultWorldTest, PhysXDefaultWorldTestWithParamFixture, ::testing::Values(10, 30, 60, 90, 120, 136, 180));
 
 } // namespace PhysX

--- a/Gems/PhysX/Core/Code/Tests/EditorShapeColliderComponentTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/EditorShapeColliderComponentTests.cpp
@@ -933,7 +933,7 @@ namespace PhysXEditorTests
         delete rigidBodyComponent;
     }
 
-    INSTANTIATE_TEST_CASE_P(PhysXEditorTest, PhysXEditorParamBoolFixture, ::testing::Bool());
+    INSTANTIATE_TEST_SUITE_P(PhysXEditorTest, PhysXEditorParamBoolFixture, ::testing::Bool());
 
     TEST_F(PhysXEditorFixture, EditorShapeColliderComponent_SingleSidedQuadDoesNotCollideFromBelow)
     {

--- a/Gems/PhysX/Core/Code/Tests/PhysXComponentBusTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXComponentBusTests.cpp
@@ -922,7 +922,7 @@ namespace PhysX
         return ret;
     };
 
-    INSTANTIATE_TEST_CASE_P(, PhysicsRigidBodyRayBusTest,
+    INSTANTIATE_TEST_SUITE_P(, PhysicsRigidBodyRayBusTest,
         ::testing::Values(RigidBodyRaycastEBusCall, WorldBodyRaycastEBusCall),
         // Provide nice names for the tests runs
         [](const testing::TestParamInfo<PhysicsRigidBodyRayBusTest::ParamType>& info)

--- a/Gems/PhysX/Core/Code/Tests/PhysXForceRegionTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXForceRegionTest.cpp
@@ -357,7 +357,7 @@ namespace PhysX
         EXPECT_LE(maxVelocityZ, 0.0f);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         PhysXForceRegion,
         PhysXForceRegionTestParameterized,
         ::testing::Combine(::testing::Values(1.0f, 1e2f, 1e4f, 1e6f), ::testing::Values(1e-3f, 1e-2f, 1e-1f, 1.0f)));

--- a/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
@@ -318,7 +318,7 @@ namespace PhysX
         FixedJointConfiguration, 
         BallJointConfiguration, 
         HingeJointConfiguration>;
-    TYPED_TEST_CASE(PhysXJointsApiTest, JointTypes);
+    TYPED_TEST_SUITE(PhysXJointsApiTest, JointTypes);
 
     TYPED_TEST(PhysXJointsApiTest, Joint_ChildFollowsParent)
     {

--- a/Gems/PhysX/Core/Code/Tests/PhysXMultithreadingTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXMultithreadingTest.cpp
@@ -709,7 +709,7 @@ namespace PhysX
     }
 
 
-    INSTANTIATE_TEST_CASE_P(PhysXMultithreading, PhysXMultithreadingTest, ::testing::Values(1, 42, 123, 1337, 1403, 5317, 133987258));
+    INSTANTIATE_TEST_SUITE_P(PhysXMultithreading, PhysXMultithreadingTest, ::testing::Values(1, 42, 123, 1337, 1403, 5317, 133987258));
 }
 
 #ifdef PHYSX_MT_DEBUG_LOGS

--- a/Gems/PhysX/Core/Code/Tests/PhysXSceneQueryTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXSceneQueryTests.cpp
@@ -547,7 +547,7 @@ namespace PhysX
         EXPECT_EQ(result.m_hits[0].m_shape, sphereShape.get());
     }
 
-    INSTANTIATE_TEST_CASE_P(PhysX, SceneQueryFlagsTestFixture, ::testing::Combine(
+    INSTANTIATE_TEST_SUITE_P(PhysX, SceneQueryFlagsTestFixture, ::testing::Combine(
         ::testing::Bool(),
         ::testing::Bool()));
 

--- a/Gems/PhysX/Core/Code/Tests/PhysXSpecificTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXSpecificTest.cpp
@@ -281,7 +281,7 @@ namespace PhysX
     }
 
     auto entityFactories = { TestUtils::AddUnitTestObject<BoxColliderComponent>, TestUtils::AddUnitTestBoxComponentsMix };
-    INSTANTIATE_TEST_CASE_P(DifferentBoxes, PhysXEntityFactoryParamTest, ::testing::ValuesIn(entityFactories));
+    INSTANTIATE_TEST_SUITE_P(DifferentBoxes, PhysXEntityFactoryParamTest, ::testing::ValuesIn(entityFactories));
 
     TEST_F(PhysXSpecificTest, RigidBody_GetNativeType_ReturnsPhysXRigidBodyType)
     {
@@ -1299,7 +1299,7 @@ namespace PhysX
     }
 
     // Valid material density values: [0.01f, 1e5f]
-    INSTANTIATE_TEST_CASE_P(PhysX, MultiShapesDensityTestFixture,
+    INSTANTIATE_TEST_SUITE_P(PhysX, MultiShapesDensityTestFixture,
         ::testing::Values(
             AZStd::make_pair(0.01f, 0.01f),
             AZStd::make_pair(1e5f, 1e5f),
@@ -1351,7 +1351,7 @@ namespace PhysX
     }
 
     // Valid material density values: [0.01f, 1e5f]
-    INSTANTIATE_TEST_CASE_P(PhysX, DensityBoundariesTestFixture,
+    INSTANTIATE_TEST_SUITE_P(PhysX, DensityBoundariesTestFixture,
         ::testing::Values(
             std::numeric_limits<float>::min(),
             std::numeric_limits<float>::max(),
@@ -1575,7 +1575,7 @@ namespace PhysX
         AzPhysics::MassComputeFlags::DEFAULT, // COMPUTE_COM | COMPUTE_INERTIA | COMPUTE_MASS
     };
 
-    INSTANTIATE_TEST_CASE_P(PhysX, MassComputeFixture, ::testing::Combine(
+    INSTANTIATE_TEST_SUITE_P(PhysX, MassComputeFixture, ::testing::Combine(
         ::testing::ValuesIn({ Physics::ShapeType::Sphere, Physics::ShapeType::Box, Physics::ShapeType::Capsule }), // Values for GetShapeType() const
         ::testing::ValuesIn({ SimulatedShapesMode::NONE, SimulatedShapesMode::MIXED, SimulatedShapesMode::ALL }), // Values for GetShapesMode()
         ::testing::ValuesIn(PossibleMassComputeFlags), // Values for GetMassComputeFlags()
@@ -1642,7 +1642,7 @@ namespace PhysX
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(PhysX, MassPropertiesWithTriangleMesh,
+    INSTANTIATE_TEST_SUITE_P(PhysX, MassPropertiesWithTriangleMesh,
         ::testing::ValuesIn(PossibleMassComputeFlags)); // Values for GetMassComputeFlags()
 
     TEST_F(PhysXSpecificTest, RigidBodyWithBoxGeometryCanSwitchFromKinematicToDynamic)

--- a/Gems/PhysX/Core/Code/Tests/PrimitiveShapeFitterTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PrimitiveShapeFitterTests.cpp
@@ -137,7 +137,7 @@ namespace PhysX::Pipeline
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         ArgumentPackingTestFixture,
         ::testing::Values(
@@ -176,7 +176,7 @@ namespace PhysX::Pipeline
         EXPECT_NEAR(testData.m_shape->GetVolume(), testData.m_expectedVolume, 1e-6);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         VolumeTestFixture,
         ::testing::Values(
@@ -234,7 +234,7 @@ namespace PhysX::Pipeline
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         SquaredDistanceTestFixture,
         ::testing::Values(
@@ -477,7 +477,7 @@ namespace PhysX::Pipeline
         EXPECT_THAT(pair.second, ::testing::IsNull());
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         GetDegenerateShapeConfigurationTestFixture,
         ::testing::Values(
@@ -661,7 +661,7 @@ namespace PhysX::Pipeline
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         All,
         FitPrimitiveShapeTestFixture,
         ::testing::ValuesIn(TestTransforms)

--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshBuilderTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshBuilderTests.cpp
@@ -199,7 +199,7 @@ namespace AZ::MeshBuilder
         }
     };
 
-    INSTANTIATE_TEST_CASE_P(MeshBuilderTest_MaxSubMeshVertices,
+    INSTANTIATE_TEST_SUITE_P(MeshBuilderTest_MaxSubMeshVertices,
         MeshBuilderFixture,
         ::testing::ValuesIn(meshBuilderMaxSubMeshVerticesTestData));
 } // namespace AZ::MeshBuilder

--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshVerticesTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshVerticesTests.cpp
@@ -224,7 +224,7 @@ namespace AZ::MeshBuilder
         9
     };
 
-    INSTANTIATE_TEST_CASE_P(TriangleFanZVertexDedupTests,
+    INSTANTIATE_TEST_SUITE_P(TriangleFanZVertexDedupTests,
         TriangleFanMeshVerticesTestsFixture,
         ::testing::ValuesIn(meshVerticesTestData)
     );

--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/SkinInfluencesTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/SkinInfluencesTests.cpp
@@ -134,7 +134,7 @@ namespace AZ::MeshBuilder
         SkinInfluencesTestParam {/*.numOrgVertices =*/700, /*.maxSourceInfluences =*/12, /*.maxInfluencesAfterOptimization =*/3},
     };
 
-    INSTANTIATE_TEST_CASE_P(SkinInfluenceOptimizeTests,
+    INSTANTIATE_TEST_SUITE_P(SkinInfluenceOptimizeTests,
         SkinInfluencesFixture,
         ::testing::ValuesIn(skinInfluenceTestData)
     );

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxRenderDataTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxRenderDataTest.cpp
@@ -94,12 +94,12 @@ namespace UnitTest
         EXPECT_EQ(numOutTriangles, numInTriangles - faceData.m_numCulledFaces);
     }
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         NonDegenerateFaceList, WhiteBoxVertexDataTestFixture, ::testing::Values(NonDegenerateFaceList));
 
-    INSTANTIATE_TEST_CASE_P(DegenerateFaceList, WhiteBoxVertexDataTestFixture, ::testing::Values(DegenerateFaceList));
+    INSTANTIATE_TEST_SUITE_P(DegenerateFaceList, WhiteBoxVertexDataTestFixture, ::testing::Values(DegenerateFaceList));
 
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         DegenerateAndNonDegenerateFaceList, WhiteBoxVertexDataTestFixture,
         ::testing::Values(DegenerateAndNonDegenerateFaceList));
 } // namespace UnitTest

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxUVTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxUVTest.cpp
@@ -274,7 +274,7 @@ namespace UnitTest
     }
 
     // test with permutations of all noise values and sources with rotations around the x and z axis
-    INSTANTIATE_TEST_CASE_P(
+    INSTANTIATE_TEST_SUITE_P(
         , WhiteBoxUVTestFixture,
         ::testing::Combine(
             ::testing::ValuesIn(Noise), ::testing::ValuesIn(Source),


### PR DESCRIPTION
## What does this PR do?

Fix https://github.com/o3de/o3de/issues/18471#issue-2658482051

Upgrade google-test from 1.8.1 to 1.15.2 (latest release).
After upgrade, many macros are deprecated.  Change xx_CASE into xx_SUITE.

## How was this PR tested?

`ctest -C profile -L "(SUITE_smoke|SUITE_main)"`

Result:
```
The following tests FAILED:
          8 - AZ::AzToolsFramework.Tests.main::TEST_RUN (Failed)
         20 - AZ::AssetProcessor.Tests.main::TEST_RUN (Failed)
         30 - AZ::ProjectManager.Tests.main::TEST_RUN (Failed)
         77 - Gem::ImageProcessingAtom.Editor.Tests.main::TEST_RUN (Failed)
         91 - Gem::AssetValidation.Tests.main::TEST_RUN (Failed)
         93 - Gem::EMotionFX.Editor.Tests.main::TEST_RUN (SEGFAULT)
         95 - Gem::Atom_Utils.Tests.main::TEST_RUN (Failed)
        105 - Gem::AWSMetrics.Tests.main::TEST_RUN (Failed)
        129 - Gem::PhysX.Tests.main::TEST_RUN (Failed)
        131 - Gem::PhysX5.Tests.main::TEST_RUN (Failed)
        138 - Gem::ScriptCanvasTesting.Editor.Tests.main::TEST_RUN (Failed)
```
