### PR TITLE
Multiplayer Compression System Component Dependency Crash Fix

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Framework/INetworking.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/INetworking.h
@@ -57,6 +57,7 @@ namespace AzNetworking
         virtual bool DestroyNetworkInterface(const AZ::Name& name) = 0;
 
         //! Registers a Compressor Factory that can be used to create compressors for INetworkInterfaces
+        //! Upon registry, INetworking assumes ownership of the factory pointer.
         //! @param factory The ICompressorFactory to register
         virtual void RegisterCompressorFactory(ICompressorFactory* factory) = 0;
 

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
@@ -54,7 +54,7 @@ namespace MultiplayerCompression
     void MultiplayerCompressionSystemComponent::Activate()
     {
         // The registering class is responsible for managing the lifetime of the factory.
-        // We'll save the factory name required for unregistering later, but not manager the pointer ourselves.
+        // We'll save the factory name required for unregistering later, but not manage the pointer ourselves.
         auto* compressionFactory = new MultiplayerCompressionFactory();
         m_multiplayerCompressionFactoryName = compressionFactory->GetFactoryName();
         AZ::Interface<AzNetworking::INetworking>::Get()->RegisterCompressorFactory(compressionFactory);

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
@@ -51,15 +51,29 @@ namespace MultiplayerCompression
         required.push_back(AZ_CRC_CE("NetworkingService"));  // Required for getting AzNetworking::INetworking interface
     }
 
-    MultiplayerCompressionSystemComponent::MultiplayerCompressionSystemComponent()
+    MultiplayerCompressionSystemComponent::~MultiplayerCompressionSystemComponent()
+    {
+        if (m_multiplayerCompressionFactory)
+        {
+            delete m_multiplayerCompressionFactory;
+            m_multiplayerCompressionFactory = nullptr;
+        }
+    }
+
+    void MultiplayerCompressionSystemComponent::Activate()
     {
         m_multiplayerCompressionFactory = new MultiplayerCompressionFactory();
         AZ::Interface<AzNetworking::INetworking>::Get()->RegisterCompressorFactory(m_multiplayerCompressionFactory);
     }
 
-    MultiplayerCompressionSystemComponent::~MultiplayerCompressionSystemComponent()
+    void MultiplayerCompressionSystemComponent::Deactivate()
     {
         AZ::Interface<AzNetworking::INetworking>::Get()->UnregisterCompressorFactory(m_multiplayerCompressionFactory->GetFactoryName());
-        delete m_multiplayerCompressionFactory;
+
+        if (m_multiplayerCompressionFactory)
+        {
+            delete m_multiplayerCompressionFactory;
+            m_multiplayerCompressionFactory = nullptr;
+        }
     }
 }

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
@@ -51,29 +51,17 @@ namespace MultiplayerCompression
         required.push_back(AZ_CRC_CE("NetworkingService"));  // Required for getting AzNetworking::INetworking interface
     }
 
-    MultiplayerCompressionSystemComponent::~MultiplayerCompressionSystemComponent()
-    {
-        if (m_multiplayerCompressionFactory)
-        {
-            delete m_multiplayerCompressionFactory;
-            m_multiplayerCompressionFactory = nullptr;
-        }
-    }
-
     void MultiplayerCompressionSystemComponent::Activate()
     {
-        m_multiplayerCompressionFactory = new MultiplayerCompressionFactory();
-        AZ::Interface<AzNetworking::INetworking>::Get()->RegisterCompressorFactory(m_multiplayerCompressionFactory);
+        // The registering class is responsible for managing the lifetime of the factory.
+        // We'll save the factory name required for unregistering later, but not manager the pointer ourselves.
+        auto* compressionFactory = new MultiplayerCompressionFactory();
+        m_multiplayerCompressionFactoryName = compressionFactory->GetFactoryName();
+        AZ::Interface<AzNetworking::INetworking>::Get()->RegisterCompressorFactory(compressionFactory);
     }
 
     void MultiplayerCompressionSystemComponent::Deactivate()
     {
-        AZ::Interface<AzNetworking::INetworking>::Get()->UnregisterCompressorFactory(m_multiplayerCompressionFactory->GetFactoryName());
-
-        if (m_multiplayerCompressionFactory)
-        {
-            delete m_multiplayerCompressionFactory;
-            m_multiplayerCompressionFactory = nullptr;
-        }
+        AZ::Interface<AzNetworking::INetworking>::Get()->UnregisterCompressorFactory(m_multiplayerCompressionFactoryName);
     }
 }

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.cpp
@@ -46,6 +46,11 @@ namespace MultiplayerCompression
         incompatible.push_back(AZ_CRC_CE("MultiplayerCompressionService"));
     }
 
+    void MultiplayerCompressionSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("NetworkingService"));  // Required for getting AzNetworking::INetworking interface
+    }
+
     MultiplayerCompressionSystemComponent::MultiplayerCompressionSystemComponent()
     {
         m_multiplayerCompressionFactory = new MultiplayerCompressionFactory();

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
@@ -26,7 +26,7 @@ namespace MultiplayerCompression
         AZ_COMPONENT(MultiplayerCompressionSystemComponent, "{C3099AC9-47A6-41D2-8928-F38F904BAC1B}");
 
         MultiplayerCompressionSystemComponent() = default;
-        ~MultiplayerCompressionSystemComponent() override;
+        ~MultiplayerCompressionSystemComponent() override = default;
 
         static void Reflect(AZ::ReflectContext* context);
 
@@ -41,6 +41,6 @@ namespace MultiplayerCompression
         void Deactivate() override;
         ////////////////////////////////////////////////////////////////////////
     private:
-        MultiplayerCompressionFactory* m_multiplayerCompressionFactory = nullptr;
+        AZStd::string_view m_multiplayerCompressionFactoryName;
     };
 }

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
@@ -32,6 +32,7 @@ namespace MultiplayerCompression
 
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
         ////////////////////////////////////////////////////////////////////////
         // AZ::Component interface implementation

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
@@ -41,6 +41,6 @@ namespace MultiplayerCompression
         void Deactivate() override;
         ////////////////////////////////////////////////////////////////////////
     private:
-        MultiplayerCompressionFactory* m_multiplayerCompressionFactory;
+        MultiplayerCompressionFactory* m_multiplayerCompressionFactory = nullptr;
     };
 }

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionSystemComponent.h
@@ -25,7 +25,7 @@ namespace MultiplayerCompression
     public:
         AZ_COMPONENT(MultiplayerCompressionSystemComponent, "{C3099AC9-47A6-41D2-8928-F38F904BAC1B}");
 
-        MultiplayerCompressionSystemComponent();
+        MultiplayerCompressionSystemComponent() = default;
         ~MultiplayerCompressionSystemComponent() override;
 
         static void Reflect(AZ::ReflectContext* context);
@@ -37,8 +37,8 @@ namespace MultiplayerCompression
         ////////////////////////////////////////////////////////////////////////
         // AZ::Component interface implementation
         void Init() override {}
-        void Activate() override {}
-        void Deactivate() override {}
+        void Activate() override;
+        void Deactivate() override;
         ////////////////////////////////////////////////////////////////////////
     private:
         MultiplayerCompressionFactory* m_multiplayerCompressionFactory;


### PR DESCRIPTION
Multiplayer Compression requires NetworkSystemComponent to function
Fixes a crash on startup when Compression tries to call AZ::Interface<AzNetworking::INetworking>::Get() but receives a nullptr

Issue uncovered via Discord chat: https://discord.com/channels/805939474655346758/1318673254184910969 
