### PR TITLE
Fix import location of gmock library in install target not being set

### DIFF
--- a/Code/Framework/AzTest/CMakeLists.txt
+++ b/Code/Framework/AzTest/CMakeLists.txt
@@ -71,7 +71,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         ly_target_include_system_directories(TARGET gtest INTERFACE "${LY_ROOT_FOLDER}/include/gtest")
         
         add_library(gmock STATIC IMPORTED GLOBAL)
-        set_target_properties(gtest PROPERTIES IMPORTED_LOCATION "${LY_ROOT_FOLDER}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set_target_properties(gmock PROPERTIES IMPORTED_LOCATION "${LY_ROOT_FOLDER}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}")
         ly_target_include_system_directories(TARGET gmock INTERFACE "${LY_ROOT_FOLDER}/include/gmock")
             
         ly_create_alias(NAME googletest::GTest NAMESPACE 3rdParty TARGETS gtest)


### PR DESCRIPTION
## What does this PR do?

The import location of the `gmock` library, which is built from source via FetchContent, is not set correctly for the install layout of the engine, leading to the following error:
```
CMake Error in D:/code/o3de/install/Code/Framework/AzTest/CMakeLists.txt:
  IMPORTED_LOCATION not set for imported target "gmock" configuration
  "Profile".
```

## How was this PR tested?

Build the install target of the engine and check if the aforementioned error is no longer happening.
