### PR TITLE
Assimp importer use DCC (Y-Up) coordinate system by default.

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -167,7 +167,7 @@ namespace AZ
 
         AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> AssImpSceneWrapper::GetUpVectorAndSign() const
         {
-            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Z, 1);
+            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Y, 1);
             int32_t upVectorRead(static_cast<int32_t>(result.first));
             m_assImpScene->mMetaData->Get("UpAxis", upVectorRead);
             m_assImpScene->mMetaData->Get("UpAxisSign", result.second);
@@ -177,7 +177,7 @@ namespace AZ
 
         AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> AssImpSceneWrapper::GetFrontVectorAndSign() const
         {
-            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Y, 1);
+            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Z, -1);
             int32_t frontVectorRead(static_cast<int32_t>(result.first));
             m_assImpScene->mMetaData->Get("FrontAxis", frontVectorRead);
             m_assImpScene->mMetaData->Get("FrontAxisSign", result.second);

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -67,8 +67,7 @@ namespace AZ
 
             AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> frontAxisAndSign = assImpScene->GetFrontVectorAndSign();
 
-            if (upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Z &&
-                upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Unknown)
+            if (upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Z)
             {
                 AZ::Matrix4x4 currentCoordMatrix = AZ::Matrix4x4::CreateIdentity();
                 //(UpVector = +Z, FrontVector = +Y, CoordSystem = -X(RightHanded))


### PR DESCRIPTION
This aims to fix the issue where some glTF files being imported with wrong rotations.

## What does this PR do?

Some glTF files don't store coordinate system information and require manual adjust when imported into O3DE (rotate 90 degrees on X axis). This PR fixes this by assuming model files using DCC coordinate system unless explicitly specified by the model.

## How was this PR tested?

Export a glTF file from Unreal Engine to O3DE.
