### PR TITLE
Fix intrusive_multiset::Rotate compilation error when using intrusive_multiset_member_hook

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h
@@ -24,7 +24,7 @@ namespace AZStd
     #define AZSTD_RBTREE_RIGHT  1
 
     /**
-     * This is the node you need to include in you objects, if you want to use
+     * This is the node you need to include in your objects, if you want to use
      * it in intrusive multi set. You can do that either by inheriting it
      * or add it as a \b public member. They way you include the node should be in
      * using the appropriate hooks.
@@ -928,14 +928,15 @@ namespace AZStd
         inline void Rotate(node_ptr_type node, SideType side) const
         {
             hook_node_ptr_type hookNode = Hook::to_node_ptr(node);
-            AZSTD_CONTAINER_ASSERT(Hook::to_node_ptr(hookNode->getParent())->m_children[node->getParentSide()] == node, "Invalid node structure");
+            AZSTD_CONTAINER_ASSERT(Hook::to_node_ptr(hookNode->getParent())->m_children[hookNode->getParentSide()] == node, "Invalid node structure");
             SideType o = static_cast<SideType>(1 - side);
             SideType ps = hookNode->getParentSide();
             node_ptr_type top = hookNode->m_children[o];
             hook_node_ptr_type topHook = Hook::to_node_ptr(top);
             hookNode->m_children[o] = topHook->m_children[side];
-            hookNode->m_children[o]->setParent(node);
-            hookNode->m_children[o]->setParentSide(o);
+            hook_node_ptr_type childHook = Hook::to_node_ptr(hookNode->m_children[o]);
+            childHook->setParent(node);
+            childHook->setParentSide(o);
             node_ptr_type parent = hookNode->getParent();
             hook_node_ptr_type parentHook = Hook::to_node_ptr(parent);
             topHook->setParent(parent);


### PR DESCRIPTION
## What does this PR do?

When using [intrusive_multiset_member_hook](https://github.com/o3de/o3de/blob/b8a8d94a5b3fb0819eec2e8886fdf297ab074c9d/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h#L120) in conjunction with [intrusive_multiset](https://github.com/o3de/o3de/blob/b8a8d94a5b3fb0819eec2e8886fdf297ab074c9d/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h#L144), a compile error when instantiating the template  occurs in the member function [Rotate](https://github.com/o3de/o3de/blob/b8a8d94a5b3fb0819eec2e8886fdf297ab074c9d/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h#L928) saying that:

```
getParentSide': is not a member of ....
```
When instantiating `intrusive_multiset`, the `Hook` template parameter can either be `intrusive_multiset_base_hook` or `intrusive_multiset_member_hook`. When using `intrusive_multiset_base_hook`, the base template type `T` must be derive from [intrusive_multiset_node](https://github.com/o3de/o3de/blob/b8a8d94a5b3fb0819eec2e8886fdf297ab074c9d/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h#L34). [intrusive_multiset_member_hook](https://github.com/o3de/o3de/blob/b8a8d94a5b3fb0819eec2e8886fdf297ab074c9d/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h#L120) is used when you don't want to derive from `intrusive_multiset_node` but rather have an instance of it as a member variable in the input template type `T`.  (See the description [here](https://github.com/o3de/o3de/blob/b8a8d94a5b3fb0819eec2e8886fdf297ab074c9d/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h#L135-L141))

For this mechanism to work, the 2 hook template types have forwarding methods to either return the node itself (when it is derived from `intrusive_multiset_node`), or forwards the underlying reference to the member of the node type (when it has a member `intrusive_multiset_node` type). 

The method [Rotate](https://github.com/o3de/o3de/blob/b8a8d94a5b3fb0819eec2e8886fdf297ab074c9d/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h#L928) was the only function that was missing these forwarding methods and was returning the node itself, which in the case of `intrusive_multiset_base_hook` is just return the input `nodePtr`. The assert and the child hooks in the function needed to follow the pattern of using `Hook::to_node_ptr` like the other methods.

This fixes https://github.com/o3de/o3de/issues/18304 

## How was this PR tested?
The steps described in https://github.com/o3de/o3de/issues/18304 was used to replicate this issue.
