### PR TITLE
Track View: Remove the Environment node UI (GHI-7025)

### DIFF
--- a/Code/Editor/TrackView/TrackViewNode.cpp
+++ b/Code/Editor/TrackView/TrackViewNode.cpp
@@ -588,8 +588,7 @@ namespace
         nodeOrder[static_cast<int>(AnimNodeType::ScreenFader)] = 15;
         nodeOrder[static_cast<int>(AnimNodeType::Light)] = 16;
         nodeOrder[static_cast<int>(AnimNodeType::ShadowSetup)] = 17;
-        nodeOrder[static_cast<int>(AnimNodeType::Environment)] = 18;
-        nodeOrder[static_cast<int>(AnimNodeType::Group)] = 19;
+        nodeOrder[static_cast<int>(AnimNodeType::Group)] = 18;
 
         return nodeOrder[static_cast<int>(nodeType)];
     }

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -326,7 +326,6 @@ enum EMenuItem
     eMI_AddDOF = 510,
     eMI_AddScreenfader = 511,
     eMI_AddShadowSetup = 513,
-    eMI_AddEnvironment = 514,
     eMI_EditEvents = 550,
     eMI_SaveToFBX = 12,
     eMI_ImportFromFBX = 14,
@@ -970,12 +969,6 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                 groupNode->CreateSubNode("ShadowsSetup", AnimNodeType::ShadowSetup);
                 undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
             }
-            else if (cmd == eMI_AddEnvironment)
-            {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Add Track View Environment Node");
-                groupNode->CreateSubNode("Environment", AnimNodeType::Environment);
-                undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
-            }
             else if (cmd == eMI_AddDirectorNode)
             {
                 QString name = groupNode->GetAvailableNodeNameStartingWith("Director");
@@ -1399,11 +1392,6 @@ void CTrackViewNodesCtrl::AddGroupNodeAddItems(SContextMenu& contextMenu, CTrack
     if (pDirector->GetAnimNodesByType(AnimNodeType::ShadowSetup).GetCount() == 0)
     {
         contextMenu.main.addAction("Add Shadows Setup Node")->setData(eMI_AddShadowSetup);
-    }
-
-    if (pDirector->GetAnimNodesByType(AnimNodeType::Environment).GetCount() == 0)
-    {
-        contextMenu.main.addAction("Add Environment Node")->setData(eMI_AddEnvironment);
     }
 
     // A director node cannot have another director node as a child.

--- a/Code/Legacy/CryCommon/Maestro/Types/AnimNodeType.h
+++ b/Code/Legacy/CryCommon/Maestro/Types/AnimNodeType.h
@@ -39,7 +39,6 @@ enum class AnimNodeType
     ShadowSetup               = 0x17,
     Alembic                   = 0x18,       // Used in cinebox, added so nobody uses that number
     GeomCache                 = 0x19,
-    // Environment,
     ScreenDropsSetup,                       // deprecated Jan 2016
     AzEntity,
     Component,

--- a/Code/Legacy/CryCommon/Maestro/Types/AnimNodeType.h
+++ b/Code/Legacy/CryCommon/Maestro/Types/AnimNodeType.h
@@ -39,7 +39,7 @@ enum class AnimNodeType
     ShadowSetup               = 0x17,
     Alembic                   = 0x18,       // Used in cinebox, added so nobody uses that number
     GeomCache                 = 0x19,
-    Environment,
+    // Environment,
     ScreenDropsSetup,                       // deprecated Jan 2016
     AzEntity,
     Component,

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
@@ -101,7 +101,6 @@ void CMovieSystem::RegisterNodeTypes()
     REGISTER_NODE_TYPE(ShadowSetup)
     REGISTER_NODE_TYPE(Alembic)
     REGISTER_NODE_TYPE(GeomCache)
-    REGISTER_NODE_TYPE(Environment)
     REGISTER_NODE_TYPE(AzEntity)
     REGISTER_NODE_TYPE(Component)
 }


### PR DESCRIPTION
## What does this PR do?

Closes #7025 describes the bug when adding an Environment node to a sequence fails with the warning and has no effect.

Upon looking in the code it was found out that this node type was deprecated in Jan 2016. There is no code implementation for this node.

This PR removes the UI for the Environment node. The respective popup menu looks as following after the change:

![ghi-7025](https://github.com/user-attachments/assets/65b0a812-70cd-44cc-ad8e-4d5cb958ded7)

Closes [7025](https://github.com/o3de/o3de/issues/7025)

## How was this PR tested?

Tested locally, Windows 10.
