### PR TITLE
Fixes memory corruption issues in ArchiveAPI

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/ZipDirStructures.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ZipDirStructures.cpp
@@ -498,54 +498,57 @@ namespace AZ::IO::ZipDir
         int nReturnCode = Z_OK;
 
         //check first 4 bytes to see what compression codec was used
-        if (CompressionCodec::TestForZSTDMagic(pCompressed))
+        if (nSrcSize >= 4)
         {
-            size_t result = ZSTD_decompress(pUncompressed, *pDestSize, pCompressed, nSrcSize);
+            if (CompressionCodec::TestForZSTDMagic(pCompressed))
+            {
+                size_t result = ZSTD_decompress(pUncompressed, *pDestSize, pCompressed, nSrcSize);
 
-            if (ZSTD_isError(result))
-            {
-                AZ_Error("ZipDirStructures", false, "Error decompressing using zstd: %s", ZSTD_getErrorName(result));
-                nReturnCode = Z_BUF_ERROR;
+                if (ZSTD_isError(result))
+                {
+                    AZ_Error("ZipDirStructures", false, "Error decompressing using zstd: %s", ZSTD_getErrorName(result));
+                    nReturnCode = Z_BUF_ERROR;
+                }
+                else
+                {
+                    *pDestSize = result;
+                }
+                return nReturnCode;
             }
-            else
+            else if (CompressionCodec::TestForLZ4Magic(pCompressed))
             {
-                *pDestSize = result;
-            }
-            return nReturnCode;
-        }
-        else if (CompressionCodec::TestForLZ4Magic(pCompressed))
-        {
-            size_t result;
-            LZ4F_decompressionContext_t dctx;
-            result = LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
-            if (LZ4F_isError(result))
-            {
-                AZ_Error("ZipDirStructures", false, "Error creating lz4 decompression context: %s", LZ4F_getErrorName(result));
-                return Z_BUF_ERROR;
-            }
+                size_t result;
+                LZ4F_decompressionContext_t dctx;
+                result = LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
+                if (LZ4F_isError(result))
+                {
+                    AZ_Error("ZipDirStructures", false, "Error creating lz4 decompression context: %s", LZ4F_getErrorName(result));
+                    return Z_BUF_ERROR;
+                }
 
-            size_t dstSize = *pDestSize;
-            size_t srcSize = nSrcSize;
-            result = LZ4F_decompress(dctx, pUncompressed, &dstSize, pCompressed, &srcSize, nullptr);
-            if (LZ4F_isError(result))
-            {
-                AZ_Error("ZipDirStructures", false, "Error decompressing using lz4: %s", LZ4F_getErrorName(result));
-                nReturnCode = Z_BUF_ERROR;
-            }
-            else
-            {
-                *pDestSize = dstSize;
-            }
+                size_t dstSize = *pDestSize;
+                size_t srcSize = nSrcSize;
+                result = LZ4F_decompress(dctx, pUncompressed, &dstSize, pCompressed, &srcSize, nullptr);
+                if (LZ4F_isError(result))
+                {
+                    AZ_Error("ZipDirStructures", false, "Error decompressing using lz4: %s", LZ4F_getErrorName(result));
+                    nReturnCode = Z_BUF_ERROR;
+                }
+                else
+                {
+                    *pDestSize = dstSize;
+                }
 
-            size_t freeCode = LZ4F_freeDecompressionContext(dctx);
-            if (LZ4F_isError(freeCode))
-            {
-                //We are not changing the return code in this case, but it is good to record that releasing the
-                //decompression context failed.
-                AZ_Error("ZipDirStructures", false, "Error releasing lz4 decompression context: %s", LZ4F_getErrorName(freeCode));
-            }
+                size_t freeCode = LZ4F_freeDecompressionContext(dctx);
+                if (LZ4F_isError(freeCode))
+                {
+                    //We are not changing the return code in this case, but it is good to record that releasing the
+                    //decompression context failed.
+                    AZ_Error("ZipDirStructures", false, "Error releasing lz4 decompression context: %s", LZ4F_getErrorName(freeCode));
+                }
 
-            return nReturnCode;
+                return nReturnCode;
+            }
         }
 
         //fallback to zlib

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.cpp
@@ -98,12 +98,6 @@ namespace AzToolsFramework
 
         m_fileIO = nullptr;
         m_archive = nullptr;
-
-        for (AZStd::thread& t : m_threads)
-        {
-            t.join();
-        }
-        m_threads = {};
     }
 
     void ArchiveComponent::Reflect(AZ::ReflectContext * context)
@@ -137,22 +131,20 @@ namespace AzToolsFramework
             return p.get_future();
         }
 
-        auto FnCreateArchive = [this, archivePath, dirToArchive](std::promise<bool>&& p) -> void
+        auto FnCreateArchive = [this](AZStd::string archivePath, AZStd::string dirToArchive) -> bool
         {
             auto archive = m_archive->OpenArchive(archivePath, {}, AZ::IO::INestedArchive::FLAGS_CREATE_NEW);
             if (!archive)
             {
                 AZ_Error(s_traceName, false, "Failed to create archive file '%s'", archivePath.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             auto foundFiles = AzFramework::FileFunc::FindFilesInPath(dirToArchive, "*", true);
             if (!foundFiles.IsSuccess())
             {
                 AZ_Error(s_traceName, false, "Failed to find file listing under directory '%d'", dirToArchive.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             bool success = true;
@@ -188,17 +180,10 @@ namespace AzToolsFramework
             }
 
             archive.reset();
-            p.set_value(success);
+            return success;
         };
 
-        // Async task...
-        std::promise<bool> p;
-        std::future<bool> f = p.get_future();
-
-        AZStd::thread_desc threadDesc;
-        threadDesc.m_name = "Archive Task (Create)";
-        m_threads.emplace_back(threadDesc, FnCreateArchive, AZStd::move(p));
-        return f;
+        return std::async(std::launch::async, FnCreateArchive, archivePath, dirToArchive);
     }
 
 
@@ -213,22 +198,20 @@ namespace AzToolsFramework
             return p.get_future();
         }
 
-        auto FnExtractArchive = [this, archivePath, destinationPath](std::promise<bool>&& p) -> void
+        auto FnExtractArchive = [this, archivePath, destinationPath]() -> bool
         {
             auto archive = m_archive->OpenArchive(archivePath, {}, AZ::IO::INestedArchive::FLAGS_READ_ONLY);
             if (!archive)
             {
                 AZ_Error(s_traceName, false, "Failed to open archive file '%s'", archivePath.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             AZStd::vector<AZ::IO::Path> filesInArchive;
             if (int result = archive->ListAllFiles(filesInArchive); result != AZ::IO::ZipDir::ZD_ERROR_SUCCESS)
             {
                 AZ_Error(s_traceName, false, "Failed to get list of files in archive '%s'", archivePath.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             AZStd::vector<AZ::u8> fileBuffer;
@@ -275,17 +258,10 @@ namespace AzToolsFramework
                 m_fileIO->Close(dstHandle);
             }
 
-            p.set_value(numFilesWritten == filesInArchive.size());
+            return (numFilesWritten == filesInArchive.size());
         };
 
-        // Async task...
-        std::promise<bool> p;
-        std::future<bool> f = p.get_future();
-
-        AZStd::thread_desc threadDesc;
-        threadDesc.m_name = "Archive Task (Extract)";
-        m_threads.emplace_back(threadDesc, FnExtractArchive, AZStd::move(p));
-        return f;
+        return std::async(std::launch::async, FnExtractArchive);
     }
 
 
@@ -301,22 +277,20 @@ namespace AzToolsFramework
             return p.get_future();
         }
 
-        auto FnExtractFile = [this, archivePath, fileInArchive, destinationPath](std::promise<bool>&& p) -> void
+        auto FnExtractFile = [this, archivePath, fileInArchive, destinationPath]() -> bool
         {
             auto archive = m_archive->OpenArchive(archivePath, {}, AZ::IO::INestedArchive::FLAGS_READ_ONLY);
             if (!archive)
             {
                 AZ_Error(s_traceName, false, "Failed to open archive file '%s'", archivePath.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             AZ::IO::INestedArchive::Handle fileHandle = archive->FindFile(fileInArchive);
             if (!fileHandle)
             {
                 AZ_Error(s_traceName, false, "File '%s' does not exist inside archive '%s'", fileInArchive.c_str(), archivePath.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             AZ::u64 fileSize = archive->GetFileSize(fileHandle);
@@ -328,8 +302,7 @@ namespace AzToolsFramework
                 AZ_Error(
                     s_traceName, false, "Failed to read file '%s' in archive '%s' with error %d", fileInArchive.c_str(),
                     archivePath.c_str(), result);
-                p.set_value(false);
-                return;
+                return false;
             }
 
             AZ::IO::HandleType destFileHandle = AZ::IO::InvalidHandle;
@@ -339,8 +312,7 @@ namespace AzToolsFramework
             if (!m_fileIO->Open(destinationFile.c_str(), openMode, destFileHandle))
             {
                 AZ_Error(s_traceName, false, "Failed to open destination file '%s' for writing", destinationFile.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             AZ::u64 bytesWritten = 0;
@@ -350,17 +322,11 @@ namespace AzToolsFramework
             }
 
             m_fileIO->Close(destFileHandle);
-            p.set_value(bytesWritten == fileSize);
+            return (bytesWritten == fileSize);
         };
 
         // Async task...
-        std::promise<bool> p;
-        std::future<bool> f = p.get_future();
-
-        AZStd::thread_desc threadDesc;
-        threadDesc.m_name = "Archive Task (Extract Single)";
-        m_threads.emplace_back(threadDesc, FnExtractFile, AZStd::move(p));
-        return f;
+        return std::async(std::launch::async, FnExtractFile);
     }
 
 
@@ -407,14 +373,13 @@ namespace AzToolsFramework
             return p.get_future();
         }
 
-        auto FnAddFileToArchive = [this, archivePath, workingDirectory, fileToAdd](std::promise<bool>&& p) -> void
+        auto FnAddFileToArchive = [this, archivePath, workingDirectory, fileToAdd]() -> bool
         {
             auto archive = m_archive->OpenArchive(archivePath);
             if (!archive)
             {
                 AZ_Error(s_traceName, false, "Failed to open archive file '%s'", archivePath.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             AZ::IO::Path workingPath{ workingDirectory };
@@ -442,17 +407,10 @@ namespace AzToolsFramework
             }
 
             archive.reset();
-            p.set_value(success);
+            return success;
         };
 
-        // Async task...
-        std::promise<bool> p;
-        std::future<bool> f = p.get_future();
-
-        AZStd::thread_desc threadDesc;
-        threadDesc.m_name = "Archive Task (Add Single)";
-        m_threads.emplace_back(threadDesc, FnAddFileToArchive, AZStd::move(p));
-        return f;
+        return std::async(std::launch::async, FnAddFileToArchive); 
     }
 
 
@@ -468,14 +426,13 @@ namespace AzToolsFramework
             return p.get_future();
         }
 
-        auto FnAddFilesToArchive = [this, archivePath, workingDirectory, listFilePath](std::promise<bool>&& p) -> void
+        auto FnAddFilesToArchive = [this, archivePath, workingDirectory, listFilePath]() -> bool
         {
             auto archive = m_archive->OpenArchive(archivePath);
             if (!archive)
             {
                 AZ_Error(s_traceName, false, "Failed to open archive file '%s'", archivePath.c_str());
-                p.set_value(false);
-                return;
+                return false;
             }
 
             bool success = true; // starts true and turns false when any error is encountered.
@@ -508,17 +465,10 @@ namespace AzToolsFramework
             ArchiveUtils::ProcessFileList(listFilePath, PerLineCallback);
 
             archive.reset();
-            p.set_value(success);
+            return success;
         };
 
-        // Async task...
-        std::promise<bool> p;
-        std::future<bool> f = p.get_future();
-
-        AZStd::thread_desc threadDesc;
-        threadDesc.m_name = "Archive Task (Add)";
-        m_threads.emplace_back(threadDesc, FnAddFilesToArchive, AZStd::move(p));
-        return f;
+        return std::async(std::launch::async, FnAddFilesToArchive); 
     }
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.h
@@ -75,7 +75,6 @@ namespace AzToolsFramework
     private:
         AZ::IO::FileIOBase* m_fileIO = nullptr;
         AZ::IO::IArchive* m_archive = nullptr;
-        AZStd::vector<AZStd::thread> m_threads;
 
         bool CheckParamsForAdd(const AZStd::string& directory, const AZStd::string& file);
         bool CheckParamsForExtract(const AZStd::string& archive, const AZStd::string& directory);

--- a/Code/Framework/AzToolsFramework/Tests/ArchiveTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ArchiveTests.cpp
@@ -279,13 +279,14 @@ namespace UnitTest
             // to simulate this, we're going to start 8 threads
             // those 8 threads will continuously create files in a folder, then archive them, then add additional files to that archive.
 
-            const int numDummyFiles = 5;
             const int numThreads = 8;
             const int numIterationsPerThread = 100; // takes about 20sec in debug on good HW with ASAN, much faster in profile.
 
             auto threadFn =
-                [this, numDummyFiles](int threadIndex, int iterations)
+                [this](int threadIndex, int iterations)
             {
+                const int numDummyFiles = 5;
+
                 for (int iteration = 0; iteration < iterations; ++iteration)
                 {
                     // create a temp folder and then 5 dummy files in that folder to represent the files that will be archived

--- a/Code/Framework/AzToolsFramework/Tests/ArchiveTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ArchiveTests.cpp
@@ -138,7 +138,14 @@ namespace UnitTest
 
                 if (auto fileIoBase = AZ::IO::FileIOBase::GetInstance(); fileIoBase != nullptr)
                 {
-                    fileIoBase->SetAlias("@products@", m_tempDir.GetDirectory());
+                    QDir cacheFolder(m_tempDir.GetDirectory());
+                    // set the product tree folder to somewhere besides the root temp dir.
+                    // This is to avoid error spam - if you try to write to the Cache folder or a subfolder,
+                    // AZ::IO will issue an error, since the cache is supposed to be read-only.
+                    // here we set it to (tempFolder)/Cache subfolder so that if you want a folder in your test to act like
+                    // the read-only cache folder, you can use that folder, but otherwise, all other folders are fair game to
+                    // use for your tests without triggering the "you cannot write to the cache" error.
+                    fileIoBase->SetAlias("@products@", cacheFolder.absoluteFilePath("Cache").toUtf8().constData());
                 }
             }
 
@@ -156,9 +163,7 @@ namespace UnitTest
         {
             CreateArchiveFolder();
 
-            AZ_TEST_START_TRACE_SUPPRESSION;
             bool createResult = CreateArchive();
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
 
             EXPECT_TRUE(createResult);
         }
@@ -167,7 +172,6 @@ namespace UnitTest
         {
             CreateArchiveFolder();
 
-            AZ_TEST_START_TRACE_SUPPRESSION;
             EXPECT_EQ(CreateArchive(), true);
 
             AZStd::vector<AZStd::string> fileList;
@@ -175,7 +179,6 @@ namespace UnitTest
             AzToolsFramework::ArchiveCommandsBus::BroadcastResult(listResult,
                 &AzToolsFramework::ArchiveCommandsBus::Events::ListFilesInArchive,
                 GetArchivePath().toUtf8().constData(), fileList);
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
 
             EXPECT_TRUE(listResult);
             EXPECT_EQ(fileList.size(), 6);
@@ -186,9 +189,7 @@ namespace UnitTest
             QStringList fileList = CreateArchiveFileList();
 
             CreateArchiveFolder(GetArchiveFolderName(), fileList);
-            AZ_TEST_START_TRACE_SUPPRESSION;
             bool createResult = CreateArchive();
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
 
             EXPECT_EQ(createResult, true);
 
@@ -205,13 +206,11 @@ namespace UnitTest
             QString listFile = CreateArchiveListTextFile();
             CreateArchiveFolder(GetArchiveFolderName(), CreateArchiveFileList());
 
-            AZ_TEST_START_TRACE_SUPPRESSION;
             std::future<bool> addResult;
             AzToolsFramework::ArchiveCommandsBus::BroadcastResult(
                 addResult, &AzToolsFramework::ArchiveCommandsBus::Events::AddFilesToArchive, GetArchivePath().toUtf8().constData(),
                 GetArchiveFolder().toUtf8().constData(), listFile.toUtf8().constData());
             bool result = addResult.get();
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
 
             EXPECT_TRUE(result);
         }
@@ -219,18 +218,14 @@ namespace UnitTest
         TEST_F(ArchiveComponentTest, ExtractArchive_AllFiles_Success)
         {
             CreateArchiveFolder();
-            AZ_TEST_START_TRACE_SUPPRESSION;
             bool createResult = CreateArchive();
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
             EXPECT_TRUE(createResult);
 
-            AZ_TEST_START_TRACE_SUPPRESSION;
             std::future<bool> extractResult;
             AzToolsFramework::ArchiveCommandsBus::BroadcastResult(
                 extractResult, &AzToolsFramework::ArchiveCommandsBus::Events::ExtractArchive, GetArchivePath().toUtf8().constData(),
                 GetExtractFolder().toUtf8().constData());
             bool result = extractResult.get();
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
 
             EXPECT_TRUE(result);
 
@@ -249,9 +244,7 @@ namespace UnitTest
 
             CreateArchiveFolder(GetArchiveFolderName(), fileList);
 
-            AZ_TEST_START_TRACE_SUPPRESSION;
             bool createResult = CreateArchive();
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
 
             EXPECT_EQ(createResult, true);
 
@@ -267,12 +260,97 @@ namespace UnitTest
                 AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::RegisterAsset, generatedID, newInfo);
             }
 
-            bool catalogCreated{ false };
             AZ_TEST_START_TRACE_SUPPRESSION;
+            bool catalogCreated{ false };
             AzToolsFramework::AssetBundleCommandsBus::BroadcastResult(catalogCreated, &AzToolsFramework::AssetBundleCommandsBus::Events::CreateDeltaCatalog, GetArchivePath().toUtf8().constData(), true);
-            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT; // produces different counts in different platforms
+            AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT; // the above raises at least one complaint, but is os specific, since it creates a file in the cache (and then deletes it)
+
             EXPECT_EQ(catalogCreated, true);
         }
+
+
+        TEST_F(ArchiveComponentTest, SUITE_periodic_ArchiveAsyncMemoryCorruptionTest)
+        {
+            // simulate the way the Asset Processor might create many archives asynchronously, overlapping.
+            // The general pattern the AP uses is that NCPUs threads are created, and each thread could be creating an archive
+            // at the same time.  Each thread is operating on its own temp directory, and calls two APIs:
+            // CreateArchive (every time), and then AddFileToArchive (some of the time).
+            // There is always a file in the archive, but not always one in the extra API call.
+            // to simulate this, we're going to start 8 threads
+            // those 8 threads will continuously create files in a folder, then archive them, then add additional files to that archive.
+
+            const int numDummyFiles = 5;
+            const int numThreads = 8;
+            const int numIterationsPerThread = 100; // takes about 20sec in debug on good HW with ASAN, much faster in profile.
+
+            auto threadFn =
+                [this, numDummyFiles](int threadIndex, int iterations)
+            {
+                for (int iteration = 0; iteration < iterations; ++iteration)
+                {
+                    // create a temp folder and then 5 dummy files in that folder to represent the files that will be archived
+                    // tempfolder/archive_n_n = folder containing files to archive initially, in the "CreateArchive" API call.
+                    // tempfolder/extra_n_n = folder containing files to add to archive afterwards, in the "AddFilesToArchive" API call.
+                    // tempfolder/TestArchive_n_n.zip = archive output file.
+                    // tempfolder/extra_n_n/filelist.txt = list of files to add to archive in the "AddFilesToArchive" call.
+                    // we do not attempt to read the archive back, this is just a thrash test.
+                    QString folderName = QString("archive%1_%2").arg(threadIndex).arg(iteration);
+                    QString extraFolderName = QString("extra%1_%2").arg(threadIndex).arg(iteration);
+                    QString archivePath = QDir(m_tempDir.GetDirectory()).filePath(QString("TestArchive%1_%2.zip").arg(threadIndex).arg(iteration));
+                    QString folderPath = QDir(m_tempDir.GetDirectory()).filePath(folderName);
+                    QString extraFolderPath = QDir(m_tempDir.GetDirectory()).filePath(extraFolderName);
+                    QString dummyFileContent;
+
+                    for (int fileToArchive = 0; fileToArchive < numDummyFiles; ++fileToArchive)
+                    {
+                        QString filePath = QDir(folderPath).filePath(QString("file%1.txt").arg(fileToArchive));
+                        QString extraFileName = QString("extrafile%1.txt").arg(fileToArchive);
+                        QString extraFilePath = QDir(extraFolderPath).filePath(extraFileName);
+                        CreateDummyFile(filePath, QString(1024 * iteration, QChar('C')));
+                        CreateDummyFile(extraFilePath, QString(1024 * iteration, QChar('C')));
+                        dummyFileContent.append(QDir::toNativeSeparators(extraFileName));
+                        dummyFileContent.append("\n");
+                    }
+                    QString fileListPath = QDir(extraFolderPath).filePath("filelist.txt");
+                    CreateDummyFile(fileListPath, dummyFileContent);
+
+                    std::future<bool> createResult;
+                    AzToolsFramework::ArchiveCommandsBus::BroadcastResult(
+                        createResult,
+                        &AzToolsFramework::ArchiveCommandsBus::Events::CreateArchive,
+                        archivePath.toUtf8().constData(),
+                        folderPath.toUtf8().constData());
+                    EXPECT_TRUE(createResult.valid() ? createResult.get() : false);
+
+                    std::future<bool> addResult;
+                    AzToolsFramework::ArchiveCommandsBus::BroadcastResult(
+                        addResult,
+                        &AzToolsFramework::ArchiveCommandsBus::Events::AddFilesToArchive,
+                        archivePath.toUtf8().constData(),
+                        extraFolderPath.toUtf8().constData(),
+                        fileListPath.toUtf8().constData());
+
+                    EXPECT_TRUE(addResult.valid() ? addResult.get() : false);
+                }
+            };
+
+            // spawn 8 threads to do the above and then wait for all of them to complete.
+            AZStd::vector<AZStd::thread> threads;
+
+            for (int i = 0; i < numThreads; ++i)
+            {
+                threads.emplace_back(threadFn, i, numIterationsPerThread);
+            }
+
+            for (int i = 0; i < numThreads; ++i)
+            {
+                if (threads[i].joinable())
+                {
+                    threads[i].join();
+                }
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION

## What does this PR do?

POTENTIAL fix to https://github.com/o3de/o3de/issues/18421
(more testing required, its not a 100% repro of the above, but these are definitely corruption issues anyway even if it doesn't solve the above).

* Fixes a memory corruption issue caused by concurrent access of the m_threads member of the Archive Component class by eliminating this member and replacing it with std::async usage.  This is simpler, and eliminates the need to manually mess with promise and future.
* Adds back the ability for AzCore systemAllocator to use the os allocator when a flag is set for it to do so.  Note that this flag was already being set when ASAN was enabled but was not being honored.
* Fixes a buffer overrun detected by ASAN in the ZipDirStructures.cpp
* Fixes a buffer overrun detected by ASAN in main.cpp in the AzTestRunner
* Adds a "periodic" stress test to the Archive Tests to reproduce the same environment as AP uses it in.

  Note that the stress test produced the memory corruption.  After the fix the corruption is no longer present.

## How was this PR tested?

Running the periodic test on gtest_repeat=100 in both profile and debug, with ASAN and maximum memory checking. 
Before the changes, it would crash almost immediately.  After the changes, no crashes thru 100 iterations in both debug and profile.

Running the CI build cpu test.  (successfully).
```
100% tests passed, 0 tests failed out of 49

Label Time Summary:
COMPONENT_Editor                = 931.73 sec*proc (2 tests)
COMPONENT_MetadataRelocation    =  56.97 sec*proc (1 test)
COMPONENT_Physics               =  44.01 sec*proc (1 test)
COMPONENT_ScriptCanvas          =  27.24 sec*proc (1 test)
COMPONENT_Smoke                 =   2.64 sec*proc (1 test)
COMPONENT_TestTools             =  68.20 sec*proc (5 tests)
FRAMEWORK_googletest            =  55.88 sec*proc (14 tests)
FRAMEWORK_pytest                = 1276.94 sec*proc (34 tests)
SUITE_main                      = 1144.40 sec*proc (23 tests)
SUITE_smoke                     = 200.71 sec*proc (26 tests)

Total Test time (real) = 1139.91 sec
--------------------------------------------------------------------------------
[ci_build] OK
```

