### PR TITLE
Fixed the crash on hovering over the Stop With Hard Reset option in Track View (GHI-4113)

### DIFF
--- a/Code/Editor/Resource.h
+++ b/Code/Editor/Resource.h
@@ -173,6 +173,7 @@
 #define ID_SWITCHCAMERA_SEQUENCECAMERA             33701
 #define ID_SWITCHCAMERA_SELECTEDCAMERA             33702
 #define ID_TV_RECORD_AUTO                          33703
+#define ID_TV_STOP_HARD_RESET                      33704
 #define ID_VIEW_OPENVIEWPANE                       33709
 #define ID_VIEW_OPENPANE_FIRST          33712
 #define ID_VIEW_OPENPANE_LAST           33811

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -451,6 +451,7 @@ void CTrackViewDialog::InitToolbar()
     {
         QMenu* buttonMenu = new QMenu(this);
         toolButton->setMenu(buttonMenu);
+
         buttonMenu->addAction(qaction);
         qaction = buttonMenu->addAction("Stop with Hard Reset");
         qaction->setData(ID_TV_STOP_HARD_RESET);

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -451,11 +451,10 @@ void CTrackViewDialog::InitToolbar()
     {
         QMenu* buttonMenu = new QMenu(this);
         toolButton->setMenu(buttonMenu);
-        qaction = buttonMenu->addAction("Stop");
-        connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnStop);
-        toolButton->addAction(qaction);
+        buttonMenu->addAction(qaction);
         qaction = buttonMenu->addAction("Stop with Hard Reset");
-        qaction->setData(true);
+        qaction->setData(ID_TV_STOP_HARD_RESET);
+        m_actions[ID_TV_STOP_HARD_RESET] = qaction;
         connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnStopHardReset);
     }
     m_playToolBar->addWidget(toolButton);


### PR DESCRIPTION
## What does this PR do?

As reported in https://github.com/o3de/o3de/issues/4113, hovering over the Stop With Hard Reset option in Track View crashes the Editor.

The cause of the crash in `EntityPropertyEditor::HandleMenuEvent` was incorrect setting of action data in `CTrackViewDialog::InitToolbar`. Namely, 

`qaction->setData(true);`

for the Stop with Hard Reset action resulted in an unexpected side-effect in `EntityPropertyEditor::HandleMenuEvent`. Comparison 

`if (action->data() == kPropertyEditorMenuActionMoveUp)`

is true when the `QVariant` holds boolean `true` as returned by `action->data()`.

The fix is to set up the action data with a unique value as done for other menu actions.

The current behavior is recorded:

https://github.com/user-attachments/assets/1a421a6c-f050-431f-b98b-049eaa83ee76

## How was this PR tested?

Tested locally, Windows 10.
