### PR TITLE
Add recent files menu to the Lua Editor

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
@@ -209,10 +209,13 @@ namespace LUAEditor
         AzToolsFramework::AssetBrowser::AssetBrowserFilterModel* m_filterModel;
         QSharedPointer<AzToolsFramework::AssetBrowser::CompositeFilter> CreateFilter();
 
+        QAction* m_actionClearRecentFiles;
+
         void LogLineSelectionChanged(const AzToolsFramework::Logging::LogLine& logLine);
 
         void OnOptionsMenuRequested();
 
+        void UpdateOpenRecentMenu();
     public:
 
         void SetupLuaFilesPanel();

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.ui
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.ui
@@ -36,6 +36,12 @@
     </property>
     <addaction name="actionNew"/>
     <addaction name="actionOpen"/>
+    <widget class="QMenu" name="menuOpenRecent">
+      <property name="title">
+         <string>Open Recent</string>
+      </property>
+    </widget>
+    <addaction name="menuOpenRecent"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
     <addaction name="actionSaveAll"/>

--- a/Code/Tools/LuaIDE/Source/LUA/RecentFiles.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/RecentFiles.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <QSettings>
+
+#define LUAEDITOR_SETTINGS_RECENT_FILES_KEY        (QString("Recent Files"))
+#define LUAEDITOR_SETTINGS_RECENT_FILES_PATH_KEY   (QString("path"))
+#define LUAEDITOR_SETTINGS_RECENT_FILES_COUNT_MAX  (10)
+#define LUAEDITOR_GROUPNAME "Lua Editor"
+
+#define AZ_QCOREAPPLICATION_SETTINGS_ORGANIZATION_NAME "O3DE"
+#define AZ_QCOREAPPLICATION_SETTINGS_APPLICATION_NAME "O3DE"
+
+QStringList ReadRecentFiles()
+{
+    QSettings settings(QSettings::IniFormat, QSettings::UserScope, AZ_QCOREAPPLICATION_SETTINGS_ORGANIZATION_NAME);
+
+    settings.beginGroup(LUAEDITOR_GROUPNAME);
+    int count = std::min(settings.beginReadArray(LUAEDITOR_SETTINGS_RECENT_FILES_KEY), LUAEDITOR_SETTINGS_RECENT_FILES_COUNT_MAX);
+
+    // QSettings -> QStringList.
+    QStringList recentFiles;
+    {
+        for (int i = 0; i < count; ++i)
+        {
+            settings.setArrayIndex(i);
+            recentFiles.append(settings.value(LUAEDITOR_SETTINGS_RECENT_FILES_PATH_KEY).toString());
+        }
+    }
+
+    settings.endArray();
+    settings.endGroup();
+
+    return recentFiles;
+}
+
+void WriteRecentFiles(const QStringList& recentFiles)
+{
+    QSettings settings(QSettings::IniFormat, QSettings::UserScope, AZ_QCOREAPPLICATION_SETTINGS_ORGANIZATION_NAME);
+
+    settings.beginGroup(LUAEDITOR_GROUPNAME);
+    settings.beginWriteArray(LUAEDITOR_SETTINGS_RECENT_FILES_KEY);
+    int count = std::min(recentFiles.size(),
+            LUAEDITOR_SETTINGS_RECENT_FILES_COUNT_MAX);
+
+    // QSettings -> QStringList.
+    {
+        for (int i = 0; i < count; ++i)
+        {
+            settings.setArrayIndex(i);
+            settings.setValue(LUAEDITOR_SETTINGS_RECENT_FILES_PATH_KEY, recentFiles.at(i));
+        }
+    }
+
+    settings.endArray();
+    settings.endGroup();
+}
+
+void AddRecentFile(const QString& filename)
+{
+    // QSettings -> QStringList.
+    QStringList recentFiles = ReadRecentFiles();
+
+    recentFiles.prepend(filename);
+    recentFiles.removeDuplicates();
+
+    WriteRecentFiles(recentFiles);
+}
+
+void ClearRecentFile()
+{
+    WriteRecentFiles(QStringList());
+}

--- a/Code/Tools/LuaIDE/Source/LUA/RecentFiles.h
+++ b/Code/Tools/LuaIDE/Source/LUA/RecentFiles.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+QStringList ReadRecentFiles();
+void WriteRecentFiles(const QStringList& filenames);
+void AddRecentFile(const QString& filename);
+void ClearRecentFile();

--- a/Code/Tools/LuaIDE/lua_ide_files.cmake
+++ b/Code/Tools/LuaIDE/lua_ide_files.cmake
@@ -66,6 +66,8 @@ set(FILES
     Source/LUA/LUAStackTrackerMessages.h
     Source/LUA/LUATargetContextTrackerMessages.h
     Source/LUA/LUAWatchesDebuggerMessages.h
+    Source/LUA/RecentFiles.cpp
+    Source/LUA/RecentFiles.h
     Source/LUA/StackPanel.cpp
     Source/LUA/StackPanel.hxx
     Source/LUA/TargetContextButton.cpp


### PR DESCRIPTION
## What does this PR do?

Fix https://github.com/o3de/o3de/issues/14078

Whenever a lua script is opened, it is added to the list of recent files and the user can have an history of those recently opened files. Clicking on any file in this list will open that specific file. Additionally, the user has the option to clear the list of recent files.

![image](https://github.com/user-attachments/assets/2ee19b4b-dd3d-4acd-b7d1-01bf37d33196)

## How was this PR tested?

Local windows build

- Opened the Lua editor and a few scripts. Clicked on the new "Open Recent Files" option from the menu. Noted that the list was fully populated and proceeded to open a script from the recent files list.
- Closed the editor to check that the recent files list was saved