### PR TITLE
Fix for shadows not working after switching levels

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -721,13 +721,9 @@ namespace AZ
             }
         }
 
-        void DirectionalLightFeatureProcessor::OnRenderPipelinePersistentViewChanged(RPI::RenderPipeline* pipeline, RPI::PipelineViewTag, RPI::ViewPtr, RPI::ViewPtr)
+        void DirectionalLightFeatureProcessor::OnRenderPipelinePersistentViewChanged(RPI::RenderPipeline*, RPI::PipelineViewTag, RPI::ViewPtr, RPI::ViewPtr)
         {
-            if (m_cascadedShadowmapsPasses.find(pipeline->GetId()) != m_cascadedShadowmapsPasses.end() ||
-                m_esmShadowmapsPasses.find(pipeline->GetId()) != m_esmShadowmapsPasses.end())
-            {
-                PrepareForChangingRenderPipelineAndCameraView();
-            }
+            PrepareForChangingRenderPipelineAndCameraView();
         }
 
         void DirectionalLightFeatureProcessor::PrepareForChangingRenderPipelineAndCameraView() 


### PR DESCRIPTION
## What does this PR do?

The issue was happening because during level switch we had following logic
 1. RenderPipeline::ResetPersistentView is called which clears the main view
 2.  DirectionalLightFeatureProcessor::CacheCascadedShadowmapsPass clears m_cascadedShadowmapsPasses
 3.  RenderPipeline::SetPersistentView sets the main view
 4. DirectionalLightFeatureProcessor::OnRenderPipelinePersistentViewChanged gets called but it incorrectly wasnt re-adding the cascade passes.
 
 Fix - Remove the check within Step 4 that was skipping the part that re-added all the needed passes


Fixes https://github.com/o3de/o3de/issues/18477
## How was this PR tested?

Tested on shader ball scene within the editor (platform: PC)
