### PR TITLE
sig-simulation cherries for 2409.2 point release

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -671,7 +671,8 @@ namespace AZ
                // As part of our initialization we need to create the BRDF texture generation pipeline
                AZ::RPI::RenderPipelineDescriptor pipelineDesc;
                pipelineDesc.m_mainViewTagName = "MainCamera";
-               pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%i", viewportContext->GetId());
+               const AzFramework::ViewportId viewportId = viewportContext ? viewportContext->GetId() : AzFramework::InvalidViewportId;
+               pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%i", viewportId);
                pipelineDesc.m_rootPassTemplate = "BRDFTexturePipeline";
                pipelineDesc.m_executeOnce = true;
 

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -607,7 +607,10 @@ namespace AZ
                     {
                         renderPipeline->SetActiveAAMethod(antiAliasing.c_str());
                     }
+                }
 
+                // BRDF Texture Pipeline
+                {
                     // As part of our initialization we need to create the BRDF texture generation pipeline
                     AZ::RPI::RenderPipelineDescriptor pipelineDesc;
                     pipelineDesc.m_mainViewTagName = "MainCamera";

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -446,6 +446,16 @@ namespace AZ
                         CreateDefaultRenderPipeline();
                     }
                 }
+                else
+                {
+                    AZ::ApplicationTypeQuery appType;
+                    AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
+                    // Run BRDF pipeline for the app in console mode, to use it in render-to-texture pipelines.
+                    if (appType.IsConsoleMode())
+                    {
+                        RunBRDFPipeline(m_defaultScene, nullptr);
+                    }
+                }
             }
 
             void BootstrapSystemComponent::OnWindowCreated(AzFramework::NativeWindowHandle windowHandle)
@@ -609,35 +619,7 @@ namespace AZ
                     }
                 }
 
-                // BRDF Texture Pipeline
-                {
-                    // As part of our initialization we need to create the BRDF texture generation pipeline
-                    AZ::RPI::RenderPipelineDescriptor pipelineDesc;
-                    pipelineDesc.m_mainViewTagName = "MainCamera";
-                    pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%i", viewportContext->GetId());
-                    pipelineDesc.m_rootPassTemplate = "BRDFTexturePipeline";
-                    pipelineDesc.m_executeOnce = true;
-
-                    // Save a reference to the generated BRDF texture so it doesn't get deleted if all the passes refering to it get deleted
-                    // and it's ref count goes to zero
-                    if (!m_brdfTexture)
-                    {
-                        const AZStd::shared_ptr<const RPI::PassTemplate> brdfTextureTemplate =
-                            RPI::PassSystemInterface::Get()->GetPassTemplate(Name("BRDFTextureTemplate"));
-                        Data::Asset<RPI::AttachmentImageAsset> brdfImageAsset = RPI::AssetUtils::LoadAssetById<RPI::AttachmentImageAsset>(
-                            brdfTextureTemplate->m_imageAttachments[0].m_assetRef.m_assetId, RPI::AssetUtils::TraceLevel::Error);
-                        if (brdfImageAsset.IsReady())
-                        {
-                            m_brdfTexture = RPI::AttachmentImage::FindOrCreate(brdfImageAsset);
-                        }
-                    }
-
-                    if (!scene->GetRenderPipeline(AZ::Name(pipelineDesc.m_name)))
-                    {
-                        RPI::RenderPipelinePtr brdfTexturePipeline = AZ::RPI::RenderPipeline::CreateRenderPipeline(pipelineDesc);
-                        scene->AddRenderPipeline(brdfTexturePipeline);
-                    }
-                }
+                RunBRDFPipeline(scene, viewportContext);
 
                 // Load XR pipelines if applicable
                 if (xrSystem)
@@ -682,6 +664,36 @@ namespace AZ
                 }
 
                 return true;
+            }
+
+            void BootstrapSystemComponent::RunBRDFPipeline(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext)
+            {
+               // As part of our initialization we need to create the BRDF texture generation pipeline
+               AZ::RPI::RenderPipelineDescriptor pipelineDesc;
+               pipelineDesc.m_mainViewTagName = "MainCamera";
+               pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%i", viewportContext->GetId());
+               pipelineDesc.m_rootPassTemplate = "BRDFTexturePipeline";
+               pipelineDesc.m_executeOnce = true;
+
+               // Save a reference to the generated BRDF texture so it doesn't get deleted if all the passes refering to it get deleted
+               // and it's ref count goes to zero
+               if (!m_brdfTexture)
+               {
+                   const AZStd::shared_ptr<const RPI::PassTemplate> brdfTextureTemplate =
+                       RPI::PassSystemInterface::Get()->GetPassTemplate(Name("BRDFTextureTemplate"));
+                   Data::Asset<RPI::AttachmentImageAsset> brdfImageAsset = RPI::AssetUtils::LoadAssetById<RPI::AttachmentImageAsset>(
+                       brdfTextureTemplate->m_imageAttachments[0].m_assetRef.m_assetId, RPI::AssetUtils::TraceLevel::Error);
+                   if (brdfImageAsset.IsReady())
+                   {
+                       m_brdfTexture = RPI::AttachmentImage::FindOrCreate(brdfImageAsset);
+                   }
+                }
+
+                if (!scene->GetRenderPipeline(AZ::Name(pipelineDesc.m_name)))
+                {
+                    RPI::RenderPipelinePtr brdfTexturePipeline = AZ::RPI::RenderPipeline::CreateRenderPipeline(pipelineDesc);
+                    scene->AddRenderPipeline(brdfTexturePipeline);
+                }
             }
 
             void BootstrapSystemComponent::SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext)

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -105,6 +105,9 @@ namespace AZ
                 void CreateViewportContext();
                 void SetWindowResolution();
 
+                //! Run the BRDF pipeline to generate the BRDF texture
+                void RunBRDFPipeline(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext);
+
                 //! Load a render pipeline from disk and add it to the scene
                 RPI::RenderPipelinePtr LoadPipeline(
                     const AZ::RPI::ScenePtr scene,

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.cpp
@@ -38,7 +38,7 @@ namespace AZ::Render
         DisableSceneNotification();
 
         m_atmospheres.Clear();
-        m_skyAtmosphereParentPasses.clear();
+        m_renderPipelineToSkyAtmosphereParentPasses.clear();
     }
 
     SkyAtmosphereFeatureProcessor::AtmosphereId SkyAtmosphereFeatureProcessor::CreateAtmosphere()
@@ -63,10 +63,11 @@ namespace AZ::Render
             m_atmospheres.Release(id.GetIndex());
         }
 
-        for (auto pass : m_skyAtmosphereParentPasses )
-        {
-            pass->ReleaseAtmospherePass(id);
-        }
+        for (auto& [_, skyAtmosphereParentPasses] : m_renderPipelineToSkyAtmosphereParentPasses)
+            for (auto pass : skyAtmosphereParentPasses)
+            {
+                pass->ReleaseAtmospherePass(id);
+            }
     }
 
     void SkyAtmosphereFeatureProcessor::SetAtmosphereParams(AtmosphereId id, const SkyAtmosphereParams& params)
@@ -104,24 +105,34 @@ namespace AZ::Render
         atmosphere.m_passNeedsUpdate = true;
         atmosphere.m_enabled = true;
 
-        for (auto pass : m_skyAtmosphereParentPasses )
+        for (auto& [_, skyAtmosphereParentPasses] : m_renderPipelineToSkyAtmosphereParentPasses)
         {
-            pass->CreateAtmospherePass(id);
+            for (auto pass : skyAtmosphereParentPasses)
+            {
+                pass->CreateAtmospherePass(id);
+            }
         }
     }
 
     void SkyAtmosphereFeatureProcessor::AddRenderPasses(RPI::RenderPipeline* renderPipeline)
     {
-        m_skyAtmosphereParentPasses.clear();
+        if (m_renderPipelineToSkyAtmosphereParentPasses.find(renderPipeline) != m_renderPipelineToSkyAtmosphereParentPasses.end())
+        {
+            m_renderPipelineToSkyAtmosphereParentPasses.erase(renderPipeline);
+        }
+        m_renderPipelineToSkyAtmosphereParentPasses[renderPipeline] = {};
+
+        auto& skyAtmosphereParentPasses = m_renderPipelineToSkyAtmosphereParentPasses[renderPipeline];
 
         RPI::PassFilter passFilter = RPI::PassFilter::CreateWithTemplateName(Name("SkyAtmosphereParentTemplate"), renderPipeline);
-        RPI::PassSystemInterface::Get()->ForEachPass(passFilter, [this](RPI::Pass* pass) -> RPI::PassFilterExecutionFlow
+        RPI::PassSystemInterface::Get()->ForEachPass(
+            passFilter,
+            [&skyAtmosphereParentPasses](RPI::Pass* pass) -> RPI::PassFilterExecutionFlow
             {
                 SkyAtmosphereParentPass* parentPass = static_cast<SkyAtmosphereParentPass*>(pass);
-                m_skyAtmosphereParentPasses.emplace_back(parentPass);
+                skyAtmosphereParentPasses.emplace_back(parentPass);
                 return RPI::PassFilterExecutionFlow::ContinueVisitingPasses;
             });
-
 
         // make sure atmospheres are created if needed
         for (size_t i = 0; i < m_atmospheres.GetSize(); ++i)
@@ -142,6 +153,11 @@ namespace AZ::Render
         {
             UpdateBackgroundClearColor();
         }
+
+        if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
+        {
+            m_renderPipelineToSkyAtmosphereParentPasses.erase(pipeline);
+        }
     }
     
     void SkyAtmosphereFeatureProcessor::Render([[maybe_unused]] const FeatureProcessor::RenderPacket& packet)
@@ -154,9 +170,12 @@ namespace AZ::Render
             if (atmosphere.m_id.IsValid() && atmosphere.m_enabled && atmosphere.m_passNeedsUpdate)
             {
                 // update every atmosphere parent pass (per-pipeline)
-                for (auto pass : m_skyAtmosphereParentPasses)
+                for (auto& [_, skyAtmosphereParentPasses] : m_renderPipelineToSkyAtmosphereParentPasses)
                 {
-                    pass->UpdateAtmospherePassSRG(atmosphere.m_id, atmosphere.m_params);
+                    for (auto pass : skyAtmosphereParentPasses)
+                    {
+                        pass->UpdateAtmospherePassSRG(atmosphere.m_id, atmosphere.m_params);
+                    }
                 }
 
                 atmosphere.m_passNeedsUpdate = false;

--- a/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyAtmosphere/SkyAtmosphereFeatureProcessor.h
@@ -61,6 +61,6 @@ namespace AZ::Render
         };
 
         SparseVector<SkyAtmosphere> m_atmospheres;
-        AZStd::vector<SkyAtmosphereParentPass*> m_skyAtmosphereParentPasses;
+        AZStd::map<RPI::RenderPipeline*, AZStd::vector<SkyAtmosphereParentPass*>> m_renderPipelineToSkyAtmosphereParentPasses;
     };
 }

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -57,6 +57,7 @@ namespace Camera
         bool m_specifyFrustumDimensions = false;
         bool m_makeActiveViewOnActivation = true;
         bool m_orthographic = false;
+        bool m_allowPipelineChanges = false;
         float m_orthographicHalfWidth = 5.f;
 
         AZ::u64 m_editorEntityId = AZ::EntityId::InvalidEntityId;
@@ -66,6 +67,9 @@ namespace Camera
         AZ::Data::Asset<AZ::RPI::AttachmentImageAsset> m_renderTextureAsset;
         // The pass template name used for render pipeline's root template
         AZStd::string m_pipelineTemplate = "CameraPipeline";
+    private:
+        //! Check if experimental features are enabled
+        AZ::u32 GetAllowPipelineChangesVisibility() const;
     };
 
     class CameraComponentController


### PR DESCRIPTION
## What does this PR do?

This is a collection of simulation-related cherry-picks that should be integrated into the next `point release`.

- #18475 - fixes the issue with stars rendering in ROS2 Camera
- #18476 - fixes the issue with sky rendering in ROS2 Camera
- #18524 - experimental feature (hidden behind the registry setting) to allow pipeline modifications in render-to-texture functionality (used in ROS2 Camera)
- #18531 - fixes the issue with terrain rendering in ROS2 Camera

One additional fix from #18510 was included in this PR, as it was related to the same codebase, namely:

> The BRDF texture pipeline was included under "if (loadDefaultRenderPipeline)", which means if the default pipeline isn't loaded, as is the case for VR/XR, the BRDF texture pipeline wouldn't run and the BRDF texture would never get created. There is no reason for this behavior, so moved the BRDF texture pipeline creation out of that 'if' block


## How was this PR tested?

The PR was built against https://github.com/o3de/o3de-extras/pull/821
ROS 2 Camera (+ render-to-texture) features were tested.
