### PR TITLE
Fixed race condition related with Material::m_shaderVariantReadyEvent.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -147,7 +147,8 @@ namespace AZ
             bool NeedsCompile() const;
 
             using OnMaterialShaderVariantReadyEvent = AZ::Event<>;
-            //! Connect a handler to listen to the event that a shader variant asset of the shaders used by this material is ready
+            //! Connect a handler to listen to the event that a shader variant asset of the shaders used by this material is ready.
+            //! This is a thread safe function.
             void ConnectEvent(OnMaterialShaderVariantReadyEvent::Handler& handler);
 
         private:
@@ -228,6 +229,9 @@ namespace AZ
 
             MaterialPropertyPsoHandling m_psoHandling = MaterialPropertyPsoHandling::Warning;
 
+            //! AZ::Event is not thread safe, so we have to do our own thread safe code
+            //! because MeshDrawPacket can connect to this event from different threads.
+            AZStd::recursive_mutex m_shaderVariantReadyEventMutex;
             OnMaterialShaderVariantReadyEvent m_shaderVariantReadyEvent;
         };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -64,6 +64,7 @@ namespace AZ
             m_generalShaderCollection = {};
             m_materialPipelineData = {};
             m_materialAsset = { &materialAsset, AZ::Data::AssetLoadBehavior::PreLoad };
+
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
             if (!m_materialAsset.IsReady())
             {
@@ -322,10 +323,32 @@ namespace AZ
         {
             ShaderReloadDebugTracker::ScopedSection reloadSection("{%p}->Material::OnShaderVariantReinitialized %s", this, shaderVariant.GetShaderVariantAsset().GetHint().c_str());
 
+            // Move m_shaderVariantReadyEvent to a local AZ::Event in order to allow
+            // the handlers to be signaled outside of the mutex lock.
+            // This allows other threads to register their handlers while this thread
+            // is invoking Signal() on the current snapshot of handlers.
+            decltype(m_shaderVariantReadyEvent) localShaderVariantReadyEvent;
+            {
+                AZStd::scoped_lock lock(m_shaderVariantReadyEventMutex);
+                localShaderVariantReadyEvent = AZStd::move(m_shaderVariantReadyEvent);
+            }
+
             // Note: we don't need to re-compile the material if a shader variant is ready or changed
             // The DrawPacket created for the material need to be updated since the PSO need to be re-creaed.
-            // This event can be used to notify the owners to update their DrawPackets
-            m_shaderVariantReadyEvent.Signal();
+            // This event can be used to notify the owners to update their DrawPackets.
+            localShaderVariantReadyEvent.Signal();
+
+            // Finally restore m_shaderVariantReadyEvent but making sure to claim any new handlers that were added
+            // in other threads while Signal() was being called.
+            {
+                // Swap the local handlers with the current m_notifiers which
+                // will contain any handlers added during the signaling of the
+                // local event
+                AZStd::scoped_lock lock(m_shaderVariantReadyEventMutex);
+                AZStd::swap(m_shaderVariantReadyEvent, localShaderVariantReadyEvent);
+                // Append any added handlers to the m_notifier structure
+                m_shaderVariantReadyEvent.ClaimHandlers(AZStd::move(localShaderVariantReadyEvent));
+            }
         }
 
         void Material::ReInitKeepPropertyValues()
@@ -377,6 +400,7 @@ namespace AZ
 
         void Material::ConnectEvent(OnMaterialShaderVariantReadyEvent::Handler& handler)
         {
+            AZStd::scoped_lock lock(m_shaderVariantReadyEventMutex);
             handler.Connect(m_shaderVariantReadyEvent);
         }
 


### PR DESCRIPTION
## What does this PR do?
Fixed race condition related with Material::m_shaderVariantReadyEvent.

`AZ::Event` is not thread safe. `MeshDrawPacket::Update()` was calling
`m_material->ConnectEvent(m_shaderVariantHandler);` from multiple threads.

The fix was to add a Mutex in Material class
that protects usage of `Material::m_shaderVariantReadyEvent`

fixes #18561

## How was this PR tested?

Tested in the Editor with `--rhi=vulkan` because there's a deadlock in DX12 when switching levels (Another issue to debug later see #18597).

Before this fix, When loading `SinglePlayer` level from `StarterGame` project, the Editor would always crash assert
as described in GHI #18561.

Then I created a `Default` level, to have a level I can switch to.

After the fix, loading the `SinglePlayer` level always succeeded, and I was able to change levels back and forth between "Default" level and   `SinglePlayer` without crashes. Granted, each time the level changed it took a long time for Editor to destroy or re-create `SinglePlayer` level , but at least it did not crash anymore.
