### PR TITLE
Don't try to evict mipchain-assets after the image has been shutdown

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
@@ -164,6 +164,8 @@ namespace AZ
             // Uploads the mip chain content from the asset to the GPU
             RHI::ResultCode UploadMipChain(size_t mipChainIndex);
 
+            AZStd::mutex m_mipChainMutex;
+
             struct MipChainState
             {
                 static const uint16_t InvalidMipChain = (uint16_t)-1;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -497,14 +497,16 @@ namespace AZ
                 request.m_image = GetRHIImage();
                 request.m_mipSlices = mipSlices;
 
-                request.m_completeCallback = [=]()
+                // thisPtr makes sure the request holds an intrusive ptr to the current StreamingImage, so it doesn't get destroyed before
+                // the callback is executed
+                request.m_completeCallback = [=, thisPtr = RHI::Ptr<StreamingImage>(this)]()
                 {
 #ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG
                     AZ_TracePrintf("StreamingImage", "Upload mipchain done [%s]\n", mipChainAsset.GetHint().c_str());
 #endif
                     // make sure the callback isn't interrupted by Shutdown(), which could remove mipchains mid-processing
                     AZStd::scoped_lock<AZStd::mutex> guard(m_mipChainMutex);
-                    EvictMipChainAsset(mipChainIndex); 
+                    EvictMipChainAsset(mipChainIndex);
                 };
 
 #ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -223,6 +223,8 @@ namespace AZ
 
                 GetRHIImage()->Shutdown();
 
+                // make sure we aren't iterrupting an active upload-callback
+                AZStd::scoped_lock<AZStd::mutex> guard(m_mipChainMutex);
                 // Evict all active mip chains
                 for (size_t mipChainIndex = 0; mipChainIndex < m_mipChains.size(); ++mipChainIndex)
                 {
@@ -400,6 +402,11 @@ namespace AZ
 
         void StreamingImage::EvictMipChainAsset(size_t mipChainIndex)
         {
+            if (m_mipChains.empty())
+            {
+                // it's possible we get here from a callback after the image was already destroyed
+                return;
+            }
             AZ_Assert(mipChainIndex < m_mipChains.size(), "Exceeded total number of mip chains.");
 
             const uint16_t mipChainBit = static_cast<uint16_t>(1 << mipChainIndex);
@@ -495,6 +502,8 @@ namespace AZ
 #ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG
                     AZ_TracePrintf("StreamingImage", "Upload mipchain done [%s]\n", mipChainAsset.GetHint().c_str());
 #endif
+                    // make sure the callback isn't interrupted by Shutdown(), which could remove mipchains mid-processing
+                    AZStd::scoped_lock<AZStd::mutex> guard(m_mipChainMutex);
                     EvictMipChainAsset(mipChainIndex); 
                 };
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #18479: This PR avoids an assert that is triggered if the upload-callback is executed after Shutdown() was already called.

This also introduces a mutex to ensure the upload-callback and shutdown interfere, since both can be triggered from separate threads. 

## How was this PR tested?

Vulkan on Windows, making sure default behavior still works, especially the preview-renderer.
