### PR TITLE
DX12: Fix binding of bindless resources

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -209,6 +209,7 @@ namespace AZ
                 AZStd::array<const ShaderResourceGroup*, RHI::Limits::Pipeline::ShaderResourceGroupCountMax> m_srgsByIndex;
                 AZStd::array<const ShaderResourceGroup*, RHI::Limits::Pipeline::ShaderResourceGroupCountMax> m_srgsBySlot;
                 bool m_hasRootConstants = false;
+                int m_bindlessHeapLastIndex = -1;
             };
 
             ShaderResourceBindings& GetShaderResourceBindingsByPipelineType(RHI::PipelineStateType pipelineType);
@@ -242,9 +243,6 @@ namespace AZ
 
                 // A queue of tile mappings to execute on the command queue at submission time (prior to executing the command list).
                 TileMapRequestList m_tileMapRequests;
-
-                // Signal that the global bindless heap is bound to the index
-                int m_bindlessHeapLastIndex = -1;
 
                 // The currently bound shading rate image
                 const ImageView* m_shadingRateImage = nullptr;
@@ -338,6 +336,7 @@ namespace AZ
                     {
                         bindings.m_srgsByIndex[i] = nullptr;
                     }
+                    bindings.m_bindlessHeapLastIndex = -1;
                 }
 
                 m_state.m_pipelineState = pipelineState;
@@ -387,7 +386,7 @@ namespace AZ
                 if (srgSlot == device.GetBindlessSrgSlot() && shaderResourceGroup == nullptr)
                 {
                     // Skip in case the global static heap is already bound
-                    if (m_state.m_bindlessHeapLastIndex == binding.m_bindlessTable.GetIndex())
+                    if (bindings.m_bindlessHeapLastIndex == binding.m_bindlessTable.GetIndex())
                     {
                         continue;
                     }
@@ -411,7 +410,7 @@ namespace AZ
                         AZ_Assert(false, "Invalid PipelineType");
                         break;
                     }
-                    m_state.m_bindlessHeapLastIndex = binding.m_bindlessTable.GetIndex();
+                    bindings.m_bindlessHeapLastIndex = binding.m_bindlessTable.GetIndex();
                     continue;
                 }
                 


### PR DESCRIPTION
## What does this PR do?

This fixes the problem described in https://github.com/o3de/o3de/pull/16850

The remembered bindless index is reset when the pipeline layout changes.
The srg indices should only change when the pipeline layout changes, if I understand this correctly. So as long as the pipeline layout stays the same the bindless srg cannot be overwritten by another srg.

## How was this PR tested?

Windows and DX12. Tested the MainPipeline and a Pipeline where problems with bindless occur
