### PR TITLE
Change Atom_Feature_Common.Public back to static library

### DIFF
--- a/Gems/Atom/Feature/Common/Code/CMakeLists.txt
+++ b/Gems/Atom/Feature/Common/Code/CMakeLists.txt
@@ -40,9 +40,8 @@ ly_add_target(
 )
 
 ly_add_target(
-    NAME ${gem_name}.Public ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
+    NAME ${gem_name}.Public STATIC
     NAMESPACE Gem
-    EXPORT_ALL_SYMBOLS
     FILES_CMAKE
         atom_feature_common_public_files.cmake
     INCLUDE_DIRECTORIES


### PR DESCRIPTION
## What does this PR do?

This PR changes the `Atom_Feature_Common.Public` target back to a static library, since the current version with a shared library leads to occasional crashes when selecting an Entity in the editor (The hash value of an `AZ::Name` variable is 0 in `AZ::DocumentPropertyEditor::CallbackAttributeDefinition::InvokeOnDomValue`, which leads to a wrong codepath being chosen which eventually leads to a crash). This error was introduced in #18405, but the change to a shared library was not supposed to be in there; it was likely an oversight when rebasing the PR which was originally developed on top of #18315 (which itself was partially reverted with a more correct version still being in development).
This crash does not happen every time and does also not happen with the same likelyhood on different machines, so I am not sure what the root cause is; it could be due to how static data is handled within `AZ::Name`, but I did neither confirm nor disproof this. This will need to be revisited if the Atom_Feature_Common targets are to be properly converted to shared libraries.

## How was this PR tested?

Open the editor, select a few entities, and make sure the editor does not crash
