### PR TITLE
Fix Lua Editor: Only run regex on subset provided by parser instead of entire line

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
@@ -575,10 +575,10 @@ namespace LUAEditor
             m_highlightingRules.push_back(rule);
         }
 
-        // Match against local and self keywords
+        // Match against local, self, true and false keywords
         {
             HighlightingRule rule;
-            rule.pattern = QRegularExpression(R"(\bself\b|\blocal\b)");
+            rule.pattern = QRegularExpression(R"(\bself\b|\blocal\b|\btrue\b|\bfalse\b)");
             rule.colorCB = [colors]()
             {
                 return colors->GetSpecialKeywordColor();
@@ -664,7 +664,7 @@ namespace LUAEditor
             {
                 if (state == ParserStates::Name)
                 {
-                    AZStd::string dhText(text.mid(position, length).toUtf8().constData());
+                    const AZStd::string dhText(text.mid(position, length).toUtf8().constData());
                     if (keywords && keywords->find(dhText) != keywords->end())
                     {
                         textFormat.setForeground(colors->GetKeywordColor());

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
@@ -711,14 +711,19 @@ namespace LUAEditor
                 if (!canRunRegEx)
                     return;
 
+                // Special case to allow to lint methods via regex
+                const int nextCharPos = position + length;
+                const bool nextCharIsStartParenthesis = text.at(nextCharPos) == '(';
+
+                const QString dhText = nextCharIsStartParenthesis ? text.mid(position, length + 1) : text.mid(position, length);
                 for (const HighlightingRule& rule : m_highlightingRules)
                 {
-                    QRegularExpressionMatchIterator i = rule.pattern.globalMatch(text);
+                    QRegularExpressionMatchIterator i = rule.pattern.globalMatch(dhText);
                     while (i.hasNext())
                     {
                         QRegularExpressionMatch match = i.next();
                         textFormat.setForeground(rule.colorCB());
-                        setFormat(match.capturedStart(), match.capturedLength(), textFormat);
+                        setFormat(position + match.capturedStart(), match.capturedLength(), textFormat);
                     }
                 }
             };

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.hxx
@@ -58,6 +58,7 @@ namespace LUAEditor
 
         struct HighlightingRule
         {
+            bool stopProcessingMoreRulesAfterThis = false;
             QRegularExpression pattern;
             AZStd::function<QColor()> colorCB;
         };


### PR DESCRIPTION
## What does this PR do?

This change should both improve performance of parsing and prevent unwanted highlighting in comment blocks. The regex was simply run on too much content.

Follow-up to https://github.com/o3de/o3de/pull/17894. Issue also mentionned in https://github.com/o3de/o3de/pull/17915

Before

![image](https://github.com/user-attachments/assets/de13ab34-3541-490c-be82-3b1f5146de99)

After the fix

![image](https://github.com/user-attachments/assets/100b73a6-a30c-42e2-9854-eebe93189603)


## How was this PR tested?

Local build on windows in dev branch, tried various lua scripts
