### PR TITLE
Bugfix: linking on Linux doesn't work.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/IShaderVariantFinder.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/IShaderVariantFinder.h
@@ -108,4 +108,4 @@ namespace AZ
     } // namespace RPI
 }// namespace AZ
 
-DECLARE_EBUS_EXTERN(RPI::ShaderVariantFinderNotification);
+DECLARE_EBUS_EXTERN_DLL_MULTI_ADDRESS(RPI::ShaderVariantFinderNotification);

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
@@ -21,7 +21,7 @@
 #include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 
-DECLARE_EBUS_INSTANTIATION(RPI::ShaderVariantFinderNotification);
+DECLARE_EBUS_INSTANTIATION_DLL_MULTI_ADDRESS(RPI::ShaderVariantFinderNotification);
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

Fixes a linking error for the `ShaderVariantFinderNotification` ebus introduced after #18427.

## How was this PR tested?

Build the engine.