### PR TITLE
Fallback to LoadLibraryW in case a dll cannot be loaded

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
@@ -114,7 +114,7 @@ namespace AZ
                         // If the first time failed, most likely occurred because @fileNameW is not a fully qualified path.
                         // Per API spec, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR requires a fully qualified path.
                         // Cases like "XInput9_1_0.dll" should be loaded without LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR.
-                        m_handle = LoadLibraryExW(fileNameW, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+                        m_handle = LoadLibraryW(fileNameW);
                     }
                 }
             }


### PR DESCRIPTION
## What does this PR do?

This is a fix for a problem introduced by https://github.com/o3de/o3de/pull/18525
I encountered a problem when loading a dll that is not in the engine path, but in an installed library that is in the dll search path.
A previous fix (https://github.com/o3de/o3de/pull/18535) solved a related problem when loading dlls with a relativ path.

According to the [documentation](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw) the `LoadLibraryExW` function behaves the same as the (previously used) `LoadLibraryW` function when the flags are `0`. So `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` are not really the default dirs used in `LoadLibraryW`.

@galibzon Can you check if loading `XInput9_1_0.dll` still works with these changes. I think it should as it uses the same function as before https://github.com/o3de/o3de/pull/18525 

## How was this PR tested?

Loaded a Gem that loads a dll from an installed library
