### PR TITLE
Fix usage of RayTracing feature mask in mixed multi-GPU scenario

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -45,7 +45,7 @@ namespace AZ
         RayTracingPass::RayTracingPass(const RPI::PassDescriptor& descriptor)
             : RenderPass(descriptor)
             , m_passDescriptor(descriptor)
-            , m_dispatchRaysItem(RHI::MultiDevice::AllDevices)
+            , m_dispatchRaysItem(RHI::RHISystemInterface::Get()->GetRayTracingSupport())
         {
             m_flags.m_canBecomeASubpass = false;
             if (RHI::RHISystemInterface::Get()->GetRayTracingSupport() == RHI::MultiDevice::NoDevices)
@@ -278,8 +278,8 @@ namespace AZ
                     m_indirectDispatchRaysBufferSignature = aznew AZ::RHI::IndirectBufferSignature();
                     AZ::RHI::IndirectBufferSignatureDescriptor signatureDescriptor{};
                     signatureDescriptor.m_layout = bufferLayout;
-                    [[maybe_unused]] auto result =
-                        m_indirectDispatchRaysBufferSignature->Init(AZ::RHI::MultiDevice::AllDevices, signatureDescriptor);
+                    [[maybe_unused]] auto result = m_indirectDispatchRaysBufferSignature->Init(
+                        AZ::RHI::RHISystemInterface::Get()->GetRayTracingSupport(), signatureDescriptor);
 
                     AZ_Assert(result == AZ::RHI::ResultCode::Success, "Fail to initialize Indirect Buffer Signature");
                 }
@@ -320,7 +320,8 @@ namespace AZ
 
                 if (!m_dispatchRaysIndirectBuffer)
                 {
-                    m_dispatchRaysIndirectBuffer = aznew AZ::RHI::DispatchRaysIndirectBuffer{ AZ::RHI::MultiDevice::AllDevices };
+                    m_dispatchRaysIndirectBuffer =
+                        aznew AZ::RHI::DispatchRaysIndirectBuffer{ AZ::RHI::RHISystemInterface::Get()->GetRayTracingSupport() };
                     m_dispatchRaysIndirectBuffer->Init(
                         AZ::RPI::BufferSystemInterface::Get()->GetCommonBufferPool(AZ::RPI::CommonBufferPoolType::Indirect).get());
                 }
@@ -484,7 +485,8 @@ namespace AZ
                 // scene changed, need to rebuild the shader table
                 m_rayTracingShaderTableRevision = rayTracingFeatureProcessor->GetRevision();
                 m_rayTracingShaderTable = aznew AZ::RHI::RayTracingShaderTable();
-                m_rayTracingShaderTable->Init(AZ::RHI::MultiDevice::AllDevices, rayTracingFeatureProcessor->GetBufferPools());
+                m_rayTracingShaderTable->Init(
+                    AZ::RHI::RHISystemInterface::Get()->GetRayTracingSupport(), rayTracingFeatureProcessor->GetBufferPools());
 
                 AZStd::shared_ptr<RHI::RayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RHI::RayTracingShaderTableDescriptor>();
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -102,7 +102,7 @@ namespace AZ
 
             // create the ray tracing pipeline state object
             m_rayTracingPipelineState = aznew RHI::RayTracingPipelineState;
-            m_rayTracingPipelineState->Init(RHI::MultiDevice::AllDevices, descriptor);
+            m_rayTracingPipelineState->Init(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), descriptor);
 
             // Since the ray tracing pipeline state changed, we need to rebuilt the shader table
             m_rayTracingRevision = 0;
@@ -155,7 +155,7 @@ namespace AZ
                 RHI::RayTracingBufferPools& rayTracingBufferPools = rayTracingFeatureProcessor->GetBufferPools();
 
                 m_rayTracingShaderTable = aznew RHI::RayTracingShaderTable;
-                m_rayTracingShaderTable->Init(RHI::MultiDevice::AllDevices, rayTracingBufferPools);
+                m_rayTracingShaderTable->Init(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), rayTracingBufferPools);
             }
 
             RenderPass::FrameBeginInternal(params);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -95,7 +95,7 @@ namespace AZ
 
             // create the ray tracing pipeline state object
             m_rayTracingPipelineState = aznew RHI::RayTracingPipelineState;
-            m_rayTracingPipelineState->Init(RHI::MultiDevice::AllDevices, descriptor);
+            m_rayTracingPipelineState->Init(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), descriptor);
         }
 
         bool DiffuseProbeGridVisualizationRayTracingPass::IsEnabled() const
@@ -142,7 +142,7 @@ namespace AZ
                 RHI::RayTracingBufferPools& rayTracingBufferPools = diffuseProbeGridFeatureProcessor->GetVisualizationBufferPools();
 
                 m_rayTracingShaderTable = aznew RHI::RayTracingShaderTable;
-                m_rayTracingShaderTable->Init(RHI::MultiDevice::AllDevices, rayTracingBufferPools);
+                m_rayTracingShaderTable->Init(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), rayTracingBufferPools);
 
                 AZStd::shared_ptr<RHI::RayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RHI::RayTracingShaderTableDescriptor>();
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes some inconsistent usage of `RHISystemInterface::Get()->GetRayTracingSupport()` vs. `RHI::MultiDevice::AllDevices` in some RT-related classes.
This is noticeable when running multi-GPU code on mixed hardware, where the two masks do not align (i.e. on a notebook with integrated graphics and a discrete GPU as well), leading to crashes when accessing multi-device objects not available on non-RT cards.

## How was this PR tested?

Tested the multi-GPU samples in ASV on a notebook with Intel integrated graphics and a dedicated NVIDIA GPU.
