### PR TITLE
Added Compute Shader support in *.MaterialPipeline

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ibl.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ibl.azsli
@@ -37,7 +37,11 @@ real3 GetIblDiffuse(
     real3 diffuseResponse)
 {
     real3 irradianceDir = MultiplyVectorQuaternion(normal, real4(SceneSrg::m_iblOrientation));
+    #ifdef SAMPLE_LEVEL_LOD
+    real3 diffuseSample = real3(SceneSrg::m_diffuseEnvMap.SampleLevel(SceneSrg::m_samplerEnv, GetCubemapCoords(irradianceDir), SAMPLE_LEVEL_LOD).rgb);
+    #else
     real3 diffuseSample = real3(SceneSrg::m_diffuseEnvMap.Sample(SceneSrg::m_samplerEnv, GetCubemapCoords(irradianceDir)).rgb);
+    #endif
 
     return diffuseResponse * albedo * diffuseSample;
 }
@@ -127,7 +131,11 @@ void ApplyIBL(Surface surface, inout LightingData lightingData, bool useDiffuseI
             {
                 real clearCoatNdotV = saturate(dot(surface.clearCoat.normal, lightingData.dirToCamera));
                 clearCoatNdotV = max(clearCoatNdotV, 0.01);  // [GFX TODO][ATOM-4466] This is a current band-aid for specular noise at grazing angles.
+                #ifdef SAMPLE_LEVEL_LOD
+                real2 clearCoatBrdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, GetBRDFTexCoords(surface.clearCoat.roughness, clearCoatNdotV), SAMPLE_LEVEL_LOD).rg);
+                #else
                 real2 clearCoatBrdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, GetBRDFTexCoords(surface.clearCoat.roughness, clearCoatNdotV)).rg);
+                #endif
 
                 // clear coat uses fixed IOR = 1.5 represents polyurethane which is the most common material for gloss clear coat
                 // coat layer assumed to be dielectric thus don't need multiple scattering compensation
@@ -145,7 +153,11 @@ void ApplyIBL(Surface surface, inout LightingData lightingData, bool useDiffuseI
 #if ENABLE_DUAL_SPECULAR
             if(o_enableDualSpecular)
             {
+                #ifdef SAMPLE_LEVEL_LOD
+                real2 dualSpecularBrdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, GetBRDFTexCoords(surface.dualSpecRoughness, lightingData.GetSpecularNdotV()), SAMPLE_LEVEL_LOD).rg);
+                #else
                 real2 dualSpecularBrdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, GetBRDFTexCoords(surface.dualSpecRoughness, lightingData.GetSpecularNdotV())).rg);
+                #endif
                 real3 dualSpecular = GetIblSpecular(surface.position, surface.GetSpecularNormal(), surface.dualSpecF0.xxx, surface.dualSpecRoughness, lightingData.dirToCamera, dualSpecularBrdf, reflectionProbe, reflectionProbeCubemap);
                 iblSpecular = lerp(iblSpecular, dualSpecular, surface.dualSpecFactor);
             }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ibl.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ibl.azsli
@@ -37,8 +37,8 @@ real3 GetIblDiffuse(
     real3 diffuseResponse)
 {
     real3 irradianceDir = MultiplyVectorQuaternion(normal, real4(SceneSrg::m_iblOrientation));
-    #ifdef SAMPLE_LEVEL_LOD
-    real3 diffuseSample = real3(SceneSrg::m_diffuseEnvMap.SampleLevel(SceneSrg::m_samplerEnv, GetCubemapCoords(irradianceDir), SAMPLE_LEVEL_LOD).rgb);
+    #ifdef CS_SAMPLERS
+    real3 diffuseSample = real3(SceneSrg::m_diffuseEnvMap.SampleLevel(SceneSrg::m_samplerEnv, GetCubemapCoords(irradianceDir), 0).rgb);
     #else
     real3 diffuseSample = real3(SceneSrg::m_diffuseEnvMap.Sample(SceneSrg::m_samplerEnv, GetCubemapCoords(irradianceDir)).rgb);
     #endif
@@ -131,8 +131,8 @@ void ApplyIBL(Surface surface, inout LightingData lightingData, bool useDiffuseI
             {
                 real clearCoatNdotV = saturate(dot(surface.clearCoat.normal, lightingData.dirToCamera));
                 clearCoatNdotV = max(clearCoatNdotV, 0.01);  // [GFX TODO][ATOM-4466] This is a current band-aid for specular noise at grazing angles.
-                #ifdef SAMPLE_LEVEL_LOD
-                real2 clearCoatBrdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, GetBRDFTexCoords(surface.clearCoat.roughness, clearCoatNdotV), SAMPLE_LEVEL_LOD).rg);
+                #ifdef CS_SAMPLERS
+                real2 clearCoatBrdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, GetBRDFTexCoords(surface.clearCoat.roughness, clearCoatNdotV), 0).rg);
                 #else
                 real2 clearCoatBrdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, GetBRDFTexCoords(surface.clearCoat.roughness, clearCoatNdotV)).rg);
                 #endif
@@ -153,8 +153,8 @@ void ApplyIBL(Surface surface, inout LightingData lightingData, bool useDiffuseI
 #if ENABLE_DUAL_SPECULAR
             if(o_enableDualSpecular)
             {
-                #ifdef SAMPLE_LEVEL_LOD
-                real2 dualSpecularBrdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, GetBRDFTexCoords(surface.dualSpecRoughness, lightingData.GetSpecularNdotV()), SAMPLE_LEVEL_LOD).rg);
+                #ifdef CS_SAMPLERS
+                real2 dualSpecularBrdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, GetBRDFTexCoords(surface.dualSpecRoughness, lightingData.GetSpecularNdotV()), 0).rg);
                 #else
                 real2 dualSpecularBrdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, GetBRDFTexCoords(surface.dualSpecRoughness, lightingData.GetSpecularNdotV())).rg);
                 #endif

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
@@ -61,8 +61,8 @@ float2 LtcCoords(float cosTheta, float roughness)
 // Constructs an LTC matrix from the provided texture and coordinates.
 float3x3 LtcMatrix(Texture2D<float4> ltcMatrix, float2 coord)
 {
-    #ifdef SAMPLE_LEVEL_LOD
-    float4 t = ltcMatrix.SampleLevel(SceneSrg::LtcSampler, coord, SAMPLE_LEVEL_LOD);
+    #ifdef CS_SAMPLERS
+    float4 t = ltcMatrix.SampleLevel(SceneSrg::LtcSampler, coord, 0);
     #else
     float4 t = ltcMatrix.Sample(SceneSrg::LtcSampler, coord);
     #endif
@@ -409,8 +409,8 @@ void LtcQuadEvaluate(
     float specular = LtcEvaluateSpecularUnscaled(ltcCoords, ltcMatrix, polygon, vertexCount, doubleSided);
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
-    #ifdef SAMPLE_LEVEL_LOD
-    float2 schlick = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoords, SAMPLE_LEVEL_LOD).xy;
+    #ifdef CS_SAMPLERS
+    float2 schlick = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoords, 0).xy;
     #else
     float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
     #endif
@@ -639,8 +639,8 @@ void LtcPolygonEvaluate(
     specular = -specular;
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
-    #ifdef SAMPLE_LEVEL_LOD
-    float2 schlick = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoords, SAMPLE_LEVEL_LOD).xy;
+    #ifdef CS_SAMPLERS
+    float2 schlick = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoords, 0).xy;
     #else
     float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
     #endif

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
@@ -61,7 +61,11 @@ float2 LtcCoords(float cosTheta, float roughness)
 // Constructs an LTC matrix from the provided texture and coordinates.
 float3x3 LtcMatrix(Texture2D<float4> ltcMatrix, float2 coord)
 {
+    #ifdef SAMPLE_LEVEL_LOD
+    float4 t = ltcMatrix.SampleLevel(SceneSrg::LtcSampler, coord, SAMPLE_LEVEL_LOD);
+    #else
     float4 t = ltcMatrix.Sample(SceneSrg::LtcSampler, coord);
+    #endif
 
     return float3x3(
         1.0, 0.0, t.w,
@@ -405,7 +409,11 @@ void LtcQuadEvaluate(
     float specular = LtcEvaluateSpecularUnscaled(ltcCoords, ltcMatrix, polygon, vertexCount, doubleSided);
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
+    #ifdef SAMPLE_LEVEL_LOD
+    float2 schlick = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoords, SAMPLE_LEVEL_LOD).xy;
+    #else
     float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
+    #endif
     float3 specularRgb = specular * (schlick.x * surface.GetSpecularF0() + (1.0 - surface.GetSpecularF0()) * schlick.y);
     
 #if ENABLE_CLEAR_COAT
@@ -631,7 +639,11 @@ void LtcPolygonEvaluate(
     specular = -specular;
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
+    #ifdef SAMPLE_LEVEL_LOD
+    float2 schlick = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoords, SAMPLE_LEVEL_LOD).xy;
+    #else
     float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
+    #endif
     float3 specularRgb = specular * ((schlick.x * surface.GetSpecularF0()) + (1.0 - surface.GetSpecularF0()) * schlick.y);
 
 #if ENABLE_CLEAR_COAT

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -65,8 +65,8 @@ void ApplySimpleSpotLight(SimpleSpotLight light, Surface surface, inout Lighting
             float4 positionInView = mul(light.m_viewProjectionMatrix, float4(surface.position, 1.0));
             positionInView /= positionInView.w;
             float2 goboUv = float2((positionInView.x + 1.0)/2.0, (positionInView.y + 1.0)/2.0);
-            #ifdef SAMPLE_LEVEL_LOD
-            lightIntensity *= ViewSrg::m_goboTextures[light.m_goboTexIndex].SampleLevel(PassSrg::LinearSampler, goboUv, SAMPLE_LEVEL_LOD);
+            #ifdef CS_SAMPLERS
+            lightIntensity *= ViewSrg::m_goboTextures[light.m_goboTexIndex].SampleLevel(PassSrg::LinearSampler, goboUv, 0);
             #else
             lightIntensity *= ViewSrg::m_goboTextures[light.m_goboTexIndex].Sample(PassSrg::LinearSampler, goboUv);
             #endif

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -65,7 +65,11 @@ void ApplySimpleSpotLight(SimpleSpotLight light, Surface surface, inout Lighting
             float4 positionInView = mul(light.m_viewProjectionMatrix, float4(surface.position, 1.0));
             positionInView /= positionInView.w;
             float2 goboUv = float2((positionInView.x + 1.0)/2.0, (positionInView.y + 1.0)/2.0);
+            #ifdef SAMPLE_LEVEL_LOD
+            lightIntensity *= ViewSrg::m_goboTextures[light.m_goboTexIndex].SampleLevel(PassSrg::LinearSampler, goboUv, SAMPLE_LEVEL_LOD);
+            #else
             lightIntensity *= ViewSrg::m_goboTextures[light.m_goboTexIndex].Sample(PassSrg::LinearSampler, goboUv);
+            #endif
         }
 
         if (dotWithDirection < cosInnerConeAngle) // in penumbra

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli
@@ -85,8 +85,8 @@ void LightingData_BasePBR::Init(float3 positionWS, real3 specularNormal, real ro
     // sample BRDF map (indexed by smoothness values rather than roughness)
     NdotV = saturate(dot(specularNormal, dirToCamera));
     float2 brdfUV = float2(NdotV, (1.0 - roughnessLinear));
-    #ifdef SAMPLE_LEVEL_LOD
-    brdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, brdfUV, SAMPLE_LEVEL_LOD).rg);
+    #ifdef CS_SAMPLERS
+    brdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, brdfUV, 0).rg);
     #else
     brdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, brdfUV).rg);
     #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli
@@ -85,7 +85,11 @@ void LightingData_BasePBR::Init(float3 positionWS, real3 specularNormal, real ro
     // sample BRDF map (indexed by smoothness values rather than roughness)
     NdotV = saturate(dot(specularNormal, dirToCamera));
     float2 brdfUV = float2(NdotV, (1.0 - roughnessLinear));
+    #ifdef SAMPLE_LEVEL_LOD
+    brdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, brdfUV, SAMPLE_LEVEL_LOD).rg);
+    #else
     brdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, brdfUV).rg);
+    #endif
 }
 
 void LightingData_BasePBR::CalculateMultiscatterCompensation(real3 specularF0, bool enabled)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_VertexEval.azsli
@@ -51,6 +51,21 @@ VsOutput EvaluateVertexGeometry_Eye(
     return output;
 }
 
+// Added this version to make it compatible with the number of arguments in BasePBR.
+// Avoids compilation errors for compute shaders, listed in a materialpipeline,
+// that call EvaluateVertexGeometry().
+VsOutput EvaluateVertexGeometry_Eye(
+    float3 position,
+    float3 normal,
+    float4 tangent,
+    float2 uv0,
+    float2 uv1,
+    uint instanceId)
+{
+    const float3 bitangent = float3(0, 0, 0);
+    return EvaluateVertexGeometry_Eye(position, normal, tangent, bitangent, uv0, uv1, instanceId);
+}
+
 VsOutput EvaluateVertexGeometry_Eye(VsInput IN, VsSystemValues SV)
 {
     return EvaluateVertexGeometry_Eye(

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/BaseColorInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/BaseColorInput.azsli
@@ -44,7 +44,11 @@ real3 GetBaseColorInput(Texture2D map, sampler mapSampler, float2 uv, real3 base
         }
         else
         {
+            #ifdef SAMPLE_LEVEL_LOD
+            sampledAbledo = real3(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).rgb);
+            #else
             sampledAbledo = real3(map.Sample(mapSampler, uv).rgb);
+            #endif
         }
         //Convert to ACEScg as that is our intermediate working space. 
         //Todo - We should data drive this color space

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/BaseColorInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/BaseColorInput.azsli
@@ -44,8 +44,8 @@ real3 GetBaseColorInput(Texture2D map, sampler mapSampler, float2 uv, real3 base
         }
         else
         {
-            #ifdef SAMPLE_LEVEL_LOD
-            sampledAbledo = real3(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).rgb);
+            #ifdef CS_SAMPLERS
+            sampledAbledo = real3(map.SampleLevel(mapSampler, uv, 0).rgb);
             #else
             sampledAbledo = real3(map.Sample(mapSampler, uv).rgb);
             #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DetailMapsInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DetailMapsInput.azsli
@@ -60,8 +60,8 @@ real GetDetailLayerBlendFactor(Texture2D detailLayerBlendMask, sampler detailLay
         }
         else
         {
-            #ifdef SAMPLE_LEVEL_LOD
-            detailLayerBlendFactor *= real(detailLayerBlendMask.SampleLevel(detailLayerBlendMaskSampler, detailLayerBlendMaskUv, SAMPLE_LEVEL_LOD).r);
+            #ifdef CS_SAMPLERS
+            detailLayerBlendFactor *= real(detailLayerBlendMask.SampleLevel(detailLayerBlendMaskSampler, detailLayerBlendMaskUv, 0).r);
             #else
             detailLayerBlendFactor *= real(detailLayerBlendMask.Sample(detailLayerBlendMaskSampler, detailLayerBlendMaskUv).r);
             #endif
@@ -168,8 +168,8 @@ real3 ApplyTextureOverlay(bool applyOverlay, real3 baseColor, Texture2D map, sam
         }
         else
         {
-            #ifdef SAMPLE_LEVEL_LOD
-            sampledColor = real3(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).rgb);
+            #ifdef CS_SAMPLERS
+            sampledColor = real3(map.SampleLevel(mapSampler, uv, 0).rgb);
             #else
             sampledColor = real3(map.Sample(mapSampler, uv).rgb);
             #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DetailMapsInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/DetailMapsInput.azsli
@@ -60,7 +60,11 @@ real GetDetailLayerBlendFactor(Texture2D detailLayerBlendMask, sampler detailLay
         }
         else
         {
+            #ifdef SAMPLE_LEVEL_LOD
+            detailLayerBlendFactor *= real(detailLayerBlendMask.SampleLevel(detailLayerBlendMaskSampler, detailLayerBlendMaskUv, SAMPLE_LEVEL_LOD).r);
+            #else
             detailLayerBlendFactor *= real(detailLayerBlendMask.Sample(detailLayerBlendMaskSampler, detailLayerBlendMaskUv).r);
+            #endif
         }
     }
 
@@ -164,7 +168,11 @@ real3 ApplyTextureOverlay(bool applyOverlay, real3 baseColor, Texture2D map, sam
         }
         else
         {
+            #ifdef SAMPLE_LEVEL_LOD
+            sampledColor = real3(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).rgb);
+            #else
             sampledColor = real3(map.Sample(mapSampler, uv).rgb);
+            #endif
         }
         sampledColor = TransformColor(sampledColor, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
         return ApplyTextureBlend(baseColor, sampledColor, factor, TextureBlendMode::Overlay);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
@@ -44,7 +44,11 @@ real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv, float4 uvDxDy
     }
     else
     {
+        #ifdef SAMPLE_LEVEL_LOD
+        sampledValue = real2(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).xy);
+        #else
         sampledValue = real2(map.Sample(mapSampler, uv).xy);
+        #endif
     }
     
 #if AZ_TRAIT_ASTC_COMPRESSION

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
@@ -44,8 +44,8 @@ real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv, float4 uvDxDy
     }
     else
     {
-        #ifdef SAMPLE_LEVEL_LOD
-        sampledValue = real2(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).xy);
+        #ifdef CS_SAMPLERS
+        sampledValue = real2(map.SampleLevel(mapSampler, uv, 0).xy);
         #else
         sampledValue = real2(map.Sample(mapSampler, uv).xy);
         #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/OcclusionInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/OcclusionInput.azsli
@@ -37,8 +37,8 @@ real GetOcclusionInput(Texture2D map, sampler mapSampler, float2 uv, real factor
         }
         else
         {
-            #ifdef SAMPLE_LEVEL_LOD
-            occlusion = real(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).r);
+            #ifdef CS_SAMPLERS
+            occlusion = real(map.SampleLevel(mapSampler, uv, 0).r);
             #else
             occlusion = real(map.Sample(mapSampler, uv).r);
             #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/OcclusionInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/OcclusionInput.azsli
@@ -37,7 +37,11 @@ real GetOcclusionInput(Texture2D map, sampler mapSampler, float2 uv, real factor
         }
         else
         {
+            #ifdef SAMPLE_LEVEL_LOD
+            occlusion = real(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).r);
+            #else
             occlusion = real(map.Sample(mapSampler, uv).r);
+            #endif
         }
         occlusion = pow(occlusion, factor);
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/RoughnessInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/RoughnessInput.azsli
@@ -43,7 +43,11 @@ real GetRoughnessInput(Texture2D map, sampler mapSampler, float2 uv, real factor
         }
         else
         {
+            #ifdef SAMPLE_LEVEL_LOD
+            sampledValue = real(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).r);
+            #else
             sampledValue = real(map.Sample(mapSampler, uv).r);
+            #endif
         }
         return lerp(roughnessLowerBound, roughnessUpperBound, sampledValue);
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/RoughnessInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/RoughnessInput.azsli
@@ -43,8 +43,8 @@ real GetRoughnessInput(Texture2D map, sampler mapSampler, float2 uv, real factor
         }
         else
         {
-            #ifdef SAMPLE_LEVEL_LOD
-            sampledValue = real(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).r);
+            #ifdef CS_SAMPLERS
+            sampledValue = real(map.SampleLevel(mapSampler, uv, 0).r);
             #else
             sampledValue = real(map.Sample(mapSampler, uv).r);
             #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SpecularInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SpecularInput.azsli
@@ -32,7 +32,11 @@ real GetSpecularInput(Texture2D map, sampler mapSampler, float2 uv, real specula
         }
         else
         {
+            #ifdef SAMPLE_LEVEL_LOD
+            specularFactor *= real(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).r);
+            #else
             specularFactor *= real(map.Sample(mapSampler, uv).r);
+            #endif
         }
     }
     return specularFactor;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SpecularInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SpecularInput.azsli
@@ -32,8 +32,8 @@ real GetSpecularInput(Texture2D map, sampler mapSampler, float2 uv, real specula
         }
         else
         {
-            #ifdef SAMPLE_LEVEL_LOD
-            specularFactor *= real(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).r);
+            #ifdef CS_SAMPLERS
+            specularFactor *= real(map.SampleLevel(mapSampler, uv, 0).r);
             #else
             specularFactor *= real(map.Sample(mapSampler, uv).r);
             #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
@@ -54,8 +54,8 @@ real3 ApplyBaseColorWrinkleMap(bool shouldApply, real3 baseColor, Texture2D map,
         }
         else
         {
-            #ifdef SAMPLE_LEVEL_LOD
-            sampledColor = real3(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).rgb);
+            #ifdef CS_SAMPLERS
+            sampledColor = real3(map.SampleLevel(mapSampler, uv, 0).rgb);
             #else
             sampledColor = real3(map.Sample(mapSampler, uv).rgb);
             #endif
@@ -125,8 +125,8 @@ Surface EvaluateSurface_Skin(
             }
             else
             {
-                #ifdef SAMPLE_LEVEL_LOD
-                wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].SampleLevel(MaterialSrg::m_sampler, normalUv, SAMPLE_LEVEL_LOD) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
+                #ifdef CS_SAMPLERS
+                wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].SampleLevel(MaterialSrg::m_sampler, normalUv, 0) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
                 #else
                 wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].Sample(MaterialSrg::m_sampler, normalUv) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
                 #endif

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
@@ -54,7 +54,11 @@ real3 ApplyBaseColorWrinkleMap(bool shouldApply, real3 baseColor, Texture2D map,
         }
         else
         {
+            #ifdef SAMPLE_LEVEL_LOD
+            sampledColor = real3(map.SampleLevel(mapSampler, uv, SAMPLE_LEVEL_LOD).rgb);
+            #else
             sampledColor = real3(map.Sample(mapSampler, uv).rgb);
+            #endif
         }
         sampledColor = TransformColor(sampledColor, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
         return lerp(baseColor, sampledColor, factor);
@@ -121,7 +125,11 @@ Surface EvaluateSurface_Skin(
             }
             else
             {
+                #ifdef SAMPLE_LEVEL_LOD
+                wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].SampleLevel(MaterialSrg::m_sampler, normalUv, SAMPLE_LEVEL_LOD) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
+                #else
                 wrinkleMaskBlendFactors += real4(ObjectSrg::m_wrinkle_masks[wrinkleMaskIndex].Sample(MaterialSrg::m_sampler, normalUv) * ObjectSrg::GetWrinkleMaskWeight(wrinkleMaskIndex));
+                #endif
             }
         }
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_VertexEval.azsli
@@ -75,6 +75,20 @@ VsOutput EvaluateVertexGeometry_Skin(
     return output;
 }
 
+// Added this version to make it compatible with the number of arguments in BasePBR.
+// Avoids compilation errors for compute shaders, listed in a materialpipeline,
+// that call EvaluateVertexGeometry().
+VsOutput EvaluateVertexGeometry_Skin(
+    float3 position,
+    float3 normal,
+    float4 tangent,
+    float2 uv0_tiled,
+    float2 uv1_unwrapped,
+    uint instanceId)
+{
+    return EvaluateVertexGeometry_Skin(position, normal, tangent, uv0_tiled, uv1_unwrapped, float4(0, 0, 0, 0), instanceId);
+}
+
 VsOutput EvaluateVertexGeometry_Skin(VsInput IN, VsSystemValues SV)
 {
     return EvaluateVertexGeometry_Skin(

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessorInterface.h>
+#include <Atom/RHI/DispatchItem.h>
 #include <Atom/RPI.Public/Culling.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/RPI.Public/MeshDrawPacket.h>
@@ -68,6 +69,21 @@ namespace AZ
             "This is helpful for simulating the worst case scenario for instancing for profiling performance.");
 
         struct MeshInstanceGroupData;
+        class StreamBufferViewsBuilderInterface;
+
+        //! Custom material infill containing a material instance that will be substituted for an embedded material on a model and UV
+        //! mapping reassignments
+        struct CustomMaterialInfo
+        {
+            Data::Instance<RPI::Material> m_material;
+            RPI::MaterialModelUvOverrideMap m_uvMapping;
+        };
+
+        //! Mesh feature processor data types for customizing model materials
+        using CustomMaterialLodIndex = AZ::u64;
+
+        //! Pair referring to the lod index and unique id corresponding to the material slot where the material should be applied 
+        using CustomMaterialId = AZStd::pair<CustomMaterialLodIndex, uint32_t>;
 
         // ModelDataInstanceInterface provides an interface to ModelDataInstance
         // It provides information about an instance of a model in the scene
@@ -102,31 +118,20 @@ namespace AZ
             virtual const AZ::Uuid& GetRayTracingUuid() const = 0;
 
             //! Internally called when a DrawPacket used by this ModelDataInstance was updated.
-            virtual void HandleDrawPacketUpdate(RPI::MeshDrawPacket& meshDrawPacket) = 0;
+            virtual void HandleDrawPacketUpdate(uint32_t lodIndex, uint32_t meshIndex, RPI::MeshDrawPacket& meshDrawPacket) = 0;
 
             //! Event that let's us know whenever one of the MeshDrawPackets has been updated.
             //! This event can occur on multiple threads.
             //! Provides the ModelDataInstance parent object that owns the MeshDrawPacket.
-            using MeshDrawPacketUpdatedEvent = Event<const ModelDataInstanceInterface&, const AZ::RPI::MeshDrawPacket&>;
+            using MeshDrawPacketUpdatedEvent = Event<const ModelDataInstanceInterface&, uint32_t /*lodIndex*/, uint32_t /*meshIndex*/, const AZ::RPI::MeshDrawPacket&>;
             //! Connects @handler to the MeshDrawPacketUpdatedEvent.
             //! One of the most common reasons a MeshDrawPacket gets updated is
             //! when a RenderPipeline is instantiated at runtime and it happens to contain
             //! a RasterPass with a DrawListTag that matches one of the Shaders of one of the Materials in
-            //! a Mesh.
+            //! a Mesh. Another scenario is when Shader assets or Material assets are reloaded.
             virtual void ConnectMeshDrawPacketUpdatedHandler(MeshDrawPacketUpdatedEvent::Handler& handler) = 0;
-        };
 
-        //! Mesh feature processor data types for customizing model materials
-        using CustomMaterialLodIndex = AZ::u64;
-
-        //! Pair referring to the lod index and unique id corresponding to the material slot where the material should be applied 
-        using CustomMaterialId = AZStd::pair<CustomMaterialLodIndex, uint32_t>;
-
-        //! Custom material infill containing a material instance that will be substituted for an embedded material on a model and UV mapping reassignments 
-        struct CustomMaterialInfo
-        {
-            Data::Instance<RPI::Material> m_material;
-            RPI::MaterialModelUvOverrideMap m_uvMapping;
+            virtual CustomMaterialInfo GetCustomMaterialWithFallback(const CustomMaterialId& id) const = 0;
         };
 
         using CustomMaterialMap = AZStd::unordered_map<CustomMaterialId, CustomMaterialInfo>;
@@ -181,6 +186,22 @@ namespace AZ
             ObjectSrgCreatedEvent::Handler m_objectSrgCreatedHandler{ [](const Data::Instance<RPI::ShaderResourceGroup>&){} };
         };
 
+        //! Helper structure used to create a DispatchItem from a DrawItem.
+        //! This structure is created, optionally and on demand, by the MeshFeatureProcessor
+        //! only for DrawItems with a PipelineState of Compute type.
+        struct DispatchDrawItem
+        {
+            DispatchDrawItem() = delete;
+            explicit DispatchDrawItem(const RHI::DrawItem* drawItem)
+                : m_drawItem(drawItem)
+                , m_distpatchItem(RHI::MultiDevice::AllDevices)
+            {
+            }
+            const RHI::DrawItem* m_drawItem = nullptr;
+            RHI::DispatchItem m_distpatchItem;
+        };
+        using DispatchDrawItemList = AZStd::vector<DispatchDrawItem>;
+
         //! MeshFeatureProcessorInterface provides an interface to acquire and release a MeshHandle from the underlying
         //! MeshFeatureProcessor
         class MeshFeatureProcessorInterface : public RPI::FeatureProcessor
@@ -204,8 +225,9 @@ namespace AZ
             virtual Data::Instance<RPI::Model> GetModel(const MeshHandle& meshHandle) const = 0;
             //! Gets the underlying RPI::ModelAsset for a meshHandle.
             virtual Data::Asset<RPI::ModelAsset> GetModelAsset(const MeshHandle& meshHandle) const = 0;
-            //! This function is primarily intended for debug output and testing, by providing insight into what
-            //! materials, shaders, etc. are actively being used to render the model.
+
+            //! This function provides insight into what materials, shaders, etc. are actively being used to render the model.
+            //! Useful for custom feature processors that work in tandem with the MeshFeatureProcessor.
             virtual const RPI::MeshDrawPacketLods& GetDrawPackets(const MeshHandle& meshHandle) const = 0;
 
             //! Gets the ObjectSrgs for a meshHandle.
@@ -274,6 +296,29 @@ namespace AZ
             virtual void SetRayTracingDirty(const MeshHandle& meshHandle) = 0;
             //! Print out info about the mesh draw packet
             virtual void PrintDrawPacketInfo(const MeshHandle& meshHandle) = 0;
+            //! A helper function, typically called by another FeatureProcessor, when Compute or RayTracing shaders need to bind
+            //! Mesh Input Streams like "POSITION", "NORMAL", "UV1" etc as regular AZ::RHI::BufferViews.
+            //! This function instantiates a concrete Builder-like object that helps creating the RHI::BufferViews. 
+            virtual AZStd::unique_ptr<StreamBufferViewsBuilderInterface> CreateStreamBufferViewsBuilder(const MeshHandle& meshHandle) const = 0;
+            //! MaterialTypes and MaterialPipelines support Compute Shaders (With DrawListTag) in their ShaderItem collections.
+            //! Given that this is an uncommon use case, the DispatchItems are not created automatically by the MeshDrawPacket.
+            //! Additionally DispatchItems require knowledge of the Total number of threads X,Y,Z, which should be customizable.
+            //! The following function helps the creation of the DispatchItems and the user must supply a callback that
+            //! allows full control on the number of Total Threads X,Y,Z.
+            //! REMARK 1: It is recommended to call this function whenever ModelDataInstanceInterface::MeshDrawPacketUpdatedEvent is signaled.
+            //! REMARK 2: This function is typically called by a custom FeatureProcessor that leverages the MeshFeatureProcessor.
+            //!           The custom FeatureProcessor will own the returned list and submit the DispatchItems in a custom Pass.
+            using DispatchArgumentsSetupCB = AZStd::function<void(uint32_t /*lodIndex*/, uint32_t /*meshIndex*/, uint32_t /*drawItemIdx*/, const RHI::DrawItem*, RHI::DispatchDirect&)>;
+            //! DisptachItems will be created for the DrawItems that match both the @drawListTagsFilter and @materialPipelineFilter.
+            //! Also, only DrawItems whose PipelineState is of Compute type will be considered.
+            virtual DispatchDrawItemList BuildDispatchDrawItemList(
+                const MeshHandle& meshHandle,
+                const uint32_t lodIndex,
+                const uint32_t meshIndex,
+                const RHI::DrawListMask drawListTagsFilter,
+                const RHI::DrawFilterMask materialPipelineFilter,
+                DispatchArgumentsSetupCB dispatchArgumentsSetupCB) const = 0;
+
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+
+        // An Interface that contains all Stream BufferViews (AZ::RHI::BufferView)
+        // requested to @StreamBufferViewsBuilderInterface.
+        // This is useful to manually bind Mesh Stream Buffers in a Compute or RayTracing Shader.
+        class ShaderStreamBufferViewsInterface
+        {
+        public:
+            AZ_RTTI(AZ::Render::ShaderStreamBufferViewsInterface, "{3A80C85C-DD3A-4A1D-B564-291EB463CD0B}");
+            virtual ~ShaderStreamBufferViewsInterface() = default;
+
+            //! Returns the Shader-bindable RHI::BufferView for the Vertex Indices from a particular mesh. 
+            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetIndexBufferView() const = 0;
+            //! Returns the Shader-bindable RHI::BufferView for a Vertex Stream, identifiable by @shaderSemantic, from a particular mesh.
+            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetStreamBufferView(const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
+            //! Same as above, but provides the convenience of finding the vertex stream by name, like "POSITION" or "UV1", etc.
+            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetStreamBufferView(const char* semanticName) const = 0;
+            //! For informational purposes. Returns the LOD Index of the Mesh.
+            virtual uint32_t GetLodIndex() const = 0;
+            // For informational purposes. Returns the Mesh Index (Within the current LOD index) of the Mesh.
+            virtual uint32_t GetMeshIndex() const = 0;
+        };
+
+
+        // This helper interface is typically used to manually define a set of Stream Buffers, identifiable
+        // by their Shader Semantics, like POSITION, NORMAL, UV0, UV1, etc... and create Buffer Views that can be bound
+        // to a Shader (typically Compute or RayTracing, because Raster shaders get the streams automatically bound to the InputAssembly stage).
+        // The most common use case is a non-Raster shader that uses the BindlessSrg and needs to know the indices
+        // of each StreamBuffer within the BindlessSrg::m_ByteAddressBuffer.
+        // To create one of these builders please use ModelDataInstanceInterface::CreateStreamBufferViewsBuilder().
+        class StreamBufferViewsBuilderInterface
+        {
+        public:
+            AZ_RTTI(AZ::Render::StreamBufferViewsBuilderInterface, "{B0004EA8-C829-427D-8F3B-0FBB060CB385}");
+            virtual ~StreamBufferViewsBuilderInterface() = default;
+
+            //! All streams that need to be queried must be added before calling BuildShaderStreamBufferViews();
+            virtual bool AddStream(const char* semanticName, AZ::RHI::Format streamFormat, bool isOptional) = 0;
+
+            //! Returns the number of streams that were successfully added via @AddStream(...)
+            virtual AZ::u8 GetStreamCount() const = 0;
+
+            //! If @AddStream() is never called, the returned  @ShaderStreamBufferViewsInterface may only be useful
+            //! for GetIndexBufferView().
+            //! The returned ShaderStreamBufferViewsInterface can only get the Streams on the particular
+            //! @meshIndex within the @lodIndex.
+            virtual AZStd::unique_ptr<ShaderStreamBufferViewsInterface> BuildShaderStreamBufferViews(
+                uint32_t lodIndex, uint32_t meshIndex) = 0;
+
+            //! For informational purposes. Gets a reference to the MeshHandle used when this builder was created.
+            virtual const MeshFeatureProcessorInterface::MeshHandle& GetMeshHandle() const = 0;
+        };
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1227,6 +1227,8 @@ namespace AZ
                     {
                         continue;
                     }
+                    // Only create the DispatchItems for DrawItems whose DrawListTag is included
+                    // in @drawListTagsFilter AND their DrawFilterMask is included in @materialPipelineFilter.
                     RHI::DrawListTag tag = drawPacket->GetDrawListTag(drawItemIdx);
                     RHI::DrawFilterMask drawItemPipelineFilter = drawPacket->GetDrawFilterMask(drawItemIdx);
                     if (

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Mesh/MeshFeatureProcessor.h>
+#include <Mesh/StreamBufferViewsBuilder.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 #include <Atom/Feature/Material/ConvertEmissiveUnitFunctor.h>
 #include <Atom/Feature/Mesh/MeshCommon.h>
@@ -1178,6 +1179,99 @@ namespace AZ
         const CustomMaterialMap& MeshFeatureProcessor::GetCustomMaterials(const MeshHandle& meshHandle) const
         {
             return meshHandle.IsValid() ? ToModelDataInstance(meshHandle).m_descriptor.m_customMaterials : DefaultCustomMaterialMap;
+        }
+
+        AZStd::unique_ptr<StreamBufferViewsBuilderInterface> MeshFeatureProcessor::CreateStreamBufferViewsBuilder(
+            const MeshHandle& meshHandle) const
+        {
+            return AZStd::make_unique<ShaderStreamBufferViewsBuilder>(meshHandle);
+        }
+
+        DispatchDrawItemList MeshFeatureProcessor::BuildDispatchDrawItemList(
+            const MeshHandle& meshHandle,
+            const uint32_t lodIndex,
+            const uint32_t meshIndex,
+            const RHI::DrawListMask drawListTagsFilter,
+            const RHI::DrawFilterMask materialPipelineFilter,
+            DispatchArgumentsSetupCB dispatchArgumentsSetupCB) const
+        {
+            DispatchDrawItemList retList;
+
+            const AZ::RPI::MeshDrawPacketLods& drawPacketListByLod = GetDrawPackets(meshHandle);
+            const uint32_t lodCount = aznumeric_caster(drawPacketListByLod.size());
+            if (lodIndex >= lodCount)
+            {
+                // This is normal. May happen if a caller got a valid MeshHandle before
+                // a mesh is fully loaded from assets.
+                return retList;
+            }
+            const AZ::RPI::MeshDrawPacketList& drawPacketList = drawPacketListByLod[lodIndex];
+            const uint32_t meshCount = aznumeric_caster(drawPacketList.size());
+            if (meshIndex >= meshCount)
+            {
+                AZ_Error("MeshFeatureProcessor", false,
+                    "For lodIndex=%u, got invalid meshIndex=%u, maxMeshCount=%u",
+                    lodIndex, meshIndex, meshCount);
+                return retList;
+            }
+            const AZ::RPI::MeshDrawPacket& meshDrawPacket = drawPacketList[meshIndex];
+            const RHI::DrawPacket* drawPacket = meshDrawPacket.GetRHIDrawPacket();
+            const auto& shadersList = meshDrawPacket.GetActiveShaderList();
+            if (drawPacket)
+            {
+                const uint32_t drawItemCount = aznumeric_caster(drawPacket->GetDrawItemCount());
+                for (uint32_t drawItemIdx = 0; drawItemIdx < drawItemCount; ++drawItemIdx)
+                {
+                    const RHI::DrawItem* drawItem = drawPacket->GetDrawItem(drawItemIdx);
+                    if (drawItem->GetPipelineStateType() != RHI::PipelineStateType::Dispatch)
+                    {
+                        continue;
+                    }
+                    RHI::DrawListTag tag = drawPacket->GetDrawListTag(drawItemIdx);
+                    RHI::DrawFilterMask drawItemPipelineFilter = drawPacket->GetDrawFilterMask(drawItemIdx);
+                    if (
+                        drawListTagsFilter.test(tag.GetIndex()) &&
+                        (materialPipelineFilter & drawItemPipelineFilter)
+                        )
+                    {
+                        retList.emplace_back(DispatchDrawItem(drawItem));
+                        auto& dispatchDrawItem = retList.back();
+                        const auto& shaderAsset = shadersList[drawItemIdx].m_shader->GetAsset();
+                        RHI::DispatchDirect dispatchDirect;
+                        RPI::GetComputeShaderNumThreads(shaderAsset, dispatchDirect);
+                        dispatchArgumentsSetupCB(lodIndex, meshIndex, drawItemIdx, drawItem, dispatchDirect);
+                        InitializeDispatchItemFromDrawItem(dispatchDrawItem.m_distpatchItem, drawItem, dispatchDirect);
+                    }
+                }
+            }
+
+            return retList;
+        }
+
+        void MeshFeatureProcessor::InitializeDispatchItemFromDrawItem(
+            RHI::DispatchItem& dstDispatchItem, const RHI::DrawItem* srcDrawItem, const RHI::DispatchDirect& dispatchDirect) const
+        {
+            RHI::DispatchArguments dispatchArguments(dispatchDirect);
+            dstDispatchItem.SetArguments(dispatchArguments);
+
+            bool deviceCommonDataIsSet = false;
+            RHI::MultiDeviceObject::IterateDevices(
+                RHI::MultiDevice::AllDevices,
+                [&](int deviceIndex)
+                {
+                    const auto& deviceDrawItem = srcDrawItem->GetDeviceDrawItem(deviceIndex);
+                    dstDispatchItem.SetDeviceShaderResourceGroups(
+                        deviceIndex, deviceDrawItem.m_shaderResourceGroups, deviceDrawItem.m_shaderResourceGroupCount);
+                    dstDispatchItem.SetUniqueDeviceShaderResourceGroup(deviceIndex, deviceDrawItem.m_uniqueShaderResourceGroup);
+                    dstDispatchItem.SetDevicePipelineState(deviceIndex, deviceDrawItem.m_pipelineState);
+                    if (!deviceCommonDataIsSet)
+                    {
+                        dstDispatchItem.SetRootConstantSize(deviceDrawItem.m_rootConstantSize);
+                        dstDispatchItem.SetRootConstants(deviceDrawItem.m_rootConstants);
+                        deviceCommonDataIsSet = true;
+                    }
+                    return true;
+                });
         }
 
         void MeshFeatureProcessor::SetTransform(const MeshHandle& meshHandle, const AZ::Transform& transform, const AZ::Vector3& nonUniformScale)
@@ -2704,8 +2798,10 @@ namespace AZ
                 meshMotionDrawListTag = AZ::RHI::RHISystemInterface::Get()->GetDrawListTagRegistry()->FindTag(MeshCommon::MotionDrawListTagName);
             }
 
+            uint32_t lodIndex = 0;
             for (auto& meshDrawPacketList : m_meshDrawPacketListsByLod)
             {
+                uint32_t meshIndex = 0;
                 for (auto& meshDrawPacket : meshDrawPacketList)
                 {
                     if (enableDrawMotion)
@@ -2714,9 +2810,11 @@ namespace AZ
                     }
                     if (meshDrawPacket.Update(*m_scene, forceUpdate))
                     {
-                        HandleDrawPacketUpdate(meshDrawPacket);
+                        HandleDrawPacketUpdate(lodIndex, meshIndex, meshDrawPacket);
                     }
+                    meshIndex++;
                 }
+                lodIndex++;
             }
         }
 
@@ -2992,11 +3090,11 @@ namespace AZ
             return CustomMaterialInfo{};
         }
 
-        void ModelDataInstance::HandleDrawPacketUpdate(RPI::MeshDrawPacket& meshDrawPacket)
+        void ModelDataInstance::HandleDrawPacketUpdate(uint32_t lodIndex, uint32_t meshIndex, RPI::MeshDrawPacket& meshDrawPacket)
         {
             // When the drawpacket is updated, the cullable must be rebuilt to use the latest draw packet
             m_flags.m_cullableNeedsRebuild = true;
-            m_meshDrawPacketUpdatedEvent.Signal(*this, meshDrawPacket);
+            m_meshDrawPacketUpdatedEvent.Signal(*this, lodIndex, meshIndex, meshDrawPacket);
         }
 
         void ModelDataInstance::ConnectMeshDrawPacketUpdatedHandler(MeshDrawPacketUpdatedEvent::Handler& handler)

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.cpp
@@ -21,7 +21,7 @@ namespace AZ::Render
             m_perViewDrawPackets.clear();
             for (auto modelDataInstance : m_associatedInstances)
             {
-                modelDataInstance->HandleDrawPacketUpdate(m_drawPacket);
+                modelDataInstance->HandleDrawPacketUpdate(m_key.m_lodIndex, m_key.m_meshIndex, m_drawPacket);
             }
             return true;
         }

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
@@ -114,7 +114,7 @@ namespace AZ
                 FinalizeShaderInputContract();
             }
 
-            AZStd::unique_ptr<ShaderStreamBufferViews> shaderStreamBufferViews = AZStd::make_unique<ShaderStreamBufferViews>();
+            AZStd::unique_ptr<ShaderStreamBufferViews> shaderStreamBufferViews = AZStd::make_unique<ShaderStreamBufferViews>(lodIndex, meshIndex);
 
             const auto& modelInstance = (*m_meshHandle)->GetModel();
             if (!modelInstance)

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "StreamBufferViewsBuilder.h"
+
+namespace AZ
+{
+    namespace Render
+    {
+
+        class ShaderStreamBufferViews final : public ShaderStreamBufferViewsInterface
+        {
+        public:
+            AZ_RTTI(
+                AZ::Render::ShaderStreamBufferViews,
+                "{35C88638-C8F8-4124-B7AD-269ED7BFE6BE}",
+                AZ::Render::ShaderStreamBufferViewsInterface);
+            ShaderStreamBufferViews() = delete;
+            explicit ShaderStreamBufferViews(uint32_t lodIndex, uint32_t meshIndex)
+                : m_lodIndex(lodIndex), m_meshIndex(meshIndex)
+            {
+            }
+            ~ShaderStreamBufferViews() = default;
+
+            ////////////////////////////////////////////////////////////
+            // ShaderStreamBufferViewsInterface overrides Start...
+            const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetIndexBufferView() const override
+            {
+                return m_indexBufferView;
+            }
+
+            const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetStreamBufferView(const AZ::RHI::ShaderSemantic& shaderSemantic) const override
+            {
+                static AZ::RHI::Ptr<AZ::RHI::BufferView> InvalidBufferView;
+                if (!m_streamViewsBySemantic.contains(shaderSemantic))
+                {
+                    return InvalidBufferView;
+                }
+                return m_streamViewsBySemantic.at(shaderSemantic);
+            }
+
+            const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetStreamBufferView(const char* semanticName) const override
+            {
+                return GetStreamBufferView(AZ::RHI::ShaderSemantic::Parse(semanticName));
+            }
+
+            uint32_t GetLodIndex() const override
+            {
+                return m_lodIndex;
+            }
+
+            uint32_t GetMeshIndex() const override
+            {
+                return m_meshIndex;
+            }
+            // ShaderStreamBufferViewsInterface overrides End...
+            ////////////////////////////////////////////////////////////
+
+        private:
+            friend class ShaderStreamBufferViewsBuilder;
+            uint32_t m_lodIndex; //Kept for informational purposes.
+            uint32_t m_meshIndex; //Kept for informational purposes.
+            AZ::RHI::Ptr<AZ::RHI::BufferView> m_indexBufferView;
+            using StreamBufferViewsBySemantic = AZStd::unordered_map<AZ::RHI::ShaderSemantic, AZ::RHI::Ptr<AZ::RHI::BufferView>>;
+            StreamBufferViewsBySemantic m_streamViewsBySemantic;
+        }; // class ShaderStreamBufferViews
+
+
+        ShaderStreamBufferViewsBuilder::ShaderStreamBufferViewsBuilder(const AZ::Render::MeshFeatureProcessorInterface::MeshHandle& meshHandle)
+            : m_meshHandle(&meshHandle)
+        {
+        }
+
+        ////////////////////////////////////////////////////////////
+        // StreamBufferViewsBuilderInterface overrides Start...
+        bool ShaderStreamBufferViewsBuilder::AddStream(const char* semanticName, AZ::RHI::Format streamFormat, bool isOptional)
+        {
+            if (m_shaderInputContract)
+            {
+                AZ_Error(LogWindow, false, "Can not add stream '%s' because the ShaderInputContract was finalized!", semanticName);
+                return false;
+            }
+            auto it = std::find_if(
+                m_streamsList.cbegin(),
+                m_streamsList.cend(),
+                [semanticName](const StreamInfo& item) -> bool
+                {
+                    return strcmp(item.m_semanticName, semanticName) == 0;
+                });
+            if (it != m_streamsList.end())
+            {
+                AZ_Error(LogWindow, false, "%s. A stream with name '%s' already exists!", __FUNCTION__, semanticName);
+                return false;
+            }
+            m_streamsList.emplace_back(semanticName, streamFormat, isOptional);
+            return true;
+        }
+
+        AZ::u8 ShaderStreamBufferViewsBuilder::GetStreamCount() const
+        {
+            return aznumeric_caster(m_streamsList.size());
+        }
+
+        AZStd::unique_ptr<ShaderStreamBufferViewsInterface> ShaderStreamBufferViewsBuilder::BuildShaderStreamBufferViews(
+            uint32_t lodIndex, uint32_t meshIndex)
+        {
+            if (!m_shaderInputContract)
+            {
+                FinalizeShaderInputContract();
+            }
+
+            AZStd::unique_ptr<ShaderStreamBufferViews> shaderStreamBufferViews = AZStd::make_unique<ShaderStreamBufferViews>();
+
+            const auto& modelInstance = (*m_meshHandle)->GetModel();
+            if (!modelInstance)
+            {
+                // A valid MeshHandle, when the Mesh Asset is being loaded, may temporary not have a model instance.
+                return shaderStreamBufferViews;
+            }
+
+            const auto& modelLods = modelInstance->GetLods();
+            const auto& modelLod = modelLods[lodIndex];
+            const auto& modelLodMeshList = modelLod->GetMeshes();
+            const auto& modelLodMesh = modelLodMeshList[meshIndex];
+
+            shaderStreamBufferViews->m_indexBufferView = BuildShaderIndexBufferView(modelLodMesh);
+
+            // retrieve the material
+            const AZ::Render::CustomMaterialId customMaterialId(lodIndex, modelLodMesh.m_materialSlotStableId);
+            // This is a private function!
+            const auto& customMaterialInfo = (*m_meshHandle)->GetCustomMaterialWithFallback(customMaterialId);
+            const auto& material = customMaterialInfo.m_material ? customMaterialInfo.m_material : modelLodMesh.m_material;
+
+            // retrieve vertex/index buffers
+            AZ::RHI::InputStreamLayout inputStreamLayout;
+            AZ::RHI::StreamBufferIndices streamIndices;
+
+            [[maybe_unused]] bool result = modelLod->GetStreamsForMesh(
+                inputStreamLayout,
+                streamIndices,
+                nullptr,
+                *m_shaderInputContract.get(),
+                meshIndex,
+                customMaterialInfo.m_uvMapping,
+                material->GetAsset()->GetMaterialTypeAsset()->GetUvNameMap());
+            AZ_Assert(result, "Failed to retrieve mesh stream buffer views");
+
+            const AZ::u8 streamCount = GetStreamCount();
+            auto streamIter = modelLodMesh.CreateStreamIterator(streamIndices);
+            auto streamChannels = inputStreamLayout.GetStreamChannels();
+            for (AZ::u8 streamIdx = 0; streamIdx < streamCount; streamIdx++)
+            {
+                auto shaderSemantic = streamChannels[streamIdx].m_semantic;
+                AZ::RHI::Buffer* rhiBuffer = const_cast<AZ::RHI::Buffer*>(streamIter[streamIdx].GetBuffer());
+                uint32_t streamByteCount = static_cast<uint32_t>(rhiBuffer->GetDescriptor().m_byteCount);
+                auto bufferViewDescriptor = AZ::RHI::BufferViewDescriptor::CreateRaw(0, streamByteCount);
+                auto ptrBufferView = rhiBuffer->BuildBufferView(bufferViewDescriptor);
+                shaderStreamBufferViews->m_streamViewsBySemantic.emplace(AZStd::move(shaderSemantic), ptrBufferView);
+            }
+
+            return shaderStreamBufferViews;
+        }
+
+        const MeshFeatureProcessorInterface::MeshHandle& ShaderStreamBufferViewsBuilder::GetMeshHandle() const
+        {
+            return *m_meshHandle;
+        }
+        // StreamBufferViewsBuilderInterface overrides End...
+        ////////////////////////////////////////////////////////////
+
+        void ShaderStreamBufferViewsBuilder::FinalizeShaderInputContract()
+        {
+            AZ_Assert(!m_shaderInputContract, "ShaderInputContract was already finalized.");
+            m_shaderInputContract = AZStd::make_unique<AZ::RPI::ShaderInputContract>();
+            for (const auto& streamInfo : m_streamsList)
+            {
+                AZ::RPI::ShaderInputContract::StreamChannelInfo streamChannelInfo;
+                streamChannelInfo.m_semantic = AZ::RHI::ShaderSemantic::Parse(streamInfo.m_semanticName);
+                streamChannelInfo.m_componentCount = AZ::RHI::GetFormatComponentCount(streamInfo.m_streamFormat);
+                streamChannelInfo.m_isOptional = streamInfo.m_isOptional;
+                m_shaderInputContract->m_streamChannels.emplace_back(streamChannelInfo);
+            }
+        }
+
+        AZ::RHI::Ptr<AZ::RHI::BufferView> ShaderStreamBufferViewsBuilder::BuildShaderIndexBufferView(
+            const AZ::RPI::ModelLod::Mesh& modelLodMesh) const
+        {
+            AZ_Assert(modelLodMesh.GetDrawArguments().m_type == AZ::RHI::DrawType::Indexed, "We only support indexed geometry!");
+            const AZ::RHI::IndexBufferView& indexBufferView = modelLodMesh.GetIndexBufferView();
+
+            uint32_t indexElementSize = indexBufferView.GetIndexFormat() == AZ::RHI::IndexFormat::Uint16 ? 2 : 4;
+            uint32_t indexElementCount = (uint32_t)indexBufferView.GetBuffer()->GetDescriptor().m_byteCount / indexElementSize;
+            AZ::RHI::BufferViewDescriptor indexBufferDescriptor;
+            indexBufferDescriptor.m_elementOffset = 0;
+            indexBufferDescriptor.m_elementCount = indexElementCount;
+            indexBufferDescriptor.m_elementSize = indexElementSize;
+            indexBufferDescriptor.m_elementFormat =
+                indexBufferView.GetIndexFormat() == AZ::RHI::IndexFormat::Uint16 ? AZ::RHI::Format::R16_UINT : AZ::RHI::Format::R32_UINT;
+            auto* rhiBuffer = const_cast<AZ::RHI::Buffer*>(indexBufferView.GetBuffer());
+
+            return rhiBuffer->BuildBufferView(indexBufferDescriptor);
+        }
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
+#include <Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        class ShaderStreamBufferViewsBuilder final
+            : public StreamBufferViewsBuilderInterface
+        {
+        public:
+            AZ_RTTI(AZ::Render::ShaderStreamBufferViewsBuilder,
+                "{427005C5-DB26-4DB2-992C-9E080DE9202C}", AZ::Render::StreamBufferViewsBuilderInterface);
+            ShaderStreamBufferViewsBuilder() = delete;
+            ShaderStreamBufferViewsBuilder(const MeshFeatureProcessorInterface::MeshHandle& meshHandle);
+            virtual ~ShaderStreamBufferViewsBuilder() = default;
+
+            
+            ////////////////////////////////////////////////////////////
+            // StreamBufferViewsBuilderInterface overrides Start...
+            bool AddStream(const char* semanticName, AZ::RHI::Format streamFormat, bool isOptional) override;
+            AZ::u8 GetStreamCount() const override;
+            AZStd::unique_ptr<ShaderStreamBufferViewsInterface> BuildShaderStreamBufferViews(
+                uint32_t lodIndex, uint32_t meshIndex) override;
+            const MeshFeatureProcessorInterface::MeshHandle& GetMeshHandle() const override;
+            // StreamBufferViewsBuilderInterface overrides End...
+            ////////////////////////////////////////////////////////////
+
+
+        private:
+            void FinalizeShaderInputContract();
+            AZ::RHI::Ptr<AZ::RHI::BufferView> BuildShaderIndexBufferView(const AZ::RPI::ModelLod::Mesh& modelLodMesh) const;
+
+            static constexpr char LogWindow[] = "ShaderStreamBufferViewsBuilder";
+
+            const AZ::Render::MeshFeatureProcessorInterface::MeshHandle* m_meshHandle = nullptr;
+
+            //! Used to keep track of all calls to @AddStream(...)
+            struct StreamInfo
+            {
+                StreamInfo(const char* semanticName, AZ::RHI::Format streamFormat, bool isOptional)
+                    : m_semanticName(semanticName)
+                    , m_streamFormat(streamFormat)
+                    , m_isOptional(isOptional)
+                {
+                }
+                const char* m_semanticName;
+                AZ::RHI::Format m_streamFormat;
+                bool m_isOptional;
+            };
+            AZStd::vector<StreamInfo> m_streamsList;
+            //! Instantiated the first time BuildShaderStreamBufferViews() is called.
+            AZStd::unique_ptr<AZ::RPI::ShaderInputContract> m_shaderInputContract;
+        };
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
@@ -137,6 +137,8 @@ set(FILES
     Source/Mesh/ModelReloader.h
     Source/Mesh/ModelReloaderSystem.cpp
     Source/Mesh/ModelReloaderSystem.h
+    Source/Mesh/StreamBufferViewsBuilder.cpp
+    Source/Mesh/StreamBufferViewsBuilder.h
     Source/MorphTargets/MorphTargetComputePass.cpp
     Source/MorphTargets/MorphTargetComputePass.h
     Source/MorphTargets/MorphTargetDispatchItem.cpp

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -45,6 +45,7 @@ set(FILES
     Include/Atom/Feature/Mesh/MeshCommon.h
     Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
     Include/Atom/Feature/Mesh/ModelReloaderSystemInterface.h
+    Include/Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h
     Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
     Include/Atom/Feature/OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessorInterface.h
     Include/Atom/Feature/ParamMacros/EndParams.inl

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawItem.h
@@ -92,6 +92,16 @@ namespace AZ::RHI
 
     // A filter associate to a DeviceDrawItem which can be used to filter the DeviceDrawItem when submitting to command list
     using DrawFilterTag = Handle<uint8_t, DefaultNamespaceType>;
+    // This mask is typically used to filter out DrawItems that should or shouldn't be submitted
+    // to a particular RenderPipeline.
+    // A RenderPipeline builds it DrawFilterMask using two bits (Tags):
+    // 1- Tag from its m_nameId
+    // 2- Tag from its m_materialPipelineTagName
+    // On the other hand, a DrawItem has two options:
+    // 1- If it doesn't come from a shader listed under a MaterialPipeline, then all bits are enabled.
+    //    Which means the DrawItem will be valid for all active RenderPipelines.
+    // 2- If it comes from a shader listed under a MaterialPipeline, then only the bit of the given
+    //    MaterialPipelineTag is enabled.
     using DrawFilterMask = uint32_t; // AZStd::bitset's impelmentation is too expensive.
     constexpr uint32_t DrawFilterMaskDefaultValue = uint32_t(-1);  // Default all bit to 1.
     static_assert(sizeof(DrawFilterMask) * 8 >= Limits::Pipeline::DrawFilterTagCountMax, "DrawFilterMask doesn't have enough bits for maximum tag count");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawPacket.h
@@ -98,7 +98,7 @@ namespace AZ::RHI
 
         DrawInstanceArguments m_drawInstanceArgs;
 
-        // The bit-mask of all active filter tags.
+        // The bit-mask of all active DrawListTags.
         DrawListMask m_drawListMask = 0;
 
         uint8_t m_drawItemCount = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DispatchItem.h
@@ -131,6 +131,12 @@ namespace AZ::RHI
             }
         }
 
+        void SetDevicePipelineState(int deviceIndex, const DevicePipelineState* devicePipelineState)
+        {
+            auto& dispatchItem = m_deviceDispatchItems.at(deviceIndex);
+            dispatchItem.m_pipelineState = devicePipelineState;
+        }
+
         //! Array of shader resource groups to bind (count must match m_shaderResourceGroupCount).
         void SetShaderResourceGroups(
             const AZStd::span<const ShaderResourceGroup*> shaderResourceGroups)
@@ -145,6 +151,18 @@ namespace AZ::RHI
             }
         }
 
+        void SetDeviceShaderResourceGroups(int deviceIndex,
+            const DeviceShaderResourceGroup* const* shaderResourceGroups,
+            uint8_t shaderResourceGroupCount)
+        {
+            auto& dispatchItem = m_deviceDispatchItems.at(deviceIndex);
+            dispatchItem.m_shaderResourceGroupCount = shaderResourceGroupCount;
+            for (uint8_t i = 0; i < shaderResourceGroupCount; i++)
+            {
+                dispatchItem.m_shaderResourceGroups[i] = shaderResourceGroups[i];
+            }
+        }
+
         //! Unique SRG, not shared within the draw packet. This is usually a per-draw SRG, populated with the shader variant fallback
         //! key
         void SetUniqueShaderResourceGroup(const ShaderResourceGroup* uniqueShaderResourceGroup)
@@ -153,6 +171,13 @@ namespace AZ::RHI
             {
                 dispatchItem.m_uniqueShaderResourceGroup = uniqueShaderResourceGroup->GetDeviceShaderResourceGroup(deviceIndex).get();
             }
+        }
+
+        void SetUniqueDeviceShaderResourceGroup(int deviceIndex,
+            const DeviceShaderResourceGroup* uniqueShaderResourceGroup)
+        {
+            auto& dispatchItem = m_deviceDispatchItems.at(deviceIndex);
+            dispatchItem.m_uniqueShaderResourceGroup = uniqueShaderResourceGroup;
         }
 
         //! Inline constants data.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
@@ -59,6 +59,14 @@ namespace AZ::RHI
             return m_enabled;
         }
 
+        //! The pipeline state type is the same regardless of the device,
+        //! so we query here the default device.
+        PipelineStateType GetPipelineStateType() const
+        {
+            const auto& deviceDrawItem = GetDeviceDrawItem(MultiDevice::DefaultDeviceIndex);
+            return deviceDrawItem.m_pipelineState->GetType();
+        }
+
         void SetEnabled(bool enabled)
         {
             m_enabled = enabled;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
@@ -49,9 +49,11 @@ namespace AZ::RHI
 
         //! Returns the DeviceDrawItem at the given index
         DrawItem* GetDrawItem(size_t index);
+        const DrawItem* GetDrawItem(size_t index) const;
 
         //! Returns the DeviceDrawItem associated with the given DrawListTag
         DrawItem* GetDrawItem(DrawListTag drawListTag);
+        const DrawItem* GetDrawItem(DrawListTag drawListTag) const;
 
         //! Returns the draw item and its properties associated with the provided index.
         DrawItemProperties GetDrawItemProperties(size_t index) const;

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawPacket.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawPacket.cpp
@@ -37,7 +37,22 @@ namespace AZ::RHI
         return (index < m_drawItems.size()) ? &m_drawItems[index] : nullptr;
     }
 
+    const DrawItem* DrawPacket::GetDrawItem(size_t index) const
+    {
+        return (index < m_drawItems.size()) ? &m_drawItems[index] : nullptr;
+    }
+
     DrawItem* DrawPacket::GetDrawItem(DrawListTag drawListTag)
+    {
+        s32 index = GetDrawListIndex(drawListTag);
+        if (index > -1)
+        {
+            return GetDrawItem(index);
+        }
+        return nullptr;
+    }
+
+    const DrawItem* DrawPacket::GetDrawItem(DrawListTag drawListTag) const
     {
         s32 index = GetDrawListIndex(drawListTag);
         if (index > -1)


### PR DESCRIPTION
## What does this PR do?

Added Compute Shader support in *.MaterialPipeline
and *.MaterialType.

This feature is important for alternative rendering methods
like Texture/Object Space Shading that need to leverage
the O3DE Material pipeline.

The RFC is here: https://github.com/o3de/sig-graphics-audio/pull/167  
Please follow the RFC for details.

## How was this PR tested?

New APIs tested on Quest3 with our private project, and made sure the Engine worked fine with AutomatedTesting and AtomSampleViewer.
