### PR TITLE
[Dx12] SetDebugParameter instead of (deprecated) SetFeatureMask

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
@@ -84,10 +84,13 @@ namespace AZ
 
         void EnableDebugDeviceFeatures(Microsoft::WRL::ComPtr<ID3D12DeviceX>& dx12Device)
         {
-            Microsoft::WRL::ComPtr<ID3D12DebugDevice> debugDevice;
+            Microsoft::WRL::ComPtr<ID3D12DebugDevice2> debugDevice;
             if (SUCCEEDED(dx12Device->QueryInterface(debugDevice.GetAddressOf())))
             {
-                debugDevice->SetFeatureMask(D3D12_DEBUG_FEATURE_ALLOW_BEHAVIOR_CHANGING_DEBUG_AIDS | D3D12_DEBUG_FEATURE_CONSERVATIVE_RESOURCE_STATE_TRACKING);
+                D3D12_DEBUG_FEATURE featureFlags{ D3D12_DEBUG_FEATURE_ALLOW_BEHAVIOR_CHANGING_DEBUG_AIDS };
+                debugDevice->SetDebugParameter(D3D12_DEBUG_DEVICE_PARAMETER_FEATURE_FLAGS, &featureFlags, sizeof(featureFlags));
+                featureFlags = D3D12_DEBUG_FEATURE_CONSERVATIVE_RESOURCE_STATE_TRACKING;
+                debugDevice->SetDebugParameter(D3D12_DEBUG_DEVICE_PARAMETER_FEATURE_FLAGS, &featureFlags, sizeof(featureFlags));
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

Running an application with `dx12` in `Debug` mode currently prints the following deprecation warning:

```
D3D12 MESSAGE: ID3D12Device::SetFeatureMask: ID3D12DebugDevice::SetFeatureMask has been replaced by ID3D12DebugDevice2::SetDebugParameter [ MISCELLANEOUS MESSAGE #989: DEPRECATED_API]
```

This PR implements the debug parameter setting via the new functionality.

## How was this PR tested?
Run atom-sampleviewer with `dx12` in `Debug` mode.
