### PR TITLE
Fixed crash when opening invalid ScriptCanvas file and fixed graph de…

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
@@ -276,17 +276,19 @@ namespace ScriptCanvas
         {
             result.m_fileReadErrors = "Script Canvas Graph Deserialization Failed - " + result.m_deserializeResult.m_errors + "\n";
         }
-
-        const auto& graphDataPtr = result.m_deserializeResult.m_graphDataPtr;
-        if (graphDataPtr && graphDataPtr->GetEditorGraph())
+        else
         {
-            ScriptCanvasEditor::EditorGraphRequestBus::Event(
-                graphDataPtr->GetEditorGraph()->GetScriptCanvasId(),
-                &ScriptCanvasEditor::EditorGraphRequests::SetOriginalToNewIdsMap,
-                result.m_deserializeResult.m_originalIdsToNewIds);
-        }
+            const auto& graphDataPtr = result.m_deserializeResult.m_graphDataPtr;
+            if (graphDataPtr && graphDataPtr->GetEditorGraph())
+            {
+                ScriptCanvasEditor::EditorGraphRequestBus::Event(
+                    graphDataPtr->GetEditorGraph()->GetScriptCanvasId(),
+                    &ScriptCanvasEditor::EditorGraphRequests::SetOriginalToNewIdsMap,
+                    result.m_deserializeResult.m_originalIdsToNewIds);
+            }
 
-        result.m_handle = SourceHandle::FromRelativePath(result.m_deserializeResult.m_graphDataPtr, path);
+            result.m_handle = SourceHandle::FromRelativePath(result.m_deserializeResult.m_graphDataPtr, path);
+        }
         return result;
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
@@ -126,10 +126,10 @@ namespace ScriptCanvas
         if (m_executionState)
         {
             m_executionState->StopExecution();
-            Execution::Destruct(m_executionStateStorage);
             SCRIPT_CANVAS_PERFORMANCE_FINALIZE_TIMER(m_executionState);
             ScriptCanvas::ExecutionNotificationsBus::Broadcast(
-                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphActivation(GraphInfo(m_executionState)));
+                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphDeactivation(GraphInfo(m_executionState)));
+            Execution::Destruct(m_executionStateStorage);
             m_executionState = nullptr;
         }
     }


### PR DESCRIPTION
…activation error

## What does this PR do?

- Fixed a crash that would happen if an invalid or corrupt Script Canvas file was loaded

- When deactivating the game, the message `Failed to get user data from graph. Constructed with invalid values` would be triggered. This is because the deactivation order was incorrect, the graph's execution state was being destroyed, then, the notification that the graph deactivation was sent out which needs the graph's execution state. This fix moves the destruction after the notification is sent out to ensure any listening systems can still uses the graph's data.

