### PR TITLE
Track View Fix: AzQtComponents::InputDialog should be modal (GHI-15048)

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
@@ -63,9 +63,9 @@ namespace AzQtComponents
 
     int InputDialog::exec()
     {
+        setWindowModality(Qt::WindowModality::WindowModal);
         show();
 
-        this->setWindowModality(Qt::WindowModality::WindowModal);
         return QInputDialog::exec();
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
@@ -65,7 +65,7 @@ namespace AzQtComponents
     {
         setWindowModality(Qt::WindowModality::WindowModal);
         show();
- 
+
         return QInputDialog::exec();
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.cpp
@@ -65,7 +65,7 @@ namespace AzQtComponents
     {
         setWindowModality(Qt::WindowModality::WindowModal);
         show();
-
+ 
         return QInputDialog::exec();
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/InputDialog.h
@@ -45,7 +45,7 @@ namespace AzQtComponents
         void SetMaxLength(int length);
 
         void show();
-        int exec();
+        int exec() override;
 
         static QString getText(QWidget* parent,
                                const QString& title,


### PR DESCRIPTION
## What does this PR do?

As described in the GHI https://github.com/o3de/o3de/issues/15048, renaming a deleted Track View node crashes the Editor. 

https://github.com/o3de/o3de/pull/17882 provided a partial fix with remaining occasional assert hit in CTrackViewSequence.

I was not able to reproduce this assert hit. However, there is an obvious UI issue that allows to delete the node in the process of its renaming or even open multiple rename popups simultaneously. 

![RenameNodeUI](https://github.com/user-attachments/assets/60e8ba8c-b339-4977-8a64-f9327f9ede4e)

The root cause is the bug in AzQtComponents::InputDialog that prevents it to be modal. Namely, accordingly to QT docs, the `setWindowModality` method has no effect is called after `show`. Please see https://doc.qt.io/qt-6/qwidget.html#windowModality-prop.

The PR fixes this issue. The "Console Variable Name" window is now modal as it's supposed to.

The override specifier has been added to the `exec()` function to avoid VC warning C26433.

## How was this PR tested?

Tested locally in the Editor on Windows 10.
