### PR TITLE
Fix a compile error with Clang on Windows in Release build

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_win.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_win.cpp
@@ -29,7 +29,7 @@ namespace AzQtComponents
 
     namespace
     {
-        std::string GetLastErrorString()
+        [[maybe_unused]] std::string GetLastErrorString()
         {
             DWORD error = GetLastError();
             if (!error)


### PR DESCRIPTION
## What does this PR do?

This PR fixes a compile error that occurs when compiling the engine with Clang on Windows in a release build. The locally defined function `GetLastErrorString()` is only used as parameter to `AZ_Assert`, meaning it is not called in release builds, which leads to a unused function warning.

## How was this PR tested?

Compile with Clang on Windows with Release configuration
