### PR TITLE
Track View: Fix issue #15042 , - update code forming UI context sub-menus for adding / managing tracks of a component.

### DIFF
--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -1609,11 +1609,17 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
                 // Create 'Add Tracks' submenu
                 m_menuParamTypeMap.clear();
 
+                const QString addTracksMenuName = "Add Tracks";
                 if (FillAddTrackMenu(contextMenu.addTrackSub, animNode))
                 {
-                    // add script table properties
+                    // add script table properties -> tracks available for adding
                     unsigned int currentId = 0;
-                    CreateAddTrackMenuRec(contextMenu.main, "Add Track", animNode, contextMenu.addTrackSub, currentId);
+                    CreateAddTrackMenuRec(contextMenu.main, addTracksMenuName, animNode, contextMenu.addTrackSub, currentId);
+                }
+                else
+                {
+                    // no tracks available for adding -> add empty disabled submenu for UI consistency
+                    contextMenu.main.addMenu(addTracksMenuName)->setEnabled(false);
                 }
             }
 
@@ -1669,8 +1675,10 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     if (bOnNode && !pNode->IsGroupNode())
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
-        QString string = QString("%1 Tracks").arg(animNode->GetName().c_str());
-        contextMenu.main.addAction(string)->setEnabled(false);
+
+        // Create 'Manage Tracks' submenu with already added tracks ...
+        const QString manageTracksMenuName = "Manage Tracks";
+        auto manageTracksAction = contextMenu.main.addAction(manageTracksMenuName);
 
         bool bAppendedTrackFlag = false;
 
@@ -1694,6 +1702,8 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
                 bAppendedTrackFlag = true;
             }
         }
+
+        manageTracksAction->setEnabled(bAppendedTrackFlag); // ... and disable this sub-menu if no tracks were added.
 
         bAppended = bAppendedTrackFlag || bAppended;
     }
@@ -1864,12 +1874,7 @@ bool CTrackViewNodesCtrl::FillAddTrackMenu(STrackMenuTreeNode& menuAddTrack, con
             {
                 pCurrentNode = findIter->second.get();
             }
-            else
-            {
-                STrackMenuTreeNode* pNewNode = new STrackMenuTreeNode;
-                pCurrentNode->children[segment] = std::unique_ptr<STrackMenuTreeNode>(pNewNode);
-                pCurrentNode = pNewNode;
-            }
+            //else {} - keep current node to avoid unnecessary nesting
         }
 
         // only add tracks to the that STrackMenuTreeNode tree that haven't already been added

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -1676,8 +1676,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
 
-        // Create 'Manage Tracks' submenu with already added tracks ...
-        const QString manageTracksMenuName = "Manage Tracks";
+        const QString manageTracksMenuName = "Toggle Tracks";
         auto manageTracksAction = contextMenu.main.addAction(manageTracksMenuName);
 
         bool bAppendedTrackFlag = false;
@@ -1703,7 +1702,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
             }
         }
 
-        manageTracksAction->setEnabled(bAppendedTrackFlag); // ... and disable this sub-menu if no tracks were added.
+        manageTracksAction->setEnabled(bAppendedTrackFlag); // Disable this submenu if no tracks were added.
 
         bAppended = bAppendedTrackFlag || bAppended;
     }


### PR DESCRIPTION
## What does this PR do?
Closes https://github.com/o3de/o3de/issues/15042

Previous UI context menus for adding / managing tracks of a component were shown in the movie attached to the GHI https://github.com/o3de/o3de/issues/15042.
I understand that the issue was filed by the author because he was confused by UI inconsistency:
 - The "`Add Tracks`" menu item disappeared after adding all possible tracks for a selected component node, 
 - The name of the "`<Component Node Name> Tracks`" menu item, designed to list the added and thus manageable tracks,  was probably misleading, especially because this menu item always remained disabled. And the "`<Component Node Name>`" part of the menu item name seems ambiguous as the context menu anyway belongs to the component node selected by RMB (right mouse button) click.

So this PR updates code forming UI context sub-menus for adding / managing tracks of a component to make it consistent and remove unnecessary nesting of sub-menus of tracks being candidates for addition:
* The "`Add Tracks`" menu item is always added to the context menu for UI consistency, and when all possible candidates for adding tracks for a selected component node are already added, this menu item is disabled (greyed-out).
* The "`Add Tracks`" sub-menus with names of possible candidates for adding tracks for a selected component node are formed without unnecessary nesting of names of tracks being candidates for addition.
* The "`<Component Node Name> Tracks`" menu item is renamed to "`Toggle Tracks`" - in order to better describe the menu section destination; it is initially disabled (greyed-out), and becomes enabled after adding at least one component track menu item below.

**Note:** Probably the "`Toggle Tracks`" section in the context menu by RMB is to be deleted? An added track can be deleted by RMB on this track.

## How was this PR tested?
Under Windows Editor, a test scene was created, then a cutscene sequence with an animated entity (the default level "Camera" in the screen movie clip attached below) was added. Then tracks to the "Camera" component node were added / managed / deleted.
Same functionality was tested with adding tracks for a Director component node (in the movie).

Same functionality was tested with Actor, Mesh, Simple Motion ..., etc., components of other default and added animated entities (not included in the screen movie clip).

Desired (changed) functionality was observed.

https://github.com/user-attachments/assets/cfd88d30-1098-4eff-8cdf-b0edd5c17531


