### PR TITLE
Multiplayer Connect Console Command Accepts Ticket

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -114,8 +114,9 @@ namespace Multiplayer
         //! Connects to the specified IP as a Client.
         //! @param remoteAddress The domain or IP to connect to
         //! @param port The port to connect to
+        //! @param connectionTicket Some form of authentication to validate the connection (if required by the server)
         //! @result if a connection was successfully created
-        virtual bool Connect(const AZStd::string& remoteAddress, uint16_t port) = 0;
+        virtual bool Connect(const AZStd::string& remoteAddress, uint16_t port, const AZStd::string& connectionTicket = "") = 0;
 
         // Disconnects all multiplayer connections, stops listening on the server and invokes handlers appropriate to network context.
         //! @param reason The reason for terminating connections

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -123,7 +123,7 @@ namespace Multiplayer
         MultiplayerAgentType GetAgentType() const override;
         void InitializeMultiplayer(MultiplayerAgentType state) override;
         bool StartHosting(uint16_t port = UseDefaultHostPort, bool isDedicated = true) override;
-        bool Connect(const AZStd::string& remoteAddress, uint16_t port) override;
+        bool Connect(const AZStd::string& remoteAddress, uint16_t port, const AZStd::string& connectionTicket = "") override;
         void Terminate(AzNetworking::DisconnectReason reason) override;
         void AddClientMigrationStartEventHandler(ClientMigrationStartEvent::Handler& handler) override;
         void AddClientMigrationEndEventHandler(ClientMigrationEndEvent::Handler& handler) override;

--- a/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonBenchmarkSetup.h
@@ -306,7 +306,7 @@ namespace Multiplayer
         MultiplayerAgentType GetAgentType() const override { return {}; }
         void InitializeMultiplayer([[maybe_unused]] MultiplayerAgentType state) override {}
         bool StartHosting([[maybe_unused]] uint16_t port, [[maybe_unused]] bool isDedicated) override { return {}; }
-        bool Connect([[maybe_unused]] const AZStd::string& remoteAddress, [[maybe_unused]] uint16_t port) override { return {}; }
+        bool Connect([[maybe_unused]] const AZStd::string& remoteAddress, [[maybe_unused]] uint16_t port, [[maybe_unused]] const AZStd::string& connectionTicket) override { return {}; }
         void Terminate([[maybe_unused]] AzNetworking::DisconnectReason reason) override {}
         void AddNetworkInitHandler([[maybe_unused]] NetworkInitEvent::Handler& handler) override {}
         void AddEndpointDisconnectedHandler([[maybe_unused]] EndpointDisconnectedEvent::Handler& handler) override {}

--- a/Gems/Multiplayer/Code/Tests/MockInterfaces.h
+++ b/Gems/Multiplayer/Code/Tests/MockInterfaces.h
@@ -23,7 +23,7 @@ namespace UnitTest
         MOCK_CONST_METHOD0(GetAgentType, Multiplayer::MultiplayerAgentType());
         MOCK_METHOD1(InitializeMultiplayer, void(Multiplayer::MultiplayerAgentType));
         MOCK_METHOD2(StartHosting, bool(uint16_t, bool));
-        MOCK_METHOD2(Connect, bool(const AZStd::string&, uint16_t));
+        MOCK_METHOD3(Connect, bool(const AZStd::string&, uint16_t, const AZStd::string&));
         MOCK_METHOD1(Terminate, void(AzNetworking::DisconnectReason));
         MOCK_METHOD1(AddNetworkInitHandler, void(AZ::Event<INetworkInterface*>::Handler&));
         MOCK_METHOD1(AddClientMigrationStartEventHandler, void(Multiplayer::ClientMigrationStartEvent::Handler&));


### PR DESCRIPTION
Connect console command now accepts a connection ticket for servers that need some validation to allow a client connection. Separated by : `connect <ip_address>:<port>:<connection_ticket>`

This is a quality of life ask from the recent GameLift demo. Removes the need to add any client-side logic for connecting to GameLift servers (or any server that needs some form of auth during connection) 

Fixes #18542 

Tested by connecting to a GameLift server using the connection ticket
Tested by running 4 possibilities
1. `"connect"`
2. `"connect <ip-address>"`
3. `"connect <ip-address>:<port>"`
4. `"connect <ip-address>:<port>:<ticket>"`