### PR TITLE
Vulkan RHI: HDR Support

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -80,6 +80,7 @@ namespace AZ
 #if defined(AZ_VULKAN_USE_DEBUG_LABELS)
             m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 #endif
+            m_descriptor.m_optionalExtensions.push_back(VK_EXT_HDR_METADATA_EXTENSION_NAME);
 
             uint32_t appApiVersion = VK_API_VERSION_1_0;
             m_instanceVersion = VK_API_VERSION_1_0;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -394,7 +394,9 @@ namespace AZ
             hdrMetadata.displayPrimaryGreen = {Chroma.GreenX, Chroma.GreenY};
             hdrMetadata.displayPrimaryBlue = {Chroma.BlueX, Chroma.BlueY};
             hdrMetadata.whitePoint = {Chroma.WhiteX, Chroma.WhiteY};
-            hdrMetadata.maxLuminance = maxOutputNits; // * 10000.0f;
+            //Mult. by 10,000 because its what VKD3D does
+            //https://github.com/HansKristian-Work/vkd3d-proton/blob/8165096180a9019542b693ce1fcb80f44433b1e2/libs/vkd3d/swapchain.c#L866C36-L866C57
+            hdrMetadata.maxLuminance = maxOutputNits * 10000.0f;
             hdrMetadata.minLuminance = minOutputNits;
             hdrMetadata.maxContentLightLevel = maxContentLightLevel;
             hdrMetadata.maxFrameAverageLightLevel = maxFrameAverageLightLevel;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -349,7 +349,8 @@ namespace AZ
         }
 
         void SwapChain::SetHDRMetaData(float maxOutputNits, float minOutputNits, float maxContentLightLevel,
-            float maxFrameAverageLightLevel) {
+            float maxFrameAverageLightLevel)
+        {
             auto& device = static_cast<Device&>(GetDevice());
 
             //From DX12 RHI

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -70,7 +70,6 @@ namespace AZ
             void SetVerticalSyncIntervalInternal(uint32_t previousVsyncInterval) override;
             //////////////////////////////////////////////////////////////////////
 
-            void DisableHdr();
             void SetHDRMetaData(float maxOutputNits, float minOutputNits, float maxContentLightLevel, float maxFrameAverageLightLevel);
 
             RHI::ResultCode BuildSurface(const RHI::SwapChainDescriptor& descriptor);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -114,7 +114,7 @@ namespace AZ
             VkSurfaceFormatKHR m_surfaceFormat = {};
             VkSurfaceCapabilitiesKHR m_surfaceCapabilities = {};
             VkPresentModeKHR m_presentMode = {};
-            VkCompositeAlphaFlagBitsKHR m_compositeAlphaFlagBits = {}; 
+            VkCompositeAlphaFlagBitsKHR m_compositeAlphaFlagBits = {};
             AZStd::vector<VkImage> m_swapchainNativeImages;
             RHI::SwapChainDimensions m_dimensions;
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -70,6 +70,9 @@ namespace AZ
             void SetVerticalSyncIntervalInternal(uint32_t previousVsyncInterval) override;
             //////////////////////////////////////////////////////////////////////
 
+            void DisableHdr();
+            void SetHDRMetaData(float maxOutputNits, float minOutputNits, float maxContentLightLevel, float maxFrameAverageLightLevel);
+
             RHI::ResultCode BuildSurface(const RHI::SwapChainDescriptor& descriptor);
 
             //! Returns true is the swapchain dimensions are supported by the current surface.
@@ -99,6 +102,8 @@ namespace AZ
             void InvalidateSurface();
             //! Destroy the swapchain.
             void InvalidateNativeSwapChain(VkSwapchainKHR swapchain);
+
+            VkColorSpaceKHR m_colorSpace = VK_COLOR_SPACE_MAX_ENUM_KHR;
 
             RHI::Ptr<WSISurface> m_surface;
             VkSwapchainKHR m_nativeSwapChain = VK_NULL_HANDLE;


### PR DESCRIPTION
## What does this PR do?
This adds initial support for HDR output on the Vulkan RHI, the same amount of support as the DX12 RHI.

This should be possible even though there isn't a direct P2020 color space available in Vulkan as [VKD3D](https://github.com/HansKristian-Work/vkd3d-proton) can handle
displaying DX12 games using that color space (by the looks of it) just fine.
You can see some parts on how this is handled:
 - Converting the DX12 color space enum: [here](https://github.com/HansKristian-Work/vkd3d-proton/blob/b5696e19c4b22b1c341a78391d9618acf8e004ff/libs/vkd3d/swapchain.c#L1496)
 - Converting the DX12 HDR metadata: [here](https://github.com/HansKristian-Work/vkd3d-proton/blob/b5696e19c4b22b1c341a78391d9618acf8e004ff/libs/vkd3d/swapchain.c#L859)

## How was this PR tested?
- Distro: Fedora KDE Spin 41
- Enabled HDR on my main monitor
- Launched the GameLauncher with the env var `ENABLE_HDR_WSI=1` to enable the vulkan extension for HDR metadata. 

You do need to use the wayland-hdr branch on my fork for this to work on Linux and a Wayland compositor with support for HDR.