### PR TITLE
initialize AZ::SerializeContext to nullptr

### DIFF
--- a/Code/Editor/Core/QtEditorApplication.cpp
+++ b/Code/Editor/Core/QtEditorApplication.cpp
@@ -271,7 +271,7 @@ namespace Editor
 
     void EditorQtApplication::LoadSettings()
     {
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(context, "No serialize context");
         char resolvedPath[AZ_MAX_PATH_LEN];
@@ -297,7 +297,7 @@ namespace Editor
     {
         if (m_activatedLocalUserSettings)
         {
-            AZ::SerializeContext* context;
+            AZ::SerializeContext* context = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             AZ_Assert(context, "No serialize context");
 

--- a/Code/Framework/AzCore/AzCore/Serialization/DataPatch.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/DataPatch.cpp
@@ -1344,7 +1344,7 @@ namespace AZ
             , m_addressClassVersion(newElementVersion)
             , m_isValid(true)
         {
-            AZ::SerializeContext* context;
+            AZ::SerializeContext* context = nullptr;
             ComponentApplicationBus::BroadcastResult(context, &ComponentApplicationBus::Events::GetSerializeContext);
 
             auto classData = context->FindClassData(original.GetElementTypeId());

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -24,7 +24,7 @@ namespace AZ::DocumentPropertyEditor
 {
     struct ReflectionAdapterReflectionImpl : public AZ::Reflection::IReadWrite
     {
-        AZ::SerializeContext* m_serializeContext;
+        AZ::SerializeContext* m_serializeContext = nullptr;
         ReflectionAdapter* m_adapter;
         AdapterBuilder m_builder;
         // Look-up table of onChanged callbacks for handling property changes

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentMimeData.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentMimeData.cpp
@@ -100,7 +100,7 @@ namespace AzToolsFramework
 
     AZStd::unique_ptr<QMimeData> ComponentMimeData::Create(AZStd::span<AZ::Component* const> components)
     {
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         if (!context)
         {

--- a/Code/Framework/AzToolsFramework/Tests/AssetFileInfoListComparison.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/AssetFileInfoListComparison.cpp
@@ -103,7 +103,7 @@ namespace UnitTest
             // in the unit tests.
             AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
 
-            AZ::SerializeContext* context;
+            AZ::SerializeContext* context = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             ASSERT_TRUE(context) << "No serialize context.\n";
 

--- a/Code/Framework/AzToolsFramework/Tests/AssetSeedManager.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/AssetSeedManager.cpp
@@ -172,7 +172,7 @@ namespace UnitTest
             // in the unit tests.
             AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
 
-            AZ::SerializeContext* context;
+            AZ::SerializeContext* context = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             ASSERT_TRUE(context) << "No serialize context.\n";
 

--- a/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
+++ b/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
@@ -73,7 +73,7 @@ namespace AssetBundler
         startupParameters.m_loadDynamicModules = false;
         Start(AzFramework::Application::Descriptor(), startupParameters);
 
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(context, "No serialize context");
         AzToolsFramework::AssetSeedManager::Reflect(context);

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -1669,7 +1669,7 @@ bool ApplicationManagerBase::PostActivate()
 
 void ApplicationManagerBase::Reflect()
 {
-    AZ::SerializeContext* context;
+    AZ::SerializeContext* context = nullptr;
     AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
     AZ_Assert(context, "SerializeContext is not available");

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -376,7 +376,7 @@ bool GUIApplicationManager::Run()
     delete m_mainWindow;
     m_mainWindow = nullptr;
 
-    AZ::SerializeContext* context;
+    AZ::SerializeContext* context = nullptr;
     AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(context, "No serialize context");
     QDir projectCacheRoot;
@@ -504,7 +504,7 @@ bool GUIApplicationManager::Activate()
 {
     m_startupErrorCollector = AZStd::make_unique<ErrorCollector>(m_mainWindow);
 
-    AZ::SerializeContext* context;
+    AZ::SerializeContext* context = nullptr;
     AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
     AZ_Assert(context, "No serialize context");
     QDir projectCacheRoot;

--- a/Code/Tools/PythonBindingsExample/source/Application.cpp
+++ b/Code/Tools/PythonBindingsExample/source/Application.cpp
@@ -41,7 +41,7 @@ namespace PythonBindingsExample
         // prepare the Python binding gem(s)
         Start(Descriptor());
 
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AZ_Assert(context, "Application did not start; detected no serialize context");
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.cpp
@@ -77,7 +77,7 @@ namespace EMStudio
 
     void EventDataEditor::Init()
     {
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         m_eventDataSelectionMenu = new QMenu(this);
@@ -263,7 +263,7 @@ namespace EMStudio
 
     void EventDataEditor::AppendEventData(const AZ::Uuid& newTypeId)
     {
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         const AZ::SerializeContext::ClassData* classData = context->FindClassData(newTypeId);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.cpp
@@ -29,7 +29,7 @@ namespace EMStudio
 
     void MotionEventEditor::Init()
     {
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         m_baseObjectEditor = new EMotionFX::ObjectEditor(context);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventPresetCreateDialog.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventPresetCreateDialog.cpp
@@ -24,7 +24,7 @@ namespace EMStudio
         , m_eventDataEditor(nullptr, nullptr, &m_preset.GetEventDatas(), this)
     {
         setWindowTitle("Motion Event Preset Creation");
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         m_editor = new EMotionFX::ObjectEditor(context, this);

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedObjectWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedObjectWidget.cpp
@@ -120,7 +120,7 @@ namespace EMotionFX
             m_actionManager->OnAddNewObjectAndAddJoints(m_actor, /*selectedJoints=*/{}, /*addChildJoints=*/false, m_dock);
         });
 
-        AZ::SerializeContext* serializeContext;
+        AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         m_selectionWidget = new QWidget();

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/EventDataHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/EventDataHandler.cpp
@@ -44,7 +44,7 @@ namespace EMotionFX
 
     EventDataTypeSelectionWidget::EventDataTypesModel::EventDataTypesModel()
     {
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         m_eventDataClassNames.emplace_back("<none>", AZ::Uuid::CreateNull());
@@ -190,7 +190,7 @@ namespace EMotionFX
         }
         else
         {
-            AZ::SerializeContext* context;
+            AZ::SerializeContext* context = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             const AZ::SerializeContext::ClassData* classData = context->FindClassData(newTypeId);
             instance.reset(static_cast<EMotionFX::EventData*>(classData->m_factory->Create(classData->m_name)));

--- a/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
@@ -197,7 +197,7 @@ namespace SliceBuilder
         bool sliceWritable = AZ::IO::SystemFile::IsWritable(fullPath.c_str());
         bool createDynamicSlice = sourcePrefab->IsDynamic();
 
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         AzToolsFramework::Fingerprinting::TypeFingerprint sourceSliceTypeFingerprint = CalculateFingerprintForSlice(*sourcePrefab, *m_typeFingerprinter, *context);
 
@@ -418,7 +418,7 @@ namespace SliceBuilder
             {
                 AZ_TracePrintf(s_sliceBuilder, "Slice Upgrade: Instantiating Slice");
 
-                AZ::SerializeContext* context;
+                AZ::SerializeContext* context = nullptr;
                 AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
                 AZ::Data::Asset<AZ::SliceAsset> sourceAsset;
@@ -538,7 +538,7 @@ namespace SliceBuilder
     {
         AssetBuilderSDK::AssertAndErrorAbsorber assertAndErrorAbsorber(true);
 
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         sourceAsset.Create(AZ::Data::AssetId(AZ::Uuid::CreateRandom()));
@@ -564,7 +564,7 @@ namespace SliceBuilder
     bool SliceBuilderWorker::GetCompiledSliceAsset(AZStd::shared_ptr<AZ::Data::AssetDataStream> stream, const char* fullPath,
         const AZ::PlatformTagSet& platformTags, AZ::Data::Asset<AZ::SliceAsset>& outSliceAsset)
     {
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         AssetBuilderSDK::AssertAndErrorAbsorber assertAndErrorAbsorber(true);

--- a/Gems/LyShine/Code/Editor/PropertiesContainer.cpp
+++ b/Gems/LyShine/Code/Editor/PropertiesContainer.cpp
@@ -117,8 +117,7 @@ private:
 
 //-------------------------------------------------------------------------------
 
-PropertiesContainer::PropertiesContainer(PropertiesWidget* propertiesWidget,
-    EditorWindow* editorWindow)
+PropertiesContainer::PropertiesContainer(PropertiesWidget* propertiesWidget, EditorWindow* editorWindow)
     : QScrollArea(propertiesWidget)
     , m_propertiesWidget(propertiesWidget)
     , m_editorWindow(editorWindow)
@@ -127,6 +126,7 @@ PropertiesContainer::PropertiesContainer(PropertiesWidget* propertiesWidget,
     , m_isCanvasSelected(false)
     , m_selectionEventAccepted(false)
     , m_componentEditorLastSelectedIndex(-1)
+    , m_serializeContext(nullptr)
 {
     setFocusPolicy(Qt::ClickFocus);
     setFrameShape(QFrame::NoFrame);

--- a/Gems/LyShine/Code/Pipeline/LyShineBuilder/UiCanvasBuilderWorker.cpp
+++ b/Gems/LyShine/Code/Pipeline/LyShineBuilder/UiCanvasBuilderWorker.cpp
@@ -251,7 +251,7 @@ namespace LyShine
             return false;
         }
 
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         if (!context)
         {

--- a/Gems/PhysX/Core/Code/Source/ForceRegion.cpp
+++ b/Gems/PhysX/Core/Code/Source/ForceRegion.cpp
@@ -75,7 +75,7 @@ namespace PhysX
     ForceRegion::ForceRegion(const ForceRegion& forceRegion)
     {
         // Force region must be deep copied as it contains pointers
-        AZ::SerializeContext* context;
+        AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
         context->CloneObjectInplace<ForceRegion>(*this, &forceRegion);
     }

--- a/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
+++ b/Gems/RemoteTools/Code/Source/RemoteToolsSystemComponent.cpp
@@ -326,7 +326,7 @@ namespace RemoteTools
     void RemoteToolsSystemComponent::SendRemoteToolsMessage(
         const AzFramework::RemoteToolsEndpointInfo& target, const AzFramework::RemoteToolsMessage& msg)
     {
-        AZ::SerializeContext* serializeContext;
+        AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         AZStd::vector<char, AZ::OSStdAllocator> msgBuffer;
@@ -560,7 +560,7 @@ namespace RemoteTools
     AzFramework::RemoteToolsMessage* RemoteToolsSystemComponent::DeserializeMessage(
         const AZ::Crc32& key, AZStd::vector<AZStd::byte>& buffer, const uint32_t& totalBufferSize)
     {
-        AZ::SerializeContext* serializeContext;
+        AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
         // Deserialize the complete buffer


### PR DESCRIPTION
## What does this PR do?

Initialize the Serialize-context to nullptr, so the user gets an assert instead of a crash caused by accessing an uninitialized pointer.

