### PR TITLE
Introduce Vulkan HOST_CACHED_BIT

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/Conversion.cpp
@@ -193,7 +193,7 @@ namespace AZ
             switch (heapMemoryLevel)
             {
             case RHI::HeapMemoryLevel::Host:
-                return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+                return VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
             case RHI::HeapMemoryLevel::Device:
                 return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
             default:

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -499,6 +499,7 @@ namespace AZ
             case RHI::HeapMemoryLevel::Host:
                 allocInfo.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
                 allocInfo.requiredFlags |= VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+                allocInfo.requiredFlags |= VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
                 break;
             case RHI::HeapMemoryLevel::Device:
                 allocInfo.requiredFlags |= VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;


### PR DESCRIPTION
## What does this PR do?

During testing, we found that copy performance is significantly slower (multiple times) on `vulkan` compared to `dx12` and found that it can be traced back to how memory is held on the host side.
By introducing the `VK_MEMORY_PROPERTY_HOST_CACHED_BIT`, the performance for copy operations involving the host on `vulkan` is now "identical" to `dx12`.

From the [specification](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkMemoryPropertyFlagBits.html)
> VK_MEMORY_PROPERTY_HOST_CACHED_BIT bit specifies that memory allocated with this type is cached on the host. Host memory accesses to uncached memory are slower than to cached memory, however uncached memory is always host coherent.