### PR TITLE
Expand ifdef guard for SC_EXECUTION_TRACE_ENABLED to include m_logAsset

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
@@ -34,7 +34,9 @@ namespace ScriptCanvas
 
         void Logger::ClearLog()
         {
+#if defined(SC_EXECUTION_TRACE_ENABLED)
             m_logAsset.GetData().Clear();
+#endif // SC_EXECUTION_TRACE_ENABLED
         }
 
         void Logger::ClearLogExecutionOverride()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
@@ -66,10 +66,10 @@ namespace ScriptCanvas
             template<typename t_Event>
             void AddToLog([[maybe_unused]] const t_Event& loggableEvent)
             {
-#if defined(SC_EXECUTION_TRACE_ENABLED) 
+#if defined(SC_EXECUTION_TRACE_ENABLED)
                 SCRIPT_CANVAS_DEBUGGER_TRACE_CLIENT("Logging: %s", loggableEvent.ToString().data());
-#endif
                 m_logAsset.GetData().m_events.emplace_back(loggableEvent.Duplicate());
+#endif
             }
 
         private:
@@ -78,7 +78,9 @@ namespace ScriptCanvas
             bool m_logExecutionOverrideEnabled = false;
             bool m_logExecutionOverride = false;
 
+#if defined(SC_EXECUTION_TRACE_ENABLED)
             ExecutionLogAsset m_logAsset;
+#endif
             ScriptCanvas::Debugger::Target m_target;
         };
     }


### PR DESCRIPTION
## What does this PR do?

Cherry picks the commit that fixes a linker error when building the ScriptCanvas.Editor gem in release mode, but only when unity builds are turned off.

## How was this PR tested?
Built the Editor in release mode in unity and non-unity mode
