### PR TITLE
Fixes for some use cases of uninitialized variables

### DIFF
--- a/Code/Editor/TrackView/TrackViewSequence.h
+++ b/Code/Editor/TrackView/TrackViewSequence.h
@@ -321,7 +321,7 @@ private:
     int RecordTrackChangesForNode(CTrackViewAnimNode* componentNode);
 
     // Current time when animated
-    float m_time;
+    float m_time = 0;
 
     // Stores if sequence is bound
     bool m_bBoundToEditorObjects = false;

--- a/Code/Editor/TrackView/TrackViewSequence.h
+++ b/Code/Editor/TrackView/TrackViewSequence.h
@@ -321,7 +321,7 @@ private:
     int RecordTrackChangesForNode(CTrackViewAnimNode* componentNode);
 
     // Current time when animated
-    float m_time = 0;
+    float m_time = 0.f;
 
     // Stores if sequence is bound
     bool m_bBoundToEditorObjects = false;

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
@@ -199,6 +199,7 @@ namespace AzFramework
         , m_rawMovementSampleRate()
         , m_rawButtonEventQueuesById()
         , m_rawMovementEventQueuesById()
+        , m_captureCursor()
     {
         m_timeOfLastRawMovementSample[0] = m_timeOfLastRawMovementSample[1] = m_timeOfLastRawMovementSample[2] = AZStd::chrono::steady_clock::now();
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -565,7 +565,7 @@ namespace AZ
             
             // For read back attachment
             AZStd::shared_ptr<AttachmentReadback> m_attachmentReadback;
-            PassAttachmentReadbackOption m_readbackOption;
+            PassAttachmentReadbackOption m_readbackOption = PassAttachmentReadbackOption::Input;
 
             // For image attachment preview
             AZStd::weak_ptr<ImageAttachmentCopy> m_attachmentCopy;

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewSequence.h
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewSequence.h
@@ -239,7 +239,7 @@ private:
     void EndRestoreTransaction() override;
 
     // Current time when animated
-    float m_time;
+    float m_time = 0;
 
     // Stores if sequence is bound
     bool m_bBoundToEditorObjects;

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewSequence.h
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewSequence.h
@@ -239,7 +239,7 @@ private:
     void EndRestoreTransaction() override;
 
     // Current time when animated
-    float m_time = 0;
+    float m_time;
 
     // Stores if sequence is bound
     bool m_bBoundToEditorObjects;


### PR DESCRIPTION
## What does this PR do?

It is known that the Editor does not pass Valgrind Memcheck test on Linux, see GHI https://github.com/o3de/o3de/issues/12217

This PR addresses some use cases of uninitialized variables
1. `CTrackViewSequence m_time` found by code review

2. `InputDeviceMouse::Implementation  m_captureCursor`

Valgrind analysis 

```
==24779== Conditional jump or move depends on uninitialised value(s)
==24779==    at 0x8AE594B: AzFramework::XcbInputDeviceMouse::SetSystemCursorState(AzFramework::SystemCursorState) (o3de-maestro/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp:319)
==24779==    by 0x8AE4FF9: XcbInputDeviceMouse (o3de-maestro/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp:94)
==24779==    by 0x8AE4FF9: AzFramework::XcbInputDeviceMouse::Create(AzFramework::InputDeviceMouse&) (o3de-maestro/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp:142)
==24779==    by 0x8AF276D: AzFramework::LinuxDeviceMouseImplFactory::Create(AzFramework::InputDeviceMouse&) (o3de-maestro/Code/Framework/AzFramework/Platform/Linux/AzFramework/Components/NativeUISystemComponent_Linux.cpp:94)
==24779==    by 0x9067365: AzFramework::InputDeviceMouse::InputDeviceMouse(AzFramework::InputDeviceId const&, AzFramework::InputDeviceMouse::ImplementationFactory*) (o3de-maestro/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp:90)
==24779==    by 0x8FC71B5: AzFramework::InputSystemComponent::CreateEnabledInputDevices() (o3de-maestro/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp:316)
==24779==    by 0x8FC6D39: AzFramework::InputSystemComponent::Activate() (o3de-maestro/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp:238)
==24779==    by 0xA0898F8: ActivateComponent (o3de-maestro/Code/Framework/AzCore/./AzCore/Component/Entity.h:399)
==24779==    by 0xA0898F8: AZ::Entity::Activate() (o3de-maestro/Code/Framework/AzCore/AzCore/Component/Entity.cpp:208)
==24779==    by 0x97EA90A: AzFramework::Application::StartCommon(AZ::Entity*) (o3de-maestro/Code/Framework/AzFramework/AzFramework/Application/Application.cpp:230)
==24779==    by 0x80FB038: AzToolsFramework::ToolsApplication::StartCommon(AZ::Entity*) (o3de-maestro/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp:273)
==24779==    by 0x7315D5B: EditorInternal::EditorToolsApplication::StartCommon(AZ::Entity*) (o3de-maestro/Code/Editor/EditorToolsApplication.cpp:99)
==24779==    by 0x97EA84B: AzFramework::Application::Start(AZ::ComponentApplication::Descriptor const&, AZ::ComponentApplication::StartupParameters const&) (o3de-maestro/Code/Framework/AzFramework/AzFramework/Application/Application.cpp:220)
==24779==    by 0x80FAF9A: AzToolsFramework::ToolsApplication::Start(AZ::ComponentApplication::Descriptor const&, AZ::ComponentApplication::StartupParameters const&) (o3de-maestro/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp:259)
```

3. `class ATOM_RPI_PUBLIC_API RPI::Pass m_readbackOption`

Valgrind analysis 

```
==24779== Conditional jump or move depends on uninitialised value(s)
==24779==    at 0x148D7588: UpdateReadbackAttachment (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp:1690)
==24779==    by 0x148D7588: AZ::RPI::Pass::FrameBegin(AZ::RPI::Pass::FramePrepareParams) (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp:1498)
==24779==    by 0x148D7250: AZ::RPI::ParentPass::FrameBeginInternal(AZ::RPI::Pass::FramePrepareParams) (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp:478)
==24779==    by 0x148D75B2: AZ::RPI::Pass::FrameBegin(AZ::RPI::Pass::FramePrepareParams) (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp:1502)
==24779==    by 0x149F3090: AZ::RPI::RenderPipeline::PassSystemFrameBegin(AZ::RPI::Pass::FramePrepareParams) (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp:733)
==24779==    by 0x148EAC0B: AZ::RPI::PassSystem::FrameUpdate(AZ::RHI::FrameGraphBuilder&) (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp:225)
==24779==    by 0x14A09FBA: operator() (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp:352)
==24779==    by 0x14A09FBA: INVOKE<(lambda at /home/osboxes/o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp:348:17) &, AZ::RHI::FrameGraphBuilder &> (o3de-maestro/Code/Framework/AzCore/./AzCore/std/typetraits/invoke_traits.h:208)
==24779==    by 0x14A09FBA: invoke<(lambda at /home/osboxes/o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp:348:17) &, AZ::RHI::FrameGraphBuilder &> (o3de-maestro/Code/Framework/AzCore/./AzCore/std/function/invoke.h:54)
==24779==    by 0x14A09FBA: call<(lambda at /home/osboxes/o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp:348:17) &, AZ::RHI::FrameGraphBuilder &> (o3de-maestro/Code/Framework/AzCore/./AzCore/std/function/function_template.h:41)
==24779==    by 0x14A09FBA: void AZStd::Internal::function_util::get_invoker<void (AZ::RHI::FrameGraphBuilder&), AZStd::Internal::function_util::function_obj_tag, AZStd::allocator>::call<AZ::RPI::RPISystem::RenderTick()::$_2>(AZStd::Internal::function_util::function_buffer&, AZ::RHI::FrameGraphBuilder&) (o3de-maestro/Code/Framework/AzCore/./AzCore/std/function/function_template.h:172)
==24779==    by 0x1583B041: operator() (o3de-maestro/Code/Framework/AzCore/./AzCore/std/function/function_template.h:604)
==24779==    by 0x1583B041: operator() (o3de-maestro/Code/Framework/AzCore/./AzCore/std/function/function_template.h:684)
==24779==    by 0x1583B041: AZ::RHI::RHISystem::FrameUpdate(AZStd::function<void (AZ::RHI::FrameGraphBuilder&)>) (o3de-maestro/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp:271)
==24779==    by 0x149F5F29: AZ::RPI::RPISystem::RenderTick() (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp:347)
==24779==    by 0x878183E2: AZ::RPI::RPISystemComponent::OnSystemTick() (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp:185)
==24779==    by 0x87818476: non-virtual thunk to AZ::RPI::RPISystemComponent::OnSystemTick() (o3de-maestro/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp:0)
==24779==    by 0xA12EA01: INVOKE<void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::EBusAddressPolicy::Single, AZ::EBusHandlerPolicy::Multiple>::HandlerHolder, false> &, void> (o3de-maestro/Code/Framework/AzCore/./AzCore/std/typetraits/invoke_traits.h:177)
==24779==    by 0xA12EA01: invoke<void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::EBusAddressPolicy::Single, AZ::EBusHandlerPolicy::Multiple>::HandlerHolder, false> &> (o3de-maestro/Code/Framework/AzCore/./AzCore/std/function/invoke.h:54)
==24779==    by 0xA12EA01: Call<void (AZ::SystemTickEvents::*&)(), AZ::Internal::HandlerNode<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, AZ::EBusAddressPolicy::Single, AZ::EBusHandlerPolicy::Multiple>::HandlerHolder, false> &> (o3de-maestro/Code/Framework/AzCore/./AzCore/EBus/Policies.h:437)
==24779==    by 0xA12EA01: void AZ::Internal::EBusContainer<AZ::SystemTickEvents, AZ::SystemTickEvents, (AZ::EBusAddressPolicy)0, (AZ::EBusHandlerPolicy)1>::Dispatcher<AZ::EBus<AZ::SystemTickEvents, AZ::SystemTickEvents> >::Broadcast<void (AZ::SystemTickEvents::*)()>(void (AZ::SystemTickEvents::*&&)()) (o3de-maestro/Code/Framework/AzCore/./AzCore/EBus/Internal/BusContainer.h:1365)
==24779==    by 0xA12411A: AZ::ComponentApplication::TickSystem() (o3de-maestro/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp:1650)
```

## How was this PR tested?

Ubuntu 20.04 VirtualBox
