### PR TITLE
Add function "Allow pipeline changes" to CameraComponent

### DIFF
--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -21,7 +21,7 @@
 #include <AzCore/Math/Vector2.h>
 
 #include <AzFramework/Viewport/ViewportScreen.h>
-
+#include <AzCore/Settings/SettingsRegistry.h>
 
 namespace Camera
 {
@@ -42,6 +42,7 @@ namespace Camera
                 ->Field("MakeActiveViewOnActivation", &CameraComponentConfig::m_makeActiveViewOnActivation)
                 ->Field("RenderToTexture", &CameraComponentConfig::m_renderTextureAsset)
                 ->Field("PipelineTemplate", &CameraComponentConfig::m_pipelineTemplate)
+                ->Field("AllowPipelineChange", &CameraComponentConfig::m_allowPipelineChanges)
             ;
 
             if (auto editContext = serializeContext->GetEditContext())
@@ -82,9 +83,21 @@ namespace Camera
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Render To Texture")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraComponentConfig::m_renderTextureAsset, "Target texture", "The render target texture which the camera renders to.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraComponentConfig::m_pipelineTemplate, "Pipeline template", "The root pass template for the camera's render pipeline")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CameraComponentConfig::m_allowPipelineChanges, "Allow pipeline changes", "If true, the camera's render pipeline can be changed at runtime.")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &CameraComponentConfig::GetAllowPipelineChangesVisibility)
                 ;
             }
         }
+    }
+    AZ::u32 CameraComponentConfig::GetAllowPipelineChangesVisibility() const
+    {
+        bool experimentalFeaturesEnabled = false;
+        const auto registry = AZ::SettingsRegistry::Get();
+        if (registry)
+        {
+            registry->Get(experimentalFeaturesEnabled, "/O3DE/Atom/ExperimentalFeaturesEnabled");
+        }
+        return experimentalFeaturesEnabled ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
     }
 
     float CameraComponentConfig::GetFarClipDistance() const
@@ -326,7 +339,7 @@ namespace Camera
         pipelineDesc.m_name = pipelineName;
         pipelineDesc.m_rootPassTemplate = m_config.m_pipelineTemplate;
         pipelineDesc.m_renderSettings.m_multisampleState = AZ::RPI::RPISystemInterface::Get()->GetApplicationMultisampleState();
-        pipelineDesc.m_allowModification = false;
+        pipelineDesc.m_allowModification = m_config.m_allowPipelineChanges;
         m_renderToTexturePipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForImage(pipelineDesc, m_config.m_renderTextureAsset);
 
         if (!m_renderToTexturePipeline)

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -92,7 +92,7 @@ namespace Camera
     AZ::u32 CameraComponentConfig::GetAllowPipelineChangesVisibility() const
     {
         bool experimentalFeaturesEnabled = false;
-        const auto registry = AZ::SettingsRegistry::Get();
+        const auto* registry = AZ::SettingsRegistry::Get();
         if (registry)
         {
             registry->Get(experimentalFeaturesEnabled, "/O3DE/Atom/ExperimentalFeaturesEnabled");

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -57,6 +57,7 @@ namespace Camera
         bool m_specifyFrustumDimensions = false;
         bool m_makeActiveViewOnActivation = true;
         bool m_orthographic = false;
+        bool m_allowPipelineChanges = false;
         float m_orthographicHalfWidth = 5.f;
 
         AZ::u64 m_editorEntityId = AZ::EntityId::InvalidEntityId;
@@ -66,6 +67,9 @@ namespace Camera
         AZ::Data::Asset<AZ::RPI::AttachmentImageAsset> m_renderTextureAsset;
         // The pass template name used for render pipeline's root template
         AZStd::string m_pipelineTemplate = "CameraPipeline";
+    private:
+        //! Check if experimental features are enabled
+        AZ::u32 GetAllowPipelineChangesVisibility() const;
     };
 
     class CameraComponentController


### PR DESCRIPTION
## What does this PR do?
This is useful for rendering to texture using features like:
- Sky atmosphere
- Global illumination 
Since a lot of features processors don't behave with multiple cameras this function is activated after changing registry setting: `/O3DE/Atom/ExperimentalFeaturesEnabled` to `true` It is to prevent exposure of this function to the majority of users.
**Note** that some of existing feature processors, are not supporting multiple cameras correctly at the moment. Using this feature with those can lead to UB also in Editor, which is not beneficial. This feature is intended for advanced cases. I would consider to hide all render to texture section in next PR.

This function allows to change the camera pipeline (both in Editor and GameMode):
![image](https://github.com/user-attachments/assets/cf9f94ee-838b-4c35-a859-c5373ea28d73)

https://github.com/o3de/o3de/issues/18473
## How was this PR tested?
I've run 2409 with cherry picked:
- this commit (effbe41ed00d66b3dbbd372a672ba6f6c73f51bd)
- commit 159bf3c (fix for feature processor that is already in development)
against those assets (from issue #18473):
https://gist.github.com/michalpelka/2bc19beb566c7a2ea869c064de4dbfed
![image](https://github.com/user-attachments/assets/990eeec3-09f6-4c86-8864-5110f9ba8b28)

