### PR TITLE
Added logic to boostrap component that run BRDF pipeline in console mode

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -450,6 +450,7 @@ namespace AZ
                 {
                     AZ::ApplicationTypeQuery appType;
                     AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+                    // Run BRDF pipeline for the app in console mode, to use it in render-to-texture pipelines.
                     if (appType.IsConsoleMode())
                     {
                         RunBRDFPipeline(m_defaultScene, nullptr);

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -446,6 +446,15 @@ namespace AZ
                         CreateDefaultRenderPipeline();
                     }
                 }
+                else
+                {
+                    AZ::ApplicationTypeQuery appType;
+                    AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+                    if (appType.IsConsoleMode())
+                    {
+                        RunBRDFPipeline(m_defaultScene, nullptr);
+                    }
+                }
             }
 
             void BootstrapSystemComponent::OnWindowCreated(AzFramework::NativeWindowHandle windowHandle)
@@ -609,41 +618,7 @@ namespace AZ
                     }
                 }
 
-                // BRDF Texture Pipeline
-                {
-                    // As part of our initialization we need to create the BRDF texture generation pipeline
-
-                    // Save a reference to the generated BRDF texture so it doesn't get deleted if all the passes refering to it get deleted
-                    // and it's ref count goes to zero
-                    if (!m_brdfTexture)
-                    {
-                        const AZStd::shared_ptr<const RPI::PassTemplate> brdfTextureTemplate =
-                            RPI::PassSystemInterface::Get()->GetPassTemplate(Name("BRDFTextureTemplate"));
-                        Data::Asset<RPI::AttachmentImageAsset> brdfImageAsset = RPI::AssetUtils::LoadAssetById<RPI::AttachmentImageAsset>(
-                            brdfTextureTemplate->m_imageAttachments[0].m_assetRef.m_assetId, RPI::AssetUtils::TraceLevel::Error);
-                        if (brdfImageAsset.IsReady())
-                        {
-                            m_brdfTexture = RPI::AttachmentImage::FindOrCreate(brdfImageAsset);
-                        }
-                    }
-
-                    AZ::RPI::RenderPipelineDescriptor pipelineDesc;
-                    pipelineDesc.m_mainViewTagName = "MainCamera";
-                    pipelineDesc.m_rootPassTemplate = "BRDFTexturePipeline";
-                    pipelineDesc.m_executeOnce = true;
-
-                    for (int deviceIndex{ 0 }; deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount(); ++deviceIndex)
-                    {
-                        pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%d_%d", viewportContext->GetId(), deviceIndex);
-
-                        if (!scene->GetRenderPipeline(AZ::Name(pipelineDesc.m_name)))
-                        {
-                            RPI::RenderPipelinePtr brdfTexturePipeline = AZ::RPI::RenderPipeline::CreateRenderPipeline(pipelineDesc);
-                            brdfTexturePipeline->GetRootPass()->SetDeviceIndex(deviceIndex);
-                            scene->AddRenderPipeline(brdfTexturePipeline);
-                        }
-                    }
-                }
+                RunBRDFPipeline(scene, viewportContext);
 
                 // Load XR pipelines if applicable
                 if (xrSystem)
@@ -688,6 +663,43 @@ namespace AZ
                 }
 
                 return true;
+            }
+
+            void BootstrapSystemComponent::RunBRDFPipeline(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext)
+            {
+                // As part of our initialization we need to create the BRDF texture generation pipeline
+
+                // Save a reference to the generated BRDF texture so it doesn't get deleted if all the passes refering to it get deleted
+                // and it's ref count goes to zero
+                if (!m_brdfTexture)
+                {
+
+                    const AZStd::shared_ptr<const RPI::PassTemplate> brdfTextureTemplate =
+                        RPI::PassSystemInterface::Get()->GetPassTemplate(Name("BRDFTextureTemplate"));
+                    Data::Asset<RPI::AttachmentImageAsset> brdfImageAsset = RPI::AssetUtils::LoadAssetById<RPI::AttachmentImageAsset>(
+                        brdfTextureTemplate->m_imageAttachments[0].m_assetRef.m_assetId, RPI::AssetUtils::TraceLevel::Error);
+                    if (brdfImageAsset.IsReady())
+                    {
+                        m_brdfTexture = RPI::AttachmentImage::FindOrCreate(brdfImageAsset);
+                    }
+                }
+
+                AZ::RPI::RenderPipelineDescriptor pipelineDesc;
+                pipelineDesc.m_mainViewTagName = "MainCamera";
+                pipelineDesc.m_rootPassTemplate = "BRDFTexturePipeline";
+                pipelineDesc.m_executeOnce = true;
+                const AzFramework::ViewportId viewportId = viewportContext ? viewportContext->GetId() : AzFramework::InvalidViewportId;
+                for (int deviceIndex{ 0 }; deviceIndex < RHI::RHISystemInterface::Get()->GetDeviceCount(); ++deviceIndex)
+                {
+                    pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%d_%d", viewportId, deviceIndex);
+
+                    if (!scene->GetRenderPipeline(AZ::Name(pipelineDesc.m_name)))
+                    {
+                        RPI::RenderPipelinePtr brdfTexturePipeline = AZ::RPI::RenderPipeline::CreateRenderPipeline(pipelineDesc);
+                        brdfTexturePipeline->GetRootPass()->SetDeviceIndex(deviceIndex);
+                        scene->AddRenderPipeline(brdfTexturePipeline);
+                    }
+                }
             }
 
             void BootstrapSystemComponent::SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext)

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -105,6 +105,9 @@ namespace AZ
                 void CreateViewportContext();
                 void SetWindowResolution();
 
+                //! Run the BRDF pipeline to generate the BRDF texture
+                void RunBRDFPipeline(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext);
+
                 //! Load a render pipeline from disk and add it to the scene
                 RPI::RenderPipelinePtr LoadPipeline(
                     const AZ::RPI::ScenePtr scene,


### PR DESCRIPTION
## What does this PR do?

This PR modifies Bootstrap component to run BRDF pipeline. 
It fixes : https://github.com/o3de/o3de-extras/issues/792 

PR is meant to not change execution of non-console mode app.


## How was this PR tested?
Build and run test level with terrain and ROS 2 camera:
- [x] Editor 
- [x]  GameLauncher 
- [x]  GameLauncher --console mode
- [x]  GameLauncher --rhi=null


![image](https://github.com/user-attachments/assets/f51e3018-aafc-4135-99b8-b4ac7e02e951)

There is version of this fix targeted for main:
https://github.com/RobotecAI/o3de/commit/82ef86146b5337d4730744a7a8347ead549575be#diff-1d5588829cc3fe55631fa88df3454631556b59d34e30078021c425963cf75f6bR608
There is also fix that exists only in o3de-extras:
https://github.com/o3de/o3de-extras/pull/801