### PR TITLE
introduce scene/viewsrg_all.srgi as a wrapper around scene/viewsrg.srgi

### DIFF
--- a/AutomatedTesting/Levels/ShaderReloadTest/SimpleMesh.azsl
+++ b/AutomatedTesting/Levels/ShaderReloadTest/SimpleMesh.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 // To get the world matrix shader constant for the current object.
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 

--- a/AutomatedTesting/Materials/UVs.azsl
+++ b/AutomatedTesting/Materials/UVs.azsl
@@ -7,7 +7,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/AutomatedTesting/ShaderLib/scenesrg.srgi
+++ b/AutomatedTesting/ShaderLib/scenesrg.srgi
@@ -14,15 +14,7 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/AutomatedTesting/ShaderLib/scenesrg.srgi
+++ b/AutomatedTesting/ShaderLib/scenesrg.srgi
@@ -1,3 +1,4 @@
+// {BEGIN_LICENSE}
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
@@ -5,9 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+// {END_LICENSE}
 
 #pragma once
 
+// this file is included by 'scenesrg_all.srgi', which is included by each shader using the scene-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
@@ -16,5 +19,5 @@
 
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
-/* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };

--- a/AutomatedTesting/ShaderLib/viewsrg.srgi
+++ b/AutomatedTesting/ShaderLib/viewsrg.srgi
@@ -14,15 +14,7 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/AutomatedTesting/ShaderLib/viewsrg.srgi
+++ b/AutomatedTesting/ShaderLib/viewsrg.srgi
@@ -1,3 +1,4 @@
+// {BEGIN_LICENSE}
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
@@ -5,9 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+// {END_LICENSE}
 
 #pragma once
 
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the view-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
@@ -16,5 +19,5 @@
 
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
-/* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/MeshMotionVector.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/MeshMotionVector.azsli
@@ -16,8 +16,8 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 struct PsOutput
 {

--- a/Gems/Atom/Feature/Common/Assets/Materials/ReflectionProbe/ReflectionProbeVisualization.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/ReflectionProbe/ReflectionProbeVisualization.azsli
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/VertexUtility.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Materials/Special/DebugVertexStreams.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Special/DebugVertexStreams.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #define UvSetCount 2
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Materials/Special/ShadowCatcher.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Special/ShadowCatcher.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 option enum class OpacityMode 
 {

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Eye.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Eye.azsli
@@ -9,8 +9,8 @@
 //TODO(MaterialPipeline): Inline the MaterialSrg files since they aren't reused.
 #include <Atom/Feature/Common/Assets/Shaders/Materials/Eye/Eye_MaterialSrg.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
@@ -6,8 +6,8 @@
  *
  */
     
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Debug.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Debug.azsli
@@ -10,8 +10,8 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/RPI/BitOperations.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/DefaultObjectSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/DefaultObjectSrg.azsli
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 #include <Atom/Features/PBR/Lights/ReflectionProbeData.azsli>
 
 #ifndef MATERIAL_PIPELINE_OBJECT_SRG_MEMBERS

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/Debug.azsli>
 #include <Atom/Features/LightCulling/LightCullingTileIterator.azsli>
 #include <Atom/Features/PBR/LightingUtils.azsli>

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSrgs.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSrgs.azsli
@@ -12,8 +12,8 @@
 // register/space assignment (DX12) or descriptor set/binding slot (Vulkan) for all SRG members. This is achieved by including the exact
 // same SRGs in all shaders, which are all defined here.
 
-#include <viewsrg.srgi>
-#include <scenesrg.srgi>
+#include <viewsrg_all.srgi>
+#include <scenesrg_all.srgi>
 #include <Atom/Features/RayTracing/RayTracingSceneSrg.azsli>
 #include <Atom/Features/RayTracing/RayTracingMaterialSrg.azsli>
 #include <Atom/Features/RayTracing/RayTracingGlobalSrg.azsli>

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ScreenSpace/ScreenSpaceUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ScreenSpace/ScreenSpaceUtil.azsli
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 // Given a depthStencil depth and the fragment XY position, reconstruct the world space position
 // screenCoords - from 0.. dimension of the screen of the current pixel

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -18,8 +18,8 @@
 #define ENABLE_FULLSCREEN_SHADOW              1
 #endif
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/RPI/Math.azsli>
 #include "Shadow.azsli"
 #include "ShadowmapAtlasLib.azsli"

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
@@ -14,8 +14,8 @@
 
 #if ENABLE_SHADOWS
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/Shadow/ShadowmapAtlasLib.azsli>
 #include <Atom/RPI/Math.azsli>
 #include "BicubicPcfFilters.azsli"

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/VertexUtility.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/VertexUtility.azsli
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/InstancedTransforms.azsli>
 
 // Helper functions for doing common transformations.

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/scenesrg_all.srgi
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/scenesrg_all.srgi
@@ -1,0 +1,31 @@
+// {BEGIN_LICENSE}
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+// {END_LICENSE}
+
+#pragma once
+
+// Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
+// located in this folder (And how you can optionally customize your own scenesrg.srgi
+// and viewsrg.srgi in your game project).
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+// we need all data-types to be fully defined before the first partial srg definition
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
+// this file is from the project, and contains the first partial SceneSrg definition.
+// it can also contain project-specific fields
+#include <scenesrg.srgi>
+
+#define AZ_COLLECTING_PARTIAL_SRGS
+// Include all partial SceneSrg - definitions from the engine
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/viewsrg_all.srgi
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/viewsrg_all.srgi
@@ -1,0 +1,26 @@
+// {BEGIN_LICENSE}
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+// {END_LICENSE}
+
+#pragma once
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+// we need all data-types to be fully defined before the first partial srg definition
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
+// this file is from the project, and contains the first partial ViewSrg definition.
+// it can also contain project-specific fields
+#include <viewsrg.srgi>
+
+#define AZ_COLLECTING_PARTIAL_SRGS
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObject.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObject.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include "ObjectSrg.azsli"
 
 option enum class ViewProjectionMode { ViewProjection, ManualOverride } o_viewProjMode;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObjectLit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObjectLit.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include "ObjectSrgLit.azsli"
 
 option enum class ViewProjectionMode { ViewProjection, ManualOverride } o_viewProjMode;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomWorld.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomWorld.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PerDrawSrg : SRG_PerDraw
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Checkerboard/CheckerboardColorResolveCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Checkerboard/CheckerboardColorResolveCS.azsl
@@ -11,7 +11,7 @@
 // This resolve function need to be reworked to achieve better reconstruct result.  
 // [GFX TODO] [ATOM-5411] Checkerboard color resolve shader rework 
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 // Maximum number of textures it can resolve at same time
 #define MaxNumberResolveTextures 3

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Depth/DepthPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Depth/DepthPass.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseGlobalFullscreen.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseGlobalFullscreen.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 // Perform light culling on a compute shader
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingData.azsli
@@ -15,7 +15,7 @@
 #define LightingData        LightingData_BasePBR
 #endif
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/Debug.azsli>
 #include <Atom/Features/LightCulling/LightCullingTileIterator.azsli>
 #include <Atom/Features/PBR/LightingUtils.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
@@ -19,7 +19,7 @@
 #define EvaluateVertexGeometry EvaluateVertexGeometry_BasePBR
 #endif
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/RPI/TangentSpace.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_DepthPass_WithPS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_DepthPass_WithPS.azsl
@@ -6,7 +6,7 @@
  *
  */
  
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/Features/ParallaxMapping.azsli>
 #include <Atom/Features/MatrixUtility.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Shadowmap_WithPS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Shadowmap_WithPS.azsl
@@ -10,8 +10,8 @@
 #define ENABLE_ALPHA_CLIP 0
 #define SHADOWMAP 1
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/Features/ParallaxMapping.azsli>
 #include <Atom/Features/MatrixUtility.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/CameraMotionVector.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/CameraMotionVector.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ChromaticAberration.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ChromaticAberration.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ContrastAdaptiveSharpening.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ContrastAdaptiveSharpening.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 #include <Atom/Features/PostProcessing/PostProcessUtil.azsli>
 
 #define TILE_DIM_X 16

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldBlurBokeh.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldBlurBokeh.azsl
@@ -13,8 +13,8 @@
 
 #define SampleMax 60
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldComposite.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldComposite.azsl
@@ -10,7 +10,7 @@
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include "DepthOfField.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldDownSample.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldDownSample.azsl
@@ -10,7 +10,7 @@
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include "DepthOfField.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldMask.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldMask.azsl
@@ -10,7 +10,7 @@
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include "DepthOfField.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #define SQRT2_HALF 0.707106781  // sqrt(2) / 2
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldPrepare.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldPrepare.azsl
@@ -10,7 +10,7 @@
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include "DepthOfField.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthToLinearDepth.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthToLinearDepth.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EyeAdaptation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EyeAdaptation.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/RPI/Math.azsli>
 #include "EyeAdaptationUtil.azsli"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FilmGrain.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FilmGrain.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LookModificationTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LookModificationTransform.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/Aces.azsli>
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHeatmap.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHeatmap.azsl
@@ -9,7 +9,7 @@
 // This is a fullscreen debug pass that draws luminance/exposure debugging information. 
 
 #include <Atom/Features/SrgSemantics.azsli>
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldCommon.azsli
@@ -7,7 +7,7 @@
  */
 
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #define COC_EPSILON 0.0001
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldComposite.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldComposite.azsl
@@ -12,7 +12,7 @@
 #include "NewDepthOfFieldCommon.azsli"
 #include "DepthOfField.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #define COC_EPSILON 0.0001
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldDownsample.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldDownsample.azsl
@@ -12,7 +12,7 @@
 #include "NewDepthOfFieldCommon.azsli"
 #include "DepthOfField.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #define COC_EPSILON 0.0001
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldFilterLarge.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldFilterLarge.azsl
@@ -11,7 +11,7 @@
 #include "DepthOfField.azsli"
 #include "NewDepthOfFieldCommon.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldFilterSmall.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/NewDepthOfFieldFilterSmall.azsl
@@ -11,7 +11,7 @@
 #include "DepthOfField.azsli"
 #include "NewDepthOfFieldCommon.azsli"
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/PaniniProjection.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/PaniniProjection.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PBR/Hammersley.azsli>
 #include <Atom/RPI/Math.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SsaoCompute.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SsaoCompute.azsl
@@ -8,8 +8,8 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/RPI/Math.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/Taa.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/Taa.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 #include <Atom/Features/PostProcessing/PostProcessUtil.azsli>
 
 #define TILE_DIM_X 16

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/Vignette.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/Vignette.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/WhiteBalance.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/WhiteBalance.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionComposite.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionComposite.azsl
@@ -14,7 +14,7 @@
 // fullscreen pass, for pixels that have a non-zero stencil value.  Output values are
 // box-filtered from the MSAA sub-pixels of the reflection texture.
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 #include <Atom/Features/Debug.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.azsl
@@ -26,8 +26,8 @@
 //   This is necessary to clear the pixel since the probes additively write their specular values
 //   in the following passes.
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeBlendWeight.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeBlendWeight.azsl
@@ -16,8 +16,8 @@
 // to the outer volumes.  Inner volumes always blend at 100% so there is no need to write them
 // to the blend weight texture.
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "ReflectionProbeRenderObjectSrg.azsli"
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderInner.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderInner.azsl
@@ -14,8 +14,8 @@
 // by the inner probe volume so there is no blending.  Note that this shader only considers 
 // pixels stenciled to the inner volume.
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "ReflectionProbeRenderObjectSrg.azsli"
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderOuter.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderOuter.azsl
@@ -16,8 +16,8 @@
 // to this location as well.  Note that this shader only considers pixels stenciled to the
 // outer volume.  Inner volume pixels are written in the next pass.
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "ReflectionProbeRenderObjectSrg.azsli"
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeStencil.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeStencil.azsl
@@ -16,7 +16,7 @@
 // stenciled with the UseIBLSpecularPass value when they were rendered in the forward pass.
 // It increases the stencil value if they are in an inner volume.
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup ObjectSrg : SRG_PerObject
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceComposite.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceComposite.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/RPI/Math.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceFilter.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceFilter.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
 #include <Atom/Features/PostProcessing/PostProcessUtil.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/RPI/Math.azsli>
 
 float DistanceSqr(float2 v1, float2 v2) 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/ScreenSpace/DeferredFog.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/ScreenSpace/DeferredFog.azsl
@@ -11,8 +11,8 @@
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
 #include <Atom/Features/ScreenSpace/ScreenSpaceUtil.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #ifndef ENABLE_FOG_LAYER
 #define ENABLE_FOG_LAYER    1

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
@@ -12,8 +12,8 @@
 #define USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT 0
 
 #include <Atom/Features/SrgSemantics.azsli>
-#include <viewsrg.srgi>
-#include <scenesrg.srgi>
+#include <viewsrg_all.srgi>
+#include <scenesrg_all.srgi>
 
 #include <Atom/RPI/Math.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/Shadowmap.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/Shadowmap.azsl
@@ -7,8 +7,8 @@
  */
 
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/Silhouette.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/Silhouette.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyRayMarching.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyRayMarching.azsl
@@ -10,7 +10,7 @@
 
 #define ENABLE_ATMOSPHERE_SHADOWS 1
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/SrgSemantics.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include <Atom/Features/ColorManagement/TransformColor.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyViewLUT.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyViewLUT.azsl
@@ -11,7 +11,7 @@
 // SkyViewLUT does not support shadows currently because it does not bind or sample the depth buffer
 #define ENABLE_ATMOSPHERE_SHADOWS 0
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include <Atom/Features/ColorManagement/TransformColor.azsli>
 #include <SkyAtmosphereCommon.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyVolumeLUT.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyAtmosphere/SkyVolumeLUT.azsl
@@ -9,7 +9,7 @@
  // Based on https://github.com/sebh/UnrealEngineSkyAtmosphere by Sébastien Hillaire
 
 #define ENABLE_ATMOSPHERE_SHADOWS 0
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/SrgSemantics.azsli>
 #include <SkyAtmosphereCommon.azsli>
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox.azsl
@@ -15,8 +15,8 @@
 #include <Atom/Features/MatrixUtility.azsli>
 #include <Atom/Features/ShaderQualityOptions.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #ifndef ENABLE_PHYSICAL_SKY
 #define ENABLE_PHYSICAL_SKY              1

--- a/Gems/Atom/RPI/Assets/Shaders/SceneAndViewSrgs.azsl
+++ b/Gems/Atom/RPI/Assets/Shaders/SceneAndViewSrgs.azsl
@@ -10,7 +10,7 @@
 // The only purpose of this shader is to have a shader asset that can be used
 // at runtime to find the SceneSrg & ViewSrg layouts.
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/Bindless.azsli>
 #include <Atom/RPI/DummyEntryFunctions.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
@@ -25,8 +25,8 @@
 #include <Atom/Features/PBR/LightingOptions.azsli>
 #include <Atom/Features/PBR/AlphaUtils.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
@@ -29,8 +29,8 @@
 #include <Atom/Features/PBR/LightingOptions.azsli>
 #include <Atom/Features/PBR/AlphaUtils.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/AutoBrick_ForwardPass.azsl
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/AutoBrick_ForwardPass.azsl
@@ -8,8 +8,8 @@
 
 #define FORCE_OPAQUE 1
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Animated.azsli
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Animated.azsli
@@ -7,8 +7,8 @@
  */
 
  
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/VertexUtility.azsli>

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Empty.azsli
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Empty.azsli
@@ -7,8 +7,8 @@
  */
 
  
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/VertexUtility.azsli>

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MinimalPBR_ForwardPass.azsl
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MinimalPBR_ForwardPass.azsl
@@ -8,8 +8,8 @@
 
 #define FORCE_OPAQUE 1
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Shaders/EditorModeCommon.azsli
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Shaders/EditorModeCommon.azsli
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/SrgSemantics.azsli> 
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Shaders/EditorModeMask.azsl
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Assets/Shaders/EditorModeMask.azsl
@@ -8,8 +8,8 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#include <viewsrg.srgi>
-#include <scenesrg.srgi>
+#include <viewsrg_all.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroup ObjectSrg : SRG_PerObject
 {

--- a/Gems/AtomTressFX/Assets/Shaders/HairFullScreenUtils.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairFullScreenUtils.azsli
@@ -8,7 +8,7 @@
 
 #include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 //==============================================================================
 // Generate a fullscreen triangle from pipeline provided vertex id 

--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingSrgs.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingSrgs.azsli
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 //------------------------------------------------------------------------------
 #define g_mVP               ViewSrg::m_viewProjectionMatrix

--- a/Gems/DiffuseProbeGrid/Assets/Shaders/DiffuseGlobalIllumination/DiffuseComposite.azsl
+++ b/Gems/DiffuseProbeGrid/Assets/Shaders/DiffuseGlobalIllumination/DiffuseComposite.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/Debug.azsli>
 

--- a/Gems/DiffuseProbeGrid/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridDownsample.azsl
+++ b/Gems/DiffuseProbeGrid/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridDownsample.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>

--- a/Gems/DiffuseProbeGrid/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridVisualizationComposite.azsl
+++ b/Gems/DiffuseProbeGrid/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridVisualizationComposite.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>

--- a/Gems/Meshlets/ASV_GPU_and_CPU_Demo/DebugShaderPBR_ForwardPass.azsl
+++ b/Gems/Meshlets/ASV_GPU_and_CPU_Demo/DebugShaderPBR_ForwardPass.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/InstancedTransforms.azsli>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/Features/PBR/ForwardPassSrg.azsli>

--- a/Gems/Meshlets/Assets/Shaders/MeshletsDebugRenderShader.azsl
+++ b/Gems/Meshlets/Assets/Shaders/MeshletsDebugRenderShader.azsl
@@ -63,7 +63,7 @@ struct MeshletsPassOutputWithDepth
 };
 
 // Shader Resource Groups
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <MeshletsPerObjectRenderSrg.azsli>
 
 #include <Atom/RPI/Math.azsli>

--- a/Gems/Meshlets/Assets/Shaders/MeshletsPerObjectRenderSrg.azsli
+++ b/Gems/Meshlets/Assets/Shaders/MeshletsPerObjectRenderSrg.azsli
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 /*
 // Utilize the following PerDraw srg for instancing - currently not used yet.

--- a/Gems/Stars/Assets/Shaders/Stars/Stars.azsl
+++ b/Gems/Stars/Assets/Shaders/Stars/Stars.azsl
@@ -8,8 +8,8 @@
 
 #include <Atom/Features/ColorManagement/TransformColor.azsli>
 #include <Atom/Features/SrgSemantics.azsli>
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PerDrawSrg : SRG_PerDraw
 {

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainClipmapDebugPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainClipmapDebugPass.azsl
@@ -7,8 +7,8 @@
  */
  
 #include <Atom/Features/SrgSemantics.azsli>
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <TerrainSrg.azsli>
 
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainPBR_ForwardPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainPBR_ForwardPass.azsl
@@ -8,8 +8,8 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <TerrainSrg.azsli>
 #include <TerrainCommon.azsli>
 #include <TerrainDetailHelpers.azsli>

--- a/Gems/Terrain/Assets/Shaders/Terrain/Terrain_DepthPass.azsl
+++ b/Gems/Terrain/Assets/Shaders/Terrain/Terrain_DepthPass.azsl
@@ -6,8 +6,8 @@
  */
 
 #include <Atom/Features/SrgSemantics.azsli>
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <TerrainCommon.azsli>
 
 struct VSDepthOutput

--- a/Templates/DefaultProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/DefaultProject/Template/ShaderLib/scenesrg.srgi
@@ -10,21 +10,14 @@
 
 #pragma once
 
+// this file is included by 'scenesrg_all.srgi', which is included by each shader using the scene-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Templates/DefaultProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/DefaultProject/Template/ShaderLib/scenesrg.srgi
@@ -19,5 +19,5 @@
 
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
-/* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };

--- a/Templates/DefaultProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/DefaultProject/Template/ShaderLib/viewsrg.srgi
@@ -10,21 +10,14 @@
 
 #pragma once
 
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the scene-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Templates/DefaultProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/DefaultProject/Template/ShaderLib/viewsrg.srgi
@@ -10,7 +10,7 @@
 
 #pragma once
 
-// this file is included by 'viewsrg_all.srgi', which is included by each shader using the scene-srg.
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the view-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
@@ -19,5 +19,5 @@
 
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
-/* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };

--- a/Templates/MinimalProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/MinimalProject/Template/ShaderLib/scenesrg.srgi
@@ -19,6 +19,6 @@
 
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
-/* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };
 

--- a/Templates/MinimalProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/MinimalProject/Template/ShaderLib/scenesrg.srgi
@@ -10,21 +10,15 @@
 
 #pragma once
 
+// this file is included by 'scenesrg_all.srgi', which is included by each shader using the scene-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
 };
 
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Templates/MinimalProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/MinimalProject/Template/ShaderLib/viewsrg.srgi
@@ -10,21 +10,14 @@
 
 #pragma once
 
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the scene-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Templates/MinimalProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/MinimalProject/Template/ShaderLib/viewsrg.srgi
@@ -10,7 +10,7 @@
 
 #pragma once
 
-// this file is included by 'viewsrg_all.srgi', which is included by each shader using the scene-srg.
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the view-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
@@ -19,5 +19,5 @@
 
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
-/* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };

--- a/Templates/ScriptOnlyProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/ScriptOnlyProject/Template/ShaderLib/scenesrg.srgi
@@ -10,21 +10,14 @@
 
 #pragma once
 
+// this file is included by 'scenesrg_all.srgi', which is included by each shader using the scene-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Templates/ScriptOnlyProject/Template/ShaderLib/scenesrg.srgi
+++ b/Templates/ScriptOnlyProject/Template/ShaderLib/scenesrg.srgi
@@ -19,5 +19,5 @@
 
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
-/* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };

--- a/Templates/ScriptOnlyProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/ScriptOnlyProject/Template/ShaderLib/viewsrg.srgi
@@ -10,21 +10,14 @@
 
 #pragma once
 
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the scene-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Templates/ScriptOnlyProject/Template/ShaderLib/viewsrg.srgi
+++ b/Templates/ScriptOnlyProject/Template/ShaderLib/viewsrg.srgi
@@ -10,7 +10,7 @@
 
 #pragma once
 
-// this file is included by 'viewsrg_all.srgi', which is included by each shader using the scene-srg.
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the view-srg.
 // Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
 // located in this folder (And how you can optionally customize your own scenesrg.srgi
 // and viewsrg.srgi in your game project).
@@ -19,5 +19,5 @@
 
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
-/* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };


### PR DESCRIPTION
## What does this PR do?

This PR adds `scenesrg_all.srgi` in an engine ShaderLib folder and modifies all shaders to use 

`#include <scenesrg_all.srgi>` 
instead of 
`#include <scenesrg.srgi>`

`scenesrg_all.srgi` in turn includes the project - specific `scenesrg.srgi`.

And it does the same for all `viewsrg` things respectively.

This PR is an alternative for #18536, both are attempts to allow existing, non-code projects to keep functioning unchanged
after the introduction of the include-path before the partial srg definition. 
The other PR uses either the scenesrg.srgi - file from the project or the engine, but never both. 
This PR always uses both files. 

## How was this PR tested?

Compile all assets on Windows
