### PR TITLE
DocMenu: Fix broken help links, move AWS doc and remove unused methods from cryedit.h

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -1417,21 +1417,6 @@ void EditorActionsHandler::OnActionRegistrationHook()
         );
     }
 
-    // GameLift Documentation
-    {
-        AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_name = "GameLift Documentation";
-        actionProperties.m_category = "Help";
-
-        m_actionManagerInterface->RegisterAction(
-            EditorIdentifiers::MainWindowActionContextIdentifier, "o3de.action.help.documentation.gamelift", actionProperties,
-            [cryEdit = m_cryEditApp]
-            {
-                cryEdit->OnDocumentationGamelift();
-            }
-        );
-    }
-
     // Release Notes
     {
         AzToolsFramework::ActionProperties actionProperties;
@@ -1473,21 +1458,6 @@ void EditorActionsHandler::OnActionRegistrationHook()
             [cryEdit = m_cryEditApp]
             {
                 cryEdit->OnDocumentationForums();
-            }
-        );
-    }
-
-    // AWS Support
-    {
-        AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_name = "AWS Support";
-        actionProperties.m_category = "Help";
-
-        m_actionManagerInterface->RegisterAction(
-            EditorIdentifiers::MainWindowActionContextIdentifier, "o3de.action.help.resources.awssupport", actionProperties,
-            [cryEdit = m_cryEditApp]
-            {
-                cryEdit->OnDocumentationAWSSupport();
             }
         );
     }
@@ -1967,7 +1937,6 @@ void EditorActionsHandler::OnMenuBindingHook()
         {
             m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::HelpGameDevResourcesMenuIdentifier, "o3de.action.help.resources.gamedevblog", 100);
             m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::HelpGameDevResourcesMenuIdentifier, "o3de.action.help.resources.forums", 200);
-            m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::HelpGameDevResourcesMenuIdentifier, "o3de.action.help.resources.awssupport", 300);
         }
         m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::HelpMenuIdentifier, 500);
         m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::HelpMenuIdentifier, "o3de.action.help.abouto3de", 600);

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1962,12 +1962,6 @@ void CCryEditApp::OnDocumentationO3DE()
     QDesktopServices::openUrl(QUrl(webLink));
 }
 
-void CCryEditApp::OnDocumentationGamelift()
-{
-    QString webLink = tr("https://docs.aws.amazon.com/gamelift/");
-    QDesktopServices::openUrl(QUrl(webLink));
-}
-
 void CCryEditApp::OnDocumentationReleaseNotes()
 {
     QString webLink = tr("https://o3de.org/docs/release-notes/");
@@ -1976,19 +1970,13 @@ void CCryEditApp::OnDocumentationReleaseNotes()
 
 void CCryEditApp::OnDocumentationGameDevBlog()
 {
-    QString webLink = tr("https://aws.amazon.com/blogs/gamedev");
+    QString webLink = tr("https://o3de.org/news-blogs/");
     QDesktopServices::openUrl(QUrl(webLink));
 }
 
 void CCryEditApp::OnDocumentationForums()
 {
-    QString webLink = tr("https://o3de.org/community/");
-    QDesktopServices::openUrl(QUrl(webLink));
-}
-
-void CCryEditApp::OnDocumentationAWSSupport()
-{
-    QString webLink = tr("https://aws.amazon.com/contact-us");
+    QString webLink = tr("https://discord.com/invite/o3de");
     QDesktopServices::openUrl(QUrl(webLink));
 }
 
@@ -3316,11 +3304,6 @@ void CCryEditApp::OpenLUAEditor(const char* files)
 void CCryEditApp::PrintAlways(const AZStd::string& output)
 {
     m_stdoutRedirection.WriteBypassingRedirect(output.c_str(), static_cast<unsigned int>(output.size()));
-}
-
-QString CCryEditApp::GetRootEnginePath() const
-{
-    return m_rootEnginePath;
 }
 
 void CCryEditApp::RedirectStdoutToNull()

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -109,7 +109,6 @@ public:
 
     static CCryEditApp* instance();
 
-    bool GetRootEnginePath(QDir& rootEnginePath) const;
     bool CreateLevel(bool& wasCreateLevelOperationCancelled);
     void LoadFile(QString fileName);
     void ForceNextIdleProcessing() { m_bForceProcessIdle = true; }
@@ -170,8 +169,6 @@ public:
 
     CCryDocManager* GetDocManager() { return m_pDocManager; }
 
-    void RegisterActionHandlers();
-
     // Implementation
     void OnCreateLevel();
     void OnOpenLevel();
@@ -181,23 +178,17 @@ public:
     void OnDocumentationTutorials();
     void OnDocumentationGlossary();
     void OnDocumentationO3DE();
-    void OnDocumentationGamelift();
     void OnDocumentationReleaseNotes();
     void OnDocumentationGameDevBlog();
     void OnDocumentationForums();
-    void OnDocumentationAWSSupport();
-    void OnCommercePublish();
-    void OnCommerceMerch();
     void OnEditHold();
     void OnEditFetch();
     void OnFileExportToGameNoSurfaceTexture();
     void OnViewSwitchToGame();
     void OnViewSwitchToGameFullScreen();
-    void OnViewDeploy();
     void OnMoveObject();
     void OnRenameObj();
     void OnUndo();
-    void OnOpenAssetImporter();
     void OnEditLevelData();
     void OnFileEditLogFile();
     void OnFileEditEditorini();
@@ -359,7 +350,6 @@ private:
     void OnViewConfigureLayout();
 
     void OnCustomizeKeyboard();
-    void OnToolsConfiguretools();
     void OnToolsScriptHelp();
     void OnViewCycle2dviewport();
     void OnDisplayGotoPosition();

--- a/Gems/AWSCore/Code/Source/Editor/Constants/AWSCoreEditorMenuNames.h
+++ b/Gems/AWSCore/Code/Source/Editor/Constants/AWSCoreEditorMenuNames.h
@@ -73,6 +73,22 @@ namespace AWSCore
         "https://o3de.org/docs/user-guide/gems/reference/aws/aws-core/scripting/"
     };
 
+    static constexpr const char* AWSSupport[] =
+    {
+        "AWS Support",
+        "o3de.menu.editor.aws.support",
+        ":/Notifications/link.svg",
+        "https://aws.amazon.com/contact-us"
+    };
+
+    static constexpr const char* AWSGameLift[] =
+    {
+        "GameLift documentation",
+        "o3de.menu.editor.aws.gamelift",
+        ":/Notifications/link.svg",
+        "https://docs.aws.amazon.com/gamelift/"
+    };
+
     static constexpr const char* O3DEAndAWS[] =
     {
         "O3DE && AWS",

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
@@ -148,6 +148,8 @@ namespace AWSCore
         AWSCore::AWSCoreEditorRequestBus::Broadcast(&AWSCore::AWSCoreEditorRequests::AddExternalLinkAction, submenuIdentifier, AWSAndO3DEMappingsFile, 0);
         AWSCore::AWSCoreEditorRequestBus::Broadcast(&AWSCore::AWSCoreEditorRequests::AddExternalLinkAction, submenuIdentifier, AWSAndO3DEMappingsTool, 0);
         AWSCore::AWSCoreEditorRequestBus::Broadcast(&AWSCore::AWSCoreEditorRequests::AddExternalLinkAction, submenuIdentifier, AWSAndO3DEScripting, 0);
+        AWSCore::AWSCoreEditorRequestBus::Broadcast(&AWSCore::AWSCoreEditorRequests::AddExternalLinkAction, submenuIdentifier, AWSGameLift, 0);
+        AWSCore::AWSCoreEditorRequestBus::Broadcast(&AWSCore::AWSCoreEditorRequests::AddExternalLinkAction, submenuIdentifier, AWSSupport, 0);
 
     }
 


### PR DESCRIPTION
## What does this PR do?

Fix https://github.com/o3de/o3de/issues/18486

In help menu :
- Use o3de news blog instead of AWS news
- Point to discord instead of dead link to community page
- Move GameLift link and AWS support to AWS menu

In CryEdit:
- Remove methods declared without a body

This is what is is like with the change

![help menu](https://github.com/user-attachments/assets/11fb65f6-b22f-4a4d-bd73-1bf2684f9d66)
![aws menu](https://github.com/user-attachments/assets/22146bc9-c1eb-4563-bf1b-6b664911b33b)

## How was this PR tested?

Local build on windows
