### PR TITLE
Fix Linux release + non-unity builds for Empty Project

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
@@ -34,7 +34,9 @@ namespace ScriptCanvas
 
         void Logger::ClearLog()
         {
+#if defined(SC_EXECUTION_TRACE_ENABLED)
             m_logAsset.GetData().Clear();
+#endif // SC_EXECUTION_TRACE_ENABLED
         }
 
         void Logger::ClearLogExecutionOverride()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
@@ -66,10 +66,10 @@ namespace ScriptCanvas
             template<typename t_Event>
             void AddToLog([[maybe_unused]] const t_Event& loggableEvent)
             {
-#if defined(SC_EXECUTION_TRACE_ENABLED) 
+#if defined(SC_EXECUTION_TRACE_ENABLED)
                 SCRIPT_CANVAS_DEBUGGER_TRACE_CLIENT("Logging: %s", loggableEvent.ToString().data());
-#endif
                 m_logAsset.GetData().m_events.emplace_back(loggableEvent.Duplicate());
+#endif
             }
 
         private:
@@ -78,7 +78,9 @@ namespace ScriptCanvas
             bool m_logExecutionOverrideEnabled = false;
             bool m_logExecutionOverride = false;
 
+#if defined(SC_EXECUTION_TRACE_ENABLED)
             ExecutionLogAsset m_logAsset;
+#endif
             ScriptCanvas::Debugger::Target m_target;
         };
     }


### PR DESCRIPTION
## What does this PR do?

This fixes a linker error when building the ScriptCanvas.Editor gem in release mode, but only when unity builds are turned off.

```
158/267] Linking CXX shared module bin/release/libScriptCanvas.Editor.so
FAILED: bin/release/libScriptCanvas.Editor.so 
: && /usr/bin/clang++-14 -fPIC -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Werror -Wno-inconsistent-missing-override -Wrange-loop-analysis -Wno-unknown-warning-option -Wno-parentheses -Wno-reorder -Wno-switch -Wno-undefined-var-template -msse4.1  -O2  -Wl,--no-undefined -fpie -Wl,-z,relro,-z,now -Wl,-z,noexecstack -shared  -o bin/release/libScriptCanvas.Editor.so External/ScriptCanvas-ad8df5c6/Code/CMakeFiles/ScriptCanvas.Editor.dir/release/Editor/ScriptCanvasEditorGem.cpp.o  -Wl,-rpath,"\$ORIGIN"  lib/release/libAzToolsFramework.a  lib/release/libScriptCanvas.Editor.Static.a  bin/release/libEditorCore.so  lib/release/libCryCommon.a  lib/release/libScriptCanvas.API.a  lib/release/libScriptCanvasDebugger.a  lib/release/libScriptCanvas.Extensions.a  lib/release/libScriptEvents.Static.a  lib/release/libGraphCanvasWidgets.a  lib/release/libAssetBuilderSDK.a  lib/release/libAzToolsFramework.a  /home/jhanca/.o3de/3rdParty/packages/SQLite-3.37.2-rev1-linux/SQLite/lib/libsqlite3.a  lib/release/libAzFramework.NativeUI.a  /usr/lib/x86_64-linux-gnu/libxcb-xkb.so  /usr/lib/x86_64-linux-gnu/libxcb-xfixes.so  /usr/lib/x86_64-linux-gnu/libxcb.so  /usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so  /usr/lib/x86_64-linux-gnu/libxkbcommon.so  /usr/lib/x86_64-linux-gnu/libX11.so  -lxcb-xinput  bin/release/libAzQtComponents.so  /home/jhanca/.o3de/3rdParty/packages/qt-5.15.2-rev9-linux/qt/lib/libQt5Svg.so.5.15.1  /home/jhanca/.o3de/3rdParty/packages/qt-5.15.2-rev9-linux/qt/lib/libQt5Widgets.so.5.15.1  /home/jhanca/.o3de/3rdParty/packages/qt-5.15.2-rev9-linux/qt/lib/libQt5Gui.so.5.15.1  /home/jhanca/.o3de/3rdParty/packages/qt-5.15.2-rev9-linux/qt/lib/libQt5Xml.so.5.15.1  /home/jhanca/.o3de/3rdParty/packages/qt-5.15.2-rev9-linux/qt/lib/libQt5Core.so.5.15.1  lib/release/libExpressionEvaluation.Static.a  lib/release/libAzFramework.a  lib/release/libAzNetworking.a  lib/release/libAzCore.a  /usr/lib/x86_64-linux-gnu/libunwind.so  -lpthread  -latomic  -lpthread  -latomic  /home/jhanca/.o3de/3rdParty/packages/Lua-5.4.4-rev1-linux/Lua/lib/release/liblualib.a  -ldl  /home/jhanca/.o3de/3rdParty/packages/zlib-1.2.11-rev5-linux/zlib/lib/libz.a  /home/jhanca/.o3de/3rdParty/packages/cityhash-1.1-multiplatform/cityhash/build/linux/clang-3.8/release/libcityhash.a  bin/release/libO3DEKernel.so  /usr/lib/x86_64-linux-gnu/libzstd.so  /home/jhanca/.o3de/3rdParty/packages/OpenSSL-1.1.1t-rev1-linux/OpenSSL/lib/libssl.a  /home/jhanca/.o3de/3rdParty/packages/OpenSSL-1.1.1t-rev1-linux/OpenSSL/lib/libcrypto.a  /home/jhanca/.o3de/3rdParty/packages/lz4-1.9.4-rev2-linux/lz4/lib/liblz4.a && cd /home/jhanca/devroot/projects/JHO3DETestProject/build/linux/External/ScriptCanvas-ad8df5c6/Code && /usr/bin/cmake -P /home/jhanca/devroot/o3de/cmake/Platform/Linux/ProcessDebugSymbols.cmake /usr/bin/strip /usr/bin/objcopy /home/jhanca/devroot/projects/JHO3DETestProject/build/linux/bin/release/libScriptCanvas.Editor.so dbg MODULE_LIBRARY DETACH
/usr/bin/ld: lib/release/libScriptCanvasDebugger.a(Logger.cpp.o): in function `ScriptCanvas::Debugger::Logger::Logger()':
Logger.cpp:(.text+0x88): undefined reference to `ScriptCanvas::ExecutionLogAsset::ExecutionLogAsset(AZ::Data::AssetId const&, AZ::Data::AssetData::AssetStatus)'
/usr/bin/ld: lib/release/libScriptCanvasDebugger.a(Logger.cpp.o): in function `ScriptCanvas::Debugger::Logger::~Logger()':
Logger.cpp:(.text+0x1dd): undefined reference to `ScriptCanvas::ExecutionLogData::~ExecutionLogData()'
/usr/bin/ld: lib/release/libScriptCanvasDebugger.a(Logger.cpp.o): in function `ScriptCanvas::Debugger::Logger::ClearLog()':
Logger.cpp:(.text+0x388): undefined reference to `ScriptCanvas::ExecutionLogData::Clear()'
/usr/bin/ld: lib/release/libScriptCanvasDebugger.a(Logger.cpp.o): in function `non-virtual thunk to ScriptCanvas::Debugger::Logger::ClearLog()':
Logger.cpp:(.text+0x398): undefined reference to `ScriptCanvas::ExecutionLogData::Clear()'
/usr/bin/ld: lib/release/libScriptCanvasDebugger.a(Logger.cpp.o): in function `ScriptCanvas::ExecutionLogAsset::~ExecutionLogAsset()':
Logger.cpp:(.text._ZN12ScriptCanvas17ExecutionLogAssetD2Ev[_ZN12ScriptCanvas17ExecutionLogAssetD2Ev]+0x13): undefined reference to `ScriptCanvas::ExecutionLogData::~ExecutionLogData()'
/usr/bin/ld: lib/release/libScriptCanvasDebugger.a(Logger.cpp.o): in function `ScriptCanvas::ExecutionLogAsset::~ExecutionLogAsset()':
Logger.cpp:(.text._ZN12ScriptCanvas17ExecutionLogAssetD0Ev[_ZN12ScriptCanvas17ExecutionLogAssetD0Ev]+0x16): undefined reference to `ScriptCanvas::ExecutionLogData::~ExecutionLogData()'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
It is unclear why the symbols were not included during linking, but the symbols in question are controlled by a define (`SC_EXECUTION_TRACE_ENABLED`) that is set only in non-release mode set in [ScriptCanvas CMakeLsts.txt](https://github.com/o3de/o3de/blob/40cad17a9d805a1755a7292bea9c01ea4190fc97/Gems/ScriptCanvas/Code/CMakeLists.txt#L15-L17):

It's possible that somehow unity builds prevents the compiler from dead stripping out the symbol. But looking at the class [Logger](https://github.com/o3de/o3de/blob/development/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp), `m_logAsset` is only every actually used when `SC_EXECUTION_TRACE_ENABLED`, otherwise, it just collects the log but never outputs it. 

To fix for now, this change will expand the guard to include `m_logAsset`, effectively making the Logger class a no-op in release mode. 

Fixes https://github.com/o3de/o3de/issues/18534 

## How was this PR tested?
Built the Editor in release mode in unity and non-unity mode
