### PR TITLE
Make sure RHI::Images stick around while Upload - Requests are pending

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamingImagePool.h
@@ -42,14 +42,14 @@ namespace AZ::RHI
         DeviceStreamingImageInitRequest() = default;
 
         DeviceStreamingImageInitRequest(
-            DeviceImage& image, const ImageDescriptor& descriptor, AZStd::span<const StreamingImageMipSlice> tailMipSlices)
-            : m_image{ &image }
+            Ptr<DeviceImage> image, const ImageDescriptor& descriptor, AZStd::span<const StreamingImageMipSlice> tailMipSlices)
+            : m_image{ AZStd::move(image) }
             , m_descriptor{ descriptor }
             , m_tailMipSlices{ tailMipSlices }
         {}
 
         /// The image to initialize.
-        DeviceImage* m_image = nullptr;
+        Ptr<DeviceImage> m_image = nullptr;
 
         /// The descriptor used to to initialize the image.
         ImageDescriptor m_descriptor;
@@ -67,7 +67,7 @@ namespace AZ::RHI
         StreamingImageExpandRequestTemplate() = default;
 
         /// The image with which to expand its mip chain.
-        ImageClass* m_image = nullptr;
+        Ptr<ImageClass> m_image = nullptr;
 
         //! A list of image mip slices used to expand the contents. The data *must*
         //! remain valid for the duration of the upload (until m_completeCallback

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceStreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceStreamingImagePool.cpp
@@ -43,7 +43,7 @@ namespace AZ::RHI
     {
         if (Validation::IsEnabled())
         {
-            if (!ValidateIsRegistered(expandRequest.m_image))
+            if (!ValidateIsRegistered(expandRequest.m_image.get()))
             {
                 return false;
             }
@@ -93,12 +93,12 @@ namespace AZ::RHI
         }
 
         ResultCode resultCode = DeviceImagePoolBase::InitImage(
-            initRequest.m_image,
+            initRequest.m_image.get(),
             initRequest.m_descriptor,
             [this, &initRequest]()
-        {
-            return InitImageInternal(initRequest);
-        });
+            {
+                return InitImageInternal(initRequest);
+            });
 
         if (resultCode == ResultCode::Success)
         {

--- a/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/StreamingImagePool.cpp
@@ -52,7 +52,7 @@ namespace AZ::RHI
     {
         if (Validation::IsEnabled())
         {
-            if (!ValidateIsRegistered(expandRequest.m_image))
+            if (!ValidateIsRegistered(expandRequest.m_image.get()))
             {
                 return false;
             }
@@ -132,7 +132,7 @@ namespace AZ::RHI
                             }
 
                             DeviceStreamingImageInitRequest streamingImageInitRequest(
-                                *initRequest.m_image->GetDeviceImage(deviceIndex), initRequest.m_descriptor, initRequest.m_tailMipSlices);
+                                initRequest.m_image->GetDeviceImage(deviceIndex), initRequest.m_descriptor, initRequest.m_tailMipSlices);
                             return deviceStreamingImagePool->InitImage(streamingImageInitRequest);
                         }
                         else
@@ -168,7 +168,7 @@ namespace AZ::RHI
                         request.m_image->m_deviceObjects[deviceIndex] = Factory::Get().CreateImage();
 
                         DeviceStreamingImageInitRequest imageInitRequest(
-                            *request.m_image->GetDeviceImage(deviceIndex), request.m_image->m_descriptor, request.m_tailMipSlices);
+                            request.m_image->GetDeviceImage(deviceIndex), request.m_image->m_descriptor, request.m_tailMipSlices);
                         auto result = deviceStreamingImagePool->InitImage(imageInitRequest);
 
                         if (result == ResultCode::Success)
@@ -215,7 +215,7 @@ namespace AZ::RHI
         {
             DeviceStreamingImageExpandRequest expandRequest;
 
-            expandRequest.m_image = request.m_image->GetDeviceImage(deviceIndex).get();
+            expandRequest.m_image = request.m_image->GetDeviceImage(deviceIndex);
             expandRequest.m_mipSlices = request.m_mipSlices;
             expandRequest.m_waitForUpload = request.m_waitForUpload;
             expandRequest.m_completeCallback = completeCallback;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -246,7 +246,7 @@ namespace AZ
             {
                 fenceValue = m_uploadFence.Increment();
 
-                Image* image = static_cast<Image*>(request.m_image);
+                Image* image = static_cast<Image*>(request.m_image.get());
                 image->SetUploadFenceValue(fenceValue);
 
                 uint32_t startMip = residentMip - 1;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
@@ -528,7 +528,7 @@ namespace AZ
 
             // Queue upload tail mip slices
             RHI::DeviceStreamingImageExpandRequest uploadMipRequest;
-            uploadMipRequest.m_image = &image;
+            uploadMipRequest.m_image = request.m_image;
             uploadMipRequest.m_mipSlices = request.m_tailMipSlices;
             uploadMipRequest.m_waitForUpload = true;
             GetDevice().GetAsyncUploadQueue().QueueUpload(uploadMipRequest, request.m_descriptor.m_mipLevels);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/StreamingImagePool.cpp
@@ -62,7 +62,7 @@ namespace AZ
 
             // Queue upload tail mip slices
              RHI::DeviceStreamingImageExpandRequest uploadMipRequest;
-             uploadMipRequest.m_image = &image;
+             uploadMipRequest.m_image = request.m_image;
              uploadMipRequest.m_mipSlices = request.m_tailMipSlices;
              uploadMipRequest.m_waitForUpload = true;
              GetDevice().GetAsyncUploadQueue().QueueUpload(uploadMipRequest, request.m_descriptor.m_mipLevels);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -190,7 +190,7 @@ namespace AZ
                 AZ_Assert(false, "Wrong input parameter");
             }
 
-            auto* image = static_cast<Image*>(request.m_image);
+            auto* image = static_cast<Image*>(request.m_image.get());
             auto& device = static_cast<Device&>(GetDevice());
 
             const uint16_t startMip = static_cast<uint16_t>(residentMip - 1);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
@@ -159,7 +159,7 @@ namespace AZ
 
             // Queue upload tail mip slices and wait for it finished.
             RHI::DeviceStreamingImageExpandRequest uploadMipRequest;
-            uploadMipRequest.m_image = &image;
+            uploadMipRequest.m_image = request.m_image;
             uploadMipRequest.m_mipSlices = request.m_tailMipSlices;
             uploadMipRequest.m_waitForUpload = true;
             device.GetAsyncUploadQueue().QueueUpload(uploadMipRequest, request.m_descriptor.m_mipLevels);
@@ -179,7 +179,6 @@ namespace AZ
 
             const uint16_t residentMipLevelBefore = static_cast<uint16_t>(image.GetResidentMipLevel());
             const uint16_t residentMipLevelAfter = residentMipLevelBefore - static_cast<uint16_t>(request.m_mipSlices.size());
-            
             RHI::ResultCode result = image.AllocateAndBindMemory(*this, residentMipLevelAfter);
 
             if (result != RHI::ResultCode::Success)


### PR DESCRIPTION
## What does this PR do?

This fixes a crash that can happen when an Image is released very quickly after it was created, and the Image has not yet finished uploading Mip-Levels.

This can happen in the Preview Renderer for materials with textures, where the material is used in one frame and immediately released. To somewhat reliably trigger this open the material-selection dialog such that many materials are visible at once, and the preview-images are created on demand, and the detail-preview window of a random material is also accessed. 

The sequence to the crash (or assert) is roughly like this:

- `~Material` calls `~MaterialProperty` which is a streaming-Image
- `~RPI::StreamingImage()` calls `Shutdown()`
  -  This clears all references to the `DeviceResources` in the `RHI::Image`: The `DeviceResourceView` are the only object still holding a reference to the `DeviceResource` 
- Then the `~RPI::Image()` runs, and destroys the member `m_imageView` 
- `~RHI::ImageView()` eventually calls `DeviceResourceView::Shutdown()`
  - This executes `m_resouce = nullptr;` which removes the last reference to the `DeviceResource` and destroys the object with the intrusive pointer
- `Object::release()`: of the `DeviceResource` is called via the `intrusive_ptr`, sets the useCount to -1 and calls the `Shutdown()` function
- `DeviceResource::Shutdown()` calls `WaitFinishUploading()`
  -  this eventually triggers the pending callback from `ExpandImageInternal()`
- The callback has a raw-pointer to the `RHI::Image`, aka. the `DeviceResource` which already has a useCount of -1
- The callback calls `FinalizeAsyncUpload()` -> `InvalidateViews()` -> manually calls `add_ref()`
  - This triggers an Assert because useCount is -1. Skipping the assert eventually causes at least a double free, or even a destructor loop

This PR changes the raw pointers of the two Upload Requests to smart pointers, such that the resource is destroyed only once the last pending upload is finished.

## How was this PR tested?

Windows on Vulkan, with previewing of many Material-Assets, and accessing detail-views of random materials.