### PR TITLE
Vulkan: Allocate only one queue per queue family.

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -143,6 +143,10 @@ namespace AZ
                 m_supportedPipelineStageFlagsMask &= ~(VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT | VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT);
             }
 
+            static_assert(
+                AZStd::to_underlying(RHI::HardwareQueueClass::Count) == 3,
+                "Vulkan queue selection needs to be updated when new hardware queue classes are introduced.");
+
             int graphicsFamilyIndex = -1;
             int computeFamilyIndex = -1;
             int transferFamilyIndex = -1;


### PR DESCRIPTION
## What does this PR do?

Currently, the Vulkan backend allocates as many queues as reported to be available in each queue family (`Device::InitInternal` in Vulkan's `Device.cpp:162`) while only needing 3, maybe (but unlikely) 4 queues: a graphics, a compute and a transfer queue (`CommandQueueContext::BuildQueues`) and a queue to present on, which if one of the first three supports it as usually is the case, that one is used (`CommandQueueContext::GetOrCreatePresentationCommandQueue`).

The issue is that on my 4090 (https://vulkan.gpuinfo.org/displayreport.php?id=35268#queuefamilies) this creates 30 queues and if I now increase the device count to get multiple logical devices, it fails to allocate a 6th device already as apparently the nvidia driver has a hard limit on how many queues can be created (for 6 it would be 6*30=180 queues already).

This patch changes the number of queues allocated per queue family to 1 and thus on my 4090 only 6 queues get allocated. Still not perfect as 3 would be enough, but the code accomplishing that would be more involved than this quick fix. This allows me to have 28 of potentially 32 devices (the device mask is 32 bit, so we are limited to 32). Based on that, the number of allowed queues with the nvidia driver is between 168 and 173 (as with 29 devices, 6*29=174 queues it fails).

I am not sure what happens if less than 3 fitting queue families are available, which is usually the case on mobile. I can see how a Quest 3 (https://vulkan.gpuinfo.org/displayreport.php?id=35245) would work before this change with 3 queues in that one queue family, which could potentially fail now with just one queue allocated from that family. However, how does it work on other phones (e.g., even a Pixel 9 Pro only has 2 queues in 1 family available: https://vulkan.gpuinfo.org/displayreport.php?id=33450#queuefamilies) with less than 3 queues available?

## How was this PR tested?

I ran the ASV with various numbers after the ` --device-count ` parameter, e.g., `--device-count 28`.
