### PR TITLE
New: double clicking in an item in entity outliner does a camera go-to

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -844,6 +844,7 @@ namespace AzToolsFramework
 
     void EntityOutlinerWidget::OnTreeItemDoubleClicked(const QModelIndex& index)
     {
+        AzToolsFramework::EditorRequestBus::Broadcast(&AzToolsFramework::EditorRequestBus::Events::GoToSelectedEntitiesInViewports);
         if (AZ::EntityId entityId = GetEntityIdFromIndex(index); auto entityUiHandler = m_editorEntityUiInterface->GetHandler(entityId))
         {
             entityUiHandler->OnOutlinerItemDoubleClick(index);


### PR DESCRIPTION
## What does this PR do?

In most 3d authoring software, double clicking on an entity in the entity outliner window makes the camera focused on said entity in the viewport. This PR allows to reproduce this behavior.

Currently, when an entity is selected, you need to press Z to go to this entity.

This PR changes the default behavior of the double click :

- For an editor entity, for a prefab and for an entity inside a prefab : go to the selected entity

https://github.com/user-attachments/assets/c26a6cdf-e62b-4e6d-83f5-f4dafe1fecef

## How was this PR tested?

Local windows build, on the GnomebodysHome project. Selected an entity, a prefab and an entity inside a prefab.