### PR TITLE
Lua Editor : Fix issue #14153 - Crash when closing file

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -1142,7 +1142,7 @@ namespace LUAEditor
         TrackedLUAViewMap::iterator viewIter = m_dOpenLUAView.find(assetId);
         if (viewIter != m_dOpenLUAView.end())
         {
-            delete viewIter->second.luaDockWidget();
+            viewIter->second.luaDockWidget()->deleteLater();
             m_dOpenLUAView.erase(viewIter);
             TrackedLUACtrlTabOrder::iterator tabIter = m_CtrlTabOrder.begin();
             while (tabIter != m_CtrlTabOrder.end())


### PR DESCRIPTION
## What does this PR do?

Fix #14153. The Lua Editor was crashing when modifications were made to a file and closed. This was due to a manual deletion on a QWidget (Qt always have ownership of QWidget).

![nocrash](https://github.com/user-attachments/assets/2d6f7415-6ea7-4714-887a-e4bd0599e670)

## How was this PR tested?

Local build. Tested with the description of the issue :
- Open an existing script / new script
- Make a change to the file and save
- Close the script file
- Modifying a saved script in Lua Editor, then closing it's tab and choosing either Continue or Save
=> The lua editor doesn't crash anymore