### PR TITLE
Track View: Fix issues #2833 and #4590, - add switching cameras in the Editor Viewport according to a Director track keys setup.

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -275,7 +275,18 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
 // SequenceComponentNotificationBus overrider: called when a Sequence changes camera during playback in Track View.
 void CAnimationContext::OnCameraChanged([[maybe_unused]] const AZ::EntityId& oldCameraEntityId, const AZ::EntityId& newCameraEntityId)
 {
-    // Switch camera in Editor Viewport Widget to the newCameraEntityId
+    const auto sequence = GetSequence();
+    IMovieSystem* movieSystem = AZ::Interface<IMovieSystem>::Get();
+    if (!sequence || !movieSystem)
+    {
+        return;
+    }
+    const auto animSequence = movieSystem->FindSequenceById(sequence->GetCryMovieId());
+    if (!animSequence || ((animSequence->GetFlags() & IAnimSequence::eSeqFlags_PlayOnReset) == 0))
+    {
+        return;
+    }
+    // The "Autostart" flag is set for the active sequence, so switch camera in Editor Viewport Widget to the newCameraEntityId
     Camera::EditorCameraRequestBus::Broadcast(&Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, newCameraEntityId);
 }
 

--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -175,6 +175,9 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
         return;
     }
 
+    // Restore initial Editor Viewport camera EntityId
+    Camera::EditorCameraRequestBus::Broadcast(&Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, m_viewCameraEntityId);
+
     // Prevent keys being created from time change
     const bool bRecording = m_recording;
     m_recording = false;
@@ -227,6 +230,9 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
         // Set the last valid sequence that was selected.
         m_mostRecentSequenceId = m_pSequence->GetSequenceComponentEntityId();
 
+        // Get ready to handle camera switching in this sequence, if ever, in order to switch camera in Editor Viewport Widget
+        Maestro::SequenceComponentNotificationBus::Handler::BusConnect(m_mostRecentSequenceId);
+
         if (m_playing)
         {
             m_pSequence->BeginCutScene(true);
@@ -239,8 +245,6 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
         m_pSequence->PrecacheData(newSeqStartTime);
 
         m_pSequence->BindToEditorObjects();
-        // Get ready to handle camera switching in this sequence, if ever, in order to switch camera in Editor Viewport Widget
-        Maestro::SequenceComponentNotificationBus::Handler::BusConnect(m_mostRecentSequenceId);
     }
     else if (user)
     {
@@ -265,9 +269,6 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
 
     m_recording = bRecording;
     SetRecordingInternal(bRecording);
-
-    // restore initial Editor Viewport camera EntityId
-    Camera::EditorCameraRequestBus::Broadcast(&Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, m_viewCameraEntityId);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -176,7 +176,7 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
     }
 
     // Restore initial Editor Viewport camera EntityId
-    Camera::EditorCameraRequestBus::Broadcast(&Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, m_viewCameraEntityId);
+    OnCameraChanged(AZ::EntityId(), GetStoredViewCameraEntityId());
 
     // Prevent keys being created from time change
     const bool bRecording = m_recording;
@@ -286,7 +286,14 @@ void CAnimationContext::OnCameraChanged([[maybe_unused]] const AZ::EntityId& old
     {
         return;
     }
-    // The "Autostart" flag is set for the active sequence, so switch camera in Editor Viewport Widget to the newCameraEntityId
+    const auto editor = GetIEditor();
+    if (!editor || editor->IsInGameMode() || editor->IsInPreviewMode() || editor->IsInSimulationMode() || editor->IsInConsolewMode() ||
+        editor->IsInTestMode() || editor->IsInLevelLoadTestMode())
+    {
+        return;
+    }
+    // The Editor is in editing mode and the "Autostart" flag is set for the active sequence,
+    // so switch camera in Editor Viewport Widget to the newCameraEntityId
     Camera::EditorCameraRequestBus::Broadcast(&Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, newCameraEntityId);
 }
 

--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -195,8 +195,8 @@ public:
 
     /**
      * The SequenceComponentNotificationBus overrider.
-     * Switch camera in an active Editor Viewport Widget to the newCameraEntityId,
-     * only in editing mode, and only when the "Autostart" flag is set for an active sequence.
+     * Switch camera in the active Editor Viewport Widget to the newCameraEntityId,
+     * only in editing mode and only when the "Autostart" flag is set for an active sequence.
      */
     void OnCameraChanged([[maybe_unused]] const AZ::EntityId& oldCameraEntityId, const AZ::EntityId& newCameraEntityId) override;
 

--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -193,6 +193,13 @@ public:
      */
     AZ::EntityId GetStoredViewCameraEntityId() const { return m_viewCameraEntityId; }
 
+    /**
+     * The SequenceComponentNotificationBus overrider.
+     * Switch camera in an active Editor Viewport Widget to the newCameraEntityId,
+     * only in editing mode, and only when the "Autostart" flag is set for an active sequence.
+     */
+    void OnCameraChanged([[maybe_unused]] const AZ::EntityId& oldCameraEntityId, const AZ::EntityId& newCameraEntityId) override;
+
 private:
     static void GoToFrameCmd(IConsoleCmdArgs* pArgs);
 
@@ -210,9 +217,6 @@ private:
     void AnimateActiveSequence();
 
     void SetRecordingInternal(bool enableRecording);
-
-    // SequenceComponentNotificationBus
-    void OnCameraChanged([[maybe_unused]] const AZ::EntityId& oldCameraEntityId, const AZ::EntityId& newCameraEntityId) override;
 
     //! Current time within active animation sequence.
     float m_currTime;

--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -17,6 +17,8 @@
 #include <Range.h>
 #include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
 
+#include <CryCommon/Maestro/Bus/SequenceComponentBus.h>
+
 struct IMovieSystem;
 class CTrackViewSequence;
 
@@ -37,6 +39,8 @@ class CAnimationContext
     , public IUndoManagerListener
     , public ITrackViewSequenceManagerListener
     , public AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
+    , public Maestro::SequenceComponentNotificationBus::Handler
+
 {
 public:
     //////////////////////////////////////////////////////////////////////////
@@ -133,7 +137,7 @@ public:
     */
     void SetResetTime(float t) {m_resetTime = t; };
 
-    /** Start animation recorduing.
+    /** Start animation recording.
         Automatically stop playing.
         @param recording True to start recording, false to stop.
     */
@@ -184,6 +188,11 @@ public:
     */
     void OnSequenceActivated(AZ::EntityId entityId);
 
+    /** Get stored entity ID of a camera in an active editor viewport at the moment a sequence was activated
+     *  (invalid if the default editor camera was used).
+     */
+    AZ::EntityId GetStoredViewCameraEntityId() const { return m_viewCameraEntityId; }
+
 private:
     static void GoToFrameCmd(IConsoleCmdArgs* pArgs);
 
@@ -201,6 +210,9 @@ private:
     void AnimateActiveSequence();
 
     void SetRecordingInternal(bool enableRecording);
+
+    // SequenceComponentNotificationBus
+    void OnCameraChanged([[maybe_unused]] const AZ::EntityId& oldCameraEntityId, const AZ::EntityId& newCameraEntityId) override;
 
     //! Current time within active animation sequence.
     float m_currTime;
@@ -227,6 +239,10 @@ private:
     Range m_timeRange;
 
     Range m_timeMarker;
+
+    //! An entity ID of a current camera in an active editor viewport, at the moment a sequence is activated,
+    //! or invalid if the default editor camera is used at the moment.
+    AZ::EntityId m_viewCameraEntityId = AZ::EntityId();
 
     //! Currently active animation sequence.
     CTrackViewSequence* m_pSequence;

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -3028,20 +3028,6 @@ void CCryEditApp::OnToolsPreferences()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnSwitchToDefaultCamera()
-{
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnUpdateSwitchToDefaultCamera(QAction* action)
-{
-    Q_ASSERT(action->isCheckable());
-    {
-        action->setEnabled(false);
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
 void CCryEditApp::OnSwitchToSequenceCamera()
 {
 }

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -355,8 +355,6 @@ private:
     void OnDisplayGotoPosition();
     void OnFileSavelevelresources();
     void OnClearRegistryData();
-    void OnSwitchToDefaultCamera();
-    void OnUpdateSwitchToDefaultCamera(QAction* action);
     void OnSwitchToSequenceCamera();
     void OnUpdateSwitchToSequenceCamera(QAction* action);
     void OnSwitchToSelectedcamera();

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -272,7 +272,7 @@ void EditorViewportWidget::resizeEvent(QResizeEvent* event)
 
     // In the case of the default viewport camera, we must re-set the FOV, which also updates the aspect ratio
     // Component cameras hand this themselves
-    if (m_viewSourceType == ViewSourceType::None)
+    if (!m_viewEntityId.IsValid())
     {
         SetFOV(GetFOV());
     }
@@ -544,7 +544,7 @@ void EditorViewportWidget::PostCameraSet()
     // Special case in the editor; if the camera is the default editor camera,
     // notify that the active view changed. In game mode, it is a hard error to not have
     // any cameras on the view stack!
-    if (m_viewSourceType == ViewSourceType::None)
+    if (!m_viewEntityId.IsValid())
     {
         m_sendingOnActiveChanged = true;
         Camera::CameraNotificationBus::Broadcast(&Camera::CameraNotificationBus::Events::OnActiveViewChanged, AZ::EntityId());
@@ -848,7 +848,7 @@ void EditorViewportWidget::SetViewportId(int id)
     m_perspectiveChangeHandler = SandboxEditor::PerspectiveChangedEvent::Handler(
         [this](const float fovRadians)
         {
-            if (m_viewSourceType == ViewSourceType::None)
+            if (!m_viewEntityId.IsValid())
             {
                 if (m_viewPane)
                 {
@@ -1054,7 +1054,7 @@ bool EditorViewportWidget::AddCameraMenuItems(QMenu* menu)
 
     QAction* action = customCameraMenu->addAction("Editor Camera");
     action->setCheckable(true);
-    action->setChecked(m_viewSourceType == ViewSourceType::None);
+    action->setChecked(!m_viewEntityId.IsValid());
     connect(action, &QAction::triggered, this, &EditorViewportWidget::SetDefaultCamera);
 
     AZ::EBusAggregateResults<AZ::EntityId> getCameraResults;
@@ -1070,7 +1070,7 @@ bool EditorViewportWidget::AddCameraMenuItems(QMenu* menu)
         action = new QAction(QString(entityName.c_str()), nullptr);
         additionalCameras.append(action);
         action->setCheckable(true);
-        action->setChecked(m_viewEntityId == entityId && m_viewSourceType == ViewSourceType::CameraComponent);
+        action->setChecked(m_viewEntityId == entityId && m_viewEntityId.IsValid());
         connect(
             action, &QAction::triggered, this,
             [this, entityId](bool isChecked)
@@ -1193,7 +1193,7 @@ const Matrix34& EditorViewportWidget::GetViewTM() const
 AZ::EntityId EditorViewportWidget::GetCurrentViewEntityId()
 {
     // Sanity check that this camera entity ID is actually the camera entity which owns the current active render view
-    if (m_viewSourceType == ViewSourceType::CameraComponent)
+    if (m_viewEntityId.IsValid())
     {
         // Check that the current view is the same view as the view entity view
         AZ::RPI::ViewPtr viewEntityView;
@@ -1483,7 +1483,6 @@ void EditorViewportWidget::OnActiveViewChanged(const AZ::EntityId& viewEntityId)
             "Please report this as a bug.");
 
         m_viewEntityId = viewEntityId;
-        m_viewSourceType = ViewSourceType::CameraComponent;
         AZStd::string entityName;
         AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, viewEntityId);
         SetName(QString("Camera entity: %1").arg(entityName.c_str()));
@@ -1506,7 +1505,6 @@ void EditorViewportWidget::SetDefaultCamera()
     }
 
     m_viewEntityId.SetInvalid();
-    m_viewSourceType = ViewSourceType::None;
     SetName(m_defaultViewName);
 
     // synchronize the configured editor viewport FOV to the default camera
@@ -1543,7 +1541,7 @@ void EditorViewportWidget::SetDefaultCameraNearFar()
 
 void EditorViewportWidget::OnDefaultCameraNearFarChanged()
 {
-    if (m_viewSourceType == ViewSourceType::None)
+    if (!m_viewEntityId.IsValid())
     {
         SetDefaultCameraNearFar();
     }
@@ -1608,7 +1606,7 @@ bool EditorViewportWidget::IsSelectedCamera() const
     AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
         selectedEntityList, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
 
-    if ((m_viewSourceType == ViewSourceType::CameraComponent) && !selectedEntityList.empty() &&
+    if (m_viewEntityId.IsValid() && !selectedEntityList.empty() &&
         AZStd::find(selectedEntityList.begin(), selectedEntityList.end(), m_viewEntityId) != selectedEntityList.end())
     {
         return true;
@@ -1620,38 +1618,27 @@ bool EditorViewportWidget::IsSelectedCamera() const
 //////////////////////////////////////////////////////////////////////////
 void EditorViewportWidget::CycleCamera()
 {
-    // None -> Sequence -> LegacyCamera -> ... LegacyCamera -> CameraComponent -> ... CameraComponent -> None
-    // AZ_Entity has been intentionally left out of the cycle for now.
-    switch (m_viewSourceType)
+    // None (default editor camera) -> CameraComponent (added editor camera component) -> ... CameraComponent -> None
+    if (!m_viewEntityId.IsValid())
     {
-    case EditorViewportWidget::ViewSourceType::None:
+        SetFirstComponentCamera();
+        return;
+    }
+    {
+        AZ::EBusAggregateResults<AZ::EntityId> results;
+        Camera::CameraBus::BroadcastResult(results, &Camera::CameraRequests::GetCameras);
+        AZStd::sort_heap(results.values.begin(), results.values.end());
+        auto&& currentCameraIterator = AZStd::find(results.values.begin(), results.values.end(), m_viewEntityId);
+        if (currentCameraIterator != results.values.end())
         {
-            SetFirstComponentCamera();
-            break;
-        }
-    case EditorViewportWidget::ViewSourceType::CameraComponent:
-        {
-            AZ::EBusAggregateResults<AZ::EntityId> results;
-            Camera::CameraBus::BroadcastResult(results, &Camera::CameraRequests::GetCameras);
-            AZStd::sort_heap(results.values.begin(), results.values.end());
-            auto&& currentCameraIterator = AZStd::find(results.values.begin(), results.values.end(), m_viewEntityId);
+            ++currentCameraIterator;
             if (currentCameraIterator != results.values.end())
             {
-                ++currentCameraIterator;
-                if (currentCameraIterator != results.values.end())
-                {
-                    SetEntityAsCamera(*currentCameraIterator);
-                    break;
-                }
+                SetEntityAsCamera(*currentCameraIterator);
+                return;
             }
-            SetDefaultCamera();
-            break;
         }
-    default:
-        {
-            SetDefaultCamera();
-            break;
-        }
+        SetDefaultCamera();
     }
 }
 

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -130,13 +130,6 @@ private:
     ////////////////////////////////////////////////////////////////////////
     // Private types ...
 
-    enum class ViewSourceType
-    {
-        None,
-        CameraComponent,
-        ViewSourceTypesCount,
-    };
-
     enum class PlayInEditorState
     {
         Editor,
@@ -324,9 +317,6 @@ private:
 
     // The entity ID of the current camera for this viewport, or invalid if the default editor camera
     AZ::EntityId m_viewEntityId;
-
-    // Determines also if the current camera for this viewport is default editor camera
-    ViewSourceType m_viewSourceType = ViewSourceType::None;
 
     // During play game in editor, holds the editor entity ID of the last
     AZ::EntityId m_viewEntityIdCachedForEditMode;

--- a/Code/Editor/TrackView/TVSequenceProps.cpp
+++ b/Code/Editor/TrackView/TVSequenceProps.cpp
@@ -169,6 +169,10 @@ void CTVSequenceProps::UpdateSequenceProps(const QString& name)
     else
     {
         seqFlags &= ~IAnimSequence::eSeqFlags_PlayOnReset;
+        if (ac)
+        {
+            ac->OnCameraChanged(AZ::EntityId(), ac->GetStoredViewCameraEntityId()); // Restore camera in the active Editor Viewport
+        }
     }
 
     if (ui->CUT_SCENE->isChecked())

--- a/Code/Editor/TrackView/TVSequenceProps.cpp
+++ b/Code/Editor/TrackView/TVSequenceProps.cpp
@@ -169,10 +169,6 @@ void CTVSequenceProps::UpdateSequenceProps(const QString& name)
     else
     {
         seqFlags &= ~IAnimSequence::eSeqFlags_PlayOnReset;
-        if (ac)
-        {
-            ac->OnCameraChanged(AZ::EntityId(), ac->GetStoredViewCameraEntityId()); // Restore camera in the active Editor Viewport
-        }
     }
 
     if (ui->CUT_SCENE->isChecked())

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -1156,6 +1156,7 @@ void CTrackViewDialog::ReloadSequencesComboBox()
         m_sequencesComboBox->setCurrentIndex(0);
     }
     m_sequencesComboBox->blockSignals(false);
+    InvalidateSequence();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -917,14 +917,16 @@ void CTrackViewDialog::Update()
                 m_activeCamStatic->setText(entity->GetName().c_str());
                 cameraNameSet = true;
 
-                // A corner case when reloaded: prepare manually scrubbing this sequence with time = 0.0f and a Camera key at 0.0f
-                if (wasReloading && fabs(fTime) < AZ::Constants::Tolerance)
+                // Evaluate the corner case when the sequence is reloaded and the "Autostart" flag is set for the sequence:
+                // prepare to manually scrub this sequence if time == 0.0 and a Camera key exists at 0.0:
+                if (wasReloading && (fabs(fTime) < AZ::Constants::Tolerance) &&
+                    ((animSequence->GetFlags() & IAnimSequence::eSeqFlags_PlayOnReset) != 0))
                 {
                     AZ::EntityId currentEditorViewportCamId;
-                    Camera::EditorCameraRequestBus::BroadcastResult(
-                        currentEditorViewportCamId, &Camera::EditorCameraRequestBus::Events::GetCurrentViewEntityId);
-                    if (currentEditorViewportCamId != camId)
+                    Camera::EditorCameraRequestBus::BroadcastResult(currentEditorViewportCamId, &Camera::EditorCameraRequestBus::Events::GetCurrentViewEntityId);
+                    if (currentEditorViewportCamId != camId) // ... if camera has not been already switched ...
                     {
+                        // ... switch camera in Editor Viewport Widget to the CameraComponent with the EntityId from this key.
                         Camera::EditorCameraRequestBus::Broadcast(
                             &Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, camId);
                     }

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -918,17 +918,12 @@ void CTrackViewDialog::Update()
                 cameraNameSet = true;
 
                 // Evaluate the corner case when the sequence is reloaded and the "Autostart" flag is set for the sequence:
-                // prepare to manually scrub this sequence if time == 0.0 and a Camera key exists at 0.0:
-                if (wasReloading && (fabs(fTime) < AZ::Constants::Tolerance) &&
-                    ((animSequence->GetFlags() & IAnimSequence::eSeqFlags_PlayOnReset) != 0))
+                // prepare to manually scrub this sequence if the "Autostart" flag is set.
+                if (wasReloading && ((animSequence->GetFlags() & IAnimSequence::eSeqFlags_PlayOnReset) != 0))
                 {
-                    AZ::EntityId currentEditorViewportCamId;
-                    Camera::EditorCameraRequestBus::BroadcastResult(currentEditorViewportCamId, &Camera::EditorCameraRequestBus::Events::GetCurrentViewEntityId);
-                    if (currentEditorViewportCamId != camId) // ... if camera has not been already switched ...
-                    {
-                        // ... switch camera in Editor Viewport Widget to the CameraComponent with the EntityId from this key.
-                        pAnimationContext->OnCameraChanged(AZ::EntityId(), camId);
-                    }
+                    // Try to switch camera in the Editor Viewport Widget to the CameraComponent with the EntityId from this key,
+                    // works only in Editing mode (checked in the called method).
+                    pAnimationContext->SwitchEditorViewportCamera(camId);
                 }
             }
         }
@@ -1478,8 +1473,6 @@ void CTrackViewDialog::OnStopHardReset()
         sequence->ResetHard();
     }
     UpdateActions();
-    // Restore initial Editor Viewport camera EntityId
-    pAnimationContext->OnCameraChanged(AZ::EntityId(), pAnimationContext->GetStoredViewCameraEntityId());
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -2263,10 +2256,6 @@ void CTrackViewDialog::OnSequenceSettingsChanged(CTrackViewSequence* sequence)
 //////////////////////////////////////////////////////////////////////////
 void CTrackViewDialog::OnSequenceAdded([[maybe_unused]] CTrackViewSequence* sequence)
 {
-    // Restore initial Editor Viewport camera EntityId
-    const auto pAnimationContext = GetIEditor()->GetAnimation();
-    pAnimationContext->OnCameraChanged(AZ::EntityId(), pAnimationContext->GetStoredViewCameraEntityId());
-
     ReloadSequencesComboBox();
     UpdateActions();
 }

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -927,8 +927,7 @@ void CTrackViewDialog::Update()
                     if (currentEditorViewportCamId != camId) // ... if camera has not been already switched ...
                     {
                         // ... switch camera in Editor Viewport Widget to the CameraComponent with the EntityId from this key.
-                        Camera::EditorCameraRequestBus::Broadcast(
-                            &Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, camId);
+                        pAnimationContext->OnCameraChanged(AZ::EntityId(), camId);
                     }
                 }
             }
@@ -1480,8 +1479,7 @@ void CTrackViewDialog::OnStopHardReset()
     }
     UpdateActions();
     // Restore initial Editor Viewport camera EntityId
-    Camera::EditorCameraRequestBus::Broadcast(
-        &Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective, pAnimationContext->GetStoredViewCameraEntityId());
+    pAnimationContext->OnCameraChanged(AZ::EntityId(), pAnimationContext->GetStoredViewCameraEntityId());
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -2266,8 +2264,8 @@ void CTrackViewDialog::OnSequenceSettingsChanged(CTrackViewSequence* sequence)
 void CTrackViewDialog::OnSequenceAdded([[maybe_unused]] CTrackViewSequence* sequence)
 {
     // Restore initial Editor Viewport camera EntityId
-    Camera::EditorCameraRequestBus::Broadcast(&Camera::EditorCameraRequestBus::Events::SetViewFromEntityPerspective,
-        GetIEditor()->GetAnimation()->GetStoredViewCameraEntityId());
+    const auto pAnimationContext = GetIEditor()->GetAnimation();
+    pAnimationContext->OnCameraChanged(AZ::EntityId(), pAnimationContext->GetStoredViewCameraEntityId());
 
     ReloadSequencesComboBox();
     UpdateActions();

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -894,10 +894,10 @@ void CTrackViewDialog::Update()
     }
 
     // Display the name of the active camera in the static control, if any.
-    // The active camera node means at least the following conditions:
+    // Having an active camera means at least the following conditions:
     // 1. The movie system has the Animation Sequence corresponding to the active TrackView Sequence.
     // 2. The Animation Sequence has an active Director node.
-    // 3. The Camera parameters in the movie system are valid.
+    // 3. The current Camera parameters in the movie system are valid.
     // TODO: invalidate the Camera parameters in the movie system when conditions 1 and 2 are not valid.
 
     bool cameraNameSet = false;

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -1128,13 +1128,14 @@ void CTrackViewDialog::ReloadSequencesComboBox()
         {
             CTrackViewSequence* sequence = pSequenceManager->GetSequenceByIndex(k);
             const auto sequenceComponentEntityId = sequence->GetSequenceComponentEntityId();
-            if (sequenceComponentEntityId.IsValid())
+            if (!sequenceComponentEntityId.IsValid())
             {
-                lastIndex = static_cast<int>(k);
-                lastSequenceComponentEntityId = sequenceComponentEntityId;
-                QString entityIdString = GetEntityIdAsString(sequence->GetSequenceComponentEntityId());
-                m_sequencesComboBox->addItem(QString::fromUtf8(sequence->GetName().c_str()), entityIdString);
+                continue;
             }
+            lastIndex = static_cast<int>(k);
+            lastSequenceComponentEntityId = sequenceComponentEntityId;
+            QString entityIdString = GetEntityIdAsString(sequence->GetSequenceComponentEntityId());
+            m_sequencesComboBox->addItem(QString::fromUtf8(sequence->GetName().c_str()), entityIdString);
         }
     }
 

--- a/Code/Editor/TrackViewNewSequenceDialog.cpp
+++ b/Code/Editor/TrackViewNewSequenceDialog.cpp
@@ -48,29 +48,34 @@ class CTVNewSequenceDialogValidator : public QValidator
         {
             constexpr int MaxInputLength = 160;
 
+            SetEnabled(true);
+            SetToolTip("");
+
             if (input.isEmpty())
             {
-                SetEnabled(false);
-                return QValidator::Acceptable;
+                return QValidator::Acceptable; // Allow further editing
             }
 
-            bool isValid = false;
-            SetEnabled(true);
             if (input.contains('/'))
             {
                 SetToolTip("A sequence name cannot contain a '/' character");
+                return QValidator::Invalid; // Undo this change
             }
+
             if (input.length() > MaxInputLength)
             {
                 SetToolTip(QString("A sequence name cannot exceed %1 characters").arg(MaxInputLength).toStdString().c_str());
+                return QValidator::Invalid; // Undo this change
             }
-            else if (input == LIGHT_ANIMATION_SET_NAME)
+
+            bool isValid = true;
+            if (input == LIGHT_ANIMATION_SET_NAME)
             {
                 SetToolTip("The sequence name " LIGHT_ANIMATION_SET_NAME " is reserved.\nPlease choose a different name");
+                isValid = false;
             }
             else
             {
-                bool isNewName = true;
                 for (unsigned int k = 0; k < GetIEditor()->GetSequenceManager()->GetCount(); ++k)
                 {
                     CTrackViewSequence* pSequence = GetIEditor()->GetSequenceManager()->GetSequenceByIndex(k);
@@ -78,27 +83,15 @@ class CTVNewSequenceDialogValidator : public QValidator
 
                     if (fullname.compare(input, Qt::CaseInsensitive) == 0)
                     {
-                        isNewName = false;
+                        isValid = false;
+                        SetToolTip("Sequence with this name already exists");
                         break;
                     }
                 }
-                if (!isNewName)
-                {
-                    SetToolTip("Sequence with this name already exists");
-                }
-                else
-                {
-                    isValid = true;
-                }
             }
 
-            if (isValid)
-            {
-                SetToolTip("");
-                return QValidator::Acceptable;
-            }
-
-            return QValidator::Invalid;
+            SetEnabled(isValid);  // Disable OK button if input is invalid.
+            return QValidator::Acceptable; // Accept the change and allow further name editing even if input is invalid.
         }
 
     private:


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/o3de/o3de/issues/2833
Closes https://github.com/o3de/o3de/issues/4590
Partially fixes: https://github.com/o3de/o3de/issues/5361  -  "The camera does not move when autostarting inEditor" part.
(Whether this issue is fully fixed could be tested after merging the needed PR  https://github.com/o3de/o3de/pull/18544)

#### Preliminary notes:
1. While investigating issues I've encountered a couple of user-unfriendly UI deficiencies, so this PR fixes these, namely:
- None of existing sequences is selected when TrackView dialogue is started;
- When entering a name for a new creating sequence, the name input dialogue counterintuitively blocks text input when the input becomes equal to a name of an existing sequence, instead of disabling the OK button.
2. The PR https://github.com/o3de/o3de/pull/2840, along with other clean-up, refactored `CameraComponent` and `EditorViewportWidget`, meanwhile removing everything related to a `SequenceCamera`, which in previously implemented code was obviously trying to implement the missing functionality requested by the above 2 issues.
In this PR the missing functionality is added mainly by updating code of the CAnimationContext, without re-introducing a `SequenceCamera`.
3. Comments to the PR https://github.com/o3de/o3de/pull/2840 suggested further clean-up of and obsolete or ambiguous code left, but seems like this PR was big enough, and the fact that code pieces suggested to be removed are really obsolete became obvious after the PR changes. So the current PR continues with a small clean-up as a follow-up of the PR https://github.com/o3de/o3de/pull/2840.

#### Missing functionality basing on the target issues:
* Director node camera switches are not applied in editor viewport when scrubbing through the timeline or playing the sequence.

#### Added functionality, see attached screen clip below:
* Director track camera switches now are applied in Editor Viewport when scrubbing through the timeline or playing the sequence, but only when the "Autostart" property for the sequence is set.
* * To disable camera switching in Editor, clear the "Autostart" property in "Edit Sequence: dialogue.  
* * To enable camera switching in Editor, set the "Autostart" property in "Edit Sequence: dialogue,  
* When camera switching is enabled (the "Autostart" property is set), switching Editor Viewport Camera back to the default "Editor Camera" is available with:
* * Selecting (creating) a sequence without active camera keys in Director track in the TrackView dialogue;
* * Using the "Viewport Camera Selector" tool;

* The latest worked-on sequence is automatically selected when starting the TrackView dialogue and / or deleting a sequence in it.
* Input of a new sequence name when creating a new system is not blocked when a symbol making this new name equal to a name of an existing sequence (which is counterintuitive), - the "OK" button is disabled instead.

### Major changes:
In the `CAnimationContext`:
* Handling for `SequenceComponentNotificationBus:OnCameraChanged` event added, 
thus switching camera in Editor Viewport Widget, and then reverting camera in Editor Viewport Widget to the initial one, when needed. This adds mosr of the missing functionality requested by both issues.
This switching happens only when the "Autostart" property for the sequence is set.
* The "editing" Animation context now switches Editor Viewport Widget to the default "Editor camera" when switching into Play Game mode, regardless of what camera is actiually active at the moment. This is because, while returning from Play Game mode to Editing mode, both the "Viewport Camera Selector" tool and Editor Viewport Widget try to set the default "Editor camera" and then restore its transform, - which would be wrong for a restored camera other than default.
* As it takes 2 frames for the Editor Viewport to rollback from Play Game mode to Editing mode, restoring animation sequence state and corresponding active camera are also to be delayed for 2 frames. Thus storing / restoring states are to be made differently depending of whether Editor is being switched to Game and back Editing or switched to Save and back to Editing.
So, to make this algorithm more readable, code of  `AnimarionContext` is slightly refactored:
* * duplicate code moved to new private methods and public helpers,
* * handler for `OnCameraChanged()` event (which is to be active only in Editing Mode) is fully separated from the method used to switch cameras programmatically (the `SwitchEditorViewportCamera()` method, also used in Editor's mode transitoions),
* * unneeded calls removed,
* * obsolete syntax (like `virtual` ... `override`) fixed;
* * comments  improved.

In the `CTrackViewDialog`:
*   The code path for opening the dialogue is made more user-friendly: 
* * In the `ctor`, the call to `AddDialogListeners();` moved above the call to `OnInitDialog();` so that changes described below could update the state for a selected sequence.
* * In the 'OnSequenceComboBox()', the call to `InvalidateSequence();` is added in order to force later dialogue update.
* * In the `ReloadSequences()`, if a sequence was worked on prior to the call, the sequence `EntityId` is stored in `m_currentSequenceEntityId`, so that this sequence is later re-selected when calling `ReloadSequencesComboBox()` and and re-activated when calling 'OnSequenceComboBox()';
* * In `ReloadSequencesComboBox();`, if there are sequences registered in level, and the `m_currentSequenceEntityId` (Id of a sequence previously worked on) is invalid, the latest existing sequence is selected to become active.

* In the `CTrackViewDialog::Update()`:
* * The bug is fixed: when no sequence was selected or a selected sequence does not have active Director Camera Track, the invalid camera name was fetched from movie and displayed - for example, when adding a fresh new sequence,
* * The corner case is evaluated: when a selected sequence has an active Director Camera Track, and the 1st key is at 0.0 timeline, the camera Id from such the key is now forced into Editor Viewport Widget, so that manual scrubbing through timeline displays the view from this animated camera.
This switching happens only when the "Autostart" property for the sequence is set.

* In the `CTVNewSequenceDialogValidator` the validation function updated to improve entering of a new sequence name, -  making the process more user-friendly.

### Additional changes:
* In `Code/Editor/CryEdit .h | .cpp`: the obsolete code in the CCryEditApp removed as a follow-up to the merged PR https://github.com/o3de/o3de/pull/2840, see
https://github.com/o3de/o3de/pull/2840/files#r683305698;
* In `Code/Editor/EditorViewportWidget .h | .cpp`: ambiguous enum (`ViewSourceType`) and member (`m_viewSourceType`) removed as a follow-up to the merged PR https://github.com/o3de/o3de/pull/2840, see https://github.com/o3de/o3de/pull/2840/files#r683510637:  invalid value for the m_viewEntityId means "default Editor camera", while valid value means "another active camera".

## How was this PR tested?
Under Windows Editor, a test scene was created, with 4 cameras (one was the default "Camera") and a Track View sequence, which was animating camera switches via Director track.
The sequence was played and scrubbed,  new sequence was added / destroyed, etc.
Needed functionality observed.

https://github.com/user-attachments/assets/28524838-ca99-4164-94d6-aed50ecccbe9

### A new issue noted (probably pre-existing from the beginning?) in `development` branch:
After adding a first key to a transform track (Position or Rotation) of an animated entity, regardless of the "Autostart" property state:
* The corresponding transform part (Position or Rotation) is zeroed;
* Further manual changes (in Editor viewport) to this entity transform part (Position or Rotation) are automatically reverted.

The only way to set changed Transform keys I've found is through using "Auto Recording".
Filed the new GHI https://github.com/o3de/o3de/issues/18575