### PR TITLE
AssetProcessorBatch Reflect Fix

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
@@ -83,6 +83,12 @@ void BatchApplicationManager::OnErrorMessage([[maybe_unused]] const char* error)
 void BatchApplicationManager::Reflect()
 {
     ApplicationManagerBase::Reflect();
+
+    AZ::SerializeContext* context;
+    AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+    AZ_Assert(context, "No serialize context");
+
+    AssetProcessor::PlatformConfiguration::Reflect(context);
 }
 
 const char* BatchApplicationManager::GetLogBaseName()

--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
@@ -84,7 +84,7 @@ void BatchApplicationManager::Reflect()
 {
     ApplicationManagerBase::Reflect();
 
-    AZ::SerializeContext* context;
+    AZ::SerializeContext* context = nullptr;
     AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(context, "No serialize context");
 

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -764,7 +764,7 @@ void GUIApplicationManager::Reflect()
 {
     ApplicationManagerBase::Reflect();
 
-    AZ::SerializeContext* context;
+    AZ::SerializeContext* context = nullptr;
     AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(context, "No serialize context");
 


### PR DESCRIPTION
## What does this PR do?

Adds in the omitted `AssetProcessor::PlatformConfiguration::Reflect(context);` for the AssetProcessorBatch, without which running the APB in Asset Cache client mode would result in an error when attempting to load settings.json

## How was this PR tested?

By running the AssetProcessorBatch in client mode for the Asset Cache.
