### PR TITLE
Updated the input validation in CTVNewSequenceDialog (GHI-3941)

### DIFF
--- a/Code/Editor/TrackViewNewSequenceDialog.cpp
+++ b/Code/Editor/TrackViewNewSequenceDialog.cpp
@@ -82,7 +82,6 @@ class CTVNewSequenceDialogValidator : public QValidator
                         break;
                     }
                 }
-
                 if (!isNewName)
                 {
                     SetToolTip("Sequence with this name already exists");

--- a/Code/Editor/TrackViewNewSequenceDialog.cpp
+++ b/Code/Editor/TrackViewNewSequenceDialog.cpp
@@ -82,6 +82,7 @@ class CTVNewSequenceDialogValidator : public QValidator
                         break;
                     }
                 }
+
                 if (!isNewName)
                 {
                     SetToolTip("Sequence with this name already exists");

--- a/Code/Editor/TrackViewNewSequenceDialog.cpp
+++ b/Code/Editor/TrackViewNewSequenceDialog.cpp
@@ -135,7 +135,6 @@ CTVNewSequenceDialog::CTVNewSequenceDialog(QWidget* parent)
 
 CTVNewSequenceDialog::~CTVNewSequenceDialog()
 {
-    delete m_validator;
 }
 
 void CTVNewSequenceDialog::OnInitDialog()

--- a/Code/Editor/TrackViewNewSequenceDialog.cpp
+++ b/Code/Editor/TrackViewNewSequenceDialog.cpp
@@ -12,7 +12,8 @@
 #include "TrackViewNewSequenceDialog.h"
 
 // Qt
-#include <QMessageBox>
+#include <QValidator>
+#include <QPushButton>
 
 // CryCommon
 #include <CryCommon/Maestro/Types/SequenceType.h>
@@ -34,15 +35,98 @@ namespace
     };
 }
 
+class CTVNewSequenceDialogValidator : public QValidator
+{
+    public:
+        CTVNewSequenceDialogValidator(QObject* parent)
+            : QValidator(parent)
+        {
+            m_parentDialog = qobject_cast<CTVNewSequenceDialog*>(parent);
+        }
+
+        QValidator::State validate(QString& input, [[maybe_unused]] int& pos) const override
+        {
+            constexpr int MaxInputLength = 160;
+
+            if (input.isEmpty())
+            {
+                SetEnabled(false);
+                return QValidator::Acceptable;
+            }
+
+            bool isValid = false;
+            SetEnabled(true);
+            if (input.contains('/'))
+            {
+                SetToolTip("A sequence name cannot contain a '/' character");
+            }
+            if (input.length() > MaxInputLength)
+            {
+                SetToolTip(QString("A sequence name cannot exceed %1 characters").arg(MaxInputLength).toStdString().c_str());
+            }
+            else if (input == LIGHT_ANIMATION_SET_NAME)
+            {
+                SetToolTip("The sequence name " LIGHT_ANIMATION_SET_NAME " is reserved.\nPlease choose a different name");
+            }
+            else
+            {
+                bool isNewName = true;
+                for (unsigned int k = 0; k < GetIEditor()->GetSequenceManager()->GetCount(); ++k)
+                {
+                    CTrackViewSequence* pSequence = GetIEditor()->GetSequenceManager()->GetSequenceByIndex(k);
+                    const QString fullname = QString::fromUtf8(pSequence->GetName().c_str());
+
+                    if (fullname.compare(input, Qt::CaseInsensitive) == 0)
+                    {
+                        isNewName = false;
+                        break;
+                    }
+                }
+                if (!isNewName)
+                {
+                    SetToolTip("Sequence with this name already exists");
+                }
+                else
+                {
+                    isValid = true;
+                }
+            }
+
+            if (isValid)
+            {
+                SetToolTip("");
+                return QValidator::Acceptable;
+            }
+
+            return QValidator::Invalid;
+        }
+
+    private:
+
+        void SetEnabled(bool enable) const
+        {
+            m_parentDialog->ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enable);
+        }
+
+        void SetToolTip(const char* toolTipText) const
+        {
+            m_parentDialog->ui->NAME->setToolTip(toolTipText);
+        }
+
+        const CTVNewSequenceDialog* m_parentDialog;
+};
+
 // TrackViewNewSequenceDialog dialog
 CTVNewSequenceDialog::CTVNewSequenceDialog(QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::CTVNewSequenceDialog)
     , m_inputFocusSet(false)
+    , m_validator(new CTVNewSequenceDialogValidator(this))
 {
     ui->setupUi(this);
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &CTVNewSequenceDialog::OnOK);
     connect(ui->NAME, &QLineEdit::returnPressed, this, &CTVNewSequenceDialog::OnOK);
+    ui->NAME->setValidator(m_validator);
     setWindowTitle("Add New Sequence");
 
     OnInitDialog();
@@ -50,6 +134,7 @@ CTVNewSequenceDialog::CTVNewSequenceDialog(QWidget* parent)
 
 CTVNewSequenceDialog::~CTVNewSequenceDialog()
 {
+    delete m_validator;
 }
 
 void CTVNewSequenceDialog::OnInitDialog()
@@ -59,36 +144,7 @@ void CTVNewSequenceDialog::OnInitDialog()
 void CTVNewSequenceDialog::OnOK()
 {
     m_sequenceType = SequenceType::SequenceComponent;
-
     m_sequenceName = ui->NAME->text();
-
-    if (m_sequenceName.isEmpty())
-    {
-        QMessageBox::warning(this, "New Sequence", "A sequence name cannot be empty!");
-        return;
-    }
-    else if (m_sequenceName.contains('/'))
-    {
-        QMessageBox::warning(this, "New Sequence", "A sequence name cannot contain a '/' character!");
-        return;
-    }
-    else if (m_sequenceName == LIGHT_ANIMATION_SET_NAME)
-    {
-        QMessageBox::warning(this, "New Sequence", QString("The sequence name '%1' is reserved.\n\nPlease choose a different name.").arg(LIGHT_ANIMATION_SET_NAME));
-        return;
-    }
-
-    for (unsigned int k = 0; k < GetIEditor()->GetSequenceManager()->GetCount(); ++k)
-    {
-        CTrackViewSequence* pSequence = GetIEditor()->GetSequenceManager()->GetSequenceByIndex(k);
-        QString fullname = QString::fromUtf8(pSequence->GetName().c_str());
-
-        if (fullname.compare(m_sequenceName, Qt::CaseInsensitive) == 0)
-        {
-            QMessageBox::warning(this, "New Sequence", "Sequence with this name already exists!");
-            return;
-        }
-    }
 
     accept();
 }

--- a/Code/Editor/TrackViewNewSequenceDialog.h
+++ b/Code/Editor/TrackViewNewSequenceDialog.h
@@ -6,20 +6,23 @@
  *
  */
 
-
-#ifndef CRYINCLUDE_EDITOR_TRACKVIEWNEWSEQUENCEDIALOG_H
-#define CRYINCLUDE_EDITOR_TRACKVIEWNEWSEQUENCEDIALOG_H
 #pragma once
 
+// Qt
 #if !defined(Q_MOC_RUN)
 #include <QScopedPointer>
 #include <QDialog>
 #endif
 
+// CryCommon
+#include <CryCommon/Maestro/Types/SequenceType.h>
+
 namespace Ui {
     class CTVNewSequenceDialog;
+    class CTVNewSequenceDialogValidator;
 }
 
+class QValidator;
 
 class CTVNewSequenceDialog
     : public QDialog
@@ -29,10 +32,12 @@ public:
     CTVNewSequenceDialog(QWidget* pParent = 0);
     virtual ~CTVNewSequenceDialog();
 
-    const QString& GetSequenceName() const { return m_sequenceName; };
-    SequenceType   GetSequenceType() const { return m_sequenceType; };
+    const QString& GetSequenceName() const { return m_sequenceName; }
+    SequenceType   GetSequenceType() const { return m_sequenceType; }
 
     void showEvent(QShowEvent* event) override;
+
+    friend class CTVNewSequenceDialogValidator;
 
 protected:
     virtual void OnOK();
@@ -43,6 +48,5 @@ private:
     SequenceType   m_sequenceType;
     QScopedPointer<Ui::CTVNewSequenceDialog> ui;
     bool           m_inputFocusSet;
+    QValidator*    m_validator;
 };
-
-#endif // CRYINCLUDE_EDITOR_TRACKVIEWNEWSEQUENCEDIALOG_H


### PR DESCRIPTION
## What does this PR do?
It is shown in GHI https://github.com/o3de/o3de/issues/3941 that a very long sequence name reveals a UI  defect.

This PR addresses the issue by introducing a new input validator for this text field. In addition to previous functionality, i.e. excluding slash, duplicate name, special invalid name,  this validator limits a sequence name by 160 characters. It is assumed that 160 characters is more than enough to give a proper name. Longer name is inconvenient to perceive and fit in UI.

The video below shows an attempt to enter a longer than acceptable name and the UI behavior when the length is maximal.

https://github.com/user-attachments/assets/96c91a78-f817-414d-9fed-566c8630f919

Additionally, the validator changes the validation approach to be more user-friendly. Previously, the validation was done when the user pressed the OK button in the dialog. If the name was not validated, the user had to reenter it. Now the validation is done in-place. For example, when the user attempts to enter `/`, no input occurs, and a tooltip with the explanation appears on hovering over the input field.

Closes #3941 

## How was this PR tested?

Tested locally, Windows 10.
