### PR TITLE
Added a set of small fixes that

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
@@ -252,6 +252,19 @@ class EditorComponent:
             get_component_property_outcome.IsSuccess()
         ), f"Failure: Could not get value from {self.get_component_name()} : {component_property_path}"
         return get_component_property_outcome.GetValue()
+    
+    def check_component_property_value(self, component_property_path: str) -> tuple[bool, object]:
+        """
+        Similar as get_component_property_value, but does not assert.
+        :return: a tuple with a boolean that is True if the property exists, if the
+                 property exists, the second value in the tuple is the Value of the property.
+        """
+        get_component_property_outcome = editor.EditorComponentAPIBus(
+            bus.Broadcast, "GetComponentProperty", self.id, component_property_path
+        )
+        if get_component_property_outcome.IsSuccess():
+            return True, get_component_property_outcome.GetValue()
+        return False, None 
 
     def set_component_property_value(self, component_property_path: str, value: object):
         """

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/utils.py
@@ -18,7 +18,12 @@ try:
     import azlmbr.atomtools.general as general  # Standard MaterialEditor or similar executable test.
 except ModuleNotFoundError:  # azlmbr.atomtools is not yet available in the Editor
     import azlmbr.legacy.general as general  # Will be updated in https://github.com/o3de/o3de/issues/11056
-import azlmbr.multiplayer as multiplayer
+
+try:
+    import azlmbr.multiplayer as multiplayer
+except ModuleNotFoundError: # Not all projects enable the Multiplayer Gem.
+    pass
+
 import azlmbr.debug
 import ly_test_tools.environment.waiter as waiter
 import ly_test_tools.environment.process_utils as process_utils

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -165,6 +165,11 @@ namespace AzToolsFramework
             AZ::EntityId GetSliceEntityParentId() override;
             AZStd::vector<AZ::EntityId> GetSliceEntityChildren() override;
 
+            // For tools
+            // Returns false if the component did not exist and failed to be added.
+            // Returns true otherwise, and always updates the non-uniform scale value.
+            bool AddNonUniformScaleComponent(const AZ::Vector3& nonUniformScale);
+
         private:
             // AZ::TransformNotificationBus - Connected to parent's ID
             void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -263,7 +263,12 @@ namespace AZ
             AZStd::string materialProductPath;
             AZStd::string fileName;
             AzFramework::StringFunc::Path::GetFileName(materialSourcePath.c_str(), fileName);
-            AzFramework::StringFunc::Path::ReplaceExtension(fileName, MaterialAsset::Extension);
+            // REMARK: The reason we shouldn't call StringFunc::Path::ReplaceExtension(fileName, MaterialAsset::Extension);
+            // is because if materialSourcePath == "<folder>/bed_frame.001.material", then GetFileName (called above) returns
+            // "bed_frame.001", and calling ReplaceExtension would result in "bed_frame.azmaterial" and we'd lose
+            // the original material name. Instead, by use the append operator, the fileName results in "bed_frame.001.azmaterial".
+            fileName += ".";
+            fileName += MaterialAsset::Extension;
             AzFramework::StringFunc::Path::ConstructFull(request.m_tempDirPath.c_str(), fileName.c_str(), materialProductPath, true);
 
             if (!AZ::Utils::SaveObjectToFile(materialProductPath, AZ::DataStream::ST_BINARY, materialAsset.Get()))

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -266,7 +266,7 @@ namespace AZ
             // REMARK: The reason we shouldn't call StringFunc::Path::ReplaceExtension(fileName, MaterialAsset::Extension);
             // is because if materialSourcePath == "<folder>/bed_frame.001.material", then GetFileName (called above) returns
             // "bed_frame.001", and calling ReplaceExtension would result in "bed_frame.azmaterial" and we'd lose
-            // the original material name. Instead, by use the append operator, the fileName results in "bed_frame.001.azmaterial".
+            // the original material name. Instead, by using the append operator, the fileName results in "bed_frame.001.azmaterial".
             fileName += ".";
             fileName += MaterialAsset::Extension;
             AzFramework::StringFunc::Path::ConstructFull(request.m_tempDirPath.c_str(), fileName.c_str(), materialProductPath, true);


### PR DESCRIPTION
## What does this PR do?

Added a set of small fixes that facilitate Level creation with Python.

1. Fixed bug in the `MaterialBuilder.cpp` where Material names like "metal.001.material" were being produced as "metal.azmaterial". With this fix the same source file is now produced as "metal.001.azmaterial". This bug was messing with the possibility of finding a material product asset from the path of the source asset.

2. Improved editor_python_test_tools/utils.py by Try/Excepting the inclusion of the `multiplayer` module.
Not all projects use the Multiplayer Gem.

3. Added new Global Method to the BehaviorContext (for Automation only) that allows to add the NonUniformScaleComponent to an entity. `azlmbr.editor.AddNonUniformScaleComponent(entityId: EntityId, scale: Vector3)`

## How was this PR tested?

Validated with AutomatedTesting and our private project.
