### PR TITLE
Bugfix: Removing Clear in CopyPass Output slot.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
@@ -201,7 +201,7 @@ namespace AZ
             outputSlot.m_name = "Output";
             outputSlot.m_slotType = PassSlotType::Output;
             outputSlot.m_scopeAttachmentUsage = RHI::ScopeAttachmentUsage::Copy;
-            outputSlot.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Clear;
+            outputSlot.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Load;
             passTemplate->m_slots.emplace_back(outputSlot);
 
             AddPassTemplate(passTemplate->m_name, std::move(passTemplate));


### PR DESCRIPTION
## What does this PR do?

The output slot of a copy pass should not be cleared, especially when only copies an area and not the whole attachment bound to the slot.

## How was this PR tested?

ASV
