### PR TITLE
Homogenization of file opening windows

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -824,7 +824,7 @@ namespace LUAEditor
         AssetSelectionModel selection;
 
         StringFilter* stringFilter = new StringFilter();
-        stringFilter->SetName("Lua script");
+        stringFilter->SetName("Lua file (*.lua)");
         stringFilter->SetFilterString(".lua");
         stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
         auto stringFilterPtr = FilterConstType(stringFilter);
@@ -840,7 +840,7 @@ namespace LUAEditor
             return;
         }
 
-        auto result = selection.GetResult();
+        auto* result = selection.GetResult();
 
         if (result == nullptr)
         {

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -24,12 +24,15 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
+#include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 #include <AzToolsFramework/UI/UICore/ProgressShield.hxx>
 #include <AzToolsFramework/UI/UICore/SaveChangesDialog.hxx>
 #include <AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkAPI.h>
 #include <AzToolsFramework/UI/LegacyFramework/MainWindowSavedState.h>
 #include <AzToolsFramework/UI/UICore/TargetSelectorButton.hxx>
+#include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 #include <AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusAPI.h>
 #include <Source/LUA/TargetContextButton.hxx>
 #include <Source/LUA/LUAEditorDebuggerMessages.h>
@@ -818,19 +821,35 @@ namespace LUAEditor
 
     void LUAEditorMainWindow::OnFileMenuOpen()
     {
-        const QDir rootDir { AZ::Utils::GetProjectPath().c_str() };
-        const QString name = QFileDialog::getOpenFileName(this,
-                                                          "Open lua file",
-                                                          m_lastOpenFilePath.empty() ? rootDir.absolutePath() : m_lastOpenFilePath.c_str(),
-                                                          "Lua files (*.lua)");
-        if (name.isEmpty())
+        AssetSelectionModel selection;
+
+        StringFilter* stringFilter = new StringFilter();
+        stringFilter->SetName("Lua script");
+        stringFilter->SetFilterString(".lua");
+        stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+        auto stringFilterPtr = FilterConstType(stringFilter);
+
+        selection.SetDisplayFilter(stringFilterPtr);
+        selection.SetSelectionFilter(stringFilterPtr);
+
+        AssetBrowserComponentRequestBus::Broadcast(
+            &AssetBrowserComponentRequests::PickAssets, selection, AzToolsFramework::GetActiveWindow());
+
+        if (!selection.IsValid())
         {
             return;
         }
 
-        const AZStd::string assetId(name.toUtf8().data());
-        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, assetId, true);
+        auto result = selection.GetResult();
 
+        if (result == nullptr)
+        {
+            AZ_Assert(false, "Lua script - Incorrect entry type selected during script instantiation.");
+            return;
+        }
+
+        const AZStd::string assetId(result->GetFullPath().data());
+        Context_DocumentManagement::Bus::Broadcast(&Context_DocumentManagement::Bus::Events::OnLoadDocument, assetId, true);
         AzFramework::StringFunc::Path::Split(assetId.c_str(), nullptr, &m_lastOpenFilePath);
     }
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -842,7 +842,7 @@ namespace LUAEditor
 
         auto* result = selection.GetResult();
 
-        if (result == nullptr)
+        if (!result)
         {
             AZ_Assert(false, "Lua script - Incorrect entry type selected during script instantiation.");
             return;

--- a/Gems/LyShine/Code/Editor/EditorMenu.cpp
+++ b/Gems/LyShine/Code/Editor/EditorMenu.cpp
@@ -55,7 +55,6 @@ void EditorWindow::EditorMenu_Open(QString optional_selectedFile)
         {
             dir = Path::GetPath(recentFiles.front());
         }
-
         // Else go to the default canvas directory
         else
         {
@@ -65,8 +64,9 @@ void EditorWindow::EditorMenu_Open(QString optional_selectedFile)
         AssetSelectionModel selection;
 
         StringFilter* stringFilter = new StringFilter();
-        stringFilter->SetName("UI Canvas");
-        stringFilter->SetFilterString(".uicanvas");
+        const QString& filterString = QString(".") + UICANVASEDITOR_CANVAS_EXTENSION;
+        stringFilter->SetName("UI Canvas files (*.uicanvas)");
+        stringFilter->SetFilterString(filterString);
         stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
         auto stringFilterPtr = FilterConstType(stringFilter);
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1892,7 +1892,7 @@ namespace ScriptCanvasEditor
         AssetSelectionModel selection;
 
         StringFilter* stringFilter = new StringFilter();
-        stringFilter->SetName("Script canvas (*.scriptcanvas)");
+        stringFilter->SetName("Script Canvas (*.scriptcanvas)");
         stringFilter->SetFilterString(".scriptcanvas");
         stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
         auto stringFilterPtr = FilterConstType(stringFilter);

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -85,6 +85,8 @@
 #include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
+#include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
@@ -1887,22 +1889,33 @@ namespace ScriptCanvasEditor
 
     void MainWindow::OnFileOpen()
     {
-        const auto sourcePath = AZ::IO::FixedMaxPath(AZ::Utils::GetProjectPath()) / "scriptcanvas";
-        const QStringList nameFilters = { "All ScriptCanvas Files (*.scriptcanvas)" };
+        AssetSelectionModel selection;
 
-        QFileDialog dialog(nullptr, tr("Open..."), sourcePath.c_str());
-        dialog.setFileMode(QFileDialog::ExistingFiles);
-        dialog.setNameFilters(nameFilters);
+        StringFilter* stringFilter = new StringFilter();
+        stringFilter->SetName("Script canvas (*.scriptcanvas)");
+        stringFilter->SetFilterString(".scriptcanvas");
+        stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+        auto stringFilterPtr = FilterConstType(stringFilter);
 
-        if (dialog.exec() == QDialog::Accepted)
+        selection.SetDisplayFilter(stringFilterPtr);
+        selection.SetSelectionFilter(stringFilterPtr);
+        selection.SetMultiselect(true);
+
+        AssetBrowserComponentRequestBus::Broadcast(
+            &AssetBrowserComponentRequests::PickAssets, selection, AzToolsFramework::GetActiveWindow());
+
+        if (!selection.IsValid())
         {
-            m_filesToOpen = dialog.selectedFiles();
-
-            OpenNextFile();
+            return;
         }
 
-        EnableOpenDocumentActions(true);
+        for (const auto& result : selection.GetResults())
+        {
+            m_filesToOpen.push_back(result->GetFullPath().c_str());
+        }
 
+        OpenNextFile();
+        EnableOpenDocumentActions(true);
     }
 
     void MainWindow::EnableOpenDocumentActions(bool enable)


### PR DESCRIPTION
## What does this PR do?

Several windows for file opening have been implemented using AssetBrowserComponentRequests::PickAssets. However, a few windows remain unaddressed, specifically the file opener from the Lua editor, the UI editor and the script canvas. It previously used the os specific file opening.

This PR homogenize the remaining Windows.
  
| Name  | New | Original |
| :------------ | :---------: | ---------: |
| Script canvas |  <img src="https://github.com/user-attachments/assets/3ab0554b-84ba-43bc-bae7-56df78003463" width="800"/> |  <img src="https://github.com/user-attachments/assets/ba431d33-bd6d-40b4-bc42-86490974cc93" width="900"/> |
| UI Editor           |  <img src="https://github.com/user-attachments/assets/83d94b2e-7690-4626-91b4-1f4d16287a3b" width="800"/> |  <img src="https://github.com/user-attachments/assets/c0d36bc2-a8cc-4353-b979-b2826e186a6f" width="900"/>|
| Lua file           |  <img src="https://github.com/user-attachments/assets/cf7e7374-e1a5-456b-baad-897e9b90844d" width="800"/> |  <img src="https://github.com/user-attachments/assets/ae78dfb3-11c0-4109-a7ec-919b9f9518dd" width="900"/> |

## How was this PR tested?

Local windows build, on the GnomebodysHome project. 

Created a file, opened it, reopened the window to see if the last loaded item was pre-selected for each of the changed windows.
For the UI editor, checked that we could load multiple files.