### PR TITLE
Add current dll directory to library search path in LoadLibrary

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
@@ -108,7 +108,7 @@ namespace AZ
                 if (m_handle == nullptr && !CheckBitsAny(flags, LoadFlags::NoLoad))
                 {
                     // Note: Windows LoadLibrary has no concept of specifying that the module symbols are global or local
-                    m_handle = LoadLibraryW(fileNameW);
+                    m_handle = LoadLibraryExW(fileNameW, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
                 }
             }
             else


### PR DESCRIPTION
## What does this PR do?

I ran into a problem when using the SDK build with the following scenario:
* Engine SDK, an external gem as source code, and a project which builds the external gem from source and uses the engine SDK
* The external gem "MyGem" creates the module library `MyGem.Editor.dll`, which depends on `MyGemDependency.dll`, which is also built by this gem (The dependency could also be a prebuilt dll)
* `MyGem.Editor.dll` and  `MyGemDependency.dll` are in projectdir/build/* (project-based build)
* At runtime the editor (`Editor.exe` form the engine SDK) loads `MyGem.Editor.dll` dynamically, which needs to load `MyGemDependency.dll` as well; the search paths for `MyGemDependency.dll` according to Proecss Monitor) are:
  * `sdkdir/.../` (Editor.exe directory)
  * `sdkdir/.../MyGem.Editor.dll/MyGemDependency.dll`
  * `[SYTEM_PATH...]/MyGemDependency.dll`
* It fails to find the dependent dll which is in the project build dir, and fails to load `MyGem.Editor.dll` entirely

Am I correct in assuming that this behavior would always be a problem when using a shared library (like a closed source/source available (non open source) library which can only be used as a dll) in a gem and then trying to use this gem with the engine SDK?

The proposed fix adds the directory of the module dll, which is loaded dynamically, to the search path of `LoadLibrary`, which results in the dependent dll being found and the `MyGem.Editor.dll` being loaded successfully.
I am not sure whether there are negative consequences of this change, since it changes the library search paths globally for the entire engine, maybe someone from @o3de/sig-core has an opinion on that.

## How was this PR tested?

Test the aforementioned scenario and verify if it works.
