### PR TITLE
Fixed issues with undoing deletion of entity with SequenceAgent (GHI-14980)

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -113,7 +113,6 @@ CAnimationContext::CAnimationContext()
     GetIEditor()->GetUndoManager()->AddListener(this);
     GetIEditor()->GetSequenceManager()->AddListener(this);
     GetIEditor()->RegisterNotifyListener(this);
-
     AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusConnect();
 }
 
@@ -121,7 +120,6 @@ CAnimationContext::CAnimationContext()
 CAnimationContext::~CAnimationContext()
 {
     AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusDisconnect();
-
     GetIEditor()->GetSequenceManager()->RemoveListener(this);
     GetIEditor()->GetUndoManager()->RemoveListener(this);
     GetIEditor()->UnregisterNotifyListener(this);

--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -113,11 +113,15 @@ CAnimationContext::CAnimationContext()
     GetIEditor()->GetUndoManager()->AddListener(this);
     GetIEditor()->GetSequenceManager()->AddListener(this);
     GetIEditor()->RegisterNotifyListener(this);
+
+    AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusConnect();
 }
 
 //////////////////////////////////////////////////////////////////////////
 CAnimationContext::~CAnimationContext()
 {
+    AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusDisconnect();
+
     GetIEditor()->GetSequenceManager()->RemoveListener(this);
     GetIEditor()->GetUndoManager()->RemoveListener(this);
     GetIEditor()->UnregisterNotifyListener(this);
@@ -650,6 +654,14 @@ void CAnimationContext::EndUndoTransaction()
     }
 
     SetRecordingInternal(m_bSavedRecordingState);
+}
+
+void CAnimationContext::OnPrefabInstancePropagationEnd()
+{
+    if (m_pSequence)
+    {
+        m_pSequence->BindToEditorObjects();
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -16,6 +16,7 @@
 #include "TrackView/TrackViewSequenceManager.h"
 #include <Range.h>
 #include <IMovieSystem.h>
+#include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
 
 class CTrackViewSequence;
 
@@ -36,6 +37,7 @@ class SANDBOX_API CAnimationContext
     : public IEditorNotifyListener
     , public IUndoManagerListener
     , public ITrackViewSequenceManagerListener
+    , public AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
 {
     AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
@@ -191,6 +193,8 @@ private:
 
     virtual void BeginUndoTransaction() override;
     virtual void EndUndoTransaction() override;
+
+    void OnPrefabInstancePropagationEnd() override;
 
     virtual void OnSequenceRemoved(CTrackViewSequence* pSequence) override;
 

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -293,8 +293,12 @@ void CTrackViewAnimNode::BindToEditorObjects()
         if (const AZ::EntityId entityId = GetNodeEntityId();
             entityId.IsValid())
         {
-            RegisterEditorObjectListeners(entityId);
-            SetNodeEntityId(entityId);
+            const auto entity = AzToolsFramework::GetEntityById(entityId);
+            if (entity)
+            {
+                RegisterEditorObjectListeners(entityId);
+                SetNodeEntityId(entityId);
+            }
         }
 
         if (ownerChanged)

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -653,6 +653,10 @@ void CTrackViewNodesCtrl::UpdateAnimNodeRecord(CRecord* record, CTrackViewAnimNo
             // In case of a missing entity, color it red.
             record->setForeground(0, TextColorForMissingEntity);
         }
+        else
+        {
+            record->setData(0, Qt::ForegroundRole, QPalette::ColorRole::NoRole);
+        }
     }
 
     // Mark the active director and other directors properly.


### PR DESCRIPTION
## What does this PR do?

As it was reported in GHI https://github.com/o3de/o3de/issues/14980, there are bugs in TrackView with respect to undoing entity deletion with the SequenceAgent  component.

The PR 

1. fixes the assert failures reported in the GHI. The cause of the asserts is earlier rebounding of the entity to be undeleted by the Undo transaction. The entity has not completed the reversion process when the TrackView code tries to bound it. The fix introduces the bound call on OnPrefabInstancePropagationEnd when the entities are guaranteed to be fully reverted.

The video below shows the current behavior

https://github.com/user-attachments/assets/6e946682-c420-4953-89f4-c4e6b0997754

2. fixes the unreported issue with the color of the entity name ("Shader Ball" in this test case). When the entity is not found, the color of the entity name text in the TrackView tree widget changes to red. This is correct, however, there was no code to change it back to normal when the entity reverts. So after undoing the deletion the color remained red. The PR adds the code to set the correct color of the text.

Original GHI requires the SequenceAgent component to be deleted instead of entity on keyboard DEL. This is not addressed. One can see that some O3DE components have AddableByUser attribute false. In this case they can't be deleted by the user. The SequenceAgent component is one of that group. So deleting the selected entity on DEL appears correct since there is no delete action for the component. One can see that this is the existing UI behavior. For example, select "Shader Ball" in the test case, select its Transform component. Open the RMB popup, notice there is no option to delete the Transform component. Press DEL. "Shader Ball" will be deleted. 

To improve user experience, one can consider to disable the keyboard DEL action when an undeletable component is selected. However, this is a generic feature, and in my opinion it should be evaluated by the UI code owners and if approved applied as a standalone PR.

## How was this PR tested?

Tested on Windows 10, locally.