### PR TITLE
Vulkan RHI: Don't expose HDR surface format when SetHDRMetadata is null

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -866,6 +866,13 @@ namespace AZ
             AZStd::set<RHI::Format> formats;
             for (const VkSurfaceFormatKHR& surfaceFormat : surfaceFormats)
             {
+                // Don't expose formats for HDR output when the extension is missing
+                // This can happen on Linux with Wayland.
+                if (surfaceFormat.format == VK_FORMAT_A2R10G10B10_UNORM_PACK32 &&
+                    m_loaderContext->GetContext().SetHdrMetadataEXT == nullptr)
+                {
+                    continue;
+                }
                 formats.insert(ConvertFormat(surfaceFormat.format));
             }
             formatsList.assign(formats.begin(), formats.end());


### PR DESCRIPTION
## What does this PR do?
Removes the common `R10G10B10A2_PACK32` format from supported surface formats when SetHDRMetadata is null.

When using KDE with Wayland and enabling HDR on your monitor the engine will select the `R10G10B10A2_PACK32` which ends up looking grey and dim due to no SetHDRMetadata support in the VK RHI, this fixes that and gives you a proper SDR image.

## How was this PR tested?
I used the wayland branch on my fork with this setup:
- Fedora 41
- KDE Wayland
- Main monitor HDR Enabled

I also tested with XCB just to make sure.