### PR TITLE
Green markers should display consistent values when selected (GHI-10816)

### DIFF
--- a/Code/Editor/TrackView/2DBezierKeyUIControls.cpp
+++ b/Code/Editor/TrackView/2DBezierKeyUIControls.cpp
@@ -15,7 +15,7 @@
 #include "Controls/ReflectedPropertyControl/ReflectedPropertyItem.h"
 
 //////////////////////////////////////////////////////////////////////////
-bool C2DBezierKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool C2DBezierKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
+++ b/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
@@ -34,7 +34,7 @@ void CAssetBlendKeyUIControls::ResetStartEndLimits(float assetBlendKeyDuration)
     mv_blendOutTime.GetVar()->SetLimits(time_zero, assetBlendKeyDuration, step, true, true);
 }
 
-bool CAssetBlendKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CAssetBlendKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/CaptureKeyUIControls.cpp
+++ b/Code/Editor/TrackView/CaptureKeyUIControls.cpp
@@ -17,7 +17,7 @@
 #include "TrackViewKeyPropertiesDlg.h"
 
 //////////////////////////////////////////////////////////////////////////
-bool CCaptureKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CCaptureKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/CommentKeyUIControls.cpp
+++ b/Code/Editor/TrackView/CommentKeyUIControls.cpp
@@ -17,7 +17,7 @@
 #include "TrackViewKeyPropertiesDlg.h"
 
 //////////////////////////////////////////////////////////////////////////
-bool CCommentKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CCommentKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/ConsoleKeyUIControls.cpp
+++ b/Code/Editor/TrackView/ConsoleKeyUIControls.cpp
@@ -17,7 +17,7 @@
 #include "TrackViewKeyPropertiesDlg.h"  // for CTrackViewKeyUIControls
 
 //////////////////////////////////////////////////////////////////////////
-bool CConsoleKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CConsoleKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/EventKeyUIControls.cpp
+++ b/Code/Editor/TrackView/EventKeyUIControls.cpp
@@ -15,7 +15,7 @@
 #include <CryCommon/Maestro/Types/AnimParamType.h>  // AnimParamType
 
 //////////////////////////////////////////////////////////////////////////
-bool CEventKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CEventKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/GotoKeyUIControls.cpp
+++ b/Code/Editor/TrackView/GotoKeyUIControls.cpp
@@ -17,7 +17,7 @@
 #include "TrackViewKeyPropertiesDlg.h"
 
 //////////////////////////////////////////////////////////////////////////
-bool CGotoKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CGotoKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/KeyUIControls.h
+++ b/Code/Editor/TrackView/KeyUIControls.h
@@ -36,7 +36,7 @@ public:
     {
         return trackType == eAnimCurveType_BezierFloat;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 0; }
@@ -98,7 +98,7 @@ public:
         return valueType == AnimValueType::AssetBlend;
     }
 
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -145,7 +145,7 @@ public:
     {
         return paramType == AnimParamType::Capture;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -207,7 +207,7 @@ public:
     {
         return paramType == AnimParamType::CommentText;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -240,7 +240,7 @@ public:
     {
         return paramType == AnimParamType::Console;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -282,7 +282,7 @@ public:
     {
         return paramType == AnimParamType::Event;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -324,7 +324,7 @@ public:
             return false;
         }
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -390,7 +390,7 @@ public:
 
     //-----------------------------------------------------------------------------
     //!
-    bool OnKeySelectionChange(CTrackViewKeyBundle& keys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& keys) override;
 
     //-----------------------------------------------------------------------------
     //!
@@ -437,7 +437,7 @@ public:
     {
         return valueType == AnimValueType::Select;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -490,7 +490,7 @@ public:
     {
         return paramType == AnimParamType::Sequence;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -535,7 +535,7 @@ public:
     {
         return paramType == AnimParamType::Sound;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -575,7 +575,7 @@ public:
     {
         return paramType == AnimParamType::TimeRanges;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }
@@ -610,7 +610,7 @@ public:
     {
         return paramType == AnimParamType::TrackEvent;
     }
-    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
     void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
     unsigned int GetPriority() const override { return 1; }

--- a/Code/Editor/TrackView/ScreenFaderKeyUIControls.cpp
+++ b/Code/Editor/TrackView/ScreenFaderKeyUIControls.cpp
@@ -18,7 +18,7 @@
 #include "TrackViewKeyPropertiesDlg.h"
 
 //-----------------------------------------------------------------------------
-bool CScreenFaderKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& keys)
+bool CScreenFaderKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& keys)
 {
     if (!keys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/SelectKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SelectKeyUIControls.cpp
@@ -23,7 +23,7 @@ CSelectKeyUIControls::~CSelectKeyUIControls()
 }
 
 //////////////////////////////////////////////////////////////////////////
-bool CSelectKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CSelectKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/SequenceKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SequenceKeyUIControls.cpp
@@ -17,7 +17,7 @@
 #include "TrackViewDialog.h"
 
 //////////////////////////////////////////////////////////////////////////
-bool CSequenceKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CSequenceKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/SoundKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SoundKeyUIControls.cpp
@@ -17,7 +17,7 @@
 #include "TrackViewKeyPropertiesDlg.h"  // for CTrackViewKeyUIControls
 
 //////////////////////////////////////////////////////////////////////////
-bool CSoundKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CSoundKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/TimeRangeKeyUIControls.cpp
+++ b/Code/Editor/TrackView/TimeRangeKeyUIControls.cpp
@@ -17,7 +17,7 @@
 #include "TrackViewKeyPropertiesDlg.h"              // for CTrackViewKeyUIControls// Editor
 
 //////////////////////////////////////////////////////////////////////////
-bool CTimeRangeKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CTimeRangeKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/TrackEventKeyUIControls.cpp
+++ b/Code/Editor/TrackView/TrackEventKeyUIControls.cpp
@@ -18,7 +18,7 @@
 #include "TVEventsDialog.h"
 
 //////////////////////////////////////////////////////////////////////////
-bool CTrackEventKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys)
+bool CTrackEventKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
     if (!selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -733,7 +733,7 @@ bool CTrackViewAnimNode::GetExpanded() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewAnimNode::GetSelectedKeys()
+CTrackViewKeyBundle CTrackViewAnimNode::GetSelectedKeys() const
 {
     CTrackViewKeyBundle bundle;
 
@@ -746,7 +746,7 @@ CTrackViewKeyBundle CTrackViewAnimNode::GetSelectedKeys()
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewAnimNode::GetAllKeys()
+CTrackViewKeyBundle CTrackViewAnimNode::GetAllKeys() const
 {
     CTrackViewKeyBundle bundle;
 
@@ -759,7 +759,7 @@ CTrackViewKeyBundle CTrackViewAnimNode::GetAllKeys()
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewAnimNode::GetKeysInTimeRange(const float t0, const float t1)
+CTrackViewKeyBundle CTrackViewAnimNode::GetKeysInTimeRange(const float t0, const float t1) const
 {
     CTrackViewKeyBundle bundle;
 

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -733,7 +733,7 @@ bool CTrackViewAnimNode::GetExpanded() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewAnimNode::GetSelectedKeys() const
+CTrackViewKeyBundle CTrackViewAnimNode::GetSelectedKeys()
 {
     CTrackViewKeyBundle bundle;
 
@@ -746,7 +746,7 @@ CTrackViewKeyBundle CTrackViewAnimNode::GetSelectedKeys() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewAnimNode::GetAllKeys() const
+CTrackViewKeyBundle CTrackViewAnimNode::GetAllKeys()
 {
     CTrackViewKeyBundle bundle;
 
@@ -759,7 +759,7 @@ CTrackViewKeyBundle CTrackViewAnimNode::GetAllKeys() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewAnimNode::GetKeysInTimeRange(const float t0, const float t1) const
+CTrackViewKeyBundle CTrackViewAnimNode::GetKeysInTimeRange(const float t0, const float t1)
 {
     CTrackViewKeyBundle bundle;
 

--- a/Code/Editor/TrackView/TrackViewAnimNode.h
+++ b/Code/Editor/TrackView/TrackViewAnimNode.h
@@ -151,9 +151,9 @@ public:
     virtual CTrackViewTrackBundle GetTracksByParam(const CAnimParamType& paramType) const;
 
     // Key getters
-    virtual CTrackViewKeyBundle GetAllKeys() override;
-    virtual CTrackViewKeyBundle GetSelectedKeys() override;
-    virtual CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) override;
+    CTrackViewKeyBundle GetAllKeys() const override;
+    CTrackViewKeyBundle GetSelectedKeys() const override;
+    CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) const override;
 
     // Type getters
     AnimNodeType GetType() const;

--- a/Code/Editor/TrackView/TrackViewAnimNode.h
+++ b/Code/Editor/TrackView/TrackViewAnimNode.h
@@ -151,9 +151,9 @@ public:
     virtual CTrackViewTrackBundle GetTracksByParam(const CAnimParamType& paramType) const;
 
     // Key getters
-    CTrackViewKeyBundle GetAllKeys() const override;
-    CTrackViewKeyBundle GetSelectedKeys() const override;
-    CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) const override;
+    CTrackViewKeyBundle GetAllKeys() override;
+    CTrackViewKeyBundle GetSelectedKeys() override;
+    CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) override;
 
     // Type getters
     AnimNodeType GetType() const;

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.h
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.h
@@ -58,7 +58,7 @@ public:
 
     // Called when user changes selected keys.
     // Return true if control update UI values
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& keys) = 0;
+    virtual bool OnKeySelectionChange(const CTrackViewKeyBundle& keys) = 0;
 
     // Called when UI variable changes.
     virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& keys) = 0;
@@ -127,8 +127,7 @@ public:
     ~CTrackViewTrackPropsDlg();
 
     void OnSequenceChanged();
-    bool OnKeySelectionChange(CTrackViewKeyBundle& keys);
-    void ReloadKey();
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& keys);
 
 protected slots:
     void OnUpdateTime();
@@ -163,8 +162,8 @@ public:
     void PopulateVariables(ReflectedPropertyControl* propCtrl);
 
     // ITrackViewSequenceListener
-    virtual void OnKeysChanged(CTrackViewSequence* pSequence) override;
-    virtual void OnKeySelectionChanged(CTrackViewSequence* pSequence) override;
+    void OnKeysChanged(CTrackViewSequence* pSequence) override;
+    void OnKeySelectionChanged(CTrackViewSequence* pSequence) override;
 
 protected:
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/TrackViewNode.cpp
+++ b/Code/Editor/TrackView/TrackViewNode.cpp
@@ -17,7 +17,6 @@
 // AzCore
 #include <AzCore/std/sort.h>
 
-
 // Editor
 #include "TrackView/TrackViewTrack.h"
 #include "TrackView/TrackViewSequence.h"

--- a/Code/Editor/TrackView/TrackViewNode.cpp
+++ b/Code/Editor/TrackView/TrackViewNode.cpp
@@ -14,6 +14,10 @@
 // CryCommon
 #include <CryCommon/Maestro/Types/AnimNodeType.h>
 
+// AzCore
+#include <AzCore/std/sort.h>
+
+
 // Editor
 #include "TrackView/TrackViewTrack.h"
 #include "TrackView/TrackViewSequence.h"
@@ -555,7 +559,7 @@ void CTrackViewNode::AddNode(CTrackViewNode* pNode)
 void CTrackViewNode::SortNodes()
 {
     // Sort with operator<
-    std::stable_sort(m_childNodes.begin(), m_childNodes.end(),
+    AZStd::stable_sort(m_childNodes.begin(), m_childNodes.end(),
         [&](const std::unique_ptr<CTrackViewNode>& a, const std::unique_ptr<CTrackViewNode>& b) -> bool
         {
             const CTrackViewNode* pA = a.get();

--- a/Code/Editor/TrackView/TrackViewNode.h
+++ b/Code/Editor/TrackView/TrackViewNode.h
@@ -189,9 +189,9 @@ public:
     bool IsHidden() const;
 
     // Key getters
-    virtual CTrackViewKeyBundle GetSelectedKeys() const = 0;
-    virtual CTrackViewKeyBundle GetAllKeys() const = 0;
-    virtual CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) const = 0;
+    virtual CTrackViewKeyBundle GetSelectedKeys() = 0;
+    virtual CTrackViewKeyBundle GetAllKeys() = 0;
+    virtual CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) = 0;
 
     // Check if node itself is obsolete, or any child is an obsolete track
     bool HasObsoleteTrack() const;

--- a/Code/Editor/TrackView/TrackViewNode.h
+++ b/Code/Editor/TrackView/TrackViewNode.h
@@ -111,7 +111,7 @@ public:
     bool AreAllKeysOfSameType() const { return m_bAllOfSameType; }
 
     unsigned int GetKeyCount() const { return static_cast<unsigned int>(m_keys.size()); }
-    CTrackViewKeyHandle GetKey(unsigned int index) { return m_keys[index]; }
+    CTrackViewKeyHandle GetKey(unsigned int index) const { return m_keys[index]; }
 
     void SelectKeys(const bool bSelected);
 
@@ -189,9 +189,9 @@ public:
     bool IsHidden() const;
 
     // Key getters
-    virtual CTrackViewKeyBundle GetSelectedKeys() = 0;
-    virtual CTrackViewKeyBundle GetAllKeys() = 0;
-    virtual CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) = 0;
+    virtual CTrackViewKeyBundle GetSelectedKeys() const = 0;
+    virtual CTrackViewKeyBundle GetAllKeys() const = 0;
+    virtual CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) const = 0;
 
     // Check if node itself is obsolete, or any child is an obsolete track
     bool HasObsoleteTrack() const;

--- a/Code/Editor/TrackView/TrackViewSequence.cpp
+++ b/Code/Editor/TrackView/TrackViewSequence.cpp
@@ -604,14 +604,14 @@ void CTrackViewSequence::DequeueNotifications()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CTrackViewSequence::SubmitPendingNotifcations(bool force)
+void CTrackViewSequence::SubmitPendingNotifications(bool force)
 {
     if (force)
     {
         m_selectionRecursionLevel = 1;
     }
 
-    AZ_Assert(m_selectionRecursionLevel > 0, "Dangling SubmitPendingNotifcations()");
+    AZ_Assert(m_selectionRecursionLevel > 0, "Dangling SubmitPendingNotifications()");
     if (m_selectionRecursionLevel > 0)
     {
         --m_selectionRecursionLevel;
@@ -656,7 +656,7 @@ void CTrackViewSequence::OnSequenceRemoved(CTrackViewSequence* removedSequence)
         // submit any queued notifications before removing
         if (m_bQueueNotifications)
         {
-            SubmitPendingNotifcations(true);
+            SubmitPendingNotifications(true);
         }
 
         // remove ourselves as listeners from the undo manager
@@ -1443,7 +1443,7 @@ void CTrackViewSequence::EndUndoTransaction()
     // if we're queued
     if (m_bQueueNotifications)
     {
-        SubmitPendingNotifcations();
+        SubmitPendingNotifications();
     }
 }
 
@@ -1461,7 +1461,7 @@ void CTrackViewSequence::EndRestoreTransaction()
     // if we're queued
     if (m_bQueueNotifications)
     {
-        SubmitPendingNotifcations();
+        SubmitPendingNotifications();
     }
 }
 

--- a/Code/Editor/TrackView/TrackViewSequence.h
+++ b/Code/Editor/TrackView/TrackViewSequence.h
@@ -293,7 +293,7 @@ private:
     void QueueNotifications();
     // Used to cancel a previously queued notification.
     void DequeueNotifications();
-    void SubmitPendingNotifcations(bool force = false);
+    void SubmitPendingNotifications(bool force = false);
 
     /////////////////////////////////////////////////////////////////////////
     // overrides for ITrackViewSequenceManagerListener
@@ -356,7 +356,7 @@ public:
     {
         if (m_pSequence)
         {
-            m_pSequence->SubmitPendingNotifcations();
+            m_pSequence->SubmitPendingNotifications();
         }
     }
 

--- a/Code/Editor/TrackView/TrackViewSequenceManager.cpp
+++ b/Code/Editor/TrackView/TrackViewSequenceManager.cpp
@@ -22,6 +22,7 @@
 // AzCore
 #include <AzCore/std/sort.h>
 
+
 // Editor
 #include "AnimationContext.h"
 #include "GameEngine.h"

--- a/Code/Editor/TrackView/TrackViewSequenceManager.cpp
+++ b/Code/Editor/TrackView/TrackViewSequenceManager.cpp
@@ -19,6 +19,9 @@
 #include <CryCommon/Maestro/Bus/EditorSequenceComponentBus.h>
 #include <CryCommon/Maestro/Types/SequenceType.h>
 
+// AzCore
+#include <AzCore/std/sort.h>
+
 // Editor
 #include "AnimationContext.h"
 #include "GameEngine.h"
@@ -380,7 +383,7 @@ void CTrackViewSequenceManager::OnDeleteSequenceEntity(const AZ::EntityId& entit
 ////////////////////////////////////////////////////////////////////////////
 void CTrackViewSequenceManager::SortSequences()
 {
-    std::stable_sort(m_sequences.begin(), m_sequences.end(),
+    AZStd::stable_sort(m_sequences.begin(), m_sequences.end(),
         [](const std::unique_ptr<CTrackViewSequence>& a, const std::unique_ptr<CTrackViewSequence>& b) -> bool
         {
             QString aName = QString::fromUtf8(a.get()->GetName().c_str());

--- a/Code/Editor/TrackView/TrackViewTrack.cpp
+++ b/Code/Editor/TrackView/TrackViewTrack.cpp
@@ -198,7 +198,7 @@ CTrackViewKeyHandle CTrackViewTrack::GetNextKey(const float time)
 
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetSelectedKeys()
+CTrackViewKeyBundle CTrackViewTrack::GetSelectedKeys() const
 {
     CTrackViewKeyBundle bundle;
 
@@ -218,7 +218,7 @@ CTrackViewKeyBundle CTrackViewTrack::GetSelectedKeys()
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetAllKeys()
+CTrackViewKeyBundle CTrackViewTrack::GetAllKeys() const
 {
     CTrackViewKeyBundle bundle;
 
@@ -238,7 +238,7 @@ CTrackViewKeyBundle CTrackViewTrack::GetAllKeys()
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetKeysInTimeRange(const float t0, const float t1)
+CTrackViewKeyBundle CTrackViewTrack::GetKeysInTimeRange(const float t0, const float t1) const
 {
     CTrackViewKeyBundle bundle;
 
@@ -258,7 +258,7 @@ CTrackViewKeyBundle CTrackViewTrack::GetKeysInTimeRange(const float t0, const fl
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetKeys(const bool bOnlySelected, const float t0, const float t1)
+CTrackViewKeyBundle CTrackViewTrack::GetKeys(const bool bOnlySelected, const float t0, const float t1) const
 {
     CTrackViewKeyBundle bundle;
 
@@ -268,9 +268,9 @@ CTrackViewKeyBundle CTrackViewTrack::GetKeys(const bool bOnlySelected, const flo
         const float keyTime = m_pAnimTrack->GetKeyTime(keyIndex);
         const bool timeRangeOk = (t0 <= keyTime && keyTime <= t1);
 
-        if ((!bOnlySelected || IsKeySelected(keyIndex)) && timeRangeOk)
+        if (timeRangeOk && (!bOnlySelected || IsKeySelected(keyIndex)))
         {
-            CTrackViewKeyHandle keyHandle(this, keyIndex);
+            CTrackViewKeyHandle keyHandle(const_cast<CTrackViewTrack*>(this), keyIndex);
             bundle.AppendKey(keyHandle);
         }
     }
@@ -612,7 +612,7 @@ void CTrackViewTrack::SelectKeys(const bool bSelected)
         }
     }
 
-    m_pTrackAnimNode->GetSequence()->SubmitPendingNotifcations();
+    m_pTrackAnimNode->GetSequence()->SubmitPendingNotifications();
 }
 
 

--- a/Code/Editor/TrackView/TrackViewTrack.cpp
+++ b/Code/Editor/TrackView/TrackViewTrack.cpp
@@ -198,7 +198,7 @@ CTrackViewKeyHandle CTrackViewTrack::GetNextKey(const float time)
 
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetSelectedKeys() const
+CTrackViewKeyBundle CTrackViewTrack::GetSelectedKeys()
 {
     CTrackViewKeyBundle bundle;
 
@@ -218,7 +218,7 @@ CTrackViewKeyBundle CTrackViewTrack::GetSelectedKeys() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetAllKeys() const
+CTrackViewKeyBundle CTrackViewTrack::GetAllKeys()
 {
     CTrackViewKeyBundle bundle;
 
@@ -238,7 +238,7 @@ CTrackViewKeyBundle CTrackViewTrack::GetAllKeys() const
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetKeysInTimeRange(const float t0, const float t1) const
+CTrackViewKeyBundle CTrackViewTrack::GetKeysInTimeRange(const float t0, const float t1)
 {
     CTrackViewKeyBundle bundle;
 
@@ -258,7 +258,7 @@ CTrackViewKeyBundle CTrackViewTrack::GetKeysInTimeRange(const float t0, const fl
 }
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewKeyBundle CTrackViewTrack::GetKeys(const bool bOnlySelected, const float t0, const float t1) const
+CTrackViewKeyBundle CTrackViewTrack::GetKeys(const bool bOnlySelected, const float t0, const float t1)
 {
     CTrackViewKeyBundle bundle;
 
@@ -270,7 +270,7 @@ CTrackViewKeyBundle CTrackViewTrack::GetKeys(const bool bOnlySelected, const flo
 
         if (timeRangeOk && (!bOnlySelected || IsKeySelected(keyIndex)))
         {
-            CTrackViewKeyHandle keyHandle(const_cast<CTrackViewTrack*>(this), keyIndex);
+            CTrackViewKeyHandle keyHandle(this, keyIndex);
             bundle.AppendKey(keyHandle);
         }
     }

--- a/Code/Editor/TrackView/TrackViewTrack.h
+++ b/Code/Editor/TrackView/TrackViewTrack.h
@@ -107,9 +107,9 @@ public:
     virtual CTrackViewKeyHandle GetKeyByTime(const float time);
     virtual CTrackViewKeyHandle GetNearestKeyByTime(const float time);
 
-    CTrackViewKeyBundle GetSelectedKeys() const override;
-    CTrackViewKeyBundle GetAllKeys() const override;
-    CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) const override;
+    CTrackViewKeyBundle GetSelectedKeys() override;
+    CTrackViewKeyBundle GetAllKeys() override;
+    CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) override;
 
     // Key modifications
     virtual CTrackViewKeyHandle CreateKey(const float time);
@@ -215,7 +215,7 @@ private:
     void RemoveKey(const int index);
     int CloneKey(const int index);
 
-    CTrackViewKeyBundle GetKeys(bool bOnlySelected, float t0, float t1) const;
+    CTrackViewKeyBundle GetKeys(bool bOnlySelected, float t0, float t1);
     CTrackViewKeyHandle GetSubTrackKeyHandle(unsigned int index) const;
 
     // Copy selected keys to XML representation for clipboard

--- a/Code/Editor/TrackView/TrackViewTrack.h
+++ b/Code/Editor/TrackView/TrackViewTrack.h
@@ -107,9 +107,9 @@ public:
     virtual CTrackViewKeyHandle GetKeyByTime(const float time);
     virtual CTrackViewKeyHandle GetNearestKeyByTime(const float time);
 
-    virtual CTrackViewKeyBundle GetSelectedKeys() override;
-    virtual CTrackViewKeyBundle GetAllKeys() override;
-    virtual CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) override;
+    CTrackViewKeyBundle GetSelectedKeys() const override;
+    CTrackViewKeyBundle GetAllKeys() const override;
+    CTrackViewKeyBundle GetKeysInTimeRange(const float t0, const float t1) const override;
 
     // Key modifications
     virtual CTrackViewKeyHandle CreateKey(const float time);
@@ -215,11 +215,11 @@ private:
     void RemoveKey(const int index);
     int CloneKey(const int index);
 
-    CTrackViewKeyBundle GetKeys(bool bOnlySelected, float t0, float t1);
+    CTrackViewKeyBundle GetKeys(bool bOnlySelected, float t0, float t1) const;
     CTrackViewKeyHandle GetSubTrackKeyHandle(unsigned int index) const;
 
     // Copy selected keys to XML representation for clipboard
-    virtual void CopyKeysToClipboard(XmlNodeRef& xmlNode, const bool bOnlySelectedKeys, const bool bOnlyFromSelectedTracks) override;
+    void CopyKeysToClipboard(XmlNodeRef& xmlNode, const bool bOnlySelectedKeys, const bool bOnlyFromSelectedTracks) override;
 
     bool m_bIsCompoundTrack;
     bool m_bIsSubTrack;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -577,12 +577,12 @@ namespace AzToolsFramework
                         }
                         else
                         {
-                            m_defaultLabel->setText(QString("%1 elements").arg(m_containerSize));
+                            m_defaultLabel->setText(QString("%1 element%2").arg(m_containerSize).arg(m_containerSize > 1 ? "s" : ""));
                         }
                     }
                     else
                     {
-                        m_defaultLabel->setText(QString("%1 elements").arg(m_containerSize));
+                        m_defaultLabel->setText(QString("%1 element%2").arg(m_containerSize).arg(m_containerSize > 1 ? "s" : ""));
                     }
                 }
                 else


### PR DESCRIPTION
## What does this PR do?

As reported in https://github.com/o3de/o3de/issues/10816, the key's green marker values used to display incorrectly on selection.

This PR fixes the issue, as well as does some code refactoring.
In more details
1) green marker issue was caused by missed data propagation to the editor UI on the marker selection. The issue is fixed in the method `CTrackViewKeyPropertiesDlg::OnKeySelectionChanged`
2) unreported visual glitch was noticed. The data label for a single entry was displayed as "1 elements". Fixed.

Video shows the current behavior:

https://github.com/user-attachments/assets/320e807f-2951-4d34-8978-0ae839e333b9

3) Partial code refactoring/improving of the TrackView sources. _It's an outgoing effort._
a) Typo in the name of `CTrackViewSequence::SubmitPendingNotifcations` fixed.
b) `std::stable_sort` replaced by its engine equivalent `AzStd::stable_sort`.
c) Used range-based `for` loop in a few convenient occurrences.
d) Modified several methods to use `const` ref arguments.
e) Changed some `Get...` methods to be `const`
f) Got rid of several cases of copying the array of selected keys. Now use the const refs.
g) Removed extra `virtual` specifier in several overriding methods

## How was this PR tested?

Tested locally, Windows 10. VC 17.12.2.

