### PR TITLE
Fix Network Prefab Multi-Entity Spawn Transform

### DIFF
--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -464,6 +464,12 @@ namespace Multiplayer
                 auto it = originalToCloneIdMap.find(parentId);
                 if (it != originalToCloneIdMap.end())
                 {
+                    // Note: The need to remove and readd the transform component parent will go away once this method replaces serializeContext->CloneObject
+                    //    with the standard AzFramework::SpawnableEntitiesInterface::SpawnEntities
+                    // This stops SetParentRelative() from printing distracting warnings, due to the cloned component m_entity being null.
+                    // AddComponent properly sets the component's m_entity. 
+                    clone->RemoveComponent(cloneTransformComponent);
+                    clone->AddComponent(cloneTransformComponent);
                     cloneTransformComponent->SetParentRelative(it->second);
                 }
                 else
@@ -482,7 +488,12 @@ namespace Multiplayer
 
             const NetEntityId netEntityId = NextId();
             cloneNetBindComponent->PreInit(clone, prefabEntityId, netEntityId, netEntityRole);
-            cloneTransformComponent->SetWorldTM(transform);
+
+            // Set the transform if we're a root entity (have no parent); otherwise, keep the local transform
+            if (!parentId.IsValid() || removeParent)
+            {
+                cloneTransformComponent->SetWorldTM(transform);
+            }
 
             if (autoActivate == AutoActivate::DoNotActivate)
             {


### PR DESCRIPTION
Properly spawn network prefabs that contain multiple entities in the right location by ensuring to keep children entities local transform. The child entity (as long as it contains a Network Transform) will move along as the parent controller is updated on the server/game

Adding fix to avoid distracting warnings during the network spawn process

Tested by running a server and 2 game launchers.
 1. Created a 2-entity network player and ensured hierarchy remained
 2. Tested using spawn points off the origin
 
![image](https://github.com/user-attachments/assets/279d49e9-1891-4d08-a5bc-713508cf6cb2)

Fixes #17987 