### PR TITLE
Fixes loading XInput9_1_0.dll.

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
@@ -108,16 +108,14 @@ namespace AZ
                 if (m_handle == nullptr && !CheckBitsAny(flags, LoadFlags::NoLoad))
                 {
                     // Note: Windows LoadLibrary has no concept of specifying that the module symbols are global or local
-                    AZ::IO::PathView modulePathView{ m_fileName };
-                    DWORD loadFlags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS;
-                    if (modulePathView.HasRootPath())
+                    m_handle = LoadLibraryExW(fileNameW, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+                    if (!m_handle)
                     {
-                        // This flag only works if fileNameW is a fully qualified path.
-                        // In other words, this flag can NOT be used when the dll path is relative
-                        // to the SYSTEM32 directory like the case of "XInput9_1_0.dll".
-                        loadFlags |= LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
+                        // If the first time failed, most likely occurred because @fileNameW is not a fully qualified path.
+                        // Per API spec, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR requires a fully qualified path.
+                        // Cases like "XInput9_1_0.dll" should be loaded without LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR.
+                        m_handle = LoadLibraryExW(fileNameW, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
                     }
-                    m_handle = LoadLibraryExW(fileNameW, NULL, loadFlags);
                 }
             }
             else

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
@@ -108,7 +108,16 @@ namespace AZ
                 if (m_handle == nullptr && !CheckBitsAny(flags, LoadFlags::NoLoad))
                 {
                     // Note: Windows LoadLibrary has no concept of specifying that the module symbols are global or local
-                    m_handle = LoadLibraryExW(fileNameW, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+                    AZ::IO::PathView modulePathView{ m_fileName };
+                    DWORD loadFlags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS;
+                    if (modulePathView.HasRootPath())
+                    {
+                        // This flag only works if fileNameW is a fully qualified path.
+                        // In other words, this flag can NOT be used when the dll path is relative
+                        // to the SYSTEM32 directory like the case of "XInput9_1_0.dll".
+                        loadFlags |= LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
+                    }
+                    m_handle = LoadLibraryExW(fileNameW, NULL, loadFlags);
                 }
             }
             else


### PR DESCRIPTION
## What does this PR do?

Bug Fix.
I noticed my gamepad stopped working.
After some debugging I found that O3DE
failed to load "XInput9_1_0.dll".
The failured was introduced in PR #18525:
https://github.com/o3de/o3de/pull/18525

According to MSFT Docs:
https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw When using `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`:
```
The lpFileName parameter must specify a fully qualified path.
```

The failure occured because "XInput9_1_0.dll" is NOT a fully qualified path and it is expected to be found in the SYSTEM32 directory.

The solution is to only use `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` when the module path is fully qualified.

Gamepad Controller works again.

## How was this PR tested?

Gamepad Controller works.