### PR TITLE
⌨️ Skip stride size assert when binding a typed buffer.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupData.h
@@ -558,7 +558,7 @@ namespace AZ::RHI
                 return false;
             }
         }
-        else
+        else if (shaderInputBuffer.m_type != ShaderInputBufferType::Typed)
         {
             // For any other type the buffer view's element size should match the stride.
             if (shaderInputBuffer.m_strideSize != bufferViewDescriptor.m_elementSize)


### PR DESCRIPTION
## What does this PR do?

The main advantage of a typed buffer is to use the texture mapping and texture filtering hardware to do format conversion.

When attempting to use this feature where one for example would use an `R10G10B10A2_UNORM` format for the buffer on the C++ side, which would translate to a `float4` format in shader, it would refuse to bind it since the stride of `R10G10B10A2_UNORM` is 4, and the stride of `float4` is 16.

This check is correct when using a `StructuredBuffer`, though.

This PR changes the check to be skipped for typed buffers.

## How was this PR tested?

This PR was tested by binding a typed buffer in `R10G10B10A2_UNORM` format with the engine running in Vulkan and DirectX 12.