### PR TITLE
Track View: Optional fix for GHI #11500: fix prefabs previously stored with invalid entity parents.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -589,7 +589,7 @@ namespace AzToolsFramework
                 auto sourceIt = templateDomRef.FindMember(PrefabDomUtils::SourceName);
                 if (sourceIt == templateDomRef.MemberEnd() || !sourceIt->value.IsString())
                 {
-                    AZ_Error("Prefab", false, "lacks a 'Source' container.");
+                    AZ_Warning("Prefab", false, "lacks a 'Source' container.");
                     return false;
                 }
                 const AZStd::string path(sourceIt->value.GetString());
@@ -597,7 +597,7 @@ namespace AzToolsFramework
                 const auto containerEntityIt = templateDomRef.FindMember(PrefabDomUtils::ContainerEntityName);
                 if (containerEntityIt == templateDomRef.MemberEnd() || !containerEntityIt->value.IsObject())
                 {
-                    AZ_Error("Prefab", false, "'%s' lacks a 'ContainerEntity' container.", path.c_str());
+                    AZ_Warning("Prefab", false, "'%s' lacks a 'ContainerEntity' container.", path.c_str());
                     return false;
                 }
                 const auto containerEntityAliasIt = containerEntityIt->value.FindMember(PrefabDomUtils::EntityIdName);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -583,84 +583,108 @@ namespace AzToolsFramework
                 }
             }
 
-            bool CheckEntitiesParents(PrefabDom& templateDomRef)
+            bool SubstituteInvalidParentsInEntities(PrefabDom& templateDomRef)
             {
-                bool result = true;
                 // Search for a TransformComponent and check the "Parent Entity" statement
                 auto sourceIt = templateDomRef.FindMember(PrefabDomUtils::SourceName);
-                if (sourceIt != templateDomRef.MemberEnd() && sourceIt->value.IsString())
+                if (sourceIt == templateDomRef.MemberEnd() || !sourceIt->value.IsString())
                 {
-                    AZStd::string containerEntityAlias(PrefabDomUtils::ContainerEntityName);
-                    const auto containerEntityIt = templateDomRef.FindMember(PrefabDomUtils::ContainerEntityName);
-                    if (containerEntityIt != templateDomRef.MemberEnd() && containerEntityIt->value.IsObject())
+                    AZ_Error("Prefab", false, "lacks a 'Source' container.");
+                    return false;
+                }
+                const AZStd::string path(sourceIt->value.GetString());
+
+                const auto containerEntityIt = templateDomRef.FindMember(PrefabDomUtils::ContainerEntityName);
+                if (containerEntityIt == templateDomRef.MemberEnd() || !containerEntityIt->value.IsObject())
+                {
+                    AZ_Error("Prefab", false, "'%s' lacks a 'ContainerEntity' container.", path.c_str());
+                    return false;
+                }
+                const auto containerEntityAliasIt = containerEntityIt->value.FindMember(PrefabDomUtils::EntityIdName);
+                if (containerEntityAliasIt == containerEntityIt->value.MemberEnd() || !containerEntityAliasIt->value.IsString())
+                {
+                    AZ_Error("Prefab", false, "'%s' lacks 'Id' object for ContainerEntity.", path.c_str());
+                    return false;
+                }
+                const AZStd::string containerEntityAlias(containerEntityAliasIt->value.GetString());
+
+                const auto entitiesIt = templateDomRef.FindMember(PrefabDomUtils::EntitiesName);
+                if (entitiesIt == templateDomRef.MemberEnd() || !entitiesIt->value.IsObject())
+                {
+                    AZ_Error("Prefab", false, "'%s' lacks 'Entities' container.", path.c_str());
+                    return false;
+                }
+
+                bool result = true;
+                // Search through entities for their TransformComponents
+                for (auto entityIt = entitiesIt->value.MemberBegin(); entityIt != entitiesIt->value.MemberEnd(); ++entityIt)
+                {
+                    // More information for logs
+                    constexpr const auto unknownName = "[unknown]";
+                    AZStd::string entityAlias = unknownName;
+                    const auto entityAliasIt = entityIt->value.FindMember(PrefabDomUtils::EntityIdName);
+                    if (entityAliasIt != entityIt->value.MemberEnd() && entityAliasIt->value.IsString())
                     {
-                        const auto containerEntityAliasIt = containerEntityIt->value.FindMember(PrefabDomUtils::EntityIdName);
-                        if (containerEntityAliasIt != containerEntityIt->value.MemberEnd() && containerEntityAliasIt->value.IsString())
+                        entityAlias = entityAliasIt->value.GetString();
+                    }
+                    AZStd::string entityName = unknownName;
+                    const auto entityNameIt = entityIt->value.FindMember("Name");
+                    if (entityNameIt != entityIt->value.MemberEnd() && entityNameIt->value.IsString())
+                    {
+                        entityName = entityNameIt->value.GetString();
+                    }
+
+                    const auto componentsIt = entityIt->value.FindMember(PrefabDomUtils::ComponentsName);
+                    if (componentsIt == entityIt->value.MemberEnd() || !componentsIt->value.IsObject())
+                    {
+                        result = false;
+                        AZ_Error("Prefab", false, "'%s' lacks 'Components' container in Entity (%s, '%s').",
+                            path.c_str(), entityAlias.c_str(), entityName.c_str());
+                        continue;
+                    }
+
+                    // Search current entity object for TransformComponent looping through components
+                    for (auto componentIt = componentsIt->value.MemberBegin(); componentIt != componentsIt->value.MemberEnd();
+                         ++componentIt)
+                    {
+                        const auto componentsTypeIt = componentIt->value.FindMember(PrefabDomUtils::TypeName);
+                        if (componentsTypeIt == componentIt->value.MemberEnd() || !componentsTypeIt->value.IsString())
                         {
-                            containerEntityAlias = containerEntityAliasIt->value.GetString();
+                            result = false;
+                            AZStd::string componentName = componentIt->name.GetString();
+                            AZ_Error("Prefab", false, "'%s' lacks '$type' sub-object in a component object of Entity (%s, '%s').",
+                                path.c_str(), entityAlias.c_str(), entityName.c_str());
+                            continue;
+                        }
+                        
+                        AZStd::string componentAlias(componentsTypeIt->value.GetString());
+                        if (!componentAlias.contains("TransformComponent"))
+                        {
+                            continue;
+                        }
+                        
+                        constexpr const auto parentObjectName = "Parent Entity";
+                        auto parentIt = componentIt->value.FindMember(parentObjectName);
+                        if (parentIt == componentIt->value.MemberEnd() || !parentIt->value.IsString())
+                        {
+                            result = false;
+                            AZ_Error("Prefab", false, "'%s' lacks 'Parent Entity' object in TransformComponent of Entity (%s, '%s').",
+                                path.c_str(), entityAlias.c_str(), entityName.c_str());
+                            break; // one TransformComponent for an Entity -> invalid
                         }
 
-                        const auto entitiesIt = templateDomRef.FindMember(PrefabDomUtils::EntitiesName);
-                        if (entitiesIt != templateDomRef.MemberEnd() && entitiesIt->value.IsObject())
+                        if (AZStd::string(parentIt->value.GetString()).empty()) // parent link empty ?
                         {
-                            for (auto entityIt = entitiesIt->value.MemberBegin(); entityIt != entitiesIt->value.MemberEnd(); ++entityIt)
-                            {
-                                const auto componentsIt = entityIt->value.FindMember(PrefabDomUtils::ComponentsName);
-                                if (componentsIt != entityIt->value.MemberEnd() && componentsIt->value.IsObject())
-                                {
-                                    for (auto componentIt = componentsIt->value.MemberBegin();
-                                         componentIt != componentsIt->value.MemberEnd();
-                                         ++componentIt)
-                                    {
-                                        const auto componentsTypeIt = componentIt->value.FindMember(PrefabDomUtils::TypeName);
-                                        if (componentsTypeIt != componentIt->value.MemberEnd() && componentsTypeIt->value.IsString())
-                                        {
-                                            AZStd::string componentAlias(componentsTypeIt->value.GetString());
-                                            if (componentAlias.contains("TransformComponent"))
-                                            {
-                                                constexpr const char* const parentObjectName = "Parent Entity";
-                                                auto parentIt = componentIt->value.FindMember(parentObjectName);
-                                                const bool isFound = parentIt != componentIt->value.MemberEnd();
-                                                if (isFound && parentIt->value.IsString())
-                                                {
-                                                    if (AZStd::string(parentIt->value.GetString()).empty())
-                                                    {
-                                                        auto value = rapidjson::StringRef(containerEntityAlias.c_str());
-                                                        parentIt->value.SetString(value, templateDomRef.GetAllocator());
-                                                        result = false;
-                                                        // Get descriptive information for error logging
-                                                        AZStd::string entityAlias;
-                                                        const auto entityAliasIt = entityIt->value.FindMember(PrefabDomUtils::EntityIdName);
-                                                        if (entityAliasIt != entityIt->value.MemberEnd() && entityAliasIt->value.IsString())
-                                                        {
-                                                            entityAlias = entityAliasIt->value.GetString();
-                                                        }
-                                                        AZStd::string entityName;
-                                                        const auto entityNameIt = entityIt->value.FindMember("Name");
-                                                        if (entityNameIt != entityIt->value.MemberEnd() && entityNameIt->value.IsString())
-                                                        {
-                                                            entityName = entityNameIt->value.GetString();
-                                                        }
-                                                        const AZStd::string path(sourceIt->value.GetString());
-                                                        AZ_Error(
-                                                            "Prefab",
-                                                            false,
-                                                            "path='%s' has entity (id='%s', name='%s') with invalid patent, reset to the "
-                                                            "root "
-                                                            "'%s' entity.",
-                                                            path.c_str(),
-                                                            entityAlias.c_str(),
-                                                            entityName.c_str(),
-                                                            containerEntityAlias.c_str());
-                                                    }
-                                                }
-                                                break; // a TransformComponent object evaluated
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            // Re-link this entity under the ContainerEntity using its Alias
+                            parentIt->value.SetString(rapidjson::StringRef(containerEntityAlias.c_str()), templateDomRef.GetAllocator());
+
+                            result = false; // report that changes were needed and made 
+                            AZ_Error("Prefab", false,
+                                "'%s' lacks 'Parent Entity' value in TransformComponent of Entity (%s, '%s')"
+                                "\nEntity re-linked under the root container '%s'.",
+                                path.c_str(), entityAlias.c_str(), entityName.c_str(), containerEntityAlias.c_str());
                         }
+                        break; // single TransformComponent for an Entity -> evaluated
                     }
                 }
                 return result;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -224,7 +224,7 @@ namespace AzToolsFramework
                 PrefabDomValueConstReference nestedInstanceDom = AZStd::nullopt);
 
             //! Runs through PrefabDom structure analyzing its general correctness, and checks that
-            //! nested entity objects have non-empty parent values in their TransformComoponents.
+            //! nested entity objects have non-empty parent values in their TransformComponents.
             //! Logs errors found.
             //! In case a nested entity object has the empty parent alias, reassigns the container entity alias as the parent.
             //! This may happen, for example, when loading a spoiled prefab stored with earlier O3DE versions.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -223,12 +223,14 @@ namespace AzToolsFramework
                 const InstanceAlias& nestedInstanceAlias,
                 PrefabDomValueConstReference nestedInstanceDom = AZStd::nullopt);
 
-            //! Checks the provided PrefabDom checking that nested entity objects do have valid parents in TransformComoponents.
-            //! In case a nested entity object has invalid parent, then assign the container entity as parent.
-            //! This may happen, for example, when loading a spoiled prefab stored with early O3DE versions.
+            //! Runs through PrefabDom structure analyzing its general correctness, and checks that
+            //! nested entity objects have non-empty parent values in their TransformComoponents.
+            //! Logs errors found.
+            //! In case a nested entity object has the empty parent alias, reassigns the container entity alias as the parent.
+            //! This may happen, for example, when loading a spoiled prefab stored with earlier O3DE versions.
             //! @param prefabDom The prefab DOM to check and conditionally update. Changes will be applied in place.
-            //! @return True if checks were successful, false if a parent statement is updated with logging an error.
-            bool CheckEntitiesParents(PrefabDom& prefabDom);
+            //! @return True if all checks were successful, otherwise false. 
+            bool SubstituteInvalidParentsInEntities(PrefabDom& prefabDom);
 
             //! An empty struct for passing to JsonSerializerSettings.m_metadata that is consumed by InstanceSerializer::Store.
             //! If present in metadata, linkIds will be stored to instance dom.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -215,13 +215,20 @@ namespace AzToolsFramework
             AZStd::string PrefabDomValueToString(const PrefabDomValue& prefabDomValue);
 
             //! Adds a nested instance to the prefab DOM and optionally initialize its contents.
-            //! @param prefabDom The prefab DOM to udpate.
+            //! @param prefabDom The prefab DOM to update.
             //! @param nestedInstanceAlias The alias of the nested instance to be added.
             //! @param nestedInstanceDom An optional value to assign to the added nested instance in the prefab DOM.
             void AddNestedInstance(
                 PrefabDom& prefabDom,
                 const InstanceAlias& nestedInstanceAlias,
                 PrefabDomValueConstReference nestedInstanceDom = AZStd::nullopt);
+
+            //! Checks the provided PrefabDom checking that nested entity objects do have valid parents in TransformComoponents.
+            //! In case a nested entity object has invalid parent, then assign the container entity as parent.
+            //! This may happen, for example, when loading a spoiled prefab stored with early O3DE versions.
+            //! @param prefabDom The prefab DOM to check and conditionally update. Changes will be applied in place.
+            //! @return True if checks were successful, false if a parent statement is updated with logging an error.
+            bool CheckEntitiesParents(PrefabDom& prefabDom);
 
             //! An empty struct for passing to JsonSerializerSettings.m_metadata that is consumed by InstanceSerializer::Store.
             //! If present in metadata, linkIds will be stored to instance dom.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
@@ -606,7 +606,7 @@ namespace AzToolsFramework
             PrefabDom& loadedTemplateDomRef = loadedTemplateDom->get();
 
             // first, check and fix prefabs which could be previously stored with invalid entities' parents (GHI #11500)
-            PrefabDomUtils::CheckEntitiesParents(loadedTemplateDomRef);
+            PrefabDomUtils::SubstituteInvalidParentsInEntities(loadedTemplateDomRef);
 
             // second, decode the template DOM into actual Instance data.  This will actually create real
             // C++ classes for the instances in the template DOM and fill their member properties with the

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
@@ -605,7 +605,10 @@ namespace AzToolsFramework
 
             PrefabDom& loadedTemplateDomRef = loadedTemplateDom->get();
 
-            // first, decode the template DOM into actual Instance data.  This will actually create real
+            // first, check and fix prefabs which could be previously stored with invalid entities' parents (GHI #11500)
+            PrefabDomUtils::CheckEntitiesParents(loadedTemplateDomRef);
+
+            // second, decode the template DOM into actual Instance data.  This will actually create real
             // C++ classes for the instances in the template DOM and fill their member properties with the
             // properties from the DOM.
             Instance loadedPrefabInstance;


### PR DESCRIPTION
## What does this PR do?

Fixes one consequence of the issue #11500:

With earlier code prefabs could be saved with "torn-off" Entities having a TrackView `EditorSeqenceComponrnt`: 
with a spoiled (empty) "Parent Entity" sentence in the `TransformComponent` of this entity.
Such prefab is still loaded wrongly with the current code without even warning, which seems not very user - friendly.
 
This optional fix:
* Adds checks for "Parent Entity" sentences in the "Entities" container of a prefab being loaded;
* When an empty parent statement is found, reports error and links the entity to the `ContainerEntity` of the prefab;
* In case a user resaves this PR, it will be finally fixed.

In most practical cases the AssetBuilder now will deserialize a buggy `prefab` into a correct `spawnable` (with error report).

This PR is optional, but I remember that similar problems with "torn-off" entities made porting of LY slices into prefabs very difficult (especially for levels), so I dared to spend some (minimal) time to implement this.

## How was this PR tested?
Saved (and artificially) broken prefabs with the linked `Camera2` and `Sequence` entities evaluated by AssetProcessor and loaded into Editor under Windows:
* expected error report noted both in AssetProcessor and Editor;
* loaded prefabs had correct structure;
* in case of resaving a previously broken prefab, it is fixed.
