### PR TITLE
Consolidate structure definitions for Lights and Decals

### DIFF
--- a/AutomatedTesting/ShaderLib/scenesrg.srgi
+++ b/AutomatedTesting/ShaderLib/scenesrg.srgi
@@ -14,6 +14,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/

--- a/AutomatedTesting/ShaderLib/viewsrg.srgi
+++ b/AutomatedTesting/ShaderLib/viewsrg.srgi
@@ -14,6 +14,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Decals/DecalStructures.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Decals/DecalStructures.azsli
@@ -1,0 +1,17 @@
+#pragma once
+
+struct Decal
+{
+    float3 m_position;
+    float m_opacity;
+    float4 m_quaternion;
+    float3 m_halfSize;
+    float m_angleAttenuation;
+    float m_normalMapOpacity;
+    uint m_sortKeyPacked;
+    uint m_textureArrayIndex;
+    uint m_textureIndex;
+    float3 m_decalColor;
+    float m_decalColorFactor;
+    [[pad_to(16)]]
+};

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/CapsuleLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/CapsuleLight.azsli
@@ -14,7 +14,7 @@
 #if ENABLE_CAPSULE_LIGHTS
 // Get a uniformly distributed point on the surface of a capsule from the provided uniformly distributed 2d point. Uses
 // capsRatio to determine if the point should be on the caps or cylinder to ensure an even distribution. 
-void SampleCapsule(float2 randomPoint, ViewSrg::CapsuleLight light, float capToCylinderAreaRatio, float3x3 localToWorld, out float3 outPosition, out float3 outDirection)
+void SampleCapsule(float2 randomPoint, CapsuleLight light, float capToCylinderAreaRatio, float3x3 localToWorld, out float3 outPosition, out float3 outDirection)
 {
     float3 startToEnd = light.m_direction * light.m_length;
     float3 endPoint = light.m_startPoint + startToEnd;
@@ -54,7 +54,7 @@ void SampleCapsule(float2 randomPoint, ViewSrg::CapsuleLight light, float capToC
     }
 }
 
-void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData)
+void ApplyCapsuleLight(CapsuleLight light, Surface surface, inout LightingData lightingData)
 {
     float lightLength = light.m_length;
     float3 startPoint = light.m_startPoint;
@@ -180,7 +180,7 @@ void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout Light
     }
 }
 
-void ValidateCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData)
+void ValidateCapsuleLight(CapsuleLight light, Surface surface, inout LightingData lightingData)
 {
     const uint sampleCount = 1024;
 
@@ -232,7 +232,7 @@ void ApplyCapsuleLightInternal(uint lightIndex, Surface surface, inout LightingD
 {
     if (o_enableCapsuleLights)
     {
-        ViewSrg::CapsuleLight light = ViewSrg::m_capsuleLights[lightIndex];
+        CapsuleLight light = ViewSrg::m_capsuleLights[lightIndex];
         if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
         {
             return;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
@@ -58,7 +58,7 @@ void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, fl
     // Add the lighting contribution for each directional light
     for (int index = 0; index < SceneSrg::m_directionalLightCount; index++)
     {
-        SceneSrg::DirectionalLight light = SceneSrg::m_directionalLights[index];
+        DirectionalLight light = SceneSrg::m_directionalLights[index];
         if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
         {
             continue;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
@@ -15,12 +15,8 @@
 #endif
 
 #if ENABLE_DISK_LIGHTS
-enum DiskLightFlag
-{
-    UseConeAngle = 1,
-};
 
-void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingData lightingData)
+void ApplyDiskLight(DiskLight light, Surface surface, inout LightingData lightingData)
 {
     float3 posToLight = light.m_position - surface.position;
     float distanceToLight2 = dot(posToLight, posToLight); // light distance squared
@@ -169,7 +165,7 @@ void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingDat
     }
 }
 
-float3 SampleDisk(float2 randomPoint, ViewSrg::DiskLight light)
+float3 SampleDisk(float2 randomPoint, DiskLight light)
 {
     // Uniformly distributed point at light surface
     float distanceFromCenter = sqrt(randomPoint.x) * light.m_diskRadius;
@@ -196,7 +192,7 @@ float3 SampleDisk(float2 randomPoint, ViewSrg::DiskLight light)
     return outPoint;
 }
 
-void ValidateDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingData lightingData)
+void ValidateDiskLight(DiskLight light, Surface surface, inout LightingData lightingData)
 {
     const uint sampleCount = 512;
 
@@ -219,7 +215,7 @@ void ApplyDiskLightInternal(uint lightIndex, Surface surface, inout LightingData
 {
     if (o_enableDiskLights)
     {
-        ViewSrg::DiskLight light = ViewSrg::m_diskLights[lightIndex];
+        DiskLight light = ViewSrg::m_diskLights[lightIndex];
         if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
         {
             return;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/LightStructures.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/LightStructures.azsli
@@ -1,0 +1,140 @@
+
+#pragma once
+
+// Directional Lights
+struct DirectionalLight
+{
+    float3 m_direction;
+    float m_angularRadius;
+    float3 m_rgbIntensityLux;
+    float m_affectsGIFactor;
+    bool m_affectsGI;
+    uint m_lightingChannelMask;
+    float2 m_padding;
+};
+
+// Simple Point Lights
+
+struct SimplePointLight
+{
+    float3 m_position;
+    float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
+    float3 m_rgbIntensityCandelas;
+    float m_affectsGIFactor;
+    bool m_affectsGI;
+    uint m_lightingChannelMask;
+    float2 m_padding;
+    [[pad_to(16)]]  // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
+};
+
+// Simple Spot Lights
+
+struct SimpleSpotLight
+{
+    float4x4 m_viewProjectionMatrix; // Light's view projection matrix. Used to calculate uv for gobo
+    float3 m_position;
+    float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
+    float3 m_direction;
+    float m_cosInnerConeAngle; // cosine of the outer cone angle
+    float3 m_rgbIntensityCandelas;
+    float m_cosOuterConeAngle; // cosine of the inner cone angle
+    uint m_shadowIndex;
+    uint m_goboTexIndex;
+    float m_affectsGIFactor;
+    bool m_affectsGI;
+    uint m_lightingChannelMask;
+    [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
+};
+
+// Point lights (sphere lights)
+
+struct PointLight
+{
+    float3 m_position;
+    float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
+    float3 m_rgbIntensityCandelas;
+    float m_bulbRadius;
+    uint3 m_shadowIndices;
+    float m_affectsGIFactor;
+    bool m_affectsGI;
+    uint m_lightingChannelMask;
+    float2 m_padding;
+};
+
+// Disk Lights
+
+enum DiskLightFlag
+{
+    UseConeAngle = 1,
+};
+
+struct DiskLight
+{
+    float3 m_position;
+    float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
+    float3 m_rgbIntensityCandelas;
+    float m_diskRadius;
+    float3 m_direction;
+    uint m_flags;
+    float m_cosInnerConeAngle;
+    float m_cosOuterConeAngle;
+    float m_bulbPositionOffset;
+    uint m_shadowIndex;
+    float m_affectsGIFactor;
+    bool m_affectsGI;
+    uint m_lightingChannelMask;
+    float m_padding;
+};
+
+// Capsule Lights
+    
+struct CapsuleLight
+{
+    float3 m_startPoint;   // One of the end points of the capsule
+    float m_radius;        // Radius of the capsule, ie distance from line segment to surface.
+    float3 m_direction;    // normalized vector from m_startPoint towards the other end point.
+    float m_length;        // length of the line segment making up the inside of the capsule. Doesn't include caps (0 length capsule == sphere)
+    float3 m_rgbIntensityCandelas; // total rgb luminous intensity of the capsule in candelas
+    float m_invAttenuationRadiusSquared; // Inverse of the distance at which this light no longer has an effect, squared. Also used for falloff calculations.
+    float m_affectsGIFactor;
+    bool m_affectsGI;
+    uint m_lightingChannelMask;
+    float m_padding;
+};
+
+// Quad Lights
+
+enum QuadLightFlag
+{
+    None = 0x00,
+    EmitsBothDirections  = 0x01, // 1 << 0, // Quad should emit light from both sides
+    UseFastApproximation = 0x02, // 1 << 1, // Use a fast approximation instead of linearly transformed cosines.
+};
+
+struct QuadLight
+{
+    float3 m_position;
+    float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
+    float3 m_leftDir; // Direction from center of quad to the left edge
+    float m_halfWidth; // Half the width of the quad. m_leftDir * m_halfWidth is a vector from the center to the left edge.
+    float3 m_upDir; // Direction from center of quad to the top edge
+    float m_halfHeight; // Half the height of the quad. m_upDir * m_halfHeight is a vector from the center to the top edge.
+    float3 m_rgbIntensityNits;
+    uint m_flags; // See QuadLightFlag enum
+    float m_affectsGIFactor;
+    bool m_affectsGI;
+    uint m_lightingChannelMask;
+    float m_padding;
+};
+
+// Polygon Lights
+
+struct PolygonLight
+{
+    float3 m_position;
+    uint m_startEndIndex; // 16 bit start and end indices packed into one 32 bit uint
+    float3 m_rgbIntensityNits;
+    float m_invAttenuationRadiusSquared; // negative sign bit indicates double sided.
+    float3 m_direction;
+    uint m_lightingChannelMask;
+};

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -50,14 +50,14 @@ int GetPointLightShadowCubemapFace(const float3 targetPos, const float3 lightPos
 
 // PointLight::m_shadowIndices actually consists of uint16_t x 6 on the CPU, but visible as a uint32_t x 3 on the GPU. 
 // This function returns the proper uint16_t value given an input face in the range 0-5
-int UnpackPointLightShadowIndex(const ViewSrg::PointLight light, const int face)
+int UnpackPointLightShadowIndex(const PointLight light, const int face)
 {
     const int index = face >> 1;
     const int shiftAmount = (face & 1) * 16;
     return (light.m_shadowIndices[index] >> shiftAmount) & 0xFFFF;
 } 
 
-uint ComputeShadowIndex(const ViewSrg::PointLight light, const Surface surface)
+uint ComputeShadowIndex(const PointLight light, const Surface surface)
 {
     // shadow map size and bias are the same across all shadowmaps used by a specific point light, so just grab the first one
     const uint lightIndex0 = UnpackPointLightShadowIndex(light, 0);
@@ -73,7 +73,7 @@ uint ComputeShadowIndex(const ViewSrg::PointLight light, const Surface surface)
 
 #endif // ENABLE_SHADOWS
 
-void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
+void ApplyPointLight(PointLight light, Surface surface, inout LightingData lightingData)
 {
     real3 posToLight = real3(light.m_position) - real3(surface.position);
     real posToLightDist = length(posToLight);
@@ -160,7 +160,7 @@ real3 SampleSphere(real2 randomPoint)
     return real3(sinTheta * cos(angle), sinTheta * sin(angle), cosTheta);
 }
 
-void ValidatePointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
+void ValidatePointLight(PointLight light, Surface surface, inout LightingData lightingData)
 {
     const uint sampleCount = 512;
 
@@ -194,7 +194,7 @@ void ApplyPointLightInternal(uint lightIndex, Surface surface, inout LightingDat
 {
     if (o_enableSphereLights)
     {
-        ViewSrg::PointLight light = ViewSrg::m_pointLights[lightIndex];
+        PointLight light = ViewSrg::m_pointLights[lightIndex];
         if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
         {
             return;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PolygonLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PolygonLight.azsli
@@ -14,7 +14,7 @@
 
 #if ENABLE_POLYGON_LTC_LIGHTS
 // Polygon lights using Linearly Transformed Cosines
-void ApplyPoylgonLight(ViewSrg::PolygonLight light, Surface surface, inout LightingData lightingData)
+void ApplyPoylgonLight(PolygonLight light, Surface surface, inout LightingData lightingData)
 {
     float3 posToLight = light.m_position - surface.position;
     float distanceToLight2 = dot(posToLight, posToLight); // light distance squared
@@ -64,7 +64,7 @@ void ApplyPolygonLights(Surface surface, inout LightingData lightingData)
     {
         for (uint currLightIndex = 0; currLightIndex <  ViewSrg::m_polygonLightCount; ++currLightIndex)
         {
-            ViewSrg::PolygonLight light = ViewSrg::m_polygonLights[currLightIndex];
+            PolygonLight light = ViewSrg::m_polygonLights[currLightIndex];
             if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
             {
                 continue;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/QuadLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/QuadLight.azsli
@@ -12,12 +12,6 @@
 #include <Atom/Features/PBR/Lights/Ltc.azsli>
 
 #if ENABLE_QUAD_LIGHTS
-enum QuadLightFlag
-{
-    None = 0x00,
-    EmitsBothDirections  = 0x01, // 1 << 0, // Quad should emit light from both sides
-    UseFastApproximation = 0x02, // 1 << 1, // Use a fast approximation instead of linearly transformed cosines.
-};
 
 // Returns the solid angle at origin of a rectangle defined by points p0-p3. Does not handle horizon.
 // Modified from https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf Listing 11 on page 49.
@@ -76,7 +70,7 @@ float3 GetSpecularDominantDirection(float3 normal, float3 reflection, float roug
 }
 
 // Quad light approximation. Diffuse portion based on https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf Pages 49-50.
-void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingData lightingData)
+void ApplyQuadLight(QuadLight light, Surface surface, inout LightingData lightingData)
 {
     float3 lightDirection = cross(light.m_leftDir, light.m_upDir); // left and up are already normalized.
 
@@ -211,7 +205,7 @@ void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingDat
     }
 }
 
-float3 SampleRectangle(float2 randomPoint, ViewSrg::QuadLight light)
+float3 SampleRectangle(float2 randomPoint, QuadLight light)
 {
     randomPoint = randomPoint * 2.0 - 1.0; // transform to -1 to 1 range.
     randomPoint *= float2(light.m_halfWidth, light.m_halfHeight);
@@ -221,7 +215,7 @@ float3 SampleRectangle(float2 randomPoint, ViewSrg::QuadLight light)
     return outPoint;
 }
 
-void ValidateQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingData lightingData)
+void ValidateQuadLight(QuadLight light, Surface surface, inout LightingData lightingData)
 {
     float3 lightDirection = cross(light.m_leftDir, light.m_upDir); // left and up are already normalized.
 
@@ -256,7 +250,7 @@ void ApplyQuadLightInternal(uint lightIndex, Surface surface, inout LightingData
 {
     if (o_enableQuadLightApprox || o_enableQuadLightLTC)
     {
-        ViewSrg::QuadLight light = ViewSrg::m_quadLights[lightIndex];
+        QuadLight light = ViewSrg::m_quadLights[lightIndex];
         if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
         {
             return;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
@@ -10,7 +10,7 @@
 
 #include <Atom/Features/LightCulling/LightCullingTileIterator.azsli>
 
-void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, inout LightingData lightingData)
+void ApplySimplePointLight(SimplePointLight light, Surface surface, inout LightingData lightingData)
 {
     real3 posToLight = real3(light.m_position - surface.position);
     real d2 = dot(posToLight, posToLight); // light distance squared
@@ -40,7 +40,7 @@ void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout Light
 {
     if (o_enableSimplePointLights)
     {
-        ViewSrg::SimplePointLight light = ViewSrg::m_simplePointLights[lightIndex];
+        SimplePointLight light = ViewSrg::m_simplePointLights[lightIndex];
         if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
         {
             return;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -14,7 +14,7 @@
 #include <Atom/Features/Shadow/ProjectedShadow.azsli>
 #endif
 
-void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout LightingData lightingData)
+void ApplySimpleSpotLight(SimpleSpotLight light, Surface surface, inout LightingData lightingData)
 {
     real3 posToLight = real3(light.m_position - surface.position);
     
@@ -91,7 +91,7 @@ void ApplySimpleSpotLightInternal(uint lightIndex, Surface surface, inout Lighti
 {
     if (o_enableSimpleSpotLights)
     {
-        ViewSrg::SimpleSpotLight light = ViewSrg::m_simpleSpotLights[lightIndex];
+        SimpleSpotLight light = ViewSrg::m_simpleSpotLights[lightIndex];
         if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
         {
             return;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -16,134 +16,29 @@
 //        that must match the setting of this define.
 #define USE_BINDLESS_SRG 1
 
+#include <Atom/Features/PBR/Lights/LightStructures.azsli>
+
 ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
 {
     RaytracingAccelerationStructure m_scene;
 
-    // directional lights
-    struct DirectionalLight
-    {
-        float3 m_direction;
-        float  m_angularRadius;
-        float3 m_rgbIntensity;
-        float  m_affectsGIFactor;
-        bool   m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-    };
-    
     StructuredBuffer<DirectionalLight> m_directionalLights;
     uint m_directionalLightCount;
     
-    // simple point lights 
-    struct SimplePointLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-    };
-
     StructuredBuffer<SimplePointLight> m_simplePointLights;
     uint m_simplePointLightCount;
-
-    // simple spot lights
-    struct SimpleSpotLight
-    {
-        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used to calculate uv for gobo 
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_direction;
-        float m_cosInnerConeAngle; // cosine of the outer cone angle
-        float3 m_rgbIntensityCandelas;
-        float m_cosOuterConeAngle; // cosine of the inner cone angle
-        uint m_shadowIndex;
-        uint m_goboTexIndex;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
-    };
 
     StructuredBuffer<SimpleSpotLight> m_simpleSpotLights;
     uint m_simpleSpotLightCount;
 
-    // point lights (sphere)
-    struct PointLight
-    {
-        float3 m_position;
-        float  m_invAttenuationRadiusSquared;
-        float3 m_rgbIntensity;
-        float  m_bulbRadius;
-        uint3 m_shadowIndices;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-    };
-    
     StructuredBuffer<PointLight> m_pointLights;
     uint m_pointLightCount;
-    
-    // disk lights
-    struct DiskLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_diskRadius;
-        float3 m_direction;
-        uint m_flags;
-        float m_cosInnerConeAngle;
-        float m_cosOuterConeAngle;
-        float m_bulbPositionOffset;
-        uint m_shadowIndex;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
     
     StructuredBuffer<DiskLight> m_diskLights;
     uint m_diskLightCount;
     
-    // capsule lights
-    struct CapsuleLight
-    {
-        float3 m_startPoint;                    // one of the end points of the capsule
-        float m_radius;                         // radius of the capsule, ie distance from line segment to surface.
-        float3 m_direction;                     // normalized vector from m_startPoint towards the other end point.
-        float m_length;                         // length of the line segment making up the inside of the capsule. Doesn't include caps (0 length capsule == sphere)
-        float3 m_rgbIntensityCandelas;          // total rgb luminous intensity of the capsule in candelas
-        float m_invAttenuationRadiusSquared;    // inverse of the distance at which this light no longer has an effect, squared. Also used for falloff calculations.
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
-    
     StructuredBuffer<CapsuleLight> m_capsuleLights;
     uint m_capsuleLightCount;
-    
-    // quad lights 
-    struct QuadLight
-    {
-        float3 m_position;
-        float  m_invAttenuationRadiusSquared;   // radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_leftDir;                       // direction from center of quad to the left edge
-        float  m_halfWidth;                     // half-width of the quad. m_leftDir * m_halfWidth is a vector from the center to the left edge.
-        float3 m_upDir;                         // cirection from center of quad to the top edge
-        float  m_halfHeight;                    // half-height of the quad. m_upDir * m_halfHeight is a vector from the center to the top edge.
-        float3 m_rgbIntensityNits;
-        uint   m_flags;                         // see QuadLightFlag enum
-        float  m_affectsGIFactor;
-        bool   m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
     
     StructuredBuffer<QuadLight> m_quadLights;
     uint m_quadLightCount;

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/SceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/SceneSrg.azsli
@@ -12,17 +12,6 @@
 
 partial ShaderResourceGroup SceneSrg
 { 
-    struct DirectionalLight
-    {
-        float3 m_direction;
-        float m_angularRadius;
-        float3 m_rgbIntensityLux;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-    };
-
     StructuredBuffer<DirectionalLight> m_directionalLights;
     uint m_directionalLightCount;
     

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -34,41 +34,8 @@ partial ShaderResourceGroup ViewSrg
                      // where n: nearDepth, f: farDepth.
     };
 
-    // Simple Point Lights 
-
-    struct SimplePointLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-        [[pad_to(16)]]  // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
-    };
-
     StructuredBuffer<SimplePointLight> m_simplePointLights;
     uint m_simplePointLightCount;
-
-    // Simple Spot Lights
-
-    struct SimpleSpotLight
-    {
-        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used to calculate uv for gobo 
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_direction;
-        float m_cosInnerConeAngle; // cosine of the outer cone angle
-        float3 m_rgbIntensityCandelas;
-        float m_cosOuterConeAngle; // cosine of the inner cone angle
-        uint m_shadowIndex;
-        uint m_goboTexIndex;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
-    };
 
     StructuredBuffer<SimpleSpotLight> m_simpleSpotLights;
     uint m_simpleSpotLightCount;
@@ -77,21 +44,6 @@ partial ShaderResourceGroup ViewSrg
     
     static const uint MaxGoboTextureCount = 5;
     Texture2D<float> m_goboTextures[MaxGoboTextureCount];
-
-    // Point lights (sphere lights)
-
-    struct PointLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_bulbRadius;
-        uint3 m_shadowIndices;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-    };
 
     StructuredBuffer<PointLight> m_pointLights;
     uint m_pointLightCount;
@@ -156,82 +108,15 @@ partial ShaderResourceGroup ViewSrg
 
     StructuredBuffer<FilterParameter> m_esmsDirectional;
 
-    // Disk Lights
-    
-    struct DiskLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_diskRadius;
-        float3 m_direction;
-        uint m_flags;
-        float m_cosInnerConeAngle;
-        float m_cosOuterConeAngle;
-        float m_bulbPositionOffset;
-        uint m_shadowIndex;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
-
     StructuredBuffer<DiskLight> m_diskLights;
     uint m_diskLightCount;
     
-    // Capsule Lights
-    
-    struct CapsuleLight
-    {
-        float3 m_startPoint;   // One of the end points of the capsule
-        float m_radius;        // Radius of the capsule, ie distance from line segment to surface.
-        float3 m_direction;    // normalized vector from m_startPoint towards the other end point.
-        float m_length;        // length of the line segment making up the inside of the capsule. Doesn't include caps (0 length capsule == sphere)
-        float3 m_rgbIntensityCandelas; // total rgb luminous intensity of the capsule in candelas
-        float m_invAttenuationRadiusSquared; // Inverse of the distance at which this light no longer has an effect, squared. Also used for falloff calculations.
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
-
     StructuredBuffer<CapsuleLight> m_capsuleLights;
     uint m_capsuleLightCount;
     
-    // Quad Lights
-    
-    struct QuadLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_leftDir; // Direction from center of quad to the left edge
-        float m_halfWidth; // Half the width of the quad. m_leftDir * m_halfWidth is a vector from the center to the left edge.
-        float3 m_upDir; // Direction from center of quad to the top edge
-        float m_halfHeight; // Half the height of the quad. m_upDir * m_halfHeight is a vector from the center to the top edge.
-        float3 m_rgbIntensityNits;
-        uint m_flags; // See QuadLightFlag enum
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
-
     StructuredBuffer<QuadLight> m_quadLights;
     uint m_quadLightCount;
     
-    // Polygon Lights
-
-    struct PolygonLight
-    {
-        float3 m_position;
-        uint m_startEndIndex; // 16 bit start and end indices packed into one 32 bit uint
-        float3 m_rgbIntensityNits;
-        float m_invAttenuationRadiusSquared; // negative sign bit indicates double sided.
-        float3 m_direction;
-        uint m_lightingChannelMask;
-
-    };
-
     StructuredBuffer<PolygonLight> m_polygonLights;
     uint m_polygonLightCount;
     StructuredBuffer<float4> m_polygonLightPoints; // points for each polygon. Max 64 points per polygon.

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Please review README.md to understand how this file is used in SceneSrg.azsrg generation 
+
+#ifdef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Features/Decals/DecalStructures.azsli>
+#include <Atom/Features/PBR/Lights/LightStructures.azsli>
+#endif

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Please review README.md to understand how this file is used in ViewSrg.azsrg generation
+
+#ifdef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Features/Decals/DecalStructures.azsli>
+#include <Atom/Features/PBR/Lights/LightStructures.azsli>
+#endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
@@ -12,114 +12,11 @@
 
 #include <Atom/RPI/Math.azsli>
 #include <Atom/Features/LightCulling/LightCullingShared.azsli>
-
-enum QuadLightFlag // Copied from QuadLight.azsli. See ATOM-3731
-{
-    None = 0x00,
-    EmitsBothDirections  = 0x01, // 1 << 0, // Quad should emit light from both sides
-    UseFastApproximation = 0x02, // 1 << 1, // Use a fast approximation instead of linearly transformed cosines.
-};
-
-enum DiskLightFlag
-{
-    UseConeAngle = 1,
-};
+#include <Atom/Features/PBR/Lights/LightStructures.azsli>
+#include <Atom/Features/Decals/DecalStructures.azsli>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {
-    // Figure out how to remove duplicate struct definitions.
-    // These are also defined in View.srg
-    // ATOM-3731
-    
-    struct SimplePointLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-    };
-
-    struct SimpleSpotLight
-    {
-        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used to calculate uv for gobo 
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_direction;
-        float m_cosInnerConeAngle; // cosine of the outer cone angle
-        float3 m_rgbIntensityCandelas;
-        float m_cosOuterConeAngle; // cosine of the inner cone angle
-        uint m_shadowIndex; 
-        uint m_goboTexIndex;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
-    };
-
-    struct PointLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_bulbRadius;
-        uint3 m_shadowIndices;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float2 m_padding;
-    };
-
-    struct DiskLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_rgbIntensityCandelas;
-        float m_diskRadius;
-        float3 m_direction;
-        uint m_flags;
-        float m_cosInnerConeAngle;
-        float m_cosOuterConeAngle;
-        float m_bulbPositionOffset;
-        uint m_shadowIndex;
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
-
-    struct CapsuleLight
-    {
-        float3 m_startPoint;   // One of the end points of the capsule
-        float m_radius;        // Radius of the capsule, ie distance from line segment to surface.
-        float3 m_direction;    // normalized vector from m_startPoint towards the other end point.
-        float m_length;        // length of the line segment making up the inside of the capsule. Doesn't include caps (0 length capsule == sphere)
-        float3 m_rgbIntensityCandelas; // total rgb luminous intensity of the capsule in candela
-        float m_invAttenuationRadiusSquared; // Inverse of the distance at which this light no longer has an effect, squared. Also used for falloff calculations.
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
-    
-    struct QuadLight
-    {
-        float3 m_position;
-        float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
-        float3 m_leftDir; // Direction from center of quad to the left edge
-        float m_halfWidth; // Half the width of the quad. m_leftDir * m_halfWidth is a vector from the center to the left edge.
-        float3 m_upDir; // Direction from center of quad to the top edge
-        float m_halfHeight; // Half the height of the quad. m_upDir * m_halfHeight is a vector from the center to the top edge.
-        float3 m_rgbIntensityNits;
-        uint m_flags; // See QuadLightFlag
-        float m_affectsGIFactor;
-        bool m_affectsGI;
-        uint m_lightingChannelMask;
-        float m_padding;
-    };
-    
     struct LightCullingConstants
     {
         float4x4        m_worldToView;
@@ -153,22 +50,6 @@ ShaderResourceGroup PassSrg : SRG_PerPass
     // Destination light data
     RWStructuredBuffer<uint> m_lightList;
     RWTexture2D<uint> m_lightCount;
-    
-    struct Decal
-    {
-        float3 m_position;
-        float m_opacity;
-        float4 m_quaternion;
-        float3 m_halfSize;
-        float m_angleAttenuation;
-        float m_normalMapOpacity;
-        uint m_sortKeyPacked;
-        uint m_textureArrayIndex;
-        uint m_textureIndex;
-        float3 m_decalColor;
-        float m_decalColorFactor;
-        [[pad_to(16)]]
-    };
     
     StructuredBuffer<Decal> m_decals;
     uint m_decalCount;  
@@ -259,7 +140,7 @@ uint NextPowerTwo(uint x)
     return 2u << firstbithigh(max(1, x) - 1);
 }
 
-uint GetSortKey(PassSrg::Decal decal)
+uint GetSortKey(Decal decal)
 {
     return (decal.m_sortKeyPacked & 0xFF);
 }
@@ -268,8 +149,8 @@ bool AreDecalsOutofOrder(uint packedIndexLeft, uint packedIndexRight)
 {
     uint leftIndex = Light_GetIndex(packedIndexLeft);
     uint rightIndex = Light_GetIndex(packedIndexRight);
-    PassSrg::Decal leftDecal = PassSrg::m_decals[leftIndex];
-    PassSrg::Decal rightDecal = PassSrg::m_decals[rightIndex];
+    Decal leftDecal = PassSrg::m_decals[leftIndex];
+    Decal rightDecal = PassSrg::m_decals[rightIndex];
 
     uint leftSortIndex = GetSortKey(leftDecal);
     uint rightSortIndex = GetSortKey(rightDecal);
@@ -348,7 +229,7 @@ float2 ComputePointLightMinMaxZ(float lightRadius, float3 lightPosition)
     return minmax;
 }
 
-float2 ComputeSimpleSpotLightMinMax(PassSrg::SimpleSpotLight light, float3 lightPosition)
+float2 ComputeSimpleSpotLightMinMax(SimpleSpotLight light, float3 lightPosition)
 {
     float lightRadius = rsqrt(light.m_invAttenuationRadiusSquared);
     float2 minmax = lightPosition.z + lightRadius * float2(-1, 1) * RH_COORD_SYSTEM_REVERSE;  
@@ -357,7 +238,7 @@ float2 ComputeSimpleSpotLightMinMax(PassSrg::SimpleSpotLight light, float3 light
 
 // Return the minz and maxz of this quad light in view space 
 // Quad light must be double sided
-float2 ComputeQuadLightMinMaxZ_DoubleSided(PassSrg::QuadLight light, float3 lightPosition)
+float2 ComputeQuadLightMinMaxZ_DoubleSided(QuadLight light, float3 lightPosition)
 {
     const float lightRadius = rsqrt(light.m_invAttenuationRadiusSquared);                       
     const float2 minmax = lightPosition.z + lightRadius * float2(-1,1) * RH_COORD_SYSTEM_REVERSE;  
@@ -366,20 +247,20 @@ float2 ComputeQuadLightMinMaxZ_DoubleSided(PassSrg::QuadLight light, float3 ligh
 
 // Return the minz and maxz of this quad light in view space 
 // Quad light must be single sided
-float2 ComputeQuadLightMinMaxZ_SingleSided(PassSrg::QuadLight light, float3 lightPosition, float3 lightDirection)
+float2 ComputeQuadLightMinMaxZ_SingleSided(QuadLight light, float3 lightPosition, float3 lightDirection)
 {
     // [GFX TODO][ATOM-6170] We can compute a tighter bounds with single sided lights by bringing in one of bounds  
     return ComputeQuadLightMinMaxZ_DoubleSided(light, lightPosition);
 }
 
-float2 ComputeDiskLightMinMax(PassSrg::DiskLight light, float3 lightPosition)
+float2 ComputeDiskLightMinMax(DiskLight light, float3 lightPosition)
 {
     float lightRadius = rsqrt(light.m_invAttenuationRadiusSquared) + light.m_bulbPositionOffset;                       
     float2 minmax = lightPosition.z + lightRadius * float2(-1, 1) * RH_COORD_SYSTEM_REVERSE;  
     return minmax;
 }
 
-float2 ComputeCapsuleLightMinMax(PassSrg::CapsuleLight light, float3 lightPosition, float lightFalloffRadius)
+float2 ComputeCapsuleLightMinMax(CapsuleLight light, float3 lightPosition, float lightFalloffRadius)
 { 
     float offsetZ = abs(WorldToView_Vector(light.m_direction).z * light.m_length * 0.5f) + lightFalloffRadius;
     float nearZ = lightPosition.z - offsetZ * RH_COORD_SYSTEM_REVERSE;
@@ -392,7 +273,7 @@ void CullDecals(uint groupIndex, TileLightData tileLightData, float3 aabb_center
 {
     for (uint decalIndex = groupIndex ; decalIndex < PassSrg::m_decalCount ; decalIndex += TILE_DIM_X * TILE_DIM_Y)
     { 
-        PassSrg::Decal decal = PassSrg::m_decals[decalIndex];
+        Decal decal = PassSrg::m_decals[decalIndex];
         float3 decalPosition = WorldToView_Point(decal.m_position); 
         
         // just wrapping a bounding sphere around a cube for now to get a minor perf boost. i.e. the sphere radius is sqrt(x*x + y*y + z*z)
@@ -435,7 +316,7 @@ void CullSimplePointLights(uint groupIndex, TileLightData tileLightData, float3 
 {
     for (uint lightIndex = groupIndex ; lightIndex < PassSrg::m_simplePointLightCount ; lightIndex += TILE_DIM_X * TILE_DIM_Y)
     {
-        PassSrg::SimplePointLight light = PassSrg::m_simplePointLights[lightIndex];
+        SimplePointLight light = PassSrg::m_simplePointLights[lightIndex];
         CullPointLight(lightIndex, light.m_position, light.m_invAttenuationRadiusSquared, tileLightData, aabb_center, aabb_extents);
     }  
 }
@@ -444,7 +325,7 @@ void CullPointLights(uint groupIndex, TileLightData tileLightData, float3 aabb_c
 {
     for (uint lightIndex = groupIndex ; lightIndex < PassSrg::m_pointLightCount ; lightIndex += TILE_DIM_X * TILE_DIM_Y)
     {
-        PassSrg::PointLight light = PassSrg::m_pointLights[lightIndex];
+        PointLight light = PassSrg::m_pointLights[lightIndex];
         CullPointLight(lightIndex, light.m_position, light.m_invAttenuationRadiusSquared, tileLightData, aabb_center, aabb_extents);
     }  
 }
@@ -453,7 +334,7 @@ void CullSimpleSpotLights(uint groupIndex, TileLightData tileLightData, float3 a
 {
     for (uint lightIndex = groupIndex ; lightIndex < PassSrg::m_simpleSpotLightCount ; lightIndex += TILE_DIM_X * TILE_DIM_Y)
     {
-        PassSrg::SimpleSpotLight light = PassSrg::m_simpleSpotLights[lightIndex];
+        SimpleSpotLight light = PassSrg::m_simpleSpotLights[lightIndex];
         float3 lightPosition = WorldToView_Point(light.m_position);
         float3 lightDirection = WorldToView_Vector(light.m_direction);
         
@@ -477,7 +358,7 @@ void CullDiskLights(uint groupIndex, TileLightData tileLightData, float3 aabb_ce
 {
     for (uint lightIndex = groupIndex ; lightIndex < PassSrg::m_diskLightCount ; lightIndex += TILE_DIM_X * TILE_DIM_Y)
     {
-        PassSrg::DiskLight light = PassSrg::m_diskLights[lightIndex];
+        DiskLight light = PassSrg::m_diskLights[lightIndex];
         float3 lightPosition = WorldToView_Point(light.m_position - light.m_bulbPositionOffset * light.m_direction);
         float lightRadius = rsqrt(light.m_invAttenuationRadiusSquared) + light.m_diskRadius;
         float lightRadiusSqr = lightRadius * lightRadius;
@@ -522,7 +403,7 @@ void CullCapsuleLights(uint groupIndex, TileLightData tileLightData, float3 aabb
 {
     for (uint lightIndex = groupIndex ; lightIndex < PassSrg::m_capsuleLightCount ; lightIndex += TILE_DIM_X * TILE_DIM_Y)
     {
-        PassSrg::CapsuleLight light = PassSrg::m_capsuleLights[lightIndex];
+        CapsuleLight light = PassSrg::m_capsuleLights[lightIndex];
         float3 lightMiddleWorld = light.m_startPoint + light.m_direction * light.m_length * 0.5f;
         float3 lightMiddleView = WorldToView_Point(lightMiddleWorld);
         
@@ -553,7 +434,7 @@ void CullQuadLights(uint groupIndex, TileLightData tileLightData, float3 aabb_ce
 
     for (uint lightIndex = groupIndex ; lightIndex < PassSrg::m_quadLightCount ; lightIndex += TILE_DIM_X * TILE_DIM_Y)
     {
-        const PassSrg::QuadLight light = PassSrg::m_quadLights[lightIndex];
+        const QuadLight light = PassSrg::m_quadLights[lightIndex];
         const float3 lightPosition = WorldToView_Point(light.m_position);             
         
         bool potentiallyIntersects = TestSphereVsAabbInvSqrt(lightPosition, light.m_invAttenuationRadiusSquared, aabb_center, aabb_extents);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceRayTracingCommon.azsli
@@ -93,7 +93,7 @@ bool CheckLightVisibility(RayTracingLightingData lightingData, float3 dirToLight
     return (payload.m_hitT < 0.0f);
 }
 
-void ApplyDirectionalLight(RayTracingSceneSrg::DirectionalLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
+void ApplyDirectionalLight(DirectionalLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
 {   
     float3 dirToLight = normalize(-light.m_direction);
 
@@ -111,15 +111,15 @@ void ApplyDirectionalLight(RayTracingSceneSrg::DirectionalLight light, RayTracin
         return;
     }
 
-    diffuse += DiffuseLambertian(lightingData.m_albedo, lightingData.m_normal, dirToLight, lightingData.m_diffuseResponse) * light.m_rgbIntensity;
+    diffuse += DiffuseLambertian(lightingData.m_albedo, lightingData.m_normal, dirToLight, lightingData.m_diffuseResponse) * light.m_rgbIntensityLux;
 
     if (applySpecular)
     {
-        specular += SpecularGGX(lightingData.m_dirToCamera, dirToLight, lightingData.m_normal, lightingData.m_specularF0, lightingData.m_NdotV, lightingData.m_roughnessA2, 1.0f) * light.m_rgbIntensity;
+        specular += SpecularGGX(lightingData.m_dirToCamera, dirToLight, lightingData.m_normal, lightingData.m_specularF0, lightingData.m_NdotV, lightingData.m_roughnessA2, 1.0f) * light.m_rgbIntensityLux;
     }
 }
 
-void ApplySimplePointLight(RayTracingSceneSrg::SimplePointLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
+void ApplySimplePointLight(SimplePointLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
 {
     float3 posToLight = light.m_position - lightingData.m_worldPosition;
     float3 dirToLight = normalize(posToLight);
@@ -152,7 +152,7 @@ void ApplySimplePointLight(RayTracingSceneSrg::SimplePointLight light, RayTracin
     }
 }
 
-void ApplySimpleSpotLight(RayTracingSceneSrg::SimpleSpotLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
+void ApplySimpleSpotLight(SimpleSpotLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
 {
     float3 posToLight = light.m_position - lightingData.m_worldPosition;
     float3 dirToLight = normalize(posToLight);
@@ -190,7 +190,7 @@ void ApplySimpleSpotLight(RayTracingSceneSrg::SimpleSpotLight light, RayTracingL
     }
 }
 
-void ApplyPointLight(RayTracingSceneSrg::PointLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
+void ApplyPointLight(PointLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
 {
     float3 posToLight = light.m_position - lightingData.m_worldPosition;
     float3 dirToLight = normalize(posToLight);
@@ -213,7 +213,7 @@ void ApplyPointLight(RayTracingSceneSrg::PointLight light, RayTracingLightingDat
         
     // standard quadratic falloff
     d2 = max(0.001f * 0.001f, d2);
-    float3 lightIntensity = (light.m_rgbIntensity / d2) * radiusAttenuation;
+    float3 lightIntensity = (light.m_rgbIntensityCandelas / d2) * radiusAttenuation;
 
     diffuse += DiffuseLambertian(lightingData.m_albedo, lightingData.m_normal, dirToLight, lightingData.m_diffuseResponse) * lightIntensity;
 
@@ -223,7 +223,7 @@ void ApplyPointLight(RayTracingSceneSrg::PointLight light, RayTracingLightingDat
     }
 }
 
-void ApplyDiskLight(RayTracingSceneSrg::DiskLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
+void ApplyDiskLight(DiskLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
 {
     float3 posToLight = light.m_position - lightingData.m_worldPosition;
     float d2 = dot(posToLight, posToLight); // light distance squared
@@ -287,7 +287,7 @@ float GetIntensityAdjustedByRadiusAndRoughness(float roughnessA, float radius, f
     return intensityNormalization * intensityNormalization;
 }
 
-void ApplyCapsuleLight(RayTracingSceneSrg::CapsuleLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
+void ApplyCapsuleLight(CapsuleLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
 {
     float lightLength = light.m_length;
     float3 startPoint = light.m_startPoint;
@@ -410,13 +410,6 @@ void ApplyCapsuleLight(RayTracingSceneSrg::CapsuleLight light, RayTracingLightin
     }
 }
 
-enum QuadLightFlag
-{
-    None = 0x00,
-    EmitsBothDirections  = 0x01, // 1 << 0, // quad should emit light from both sides
-    UseFastApproximation = 0x02, // 1 << 1, // use a fast approximation instead of linearly transformed cosines.
-};
-
 // returns the solid angle at origin of a rectangle defined by points p0-p3. Does not handle horizon.
 // modified from https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf Listing 11 on page 49.
 float RectangleSolidAngle(float3 v0, float3 v1, float3 v2, float3 v3)
@@ -473,7 +466,7 @@ float3 ClosestPointRect(in float3 pos, in float3 planeOrigin, in float3 left, in
     return planeOrigin + dist2D.x * left + dist2D.y * up;
 }
 
-void ApplyQuadLight(RayTracingSceneSrg::QuadLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
+void ApplyQuadLight(QuadLight light, RayTracingLightingData lightingData, bool applySpecular, inout float3 diffuse, inout float3 specular)
 {
     float3 lightDirection = cross(light.m_leftDir, light.m_upDir); // left and up are already normalized
 
@@ -588,43 +581,43 @@ void ApplyDirectLighting(RayTracingLightingData lightingData, bool applySpecular
 
     for (index = 0; index < RayTracingSceneSrg::m_directionalLightCount; ++index)
     {
-        RayTracingSceneSrg::DirectionalLight light = RayTracingSceneSrg::m_directionalLights[index];
+        DirectionalLight light = RayTracingSceneSrg::m_directionalLights[index];
         ApplyDirectionalLight(light, lightingData, applySpecular, diffuse, specular);
     }
     
     for (index = 0; index < RayTracingSceneSrg::m_simplePointLightCount; ++index)
     {
-        RayTracingSceneSrg::SimplePointLight light = RayTracingSceneSrg::m_simplePointLights[index];
+        SimplePointLight light = RayTracingSceneSrg::m_simplePointLights[index];
         ApplySimplePointLight(light, lightingData, applySpecular, diffuse, specular);
     }
 
     for (index = 0; index < RayTracingSceneSrg::m_simpleSpotLightCount; ++index)
     {
-        RayTracingSceneSrg::SimpleSpotLight light = RayTracingSceneSrg::m_simpleSpotLights[index];
+        SimpleSpotLight light = RayTracingSceneSrg::m_simpleSpotLights[index];
         ApplySimpleSpotLight(light, lightingData, applySpecular, diffuse, specular);
     }
 
     for (index = 0; index < RayTracingSceneSrg::m_pointLightCount; ++index)
     {
-        RayTracingSceneSrg::PointLight light = RayTracingSceneSrg::m_pointLights[index];
+        PointLight light = RayTracingSceneSrg::m_pointLights[index];
         ApplyPointLight(light, lightingData, applySpecular, diffuse, specular);
     }
 
     for (index = 0; index < RayTracingSceneSrg::m_diskLightCount; ++index)
     {
-        RayTracingSceneSrg::DiskLight light = RayTracingSceneSrg::m_diskLights[index];
+        DiskLight light = RayTracingSceneSrg::m_diskLights[index];
         ApplyDiskLight(light, lightingData, applySpecular, diffuse, specular);
     }
 
     for (index = 0; index < RayTracingSceneSrg::m_capsuleLightCount; ++index)
     {
-        RayTracingSceneSrg::CapsuleLight light = RayTracingSceneSrg::m_capsuleLights[index];
+        CapsuleLight light = RayTracingSceneSrg::m_capsuleLights[index];
         ApplyCapsuleLight(light, lightingData, applySpecular, diffuse, specular);
     }
 
     for (index = 0; index < RayTracingSceneSrg::m_quadLightCount; ++index)
     {
-        RayTracingSceneSrg::QuadLight light = RayTracingSceneSrg::m_quadLights[index];
+        QuadLight light = RayTracingSceneSrg::m_quadLights[index];
         ApplyQuadLight(light, lightingData, applySpecular, diffuse, specular);
     }
 }

--- a/Gems/AtomTressFX/Assets/Shaders/HairLightTypes.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairLightTypes.azsli
@@ -147,13 +147,14 @@ void SetNormalAndUpdateLightingParams(
 
 //==============================================================================
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
+#include <Atom/Features/PBR/Lights/LightStructures.azsli>
 //==============================================================================
 
 
 //==============================================================================
 //                         Simple Point Light 
 //==============================================================================
-void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, inout LightingData lightingData)
+void ApplySimplePointLight(SimplePointLight light, Surface surface, inout LightingData lightingData)
 {  
     float3 posToLight = light.m_position - surface.position;
     float d2 = dot(posToLight, posToLight); // light distance squared
@@ -196,7 +197,7 @@ void ApplyCulledSimplePointLights(Surface surface, inout LightingData lightingDa
         uint currLightIndex = lightingData.tileIterator.GetValue(); 
         lightingData.tileIterator.LoadAdvance();
 
-        ViewSrg::SimplePointLight light = ViewSrg::m_simplePointLights[currLightIndex];
+        SimplePointLight light = ViewSrg::m_simplePointLights[currLightIndex];
         ApplySimplePointLight(light, surface, lightingData);
         ++lightCount;
     }
@@ -206,7 +207,7 @@ void ApplyAllSimplePointLights(Surface surface, inout LightingData lightingData)
 {
     for (int l = 0; l < ViewSrg::m_simplePointLightCount; ++l)
     {
-        ViewSrg::SimplePointLight light = ViewSrg::m_simplePointLights[l];
+        SimplePointLight light = ViewSrg::m_simplePointLights[l];
         ApplySimplePointLight(light, surface, lightingData);
     }
 }
@@ -214,7 +215,7 @@ void ApplyAllSimplePointLights(Surface surface, inout LightingData lightingData)
 //==============================================================================
 //                           Simple Spot Light 
 //==============================================================================
-void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout LightingData lightingData)
+void ApplySimpleSpotLight(SimpleSpotLight light, Surface surface, inout LightingData lightingData)
 {
     float3 posToLight = light.m_position - surface.position;
     float3 dirToLight = normalize(posToLight);
@@ -268,14 +269,14 @@ void ApplyAllSimpleSpotLights(Surface surface, inout LightingData lightingData)
 {
     for (int l = 0; l < ViewSrg::m_simpleSpotLightCount; ++l)
     {
-        ViewSrg::SimpleSpotLight light = ViewSrg::m_simpleSpotLights[l];
+        SimpleSpotLight light = ViewSrg::m_simpleSpotLights[l];
         ApplySimpleSpotLight(light, surface, lightingData);
     }
 }
 //==============================================================================
 //                              Point Light 
 //==============================================================================
-void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
+void ApplyPointLight(PointLight light, Surface surface, inout LightingData lightingData)
 {
     float3 posToLight = light.m_position - surface.position;
     float d2 = dot(posToLight, posToLight); // light distance squared
@@ -324,7 +325,7 @@ void ApplyAllPointLights(Surface surface, inout LightingData lightingData)
 {
     for (int l = 0; l < ViewSrg::m_pointLightCount; ++l)
     {
-        ViewSrg::PointLight light = ViewSrg::m_pointLights[l];
+        PointLight light = ViewSrg::m_pointLights[l];
         ApplyPointLight(light, surface, lightingData);
     }
 }
@@ -339,7 +340,7 @@ void ApplyAllDiskLights(Surface surface, inout LightingData lightingData)
     SetNormalAndUpdateLightingParams(surface.tangent, lightingData.dirToCamera, surface, lightingData);
     for (int l = 0; l < ViewSrg::m_diskLightCount; ++l)
     {
-        ViewSrg::DiskLight light = ViewSrg::m_diskLights[l];
+        DiskLight light = ViewSrg::m_diskLights[l];
         ApplyDiskLight(light, surface, lightingData);
     }
 }
@@ -368,7 +369,7 @@ void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, fl
     // Add the lighting contribution for each directional light
     for (int index = 0; index < SceneSrg::m_directionalLightCount; index++)
     {
-        SceneSrg::DirectionalLight light = SceneSrg::m_directionalLights[index];
+        DirectionalLight light = SceneSrg::m_directionalLights[index];
         float3 dirToLight = normalize(-light.m_direction);
 
         // Adjust the direction of the light based on its angular diameter.

--- a/Templates/MinimalProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/MinimalProject/Template/ShaderLib/scenesrg.srgi
@@ -16,6 +16,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/

--- a/Templates/MinimalProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/MinimalProject/Template/ShaderLib/viewsrg.srgi
@@ -16,6 +16,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/

--- a/Templates/ScriptOnlyProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/ScriptOnlyProject/Template/ShaderLib/scenesrg.srgi
@@ -16,6 +16,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/

--- a/Templates/ScriptOnlyProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/ScriptOnlyProject/Template/ShaderLib/viewsrg.srgi
@@ -16,6 +16,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/


### PR DESCRIPTION
## What does this PR do?

- Move duplicated structure definitions for light types and decals from `ViewSrg`, `LightCulling` and `RayTracingSceneSrg` to separate files
- Add a include to `scenesrg.srgi` and `viewsrg.srgi` before the first definiton of the partial srgs.

This is a breaking change, since `scenesrg.srgi` and `viewsrg.srgi` are part of the project, and they now need these lines:

scenesrg.srgi:
```
#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
```

viewsrg.srgi:
```
#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
```

## How was this PR tested?

Vulkan on Windows, made sure shaders compile and normal functionality still works.
