### PR TITLE
Improvements for Editor and in-Game Automation

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.cpp
@@ -54,7 +54,11 @@ namespace AzFramework::Scripts
                 ->Attribute(AZ::Script::Attributes::Module, "prefabs")
                 ->Constructor()
                 ->Method("GetAsset", &SpawnableScriptAssetRef::GetAsset)
-                ->Method("SetAsset", &SpawnableScriptAssetRef::SetAsset);
+                ->Method("SetAsset", &SpawnableScriptAssetRef::SetAsset)
+                ->Method("GetAssetId", &SpawnableScriptAssetRef::GetAssetId)
+                ->Method("SetAssetId", &SpawnableScriptAssetRef::SetAssetId)
+                ->Method("IsValid", &SpawnableScriptAssetRef::IsValid)
+                ;
         }
     }
 
@@ -114,5 +118,27 @@ namespace AzFramework::Scripts
     void SpawnableScriptAssetRef::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         m_asset = asset;
+    }
+
+    void SpawnableScriptAssetRef::SetAssetId(const AZ::Data::AssetId& assetId)
+    {
+        if (assetId == m_asset.GetId())
+        {
+            return;
+        }
+
+        AZ::Data::Asset<Spawnable> newAsset =
+            AZ::Data::AssetManager::Instance().GetAsset<Spawnable>(assetId, AZ::Data::AssetLoadBehavior::NoLoad);
+        SetAsset(newAsset);
+    }
+
+    AZ::Data::AssetId SpawnableScriptAssetRef::GetAssetId() const
+    {
+        return m_asset.GetId();
+    }
+
+    bool SpawnableScriptAssetRef::IsValid() const
+    {
+        return m_asset.GetId().IsValid();
     }
 }

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
@@ -34,6 +34,15 @@ namespace AzFramework::Scripts
 
         void SetAsset(const AZ::Data::Asset<Spawnable>& asset);
         AZ::Data::Asset<Spawnable> GetAsset() const;
+        //! Sets the Asset by AssetId, which is convenient for automation
+        //! or in-game scripting.
+        void SetAssetId(const AZ::Data::AssetId& assetId );
+        // helpful for automation to get the AssetId.
+        AZ::Data::AssetId GetAssetId() const;
+        // Returns true if the AssetId is valid.
+        // This is for convenience, because the same can be achieved
+        // by calling GetAssetId().IsValid().
+        bool IsValid() const;
 
     private:
         class SerializationEvents : public AZ::SerializeContext::IEventHandler

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
@@ -36,7 +36,7 @@ namespace AzFramework::Scripts
         AZ::Data::Asset<Spawnable> GetAsset() const;
         //! Sets the Asset by AssetId, which is convenient for automation
         //! or in-game scripting.
-        void SetAssetId(const AZ::Data::AssetId& assetId );
+        void SetAssetId(const AZ::Data::AssetId& assetId);
         // helpful for automation to get the AssetId.
         AZ::Data::AssetId GetAssetId() const;
         // Returns true if the AssetId is valid.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/PerformanceCollectionNotificationBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/PerformanceCollectionNotificationBus.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/string/string.h>
+
+#include <Atom/RPI.Public/Configuration.h>
+
+namespace AZ::RPI
+{
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    //! Connect to this EBus to be notified whenever the current RPI performance collection job
+    //! is completed. For details on how to start an RPI performance collection job see:
+    //! "o3de/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp".
+    //! This EBus is available for C++, Game Client BehaviorContext (Lua) and Editor BehaviorContext (Python).
+    class ATOM_RPI_PUBLIC_API PerformaceCollectionNotification : public AZ::EBusTraits
+    {
+    public:
+        virtual ~PerformaceCollectionNotification() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Performance collection job is completed and the results are available
+        //! in @outputfilePath.
+        virtual void OnPerformanceCollectionJobFinished(const AZStd::string& outputfilePath) = 0;
+
+    };
+    using PerformaceCollectionNotificationBus = AZ::EBus<PerformaceCollectionNotification>;
+
+} // namespace AZ::RPI
+
+DECLARE_EBUS_EXTERN_DLL_SINGLE_ADDRESS(RPI::PerformaceCollectionNotification);

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/PerformanceCVarManager.cpp
@@ -24,7 +24,7 @@ namespace AZ
             "Defines the kind of data collection and logging. If starts with 's' it will log statistical summaries, if starts with 'a' will log each sample of data (high verbosity).");
 
         AZ_CVAR(AZ::u32, r_metricsWaitTimePerCaptureBatch,
-            0, // Starts at 0, which means "do not capture performance data". When this variable changes to >0 we'll start performance capture.
+            0, // Starts at 0, which means "do not wait before starting to capture performance data".
             nullptr, //&PerformanceCvarManager::OnWaitTimePerCaptureBatchChanged,
             ConsoleFunctorFlags::DontReplicate,
             "How many seconds to wait before each batch of performance capture.");

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -27,6 +27,8 @@
 #include <AzFramework/CommandLine/CommandLine.h>
 #include <AzFramework/Components/ConsoleBus.h>
 
+#include <Atom/RPI.Public/PerformanceCollectionNotificationBus.h>
+
 #ifdef RPI_EDITOR
 #include <Atom/RPI.Edit/Material/MaterialFunctorSourceDataRegistration.h>
 #endif
@@ -241,6 +243,7 @@ namespace AZ
                     m_gpuPassProfiler->SetGpuTimeMeasurementEnabled(false);
                     // Force disabling timestamp collection in the root pass.
                     AZ::RPI::PassSystemInterface::Get()->GetRootPass()->SetTimestampQueryEnabled(false);
+                    PerformaceCollectionNotificationBus::Broadcast(&PerformaceCollectionNotification::OnPerformanceCollectionJobFinished, m_performanceCollector->GetOutputFilePath().String());
                 }
                 if (r_metricsQuitUponCompletion && (pendingBatches == 0))
                 {
@@ -267,6 +270,5 @@ namespace AZ
             m_performanceCollector->UpdateWaitTimeBeforeEachBatch(AZStd::chrono::seconds(r_metricsWaitTimePerCaptureBatch));
             m_performanceCollector->UpdateNumberOfCaptureBatches(r_metricsNumberOfCaptureBatches);
         }
-
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/PerformanceCollectionNotificationBus.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/PerformanceCollectionNotificationBus.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+
+#include <Atom/RPI.Public/PerformanceCollectionNotificationBus.h>
+
+DECLARE_EBUS_INSTANTIATION_DLL_SINGLE_ADDRESS(RPI::PerformaceCollectionNotification);
+
+namespace AZ::RPI
+{
+    /**
+     * Behavior Context forwarder
+     */
+    class PerformaceCollectionBehaviorHandler
+        : public PerformaceCollectionNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
+    {
+    public:
+        AZ_EBUS_BEHAVIOR_BINDER(
+            PerformaceCollectionBehaviorHandler, "{61464725-BDE4-465B-96BA-0409D32E29A9}",
+            AZ::SystemAllocator, OnPerformanceCollectionJobFinished);
+
+        void OnPerformanceCollectionJobFinished(const AZStd::string& outputfilePath) override
+        {
+            Call(FN_OnPerformanceCollectionJobFinished, outputfilePath);
+        }
+    };
+
+    void PerformaceCollectionNotification::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<PerformaceCollectionNotificationBus>("RPIPerformaceCollectionNotificationBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "RPI")
+                ->Attribute(AZ::Script::Attributes::Module, "rpi")
+                ->Handler<PerformaceCollectionBehaviorHandler>();
+        }
+    }
+} // namespace AZ::RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/PerformanceCollectionNotificationBus.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/PerformanceCollectionNotificationBus.cpp
@@ -24,7 +24,9 @@ namespace AZ::RPI
     public:
         AZ_EBUS_BEHAVIOR_BINDER(
             PerformaceCollectionBehaviorHandler, "{61464725-BDE4-465B-96BA-0409D32E29A9}",
-            AZ::SystemAllocator, OnPerformanceCollectionJobFinished);
+            AZ::SystemAllocator,
+            OnPerformanceCollectionJobFinished
+            );
 
         void OnPerformanceCollectionJobFinished(const AZStd::string& outputfilePath) override
         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -26,6 +26,7 @@
 #include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/Pass/PassFactory.h>
+#include <Atom/RPI.Public/PerformanceCollectionNotificationBus.h>
 
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/Device.h>
@@ -76,6 +77,8 @@ namespace AZ
             GpuQuerySystemDescriptor::Reflect(context);
 
             PipelineStatisticsResult::Reflect(context);
+
+            PerformaceCollectionNotification::Reflect(context);
         }
 
         void RPISystem::Initialize(const RPISystemDescriptor& rpiSystemDescriptor)

--- a/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
+++ b/Gems/Atom/RPI/Code/atom_rpi_public_files.cmake
@@ -110,6 +110,7 @@ set(FILES
     Include/Atom/RPI.Public/GpuQuery/GpuPassProfiler.h
     Include/Atom/RPI.Public/XR/XRRenderingInterface.h
     Include/Atom/RPI.Public/XR/XRSpaceNotificationBus.h
+    Include/Atom/RPI.Public/PerformanceCollectionNotificationBus.h
     Source/RPI.Public/Culling.cpp
     Source/RPI.Public/DllMain.cpp
     Source/RPI.Public/FeatureProcessor.cpp
@@ -195,4 +196,5 @@ set(FILES
     Source/RPI.Public/GpuQuery/QueryPool.cpp
     Source/RPI.Public/GpuQuery/TimestampQueryPool.cpp
     Source/RPI.Public/GpuQuery/GpuPassProfiler.cpp
+    Source/RPI.Public/PerformanceCollectionNotificationBus.cpp
 )

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h
@@ -10,6 +10,7 @@
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialAssignmentId.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/std/parallel/mutex.h>
 
 class QPixmap;
 
@@ -24,7 +25,8 @@ namespace AZ
         public:
             static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
             static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
-            using MutexType = AZStd::recursive_mutex;
+            //! Using a mutex because this EBus is accessed from multiple threads.
+            using MutexType = AZStd::mutex;
 
             //! This notification is sent when a material preview image for a given entity and material assignment has been rendered by the
             //! preview rendering system

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/EditorMaterialSystemComponentNotificationBus.h
@@ -24,6 +24,7 @@ namespace AZ
         public:
             static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
             static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+            using MutexType = AZStd::recursive_mutex;
 
             //! This notification is sent when a material preview image for a given entity and material assignment has been rendered by the
             //! preview rendering system


### PR DESCRIPTION
## What does this PR do?
Improvements for Editor and in-Game Automation

1. Added SetAssetId(), GetAssetId() and IsValid() to `SpawnableScriptAssetRef` class and exposed them in the BehaviorContext for both Python and Lua. This helps a Lua script to create `SpawnableScriptAssetRef`s on the fly, while being able to check their validity before attempting to spawn them.

2. Regarding RPI Performance Collection, I added the `AZ::RPI::PerformanceCollectionNotificationBus` which notifies whenever the current batch of performance collection is complete. This is important because scripts can know when the collection is completed and submit a different performance collection job as needed.

3. `EditorMaterialSystemComponentNotificationBus` now uses a `mutex`, because the Editor was crashing saying that the EditorMaterialSystemComponentNotificationBus was being used from different threads. This happens when populating a level with lots of Mesh+Material entities using Python.

## How was this PR tested?

Tested on Windows11 PC and Quest3 with a custom Lua script that automates Performance data collection, while switching and spawning  `Spawnable`(s) on the fly. 