### PR TITLE
Fix resetting and recording of timestamps

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -52,14 +52,17 @@ namespace AZ
 
         void RayTracingAccelerationStructurePass::FrameBeginInternal(FramePrepareParams params)
         {
+            if (IsTimestampQueryEnabled())
+            {
+                m_timestampResult = AZ::RPI::TimestampResult();
+            }
+
             if (GetScopeId().IsEmpty())
             {
                 InitScope(RHI::ScopeId(GetPathName()), RHI::HardwareQueueClass::Graphics, Pass::GetDeviceIndex());
             }
 
             params.m_frameGraphBuilder->ImportScopeProducer(*this);
-
-            ReadbackScopeQueryResults();
 
             RPI::Scene* scene = m_pipeline->GetScene();
             RayTracingFeatureProcessor* rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
@@ -71,6 +74,7 @@ namespace AZ
                 if (m_rayTracingRevisionOutDated)
                 {
                     m_rayTracingRevision = revision;
+                    ReadbackScopeQueryResults();
                 }
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -205,11 +205,22 @@ namespace AZ
         {
             if (m_copyMode == CopyMode::SameDevice)
             {
+                if (IsTimestampQueryEnabled())
+                {
+                    m_queryEntries[AZStd::to_underlying(CopyIndex::SameDevice)].m_timestampResult = AZ::RPI::TimestampResult();
+                }
+
                 params.m_frameGraphBuilder->ImportScopeProducer(*m_copyScopeProducerSameDevice);
                 ReadbackScopeQueryResults(CopyIndex::SameDevice);
             }
             else if (m_copyMode == CopyMode::DifferentDevicesIntermediateHost)
             {
+                if (IsTimestampQueryEnabled())
+                {
+                    m_queryEntries[AZStd::to_underlying(CopyIndex::DeviceToHost)].m_timestampResult = AZ::RPI::TimestampResult();
+                    m_queryEntries[AZStd::to_underlying(CopyIndex::HostToDevice)].m_timestampResult = AZ::RPI::TimestampResult();
+                }
+
                 params.m_frameGraphBuilder->ImportScopeProducer(*m_copyScopeProducerDeviceToHost);
                 params.m_frameGraphBuilder->ImportScopeProducer(*m_copyScopeProducerHostToDevice);
                 m_currentBufferIndex = (m_currentBufferIndex + 1) % MaxFrames;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -267,7 +267,10 @@ namespace AZ
 
         void RenderPass::FrameBeginInternal(FramePrepareParams params)
         {
-            m_timestampResult = AZ::RPI::TimestampResult();
+            if (IsTimestampQueryEnabled())
+            {
+                m_timestampResult = AZ::RPI::TimestampResult();
+            }
 
             // the pass may potentially migrate between devices dynamically at runtime so the deviceIndex is updated every frame.
             if (GetScopeId().IsEmpty() || (ScopeProducer::GetDeviceIndex() != Pass::GetDeviceIndex()))


### PR DESCRIPTION
## What does this PR do?

Previous changes to timestamp recording in the `Renderpass` as well as `RayTracingAccelerationStructurePass` lead to unusable behaviour in the ImGui Timestamp View, as can be seen here:

![GPUProfiler](https://github.com/user-attachments/assets/dba0aadc-4499-46e1-b9f2-b6aac2056f6f)

- The RT pass reported weird timings as it exists early and might report old timestamps
- Pausing cleared the latest timestamp and did not allow to inspect the results properly

With this PR, the behaviour is now again as intended:

![GPUProfilerFixed](https://github.com/user-attachments/assets/31c560b8-8a95-42fd-b375-9c8f5bee1c6b)

## How was this PR tested?

Start a sample and open up the ImGui GPU Profiler with its Timestamp View.
