### PR TITLE
Fix compilation on windows

### DIFF
--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -28,7 +28,6 @@ struct IAnimationContextListener
     virtual void OnTimeChanged([[maybe_unused]] float newTime) {}
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 /** CAnimationContext stores information about current editable animation sequence.
         Stores information about whenever animation is being recorded know,
         current sequence, current time in sequence etc.
@@ -39,7 +38,6 @@ class CAnimationContext
     , public ITrackViewSequenceManagerListener
     , public AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
 {
-    AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     //////////////////////////////////////////////////////////////////////////
     // Constructors.

--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -33,7 +33,7 @@ AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         Stores information about whenever animation is being recorded know,
         current sequence, current time in sequence etc.
 */
-class SANDBOX_API CAnimationContext
+class CAnimationContext
     : public IEditorNotifyListener
     , public IUndoManagerListener
     , public ITrackViewSequenceManagerListener


### PR DESCRIPTION
## What does this PR do?

https://github.com/o3de/o3de/pull/18496 introduced a build warning on windows preventing to build. Fix is simply to not dllexport this class by removing the macro, its only used within the editor module and thus useless.

The question remain on how the CI pipeline went through it without notifying the issue

## How was this PR tested?

Local windows build
