### PR TITLE
added missing includes in srgi files

### DIFF
--- a/Templates/DefaultProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/DefaultProject/Template/ShaderLib/scenesrg.srgi
@@ -16,6 +16,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/

--- a/Templates/DefaultProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/DefaultProject/Template/ShaderLib/viewsrg.srgi
@@ -16,6 +16,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/


### PR DESCRIPTION
## What does this PR do?

Followup to [PR 18498](https://github.com/o3de/o3de/pull/18498): add missing includes in DefaultProject - template

