### PR TITLE
Handle multiGPU Passes in ImGui Timestamp View

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -44,6 +44,9 @@ namespace AZ
             //! entry from the root entry.
             void LinkChild(PassEntry* childEntry);
 
+            //! Propagate deviceIndex to parents
+            void PropagateDeviceIndex(int deviceIndex);
+
             //! Checks if timestamp queries are enabled for this PassEntry.
             bool IsTimestampEnabled() const;
             //! Checks if PipelineStatistics queries are enabled for this PassEntry.
@@ -70,6 +73,8 @@ namespace AZ
 
             //! Mirrors the enabled/disabled state of the pass.
             bool m_enabled = false;
+            int m_deviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
+            AZStd::unordered_set<int> m_childrenDeviceIndices;
 
             //! Dirty flag to determine if this entry is linked to an parent entry.
             bool m_linked = false;
@@ -205,9 +210,9 @@ namespace AZ
         private:
             // Draw option for the hierarchical view of the passes.
             // Recursively iterates through the timestamp entries, and creates an hierarchical structure.
-            void DrawHierarchicalView(const PassEntry* entry) const;
+            void DrawHierarchicalView(const PassEntry* entry, int deviceIndex) const;
             // Draw option for the flat view of the passes.
-            void DrawFlatView() const;
+            void DrawFlatView(int deviceIndex) const;
 
             // Sorts the entries array depending on the sorting type.
             void SortFlatView();


### PR DESCRIPTION
## What does this PR do?
This PR improves the handling of multi-GPU passes in the GPU Profiler -> TimestampView.

It does the following:
- Report total frame duration per device
- Show one timeline per device vertically
- Split the pass runtime view per device horizontally

![ImguiMultiGPU](https://github.com/user-attachments/assets/b227ea1d-5ed8-48f5-bcbd-03bf064b2723)

One remaining issue is that multiple timelines are drawn and scaled independently at the moment.
Since there currently is no way to match/synchronize timestamps between devices, each GPU scales its own timeline to the full length of the window, instead of scaling all passes the same and shifting them along as needed.
This would require something like [calibrated timestamps](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_calibrated_timestamps.html) to handle better.
In the meantime, timelines are internally consistent but cannot be directly compared with one another.

## How was this PR tested?
Tested with the MultiGPU RPI sample in ASV.
