### PR TITLE
Fix a Y2038 bug by replacing `Int32x32To64` with regular multiplication

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/WinAPI/AzFramework/IO/LocalFileIO_WinAPI.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/WinAPI/AzFramework/IO/LocalFileIO_WinAPI.cpp
@@ -65,7 +65,6 @@ namespace AZ
         {
             // KB article on microsoft : https://support.microsoft.com/en-us/kb/167296
             // you need to adjust for the base time epoch difference between unix epoch and FILETIME epoch!
-            // note that Int32x32To64 is a windows only function.
             // the magic numbers represent the difference in epoch between the windows and unix file time units
             // (in FILETIME units, which are 100-nanosecond intervals, starting on Jan 1, 1601 UTC.)
             // the first 10,000,000 is the number of 100-nanosecond intervals in 1 second
@@ -73,7 +72,7 @@ namespace AZ
             // which started on Jan 1, 1970 UTC (369 years worth of 100-nanosecond chunks), and the windows
             // filetime epoch.
 
-            int64_t longTime = Int32x32To64(timeValue, 10000000) + 116444736000000000;
+            int64_t longTime = (timeValue * 10000000LL) + 116444736000000000LL;
             return longTime;
         }
 

--- a/Code/Legacy/CryCommon/WinBase.cpp
+++ b/Code/Legacy/CryCommon/WinBase.cpp
@@ -647,8 +647,6 @@ BOOL SystemTimeToFileTime(const SYSTEMTIME* syst, LPFILETIME ft)
     return TRUE;
 }
 
-#define Int32x32To64(a, b) ((uint64)((uint64)(a)) * (uint64)((uint64)(b)))
-
 //////////////////////////////////////////////////////////////////////////
 #if defined(AZ_RESTRICTED_PLATFORM)
     #define AZ_RESTRICTED_SECTION WINBASE_CPP_SECTION_4

--- a/Code/Legacy/CrySystem/LocalizedStringManager.cpp
+++ b/Code/Legacy/CrySystem/LocalizedStringManager.cpp
@@ -2638,7 +2638,7 @@ namespace
 {
     void UnixTimeToFileTime(time_t unixtime, FILETIME* filetime)
     {
-        LONGLONG longlong = Int32x32To64(unixtime, 10000000) + 116444736000000000;
+        LONGLONG longlong = (unixtime * 10000000LL) + 116444736000000000LL;
         filetime->dwLowDateTime = (DWORD) longlong;
         filetime->dwHighDateTime = (DWORD)(longlong >> 32);
     }


### PR DESCRIPTION
## What does this PR do?

`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>

One more note - `WinBase.cpp` technically redefined `Int32x32To64` as operating on `uint64`, but without a deeper dive into the codebase I couldn't ascertain if it's used everywhere. With my changes, there is no need to worry about this problem in the first place.

## How was this PR tested?

Untested. It's a simple enough change that I hope a CI success will suffice.
