### PR TITLE
Bindless fixes

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
@@ -204,7 +204,7 @@ namespace AZ::RHI
             ShaderInputBufferIndex indirectResourceBufferIndex,
             const BufferView* indirectResourceBufferView,
             AZStd::span<const ImageView* const> imageViews,
-            uint32_t* outIndices,
+            AZStd::unordered_map<int, uint32_t*> outIndices,
             AZStd::span<bool> isViewReadOnly,
             uint32_t arrayIndex = 0);
 
@@ -213,7 +213,7 @@ namespace AZ::RHI
             ShaderInputBufferIndex indirectResourceBufferIndex,
             const BufferView* indirectResourceBufferView,
             AZStd::span<const BufferView* const> bufferViews,
-            uint32_t* outIndices,
+            AZStd::unordered_map<int, uint32_t*> outIndices,
             AZStd::span<bool> isViewReadOnly,
             uint32_t arrayIndex = 0);
 

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
@@ -457,7 +457,7 @@ namespace AZ::RHI
         ShaderInputBufferIndex indirectResourceBufferIndex,
         const BufferView* indirectResourceBufferView,
         AZStd::span<const ImageView* const> imageViews,
-        uint32_t* outIndices,
+        AZStd::unordered_map<int, uint32_t*> outIndices,
         AZStd::span<bool> isViewReadOnly,
         uint32_t arrayIndex)
     {
@@ -470,11 +470,13 @@ namespace AZ::RHI
                 deviceImageViews[imageIndex] = imageViews[imageIndex] ? imageViews[imageIndex]->GetDeviceImageView(deviceIndex).get() : nullptr;
             }
 
+            auto outIndicesIt = outIndices.find(deviceIndex);
+
             deviceShaderResourceGroupData.SetBindlessViews(
                 indirectResourceBufferIndex,
                 indirectResourceBufferView->GetDeviceBufferView(deviceIndex).get(),
                 deviceImageViews,
-                outIndices,
+                outIndicesIt != outIndices.end() ? outIndicesIt->second : nullptr,
                 isViewReadOnly,
                 arrayIndex);
         }
@@ -510,7 +512,7 @@ namespace AZ::RHI
         ShaderInputBufferIndex indirectResourceBufferIndex,
         const BufferView* indirectResourceBufferView,
         AZStd::span<const BufferView* const> bufferViews,
-        uint32_t* outIndices,
+        AZStd::unordered_map<int, uint32_t*> outIndices,
         AZStd::span<bool> isViewReadOnly,
         uint32_t arrayIndex)
     {
@@ -523,11 +525,13 @@ namespace AZ::RHI
                 deviceBufferViews[bufferIndex] = bufferViews[bufferIndex] ? bufferViews[bufferIndex]->GetDeviceBufferView(deviceIndex).get() : nullptr;
             }
 
+            auto outIndicesIt = outIndices.find(deviceIndex);
+
             deviceShaderResourceGroupData.SetBindlessViews(
                 indirectResourceBufferIndex,
                 indirectResourceBufferView->GetDeviceBufferView(deviceIndex).get(),
                 deviceBufferViews,
-                outIndices,
+                outIndicesIt != outIndices.end() ? outIndicesIt->second : nullptr,
                 isViewReadOnly,
                 arrayIndex);
         }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -156,7 +156,7 @@ namespace AZ
                 RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
                 const RHI::BufferView* indirectResourceBuffer,
                 AZStd::span<const RHI::ImageView* const> imageViews,
-                uint32_t* outIndices,
+                AZStd::unordered_map<int, uint32_t*> outIndices,
                 AZStd::span<bool> isViewReadOnly,
                 uint32_t arrayIndex = 0);
 
@@ -187,10 +187,10 @@ namespace AZ
                 RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
                 const RHI::BufferView* indirectResourceBuffer,
                 AZStd::span<const RHI::BufferView* const> bufferViews,
-                uint32_t* outIndices,
+                AZStd::unordered_map<int, uint32_t*> outIndices,
                 AZStd::span<bool> isViewReadOnly,
                 uint32_t arrayIndex = 0);
-            
+
             /// Returns a single buffer view associated with the buffer shader input index and array offset.
             const RHI::ConstPtr<RHI::BufferView>& GetBufferView(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex = 0) const;
             const RHI::ConstPtr<RHI::BufferView>& GetBufferView(RHI::ShaderInputBufferIndex inputIndex, uint32_t arrayIndex = 0) const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -872,7 +872,7 @@ namespace AZ
                         indirectResourceBufferIndex,
                         indirectResourceBuffer.get(),
                         bufferViewPtrArray,
-                        nullptr,
+                        {},
                         isReadOnlyBuffer,
                         entry.first.second);
                 }
@@ -883,7 +883,7 @@ namespace AZ
                         indirectResourceBufferIndex,
                         indirectResourceBuffer.get(),
                         imageViewPtrArray,
-                        nullptr,
+                        {},
                         isReadOnlyImage,
                         entry.first.second);
                 }
@@ -906,7 +906,7 @@ namespace AZ
             RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
             const RHI::BufferView* indirectResourceBuffer,
             AZStd::span<const RHI::ImageView* const> imageViews,
-            uint32_t* outIndices,
+            AZStd::unordered_map<int, uint32_t*> outIndices,
             AZStd::span<bool> isViewReadOnly,
             uint32_t arrayIndex)
         {
@@ -918,7 +918,7 @@ namespace AZ
             RHI::ShaderInputBufferIndex indirectResourceBufferIndex,
             const RHI::BufferView* indirectResourceBuffer,
             AZStd::span<const RHI::BufferView* const> bufferViews,
-            uint32_t* outIndices,
+            AZStd::unordered_map<int, uint32_t*> outIndices,
             AZStd::span<bool> isViewReadOnly,
             uint32_t arrayIndex)
         {


### PR DESCRIPTION
## What does this PR do?

This PR fixes two issues with bindless:

1. Fix https://github.com/o3de/o3de/issues/16305 for DX12: Create raw buffers views for the bindless descriptors. According to the [documentation](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/sm5-object-rwbyteaddressbuffer) of (RW)ByteAddressBuffer, buffer descriptors bound to it need to be raw buffer descriptors.
2. Fix a MultiGPU bug in `ShaderResourceGroup::SetBindlessViews`. The returned bindless indices always contained the bindless indices of the last device. Now bindless indices per device are returned.

## How was this PR tested?

Windows + DX12/Vulkan. Tested the MainPipeline and the BindlessPrototype sample in the Atom Sample Viewer.
The BindlessPrototype sample was previously broken with DX12 or Vulkan+MultiGPU. It's now working again.

Before:
![dx12_before](https://github.com/user-attachments/assets/1907ad45-dffd-4ec4-a35c-d951c65040d4)

Fixed:
![dx12_after](https://github.com/user-attachments/assets/411160f6-3d88-4acb-82bd-fb43f244ff43)
