### PR TITLE
Calibrated Timestamps for multi-device timestamp comparability

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -128,6 +128,9 @@ namespace AZ::RHI
         //! Converts a GPU timestamp to microseconds
         virtual AZStd::chrono::microseconds GpuTimestampToMicroseconds(uint64_t gpuTimestamp, HardwareQueueClass queueClass) const = 0;
 
+        //! Get a calibrated timestamp that returns a "simultaneous" timestamp on the GPU and CPU
+        virtual AZStd::pair<uint64_t, uint64_t> GetCalibratedTimestamp(HardwareQueueClass queueClass = HardwareQueueClass::Graphics) = 0;
+
         //! Called before the device is going to be shutdown. This lets the device release any resources
         //! that also hold on to a Ptr to Device.
         virtual void PreShutdown() = 0;

--- a/Gems/Atom/RHI/Code/Tests/Device.h
+++ b/Gems/Atom/RHI/Code/Tests/Device.h
@@ -59,6 +59,11 @@ namespace UnitTest
             return AZStd::chrono::microseconds();
         }
 
+        AZStd::pair<uint64_t, uint64_t> GetCalibratedTimestamp([[maybe_unused]] AZ::RHI::HardwareQueueClass queueClass) override
+        {
+            return { 0ull, AZStd::chrono::microseconds().count() };
+        }
+
         void FillFormatsCapabilitiesInternal([[maybe_unused]] FormatCapabilitiesList& formatsCapabilities) override {}
 
         AZ::RHI::ResultCode InitializeLimits() override { return AZ::RHI::ResultCode::Success; }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.cpp
@@ -124,6 +124,13 @@ namespace AZ
             }
         }
 
+        AZStd::pair<uint64_t, uint64_t> CommandQueue::GetClockCalibration()
+        {
+            AZStd::pair<uint64_t, uint64_t> calibratedTimestamp{ 0ull, 0ull };
+            m_queue->GetClockCalibration(&calibratedTimestamp.first, &calibratedTimestamp.second);
+            return calibratedTimestamp;
+        }
+
         uint64_t CommandQueue::GetGpuTimestampFrequency() const
         {
             return m_calibratedGpuTimestampFrequency;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.h
@@ -69,6 +69,7 @@ namespace AZ
             //////////////////////////////////////////////////////////////////////////
 
             void CalibrateClock();
+            AZStd::pair<uint64_t, uint64_t> GetClockCalibration();
 
             ID3D12CommandQueue* GetPlatformQueue() const;
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.cpp
@@ -370,6 +370,11 @@ namespace AZ
             return AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(durationInSeconds);
         }
 
+        AZStd::pair<uint64_t, uint64_t> Device::GetCalibratedTimestamp(RHI::HardwareQueueClass queueClass)
+        {
+            return m_commandQueueContext.GetCommandQueue(queueClass).GetClockCalibration();
+        }
+
         void Device::FillFormatsCapabilitiesInternal(FormatCapabilitiesList& formatsCapabilities)
         {
             for (uint32_t i = 0; i < formatsCapabilities.size(); ++i)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Device.h
@@ -173,6 +173,7 @@ namespace AZ
             void EndFrameInternal() override;
             void WaitForIdleInternal() override;
             AZStd::chrono::microseconds GpuTimestampToMicroseconds(uint64_t gpuTimestamp, RHI::HardwareQueueClass queueClass) const override;
+            AZStd::pair<uint64_t, uint64_t> GetCalibratedTimestamp(RHI::HardwareQueueClass queueClass) override;
             void FillFormatsCapabilitiesInternal(FormatCapabilitiesList& formatsCapabilities) override;
             RHI::ResultCode InitializeLimits() override;
             AZStd::vector<RHI::Format> GetValidSwapChainImageFormats(const RHI::WindowHandle& windowHandle) const override;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.h
@@ -172,6 +172,7 @@ namespace AZ
             void EndFrameInternal() override;
             void WaitForIdleInternal() override;
             AZStd::chrono::microseconds GpuTimestampToMicroseconds(uint64_t gpuTimestamp, RHI::HardwareQueueClass queueClass) const override;
+            AZStd::pair<uint64_t, uint64_t> GetCalibratedTimestamp([[maybe_unused]] RHI::HardwareQueueClass queueClass) override { return {0ull, 0ull}; }
             void FillFormatsCapabilitiesInternal(FormatCapabilitiesList& formatsCapabilities) override;
             RHI::ResultCode InitializeLimits() override;
             void PreShutdown() override;

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/Device.h
@@ -38,6 +38,10 @@ namespace AZ
             void EndFrameInternal() override {}
             void WaitForIdleInternal() override {}
             AZStd::chrono::microseconds GpuTimestampToMicroseconds([[maybe_unused]] uint64_t gpuTimestamp, [[maybe_unused]] RHI::HardwareQueueClass queueClass) const override { return AZStd::chrono::microseconds();}
+            AZStd::pair<uint64_t, uint64_t> GetCalibratedTimestamp([[maybe_unused]] RHI::HardwareQueueClass queueClass) override
+            {
+                return { 0ull, AZStd::chrono::microseconds().count() };
+            };
             void FillFormatsCapabilitiesInternal([[maybe_unused]] FormatCapabilitiesList& formatsCapabilities) override;
             RHI::ResultCode InitializeLimits() override;
             void PreShutdown() override {}

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.h
@@ -199,6 +199,7 @@ namespace AZ
             void UpdateCpuTimingStatisticsInternal() const override;
             AZStd::vector<RHI::Format> GetValidSwapChainImageFormats(const RHI::WindowHandle& windowHandle) const override;
             AZStd::chrono::microseconds GpuTimestampToMicroseconds(uint64_t gpuTimestamp, RHI::HardwareQueueClass queueClass) const override;
+            AZStd::pair<uint64_t, uint64_t> GetCalibratedTimestamp(RHI::HardwareQueueClass queueClass) override;
             void FillFormatsCapabilitiesInternal(FormatCapabilitiesList& formatsCapabilities) override;
             RHI::ResultCode InitializeLimits() override;
             void PreShutdown() override;
@@ -229,6 +230,9 @@ namespace AZ
 
             VkImageUsageFlags CalculateImageUsageFlags(const RHI::ImageDescriptor& descriptor) const;
             VkImageCreateFlags CalculateImageCreateFlags(const RHI::ImageDescriptor& descriptor) const;
+
+            //! Calibrated Timestamps
+            void InitializeTimeDomains();
 
             VkDevice m_nativeDevice = VK_NULL_HANDLE;
             VmaAllocator m_vmaAllocator = VK_NULL_HANDLE;
@@ -275,6 +279,8 @@ namespace AZ
 
             BindlessDescriptorPool m_bindlessDescriptorPool;
             ShadingRateImageMode m_imageShadingRateMode = ShadingRateImageMode::None;
+
+            VkTimeDomainEXT m_hostTimeDomain = VK_TIME_DOMAIN_MAX_ENUM_EXT;
         };
 
         template<typename ObjectType, typename ...Args>

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -313,36 +313,35 @@ namespace AZ
         RawStringList PhysicalDevice::FilterSupportedOptionalExtensions()
         {
             // The order must match the enum OptionalDeviceExtensions
-            RawStringList optionalExtensions = { {
-                VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
-                VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME,
-                VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
-                VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME,
-                VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,
-                VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,
-                VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME,
-                VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
-                VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,
-                VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME,
-                VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME,
+            RawStringList optionalExtensions = { { VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
+                                                   VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME,
+                                                   VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
+                                                   VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME,
+                                                   VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,
+                                                   VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,
+                                                   VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME,
+                                                   VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
+                                                   VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,
+                                                   VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME,
+                                                   VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME,
 
-                // ray tracing extensions
-                VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
-                VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
-                VK_KHR_RAY_QUERY_EXTENSION_NAME,
-                VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
-                VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
-                VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
-                VK_KHR_SPIRV_1_4_EXTENSION_NAME,
-                VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME,
+                                                   // ray tracing extensions
+                                                   VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+                                                   VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
+                                                   VK_KHR_RAY_QUERY_EXTENSION_NAME,
+                                                   VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
+                                                   VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
+                                                   VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
+                                                   VK_KHR_SPIRV_1_4_EXTENSION_NAME,
+                                                   VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME,
 
-                VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME,
-                VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME,
-                VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
-                VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
-                VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME,
-                VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME
-            } };
+                                                   VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME,
+                                                   VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME,
+                                                   VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
+                                                   VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+                                                   VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME,
+                                                   VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME,
+                                                   VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME } };
 
             [[maybe_unused]] uint32_t optionalExtensionCount = aznumeric_cast<uint32_t>(optionalExtensions.size());
 
@@ -367,6 +366,26 @@ namespace AZ
             }
 
             return filteredOptionalExtensions;
+        }
+
+        AZStd::vector<VkTimeDomainEXT> PhysicalDevice::GetCalibratedTimeDomains(const GladVulkanContext& context) const
+        {
+            AZStd::vector<VkTimeDomainEXT> time_domains;
+
+            // Initialize time domain count:
+            auto time_domain_count{ 0u };
+            // Update time domain count:
+            auto result = context.GetPhysicalDeviceCalibrateableTimeDomainsEXT(m_vkPhysicalDevice, &time_domain_count, nullptr);
+
+            if (result == VK_SUCCESS)
+            {
+                // Resize time domains vector:
+                time_domains.resize(time_domain_count);
+                // Update time_domain vector:
+                result = context.GetPhysicalDeviceCalibrateableTimeDomainsEXT(m_vkPhysicalDevice, &time_domain_count, time_domains.data());
+            }
+
+            return time_domains;
         }
 
         uint32_t PhysicalDevice::GetVulkanVersion() const

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -67,6 +67,7 @@ namespace AZ
             TimelineSempahore,
             LoadStoreOpNone,
             SubpassMergeFeedback,
+            CalibratedTimestamps,
             Count
         };
 
@@ -121,6 +122,8 @@ namespace AZ
             RawStringList FilterSupportedOptionalExtensions();
             //! Returns the supported vulkan version of the physical device.
             uint32_t GetVulkanVersion() const;
+            //! Query the set of available time domains for timestamp calibration
+            AZStd::vector<VkTimeDomainEXT> GetCalibratedTimeDomains(const GladVulkanContext& context) const;
 
         private:
             

--- a/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
@@ -66,6 +66,10 @@ namespace UnitTest
             {
                 return AZStd::chrono::microseconds();
             }
+            AZStd::pair<uint64_t, uint64_t> GetCalibratedTimestamp([[maybe_unused]] AZ::RHI::HardwareQueueClass queueClass) override
+            {
+                return { 0ull, AZStd::chrono::microseconds().count() };
+            };
             void FillFormatsCapabilitiesInternal([[maybe_unused]] FormatCapabilitiesList& formatsCapabilities) override {}
             AZ::RHI::ResultCode InitializeLimits() override { return AZ::RHI::ResultCode::Success; }
             void PreShutdown() override {}

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -255,11 +255,15 @@ namespace AZ
 
             // Show pass execution timeline
             bool m_showTimeline = false;
+            float m_timelineOffset{ 0.f };
+            float m_timelineWindowWidth{ 1.f };
 
             // Controls how often the timestamp data is refreshed
             RefreshType m_refreshType = RefreshType::Realtime;
             AZStd::sys_time_t m_lastUpdateTimeMicroSecond = 0;
 
+            AZStd::unordered_map<int, AZStd::pair<uint64_t, uint64_t>> m_lastCalibratedTimestamps;
+            AZStd::unordered_map<int, AZStd::pair<uint64_t, uint64_t>> m_calibratedTimestamps;
         };
 
         class ImGuiGpuMemoryView

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -588,6 +588,8 @@ namespace AZ
                 return;
             }
 
+            auto* rhiSystem = AZ::RHI::RHISystemInterface::Get();
+
             // Clear the references from the previous frame.
             m_passEntryReferences.clear();
 
@@ -597,6 +599,8 @@ namespace AZ
                 AZStd::vector<PassEntry*> sortedPassEntries;
                 AZStd::vector<AZStd::vector<PassEntry*>> sortedPassGrid;
                 RPI::TimestampResult gpuTimestamp;
+                int64_t deviceReferenceDuration;
+                int64_t hostReferenceDuration;
             };
 
             AZStd::map<int, PerDevicePassData> passEntriesMap;
@@ -637,8 +641,29 @@ namespace AZ
                 }
             }
 
+            int64_t minimumHostTime{ INT64_MAX };
+            int64_t maximumHostTime{ INT64_MIN };
+
             for (auto& [deviceIndex, passEntries] : passEntriesMap)
             {
+                // Only calibrate when taking new measurements to prevent flickering
+                if (!m_paused)
+                {
+                    m_calibratedTimestamps[deviceIndex] = rhiSystem->GetDevice(deviceIndex)->GetCalibratedTimestamp();
+                }
+
+                if (m_lastCalibratedTimestamps.find(deviceIndex) == m_lastCalibratedTimestamps.end())
+                {
+                    m_lastCalibratedTimestamps[deviceIndex] = { 0, 0 };
+                }
+
+                auto& [calibratedTimestampDevice, calibratedTimestampHost] = m_calibratedTimestamps[deviceIndex];
+                auto& [lastCalibratedTimestampDevice, lastCalibratedTimestampHost] = m_lastCalibratedTimestamps[deviceIndex];
+
+                // Calculate the scaling factor to go from a host to a device timestamp
+                passEntries.deviceReferenceDuration = calibratedTimestampDevice - lastCalibratedTimestampDevice;
+                passEntries.hostReferenceDuration = calibratedTimestampHost - lastCalibratedTimestampHost;
+
                 // Sort the pass entries based on their starting time and duration
                 AZStd::sort(
                     passEntries.sortedPassEntries.begin(),
@@ -654,11 +679,51 @@ namespace AZ
                             passEntry2->m_timestampResult.GetTimestampBeginInTicks();
                     });
 
+                uint64_t lastTimestamp{ 0 };
+                PassEntry* lastPassEntry{ nullptr };
+
+                // find the maximum length, since the pass that starts last could end earlier than another pass, so the sorting doesn't help
+                for (const auto& passEntry : passEntries.sortedPassEntries)
+                {
+                    uint64_t endTimestamp{ passEntry->m_timestampResult.GetTimestampBeginInTicks() +
+                                           passEntry->m_timestampResult.GetDurationInTicks() };
+
+                    if (endTimestamp > lastTimestamp)
+                    {
+                        lastPassEntry = passEntry;
+                        lastTimestamp = endTimestamp;
+                    }
+                }
+
                 // calculate the total GPU duration.
                 if (passEntries.sortedPassEntries.size() > 0)
                 {
                     passEntries.gpuTimestamp = passEntries.sortedPassEntries.front()->m_timestampResult;
-                    passEntries.gpuTimestamp.Add(passEntries.sortedPassEntries.back()->m_timestampResult);
+                    passEntries.gpuTimestamp.Add(lastPassEntry->m_timestampResult);
+                }
+
+                // Convert a device timestamp to a host timestamp so that all timestamps are in one reference frame and hence comparable
+                auto convertToHostTime{ [lastDeviceTimestamp = lastCalibratedTimestampDevice,
+                                         lastHostTimeStamp = lastCalibratedTimestampHost,
+                                         deviceReferenceDuration = passEntries.deviceReferenceDuration,
+                                         hostReferenceDuration = passEntries.hostReferenceDuration](int64_t timestamp)
+                                        {
+                                            return (((timestamp - int64_t(lastDeviceTimestamp)) * hostReferenceDuration) /
+                                                    deviceReferenceDuration) +
+                                                int64_t(lastHostTimeStamp);
+                                        } };
+
+                int64_t hostStartTime{ convertToHostTime(passEntries.gpuTimestamp.GetTimestampBeginInTicks()) };
+                int64_t hostEndTime{ convertToHostTime(lastTimestamp) };
+
+                if (hostStartTime < minimumHostTime)
+                {
+                    minimumHostTime = hostStartTime;
+                }
+
+                if (hostEndTime > maximumHostTime)
+                {
+                    maximumHostTime = hostEndTime;
                 }
 
                 // Add a pass to the pass grid which none of the pass's timestamp range won't overlap each other.
@@ -686,6 +751,8 @@ namespace AZ
                     }
                 }
             }
+
+            auto hostDuration{ maximumHostTime - minimumHostTime };
 
             // Refresh timestamp query
             bool needEnable = false;
@@ -779,6 +846,8 @@ namespace AZ
                         const float passBarSpace = 3.f;
                         float areaWidth = ImGui::GetContentRegionAvail().x - 20.f;
 
+                        auto& [lastCalibratedTimestampDevice, lastCalibratedTimestampHost] = m_lastCalibratedTimestamps[deviceIndex];
+
                         ImGui::Text("GPU %d", deviceIndex);
                         AZStd::string childID{ "Timeline" + AZStd::to_string(deviceIndex) };
                         if (ImGui::BeginChild(
@@ -786,11 +855,19 @@ namespace AZ
                                 ImVec2(areaWidth, (passBarHeight + passBarSpace) * passEntries.sortedPassGrid.size()),
                                 false))
                         {
-                            // start tick and end tick for the area
-                            uint64_t areaStartTick = passEntries.sortedPassEntries.front()->m_timestampResult.GetTimestampBeginInTicks();
-                            uint64_t areaEndTick = passEntries.sortedPassEntries.back()->m_timestampResult.GetTimestampBeginInTicks() +
-                                passEntries.sortedPassEntries.back()->m_timestampResult.GetDurationInTicks();
-                            uint64_t areaDurationInTicks = areaEndTick - areaStartTick;
+                            // To compute the correct minimum time per device, shift the minimum host time to the start of its
+                            // host time and compute the start tick and end tick for the area for device measurements
+                            auto shiftedHostTime = minimumHostTime - int64_t(lastCalibratedTimestampHost);
+                            auto areaStartTick =
+                                ((shiftedHostTime * passEntries.deviceReferenceDuration) / passEntries.hostReferenceDuration) +
+                                int64_t(lastCalibratedTimestampDevice);
+                            auto areaDurationInTicks =
+                                (hostDuration * passEntries.deviceReferenceDuration) / passEntries.hostReferenceDuration;
+
+                            auto offset = static_cast<int64_t>(static_cast<double>(areaDurationInTicks) * m_timelineOffset);
+                            areaStartTick += offset;
+                            auto scaledAreaDurationInTicks =
+                                static_cast<int64_t>(static_cast<double>(areaDurationInTicks) * m_timelineWindowWidth);
 
                             float rowStartY = 0.f;
                             for (auto& row : passEntries.sortedPassGrid)
@@ -798,15 +875,38 @@ namespace AZ
                                 // row start y
                                 for (auto passEntry : row)
                                 {
-                                    // button start and end
-                                    float buttonStartX = (passEntry->m_timestampResult.GetTimestampBeginInTicks() - areaStartTick) *
-                                        areaWidth / areaDurationInTicks;
-                                    float buttonWidth = passEntry->m_timestampResult.GetDurationInTicks() * areaWidth / areaDurationInTicks;
+                                    // button start and width
+                                    float buttonStartX =
+                                        (int64_t(passEntry->m_timestampResult.GetTimestampBeginInTicks()) - areaStartTick) * areaWidth /
+                                        scaledAreaDurationInTicks;
+                                    float buttonWidth =
+                                        passEntry->m_timestampResult.GetDurationInTicks() * areaWidth / scaledAreaDurationInTicks;
+
+                                    // If pass duration is too small, it is not visible in the timeline
+                                    // Increase the size to at least 1.5f and color them to denote this change
+                                    bool notVisible{ false };
+                                    if (buttonWidth < 1.5f)
+                                    {
+                                        buttonWidth = 1.5f;
+                                        notVisible = true;
+                                    }
+
                                     ImGui::SetCursorPosX(buttonStartX);
                                     ImGui::SetCursorPosY(rowStartY);
 
+                                    // If the size or position needed to be modified, color it red to make this clear
+                                    if (notVisible)
+                                    {
+                                        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{ 1.0f, 0.0f, 0.0f, 1.0f });
+                                    }
+
                                     // Adds a button and the hover colors.
                                     ImGui::Button(passEntry->m_name.GetCStr(), ImVec2(buttonWidth, passBarHeight));
+
+                                    if (notVisible)
+                                    {
+                                        ImGui::PopStyleColor(1);
+                                    }
 
                                     if (ImGui::IsItemHovered())
                                     {
@@ -819,6 +919,7 @@ namespace AZ
                                         ImGui::Text(
                                             "Duration in microsecond: %.3f us",
                                             passEntry->m_timestampResult.GetDurationInNanoseconds() / 1000.f);
+                                        ImGui::Text("Relative starting position (0-1): %.3f", buttonStartX / areaWidth);
                                         ImGui::EndTooltip();
                                     }
                                 }
@@ -828,8 +929,37 @@ namespace AZ
                         }
                         ImGui::EndChild();
 
+                        // Control the timeline offset and scale
+                        ImGuiIO& io = ImGui::GetIO();
+                        if (ImGui::IsWindowFocused() && ImGui::IsItemHovered())
+                        {
+                            io.WantCaptureMouse = true;
+                            static constexpr float STEP_SIZE{ 0.1f };
+                            auto timelineXOffsetScale{ (ImGui::GetMousePos().x - ImGui::GetCursorScreenPos().x) / areaWidth };
+                            if (io.MouseWheel)
+                            {
+                                auto stepSize{ STEP_SIZE * m_timelineWindowWidth };
+                                if (io.MouseWheel > 0.f)
+                                {
+                                    m_timelineWindowWidth = AZStd::max(m_timelineWindowWidth - stepSize, 0.f);
+                                    m_timelineOffset = AZStd::min(m_timelineOffset + (stepSize * timelineXOffsetScale), 1.f);
+                                }
+                                else
+                                {
+                                    m_timelineWindowWidth = AZStd::min(m_timelineWindowWidth + stepSize, 1.f);
+                                    m_timelineOffset = AZStd::max(m_timelineOffset - (stepSize * timelineXOffsetScale), 0.f);
+                                }
+                            }
+                        }
+
                         ImGui::Separator();
                     }
+                }
+
+                // Reset m_lastCalibratedTimestamps every frame if not paused
+                if (!m_paused)
+                {
+                    m_lastCalibratedTimestamps = m_calibratedTimestamps;
                 }
 
                 // Draw the timestamp view.

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -599,8 +599,8 @@ namespace AZ
                 AZStd::vector<PassEntry*> sortedPassEntries;
                 AZStd::vector<AZStd::vector<PassEntry*>> sortedPassGrid;
                 RPI::TimestampResult gpuTimestamp;
-                int64_t deviceReferenceDuration;
-                int64_t hostReferenceDuration;
+                int64_t deviceReferenceDuration{};
+                int64_t hostReferenceDuration{};
             };
 
             AZStd::map<int, PerDevicePassData> passEntriesMap;
@@ -654,7 +654,7 @@ namespace AZ
             for (auto& [deviceIndex, passEntries] : passEntriesMap)
             {
                 // Only calibrate when taking new measurements to prevent flickering
-                if (!m_paused)
+                if (!m_paused || m_calibratedTimestamps[deviceIndex] == m_lastCalibratedTimestamps[deviceIndex])
                 {
                     m_calibratedTimestamps[deviceIndex] = rhiSystem->GetDevice(deviceIndex)->GetCalibratedTimestamp();
                 }
@@ -966,7 +966,10 @@ namespace AZ
                 // Reset m_lastCalibratedTimestamps every frame if not paused
                 if (!m_paused)
                 {
-                    m_lastCalibratedTimestamps = m_calibratedTimestamps;
+                    for (auto& [deviceIndex, timestamps] : m_calibratedTimestamps)
+                    {
+                        m_lastCalibratedTimestamps[deviceIndex] = timestamps;
+                    }
                 }
 
                 // Draw the timestamp view.

--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -641,6 +641,13 @@ namespace AZ
                 }
             }
 
+            /*
+                In order to compare timestamps recorded on multiple devices to one another, they need to be related to a common reference
+               frame. To this end, calibrated timestamps are recorded for each device, which represent a "simultaneous" timestamp on both
+               CPU and a specified GPU. With these timestamps at hand at hand, device timestamps are first related to the common CPU time
+               reference frame to allow for proper positioning and scaling of the resulting timestamp bars. The final values are again
+               displayed as device timestamps in the end.
+            */
             int64_t minimumHostTime{ INT64_MAX };
             int64_t maximumHostTime{ INT64_MIN };
 
@@ -884,18 +891,18 @@ namespace AZ
 
                                     // If pass duration is too small, it is not visible in the timeline
                                     // Increase the size to at least 1.5f and color them to denote this change
-                                    bool notVisible{ false };
+                                    bool tooNarrow{ false };
                                     if (buttonWidth < 1.5f)
                                     {
                                         buttonWidth = 1.5f;
-                                        notVisible = true;
+                                        tooNarrow = true;
                                     }
 
                                     ImGui::SetCursorPosX(buttonStartX);
                                     ImGui::SetCursorPosY(rowStartY);
 
                                     // If the size or position needed to be modified, color it red to make this clear
-                                    if (notVisible)
+                                    if (tooNarrow)
                                     {
                                         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{ 1.0f, 0.0f, 0.0f, 1.0f });
                                     }
@@ -903,7 +910,7 @@ namespace AZ
                                     // Adds a button and the hover colors.
                                     ImGui::Button(passEntry->m_name.GetCStr(), ImVec2(buttonWidth, passBarHeight));
 
-                                    if (notVisible)
+                                    if (tooNarrow)
                                     {
                                         ImGui::PopStyleColor(1);
                                     }


### PR DESCRIPTION
## What does this PR do?

https://github.com/o3de/o3de/pull/18500 introduced multiple timelines for multiple GPUs to the GPU Profiler -> TimestampView.
And it already mentioned one remaining issue, which is that GPU timestamps are not in one reference frame, hence cannot be compared directly against one another, i.e. timelines are not scaled/shifted appropriately in relation to one another.

This can be solved with calibrated timestamps ([vulkan](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_KHR_calibrated_timestamps.html) / [dx12](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12commandqueue-getclockcalibration)), which returns a "simultaneous" timestamp on the CPU and a GPU.

Given this, one can relate timestamps from multiple GPUs to CPU timestamps, hence bring them into one reference frame and make them comparable, i.e. also scale and shift them appropriately.

Additionally, we added the ability to zoom into the timeline, as is shown here:


https://github.com/user-attachments/assets/b629acbd-13c2-439e-b6a8-41ec9140e3ca



## How was this PR tested?

Running a multi-GPU workload (like ASV -> RPI -> MultiGPU sample) and look at the GPU Profiler -> TimestampView.


