### PR TITLE
Fix RayTracingTlasDescriptor not propagating m_instanceMask to DeviceRayTracingTlasDescriptor

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -93,6 +93,7 @@ namespace AZ::RHI
             descriptor.Instance()
                 ->InstanceID(instance.m_instanceID)
                 ->HitGroupIndex(instance.m_hitGroupIndex)
+                ->InstanceMask(instance.m_instanceMask)
                 ->Transform(instance.m_transform)
                 ->NonUniformScale(instance.m_nonUniformScale)
                 ->Transparent(instance.m_transparent)


### PR DESCRIPTION
## What does this PR do?

The function `RayTracingTlasDescriptor::GetDeviceRayTracingTlasDescriptor(int deviceIndex)` does not correctly propagate `m_instanceMask` to `DeviceRayTracingTlasDescriptor` (which means the default value of `1` is used for all instances of `DeviceRayTracingTlasDescriptor`.

## How was this PR tested?

Test with an external gem which uses additional bits of the instanceMask and verify that they are propagated to the GPU by using the `InstanceInclusionMask` parameter of `TraceRay()`.
