### PR TITLE
Add Blas compaction for raytracing

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
@@ -343,6 +343,10 @@ namespace AZ::Render
         //! Retrieves the GPU buffer containing information for all ray tracing materials.
         virtual const Data::Instance<RPI::Buffer> GetMaterialInfoGpuBuffer() const = 0;
 
+        //! If necessary recreates TLAS buffers and updates the ray tracing SRGs. Should only be called by the
+        //! RayTracingAccelerationStructurePass.
+        virtual void BeginFrame() = 0;
+
         //! Updates the RayTracingSceneSrg and RayTracingMaterialSrg, called after the TLAS is allocated in the
         //! RayTracingAccelerationStructurePass
         virtual void UpdateRayTracingSrgs() = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
@@ -343,10 +343,6 @@ namespace AZ::Render
         //! Retrieves the GPU buffer containing information for all ray tracing materials.
         virtual const Data::Instance<RPI::Buffer> GetMaterialInfoGpuBuffer() const = 0;
 
-        //! If necessary recreates TLAS buffers and updates the ray tracing SRGs. Should only be called by the
-        //! RayTracingAccelerationStructurePass. Returns the current revision.
-        virtual uint32_t BeginFrame() = 0;
-
         //! Updates the RayTracingSceneSrg and RayTracingMaterialSrg, called after the TLAS is allocated in the
         //! RayTracingAccelerationStructurePass
         virtual void UpdateRayTracingSrgs() = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
@@ -10,8 +10,10 @@
 
 #include <Atom/Feature/RayTracing/RayTracingIndexList.h>
 #include <Atom/RHI/RayTracingAccelerationStructure.h>
+#include <Atom/RHI/RayTracingCompactionQueryPool.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
+#include <Atom/RPI.Public/GpuQuery/Query.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Reflect/Image/Image.h>
 #include <Atom/Utils/StableDynamicArray.h>
@@ -108,8 +110,8 @@ namespace AZ::Render
             // vertex buffer usage flags
             RayTracingSubMeshBufferFlags m_bufferFlags = RayTracingSubMeshBufferFlags::None;
 
-            // ray tracing Blas
-            RHI::Ptr<RHI::RayTracingBlas> m_blas;
+            // id for accessing the blas instance (assetId, subMeshIdx)
+            AZStd::pair<Data::AssetId, int> m_blasInstanceId;
 
             // submesh material
             SubMeshMaterial m_material;
@@ -351,7 +353,22 @@ namespace AZ::Render
 
         struct SubMeshBlasInstance
         {
+            // Uncompacted Blas for the submesh
+            // When acceleration structure compaction is enabled, this will be deleted after the compacted Blas is ready
             RHI::Ptr<RHI::RayTracingBlas> m_blas;
+
+            // Compacted Blas
+            // Should be empty after creation
+            // This is created after the uncompacted Blas is built, if compaction is enabled for this submesh
+            RHI::Ptr<RHI::RayTracingBlas> m_compactBlas;
+
+            // Query for getting the compacted size of the acceleration structure buffer
+            // If this is set the RayTracingAccelerationStructurePass will compact this blas instance
+            // Either none, or all SubMeshBlasInstances in a MeshBlasInstance must have compaction enabled
+            RHI::Ptr<RHI::RayTracingCompactionQuery> m_compactionSizeQuery;
+
+            //! Descriptor from which the m_blas is built
+            RHI::RayTracingBlasDescriptor m_blasDescriptor;
         };
 
         struct MeshBlasInstance
@@ -366,6 +383,30 @@ namespace AZ::Render
 
         using BlasInstanceMap = AZStd::unordered_map<AZ::Data::AssetId, MeshBlasInstance>;
         virtual BlasInstanceMap& GetBlasInstances() = 0;
+
+        using BlasBuildList = AZStd::unordered_set<AZ::Data::AssetId>;
+
+        //! Returns the list of Blas instance asset ids that need to be built for the given device
+        //! The returned asset ids can be used to access the Blas instance returned by GetBlasInstances
+        //! The caller is responsible for deleting entries that where enqueued for building
+        virtual BlasBuildList& GetBlasBuildList(int deviceId) = 0;
+
+        //! Returns the asset id of all skinned mesh Blas instances in the scene
+        //! The returned asset ids can be used to access the Blas instance returned by GetBlasInstances
+        virtual const BlasBuildList& GetSkinnedMeshBlasList() = 0;
+
+        //! Returns the list of Blas instance asset ids that are ready for compaction
+        //! The returned asset ids can be used to access the Blas instance returned by GetBlasInstances
+        //! The caller is responsible for deleting entries that where enqueued for building
+        virtual BlasBuildList& GetBlasCompactionList(int deviceId) = 0;
+
+        //! Signals that the compaction size queries of the asset have been enqueued
+        //! The mesh will be inserted into the queue returned by GetBlasCompactionList when the compacted size is ready
+        virtual const void MarkBlasInstanceForCompaction(int deviceId, Data::AssetId assetId) = 0;
+
+        //! Signals that the Blas compaction has been enqueued
+        //! The original uncompacted BLAS will be deleted when it's no longer needed
+        virtual const void MarkBlasInstanceAsCompactionEnqueued(int deviceId, Data::AssetId assetId) = 0;
 
         //! Retrieves the list of all procedural geometry types in the scene
         virtual const ProceduralGeometryTypeList& GetProceduralGeometryTypes() const = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
@@ -385,7 +385,7 @@ namespace AZ::Render
         //! Returns the list of Blas instance asset ids that need to be built for the given device
         //! The returned asset ids can be used to access the Blas instance returned by GetBlasInstances
         //! The caller is responsible for deleting entries that where enqueued for building
-        virtual BlasBuildList& GetBlasBuildList(int deviceId) = 0;
+        virtual BlasBuildList& GetBlasBuildList(int deviceIndex) = 0;
 
         //! Returns the asset id of all skinned mesh Blas instances in the scene
         //! The returned asset ids can be used to access the Blas instance returned by GetBlasInstances
@@ -394,15 +394,15 @@ namespace AZ::Render
         //! Returns the list of Blas instance asset ids that are ready for compaction
         //! The returned asset ids can be used to access the Blas instance returned by GetBlasInstances
         //! The caller is responsible for deleting entries that where enqueued for building
-        virtual BlasBuildList& GetBlasCompactionList(int deviceId) = 0;
+        virtual BlasBuildList& GetBlasCompactionList(int deviceIndex) = 0;
 
         //! Signals that the compaction size queries of the asset have been enqueued
         //! The mesh will be inserted into the queue returned by GetBlasCompactionList when the compacted size is ready
-        virtual const void MarkBlasInstanceForCompaction(int deviceId, Data::AssetId assetId) = 0;
+        virtual const void MarkBlasInstanceForCompaction(int deviceIndex, Data::AssetId assetId) = 0;
 
         //! Signals that the Blas compaction has been enqueued
         //! The original uncompacted BLAS will be deleted when it's no longer needed
-        virtual const void MarkBlasInstanceAsCompactionEnqueued(int deviceId, Data::AssetId assetId) = 0;
+        virtual const void MarkBlasInstanceAsCompactionEnqueued(int deviceIndex, Data::AssetId assetId) = 0;
 
         //! Retrieves the list of all procedural geometry types in the scene
         virtual const ProceduralGeometryTypeList& GetProceduralGeometryTypes() const = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -320,7 +320,6 @@ namespace AZ
                 for (auto& submeshBlasInstance : blasInstance.m_subMeshes)
                 {
                     auto query = submeshBlasInstance.m_compactionSizeQuery;
-                    AZ_Assert(query, "Blas was enqueued for compaction without having a compaction query");
                     context.GetCommandList()->CompactBottomLevelAccelerationStructure(
                         *submeshBlasInstance.m_blas->GetDeviceRayTracingBlas(context.GetDeviceIndex()),
                         *submeshBlasInstance.m_compactBlas->GetDeviceRayTracingBlas(context.GetDeviceIndex()));

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -70,6 +70,7 @@ namespace AZ
 
             if (rayTracingFeatureProcessor)
             {
+                rayTracingFeatureProcessor->BeginFrame();
                 auto revision = rayTracingFeatureProcessor->GetRevision();
                 m_rayTracingRevisionOutDated = revision != m_rayTracingRevision;
                 if (m_rayTracingRevisionOutDated)

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -70,7 +70,7 @@ namespace AZ
 
             if (rayTracingFeatureProcessor)
             {
-                auto revision = rayTracingFeatureProcessor->BeginFrame();
+                auto revision = rayTracingFeatureProcessor->GetRevision();
                 m_rayTracingRevisionOutDated = revision != m_rayTracingRevision;
                 if (m_rayTracingRevisionOutDated)
                 {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -748,7 +748,7 @@ namespace AZ
             }
         }
 
-        uint32_t RayTracingFeatureProcessor::BeginFrame()
+        void RayTracingFeatureProcessor::Render(const RenderPacket&)
         {
             m_frameIndex++;
 
@@ -814,8 +814,6 @@ namespace AZ
             // be set on the RayTracingSceneSrg for this frame, and the ray tracing mesh data in the RayTracingSceneSrg must
             // exactly match the TLAS.  Any mismatch in this data may result in a TDR.
             UpdateRayTracingSrgs();
-
-            return m_revision;
         }
 
         void RayTracingFeatureProcessor::UpdateRayTracingSrgs()

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -6,23 +6,24 @@
  *
  */
 
-#include <RayTracing/RayTracingFeatureProcessor.h>
 #include <Atom/Feature/RayTracing/RayTracingPass.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/RayTracingAccelerationStructure.h>
 #include <Atom/RHI/RHISystemInterface.h>
-#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RHI/RayTracingAccelerationStructure.h>
+#include <Atom/RHI/RayTracingCompactionQueryPool.h>
 #include <Atom/RPI.Public/Pass/PassFilter.h>
+#include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
+#include <CoreLights/CapsuleLightFeatureProcessor.h>
 #include <CoreLights/DirectionalLightFeatureProcessor.h>
+#include <CoreLights/DiskLightFeatureProcessor.h>
+#include <CoreLights/PointLightFeatureProcessor.h>
+#include <CoreLights/QuadLightFeatureProcessor.h>
 #include <CoreLights/SimplePointLightFeatureProcessor.h>
 #include <CoreLights/SimpleSpotLightFeatureProcessor.h>
-#include <CoreLights/PointLightFeatureProcessor.h>
-#include <CoreLights/DiskLightFeatureProcessor.h>
-#include <CoreLights/CapsuleLightFeatureProcessor.h>
-#include <CoreLights/QuadLightFeatureProcessor.h>
 #include <ImageBasedLights/ImageBasedLightFeatureProcessor.h>
+#include <RayTracing/RayTracingFeatureProcessor.h>
 
 namespace AZ
 {
@@ -91,6 +92,18 @@ namespace AZ
             const AZ::Name rayTracingMaterialSrgName("RayTracingMaterialSrg");
             m_rayTracingMaterialSrg = RPI::ShaderResourceGroup::Create(m_rayTracingSrgAsset, Name("RayTracingMaterialSrg"));
             AZ_Assert(m_rayTracingMaterialSrg, "Failed to create RayTracingMaterialSrg");
+
+            // Setup RayTracingCompactionQueryPool
+            {
+                auto rpiDesc = RPI::RPISystemInterface::Get()->GetDescriptor();
+                RHI::RayTracingCompactionQueryPoolDescriptor desc;
+                desc.m_deviceMask = RHI::RHISystemInterface::Get()->GetRayTracingSupport();
+                desc.m_budget = rpiDesc.m_rayTracingSystemDescriptor.m_rayTracingCompactionQueryPoolSize;
+                desc.m_readbackBufferPool = AZ::RPI::BufferSystemInterface::Get()->GetCommonBufferPool(RPI::CommonBufferPoolType::ReadBack);
+                desc.m_copyBufferPool = AZ::RPI::BufferSystemInterface::Get()->GetCommonBufferPool(RPI::CommonBufferPoolType::ReadWrite);
+                m_compactionQueryPool = aznew RHI::RayTracingCompactionQueryPool;
+                m_compactionQueryPool->Init(desc);
+            }
 
             EnableSceneNotification();
         }
@@ -165,7 +178,9 @@ namespace AZ
 
             MeshBlasInstance meshBlasInstance;
             meshBlasInstance.m_count = 1;
-            meshBlasInstance.m_subMeshes.push_back(SubMeshBlasInstance{ rayTracingBlas });
+            SubMeshBlasInstance subMeshBlasInstance;
+            subMeshBlasInstance.m_blas = rayTracingBlas;
+            meshBlasInstance.m_subMeshes.push_back(subMeshBlasInstance);
 
             MaterialInfo materialInfo;
 
@@ -181,6 +196,15 @@ namespace AZ
                 ConvertMaterial(m_proceduralGeometryMaterialInfos[deviceIndex].back(), material, deviceIndex);
             }
             m_blasInstanceMap.emplace(Data::AssetId(uuid), meshBlasInstance);
+
+            RHI::MultiDeviceObject::IterateDevices(
+                RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
+                [&](int deviceIndex)
+                {
+                    m_blasToBuild[deviceIndex].insert(Data::AssetId(uuid));
+                    return true;
+                });
+
             geometryTypeHandle->m_instanceCount++;
 
             m_revision++;
@@ -277,8 +301,8 @@ namespace AZ
                 materialInfos.pop_back();
             }
 
-            m_blasInstanceMap.erase(uuid);
             m_proceduralGeometryLookup.erase(uuid);
+            RemoveBlasInstance(uuid);
 
             m_revision++;
             m_proceduralGeometryInfoBufferNeedsUpdate = true;
@@ -351,58 +375,35 @@ namespace AZ
                 meshBlasInstance.m_subMeshes.reserve(mesh.m_subMeshIndices.size());
                 meshBlasInstance.m_isSkinnedMesh = mesh.m_isSkinnedMesh;
                 itMeshBlasInstance = m_blasInstanceMap.insert({ mesh.m_assetId, meshBlasInstance }).first;
-                if (mesh.m_isSkinnedMesh)
+
+                // Note: the build flags are set to be the same for each BLAS created for the mesh
+                RHI::RayTracingAccelerationStructureBuildFlags buildFlags =
+                    CreateRayTracingAccelerationStructureBuildFlags(mesh.m_isSkinnedMesh);
+                for (uint32_t subMeshIndex = 0; subMeshIndex < mesh.m_subMeshIndices.size(); ++subMeshIndex)
                 {
-                    ++m_skinnedMeshCount;
+                    const SubMesh& subMesh = m_subMeshes[mesh.m_subMeshIndices[subMeshIndex]];
+
+                    SubMeshBlasInstance subMeshBlasInstance;
+                    subMeshBlasInstance.m_blasDescriptor.Build()
+                        ->Geometry()
+                        ->VertexFormat(subMesh.m_positionFormat)
+                        ->VertexBuffer(subMesh.m_positionVertexBufferView)
+                        ->IndexBuffer(subMesh.m_indexBufferView)
+                        ->BuildFlags(buildFlags);
+
+                    itMeshBlasInstance->second.m_subMeshes.push_back(subMeshBlasInstance);
                 }
+                m_blasToCreate.insert(mesh.m_assetId);
             }
             else
             {
                 itMeshBlasInstance->second.m_count++;
+                AZ_Assert(itMeshBlasInstance->second.m_subMeshes.size() == mesh.m_subMeshIndices.size(), "");
             }
 
-            // create the BLAS buffers for each sub-mesh, or re-use existing BLAS objects if they were already created.
-            // Note: all sub-meshes must either create new BLAS objects or re-use existing ones, otherwise it's an error (it's the same model in both cases)
-            // Note: the buffer is just reserved here, the BLAS is built in the RayTracingAccelerationStructurePass
-            // Note: the build flags are set to be the same for each BLAS created for the mesh
-            RHI::RayTracingAccelerationStructureBuildFlags buildFlags = CreateRayTracingAccelerationStructureBuildFlags(mesh.m_isSkinnedMesh);
-            [[maybe_unused]] bool blasInstanceFound = false;
             for (uint32_t subMeshIndex = 0; subMeshIndex < mesh.m_subMeshIndices.size(); ++subMeshIndex)
             {
-                SubMesh& subMesh = m_subMeshes[mesh.m_subMeshIndices[subMeshIndex]];
-
-                RHI::RayTracingBlasDescriptor blasDescriptor;
-                blasDescriptor.Build()
-                    ->Geometry()
-                        ->VertexFormat(subMesh.m_positionFormat)
-                        ->VertexBuffer(subMesh.m_positionVertexBufferView)
-                        ->IndexBuffer(subMesh.m_indexBufferView)
-                        ->BuildFlags(buildFlags)
-                ;
-
-                // determine if we have an existing BLAS object for this subMesh
-                if (itMeshBlasInstance->second.m_subMeshes.size() >= subMeshIndex + 1)
-                {
-                    // re-use existing BLAS
-                    subMesh.m_blas = itMeshBlasInstance->second.m_subMeshes[subMeshIndex].m_blas;
-
-                    // keep track of the fact that we re-used a BLAS
-                    blasInstanceFound = true;
-                }
-                else
-                {
-                    AZ_Assert(blasInstanceFound == false, "Partial set of RayTracingBlas objects found for mesh");
-
-                    // create the BLAS object and store it in the BLAS list
-                    RHI::Ptr<RHI::RayTracingBlas> rayTracingBlas = aznew RHI::RayTracingBlas;
-                    itMeshBlasInstance->second.m_subMeshes.push_back({ rayTracingBlas });
-
-                    // create the buffers from the BLAS descriptor
-                    rayTracingBlas->CreateBuffers(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &blasDescriptor, *m_bufferPools);
-
-                    // store the BLAS in the mesh
-                    subMesh.m_blas = rayTracingBlas;
-                }
+                m_subMeshes[mesh.m_subMeshIndices[subMeshIndex]].m_blasInstanceId = { mesh.m_assetId, subMeshIndex };
             }
 
             AZ::Transform noScaleTransform = mesh.m_transform;
@@ -515,7 +516,7 @@ namespace AZ
                         {
                             --m_skinnedMeshCount;
                         }
-                        m_blasInstanceMap.erase(itBlas);
+                        RemoveBlasInstance(mesh.m_assetId);
                     }
                 }
 
@@ -749,6 +750,11 @@ namespace AZ
 
         uint32_t RayTracingFeatureProcessor::BeginFrame()
         {
+            m_frameIndex++;
+
+            m_compactionQueryPool->BeginFrame(m_frameIndex);
+            UpdateBlasInstances();
+
             if (m_tlasRevision != m_revision)
             {
                 m_tlasRevision = m_revision;
@@ -760,14 +766,20 @@ namespace AZ
                 uint32_t instanceIndex = 0;
                 for (auto& subMesh : m_subMeshes)
                 {
-                    tlasDescriptorBuild->Instance()
-                        ->InstanceID(instanceIndex)
-                        ->InstanceMask(subMesh.m_mesh->m_instanceMask)
-                        ->HitGroupIndex(0)
-                        ->Blas(subMesh.m_blas)
-                        ->Transform(subMesh.m_mesh->m_transform)
-                        ->NonUniformScale(subMesh.m_mesh->m_nonUniformScale)
-                        ->Transparent(subMesh.m_material.m_irradianceColor.GetA() < 1.0f);
+                    const auto& blasInstance =
+                        m_blasInstanceMap.at(subMesh.m_blasInstanceId.first).m_subMeshes[subMesh.m_blasInstanceId.second];
+                    auto& blas = blasInstance.m_compactBlas ? blasInstance.m_compactBlas : blasInstance.m_blas;
+                    if (blas)
+                    {
+                        tlasDescriptorBuild->Instance()
+                            ->InstanceID(instanceIndex)
+                            ->InstanceMask(subMesh.m_mesh->m_instanceMask)
+                            ->HitGroupIndex(0)
+                            ->Blas(blas)
+                            ->Transform(subMesh.m_mesh->m_transform)
+                            ->NonUniformScale(subMesh.m_mesh->m_nonUniformScale)
+                            ->Transparent(subMesh.m_material.m_irradianceColor.GetA() < 1.0f);
+                    }
 
                     instanceIndex++;
                 }
@@ -840,6 +852,228 @@ namespace AZ
 
             UpdateRayTracingSceneSrg();
             UpdateRayTracingMaterialSrg();
+        }
+
+        const void RayTracingFeatureProcessor::MarkBlasInstanceForCompaction(int deviceId, Data::AssetId assetId)
+        {
+            auto it = m_blasInstanceMap.find(assetId);
+            if (RHI::Validation::IsEnabled())
+            {
+                if (it != m_blasInstanceMap.end())
+                {
+                    for (auto& subMeshInstance : it->second.m_subMeshes)
+                    {
+                        AZ_Assert(
+                            subMeshInstance.m_compactionSizeQuery, "Enqueuing a Blas without an compaction size query for compaction");
+                    }
+                }
+            }
+
+            m_blasEnqueuedForCompact[deviceId][assetId] = static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax + 1);
+        }
+
+        const void RayTracingFeatureProcessor::MarkBlasInstanceAsCompactionEnqueued(int deviceId, Data::AssetId assetId)
+        {
+            auto it = m_blasInstanceMap.find(assetId);
+            if (RHI::Validation::IsEnabled())
+            {
+                if (it != m_blasInstanceMap.end())
+                {
+                    for (auto& subMeshInstance : it->second.m_subMeshes)
+                    {
+                        AZ_Assert(subMeshInstance.m_compactBlas, "Marking a Blas without a compacted Blas as enqueued for compaction");
+                    }
+                }
+            }
+
+            m_blasEnqueuedForUncompactDeletion[deviceId][assetId] = static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax + 1);
+        }
+
+        void RayTracingFeatureProcessor::UpdateBlasInstances()
+        {
+            bool changed = false;
+            auto rpiDesc = RPI::RPISystemInterface::Get()->GetDescriptor();
+            {
+                int numModelBlasCreated = 0;
+                AZStd::unordered_set<Data::AssetId> toRemoveFromCreateList;
+                for (auto assetId : m_blasToCreate)
+                {
+                    auto it = m_blasInstanceMap.find(assetId);
+                    if (it == m_blasInstanceMap.end())
+                    {
+                        toRemoveFromCreateList.insert(assetId);
+                        continue;
+                    }
+                    auto& instance = it->second;
+
+                    for (auto& subMeshInstance : instance.m_subMeshes)
+                    {
+                        // create the BLAS object and store it in the BLAS list
+                        RHI::Ptr<RHI::RayTracingBlas> rayTracingBlas = aznew RHI::RayTracingBlas;
+                        if (RHI::CheckBitsAny(
+                                subMeshInstance.m_blasDescriptor.GetBuildFlags(),
+                                RHI::RayTracingAccelerationStructureBuildFlags::ENABLE_COMPACTION))
+                        {
+                            subMeshInstance.m_compactionSizeQuery = aznew RHI::RayTracingCompactionQuery;
+                            m_compactionQueryPool->InitQuery(subMeshInstance.m_compactionSizeQuery.get());
+                        }
+                        subMeshInstance.m_blas = rayTracingBlas;
+                        // create the buffers from the BLAS descriptor
+                        subMeshInstance.m_blas->CreateBuffers(
+                            RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &subMeshInstance.m_blasDescriptor, *m_bufferPools);
+                    }
+
+                    if (instance.m_isSkinnedMesh)
+                    {
+                        ++m_skinnedMeshCount;
+                        m_skinnedBlasIds.insert(assetId);
+                    }
+                    else
+                    {
+                        RHI::MultiDeviceObject::IterateDevices(
+                            RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
+                            [&](int deviceIndex)
+                            {
+                                m_blasToBuild[deviceIndex].insert(assetId);
+                                return true;
+                            });
+                    }
+                    toRemoveFromCreateList.insert(assetId);
+                    changed = true;
+                    numModelBlasCreated++;
+                    if (rpiDesc.m_rayTracingSystemDescriptor.m_maxBlasCreatedPerFrame > 0 &&
+                        numModelBlasCreated >= rpiDesc.m_rayTracingSystemDescriptor.m_maxBlasCreatedPerFrame)
+                    {
+                        break;
+                    }
+                }
+                for (auto toRemove : toRemoveFromCreateList)
+                {
+                    m_blasToCreate.erase(toRemove);
+                }
+            }
+
+            // Check which Blas are ready for compaction and create compacted acceleration structures for them
+            {
+                AZStd::unordered_map<Data::AssetId, AZStd::vector<AZStd::unordered_map<int, uint64_t>>> compactedBlasToCreate;
+                for (auto& [deviceId, entries] : m_blasEnqueuedForCompact)
+                {
+                    for (const auto& [assetId, frameNumber] : entries)
+                    {
+                        if (frameNumber <= m_frameIndex)
+                        {
+                            auto it = m_blasInstanceMap.find(assetId);
+                            if (it != m_blasInstanceMap.end())
+                            {
+                                {
+                                    compactedBlasToCreate[assetId].resize(it->second.m_subMeshes.size());
+                                    for (int subMeshIdx = 0; subMeshIdx < it->second.m_subMeshes.size(); subMeshIdx++)
+                                    {
+                                        auto& subMeshInstance = it->second.m_subMeshes[subMeshIdx];
+                                        AZ_Assert(!subMeshInstance.m_compactBlas, "Trying to compact a Blas twice");
+                                        auto result = subMeshInstance.m_compactionSizeQuery->GetDeviceRayTracingCompactionQuery(deviceId)
+                                                          ->GetResult();
+                                        compactedBlasToCreate[assetId][subMeshIdx][deviceId] = result;
+                                        {
+                                            // TODO debug delete
+                                            int old = static_cast<int>(
+                                                subMeshInstance.m_blas->GetDeviceRayTracingBlas(0)->GetAccelerationStructureByteSize());
+                                            int compact = static_cast<int>(result);
+                                            float ratio = static_cast<float>(compact) / old;
+                                            AZ_Printf(
+                                                "BLAS", "Compact %s %d -> %d (%f)\n", assetId.ToFixedString().c_str(), old, compact, ratio);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                int numToCompactEnqueued = 0;
+                for (const auto& [assetId, sizes] : compactedBlasToCreate)
+                {
+                    auto it = m_blasInstanceMap.find(assetId);
+                    if (it != m_blasInstanceMap.end())
+                    {
+                        // Limit the number of blas we enqueue per frame to the size of the compaction query pool
+                        if (numToCompactEnqueued + sizes.size() > rpiDesc.m_rayTracingSystemDescriptor.m_rayTracingCompactionQueryPoolSize)
+                        {
+                            break;
+                        }
+                        bool foundSubMesh = false;
+                        for (int subMeshIdx = 0; subMeshIdx < it->second.m_subMeshes.size(); subMeshIdx++)
+                        {
+                            auto& subMeshInstance = it->second.m_subMeshes[subMeshIdx];
+                            if (!subMeshInstance.m_compactBlas)
+                            {
+                                if (RHI::Validation::IsEnabled())
+                                {
+                                    RHI::MultiDevice::DeviceMask sizeDeviceMask = {};
+                                    for (auto& [deviceId, size] : sizes[subMeshIdx])
+                                    {
+                                        sizeDeviceMask = RHI::SetBit(sizeDeviceMask, deviceId);
+                                    }
+                                    AZ_Assert(
+                                        sizeDeviceMask == RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
+                                        "All device Blas of a SubMesh must be compacted in the same frame");
+                                }
+                                subMeshInstance.m_compactBlas = aznew RHI::RayTracingBlas;
+                                subMeshInstance.m_compactBlas->CreateCompactedBuffers(
+                                    *subMeshInstance.m_blas, sizes[subMeshIdx], *m_bufferPools);
+                                changed = true;
+                                foundSubMesh = true;
+                                numToCompactEnqueued++;
+                            }
+                        }
+                        if (foundSubMesh)
+                        {
+                            RHI::MultiDeviceObject::IterateDevices(
+                                RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
+                                [&, assetId = assetId](int deviceId)
+                                {
+                                    m_blasToCompact[deviceId].insert(assetId);
+                                    m_blasEnqueuedForCompact[deviceId].erase(assetId);
+                                    return true;
+                                });
+                        }
+                    }
+                }
+            }
+
+            // Check which uncompacted Blas can be deleted, and delete them
+            for (auto& [deviceId, entries] : m_blasEnqueuedForUncompactDeletion)
+            {
+                AZStd::unordered_map<Data::AssetId, int> newEntries;
+                for (const auto& [assetId, frameNumber] : entries)
+                {
+                    if (frameNumber <= m_frameIndex)
+                    {
+                        auto it = m_blasInstanceMap.find(assetId);
+                        if (it != m_blasInstanceMap.end())
+                        {
+                            for (auto& subMeshInstance : it->second.m_subMeshes)
+                            {
+                                AZ_Assert(
+                                    subMeshInstance.m_compactBlas, "Deleting a uncompacted Blas from a submesh without a compacted one");
+                                // We assume here that all device Blas are handled at the same frame for all devices
+                                subMeshInstance.m_blas = {};
+                                subMeshInstance.m_compactionSizeQuery = {};
+                                changed = true;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        newEntries.insert({ assetId, frameNumber });
+                    }
+                }
+                entries = newEntries;
+            }
+
+            if (changed)
+            {
+                m_revision++;
+            }
         }
 
         void RayTracingFeatureProcessor::UpdateMeshInfoBuffer()
@@ -1185,6 +1419,29 @@ namespace AZ
             }
         }
 
+        void RayTracingFeatureProcessor::RemoveBlasInstance(Data::AssetId id)
+        {
+            m_blasInstanceMap.erase(id);
+            m_blasToCreate.erase(id);
+            m_skinnedBlasIds.erase(id);
+            for (auto& [deviceId, entries] : m_blasToBuild)
+            {
+                entries.erase(id);
+            }
+            for (auto& [deviceId, entries] : m_blasToCompact)
+            {
+                entries.erase(id);
+            }
+            for (auto& [deviceId, entries] : m_blasEnqueuedForCompact)
+            {
+                entries.erase(id);
+            }
+            for (auto& [deviceId, entries] : m_blasEnqueuedForUncompactDeletion)
+            {
+                entries.erase(id);
+            }
+        }
+
         AZ::RHI::RayTracingAccelerationStructureBuildFlags RayTracingFeatureProcessor::CreateRayTracingAccelerationStructureBuildFlags(bool isSkinnedMesh)
         {
             AZ::RHI::RayTracingAccelerationStructureBuildFlags buildFlags;
@@ -1195,6 +1452,12 @@ namespace AZ
             else
             {
                 buildFlags = AZ::RHI::RayTracingAccelerationStructureBuildFlags::FAST_TRACE;
+
+                auto rpiDesc = RPI::RPISystemInterface::Get()->GetDescriptor();
+                if (rpiDesc.m_rayTracingSystemDescriptor.m_enableBlasCompaction)
+                {
+                    buildFlags = buildFlags | RHI::RayTracingAccelerationStructureBuildFlags::ENABLE_COMPACTION;
+                }
             }
 
             return buildFlags;
@@ -1237,5 +1500,5 @@ namespace AZ
 #endif
             });
         }
-    }
+    } // namespace Render
 }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -864,7 +864,7 @@ namespace AZ
             UpdateRayTracingMaterialSrg();
         }
 
-        const void RayTracingFeatureProcessor::MarkBlasInstanceForCompaction(int deviceId, Data::AssetId assetId)
+        const void RayTracingFeatureProcessor::MarkBlasInstanceForCompaction(int deviceIndex, Data::AssetId assetId)
         {
             AZStd::unique_lock lock(m_queueMutex);
             auto it = m_blasInstanceMap.find(assetId);
@@ -881,10 +881,10 @@ namespace AZ
             }
 
             m_blasEnqueuedForCompact[assetId].m_frameIndex = static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax);
-            m_blasEnqueuedForCompact[assetId].m_deviceMask = RHI::SetBit(m_blasEnqueuedForCompact[assetId].m_deviceMask, deviceId);
+            m_blasEnqueuedForCompact[assetId].m_deviceMask = RHI::SetBit(m_blasEnqueuedForCompact[assetId].m_deviceMask, deviceIndex);
         }
 
-        const void RayTracingFeatureProcessor::MarkBlasInstanceAsCompactionEnqueued(int deviceId, Data::AssetId assetId)
+        const void RayTracingFeatureProcessor::MarkBlasInstanceAsCompactionEnqueued(int deviceIndex, Data::AssetId assetId)
         {
             AZStd::unique_lock lock(m_queueMutex);
             auto it = m_blasInstanceMap.find(assetId);
@@ -902,7 +902,7 @@ namespace AZ
             m_uncompactedBlasEnqueuedForDeletion[assetId].m_frameIndex =
                 static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax);
             m_uncompactedBlasEnqueuedForDeletion[assetId].m_deviceMask =
-                RHI::SetBit(m_uncompactedBlasEnqueuedForDeletion[assetId].m_deviceMask, deviceId);
+                RHI::SetBit(m_uncompactedBlasEnqueuedForDeletion[assetId].m_deviceMask, deviceIndex);
         }
 
         void RayTracingFeatureProcessor::UpdateBlasInstances()
@@ -1025,9 +1025,9 @@ namespace AZ
                             }
                             RHI::MultiDeviceObject::IterateDevices(
                                 RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
-                                [&, assetId = assetId](int deviceId)
+                                [&, assetId = assetId](int deviceIndex)
                                 {
-                                    m_blasToCompact[deviceId].insert(assetId);
+                                    m_blasToCompact[deviceIndex].insert(assetId);
                                     return true;
                                 });
                         }
@@ -1422,11 +1422,11 @@ namespace AZ
             m_blasInstanceMap.erase(id);
             m_blasToCreate.erase(id);
             m_skinnedBlasIds.erase(id);
-            for (auto& [deviceId, entries] : m_blasToBuild)
+            for (auto& [deviceIndex, entries] : m_blasToBuild)
             {
                 entries.erase(id);
             }
-            for (auto& [deviceId, entries] : m_blasToCompact)
+            for (auto& [deviceIndex, entries] : m_blasToCompact)
             {
                 entries.erase(id);
             }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -979,7 +979,7 @@ namespace AZ
                     changed = true;
                     numModelBlasCreated++;
                     if (rpiDesc.m_rayTracingSystemDescriptor.m_maxBlasCreatedPerFrame > 0 &&
-                        numModelBlasCreated >= rpiDesc.m_rayTracingSystemDescriptor.m_maxBlasCreatedPerFrame)
+                        numModelBlasCreated >= static_cast<uint32_t>(rpiDesc.m_rayTracingSystemDescriptor.m_maxBlasCreatedPerFrame))
                     {
                         break;
                     }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -859,7 +859,7 @@ namespace AZ
             {
                 if (it != m_blasInstanceMap.end())
                 {
-                    for (auto& subMeshInstance : it->second.m_subMeshes)
+                    for ([[maybe_unused]] auto& subMeshInstance : it->second.m_subMeshes)
                     {
                         AZ_Assert(
                             subMeshInstance.m_compactionSizeQuery, "Enqueuing a Blas without an compaction size query for compaction");
@@ -877,7 +877,7 @@ namespace AZ
             {
                 if (it != m_blasInstanceMap.end())
                 {
-                    for (auto& subMeshInstance : it->second.m_subMeshes)
+                    for ([[maybe_unused]] auto& subMeshInstance : it->second.m_subMeshes)
                     {
                         AZ_Assert(subMeshInstance.m_compactBlas, "Marking a Blas without a compacted Blas as enqueued for compaction");
                     }
@@ -1006,7 +1006,7 @@ namespace AZ
                             {
                                 if (RHI::Validation::IsEnabled())
                                 {
-                                    RHI::MultiDevice::DeviceMask sizeDeviceMask = {};
+                                    [[maybe_unused]] RHI::MultiDevice::DeviceMask sizeDeviceMask = {};
                                     for (auto& [deviceId, size] : sizes[subMeshIdx])
                                     {
                                         sizeDeviceMask = RHI::SetBit(sizeDeviceMask, deviceId);

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -751,6 +751,18 @@ namespace AZ
         void RayTracingFeatureProcessor::Render(const RenderPacket&)
         {
             m_frameIndex++;
+        }
+
+        void RayTracingFeatureProcessor::BeginFrame()
+        {
+            if (m_updatedFrameIndex == m_frameIndex)
+            {
+                // Make sure the update is only called once per frame
+                // When multiple devices are present a RayTracingAccelerationStructurePass is created per device
+                // Thus this function is called once for each device
+                return;
+            }
+            m_updatedFrameIndex = m_frameIndex;
 
             m_compactionQueryPool->BeginFrame(m_frameIndex);
             UpdateBlasInstances();
@@ -898,8 +910,8 @@ namespace AZ
             bool changed = false;
             auto rpiDesc = RPI::RPISystemInterface::Get()->GetDescriptor();
             {
-                int numModelBlasCreated = 0;
-                int numCompactionQueriesEnqueued = 0;
+                uint32_t numModelBlasCreated = 0;
+                uint32_t numCompactionQueriesEnqueued = 0;
                 AZStd::unordered_set<Data::AssetId> toRemoveFromCreateList;
                 for (auto assetId : m_blasToCreate)
                 {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -868,7 +868,7 @@ namespace AZ
                 }
             }
 
-            m_blasEnqueuedForCompact[assetId].m_frameIndex = static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax + 1);
+            m_blasEnqueuedForCompact[assetId].m_frameIndex = static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax);
             m_blasEnqueuedForCompact[assetId].m_deviceMask = RHI::SetBit(m_blasEnqueuedForCompact[assetId].m_deviceMask, deviceId);
         }
 
@@ -888,7 +888,7 @@ namespace AZ
             }
 
             m_uncompactedBlasEnqueuedForDeletion[assetId].m_frameIndex =
-                static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax + 1);
+                static_cast<int>(m_frameIndex + RHI::Limits::Device::FrameCountMax);
             m_uncompactedBlasEnqueuedForDeletion[assetId].m_deviceMask =
                 RHI::SetBit(m_uncompactedBlasEnqueuedForDeletion[assetId].m_deviceMask, deviceId);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -97,6 +97,7 @@ namespace AZ
             const Data::Instance<RPI::Buffer> GetMeshInfoGpuBuffer() const override { return m_meshInfoGpuBuffer.GetCurrentBuffer(); }
             const Data::Instance<RPI::Buffer> GetMaterialInfoGpuBuffer() const override { return m_materialInfoGpuBuffer.GetCurrentBuffer(); }
             void Render(const RenderPacket&) override;
+            void BeginFrame();
             uint32_t GetRevision() const override { return m_revision; }
             uint32_t GetProceduralGeometryTypeRevision() const override { return m_proceduralGeometryTypeRevision; }
             RHI::RayTracingBufferPools& GetBufferPools() override { return *m_bufferPools; }
@@ -261,6 +262,7 @@ namespace AZ
             AZStd::unordered_map<Data::AssetId, BlasFrameEvent> m_uncompactedBlasEnqueuedForDeletion;
 
             int m_frameIndex = 0;
+            int m_updatedFrameIndex = 0;
 
 #if !USE_BINDLESS_SRG
             // Mesh buffer and material texture resources are managed with a RayTracingResourceList, which contains an internal

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -108,11 +108,11 @@ namespace AZ
             RHI::AttachmentId GetTlasAttachmentId() const override { return m_tlasAttachmentId; }
             BlasInstanceMap& GetBlasInstances() override { return m_blasInstanceMap; }
             AZStd::mutex& GetBlasBuiltMutex() override { return m_blasBuiltMutex; }
-            BlasBuildList& GetBlasBuildList(int deviceId) override { return m_blasToBuild[deviceId]; }
+            BlasBuildList& GetBlasBuildList(int deviceIndex) override { return m_blasToBuild[deviceIndex]; }
             const BlasBuildList& GetSkinnedMeshBlasList() override { return m_skinnedBlasIds; };
-            BlasBuildList& GetBlasCompactionList(int deviceId) override { return m_blasToCompact[deviceId]; }
-            const void MarkBlasInstanceForCompaction(int deviceId, Data::AssetId assetId) override;
-            const void MarkBlasInstanceAsCompactionEnqueued(int deviceId, Data::AssetId assetId) override;
+            BlasBuildList& GetBlasCompactionList(int deviceIndex) override { return m_blasToCompact[deviceIndex]; }
+            const void MarkBlasInstanceForCompaction(int deviceIndex, Data::AssetId assetId) override;
+            const void MarkBlasInstanceAsCompactionEnqueued(int deviceIndex, Data::AssetId assetId) override;
 
             bool HasMeshGeometry() const override { return m_subMeshCount != 0; }
             bool HasProceduralGeometry() const override { return !m_proceduralGeometry.empty(); }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -97,7 +97,7 @@ namespace AZ
             const Data::Instance<RPI::Buffer> GetMeshInfoGpuBuffer() const override { return m_meshInfoGpuBuffer.GetCurrentBuffer(); }
             const Data::Instance<RPI::Buffer> GetMaterialInfoGpuBuffer() const override { return m_materialInfoGpuBuffer.GetCurrentBuffer(); }
             void Render(const RenderPacket&) override;
-            void BeginFrame();
+            void BeginFrame() override;
             uint32_t GetRevision() const override { return m_revision; }
             uint32_t GetProceduralGeometryTypeRevision() const override { return m_proceduralGeometryTypeRevision; }
             RHI::RayTracingBufferPools& GetBufferPools() override { return *m_bufferPools; }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -96,7 +96,7 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> GetRayTracingMaterialSrg() const override { return m_rayTracingMaterialSrg; }
             const Data::Instance<RPI::Buffer> GetMeshInfoGpuBuffer() const override { return m_meshInfoGpuBuffer.GetCurrentBuffer(); }
             const Data::Instance<RPI::Buffer> GetMaterialInfoGpuBuffer() const override { return m_materialInfoGpuBuffer.GetCurrentBuffer(); }
-            uint32_t BeginFrame() override;
+            void Render(const RenderPacket&) override;
             uint32_t GetRevision() const override { return m_revision; }
             uint32_t GetProceduralGeometryTypeRevision() const override { return m_proceduralGeometryTypeRevision; }
             RHI::RayTracingBufferPools& GetBufferPools() override { return *m_bufferPools; }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
@@ -20,6 +20,7 @@
 namespace AZ::RHI
 {
     class ScopeProducer;
+    class DeviceRayTracingCompactionQuery;
 
     //! Supported operations for rendering predication.
     enum class PredicationOp : uint32_t
@@ -83,6 +84,13 @@ namespace AZ::RHI
 
         /// Updates a Bottom Level Acceleration Structure (BLAS) for ray tracing operations, which is made up of DeviceRayTracingGeometry entries
         virtual void UpdateBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& rayTracingBlas) = 0;
+
+        /// Inserts queries for the size of the compacted Blas
+        virtual void QueryBlasCompactionSizes(
+            const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>& blasToQuery) = 0;
+
+        /// Copies the given sourceBlas into the compactBlas
+        virtual void CompactBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& sourceBlas, const RHI::DeviceRayTracingBlas& compactBlas) = 0;
 
         /// Builds a Top Level Acceleration Structure (TLAS) for ray tracing operations, which is made up of RayTracingInstance entries that
         /// refer to a BLAS entry

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingAccelerationStructure.h
@@ -123,6 +123,8 @@ namespace AZ::RHI
 
         static RHI::Ptr<RHI::DeviceRayTracingBlas> CreateRHIRayTracingBlas();
 
+        //! Creates the internal BLAS buffers for the compacted version of the sourceBlas
+        //! The compactedBufferSize can be queried using a RayTracingCompactionQuery
         ResultCode CreateCompactedBuffers(
             Device& device,
             RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingAccelerationStructure.h
@@ -33,6 +33,7 @@ namespace AZ::RHI
         FAST_TRACE = AZ_BIT(1),
         FAST_BUILD = AZ_BIT(2),
         ENABLE_UPDATE = AZ_BIT(3),
+        ENABLE_COMPACTION = AZ_BIT(4),
     };
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::RayTracingAccelerationStructureBuildFlags);
 
@@ -122,6 +123,12 @@ namespace AZ::RHI
 
         static RHI::Ptr<RHI::DeviceRayTracingBlas> CreateRHIRayTracingBlas();
 
+        ResultCode CreateCompactedBuffers(
+            Device& device,
+            RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
+            uint64_t compactedBufferSize,
+            const DeviceRayTracingBufferPools& rayTracingBufferPools);
+
         //! Creates the internal BLAS buffers from the descriptor
         ResultCode CreateBuffers(Device& device, const DeviceRayTracingBlasDescriptor* descriptor, const DeviceRayTracingBufferPools& rayTracingBufferPools);
 
@@ -133,9 +140,16 @@ namespace AZ::RHI
             return m_geometries;
         }
 
+        virtual uint64_t GetAccelerationStructureByteSize() = 0;
+
     private:
         // Platform API
         virtual RHI::ResultCode CreateBuffersInternal(RHI::Device& deviceBase, const RHI::DeviceRayTracingBlasDescriptor* descriptor, const DeviceRayTracingBufferPools& rayTracingBufferPools) = 0;
+        virtual RHI::ResultCode CreateCompactedBuffersInternal(
+            Device& device,
+            RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
+            uint64_t compactedBufferSize,
+            const DeviceRayTracingBufferPools& rayTracingBufferPools) = 0;
 
         DeviceRayTracingGeometryVector m_geometries;
     };

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingCompactionQueryPool.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/Resource.h>
+
+namespace AZ::RHI
+{
+    class DeviceRayTracingCompactionQueryPool;
+
+    class DeviceRayTracingCompactionQuery : public DeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(DeviceRayTracingCompactionQuery, AZ::SystemAllocator, 0);
+        AZ_RTTI(DeviceRayTracingCompactionQuery, "{9f01df87-c773-4e9c-bdfd-93331ddbfdaf}", DeviceObject);
+        virtual ~DeviceRayTracingCompactionQuery() override = default;
+        DeviceRayTracingCompactionQuery() = default;
+
+        ResultCode Init(Device& device, DeviceRayTracingCompactionQueryPool* pool);
+
+        DeviceRayTracingCompactionQueryPool* GetPool();
+
+        virtual uint64_t GetResult() = 0;
+
+    protected:
+        virtual ResultCode InitInternal(DeviceRayTracingCompactionQueryPool* pool) = 0;
+
+        DeviceRayTracingCompactionQueryPool* m_pool = nullptr;
+    };
+
+    struct RayTracingCompactionQueryPoolDescriptor
+    {
+        MultiDevice::DeviceMask m_deviceMask = MultiDevice::NoDevices;
+        int m_budget = -1;
+
+        RHI::Ptr<BufferPool> m_readbackBufferPool;
+        RHI::Ptr<BufferPool> m_copyBufferPool;
+    };
+
+    class DeviceRayTracingCompactionQueryPool : public DeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(DeviceRayTracingCompactionQueryPool, AZ::SystemAllocator, 0);
+        AZ_RTTI(DeviceRayTracingCompactionQueryPool, "{a6b9096c-f5be-4be9-9480-485408afb358}", DeviceObject);
+        DeviceRayTracingCompactionQueryPool() = default;
+        virtual ~DeviceRayTracingCompactionQueryPool() override = default;
+
+        ResultCode Init(Device& device, RayTracingCompactionQueryPoolDescriptor desc);
+
+        const RayTracingCompactionQueryPoolDescriptor& GetDescriptor();
+
+        virtual void BeginFrame([[maybe_unused]] int frame){};
+
+    protected:
+        virtual ResultCode InitInternal(RayTracingCompactionQueryPoolDescriptor desc) = 0;
+
+        RayTracingCompactionQueryPoolDescriptor m_desc;
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingCompactionQueryPool.h
@@ -14,6 +14,20 @@ namespace AZ::RHI
 {
     class DeviceRayTracingCompactionQueryPool;
 
+    //! Class for querying the compacted size of a Raytracing Acceleration Structure
+    //!
+    //! It can be used to compact acceleration structures to save memory in the raytracing scene
+    //! Acceleration structure compaction is done by performing these steps:
+    //!
+    //! 1. Created and build the uncompacted acceleration structure
+    //! 2. Query the compacted size using DeviceRayTracingCompactionQuery and wait for it to be available on the CPU
+    //! 3. Create a new compacted acceleration structure with a buffer size returned by DeviceRayTracingCompactionQuery
+    //! 4. Copy the uncompacted acceleration structure to the compacted acceleration structure
+    //! 5. Delete the uncompacted acceleration structure to save memory
+    //!
+    //! This process takes multiple frames to complete as the compact size must be available on the CPU
+    //!
+    //! See https://developer.nvidia.com/blog/tips-acceleration-structure-compaction/ for a more detailed description
     class DeviceRayTracingCompactionQuery : public DeviceObject
     {
     public:
@@ -37,12 +51,14 @@ namespace AZ::RHI
     struct RayTracingCompactionQueryPoolDescriptor
     {
         MultiDevice::DeviceMask m_deviceMask = MultiDevice::NoDevices;
+        // Number of queries in the pool
         int m_budget = -1;
 
         RHI::Ptr<BufferPool> m_readbackBufferPool;
         RHI::Ptr<BufferPool> m_copyBufferPool;
     };
 
+    //! Provides storage for DeviceRayTracingCompactionQuery objects and handles
     class DeviceRayTracingCompactionQueryPool : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -46,6 +46,8 @@ namespace AZ::RHI
     class DeviceRayTracingTlas;
     class DeviceRayTracingPipelineState;
     class DeviceRayTracingShaderTable;
+    class DeviceRayTracingCompactionQueryPool;
+    class DeviceRayTracingCompactionQuery;
 
     //! Priority of a Factory. The lower the number the higher the priority.
     //! Used when there's multiple factories available and the user hasn't define
@@ -194,5 +196,9 @@ namespace AZ::RHI
         virtual Ptr<DeviceRayTracingShaderTable> CreateRayTracingShaderTable() = 0;
 
         virtual Ptr<DeviceDispatchRaysIndirectBuffer> CreateDispatchRaysIndirectBuffer() = 0;
+
+        virtual Ptr<DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool() = 0;
+
+        virtual Ptr<DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery() = 0;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
@@ -104,6 +104,8 @@ namespace AZ::RHI
             const RayTracingBlasDescriptor* descriptor,
             const RayTracingBufferPools& rayTracingBufferPools);
 
+        //! Creates the internal BLAS buffers for the compacted version of the sourceBlas
+        //! The compactedBufferSizes can be queried using a RayTracingCompactionQuery
         ResultCode CreateCompactedBuffers(
             const RayTracingBlas& sourceBlas,
             const AZStd::unordered_map<int, uint64_t>& compactedSizes,

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
@@ -104,6 +104,11 @@ namespace AZ::RHI
             const RayTracingBlasDescriptor* descriptor,
             const RayTracingBufferPools& rayTracingBufferPools);
 
+        ResultCode CreateCompactedBuffers(
+            const RayTracingBlas& sourceBlas,
+            const AZStd::unordered_map<int, uint64_t>& compactedSizes,
+            const RayTracingBufferPools& rayTracingBufferPools);
+
         //! Returns true if the RayTracingBlas has been initialized
         bool IsValid() const;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingCompactionQueryPool.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
+#include <Atom/RHI/Resource.h>
+#include <Atom/RHI/ResourcePool.h>
+
+namespace AZ::RHI
+{
+    class RayTracingCompactionQueryPool;
+
+    class RayTracingCompactionQuery : public MultiDeviceObject
+    {
+        friend class RayTracingCompactionQueryPool;
+
+    public:
+        AZ_CLASS_ALLOCATOR(RayTracingCompactionQuery, AZ::SystemAllocator, 0);
+        AZ_RTTI(RayTracingCompactionQuery, "{2e45d8d4-4ab2-4187-b0af-53d8e4ba9b94}", MultiDeviceObject);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(RayTracingCompactionQuery);
+        virtual ~RayTracingCompactionQuery() override = default;
+        RayTracingCompactionQuery() = default;
+    };
+
+    class RayTracingCompactionQueryPool : public MultiDeviceObject
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(RayTracingCompactionQueryPool, AZ::SystemAllocator, 0);
+        AZ_RTTI(RayTracingCompactionQueryPool, "{720A480B-AF13-4D28-8851-7C7D853927E0}", MultiDeviceObject);
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(RayTracingCompactionQueryPool);
+        RayTracingCompactionQueryPool() = default;
+        virtual ~RayTracingCompactionQueryPool() override = default;
+
+        ResultCode Init(RayTracingCompactionQueryPoolDescriptor desc);
+
+        ResultCode InitQuery(RayTracingCompactionQuery* query);
+
+        void BeginFrame(int frame);
+    };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingCompactionQueryPool.h
@@ -15,6 +15,8 @@ namespace AZ::RHI
 {
     class RayTracingCompactionQueryPool;
 
+    //! Class for querying the compacted size of a Raytracing Acceleration Structure
+    //! For more information see DeviceRayTracingCompactionQuery
     class RayTracingCompactionQuery : public MultiDeviceObject
     {
         friend class RayTracingCompactionQueryPool;
@@ -27,6 +29,7 @@ namespace AZ::RHI
         RayTracingCompactionQuery() = default;
     };
 
+    //! Provides storage for DeviceRayTracingCompactionQuery objects and handles
     class RayTracingCompactionQueryPool : public MultiDeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceRayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceRayTracingAccelerationStructure.cpp
@@ -142,6 +142,21 @@ namespace AZ::RHI
         return rayTracingBlas;
     }
 
+    ResultCode DeviceRayTracingBlas::CreateCompactedBuffers(
+        Device& device,
+        RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
+        uint64_t compactedBufferSize,
+        const DeviceRayTracingBufferPools& rayTracingBufferPools)
+    {
+        ResultCode resultCode = CreateCompactedBuffersInternal(device, sourceBlas, compactedBufferSize, rayTracingBufferPools);
+        if (resultCode == ResultCode::Success)
+        {
+            DeviceObject::Init(device);
+            m_geometries = sourceBlas->m_geometries;
+        }
+        return resultCode;
+    }
+
     ResultCode DeviceRayTracingBlas::CreateBuffers(Device& device, const DeviceRayTracingBlasDescriptor* descriptor, const DeviceRayTracingBufferPools& rayTracingBufferPools)
     {
         ResultCode resultCode = CreateBuffersInternal(device, descriptor, rayTracingBufferPools);

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceRayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceRayTracingCompactionQueryPool.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
+
+namespace AZ::RHI
+{
+    ResultCode DeviceRayTracingCompactionQuery::Init(Device& device, DeviceRayTracingCompactionQueryPool* pool)
+    {
+        DeviceObject::Init(device);
+        m_pool = pool;
+        return InitInternal(pool);
+    }
+
+    DeviceRayTracingCompactionQueryPool* DeviceRayTracingCompactionQuery::GetPool()
+    {
+        return m_pool;
+    }
+
+    ResultCode DeviceRayTracingCompactionQueryPool::Init(Device& device, RayTracingCompactionQueryPoolDescriptor desc)
+    {
+        DeviceObject::Init(device);
+        m_desc = desc;
+        return InitInternal(desc);
+    }
+
+    const RayTracingCompactionQueryPoolDescriptor& DeviceRayTracingCompactionQueryPool::GetDescriptor()
+    {
+        return m_desc;
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -226,6 +226,49 @@ namespace AZ::RHI
         return resultCode;
     }
 
+    ResultCode RayTracingBlas::CreateCompactedBuffers(
+        const RayTracingBlas& sourceBlas,
+        const AZStd::unordered_map<int, uint64_t>& compactedSizes,
+        const RayTracingBufferPools& rayTracingBufferPools)
+    {
+        m_descriptor = sourceBlas.m_descriptor;
+
+        MultiDeviceObject::Init(sourceBlas.GetDeviceMask());
+        ResultCode resultCode{ ResultCode::Success };
+
+        IterateDevices(
+            [&](auto deviceIndex)
+            {
+                auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingBlas();
+
+                auto deviceDescriptor{ m_descriptor.GetDeviceRayTracingBlasDescriptor(deviceIndex) };
+
+                resultCode = GetDeviceRayTracingBlas(deviceIndex)
+                                 ->CreateCompactedBuffers(
+                                     *device,
+                                     sourceBlas.GetDeviceRayTracingBlas(deviceIndex),
+                                     compactedSizes.at(deviceIndex),
+                                     *rayTracingBufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get());
+
+                return resultCode == ResultCode::Success;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific DeviceRayTracingBlas and set deviceMask to 0
+            m_deviceObjects.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        if (const auto& name = GetName(); !name.IsEmpty())
+        {
+            SetName(name);
+        }
+
+        return resultCode;
+    }
+
     bool RayTracingBlas::IsValid() const
     {
         if (m_deviceObjects.empty())

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -63,7 +63,7 @@ namespace AZ::RHI
     void RayTracingCompactionQueryPool::BeginFrame(int frame)
     {
         IterateObjects<DeviceRayTracingCompactionQueryPool>(
-            [&](auto deviceIndex, auto deviceQueryPool)
+            [&]([[maybe_unused]] auto deviceIndex, auto deviceQueryPool)
             {
                 deviceQueryPool->BeginFrame(frame);
             });

--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/DeviceQuery.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/RayTracingCompactionQueryPool.h>
+
+namespace AZ::RHI
+{
+    ResultCode RayTracingCompactionQueryPool::Init(RayTracingCompactionQueryPoolDescriptor desc)
+    {
+        MultiDeviceObject::Init(desc.m_deviceMask);
+
+        auto resultCode{ ResultCode::Success };
+        IterateDevices(
+            [&](int deviceIndex)
+            {
+                auto* device = RHISystemInterface::Get()->GetDevice(deviceIndex);
+                m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingCompactionQueryPool();
+                resultCode = GetDeviceRayTracingCompactionQueryPool(deviceIndex)->Init(*device, desc);
+                return resultCode == ResultCode::Success;
+            });
+
+        if (resultCode != ResultCode::Success)
+        {
+            // Reset already initialized device-specific objects and set deviceMask to 0
+            m_deviceObjects.clear();
+            MultiDeviceObject::Init(static_cast<MultiDevice::DeviceMask>(0u));
+        }
+
+        return resultCode;
+    }
+
+    ResultCode RayTracingCompactionQueryPool::InitQuery(RayTracingCompactionQuery* query)
+    {
+        AZ_Assert(query, "Null query");
+        auto resultCode = IterateObjects<DeviceRayTracingCompactionQueryPool>(
+            [&](auto deviceIndex, auto deviceQueryPool)
+            {
+                RHI::Ptr<DeviceRayTracingCompactionQuery> deviceQuery;
+                deviceQuery = RHI::Factory::Get().CreateRayTracingCompactionQuery();
+                auto resultCode = deviceQuery->Init(deviceQueryPool->GetDevice(), deviceQueryPool.get());
+
+                if (resultCode != ResultCode::Success)
+                {
+                    return resultCode;
+                }
+
+                query->m_deviceObjects[deviceIndex] = deviceQuery;
+                query->m_deviceObjects[deviceIndex]->SetName(query->GetName());
+
+                return resultCode;
+            });
+
+        return resultCode;
+    }
+
+    void RayTracingCompactionQueryPool::BeginFrame(int frame)
+    {
+        IterateObjects<DeviceRayTracingCompactionQueryPool>(
+            [&](auto deviceIndex, auto deviceQueryPool)
+            {
+                deviceQueryPool->BeginFrame(frame);
+            });
+    }
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Tests/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Tests/Factory.cpp
@@ -5,20 +5,21 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Tests/Factory.h>
 #include <Atom/RHI/DeviceDispatchRaysIndirectBuffer.h>
 #include <Atom/RHI/DeviceFence.h>
 #include <Atom/RHI/DeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/DeviceRayTracingBufferPools.h>
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
 #include <Atom/RHI/DeviceRayTracingPipelineState.h>
 #include <Atom/RHI/DeviceRayTracingShaderTable.h>
-#include <Atom/RHI/DeviceRayTracingBufferPools.h>
 #include <Atom/RHI/DeviceStreamingImagePool.h>
 #include <Atom/RHI/DeviceSwapChain.h>
 #include <Tests/Device.h>
-#include <Tests/ShaderResourceGroup.h>
+#include <Tests/Factory.h>
+#include <Tests/IndirectBuffer.h>
 #include <Tests/PipelineState.h>
 #include <Tests/Query.h>
-#include <Tests/IndirectBuffer.h>
+#include <Tests/ShaderResourceGroup.h>
 
 namespace UnitTest
 {
@@ -203,6 +204,18 @@ namespace UnitTest
     }
 
     RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> Factory::CreateDispatchRaysIndirectBuffer()
+    {
+        AZ_Assert(false, "Not implemented");
+        return nullptr;
+    }
+
+    AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQueryPool> Factory::CreateRayTracingCompactionQueryPool()
+    {
+        AZ_Assert(false, "Not implemented");
+        return nullptr;
+    }
+
+    AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQuery> Factory::CreateRayTracingCompactionQuery()
     {
         AZ_Assert(false, "Not implemented");
         return nullptr;

--- a/Gems/Atom/RHI/Code/Tests/Factory.h
+++ b/Gems/Atom/RHI/Code/Tests/Factory.h
@@ -97,5 +97,9 @@ namespace UnitTest
         AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingShaderTable> CreateRayTracingShaderTable() override;
 
         AZ::RHI::Ptr<AZ::RHI::DeviceDispatchRaysIndirectBuffer> CreateDispatchRaysIndirectBuffer() override;
+
+        AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool() override;
+
+        AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery() override;
     };
 }

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -284,4 +284,8 @@ set(FILES
     Include/Atom/RHI/DispatchRaysIndirectBuffer.h
     Include/Atom/RHI/SpecializationConstant.h
     Source/RHI/SpecializationConstant.cpp
+    Source/RHI/RayTracingCompactionQueryPool.cpp
+    Include/Atom/RHI/RayTracingCompactionQueryPool.h
+    Source/RHI/DeviceRayTracingCompactionQueryPool.cpp
+    Include/Atom/RHI/DeviceRayTracingCompactionQueryPool.h
 )

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -83,6 +83,10 @@ namespace AZ
             void UpdateBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& rayTracingBlas) override;
             void BuildTopLevelAccelerationStructure(
                 const RHI::DeviceRayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList) override;
+            void QueryBlasCompactionSizes(
+                const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>& blasToQuery) override;
+            void CompactBottomLevelAccelerationStructure(
+                const RHI::DeviceRayTracingBlas& sourceBlas, const RHI::DeviceRayTracingBlas& compactBlas) override;
             void SetFragmentShadingRate(
                 RHI::ShadingRate rate,
                 const RHI::ShadingRateCombinators& combinators = DefaultShadingRateCombinators) override;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.cpp
@@ -23,6 +23,11 @@ namespace AZ
             return aznew RayTracingBlas;
         }
 
+        uint64_t RayTracingBlas::GetAccelerationStructureByteSize()
+        {
+            return m_buffers.GetCurrentElement().m_blasBuffer->GetDescriptor().m_byteCount;
+        }
+
         RHI::ResultCode RayTracingBlas::CreateBuffersInternal([[maybe_unused]] RHI::Device& deviceBase, [[maybe_unused]] const RHI::DeviceRayTracingBlasDescriptor* descriptor, [[maybe_unused]] const RHI::DeviceRayTracingBufferPools& bufferPools)
         {
 #ifdef AZ_DX12_DXR_SUPPORT
@@ -145,6 +150,39 @@ namespace AZ
             return RHI::ResultCode::Success;
         }
 
+        RHI::ResultCode RayTracingBlas::CreateCompactedBuffersInternal(
+            RHI::Device& device,
+            RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
+            uint64_t compactedBufferSize,
+            const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools)
+        {
+#ifdef AZ_DX12_DXR_SUPPORT
+            // advance to the next buffer
+            BlasBuffers& buffers = m_buffers.AdvanceCurrentElement();
+            // create BLAS buffer
+            buffers.m_blasBuffer = RHI::Factory::Get().CreateBuffer();
+            AZ::RHI::BufferDescriptor blasBufferDescriptor;
+            blasBufferDescriptor.m_bindFlags =
+                RHI::BufferBindFlags::ShaderReadWrite | RHI::BufferBindFlags::RayTracingAccelerationStructure;
+            blasBufferDescriptor.m_byteCount = compactedBufferSize;
+
+            AZ::RHI::DeviceBufferInitRequest blasBufferRequest;
+            blasBufferRequest.m_buffer = buffers.m_blasBuffer.get();
+            blasBufferRequest.m_descriptor = blasBufferDescriptor;
+            auto resultCode = rayTracingBufferPools.GetBlasBufferPool()->InitBuffer(blasBufferRequest);
+            AZ_Assert(resultCode == RHI::ResultCode::Success, "failed to create BLAS buffer");
+
+            MemoryView& blasMemoryView = static_cast<Buffer*>(buffers.m_blasBuffer.get())->GetMemoryView();
+            blasMemoryView.SetName(L"BLAS");
+
+            const auto* dx12SourceBlas = static_cast<RayTracingBlas*>(sourceBlas.get());
+            m_inputs = dx12SourceBlas->m_inputs;
+            m_geometryDescs = dx12SourceBlas->m_geometryDescs;
+#endif
+
+            return RHI::ResultCode::Success;
+        }
+
 #ifdef AZ_DX12_DXR_SUPPORT
         D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS RayTracingBlas::GetAccelerationStructureBuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags &buildFlags)
         {
@@ -162,6 +200,11 @@ namespace AZ
             if (RHI::CheckBitsAny(buildFlags, RHI::RayTracingAccelerationStructureBuildFlags::ENABLE_UPDATE))
             {
                 dxBuildFlags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_UPDATE;
+            }
+
+            if (RHI::CheckBitsAny(buildFlags, RHI::RayTracingAccelerationStructureBuildFlags::ENABLE_COMPACTION))
+            {
+                dxBuildFlags |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_ALLOW_COMPACTION;
             }
 
             return dxBuildFlags;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.cpp
@@ -151,7 +151,7 @@ namespace AZ
         }
 
         RHI::ResultCode RayTracingBlas::CreateCompactedBuffersInternal(
-            RHI::Device& device,
+            [[maybe_unused]] RHI::Device& device,
             RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
             uint64_t compactedBufferSize,
             const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.cpp
@@ -169,7 +169,7 @@ namespace AZ
             AZ::RHI::DeviceBufferInitRequest blasBufferRequest;
             blasBufferRequest.m_buffer = buffers.m_blasBuffer.get();
             blasBufferRequest.m_descriptor = blasBufferDescriptor;
-            auto resultCode = rayTracingBufferPools.GetBlasBufferPool()->InitBuffer(blasBufferRequest);
+            [[maybe_unused]] auto resultCode = rayTracingBufferPools.GetBlasBufferPool()->InitBuffer(blasBufferRequest);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "failed to create BLAS buffer");
 
             MemoryView& blasMemoryView = static_cast<Buffer*>(buffers.m_blasBuffer.get())->GetMemoryView();

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingBlas.h
@@ -43,11 +43,18 @@ namespace AZ
             // RHI::DeviceRayTracingBlas overrides...
             virtual bool IsValid() const override { return GetBuffers().m_blasBuffer != nullptr; }
 
+            uint64_t GetAccelerationStructureByteSize() override;
+
         private:
             RayTracingBlas() = default;
 
             // RHI::DeviceRayTracingBlas overrides...
             RHI::ResultCode CreateBuffersInternal(RHI::Device& deviceBase, const RHI::DeviceRayTracingBlasDescriptor* descriptor, const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools) override;
+            RHI::ResultCode CreateCompactedBuffersInternal(
+                RHI::Device& device,
+                RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
+                uint64_t compactedBufferSize,
+                const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools) override;
 
 #ifdef AZ_DX12_DXR_SUPPORT
             AZStd::vector<D3D12_RAYTRACING_GEOMETRY_DESC> m_geometryDescs;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/Factory.h>
+#include <RHI/RayTracingCompactionQueryPool.h>
+
+namespace AZ
+{
+    namespace DX12
+    {
+        RHI::Ptr<RayTracingCompactionQuery> RayTracingCompactionQuery::Create()
+        {
+            return aznew RayTracingCompactionQuery;
+        }
+
+        int RayTracingCompactionQuery::Allocate()
+        {
+            AZ_Assert(!m_indexInPool, "RayTracingCompactionQuery::Allocate: Trying to allocate a query twice");
+            auto dx12Pool = static_cast<RayTracingCompactionQueryPool*>(m_pool);
+            m_indexInPool = dx12Pool->Allocate(this);
+            return m_indexInPool.value();
+        }
+
+        void RayTracingCompactionQuery::SetResult(uint64_t value)
+        {
+            m_result = value;
+        }
+
+        uint64_t RayTracingCompactionQuery::GetResult()
+        {
+            AZ_Assert(m_result, "RayTracingCompactionQuery::GetResult: Result not ready");
+            return m_result.value();
+        }
+
+        RHI::ResultCode RayTracingCompactionQuery::InitInternal(RHI::DeviceRayTracingCompactionQueryPool* pool)
+        {
+            m_pool = pool;
+            return RHI::ResultCode::Success;
+        }
+
+        RHI::Ptr<RayTracingCompactionQueryPool> RayTracingCompactionQueryPool::Create()
+        {
+            return aznew RayTracingCompactionQueryPool;
+        }
+
+        int RayTracingCompactionQueryPool::Allocate(RayTracingCompactionQuery* query)
+        {
+            auto& buffers = m_buffers[m_currentBufferIndex];
+            AZ_Assert(buffers.m_nextFreeIndex < m_desc.m_budget, "RayTracingCompactionQueryPool: Pool is full");
+            buffers.enqueuedQueries.emplace_back(query, buffers.m_nextFreeIndex);
+            buffers.m_nextFreeIndex++;
+            return buffers.enqueuedQueries.back().second;
+        }
+
+        RHI::DeviceBuffer* RayTracingCompactionQueryPool::GetCurrentGPUBuffer()
+        {
+            return m_buffers[m_currentBufferIndex].m_gpuBuffers.get();
+        }
+
+        RHI::DeviceBuffer* RayTracingCompactionQueryPool::GetCurrentCPUBuffer()
+        {
+            return m_buffers[m_currentBufferIndex].m_cpuBuffers.get();
+        }
+
+        RHI::ResultCode RayTracingCompactionQueryPool::InitInternal(RHI::RayTracingCompactionQueryPoolDescriptor desc)
+        {
+            for (auto& buffers : m_buffers)
+            {
+                {
+                    buffers.m_cpuBuffers = RHI::Factory::Get().CreateBuffer();
+
+                    RHI::BufferDescriptor bufferDesc;
+                    bufferDesc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+                    bufferDesc.m_byteCount = desc.m_budget * sizeof(uint64_t);
+                    bufferDesc.m_bindFlags = RHI::BufferBindFlags::CopyWrite;
+                    bufferDesc.m_alignment = sizeof(uint64_t);
+
+                    RHI::DeviceBufferInitRequest request;
+                    request.m_descriptor = bufferDesc;
+                    request.m_buffer = buffers.m_cpuBuffers.get();
+                    desc.m_readbackBufferPool->GetDeviceBufferPool(GetDevice().GetDeviceIndex())->InitBuffer(request);
+                }
+                {
+                    buffers.m_gpuBuffers = RHI::Factory::Get().CreateBuffer();
+
+                    RHI::BufferDescriptor bufferDesc;
+                    bufferDesc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+                    bufferDesc.m_byteCount = desc.m_budget * sizeof(uint64_t);
+                    bufferDesc.m_bindFlags = desc.m_copyBufferPool->GetDescriptor().m_bindFlags;
+                    bufferDesc.m_alignment = sizeof(uint64_t);
+
+                    RHI::DeviceBufferInitRequest request;
+                    request.m_descriptor = bufferDesc;
+                    request.m_buffer = buffers.m_gpuBuffers.get();
+                    desc.m_copyBufferPool->GetDeviceBufferPool(GetDevice().GetDeviceIndex())->InitBuffer(request);
+                }
+            }
+            return RHI::ResultCode::Success;
+        }
+
+        void RayTracingCompactionQueryPool::BeginFrame(int frame)
+        {
+            m_currentFrame = frame;
+            for (auto& buffers : m_buffers)
+            {
+                if (buffers.m_enqueuedFrame == m_currentFrame - RHI::Limits::Device::FrameCountMax)
+                {
+                    auto pool = azrtti_cast<RHI::DeviceBufferPool*>(buffers.m_cpuBuffers->GetPool());
+                    RHI::DeviceBufferMapRequest request;
+                    request.m_buffer = buffers.m_cpuBuffers.get();
+                    request.m_byteCount = buffers.m_cpuBuffers->GetDescriptor().m_byteCount;
+                    request.m_byteOffset = 0;
+                    RHI::DeviceBufferMapResponse response;
+                    pool->MapBuffer(request, response);
+                    AZ_Assert(response.m_data, "RayTracingCompactionQueryPool::BeginFrameInternal: Mapping result buffer failed");
+                    auto mappedMemory = static_cast<uint64_t*>(response.m_data);
+
+                    for (auto& [query, indexInBuffer] : buffers.enqueuedQueries)
+                    {
+                        query->SetResult(mappedMemory[indexInBuffer]);
+                    }
+
+                    pool->UnmapBuffer(*buffers.m_cpuBuffers);
+
+                    buffers.enqueuedQueries.clear();
+                    buffers.m_enqueuedFrame = -1;
+                    buffers.m_nextFreeIndex = -1;
+                }
+            }
+
+            m_currentBufferIndex = (m_currentFrame + 1) % m_buffers.size();
+            m_buffers[m_currentBufferIndex].m_nextFreeIndex = 0;
+            m_buffers[m_currentBufferIndex].m_enqueuedFrame = m_currentFrame;
+        }
+    } // namespace DX12
+} // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -108,7 +108,7 @@ namespace AZ
             m_currentFrame = frame;
             for (auto& buffers : m_buffers)
             {
-                if (buffers.m_enqueuedFrame == m_currentFrame - RHI::Limits::Device::FrameCountMax)
+                if (buffers.m_enqueuedFrame == m_currentFrame - static_cast<int>(RHI::Limits::Device::FrameCountMax))
                 {
                     auto pool = azrtti_cast<RHI::DeviceBufferPool*>(buffers.m_cpuBuffers->GetPool());
                     RHI::DeviceBufferMapRequest request;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -50,7 +50,7 @@ namespace AZ
 
         int RayTracingCompactionQueryPool::Allocate(RayTracingCompactionQuery* query)
         {
-            auto& buffers = m_buffers[m_currentBufferIndex];
+            auto& buffers = m_queryPoolBuffers[m_currentBufferIndex];
             AZ_Assert(buffers.m_nextFreeIndex < m_desc.m_budget, "RayTracingCompactionQueryPool: Pool is full");
             buffers.enqueuedQueries.emplace_back(query, buffers.m_nextFreeIndex);
             buffers.m_nextFreeIndex++;
@@ -59,17 +59,17 @@ namespace AZ
 
         RHI::DeviceBuffer* RayTracingCompactionQueryPool::GetCurrentGPUBuffer()
         {
-            return m_buffers[m_currentBufferIndex].m_gpuBuffers.get();
+            return m_queryPoolBuffers[m_currentBufferIndex].m_gpuBuffers.get();
         }
 
         RHI::DeviceBuffer* RayTracingCompactionQueryPool::GetCurrentCPUBuffer()
         {
-            return m_buffers[m_currentBufferIndex].m_cpuBuffers.get();
+            return m_queryPoolBuffers[m_currentBufferIndex].m_cpuBuffers.get();
         }
 
         RHI::ResultCode RayTracingCompactionQueryPool::InitInternal(RHI::RayTracingCompactionQueryPoolDescriptor desc)
         {
-            for (auto& buffers : m_buffers)
+            for (auto& buffers : m_queryPoolBuffers)
             {
                 {
                     buffers.m_cpuBuffers = RHI::Factory::Get().CreateBuffer();
@@ -106,7 +106,7 @@ namespace AZ
         void RayTracingCompactionQueryPool::BeginFrame(int frame)
         {
             m_currentFrame = frame;
-            for (auto& buffers : m_buffers)
+            for (auto& buffers : m_queryPoolBuffers)
             {
                 if (buffers.m_enqueuedFrame == m_currentFrame - static_cast<int>(RHI::Limits::Device::FrameCountMax))
                 {
@@ -133,9 +133,9 @@ namespace AZ
                 }
             }
 
-            m_currentBufferIndex = (m_currentFrame + 1) % m_buffers.size();
-            m_buffers[m_currentBufferIndex].m_nextFreeIndex = 0;
-            m_buffers[m_currentBufferIndex].m_enqueuedFrame = m_currentFrame;
+            m_currentBufferIndex = (m_currentFrame + 1) % m_queryPoolBuffers.size();
+            m_queryPoolBuffers[m_currentBufferIndex].m_nextFreeIndex = 0;
+            m_queryPoolBuffers[m_currentBufferIndex].m_enqueuedFrame = m_currentFrame;
         }
     } // namespace DX12
 } // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -133,7 +133,7 @@ namespace AZ
                 }
             }
 
-            m_currentBufferIndex = (m_currentFrame + 1) % m_queryPoolBuffers.size();
+            m_currentBufferIndex = (m_currentBufferIndex + 1) % m_queryPoolBuffers.size();
             m_queryPoolBuffers[m_currentBufferIndex].m_nextFreeIndex = 0;
             m_queryPoolBuffers[m_currentBufferIndex].m_enqueuedFrame = m_currentFrame;
         }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.h
@@ -69,7 +69,7 @@ namespace AZ
             void BeginFrame(int frame) override;
             //////////////////////////////////////////////////////////////////////////
 
-            struct Buffers
+            struct QueryPoolBuffers
             {
                 RHI::Ptr<RHI::DeviceBuffer> m_gpuBuffers;
                 RHI::Ptr<RHI::DeviceBuffer> m_cpuBuffers;
@@ -79,7 +79,7 @@ namespace AZ
                 AZStd::vector<AZStd::pair<RHI::Ptr<RayTracingCompactionQuery>, int>> enqueuedQueries;
             };
 
-            AZStd::array<Buffers, RHI::Limits::Device::FrameCountMax + 1> m_buffers;
+            AZStd::array<QueryPoolBuffers, RHI::Limits::Device::FrameCountMax> m_queryPoolBuffers;
             int m_currentBufferIndex = 0;
 
             int m_currentFrame = -1;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingCompactionQueryPool.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/DeviceBuffer.h>
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
+
+namespace AZ
+{
+    namespace DX12
+    {
+        class RayTracingCompactionQueryPool;
+
+        class RayTracingCompactionQuery final : public RHI::DeviceRayTracingCompactionQuery
+        {
+            using Base = RHI::DeviceRayTracingCompactionQuery;
+            friend class RayTracingCompactionQueryPool;
+
+        public:
+            AZ_RTTI(RayTracingCompactionQuery, "{50521a53-9740-4e35-b77c-c039016cc44f}", Base);
+            AZ_CLASS_ALLOCATOR(RayTracingCompactionQuery, AZ::SystemAllocator);
+            ~RayTracingCompactionQuery() = default;
+            static RHI::Ptr<RayTracingCompactionQuery> Create();
+
+            int Allocate();
+
+        private:
+            RayTracingCompactionQuery() = default;
+
+            void SetResult(uint64_t value);
+
+            //////////////////////////////////////////////////////////////////////////
+            // RHI::DeviceRayTracingCompactionQuery
+            uint64_t GetResult() override;
+            RHI::ResultCode InitInternal(RHI::DeviceRayTracingCompactionQueryPool* pool) override;
+            //////////////////////////////////////////////////////////////////////////
+
+            AZStd::optional<uint64_t> m_result;
+            AZStd::optional<int> m_indexInPool;
+        };
+
+        class RayTracingCompactionQueryPool final : public RHI::DeviceRayTracingCompactionQueryPool
+        {
+            using Base = RHI::DeviceRayTracingCompactionQueryPool;
+
+        public:
+            AZ_RTTI(RayTracingCompactionQueryPool, "{7bd9b295-cbb9-4fd4-95fc-0df6ad77e92a}", Base);
+            AZ_CLASS_ALLOCATOR(RayTracingCompactionQueryPool, AZ::SystemAllocator);
+            ~RayTracingCompactionQueryPool() = default;
+            static RHI::Ptr<RayTracingCompactionQueryPool> Create();
+
+            int Allocate(RayTracingCompactionQuery* query);
+
+            RHI::DeviceBuffer* GetCurrentGPUBuffer();
+            RHI::DeviceBuffer* GetCurrentCPUBuffer();
+
+        private:
+            RayTracingCompactionQueryPool() = default;
+
+            //////////////////////////////////////////////////////////////////////////
+            // RHI::DeviceRayTracingCompactionQueryPool
+            RHI::ResultCode InitInternal(RHI::RayTracingCompactionQueryPoolDescriptor desc) override;
+            void BeginFrame(int frame) override;
+            //////////////////////////////////////////////////////////////////////////
+
+            struct Buffers
+            {
+                RHI::Ptr<RHI::DeviceBuffer> m_gpuBuffers;
+                RHI::Ptr<RHI::DeviceBuffer> m_cpuBuffers;
+                int m_nextFreeIndex = 0;
+                int m_enqueuedFrame = -1;
+
+                AZStd::vector<AZStd::pair<RHI::Ptr<RayTracingCompactionQuery>, int>> enqueuedQueries;
+            };
+
+            AZStd::array<Buffers, RHI::Limits::Device::FrameCountMax + 1> m_buffers;
+            int m_currentBufferIndex = 0;
+
+            int m_currentFrame = -1;
+        };
+    } // namespace DX12
+} // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/SystemComponent.cpp
@@ -6,8 +6,10 @@
  *
  */
 
+#include <Atom/RHI.Reflect/DX12/Base.h>
+#include <Atom/RHI/FactoryManagerBus.h>
 #include <AzCore/PlatformIncl.h>
-#include <RHI/SystemComponent.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <RHI/Buffer.h>
 #include <RHI/BufferPool.h>
 #include <RHI/BufferView.h>
@@ -21,25 +23,24 @@
 #include <RHI/ImageView.h>
 #include <RHI/IndirectBufferSignature.h>
 #include <RHI/IndirectBufferWriter.h>
+#include <RHI/PhysicalDevice.h>
 #include <RHI/PipelineLibrary.h>
 #include <RHI/PipelineState.h>
-#include <RHI/PhysicalDevice.h>
 #include <RHI/Query.h>
 #include <RHI/QueryPool.h>
-#include <RHI/RayTracingBufferPools.h>
 #include <RHI/RayTracingBlas.h>
-#include <RHI/RayTracingTlas.h>
+#include <RHI/RayTracingBufferPools.h>
+#include <RHI/RayTracingCompactionQueryPool.h>
 #include <RHI/RayTracingPipelineState.h>
 #include <RHI/RayTracingShaderTable.h>
+#include <RHI/RayTracingTlas.h>
 #include <RHI/Scope.h>
 #include <RHI/ShaderResourceGroup.h>
 #include <RHI/ShaderResourceGroupPool.h>
 #include <RHI/StreamingImagePool.h>
 #include <RHI/SwapChain.h>
+#include <RHI/SystemComponent.h>
 #include <RHI/TransientAttachmentPool.h>
-#include <Atom/RHI.Reflect/DX12/Base.h>
-#include <Atom/RHI/FactoryManagerBus.h>
-#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {
@@ -246,6 +247,16 @@ namespace AZ
         RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> SystemComponent::CreateDispatchRaysIndirectBuffer()
         {
             return DispatchRaysIndirectBuffer::Create();
+        }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> SystemComponent::CreateRayTracingCompactionQueryPool()
+        {
+            return RayTracingCompactionQueryPool::Create();
+        }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> SystemComponent::CreateRayTracingCompactionQuery()
+        {
+            return RayTracingCompactionQuery::Create();
         }
     }
 }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/SystemComponent.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/SystemComponent.h
@@ -73,6 +73,8 @@ namespace AZ
             RHI::Ptr<RHI::DeviceRayTracingPipelineState> CreateRayTracingPipelineState() override;
             RHI::Ptr<RHI::DeviceRayTracingShaderTable> CreateRayTracingShaderTable() override;
             RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> CreateDispatchRaysIndirectBuffer() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery() override;
             ///////////////////////////////////////////////////////////////////
 
         private:

--- a/Gems/Atom/RHI/DX12/Code/atom_rhi_dx12_private_common_files.cmake
+++ b/Gems/Atom/RHI/DX12/Code/atom_rhi_dx12_private_common_files.cmake
@@ -117,6 +117,8 @@ set(FILES
     Source/RHI/RayTracingBufferPools.h
     Source/RHI/RayTracingBlas.cpp
     Source/RHI/RayTracingBlas.h
+    Source/RHI/RayTracingCompactionQueryPool.cpp
+    Source/RHI/RayTracingCompactionQueryPool.h
     Source/RHI/RayTracingTlas.cpp
     Source/RHI/RayTracingTlas.h
     Source/RHI/RayTracingPipelineState.cpp

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -911,6 +911,20 @@ namespace AZ
             AZ_Assert(false, "Not implemented");
         }
 
+        void CommandList::QueryBlasCompactionSizes(
+            const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>& blasToQuery)
+        {
+            // [GFX TODO][ATOM-5268] Implement Metal Ray Tracing
+            AZ_Assert(false, "Not implemented");
+        }
+
+        void CommandList::CompactBottomLevelAccelerationStructure(
+            const RHI::DeviceRayTracingBlas& sourceBlas, const RHI::DeviceRayTracingBlas& compactBlas)
+        {
+            // [GFX TODO][ATOM-5268] Implement Metal Ray Tracing
+            AZ_Assert(false, "Not implemented");
+        }
+
         void CommandList::BuildTopLevelAccelerationStructure(
             const RHI::DeviceRayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList)
         {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
@@ -69,8 +69,16 @@ namespace AZ
             void Submit(const RHI::DeviceDispatchRaysItem& dispatchRaysItem, uint32_t submitIndex = 0) override;
             void BeginPredication(const RHI::DeviceBuffer& buffer, uint64_t offset, RHI::PredicationOp operation) override {}
             void EndPredication() override {}
-            void BuildBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& rayTracingBlas) override;
+            void BuildBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas &rayTracingBlas) override;
             void UpdateBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& rayTracingBlas) override;
+            void QueryBlasCompactionSizes(
+                const AZStd::vector<
+                    AZStd::pair<RHI::DeviceRayTracingBlas *,
+                                RHI::DeviceRayTracingCompactionQuery *>>
+                    &blasToQuery) override;
+            void CompactBottomLevelAccelerationStructure(
+                const RHI::DeviceRayTracingBlas &sourceBlas,
+                const RHI::DeviceRayTracingBlas &compactBlas) override;
             void BuildTopLevelAccelerationStructure(
                 const RHI::DeviceRayTracingTlas &rayTracingTlas,
                 const AZStd::vector<const RHI::DeviceRayTracingBlas *> &changedBlasList) override;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
@@ -72,10 +72,7 @@ namespace AZ
             void BuildBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas &rayTracingBlas) override;
             void UpdateBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& rayTracingBlas) override;
             void QueryBlasCompactionSizes(
-                const AZStd::vector<
-                    AZStd::pair<RHI::DeviceRayTracingBlas *,
-                                RHI::DeviceRayTracingCompactionQuery *>>
-                    &blasToQuery) override;
+                const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas *, RHI::DeviceRayTracingCompactionQuery *>> &blasToQuery) override;
             void CompactBottomLevelAccelerationStructure(
                 const RHI::DeviceRayTracingBlas &sourceBlas,
                 const RHI::DeviceRayTracingBlas &compactBlas) override;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
@@ -249,5 +249,17 @@ namespace AZ
             AZ_Assert(false, "Not implemented");
             return nullptr;
         }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool()
+        {
+            AZ_Assert(false, "Not implemented");
+            return nullptr;
+        }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery()
+        {
+            AZ_Assert(false, "Not implemented");
+            return nullptr;
+        }
     }
 }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.h
@@ -72,6 +72,8 @@ namespace AZ
             RHI::Ptr<RHI::DeviceRayTracingPipelineState> CreateRayTracingPipelineState() override;
             RHI::Ptr<RHI::DeviceRayTracingShaderTable> CreateRayTracingShaderTable() override;
             RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> CreateDispatchRaysIndirectBuffer() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery() override;
             ///////////////////////////////////////////////////////////////////
 
         private:

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/CommandList.h
@@ -41,8 +41,8 @@ namespace AZ
             void EndPredication() override {}
             void BuildBottomLevelAccelerationStructure([[maybe_unused]] const RHI::DeviceRayTracingBlas& rayTracingBlas) override {}
             void UpdateBottomLevelAccelerationStructure([[maybe_unused]] const RHI::DeviceRayTracingBlas& rayTracingBlas) override {}
-            void QueryBlasCompactionSizes(const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>& blasToQuery) override { }
-            void CompactBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& sourceBlas, const RHI::DeviceRayTracingBlas& compactBlas) override{}
+            void QueryBlasCompactionSizes(const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>&) override {}
+            void CompactBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas&, const RHI::DeviceRayTracingBlas&) override {}
             void BuildTopLevelAccelerationStructure([[maybe_unused]] const RHI::DeviceRayTracingTlas& rayTracingTlas, [[maybe_unused]] const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList) override {}
             void SetFragmentShadingRate(
                 [[maybe_unused]] RHI::ShadingRate rate,

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/CommandList.h
@@ -41,6 +41,8 @@ namespace AZ
             void EndPredication() override {}
             void BuildBottomLevelAccelerationStructure([[maybe_unused]] const RHI::DeviceRayTracingBlas& rayTracingBlas) override {}
             void UpdateBottomLevelAccelerationStructure([[maybe_unused]] const RHI::DeviceRayTracingBlas& rayTracingBlas) override {}
+            void QueryBlasCompactionSizes(const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>& blasToQuery) override { }
+            void CompactBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& sourceBlas, const RHI::DeviceRayTracingBlas& compactBlas) override{}
             void BuildTopLevelAccelerationStructure([[maybe_unused]] const RHI::DeviceRayTracingTlas& rayTracingTlas, [[maybe_unused]] const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList) override {}
             void SetFragmentShadingRate(
                 [[maybe_unused]] RHI::ShadingRate rate,

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/RayTracingBlas.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/RayTracingBlas.h
@@ -29,11 +29,24 @@ namespace AZ
             // RHI::DeviceRayTracingBlas overrides...
             virtual bool IsValid() const override { return true; }
 
+            uint64_t GetAccelerationStructureByteSize() override
+            {
+                return 0;
+            }
+
         private:
             RayTracingBlas() = default;
 
             // RHI::DeviceRayTracingBlas overrides...
             RHI::ResultCode CreateBuffersInternal([[maybe_unused]] RHI::Device& deviceBase, [[maybe_unused]] const RHI::DeviceRayTracingBlasDescriptor* descriptor, [[maybe_unused]] const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools) override {return RHI::ResultCode::Success;}
+            RHI::ResultCode CreateCompactedBuffersInternal(
+                [[maybe_unused]] RHI::Device& device,
+                [[maybe_unused]] RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
+                [[maybe_unused]] uint64_t compactedBufferSize,
+                [[maybe_unused]] const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools) override
+            {
+                return RHI::ResultCode::Success;
+            }
         };
     }
 }

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RHI/RayTracingCompactionQueryPool.h>
+
+namespace AZ
+{
+    namespace Null
+    {
+        RHI::Ptr<RayTracingCompactionQuery> RayTracingCompactionQuery::Create()
+        {
+            return aznew RayTracingCompactionQuery;
+        }
+
+        uint64_t RayTracingCompactionQuery::GetResult()
+        {
+            return 0;
+        }
+
+        RHI::ResultCode RayTracingCompactionQuery::InitInternal([[maybe_unused]] RHI::DeviceRayTracingCompactionQueryPool* pool)
+        {
+            return RHI::ResultCode::Success;
+        }
+
+        RHI::Ptr<RayTracingCompactionQueryPool> RayTracingCompactionQueryPool::Create()
+        {
+            return aznew RayTracingCompactionQueryPool;
+        }
+
+        RHI::ResultCode RayTracingCompactionQueryPool::InitInternal([[maybe_unused]] RHI::RayTracingCompactionQueryPoolDescriptor desc)
+        {
+            return RHI::ResultCode::Success;
+        }
+
+        void RayTracingCompactionQueryPool::BeginFrame([[maybe_unused]] int frame)
+        {
+        }
+    } // namespace Null
+} // namespace AZ

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/RayTracingCompactionQueryPool.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/DeviceBuffer.h>
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
+
+namespace AZ
+{
+    namespace Null
+    {
+        class RayTracingCompactionQueryPool;
+
+        class RayTracingCompactionQuery final : public RHI::DeviceRayTracingCompactionQuery
+        {
+            using Base = RHI::DeviceRayTracingCompactionQuery;
+
+        public:
+            AZ_RTTI(RayTracingCompactionQuery, "{fbd10ff1-d508-4dee-a628-2d0db051b7f3}", Base);
+            AZ_CLASS_ALLOCATOR(RayTracingCompactionQuery, AZ::SystemAllocator);
+            ~RayTracingCompactionQuery() = default;
+            static RHI::Ptr<RayTracingCompactionQuery> Create();
+
+        private:
+            RayTracingCompactionQuery() = default;
+
+            //////////////////////////////////////////////////////////////////////////
+            // RHI::DeviceRayTracingCompactionQuery
+            uint64_t GetResult() override;
+            RHI::ResultCode InitInternal(RHI::DeviceRayTracingCompactionQueryPool* pool) override;
+            //////////////////////////////////////////////////////////////////////////
+        };
+
+        class RayTracingCompactionQueryPool final : public RHI::DeviceRayTracingCompactionQueryPool
+        {
+            using Base = RHI::DeviceRayTracingCompactionQueryPool;
+
+        public:
+            AZ_RTTI(RayTracingCompactionQueryPool, "{8048f0f9-7628-42a8-999a-c746be169eb7}", Base);
+            AZ_CLASS_ALLOCATOR(RayTracingCompactionQueryPool, AZ::SystemAllocator);
+            ~RayTracingCompactionQueryPool() = default;
+            static RHI::Ptr<RayTracingCompactionQueryPool> Create();
+
+        private:
+            RayTracingCompactionQueryPool() = default;
+
+            //////////////////////////////////////////////////////////////////////////
+            // RHI::DeviceRayTracingCompactionQueryPool
+            RHI::ResultCode InitInternal(RHI::RayTracingCompactionQueryPoolDescriptor desc) override;
+            void BeginFrame(int frame) override;
+            //////////////////////////////////////////////////////////////////////////
+        };
+    } // namespace Null
+} // namespace AZ

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/SystemComponent.cpp
@@ -5,39 +5,41 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Atom/RHI/FactoryManagerBus.h>
+#include <Atom/RHI.Reflect/Null/Base.h>
 #include <Atom/RHI/DeviceFence.h>
 #include <Atom/RHI/DeviceIndirectBufferSignature.h>
 #include <Atom/RHI/DeviceIndirectBufferWriter.h>
-#include <Atom/RHI/PhysicalDevice.h>
 #include <Atom/RHI/DeviceQueryPool.h>
-#include <Atom/RHI.Reflect/Null/Base.h>
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
+#include <Atom/RHI/FactoryManagerBus.h>
+#include <Atom/RHI/PhysicalDevice.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <RHI/BufferPool.h>
 #include <RHI/BufferView.h>
 #include <RHI/DispatchRaysIndirectBuffer.h>
 #include <RHI/Fence.h>
-#include <RHI/FrameGraphExecuter.h>
 #include <RHI/FrameGraphCompiler.h>
+#include <RHI/FrameGraphExecuter.h>
 #include <RHI/Image.h>
-#include <RHI/ImageView.h>
 #include <RHI/ImagePool.h>
+#include <RHI/ImageView.h>
 #include <RHI/PhysicalDevice.h>
 #include <RHI/PipelineLibrary.h>
 #include <RHI/PipelineState.h>
 #include <RHI/Query.h>
 #include <RHI/QueryPool.h>
-#include <RHI/RayTracingBufferPools.h>
 #include <RHI/RayTracingBlas.h>
-#include <RHI/RayTracingTlas.h>
+#include <RHI/RayTracingBufferPools.h>
+#include <RHI/RayTracingCompactionQueryPool.h>
 #include <RHI/RayTracingPipelineState.h>
 #include <RHI/RayTracingShaderTable.h>
+#include <RHI/RayTracingTlas.h>
 #include <RHI/Scope.h>
 #include <RHI/ShaderResourceGroup.h>
 #include <RHI/ShaderResourceGroupPool.h>
 #include <RHI/StreamingImagePool.h>
-#include <RHI/SystemComponent.h>
 #include <RHI/SwapChain.h>
+#include <RHI/SystemComponent.h>
 #include <RHI/TransientAttachmentPool.h>
 
 namespace AZ
@@ -235,6 +237,16 @@ namespace AZ
         RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> SystemComponent::CreateDispatchRaysIndirectBuffer()
         {
             return DispatchRaysIndirectBuffer::Create();
+        }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> SystemComponent::CreateRayTracingCompactionQueryPool()
+        {
+            return RayTracingCompactionQueryPool::Create();
+        }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> SystemComponent::CreateRayTracingCompactionQuery()
+        {
+            return RayTracingCompactionQuery::Create();
         }
     }
 }

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/SystemComponent.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/SystemComponent.h
@@ -72,6 +72,8 @@ namespace AZ
             RHI::Ptr<RHI::DeviceRayTracingPipelineState> CreateRayTracingPipelineState() override;
             RHI::Ptr<RHI::DeviceRayTracingShaderTable> CreateRayTracingShaderTable() override;
             RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> CreateDispatchRaysIndirectBuffer() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery() override;
             ///////////////////////////////////////////////////////////////////
 
         private:

--- a/Gems/Atom/RHI/Null/Code/atom_rhi_null_private_common_files.cmake
+++ b/Gems/Atom/RHI/Null/Code/atom_rhi_null_private_common_files.cmake
@@ -67,4 +67,6 @@ set(FILES
     Source/RHI/RayTracingPipelineState.h
     Source/RHI/RayTracingShaderTable.cpp
     Source/RHI/RayTracingShaderTable.h
+    Source/RHI/RayTracingCompactionQueryPool.h
+    Source/RHI/RayTracingCompactionQueryPool.cpp
 )

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -8,6 +8,7 @@
 #include <Atom/RHI.Reflect/IndirectBufferLayout.h>
 #include <Atom/RHI/DeviceDispatchRaysItem.h>
 #include <Atom/RHI/DeviceIndirectBufferSignature.h>
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
 #include <AzCore/std/containers/fixed_vector.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/parallel/lock.h>
@@ -30,12 +31,14 @@
 #include <RHI/QueryPool.h>
 #include <RHI/RayTracingAccelerationStructure.h>
 #include <RHI/RayTracingBlas.h>
+#include <RHI/RayTracingCompactionQueryPool.h>
 #include <RHI/RayTracingPipelineState.h>
 #include <RHI/RayTracingShaderTable.h>
 #include <RHI/RayTracingTlas.h>
 #include <RHI/RenderPass.h>
 #include <RHI/ShaderResourceGroup.h>
 #include <RHI/SwapChain.h>
+
 
 namespace AZ
 {
@@ -1182,6 +1185,63 @@ namespace AZ
             // submit the command to build the BLAS
             const VkAccelerationStructureBuildRangeInfoKHR* rangeInfos = blasBuffers.m_rangeInfos.data();
             context.CmdBuildAccelerationStructuresKHR(GetNativeCommandBuffer(), 1, &tempBuildInfo, &rangeInfos);
+        }
+
+        void CommandList::QueryBlasCompactionSizes(
+            const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>& blasToQuery)
+        {
+            const auto& context = static_cast<Device&>(GetDevice()).GetContext();
+
+            VkMemoryBarrier memoryBarrier = {};
+            memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+            memoryBarrier.pNext = nullptr;
+            memoryBarrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
+            memoryBarrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
+            context.CmdPipelineBarrier(
+                GetNativeCommandBuffer(),
+                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+                0,
+                1,
+                &memoryBarrier,
+                0,
+                nullptr,
+                0,
+                nullptr);
+
+            for (auto& [blas, compactionQuery] : blasToQuery)
+            {
+                auto vulkanRayTracingBlas = static_cast<const RayTracingBlas*>(blas);
+                auto vulkanCompactionQuery = static_cast<RayTracingCompactionQuery*>(compactionQuery);
+                auto vulkanCompactionQueryPool = static_cast<RayTracingCompactionQueryPool*>(compactionQuery->GetPool());
+                auto acc = vulkanRayTracingBlas->GetBuffers().m_accelerationStructure->GetNativeAccelerationStructure();
+
+                vulkanCompactionQuery->Allocate();
+                context.CmdWriteAccelerationStructuresPropertiesKHR(
+                    GetNativeCommandBuffer(),
+                    1,
+                    &acc,
+                    VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR,
+                    vulkanCompactionQueryPool->GetNativeQueryPool(),
+                    vulkanCompactionQuery->GetIndexInPool());
+            }
+        }
+
+        void CommandList::CompactBottomLevelAccelerationStructure(
+            const RHI::DeviceRayTracingBlas& sourceBlas, const RHI::DeviceRayTracingBlas& compactBlas)
+        {
+            const RayTracingBlas& vulkanSourceBlas = static_cast<const RayTracingBlas&>(sourceBlas);
+            const RayTracingBlas& vulkanCompactBlas = static_cast<const RayTracingBlas&>(compactBlas);
+
+            VkCopyAccelerationStructureInfoKHR copyInfo;
+            copyInfo.sType = VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR;
+            copyInfo.pNext = nullptr;
+            copyInfo.src = vulkanSourceBlas.GetBuffers().m_accelerationStructure->GetNativeAccelerationStructure();
+            copyInfo.dst = vulkanCompactBlas.GetBuffers().m_accelerationStructure->GetNativeAccelerationStructure();
+            copyInfo.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR;
+
+            const auto& context = static_cast<Device&>(GetDevice()).GetContext();
+            context.CmdCopyAccelerationStructureKHR(GetNativeCommandBuffer(), &copyInfo);
         }
 
         void CommandList::BuildTopLevelAccelerationStructure(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -1192,6 +1192,16 @@ namespace AZ
         {
             const auto& context = static_cast<Device&>(GetDevice()).GetContext();
 
+            AZStd::unordered_set<RayTracingCompactionQueryPool*> usedPools;
+            for (auto& [blas, compactionQuery] : blasToQuery)
+            {
+                usedPools.insert(static_cast<RayTracingCompactionQueryPool*>(compactionQuery->GetPool()));
+            }
+            for (auto pool : usedPools)
+            {
+                pool->ResetFreedQueries(this);
+            }
+
             VkMemoryBarrier memoryBarrier = {};
             memoryBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
             memoryBarrier.pNext = nullptr;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
@@ -89,6 +89,10 @@ namespace AZ
             void EndPredication() override;
             void BuildBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& rayTracingBlas) override;
             void UpdateBottomLevelAccelerationStructure(const RHI::DeviceRayTracingBlas& rayTracingBlas) override;
+            void QueryBlasCompactionSizes(
+                const AZStd::vector<AZStd::pair<RHI::DeviceRayTracingBlas*, RHI::DeviceRayTracingCompactionQuery*>>& blasToQuery) override;
+            void CompactBottomLevelAccelerationStructure(
+                const RHI::DeviceRayTracingBlas& sourceBlas, const RHI::DeviceRayTracingBlas& compactBlas) override;
             void BuildTopLevelAccelerationStructure(
                 const RHI::DeviceRayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList) override;
             void SetFragmentShadingRate(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.h
@@ -46,11 +46,18 @@ namespace AZ
             // RHI::DeviceRayTracingBlas overrides...
             virtual bool IsValid() const override { return GetBuffers().m_accelerationStructure != VK_NULL_HANDLE; }
 
+            uint64_t GetAccelerationStructureByteSize() override;
+
         private:
             RayTracingBlas() = default;
 
             // RHI::DeviceRayTracingBlas overrides...
             RHI::ResultCode CreateBuffersInternal(RHI::Device& deviceBase, const RHI::DeviceRayTracingBlasDescriptor* descriptor, const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools) override;
+            RHI::ResultCode CreateCompactedBuffersInternal(
+                RHI::Device& device,
+                RHI::Ptr<RHI::DeviceRayTracingBlas> sourceBlas,
+                uint64_t compactedBufferSize,
+                const RHI::DeviceRayTracingBufferPools& rayTracingBufferPools) override;
 
             static VkBuildAccelerationStructureFlagsKHR GetAccelerationStructureBuildFlags(const RHI::RayTracingAccelerationStructureBuildFlags &buildFlags);
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -110,7 +110,7 @@ namespace AZ
 
         RHI::ResultCode RayTracingCompactionQueryPool::InitInternal(RHI::RayTracingCompactionQueryPoolDescriptor desc)
         {
-            int queryPoolSize = desc.m_budget * (RHI::Limits::Device::FrameCountMax + 1);
+            int queryPoolSize = desc.m_budget * RHI::Limits::Device::FrameCountMax;
             VkQueryPoolCreateInfo createInfo = {};
             createInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
             createInfo.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI.Reflect/VkAllocator.h>
+#include <Atom/RHI.Reflect/Vulkan/Conversion.h>
+#include <Atom/RHI/DeviceQueryPool.h>
+#include <RHI/Device.h>
+#include <RHI/RayTracingCompactionQueryPool.h>
+
+namespace AZ
+{
+    namespace Vulkan
+    {
+        RayTracingCompactionQuery::~RayTracingCompactionQuery()
+        {
+            if (m_indexInPool)
+            {
+                auto vulkanPool = static_cast<RayTracingCompactionQueryPool*>(m_pool);
+                vulkanPool->Deallocate(m_indexInPool.value());
+            }
+        }
+
+        RHI::Ptr<RayTracingCompactionQuery> RayTracingCompactionQuery::Create()
+        {
+            return aznew RayTracingCompactionQuery;
+        }
+
+        int RayTracingCompactionQuery::GetIndexInPool()
+        {
+            return m_indexInPool.value();
+        }
+
+        void RayTracingCompactionQuery::Allocate()
+        {
+            auto vulkanPool = static_cast<RayTracingCompactionQueryPool*>(m_pool);
+            m_indexInPool = vulkanPool->Allocate();
+        }
+
+        uint64_t RayTracingCompactionQuery::GetResult()
+        {
+            auto vulkanPool = static_cast<RayTracingCompactionQueryPool*>(m_pool);
+            return vulkanPool->GetResult(m_indexInPool.value());
+        }
+
+        RHI::ResultCode RayTracingCompactionQuery::InitInternal(RHI::DeviceRayTracingCompactionQueryPool* pool)
+        {
+            m_pool = pool;
+            return RHI::ResultCode::Success;
+        }
+
+        RHI::Ptr<RayTracingCompactionQueryPool> RayTracingCompactionQueryPool::Create()
+        {
+            return aznew RayTracingCompactionQueryPool;
+        }
+
+        int RayTracingCompactionQueryPool::Allocate()
+        {
+            auto result = m_freeList.back();
+            m_freeList.pop_back();
+            return result;
+        }
+
+        void RayTracingCompactionQueryPool::Deallocate(int index)
+        {
+            m_freeList.push_back(index);
+        }
+
+        uint64_t RayTracingCompactionQueryPool::GetResult(int index)
+        {
+            uint64_t result;
+            VkQueryResultFlags vkFlags = VK_QUERY_RESULT_64_BIT;
+            auto& device = static_cast<Device&>(GetDevice());
+            VkResult vkResult = device.GetContext().GetQueryPoolResults(
+                device.GetNativeDevice(), m_nativeQueryPool, index, 1, sizeof(uint64_t), &result, sizeof(uint64_t), vkFlags);
+            auto resultCode = ConvertResult(vkResult);
+            AZ_Assert(resultCode == RHI::ResultCode::Success, "RayTracingCompactionQuery::GetResult: Result not ready");
+            return result;
+        }
+
+        VkQueryPool RayTracingCompactionQueryPool::GetNativeQueryPool()
+        {
+            return m_nativeQueryPool;
+        }
+
+        RHI::ResultCode RayTracingCompactionQueryPool::InitInternal(RHI::RayTracingCompactionQueryPoolDescriptor desc)
+        {
+            int queryPoolSize = desc.m_budget * (RHI::Limits::Device::FrameCountMax + 1);
+            VkQueryPoolCreateInfo createInfo = {};
+            createInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+            createInfo.queryType = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR;
+            createInfo.queryCount = queryPoolSize;
+
+            auto& device = static_cast<Device&>(GetDevice());
+
+            auto vkResult =
+                device.GetContext().CreateQueryPool(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeQueryPool);
+            auto resultCode = ConvertResult(vkResult);
+            AZ_Assert(
+                resultCode == RHI::ResultCode::Success, "RayTracingCompactionQuery::InitInternal: Could not initialize vulkan query pool");
+
+            m_freeList.resize(queryPoolSize);
+            for (int i = 0; i < m_freeList.size(); i++)
+            {
+                m_freeList[i] = i;
+            }
+
+            return resultCode;
+        }
+    } // namespace Vulkan
+} // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.cpp
@@ -76,7 +76,7 @@ namespace AZ
             auto& device = static_cast<Device&>(GetDevice());
             VkResult vkResult = device.GetContext().GetQueryPoolResults(
                 device.GetNativeDevice(), m_nativeQueryPool, index, 1, sizeof(uint64_t), &result, sizeof(uint64_t), vkFlags);
-            auto resultCode = ConvertResult(vkResult);
+            [[maybe_unused]] auto resultCode = ConvertResult(vkResult);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "RayTracingCompactionQuery::GetResult: Result not ready");
             return result;
         }
@@ -98,7 +98,7 @@ namespace AZ
 
             auto vkResult =
                 device.GetContext().CreateQueryPool(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_nativeQueryPool);
-            auto resultCode = ConvertResult(vkResult);
+            [[maybe_unused]] auto resultCode = ConvertResult(vkResult);
             AZ_Assert(
                 resultCode == RHI::ResultCode::Success, "RayTracingCompactionQuery::InitInternal: Could not initialize vulkan query pool");
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.h
@@ -62,6 +62,7 @@ namespace AZ
             uint64_t GetResult(int index);
 
             VkQueryPool GetNativeQueryPool();
+            void ResetFreedQueries(CommandList* commandList);
 
         private:
             RayTracingCompactionQueryPool() = default;
@@ -73,6 +74,7 @@ namespace AZ
 
             VkQueryPool m_nativeQueryPool = VK_NULL_HANDLE;
             AZStd::vector<int> m_freeList;
+            AZStd::vector<int> m_queriesEnqueuedForReset;
         };
     } // namespace Vulkan
 } // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingCompactionQueryPool.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
+#include <Atom/RHI/Query.h>
+#include <vulkan/vulkan.h>
+
+namespace AZ
+{
+    namespace Vulkan
+    {
+        class CommandList;
+
+        class RayTracingCompactionQuery final : public RHI::DeviceRayTracingCompactionQuery
+        {
+            using Base = RHI::DeviceRayTracingCompactionQuery;
+
+        public:
+            AZ_RTTI(RayTracingCompactionQuery, "{50521a53-9740-4e35-b77c-c039016cc44f}", Base);
+            AZ_CLASS_ALLOCATOR(RayTracingCompactionQuery, AZ::SystemAllocator);
+            ~RayTracingCompactionQuery();
+            static RHI::Ptr<RayTracingCompactionQuery> Create();
+
+            void Allocate();
+            int GetIndexInPool();
+
+        private:
+            RayTracingCompactionQuery() = default;
+            RayTracingCompactionQuery(const RayTracingCompactionQuery&) = delete;
+            RayTracingCompactionQuery(RayTracingCompactionQuery&&) = delete;
+            void operator=(const RayTracingCompactionQuery&) = delete;
+            void operator=(RayTracingCompactionQuery&&) = delete;
+
+            //////////////////////////////////////////////////////////////////////////
+            // RHI::DeviceRayTracingCompactionQuery
+            uint64_t GetResult() override;
+            RHI::ResultCode InitInternal(RHI::DeviceRayTracingCompactionQueryPool* pool) override;
+            //////////////////////////////////////////////////////////////////////////
+
+            AZStd::optional<int> m_indexInPool;
+        };
+
+        class RayTracingCompactionQueryPool final : public RHI::DeviceRayTracingCompactionQueryPool
+        {
+            using Base = RHI::DeviceRayTracingCompactionQueryPool;
+
+        public:
+            AZ_RTTI(RayTracingCompactionQueryPool, "{7bd9b295-cbb9-4fd4-95fc-0df6ad77e92a}", Base);
+            AZ_CLASS_ALLOCATOR(RayTracingCompactionQueryPool, AZ::SystemAllocator);
+            ~RayTracingCompactionQueryPool() = default;
+            static RHI::Ptr<RayTracingCompactionQueryPool> Create();
+
+            int Allocate();
+            void Deallocate(int index);
+
+            uint64_t GetResult(int index);
+
+            VkQueryPool GetNativeQueryPool();
+
+        private:
+            RayTracingCompactionQueryPool() = default;
+
+            //////////////////////////////////////////////////////////////////////////
+            // RHI::DeviceRayTracingCompactionQueryPool
+            RHI::ResultCode InitInternal(RHI::RayTracingCompactionQueryPoolDescriptor desc) override;
+            //////////////////////////////////////////////////////////////////////////
+
+            VkQueryPool m_nativeQueryPool = VK_NULL_HANDLE;
+            AZStd::vector<int> m_freeList;
+        };
+    } // namespace Vulkan
+} // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SystemComponent.cpp
@@ -7,51 +7,49 @@
  */
 
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayout.h>
+#include <Atom/RHI.Reflect/Vulkan/Base.h>
+#include <Atom/RHI/DeviceRayTracingPipelineState.h>
+#include <Atom/RHI/DeviceRayTracingShaderTable.h>
+#include <Atom/RHI/FactoryManagerBus.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/RHIUtils.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/CommandLine/CommandLine.h>
 #include <AzFramework/StringFunc/StringFunc.h>
-#include <RHI/SystemComponent.h>
-#include <RHI/Device.h>
-#include <RHI/DispatchRaysIndirectBuffer.h>
-#include <RHI/Instance.h>
 #include <RHI/Buffer.h>
 #include <RHI/BufferPool.h>
 #include <RHI/BufferView.h>
+#include <RHI/Device.h>
+#include <RHI/DispatchRaysIndirectBuffer.h>
 #include <RHI/Fence.h>
 #include <RHI/FrameGraphCompiler.h>
+#include <RHI/FrameGraphExecuter.h>
 #include <RHI/Image.h>
 #include <RHI/ImagePool.h>
 #include <RHI/ImageView.h>
-#include <RHI/IndirectBufferWriter.h>
 #include <RHI/IndirectBufferSignature.h>
-#include <RHI/FrameGraphExecuter.h>
+#include <RHI/IndirectBufferWriter.h>
+#include <RHI/Instance.h>
 #include <RHI/PipelineLibrary.h>
 #include <RHI/PipelineState.h>
 #include <RHI/Query.h>
 #include <RHI/QueryPool.h>
+#include <RHI/RayTracingBlas.h>
+#include <RHI/RayTracingBufferPools.h>
+#include <RHI/RayTracingCompactionQueryPool.h>
+#include <RHI/RayTracingPipelineState.h>
+#include <RHI/RayTracingShaderTable.h>
+#include <RHI/RayTracingTlas.h>
 #include <RHI/Scope.h>
 #include <RHI/ShaderResourceGroup.h>
 #include <RHI/ShaderResourceGroupPool.h>
 #include <RHI/StreamingImagePool.h>
-#include <RHI/TransientAttachmentPool.h>
 #include <RHI/SwapChain.h>
-#include <RHI/PipelineState.h>
-#include <RHI/PipelineLibrary.h>
-#include <RHI/ShaderResourceGroupPool.h>
+#include <RHI/SystemComponent.h>
 #include <RHI/TransientAttachmentPool.h>
-#include <RHI/RayTracingBufferPools.h>
-#include <RHI/RayTracingBlas.h>
-#include <RHI/RayTracingTlas.h>
-#include <RHI/RayTracingPipelineState.h>
-#include <RHI/RayTracingShaderTable.h>
-#include <Atom/RHI.Reflect/Vulkan/Base.h>
-#include <Atom/RHI/FactoryManagerBus.h>
-#include <Atom/RHI/DeviceRayTracingPipelineState.h>
-#include <Atom/RHI/DeviceRayTracingShaderTable.h>
-#include <Atom/RHI/RHIUtils.h>
-#include <Atom/RHI/RHISystemInterface.h>
+
 
 namespace AZ
 {
@@ -275,6 +273,16 @@ namespace AZ
         RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> SystemComponent::CreateDispatchRaysIndirectBuffer()
         {
             return DispatchRaysIndirectBuffer::Create();
+        }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> SystemComponent::CreateRayTracingCompactionQueryPool()
+        {
+            return RayTracingCompactionQueryPool::Create();
+        }
+
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> SystemComponent::CreateRayTracingCompactionQuery()
+        {
+            return RayTracingCompactionQuery::Create();
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SystemComponent.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SystemComponent.h
@@ -74,6 +74,8 @@ namespace AZ
             RHI::Ptr<RHI::DeviceRayTracingPipelineState> CreateRayTracingPipelineState() override;
             RHI::Ptr<RHI::DeviceRayTracingShaderTable> CreateRayTracingShaderTable() override;
             RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> CreateDispatchRaysIndirectBuffer() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool() override;
+            RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery() override;
             ///////////////////////////////////////////////////////////////////
 
         private:

--- a/Gems/Atom/RHI/Vulkan/Code/atom_rhi_vulkan_private_common_files.cmake
+++ b/Gems/Atom/RHI/Vulkan/Code/atom_rhi_vulkan_private_common_files.cmake
@@ -162,6 +162,8 @@ set(FILES
     Source/RHI/RayTracingBufferPools.h
     Source/RHI/RayTracingBlas.cpp
     Source/RHI/RayTracingBlas.h
+    Source/RHI/RayTracingCompactionQueryPool.cpp
+    Source/RHI/RayTracingCompactionQueryPool.h
     Source/RHI/RayTracingTlas.cpp
     Source/RHI/RayTracingTlas.h
     Source/RHI/RayTracingPipelineState.cpp

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/RPISystemDescriptor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/RPISystemDescriptor.h
@@ -26,6 +26,24 @@ namespace AZ
             uint32_t m_dynamicBufferPoolSize = 16 * 1024 * 1024;
         };
 
+        struct RayTracingSystemDescriptor
+        {
+            AZ_TYPE_INFO(RayTracingSystemDescriptor, "{ec80d645-561d-4207-98bb-6c07a774a02a}");
+
+            //! Enables compaction of Blas instances
+            //! This reduces the amount of memory used for raytracing acceleration structures
+            bool m_enableBlasCompaction = true;
+
+            //! The maximum number of meshes for which Blas instances are created each frame
+            //! Can be used to limit peak memory consumption for raytracing when Blas compaction is enabled
+            int32_t m_maxBlasCreatedPerFrame = -1;
+
+            //! Size of the RayTracingCompactionQueryPool
+            //! Limits the number of Blas that can be compacted each frame
+            //! This refers to the number of submeshes that can be compacted each frame, not the number of meshes
+            uint32_t m_rayTracingCompactionQueryPoolSize = 256u;
+        };
+
         struct ATOM_RPI_REFLECT_API RPISystemDescriptor final
         {
             AZ_TYPE_INFO(RPISystemDescriptor, "{96DAC3DA-40D4-4C03-8D6A-3181E843262A}");
@@ -38,6 +56,7 @@ namespace AZ
             ImageSystemDescriptor m_imageSystemDescriptor;
             GpuQuerySystemDescriptor m_gpuQuerySystemDescriptor;
             DynamicDrawSystemDescriptor m_dynamicDrawSystemDescriptor;
+            RayTracingSystemDescriptor m_rayTracingSystemDescriptor;
 
             bool m_isNullRenderer = false;
         };

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/RPISystemDescriptor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/RPISystemDescriptor.cpp
@@ -24,14 +24,20 @@ namespace AZ
                     ->Field("DynamicBufferPoolSize", &DynamicDrawSystemDescriptor::m_dynamicBufferPoolSize)
                     ;
 
+                serializeContext->Class<RayTracingSystemDescriptor>()
+                    ->Version(0)
+                    ->Field("EnableBlasCompaction", &RayTracingSystemDescriptor::m_enableBlasCompaction)
+                    ->Field("MaxBlasCreatedPerFrame", &RayTracingSystemDescriptor::m_maxBlasCreatedPerFrame)
+                    ->Field("RayTracingCompactionQueryPoolSize", &RayTracingSystemDescriptor::m_rayTracingCompactionQueryPoolSize);
+
                 serializeContext->Class<RPISystemDescriptor>()
                     ->Version(7) // ATOM-16237
                     ->Field("CommonSrgsShaderAssetPath", &RPISystemDescriptor::m_commonSrgsShaderAssetPath)
                     ->Field("ImageSystemDescriptor", &RPISystemDescriptor::m_imageSystemDescriptor)
                     ->Field("GpuQuerySystemDescriptor", &RPISystemDescriptor::m_gpuQuerySystemDescriptor)
                     ->Field("DynamicDrawSystemDescriptor", &RPISystemDescriptor::m_dynamicDrawSystemDescriptor)
-                    ->Field("NullRenderer", &RPISystemDescriptor::m_isNullRenderer)
-                    ;
+                    ->Field("RayTracingSystemDescriptor", &RPISystemDescriptor::m_rayTracingSystemDescriptor)
+                    ->Field("NullRenderer", &RPISystemDescriptor::m_isNullRenderer);
             }
         }
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Tests/Common/RHI/Factory.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/RHI/Factory.cpp
@@ -6,20 +6,22 @@
  *
  */
 
-#include <Common/RHI/Factory.h>
-#include <Common/RHI/Stubs.h>
 #include <Atom/RHI/DeviceDispatchRaysIndirectBuffer.h>
+#include <Atom/RHI/DeviceFence.h>
+#include <Atom/RHI/DevicePipelineState.h>
 #include <Atom/RHI/DeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/DeviceRayTracingBufferPools.h>
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
 #include <Atom/RHI/DeviceRayTracingPipelineState.h>
 #include <Atom/RHI/DeviceRayTracingShaderTable.h>
-#include <Atom/RHI/DeviceRayTracingBufferPools.h>
-#include <Atom/RHI/DeviceTransientAttachmentPool.h>
-#include <Atom/RHI/FrameGraphExecuter.h>
-#include <Atom/RHI/FrameGraphCompiler.h>
-#include <Atom/RHI/DevicePipelineState.h>
 #include <Atom/RHI/DeviceShaderResourceGroupPool.h>
-#include <Atom/RHI/DeviceFence.h>
 #include <Atom/RHI/DeviceSwapChain.h>
+#include <Atom/RHI/DeviceTransientAttachmentPool.h>
+#include <Atom/RHI/FrameGraphCompiler.h>
+#include <Atom/RHI/FrameGraphExecuter.h>
+#include <Common/RHI/Factory.h>
+#include <Common/RHI/Stubs.h>
+
 
 namespace UnitTest
 {
@@ -218,6 +220,18 @@ namespace UnitTest
         }
 
         RHI::Ptr<RHI::DeviceDispatchRaysIndirectBuffer> Factory::CreateDispatchRaysIndirectBuffer()
+        {
+            AZ_Assert(false, "Not implemented");
+            return nullptr;
+        }
+
+        AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQueryPool> Factory::CreateRayTracingCompactionQueryPool()
+        {
+            AZ_Assert(false, "Not implemented");
+            return nullptr;
+        }
+
+        AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQuery> Factory::CreateRayTracingCompactionQuery()
         {
             AZ_Assert(false, "Not implemented");
             return nullptr;

--- a/Gems/Atom/RPI/Code/Tests/Common/RHI/Factory.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/RHI/Factory.h
@@ -95,6 +95,10 @@ namespace UnitTest
             AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingShaderTable> CreateRayTracingShaderTable() override;
 
             AZ::RHI::Ptr<AZ::RHI::DeviceDispatchRaysIndirectBuffer> CreateDispatchRaysIndirectBuffer() override;
+
+            AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool() override;
+
+            AZ::RHI::Ptr<AZ::RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery() override;
         };
     }
 }


### PR DESCRIPTION
## What does this PR do?

Add raytracing acceleration compaction for Blas instances in the `RayTracingFeatureProcessor` as described [here](https://developer.nvidia.com/blog/tips-acceleration-structure-compaction/). This can save a lot of memory in large scenes. Usually the size of a Blas is about halfed after compaction.

We refactored the `RayTracingFeatureProcessor` so we can keep track of the state of the Blas (Blas Instance Created -> Blas Created -> Blas compaction query inserted -> Blas compaction enqueued -> Uncompacted Blas deleted). These states are defined implicitly through the lists the Blas instance is part of. This was necessary because the compaction happens over multiple frames.
The compacted sizes of Blas are queried using the newly introduced classes `RayTracingCompactionQueryPool` and `RayTracingCompactionQueryPool`
We also added the ability to limit the number of meshes for which Blas instances are created each frame. When adding all Blas instances in the same frame and then compact the Blas in the same frame, we get a memory spike while the uncompacted and compacted Blas are present at the same time. Limiting the number of Blas that are created each frame reduces this memory spike. This is turned off by default, but can be enabled through a registry setting.

This PR also fixes a MultGPU bug, where the `BeginFrame` function was called by each `RayTracingAccelerationStructurePass`, so for each device.

## How was this PR tested?

Tested on Windows with DX12 and Vulkan with different levels
