### PR TITLE
Built-in Crash Reporter : Fix and improve message box dialogs

### DIFF
--- a/Code/Legacy/CrySystem/DebugCallStack.cpp
+++ b/Code/Legacy/CrySystem/DebugCallStack.cpp
@@ -636,8 +636,8 @@ void DebugCallStack::SaveExceptionInfoAndShowUserReportDialogs(EXCEPTION_POINTER
         {
             constexpr bool showCancel = false;
             AZStd::string res = nativeUI->DisplayYesNoDialog(
-                "Save your changes ?",
-                "Do you want to try to save your changes ?\nAs O3DE is in panic state, it might corrupt your data",
+                "Save your changes?",
+                "Do you want to try to save your changes?\nAs O3DE is in a panic state, it might corrupt your data",
                 showCancel);
             if (res == "Yes")
             {
@@ -781,7 +781,9 @@ static bool IsFloatingPointException(EXCEPTION_POINTERS* pex)
 DebugCallStack::UserPostExceptionChoice DebugCallStack::AskUserToRecoverOrCrash(EXCEPTION_POINTERS* exception_pointer)
 {
     if (exception_pointer->ExceptionRecord->ExceptionFlags & EXCEPTION_NONCONTINUABLE)
+    {
         return UserPostExceptionChoice::Exit;
+    }
 
     UserPostExceptionChoice res = UserPostExceptionChoice::Exit;
     if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
@@ -797,9 +799,11 @@ DebugCallStack::UserPostExceptionChoice DebugCallStack::AskUserToRecoverOrCrash(
             pDCS->m_excCallstack);
 
         constexpr bool showCancel = false;
-        AZStd::string dialogRes = nativeUI->DisplayYesNoDialog("Try to recover ?", msg, showCancel);
+        AZStd::string dialogRes = nativeUI->DisplayYesNoDialog("Try to recover?", msg, showCancel);
         if (dialogRes == "Yes")
+        {
             res = UserPostExceptionChoice::Recover;
+        }
     }
     return res;
 }

--- a/Code/Legacy/CrySystem/DebugCallStack.cpp
+++ b/Code/Legacy/CrySystem/DebugCallStack.cpp
@@ -6,51 +6,41 @@
  *
  */
 
-
-#include "CrySystem_precompiled.h"
 #include "DebugCallStack.h"
+#include "CrySystem_precompiled.h"
 
 #if defined(WIN32) || defined(WIN64)
 
-#include <IConsole.h>
-#include <CryPath.h>
 #include "System.h"
 
+#include <CryPath.h>
+#include <IConsole.h>
+
 #include <AzCore/Debug/StackTracer.h>
-#include <AzCore/std/parallel/spin_mutex.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/NativeUI/NativeUIRequests.h>
 #include <AzCore/Utils/Utils.h>
-
-#define VS_VERSION_INFO                 1
-#define IDD_CRITICAL_ERROR              101
-#define IDB_CONFIRM_SAVE                102
-#define IDB_DONT_SAVE                   103
-#define IDD_CONFIRM_SAVE_LEVEL          127
-#define IDB_CRASH_FACE                  128
-#define IDD_EXCEPTION                   245
-#define IDC_CALLSTACK                   1001
-#define IDC_EXCEPTION_CODE              1002
-#define IDC_EXCEPTION_ADDRESS           1003
-#define IDC_EXCEPTION_MODULE            1004
-#define IDC_EXCEPTION_DESC              1005
-#define IDB_EXIT                        1008
-#define IDB_IGNORE                      1010
-__pragma(comment(lib, "version.lib"))
-
-//! Needs one external of DLL handle.
-extern HMODULE gDLLHandle;
+#include <AzCore/std/parallel/spin_mutex.h>
 
 #include <DbgHelp.h>
 
 #define MAX_PATH_LENGTH 1024
-#define MAX_SYMBOL_LENGTH 512
 
 static HWND hwndException = 0;
-static bool g_bUserDialog = true;         // true=on crash show dialog box, false=supress user interaction
+static bool g_bUserDialog = true; // true=on crash show dialog box, false=supress user interaction
+
+extern int prev_sys_float_exceptions;
+
+DWORD g_idDebugThreads[10];
+const char* g_nameDebugThreads[10];
+int g_nDebugThreads = 0;
+AZStd::spin_mutex g_lockThreadDumpList;
 
 static bool IsFloatingPointException(EXCEPTION_POINTERS* pex);
 
 extern LONG WINAPI CryEngineExceptionFilterWER(struct _EXCEPTION_POINTERS* pExceptionPointers);
-extern LONG WINAPI CryEngineExceptionFilterMiniDump(struct _EXCEPTION_POINTERS* pExceptionPointers, const char* szDumpPath, MINIDUMP_TYPE mdumpValue);
+extern LONG WINAPI
+CryEngineExceptionFilterMiniDump(struct _EXCEPTION_POINTERS* pExceptionPointers, const char* szDumpPath, MINIDUMP_TYPE mdumpValue);
 
 void MarkThisThreadForDebugging(const char* name);
 void UnmarkThisThreadFromDebugging();
@@ -72,11 +62,7 @@ LONG __stdcall CryUnhandledExceptionHandler(EXCEPTION_POINTERS* pex)
     return DebugCallStack::instance()->handleException(pex);
 }
 
-
-BOOL CALLBACK EnumModules(
-    PCSTR   ModuleName,
-    DWORD64 BaseOfDll,
-    PVOID   UserContext)
+BOOL CALLBACK EnumModules(PCSTR ModuleName, DWORD64 BaseOfDll, PVOID UserContext)
 {
     DebugCallStack::TModules& modules = *static_cast<DebugCallStack::TModules*>(UserContext);
     modules[(void*)BaseOfDll] = ModuleName;
@@ -153,12 +139,6 @@ void DebugCallStack::SetUserDialogEnable(const bool bUserDialogEnable)
     g_bUserDialog = bUserDialogEnable;
 }
 
-
-DWORD g_idDebugThreads[10];
-const char* g_nameDebugThreads[10];
-int g_nDebugThreads = 0;
-AZStd::spin_mutex g_lockThreadDumpList;
-
 void MarkThisThreadForDebugging(const char* name)
 {
     AZStd::scoped_lock lock(g_lockThreadDumpList);
@@ -194,7 +174,6 @@ void UnmarkThisThreadFromDebugging()
     }
 }
 
-extern int prev_sys_float_exceptions;
 void UpdateFPExceptionsMaskForThreads()
 {
     int mask = -iszero(g_cvars.sys_float_exceptions);
@@ -212,7 +191,7 @@ void UpdateFPExceptionsMaskForThreads()
             (*(WORD*)(ctx.ExtendedRegisters + 24) |= 0x280) &= ~0x280 | mask;
 #else
             (ctx.FltSave.ControlWord |= 7) &= ~5 | mask;
-            (ctx.FltSave.MxCsr |= 0x280) &= ~0x280  | mask;
+            (ctx.FltSave.MxCsr |= 0x280) &= ~0x280 | mask;
 #endif
             SetThreadContext(hThread, &ctx);
             ResumeThread(hThread);
@@ -294,9 +273,9 @@ int DebugCallStack::handleException(EXCEPTION_POINTERS* exception_pointer)
 
     firstTime = false;
 
-    const int ret = SubmitBug(exception_pointer);
+    const UserPostExceptionChoice ret = SubmitBugAndAskToRecoverOrCrash(exception_pointer);
 
-    if (ret != IDB_IGNORE)
+    if (ret != UserPostExceptionChoice::Recover)
     {
         CryEngineExceptionFilterWER(exception_pointer);
     }
@@ -309,20 +288,17 @@ int DebugCallStack::handleException(EXCEPTION_POINTERS* exception_pointer)
         exit(exception_pointer->ExceptionRecord->ExceptionCode);
     }
 
-    //typedef long (__stdcall *ExceptionFunc)(EXCEPTION_POINTERS*);
-    //ExceptionFunc prevFunc = (ExceptionFunc)prevExceptionHandler;
-    //return prevFunc( (EXCEPTION_POINTERS*)exception_pointer );
-    if (ret == IDB_EXIT)
+    if (ret == UserPostExceptionChoice::Exit)
     {
         // Immediate exit.
         // on windows, exit() and _exit() do all sorts of things, unfortuantely
         // TerminateProcess is the only way to die.
-        TerminateProcess(GetCurrentProcess(), exception_pointer->ExceptionRecord->ExceptionCode);  // we crashed, so don't return a zero exit code!
-        // on linux based systems, _exit will not call ATEXIT and other things, which makes it more suitable for termination in an emergency such
-        // as an unhandled exception.
-        // however, this function is a windows exception handler.
+        TerminateProcess(
+            GetCurrentProcess(), exception_pointer->ExceptionRecord->ExceptionCode); // we crashed, so don't return a zero exit code!
+        // on linux based systems, _exit will not call ATEXIT and other things, which makes it more suitable for termination in an emergency
+        // such as an unhandled exception. however, this function is a windows exception handler.
     }
-    else if (ret == IDB_IGNORE)
+    else if (ret == UserPostExceptionChoice::Recover)
     {
 #ifndef WIN64
         exception_pointer->ContextRecord->FloatSave.StatusWord &= ~31;
@@ -350,11 +326,11 @@ void DebugCallStack::ReportBug(const char* szErrorMessage)
 
     m_szBugMessage = szErrorMessage;
     m_context = CaptureCurrentContext();
-    SubmitBug(NULL);
+    SubmitBugAndAskToRecoverOrCrash(NULL);
     m_szBugMessage = NULL;
 }
 
-void DebugCallStack::dumpCallStack(std::vector<AZStd::string>& funcs)
+void DebugCallStack::dumpCallStack(AZStd::vector<AZStd::string>& funcs)
 {
     WriteLineToLog("=============================================================================");
     int len = (int)funcs.size();
@@ -366,9 +342,8 @@ void DebugCallStack::dumpCallStack(std::vector<AZStd::string>& funcs)
     WriteLineToLog("=============================================================================");
 }
 
-
 //////////////////////////////////////////////////////////////////////////
-void DebugCallStack::LogExceptionInfo(EXCEPTION_POINTERS* pex)
+void DebugCallStack::SaveExceptionInfoAndTriggerExternalCrashHandler(EXCEPTION_POINTERS* pex)
 {
     AZStd::string path("");
     if ((gEnv) && (gEnv->pFileIO))
@@ -454,7 +429,6 @@ void DebugCallStack::LogExceptionInfo(EXCEPTION_POINTERS* pex)
         azstrcpy(desc, AZ_ARRAY_SIZE(desc), "");
         sprintf_s(excDesc, "%s\r\n%s", excName, desc);
 
-
         if (pex->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
         {
             if (pex->ExceptionRecord->NumberParameters > 1)
@@ -473,27 +447,29 @@ void DebugCallStack::LogExceptionInfo(EXCEPTION_POINTERS* pex)
         }
     }
 
-
     WriteLineToLog("Exception Code: %s", excCode);
     WriteLineToLog("Exception Addr: %s", excAddr);
     WriteLineToLog("Exception Module: %s", m_excModule);
     WriteLineToLog("Exception Name  : %s", excName);
     WriteLineToLog("Exception Description: %s", desc);
 
-
     azstrcpy(m_excDesc, AZ_ARRAY_SIZE(m_excDesc), excDesc);
     azstrcpy(m_excAddr, AZ_ARRAY_SIZE(m_excAddr), excAddr);
     azstrcpy(m_excCode, AZ_ARRAY_SIZE(m_excCode), excCode);
 
-
     char errs[32768];
-    sprintf_s(errs, "Exception Code: %s\nException Addr: %s\nException Module: %s\nException Description: %s, %s\n",
-        excCode, excAddr, m_excModule, excName, desc);
-
+    sprintf_s(
+        errs,
+        "Exception Code: %s\nException Addr: %s\nException Module: %s\nException Description: %s, %s\n",
+        excCode,
+        excAddr,
+        m_excModule,
+        excName,
+        desc);
 
     azstrcat(errs, AZ_ARRAY_SIZE(errs), "\nCall Stack Trace:\n");
 
-    std::vector<AZStd::string> funcs;
+    AZStd::vector<AZStd::string> funcs;
     {
         AZ::Debug::StackFrame frames[25];
         AZ::Debug::SymbolStorage::StackLine lines[AZ_ARRAY_SIZE(frames)];
@@ -615,45 +591,46 @@ void DebugCallStack::LogExceptionInfo(EXCEPTION_POINTERS* pex)
         }
     }
 
-    //if no crash dialog don't even submit the bug
+    // if no crash dialog don't even submit the bug
     if (m_postBackupProcess && g_cvars.sys_no_crash_dialog == 0 && g_bUserDialog)
     {
         m_postBackupProcess();
     }
     else
     {
+        // TODO trigger the Tools/CrashHandler. See EXTERNAL_CRASH_REPORTING ifdefs
         // lawsonn: Disabling the JIRA-based crash reporter for now
         // we'll need to deal with it our own way, pending QA.
         // if you're customizing the engine this is also your opportunity to deal with it.
-        if (g_cvars.sys_no_crash_dialog != 0 || !g_bUserDialog)
-        {
-            // ------------ place custom crash handler here ---------------------
-            // it should launch an executable!
-            /// by  this time, error.bmp will be in the engine root folder
-            // error.log and error.dmp will also be present in the engine root folder
-            // if your error dumper wants those, it should zip them up and send them or offer to do so.
-            // ------------------------------------------------------------------
-        }
+
+        // ------------ place custom crash handler here ---------------------
+        // it should launch an executable!
+        /// by  this time, error.bmp will be in the engine root folder
+        // error.log and error.dmp will also be present in the engine root folder
+        // if your error dumper wants those, it should zip them up and send them or offer to do so.
+        // ------------------------------------------------------------------
     }
     const bool bQuitting = !gEnv || !gEnv->pSystem || gEnv->pSystem->IsQuitting();
 
-    //[AlexMcC|16.04.10] When the engine is shutting down, MessageBox doesn't display a box
-    // and immediately returns IDYES. Avoid this by just not trying to save if we're quitting.
-    // Don't ask to save if this isn't a real crash (a real crash has exception pointers)
     if (g_cvars.sys_no_crash_dialog == 0 && g_bUserDialog && gEnv->IsEditor() && !bQuitting && pex)
     {
         BackupCurrentLevel();
 
-        const INT_PTR res = DialogBoxParam(gDLLHandle, MAKEINTRESOURCE(IDD_CONFIRM_SAVE_LEVEL), NULL, DebugCallStack::ConfirmSaveDialogProc, NULL);
-        if (res == IDB_CONFIRM_SAVE)
+        if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
         {
-            if (SaveCurrentLevel())
+            constexpr bool showCancel = false;
+            AZStd::string msg = AZStd::string::format(
+                "An unexpected error occured. Do you want to try to save your changes ?"
+                "\nInformations about the issue have been saved in %s\\error.log",
+                path.c_str());
+
+            AZStd::string res = nativeUI->DisplayYesNoDialog("O3DE error. Try to save level ?", msg, showCancel);
+            if (res == "Yes")
             {
-                MessageBoxW(NULL, L"Level has been successfully saved!\r\nPress Ok to terminate Editor.", L"Save", MB_OK);
-            }
-            else
-            {
-                MessageBoxW(NULL, L"Error saving level.\r\nPress Ok to terminate Editor.", L"Save", MB_OK | MB_ICONWARNING);
+                if (SaveCurrentLevel())
+                    nativeUI->DisplayOkDialog("Save", "Level has been successfully saved!\r\nPress Ok to proceed.", showCancel);
+                else
+                    nativeUI->DisplayOkDialog("Save", "Error saving level.\r\nPress Ok to proceed.", showCancel);
             }
         }
     }
@@ -664,114 +641,6 @@ void DebugCallStack::LogExceptionInfo(EXCEPTION_POINTERS* pex)
         // calling exit will only cause further death down the line...
         TerminateProcess(GetCurrentProcess(), pex->ExceptionRecord->ExceptionCode);
     }
-}
-
-
-INT_PTR CALLBACK DebugCallStack::ExceptionDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam)
-{
-    static EXCEPTION_POINTERS* pex;
-
-    switch (message)
-    {
-    case WM_INITDIALOG:
-    {
-        pex = (EXCEPTION_POINTERS*)lParam;
-        HWND h;
-
-        if (pex->ExceptionRecord->ExceptionFlags & EXCEPTION_NONCONTINUABLE)
-        {
-            // Disable continue button for non continuable exceptions.
-            //h = GetDlgItem( hwndDlg,IDB_CONTINUE );
-            //if (h) EnableWindow( h,FALSE );
-        }
-
-        DebugCallStack* pDCS = static_cast<DebugCallStack*>(DebugCallStack::instance());
-
-        h = GetDlgItem(hwndDlg, IDC_EXCEPTION_DESC);
-        if (h)
-        {
-            SendMessage(h, EM_REPLACESEL, FALSE, (LONG_PTR)pDCS->m_excDesc);
-        }
-
-        h = GetDlgItem(hwndDlg, IDC_EXCEPTION_CODE);
-        if (h)
-        {
-            SendMessage(h, EM_REPLACESEL, FALSE, (LONG_PTR)pDCS->m_excCode);
-        }
-
-        h = GetDlgItem(hwndDlg, IDC_EXCEPTION_MODULE);
-        if (h)
-        {
-            SendMessage(h, EM_REPLACESEL, FALSE, (LONG_PTR)pDCS->m_excModule);
-        }
-
-        h = GetDlgItem(hwndDlg, IDC_EXCEPTION_ADDRESS);
-        if (h)
-        {
-            SendMessage(h, EM_REPLACESEL, FALSE, (LONG_PTR)pDCS->m_excAddr);
-        }
-
-        // Fill call stack.
-        HWND callStack = GetDlgItem(hwndDlg, IDC_CALLSTACK);
-        if (callStack)
-        {
-            SendMessage(callStack, WM_SETTEXT, FALSE, (LPARAM)pDCS->m_excCallstack);
-        }
-
-        if (hwndException)
-        {
-            DestroyWindow(hwndException);
-            hwndException = 0;
-        }
-
-        if (IsFloatingPointException(pex))
-        {
-            EnableWindow(GetDlgItem(hwndDlg, IDB_IGNORE), TRUE);
-        }
-    }
-    break;
-
-    case WM_COMMAND:
-        switch (LOWORD(wParam))
-        {
-        case IDB_EXIT:
-        case IDB_IGNORE:
-            // Fall through.
-
-            EndDialog(hwndDlg, wParam);
-            return TRUE;
-        }
-    }
-    return FALSE;
-}
-
-INT_PTR CALLBACK DebugCallStack::ConfirmSaveDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, [[maybe_unused]] LPARAM lParam)
-{
-    switch (message)
-    {
-    case WM_INITDIALOG:
-    {
-        // The user might be holding down the spacebar while the engine crashes.
-        // If we don't remove keyboard focus from this dialog, the keypress will
-        // press the default button before the dialog actually appears, even if
-        // the user has already released the key, which is bad.
-        SetFocus(NULL);
-    } break;
-    case WM_COMMAND:
-    {
-        switch (LOWORD(wParam))
-        {
-        case IDB_CONFIRM_SAVE:         // Fall through
-        case IDB_DONT_SAVE:
-        {
-            EndDialog(hwndDlg, wParam);
-            return TRUE;
-        }
-        }
-    } break;
-    }
-
-    return FALSE;
 }
 
 bool DebugCallStack::BackupCurrentLevel()
@@ -796,9 +665,9 @@ bool DebugCallStack::SaveCurrentLevel()
     return false;
 }
 
-int DebugCallStack::SubmitBug(EXCEPTION_POINTERS* exception_pointer)
+DebugCallStack::UserPostExceptionChoice DebugCallStack::SubmitBugAndAskToRecoverOrCrash(EXCEPTION_POINTERS* exception_pointer)
 {
-    int ret = IDB_EXIT;
+    UserPostExceptionChoice ret = UserPostExceptionChoice::Exit;
 
     assert(!hwndException);
 
@@ -806,12 +675,11 @@ int DebugCallStack::SubmitBug(EXCEPTION_POINTERS* exception_pointer)
 
     AZ::Debug::Trace::Instance().PrintCallstack("", 2);
 
-    LogExceptionInfo(exception_pointer);
+    SaveExceptionInfoAndTriggerExternalCrashHandler(exception_pointer);
 
     if (IsFloatingPointException(exception_pointer))
     {
-        //! Print exception dialog.
-        ret = PrintException(exception_pointer);
+        ret = AskUserToRecoverOrCrash(exception_pointer);
     }
 
     return ret;
@@ -844,7 +712,7 @@ AZStd::string DebugCallStack::GetModuleNameForAddr(void* addr)
 
     TModules::const_iterator it = m_modules.begin();
     TModules::const_iterator end = m_modules.end();
-    for (; ++it != end; )
+    for (; ++it != end;)
     {
         if (addr < it->first)
         {
@@ -852,7 +720,7 @@ AZStd::string DebugCallStack::GetModuleNameForAddr(void* addr)
         }
     }
 
-    //if address is higher than the last module, we simply assume it is in the last module.
+    // if address is higher than the last module, we simply assume it is in the last module.
     return m_modules.rbegin()->second;
 }
 
@@ -896,13 +764,37 @@ static bool IsFloatingPointException(EXCEPTION_POINTERS* pex)
     }
 }
 
-int DebugCallStack::PrintException(EXCEPTION_POINTERS* exception_pointer)
+DebugCallStack::UserPostExceptionChoice DebugCallStack::AskUserToRecoverOrCrash(EXCEPTION_POINTERS* exception_pointer)
 {
-    return (int)DialogBoxParam(gDLLHandle, MAKEINTRESOURCE(IDD_CRITICAL_ERROR), NULL, DebugCallStack::ExceptionDialogProc, (LPARAM)exception_pointer);
+    if (exception_pointer->ExceptionRecord->ExceptionFlags & EXCEPTION_NONCONTINUABLE)
+        return UserPostExceptionChoice::Exit;
+
+    UserPostExceptionChoice res = UserPostExceptionChoice::Recover;
+    if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
+    {
+        DebugCallStack* pDCS = static_cast<DebugCallStack*>(DebugCallStack::instance());
+        AZStd::string msg = AZStd::string::format(
+            "O3DE encountered an error but can recover from it.\nDo you want to try to recover ?\n\nException Code: %s\nException Addr: "
+            "%s\nException Module: %s\nException Description: %s",
+            pDCS->m_excCode,
+            pDCS->m_excAddr,
+            pDCS->m_excModule,
+            pDCS->m_excDesc);
+
+        constexpr bool showCancel = false;
+        nativeUI->DisplayYesNoDialog("Try to recover ?", msg, showCancel);
+    }
+    return res;
 }
 
 #else
-void MarkThisThreadForDebugging(const char*) {}
-void UnmarkThisThreadFromDebugging() {}
-void UpdateFPExceptionsMaskForThreads() {}
-#endif //WIN32
+void MarkThisThreadForDebugging(const char*)
+{
+}
+void UnmarkThisThreadFromDebugging()
+{
+}
+void UpdateFPExceptionsMaskForThreads()
+{
+}
+#endif // WIN32

--- a/Code/Legacy/CrySystem/DebugCallStack.cpp
+++ b/Code/Legacy/CrySystem/DebugCallStack.cpp
@@ -348,7 +348,7 @@ void DebugCallStack::dumpCallStack(AZStd::vector<AZStd::string>& funcs)
 }
 
 //////////////////////////////////////////////////////////////////////////
-void DebugCallStack::SaveExceptionInfoAndTriggerExternalCrashHandler(EXCEPTION_POINTERS* pex)
+void DebugCallStack::SaveExceptionInfoAndShowUserReportDialogs(EXCEPTION_POINTERS* pex)
 {
     AZStd::string path("");
     if ((gEnv) && (gEnv->pFileIO))
@@ -689,7 +689,7 @@ DebugCallStack::UserPostExceptionChoice DebugCallStack::SubmitBugAndAskToRecover
 
     AZ::Debug::Trace::Instance().PrintCallstack("", 2);
 
-    SaveExceptionInfoAndTriggerExternalCrashHandler(exception_pointer);
+    SaveExceptionInfoAndShowUserReportDialogs(exception_pointer);
 
     if (IsFloatingPointException(exception_pointer))
     {

--- a/Code/Legacy/CrySystem/DebugCallStack.h
+++ b/Code/Legacy/CrySystem/DebugCallStack.h
@@ -62,7 +62,7 @@ protected:
 
     static UserPostExceptionChoice AskUserToRecoverOrCrash(EXCEPTION_POINTERS* exception_pointer);
 
-    void SaveExceptionInfoAndTriggerExternalCrashHandler(EXCEPTION_POINTERS* exception_pointer);
+    void SaveExceptionInfoAndShowUserReportDialogs(EXCEPTION_POINTERS* exception_pointer);
     bool BackupCurrentLevel();
     bool SaveCurrentLevel();
     UserPostExceptionChoice SubmitBugAndAskToRecoverOrCrash(EXCEPTION_POINTERS* exception_pointer);

--- a/Code/Legacy/CrySystem/DebugCallStack.h
+++ b/Code/Legacy/CrySystem/DebugCallStack.h
@@ -6,15 +6,16 @@
  *
  */
 
-
 #ifndef CRYINCLUDE_CRYSYSTEM_DEBUGCALLSTACK_H
 #define CRYINCLUDE_CRYSYSTEM_DEBUGCALLSTACK_H
 #pragma once
 
-
 #include "IDebugCallStack.h"
 
-#if defined (WIN32) || defined (WIN64)
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/containers/map.h>
+
+#if defined(WIN32) || defined(WIN64)
 
 //! Limits the maximal number of functions in call stack.
 const int MAX_DEBUG_STACK_ENTRIES_FILE_DUMP = 12;
@@ -26,41 +27,45 @@ struct ISystem;
 //! DebugCallStack class, capture call stack information from symbol files.
 //!
 //!============================================================================
-class DebugCallStack
-    : public IDebugCallStack
+class DebugCallStack : public IDebugCallStack
 {
 public:
     DebugCallStack();
     virtual ~DebugCallStack();
 
-    ISystem* GetSystem() { return m_pSystem; };
+    ISystem* GetSystem()
+    {
+        return m_pSystem;
+    };
 
-    virtual AZStd::string GetModuleNameForAddr(void* addr);
-    virtual void GetProcNameForAddr(void* addr, AZStd::string& procName, void*& baseAddr, AZStd::string& filename, int& line);
-    virtual AZStd::string GetCurrentFilename();
+    virtual AZStd::string GetModuleNameForAddr(void* addr) override;
+    virtual void GetProcNameForAddr(void* addr, AZStd::string& procName, void*& baseAddr, AZStd::string& filename, int& line) override;
+    virtual AZStd::string GetCurrentFilename() override;
+    virtual int handleException(EXCEPTION_POINTERS* exception_pointer) override;
+    virtual void ReportBug(const char*) override;
 
     void installErrorHandler(ISystem* pSystem);
-    virtual int handleException(EXCEPTION_POINTERS* exception_pointer);
-
-    virtual void ReportBug(const char*);
-
-    void dumpCallStack(std::vector<AZStd::string>& functions);
-
+    void dumpCallStack(AZStd::vector<AZStd::string>& functions);
     void SetUserDialogEnable(const bool bUserDialogEnable);
 
-    typedef std::map<void*, AZStd::string> TModules;
+    typedef AZStd::map<void*, AZStd::string> TModules;
+
 protected:
+    enum class UserPostExceptionChoice
+    {
+        Exit,
+        Recover // Only available if the exception type allows it (eg: floating point exception)
+    };
+
     static void RemoveOldFiles();
     static void RemoveFile(const char* szFileName);
 
-    static int PrintException(EXCEPTION_POINTERS* exception_pointer);
-    static INT_PTR CALLBACK ExceptionDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
-    static INT_PTR CALLBACK ConfirmSaveDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
+    static UserPostExceptionChoice AskUserToRecoverOrCrash(EXCEPTION_POINTERS* exception_pointer);
 
-    void LogExceptionInfo(EXCEPTION_POINTERS* exception_pointer);
+    void SaveExceptionInfoAndTriggerExternalCrashHandler(EXCEPTION_POINTERS* exception_pointer);
     bool BackupCurrentLevel();
     bool SaveCurrentLevel();
-    int SubmitBug(EXCEPTION_POINTERS* exception_pointer);
+    UserPostExceptionChoice SubmitBugAndAskToRecoverOrCrash(EXCEPTION_POINTERS* exception_pointer);
     void ResetFPU(EXCEPTION_POINTERS* pex);
 
     static const int s_iCallStackSize = 32768;
@@ -81,11 +86,11 @@ protected:
     ISystem* m_pSystem;
 
     int m_nSkipNumFunctions;
-    CONTEXT  m_context;
+    CONTEXT m_context;
 
     TModules m_modules;
 };
 
-#endif //WIN32
+#endif // WIN32
 
 #endif // CRYINCLUDE_CRYSYSTEM_DEBUGCALLSTACK_H

--- a/Code/Legacy/CrySystem/IDebugCallStack.h
+++ b/Code/Legacy/CrySystem/IDebugCallStack.h
@@ -15,6 +15,9 @@
 
 #include "System.h"
 
+#include <AzCore/std/string/string.h>
+#include <AzCore/IO/FileIO.h>
+
 #if AZ_LEGACY_CRYSYSTEM_TRAIT_FORWARD_EXCEPTION_POINTERS
 struct EXCEPTION_POINTERS;
 #endif

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1205,6 +1205,16 @@ void CSystem::CreateSystemVars()
             GetISystem()->Quit();
         });
 
+    static AZ::ConsoleFunctor<void, false> s_functorCrash(
+        "crash",
+        "Crash the engine",
+        AZ::ConsoleFunctorFlags::IsInvisible | AZ::ConsoleFunctorFlags::DontReplicate,
+        AZ::TypeId::CreateNull(),
+        []([[maybe_unused]] const AZ::ConsoleCommandContainer& params)
+        {
+            AZ_Crash();
+        });
+
     m_sys_load_files_to_memory = REGISTER_STRING(
         "sys_load_files_to_memory",
         "shadercache.pak",


### PR DESCRIPTION
## What does this PR do?

First improvement over https://github.com/o3de/o3de/issues/6000. (**windows-only**)

Fixes and improve the built-in crash reporting dialog by replacing invalid MFC code with `NativeUIRequests` dialog. The MFC dialogs where compiling but never showing up as their resources IDS were never registered.

When a crash occurs, this is now what happens :

- You get a dialog to state that issue occured. If you want to report it, you can press "yes" and it will open o3de github on default browser and open the folder with crash dump and log in a windows explorer

![crash-dialog](https://github.com/user-attachments/assets/12de1db0-112a-4e4d-a587-059b1d3c1150)

- Past that you get the chance to try to save your current work (as it is using an old API, pretty sure its broken so that would need an additionnal cleanup)

![save](https://github.com/user-attachments/assets/9793ba2d-0096-4e0f-a4d6-5fe6ea4e2cdb)

- Finally, and *- only if the crash can be recoverred from -* you get this dialog. Else the process exits.

![recover](https://github.com/user-attachments/assets/8243f2bd-c21d-401e-bc9a-79e3bea7155f)

## Explanations

O3DE contains 2 mechanism to generate a crash dump and inform user that a crash occured. These two mechanism are **mutually exclusive** via the `ExceptionHandlerIsSet` environment value.
- The `DebugCallstack` class located in the legacy CrySystem which is worked on by this PR.  It works by hooking upon `SetUnhandledExceptionFilter` in the main process. It is enabled by default but only implemented for windows, and does not take external tools like the Lua editor into account.
- The `CrashHandlerTool` which is a separate executable using Google's [CrashPad](https://chromium.googlesource.com/crashpad/crashpad/+/HEAD/doc/overview_design.md) library. When the program it is hooked-on panic, it is able to generate a dump with associated symbols, and ask user if he wants to report it (see image below). It is able to work on both windows, linux, android and is also setup to hook on external tools such as the LuaEditor (to support released game/client, there is the `CrashReporting ` gem to enable). On top of the env variable above, it is also disabled behind the `EXTERNAL_CRASH_REPORTING` macro.

The second option is obviously better, but as it **depends on a server configured to recieve crashpad report** we cannot enable it as of now.

![image](https://github.com/user-attachments/assets/3ec7e5f0-f5f5-41a7-8d80-e653daa8a666)

## How was this PR tested?

I added the `crash` command to crash the editor anytime to be able to test dump generation, so just have to type it in the console. 

The dump generation works as expected, but users might not be able to attach them to their issue because of the size of them (and for custom builds, they would need to attach their symbols (.pdb) and .dll to allow someone else to debug)
