### PR TITLE
Fix Lua Editor: greyed out FindAll if no script opened

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -234,6 +234,9 @@ namespace LUAEditor
         m_gui->findAllButton->setDefault(!m_gui->findNextButton->isEnabled());
         m_gui->findNextButton->setAutoDefault(m_gui->findNextButton->isEnabled());
         m_gui->findAllButton->setAutoDefault(!m_gui->findNextButton->isEnabled());
+        m_gui->findAllButton->setEnabled(pLUAEditorMainWindow->HasAtLeastOneFileOpen());
+        m_gui->replaceButton->setEnabled(pLUAEditorMainWindow->HasAtLeastOneFileOpen());
+        m_gui->replaceAllButton->setEnabled(pLUAEditorMainWindow->HasAtLeastOneFileOpen());
 
         if (m_bWasFindInAll)
         {

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -2147,6 +2147,11 @@ namespace LUAEditor
         }
     }
 
+    bool LUAEditorMainWindow::HasAtLeastOneFileOpen() const
+    {
+        return m_StateTrack.atLeastOneFileOpen;
+    }
+
     bool LUAEditorMainWindow::eventFilter(QObject* obj, QEvent* event)
     {
         (void)obj;

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
@@ -399,6 +399,7 @@ namespace LUAEditor
         void SetCurrentFindListWidget(int index);
         LUAViewWidget* GetCurrentView();
         AZStd::vector<LUAViewWidget*> GetAllViews();
+        bool HasAtLeastOneFileOpen() const;
     };
 
     class LUAEditorMainWindowLayout : public QLayout


### PR DESCRIPTION
## What does this PR do?

Fix https://github.com/o3de/o3de/issues/14189

In the Lua Editor's Find Tool, an issue was identified with the Find All, Replace All and Replace buttons when no script was selected. Since searching for text is unnecessary without an open file, those buttons have now been greyed out if no file is opened.

![image](https://github.com/user-attachments/assets/98b6deb9-1540-4572-a04a-cc968b411e8c)

## How was this PR tested?

Local windows build

- Opened the Lua editor and the find tool with no script. Checked that the Find All, Replace All and Replace buttons was greyed out
- Opened a script and the find tool. Checked that I could search for a string with the Find All and could replace with replace All and Replace buttons