### PR TITLE
Add a mutex to the RHIRequirmentRequest Ebus

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIBus.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIBus.h
@@ -30,6 +30,7 @@ namespace AZ::RHI
 
     public:
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        using MutexType = AZStd::mutex;
     };
 
     using RHIRequirementRequestBus = AZ::EBus<RHIRequirementsRequest>;


### PR DESCRIPTION
## What does this PR do?

The `RHIRequirementRequest` Ebus (introduced in https://github.com/o3de/o3de/pull/18450) might be called from multiple threads when new buffers/images are allocated. During allocation the `GetRequiredAlignment` function is called.
This resulted in error messages like `Bus static const char *AZ::EBus<AZ::RHI::RHIRequirementsRequest>::GetName() [Interface = AZ::RHI::RHIRequirementsRequest, BusTraits = AZ::RHI::RHIRequirementsRequest] has multiple threads in its callstack records. Configure MutexType on the bus, or don't send to it from multiple threads
`.

This PR fixes this problem by adding a mutex to the Bus.

## How was this PR tested?

Tested on Windows and Linux with a Gem that implements the `RHIRequirementRequest` bus.
