### PR TITLE
Fixes DX12::StreamingImagePool related deadlock.

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
@@ -210,26 +210,36 @@ namespace AZ
 
             uint32_t totalTiles = request.m_sourceRegionSize.NumTiles;
 
-            // Check if heap memory is enough for the tiles. 
-            RHI::HeapMemoryUsage& memoryAllocatorUsage = GetDeviceHeapMemoryUsage();
-            size_t pageAllocationInBytes = m_tileAllocator.EvaluateMemoryAllocation(totalTiles);
-
-            // Try to release some memory if there isn't enough memory available in the pool
-            bool canAllocate = memoryAllocatorUsage.CanAllocate(pageAllocationInBytes);
-            if (!canAllocate && m_memoryReleaseCallback)
+            // protect access to m_tileAllocator
             {
-                // only try to release tiles the resource need
-                uint32_t maxUsedTiles = m_tileAllocator.GetTotalTileCount() - totalTiles;
-                bool releaseSuccess = m_memoryReleaseCallback(maxUsedTiles * m_tileAllocator.GetDescriptor().m_tileSizeInBytes);
+                AZStd::lock_guard<AZStd::mutex> lock(m_tileMutex);
 
-                if (!releaseSuccess)
+                // Check if heap memory is enough for the tiles.
+                RHI::HeapMemoryUsage& memoryAllocatorUsage = GetDeviceHeapMemoryUsage();
+                size_t pageAllocationInBytes = m_tileAllocator.EvaluateMemoryAllocation(totalTiles);
+
+                // Try to release some memory if there isn't enough memory available in the pool
+                bool canAllocate = memoryAllocatorUsage.CanAllocate(pageAllocationInBytes);
+                if (!canAllocate && m_memoryReleaseCallback)
                 {
-                    AZ_Warning("DX12::StreamingImagePool", false, "There isn't enough memory to allocate the image [%s]'s subresource %d. "
-                        "Using the default tile for the subresource. Try increase the StreamingImagePool memory budget", image.GetName().GetCStr(), subresourceIndex);
-                }
-            }
+                    // only try to release tiles the resource need
+                    uint32_t maxUsedTiles = m_tileAllocator.GetTotalTileCount() - totalTiles;
+                    bool releaseSuccess = m_memoryReleaseCallback(maxUsedTiles * m_tileAllocator.GetDescriptor().m_tileSizeInBytes);
 
-            image.m_heapTiles[subresourceIndex] = m_tileAllocator.Allocate(totalTiles);
+                    if (!releaseSuccess)
+                    {
+                        AZ_Warning(
+                            "DX12::StreamingImagePool",
+                            false,
+                            "There isn't enough memory to allocate the image [%s]'s subresource %d. "
+                            "Using the default tile for the subresource. Try increase the StreamingImagePool memory budget",
+                            image.GetName().GetCStr(),
+                            subresourceIndex);
+                    }
+                }
+
+                image.m_heapTiles[subresourceIndex] = m_tileAllocator.Allocate(totalTiles);
+            } // Unlock m_tileMutex.
 
             // If it failed to allocate tiles, use default tile for the sub-resource
             if (image.m_heapTiles[subresourceIndex].size() == 0)
@@ -340,12 +350,16 @@ namespace AZ
             image.m_tileLayout.GetSubresourceTileInfo(subresourceIndex, imageTileOffset, request.m_sourceCoordinate, request.m_sourceRegionSize);
             GetDevice().GetAsyncUploadQueue().QueueTileMapping(request);
 
-            // deallocate tiles and update image's sub-resource info
-            m_tileAllocator.DeAllocate(heapTilesList);
-            image.m_heapTiles[subresourceIndex] = {};
+            {
+                AZStd::lock_guard<AZStd::mutex> lock(m_tileMutex);
 
-            // Garbage collect the allocator immediately.
-            m_tileAllocator.GarbageCollect();
+                // deallocate tiles and update image's sub-resource info
+                m_tileAllocator.DeAllocate(heapTilesList);
+                image.m_heapTiles[subresourceIndex] = {};
+
+                // Garbage collect the allocator immediately.
+                m_tileAllocator.GarbageCollect();
+            }
         }
 
         void StreamingImagePool::AllocatePackedImageTiles(Image& image)
@@ -357,7 +371,6 @@ namespace AZ
             const ImageTileLayout& tileLayout = image.m_tileLayout;
             if (tileLayout.m_mipCountPacked)
             {
-                AZStd::lock_guard<AZStd::mutex> lock(m_tileMutex);
                 AllocateImageTilesInternal(image, tileLayout.GetPackedSubresourceIndex());
                 image.UpdateResidentTilesSizeInBytes(TileSizeInBytes);
             }
@@ -377,7 +390,6 @@ namespace AZ
             // Only proceed if the interval is still valid.
             if (mipInterval.m_min < mipInterval.m_max)
             {
-                AZStd::lock_guard<AZStd::mutex> lock(m_tileMutex);
                 for (uint32_t arrayIndex = 0; arrayIndex < descriptor.m_arraySize; ++arrayIndex)
                 {
                     for (uint32_t mipIndex = mipInterval.m_min; mipIndex < mipInterval.m_max; ++mipIndex)
@@ -411,7 +423,6 @@ namespace AZ
                 const Fence& fence = compiledFences.GetFence(RHI::HardwareQueueClass::Graphics);
                 GetDevice().GetAsyncUploadQueue().QueueWaitFence(fence, fence.GetPendingValue());
 
-                AZStd::lock_guard<AZStd::mutex> lock(m_tileMutex);
                 for (uint32_t arrayIndex = 0; arrayIndex < descriptor.m_arraySize; ++arrayIndex)
                 {
                     for (uint32_t mipIndex = mipInterval.m_min; mipIndex < mipInterval.m_max; ++mipIndex)
@@ -542,8 +553,8 @@ namespace AZ
         {
             Image& image = static_cast<Image&>(resourceBase);
 
-            // Wait for any upload of this image done. 
-            GetDevice().GetAsyncUploadQueue().WaitForUpload(image.GetUploadFenceValue());
+            // Wait for any upload of this image done.
+            WaitFinishUploading(image);
 
             if (auto* resolver = GetResolver())
             {
@@ -580,6 +591,9 @@ namespace AZ
         {
             Image& image = static_cast<Image&>(*request.m_image);
 
+            // Wait for any upload of this image done.
+            WaitFinishUploading(image);
+
             const uint32_t residentMipLevelBefore = image.GetResidentMipLevel();
             const uint32_t residentMipLevelAfter = residentMipLevelBefore - static_cast<uint32_t>(request.m_mipSlices.size());
 
@@ -612,7 +626,7 @@ namespace AZ
             Image& imageImpl = static_cast<Image&>(image);
 
             // Wait for any upload of this image done. 
-            GetDevice().GetAsyncUploadQueue().WaitForUpload(imageImpl.GetUploadFenceValue());
+            WaitFinishUploading(imageImpl);
 
             // Set streamed mip level to target mip level
             if (imageImpl.GetStreamedMipLevel() < targetMipLevel)
@@ -669,6 +683,11 @@ namespace AZ
         bool StreamingImagePool::SupportTiledImageInternal() const
         {
             return m_enableTileResource;
+        }
+
+        void StreamingImagePool::WaitFinishUploading(const Image& image)
+        {
+            GetDevice().GetAsyncUploadQueue().WaitForUpload(image.GetUploadFenceValue());
         }
     }
 }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.h
@@ -77,6 +77,10 @@ namespace AZ
             // Get the data reference of device heap memory usage 
             RHI::HeapMemoryUsage& GetDeviceHeapMemoryUsage();
 
+            // A helper function that makes sure any previous upload request
+            // is actually completed on @image.
+            void WaitFinishUploading(const Image& image);
+
             // whether to enable tiled resource
             bool m_enableTileResource = false;
 


### PR DESCRIPTION
## What does this PR do?

Fixes DX12::StreamingImagePool related deadlock.

Fixes #18623

Unlike Vulkan, DX12::StreamingImagePool uses a TiledAllocator, which is protected by `m_tileMutex`. The bug:
On the Main thread `m_tileMutex` was being locked before calling `AllocateImageTilesInternal`, and `AllocateImageTilesInternal` enqueues Work with AsyncUploadQueue and waits for it (While keeping `m_tileMutex` locked). This work is eventually processed by `Secondary Copy Queue`.

Due to unrelated work enqueued on The `Secondary Copy Queue`, the function `StreamingImagePool::ShutdownResourceInternal()` was being called which also locks `m_tileMutex`. The deadlock would occurred if the Main Thread already had `m_tileMutex` locked.

The Fix: Both `AllocateImageTilesInternal` and `DeAllocateImageTilesInternal` only use `m_tileMutex` before or after Async work is completed.

## How was this PR tested?

Validated with using Python uploading large levels into O3DE with scenes from KitBash3D. This used to deadlock almost immediately and now it never deadlocks. Additionally validated that `SinglePlayer` level from `StarterGame` project can load properly, and it can enter/exit game mode without additional delays or deadlocks.
