### PR TITLE
Track View: Fix issue #18639 : recording camera rotations.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -397,6 +397,172 @@ namespace AZ
         return (*this) * sclA + dest * sclB;
     }
 
+    // O3DE_DEPRECATION_NOTICE(GHI-10929)
+    // @deprecated use GetEulerRadiansXYZ(), which is somewhat improved
+    Vector3 Quaternion::GetEulerRadians() const
+    {
+        const float sinp = 2.0f * (m_w * m_y + m_z * m_x);
+        if (sinp * sinp < 0.5f)
+        {
+            // roll (x-axis rotation)
+            const float roll = Atan2(2.0f * (m_w * m_x - m_z * m_y), 1.0f - 2.0f * (m_x * m_x + m_y * m_y));
+            // pitch (y-axis rotation)
+            const float pitch = asinf(sinp);
+            // yaw (z-axis rotation)
+            const float yaw = Atan2(2.0f * (m_w * m_z - m_x * m_y), 1.0f - 2.0f * (m_y * m_y + m_z * m_z));
+            return Vector3(roll, pitch, yaw);
+        }
+        // find the pitch from its cosine instead, to avoid issues with sensitivity of asin when the sine value is close to 1
+        else
+        {
+            const float sign = sinp > 0.0f ? 1.0f : -1.0f;
+            const float m12 = 2.0f * (m_z * m_y - m_w * m_x);
+            const float m22 = 1.0f - 2.0f * (m_x * m_x + m_y * m_y);
+            const float cospSq = m12 * m12 + m22 * m22;
+            const float cosp = Sqrt(cospSq);
+            const float pitch = sign * acosf(cosp);
+            if (cospSq > Constants::FloatEpsilon)
+            {
+                const float roll = Atan2(-m12, m22);
+                const float yaw = Atan2(2.0f * (m_w * m_z - m_x * m_y), 1.0f - 2.0f * (m_y * m_y + m_z * m_z));
+                return Vector3(roll, pitch, yaw);
+            }
+            // if the pitch is close enough to +-pi/2, use a different approach because the terms used above lose roll and yaw information
+            else
+            {
+                const float m21 = 2.0f * (m_y * m_z + m_x * m_w);
+                const float m11 = 1.0f - 2.0f * (m_x * m_x + m_z * m_z);
+                const float roll = Atan2(m21, m11); // this operation has very low precision an meaning
+                return Vector3(roll, pitch, 0.0f);
+            }
+        }
+    }
+
+    /*
+    * According to Matrix3x3::SetRotationPartFromQuaternion(const Quaternion& q)
+    *
+    * x2  = m_x * 2;  y2  = m_y * 2;  z2  = m_z * 2;
+    * wx2 = m_w * x2; wy2 = m_w * y2; wz2 = m_w * z2;
+    * xx2 = m_x * x2; xy2 = m_x * y2; xz2 = m_x * z2;
+    * yy2 = m_y * y2; yz2 = m_y * z2; zz2 = m_y * z2;
+    *
+    * m11 = 1 - yy2 - zz2   m12 =     xy2 - wz2     m13 =     xz2 + wy2
+    * m21 =     xy2 + wz2   m22 = 1 - xx2 - zz2     m23 =     yz2 - wx2
+    * m31 =     xz2 - wy2   m32 =     yz2 + wx2     m33 = 1 - xx2 - yy2
+    */
+    Vector3 Quaternion::GetEulerRadiansXYZ() const
+    {
+        const float x2 = m_x * 2.0f;
+        const float y2 = m_y * 2.0f;
+        const float z2 = m_z * 2.0f;
+        const float wx2 = m_w * x2;
+        const float wy2 = m_w * y2;
+        const float wz2 = m_w * z2;
+        const float xx2 = m_x * x2;
+        const float xy2 = m_x * y2;
+        const float xz2 = m_x * z2;
+        const float yy2 = m_y * y2;
+        const float yz2 = m_y * z2;
+        const float zz2 = m_z * z2;
+
+        const float m11 = 1.f - yy2 - zz2;
+        const float m12n = wz2 - xy2;
+        const float m13 = wy2 + xz2;
+        const float m23n = wx2 - yz2;
+        const float m33 = 1.f - xx2 - yy2;
+
+        const float cospSq = m23n * m23n + m33 * m33;
+        const float signp = m13 >= 0.0f ? 1.f : -1.f;
+        if (cospSq <= Constants::FloatEpsilon) // Is the pitch angle close to +-pi/2 value ?
+        {
+            // A gimbal lock occurs, information on roll and yaw is lost.
+            // x-axis rotation (presumably roll) - deliberately zeroed.
+            constexpr float x = 0.0f;
+            // y-axis rotation (presumably pitch) - deliberately set near +-pi/2, but smaller in modulus.
+            const float y = (AZ::Constants::HalfPi - AZ::Constants::FloatEpsilon) * signp;
+            // z-axis rotation (presumably yaw) - undefined, as atan2(m21, m31) = roll - sign(pitch) * yaw;
+            // because precision is low, and in order to save performance, is deliberately zeroed.
+            constexpr float z = 0.0f;
+            return Vector3(x, y, z);
+        }
+
+        // Normal computation using rotation matrix members
+        // x-axis rotation (presumably roll)
+        const float roll = Atan2(m23n, m33);
+        // y-axis rotation (presumably pitch)
+        // In case pitch modulus < 45 degrees, use which has reasonable precision with small angles,
+        // otherwise find the pitch from its cosine for better precision.
+        const float pitch = (m13 * m13 < 0.5f) ? asinf(m13) : signp * acosf(Sqrt(cospSq));
+        // z-axis rotation (presumably yaw)
+        const float yaw = Atan2(m12n, m11);
+        return Vector3(roll, pitch, yaw);
+    }
+
+    Vector3 Quaternion::GetEulerRadiansYXZ() const
+    {
+        const float x2 = m_x * 2.0f;
+        const float y2 = m_y * 2.0f;
+        const float z2 = m_z * 2.0f;
+        const float wx2 = m_w * x2;
+        const float wy2 = m_w * y2;
+        const float wz2 = m_w * z2;
+        const float xx2 = m_x * x2;
+        const float xy2 = m_x * y2;
+        const float xz2 = m_x * z2;
+        const float yy2 = m_y * y2;
+        const float yz2 = m_y * z2;
+        const float zz2 = m_z * z2;
+
+        const float x = asinf(wx2 - yz2);
+        const float y = Atan2(wy2 + xz2, 1.0f - xx2 -yy2);
+        const float z = Atan2(wz2 + xy2, 1.0f - xx2 -zz2);
+        return Vector3(x, y, z);
+    }
+
+    Vector3 Quaternion::GetEulerRadiansZYX() const
+    {
+        const float x2 = m_x * 2.0f;
+        const float y2 = m_y * 2.0f;
+        const float z2 = m_z * 2.0f;
+        const float wx2 = m_w * x2;
+        const float wy2 = m_w * y2;
+        const float wz2 = m_w * z2;
+        const float xx2 = m_x * x2;
+        const float xy2 = m_x * y2;
+        const float xz2 = m_x * z2;
+        const float yy2 = m_y * y2;
+        const float yz2 = m_y * z2;
+        const float zz2 = m_z * z2;
+
+        const float m11 = 1.f - yy2 - zz2;
+        const float m21 = xy2 + wz2;
+        const float m31n = wy2 - xz2;
+        const float m32 = yz2 + wx2;
+        const float m33 = 1.f - xx2 - yy2;
+
+        const float cospSq = m32 * m32 + m33 * m33;
+        const float signp = m31n >= 0.0f ? 1.f : -1.f;
+        if (cospSq <= Constants::FloatEpsilon) // Is the pitch angle close to +-pi/2 value ?
+        {
+            // A gimbal lock occurs, information on roll and yaw is lost.
+            // x-axis rotation (presumably roll) - deliberately zeroed, which is better for camera rotations.
+            constexpr float x = 0.0f;
+            // y-axis rotation (presumably pitch) - deliberately set near +-pi/2, but smaller in modulus.
+            const float y = (AZ::Constants::HalfPi - AZ::Constants::FloatEpsilon) * signp;
+            // z-axis rotation (presumably yaw) - undefined, as atan2(m21, m31) = roll - sign(pitch) * yaw;
+            // because precision is low, and in order to save performance, is deliberately zeroed.
+            constexpr float z = 0.0f;
+            return Vector3(x, y, z);
+        }
+
+        // Normal computation using rotation matrix members
+        const float x = Atan2(m32, m33);
+        // In case y angle modulus < 45 degrees, use which has reasonable precision with small angles,
+        // otherwise find the pitch from its cosine for better precision.
+        const float y = (m31n * m31n < 0.5f) ? asinf(m31n) : signp * acosf(Sqrt(cospSq));
+        const float z = Atan2(m21, m11);
+        return Vector3(x, y, z);
+    }
 
     void Quaternion::SetFromEulerRadians(const Vector3& eulerRadians)
     {
@@ -431,7 +597,7 @@ namespace AZ
         const float sx = Simd::Vec3::SelectIndex0(sin);
         const float cx = Simd::Vec3::SelectIndex0(cos);
         const float sy = Simd::Vec3::SelectIndex1(sin);
-        const float cy = Simd::Vec3::SelectIndex1(cos);    
+        const float cy = Simd::Vec3::SelectIndex1(cos);
         const float sz = Simd::Vec3::SelectIndex2(sin);
         const float cz = Simd::Vec3::SelectIndex2(cos);
 
@@ -466,6 +632,7 @@ namespace AZ
             cy * cx * cz + sy * sx * sz
         );
     }
+
     Quaternion Quaternion::CreateFromEulerRadiansZYX(const Vector3& eulerRadians)
     {
         const Simd::Vec3::FloatType half = Simd::Vec3::Splat(0.5f);
@@ -524,4 +691,4 @@ namespace AZ
             return halfAngle * 2.0f * (imaginary / length);
         }
     }
-}
+} // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -243,11 +243,11 @@ namespace AZ
                 //! O3DE_DEPRECATION_NOTICE(GHI-10929)
                 //! @deprecated use GetEulerRadiansXYZ()
                 Method("GetEulerDegrees", &Quaternion::GetEulerDegrees)->
-                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)->
                 //! O3DE_DEPRECATION_NOTICE(GHI-10929)
                 //! @deprecated use GetEulerRadiansXYZ()
                 Method("GetEulerRadians", &Quaternion::GetEulerRadians)->
-                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)->
                 Method("GetEulerDegreesXYZ", &Quaternion::GetEulerDegreesXYZ)->
                 Method("GetEulerRadiansXYZ", &Quaternion::GetEulerRadiansXYZ)->
                 Method("GetEulerDegreesYXZ", &Quaternion::GetEulerDegreesYXZ)->
@@ -257,11 +257,11 @@ namespace AZ
                 //! O3DE_DEPRECATION_NOTICE(GHI-10929)
                 //! @deprecated use CreateFromEulerDegreesXYZ()
                 Method("SetFromEulerDegrees", &Quaternion::SetFromEulerDegrees)->
-                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)->
                 //! O3DE_DEPRECATION_NOTICE(GHI-10929)
                 //! @deprecated use CreateFromEulerRadiansXYZ()
                 Method("SetFromEulerRadians", &Quaternion::SetFromEulerRadians)->
-                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)->
                 Method("GetImaginary", &Quaternion::GetImaginary)->
                 Method("IsFinite", &Quaternion::IsFinite)->
                 Method("GetAngle", &Quaternion::GetAngle)->
@@ -282,7 +282,7 @@ namespace AZ
                 //! O3DE_DEPRECATION_NOTICE(GHI-10929)
                 //! @deprecated use CreateFromEulerDegreesXYZ()
                 Method("CreateFromEulerAnglesDegrees", &Quaternion::CreateFromEulerAnglesDegrees)->
-                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)->
                 Method("CreateFromEulerRadiansXYZ", &Quaternion::CreateFromEulerRadiansXYZ)->
                 Method("CreateFromEulerDegreesXYZ", &Quaternion::CreateFromEulerDegreesXYZ)->
                 Method("CreateFromEulerRadiansYXZ", &Quaternion::CreateFromEulerRadiansYXZ)->

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -240,10 +240,28 @@ namespace AZ
                 Method("IsClose", &Quaternion::IsClose, behaviorContext->MakeDefaultValues(Constants::Tolerance))->
                 Method("IsIdentity", &Quaternion::IsIdentity, behaviorContext->MakeDefaultValues(Constants::Tolerance))->
                 Method("IsZero", &Quaternion::IsZero, behaviorContext->MakeDefaultValues(Constants::FloatEpsilon))->
+                //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+                //! @deprecated use GetEulerRadiansXYZ()
                 Method("GetEulerDegrees", &Quaternion::GetEulerDegrees)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+                //! @deprecated use GetEulerRadiansXYZ()
                 Method("GetEulerRadians", &Quaternion::GetEulerRadians)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                Method("GetEulerDegreesXYZ", &Quaternion::GetEulerDegreesXYZ)->
+                Method("GetEulerRadiansXYZ", &Quaternion::GetEulerRadiansXYZ)->
+                Method("GetEulerDegreesYXZ", &Quaternion::GetEulerDegreesYXZ)->
+                Method("GetEulerRadiansYXZ", &Quaternion::GetEulerRadiansYXZ)->
+                Method("GetEulerDegreesZYX", &Quaternion::GetEulerDegreesZYX)->
+                Method("GetEulerRadiansZYX", &Quaternion::GetEulerRadiansZYX)->
+                //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+                //! @deprecated use CreateFromEulerDegreesXYZ()
                 Method("SetFromEulerDegrees", &Quaternion::SetFromEulerDegrees)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+                //! @deprecated use CreateFromEulerRadiansXYZ()
                 Method("SetFromEulerRadians", &Quaternion::SetFromEulerRadians)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
                 Method("GetImaginary", &Quaternion::GetImaginary)->
                 Method("IsFinite", &Quaternion::IsFinite)->
                 Method("GetAngle", &Quaternion::GetAngle)->
@@ -261,7 +279,16 @@ namespace AZ
                 Method("CreateFromAxisAngle", &Quaternion::CreateFromAxisAngle)->
                 Method("CreateFromScaledAxisAngle", &Quaternion::CreateFromScaledAxisAngle)->
                 Method("CreateShortestArc", &Quaternion::CreateShortestArc)->
+                //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+                //! @deprecated use CreateFromEulerDegreesXYZ()
                 Method("CreateFromEulerAnglesDegrees", &Quaternion::CreateFromEulerAnglesDegrees)->
+                    Attribute(AZ::Script::Attributes::Deprecated, true)-> // Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)->
+                Method("CreateFromEulerRadiansXYZ", &Quaternion::CreateFromEulerRadiansXYZ)->
+                Method("CreateFromEulerDegreesXYZ", &Quaternion::CreateFromEulerDegreesXYZ)->
+                Method("CreateFromEulerRadiansYXZ", &Quaternion::CreateFromEulerRadiansYXZ)->
+                Method("CreateFromEulerDegreesYXZ", &Quaternion::CreateFromEulerDegreesYXZ)->
+                Method("CreateFromEulerRadiansZYX", &Quaternion::CreateFromEulerRadiansZYX)->
+                Method("CreateFromEulerDegreesZYX", &Quaternion::CreateFromEulerDegreesZYX)->
                 Method("CreateFromValues", &Internal::CreateFromValues)->
                 Method("CreateFromBasis", &Quaternion::CreateFromBasis)
                 ;

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -252,7 +252,7 @@ namespace AZ
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
         //!  first x-axis (pitch), then y-axis (roll) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansXYZ() or CreateFromEulerDegreesXYZ().
-        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.
         //! @return Vector3 A vector containing component-wise rotation angles in degrees.
         Vector3 GetEulerDegreesXYZ() const;
@@ -260,7 +260,7 @@ namespace AZ
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
         //!  first x-axis (pitch), then y-axis (roll) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansXYZ() or CreateFromEulerDegreesXYZ().
-        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.
         //! @return Vector3 A vector containing component-wise rotation angles in radians.
         Vector3 GetEulerRadiansXYZ() const;
@@ -268,23 +268,19 @@ namespace AZ
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
         //!  first y-axis (roll), then x-axis (pitch) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansYXZ() or CreateFromEulerDegreesYXZ().
-        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
-        //!  on initial yaw and roll, and then roll is deliberately zeroed.
         //! @return Vector3 A vector containing component-wise rotation angles in degrees.
         Vector3 GetEulerDegreesYXZ() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
         //!  first y-axis (roll), then x-axis (pitch) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansYXZ() or CreateFromEulerDegreesYXZ().
-        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
-        //!  on initial yaw and roll, and then roll is deliberately zeroed.
         //! @return Vector3 A vector containing component-wise rotation angles in radians.
         Vector3 GetEulerRadiansYXZ() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
         //!  first z-axis (yaw), then y-axis (roll) and then x-axis (pith).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansZYX() or CreateFromEulerDegreesZYX().
-        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.
         //! @return Vector3 A vector containing component-wise rotation angles in degrees.
         Vector3 GetEulerDegreesZYX() const;
@@ -292,7 +288,7 @@ namespace AZ
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
         //!  first z-axis (yaw), then y-axis (roll) and then x-axis (pith).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansZYX() or CreateFromEulerDegreesZYX().
-        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.
         //! @return Vector3 A vector containing component-wise rotation angles in radians.
         Vector3 GetEulerRadiansZYX() const;

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -250,7 +250,7 @@ namespace AZ
         Vector3 GetEulerRadians() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
-        //!  first x-axis (pitch), then y-axis (roll) and then z-axis (yaw).
+        //!  first x-axis (roll), then y-axis (pitch) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansXYZ() or CreateFromEulerDegreesXYZ().
         //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.
@@ -258,7 +258,7 @@ namespace AZ
         Vector3 GetEulerDegreesXYZ() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
-        //!  first x-axis (pitch), then y-axis (roll) and then z-axis (yaw).
+        //!  first x-axis (roll), then y-axis (pitch) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansXYZ() or CreateFromEulerDegreesXYZ().
         //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.
@@ -266,19 +266,19 @@ namespace AZ
         Vector3 GetEulerRadiansXYZ() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
-        //!  first y-axis (roll), then x-axis (pitch) and then z-axis (yaw).
+        //!  first y-axis (pitch), then x-axis (roll) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansYXZ() or CreateFromEulerDegreesYXZ().
         //! @return Vector3 A vector containing component-wise rotation angles in degrees.
         Vector3 GetEulerDegreesYXZ() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
-        //!  first y-axis (roll), then x-axis (pitch) and then z-axis (yaw).
+        //!  first y-axis (pitch), then x-axis (roll) and then z-axis (yaw).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansYXZ() or CreateFromEulerDegreesYXZ().
         //! @return Vector3 A vector containing component-wise rotation angles in radians.
         Vector3 GetEulerRadiansYXZ() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
-        //!  first z-axis (yaw), then y-axis (roll) and then x-axis (pith).
+        //!  first z-axis (yaw), then y-axis (pitch) and then x-axis (roll).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansZYX() or CreateFromEulerDegreesZYX().
         //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.
@@ -286,7 +286,7 @@ namespace AZ
         Vector3 GetEulerDegreesZYX() const;
 
         //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
-        //!  first z-axis (yaw), then y-axis (roll) and then x-axis (pith).
+        //!  first z-axis (yaw), then y-axis (pitch) and then x-axis (roll).
         //! The quaternion us supposed to be created with CreateFromEulerRadiansZYX() or CreateFromEulerDegreesZYX().
         //! Note that a gimbal lock occurs with the y-axis rotation equal to +-90 degrees, loosing information
         //!  on initial yaw and roll, and then roll is deliberately zeroed.

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -90,9 +90,13 @@ namespace AZ
 
         static Quaternion CreateShortestArc(const Vector3& v1, const Vector3& v2);
 
+        //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+        //! @deprecated use CreateFromEulerDegreesXYZ()
         //! Creates a quaternion using rotation in degrees about the axes. First rotated about the X axis, followed by the Y axis, then the Z axis.
         static const Quaternion CreateFromEulerAnglesDegrees(const Vector3& anglesInDegrees);
 
+        //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+        //! @deprecated use CreateFromEulerRadiansXYZ()
         //! Creates a quaternion using rotation in radians about the axes. First rotated about the X axis, followed by the Y axis, then the Z axis.
         static const Quaternion CreateFromEulerAnglesRadians(const Vector3& anglesInRadians);
 

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -231,22 +231,76 @@ namespace AZ
         //! Transforms a vector using the rotation described by this quaternion
         Vector3 TransformVector(const Vector3& v) const;
 
-        //! Create, from the quaternion, a set of Euler angles of rotations around first z-axis, then y-axis and then x-axis.
+        //! Create, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first x-axis, then y-axis and then z-axis.
         //! @return Vector3 A vector containing component-wise rotation angles in degrees.
+        //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+        //! @deprecated use GetEulerDegreesXYZ()
         Vector3 GetEulerDegrees() const;
 
-        //! Create, from the quaternion, a set of Euler angles of rotations around first z-axis, then y-axis and then x-axis.
+        //! Create, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first x-axis, then y-axis and then z-axis.
         //! @return Vector3 A vector containing component-wise rotation angles in radians.
+        //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+        //! @deprecated use GetEulerRadiansXYZ()
         Vector3 GetEulerRadians() const;
+
+        //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first x-axis (pitch), then y-axis (roll) and then z-axis (yaw).
+        //! The quaternion us supposed to be created with CreateFromEulerRadiansXYZ() or CreateFromEulerDegreesXYZ().
+        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //!  on initial yaw and roll, and then roll is deliberately zeroed.
+        //! @return Vector3 A vector containing component-wise rotation angles in degrees.
+        Vector3 GetEulerDegreesXYZ() const;
+
+        //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first x-axis (pitch), then y-axis (roll) and then z-axis (yaw).
+        //! The quaternion us supposed to be created with CreateFromEulerRadiansXYZ() or CreateFromEulerDegreesXYZ().
+        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //!  on initial yaw and roll, and then roll is deliberately zeroed.
+        //! @return Vector3 A vector containing component-wise rotation angles in radians.
+        Vector3 GetEulerRadiansXYZ() const;
+
+        //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first y-axis (roll), then x-axis (pitch) and then z-axis (yaw).
+        //! The quaternion us supposed to be created with CreateFromEulerRadiansYXZ() or CreateFromEulerDegreesYXZ().
+        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //!  on initial yaw and roll, and then roll is deliberately zeroed.
+        //! @return Vector3 A vector containing component-wise rotation angles in degrees.
+        Vector3 GetEulerDegreesYXZ() const;
+
+        //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first y-axis (roll), then x-axis (pitch) and then z-axis (yaw).
+        //! The quaternion us supposed to be created with CreateFromEulerRadiansYXZ() or CreateFromEulerDegreesYXZ().
+        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //!  on initial yaw and roll, and then roll is deliberately zeroed.
+        //! @return Vector3 A vector containing component-wise rotation angles in radians.
+        Vector3 GetEulerRadiansYXZ() const;
+
+        //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first z-axis (yaw), then y-axis (roll) and then x-axis (pith).
+        //! The quaternion us supposed to be created with CreateFromEulerRadiansZYX() or CreateFromEulerDegreesZYX().
+        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //!  on initial yaw and roll, and then roll is deliberately zeroed.
+        //! @return Vector3 A vector containing component-wise rotation angles in degrees.
+        Vector3 GetEulerDegreesZYX() const;
+
+        //! Compute, from the quaternion, a set of Euler (actually Tait-Bryan) angles of rotations around:
+        //!  first z-axis (yaw), then y-axis (roll) and then x-axis (pith).
+        //! The quaternion us supposed to be created with CreateFromEulerRadiansZYX() or CreateFromEulerDegreesZYX().
+        //! Note that a gimbal lock occurs with the x-axis rotation equal to +-90 degrees, loosing information
+        //!  on initial yaw and roll, and then roll is deliberately zeroed.
+        //! @return Vector3 A vector containing component-wise rotation angles in radians.
+        Vector3 GetEulerRadiansZYX() const;
 
         //! @param eulerRadians A vector containing component-wise rotation angles in radians.
         //! O3DE_DEPRECATION_NOTICE(GHI-10929)
-        //! @deprecated use CreateFromEulerRadiansXYZ
+        //! @deprecated use CreateFromEulerRadiansXYZ()
         void SetFromEulerRadians(const Vector3& eulerRadians);
 
         //! @param eulerDegrees A vector containing component-wise rotation angles in degrees.
         //! O3DE_DEPRECATION_NOTICE(GHI-10929)
-        //! @deprecated use CreateFromEulerDegreesXYZ
+        //! @deprecated use CreateFromEulerDegreesXYZ()
         void SetFromEulerDegrees(const Vector3& eulerDegrees);
 
         //! Populate axis and angle of rotation from Quaternion
@@ -289,24 +343,28 @@ namespace AZ
 
     //! Non-member functionality belonging to the AZ namespace
 
+    //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+    //! @deprecated use GetEulerDegreesXYZ()
     //! Create, from a quaternion, a set of Euler angles of rotations around first z-axis, then y-axis and then x-axis.
     //! @param q a quaternion representing the rotation
     //! @return A vector containing component-wise rotation angles in degrees.
     Vector3 ConvertQuaternionToEulerDegrees(const Quaternion& q);
 
+    //! O3DE_DEPRECATION_NOTICE(GHI-10929)
+    //! @deprecated use GetEulerRadiansXYZ()
     //! Create, from a quaternion, a set of Euler angles of rotations around first z-axis, then y-axis and then x-axis.
     //! @param q a quaternion representing the rotation
     //! @return A vector containing component-wise rotation angles in radians.
     Vector3 ConvertQuaternionToEulerRadians(const Quaternion& q);
 
     //! O3DE_DEPRECATION_NOTICE(GHI-10929)
-    //! @deprecated use Quaternion::CreateFromEulerRadiansXYZ
+    //! @deprecated use Quaternion::CreateFromEulerRadiansXYZ()
     //! @param eulerRadians A vector containing component-wise rotation angles in radians.
     //! @return a quaternion made from composition of rotations around principle axes.
     Quaternion ConvertEulerRadiansToQuaternion(const Vector3& eulerRadians);
 
     //! O3DE_DEPRECATION_NOTICE(GHI-10929)
-    //! @deprecated use Quaternion::CreateFromEulerDegreesXYZ
+    //! @deprecated use Quaternion::CreateFromEulerDegreesXYZ()
     //! @param eulerDegrees A vector containing component-wise rotation angles in degrees.
     //! @return a quaternion made from composition of rotations around principle axes.
     Quaternion ConvertEulerDegreesToQuaternion(const Vector3& eulerDegrees);

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -550,48 +550,21 @@ namespace AZ
     }
 
 
-    AZ_MATH_INLINE Vector3 Quaternion::GetEulerRadians() const
+    AZ_MATH_INLINE Vector3 Quaternion::GetEulerDegreesXYZ() const
     {
-        const float sinp = 2.0f * (m_w * m_y + m_z * m_x);
+        return Vector3RadToDeg(GetEulerRadiansXYZ());
+    }
 
-        if (sinp * sinp < 0.5f)
-        {
-            // roll (x-axis rotation)
-            const float roll = Atan2(2.0f * (m_w * m_x - m_z * m_y), 1.0f - 2.0f * (m_x * m_x + m_y * m_y));
 
-            // pitch (y-axis rotation)
-            const float pitch = asinf(sinp);
+    AZ_MATH_INLINE Vector3 Quaternion::GetEulerDegreesYXZ() const
+    {
+        return Vector3RadToDeg(GetEulerRadiansYXZ());
+    }
 
-            // yaw (z-axis rotation)
-            const float yaw = Atan2(2.0f * (m_w * m_z - m_x * m_y), 1.0f - 2.0f * (m_y * m_y + m_z * m_z));
 
-            return Vector3(roll, pitch, yaw);
-        }
-
-        // find the pitch from its cosine instead, to avoid issues with sensitivity of asin when the sine value is close to 1
-        else
-        {
-            const float sign = sinp > 0.0f ? 1.0f : -1.0f;
-            const float m12 = 2.0f * (m_z * m_y - m_w * m_x);
-            const float m22 = 1.0f - 2.0f * (m_x * m_x + m_y * m_y);
-            const float cospSq = m12 * m12 + m22 * m22;
-            const float cosp = Sqrt(cospSq);
-            const float pitch = sign * acosf(cosp);
-            if (cospSq > Constants::FloatEpsilon)
-            {
-                const float roll = Atan2(-m12, m22);
-                const float yaw = Atan2(2.0f * (m_w * m_z - m_x * m_y), 1.0f - 2.0f * (m_y * m_y + m_z * m_z));
-                return Vector3(roll, pitch, yaw);
-            }
-            // if the pitch is close enough to +-pi/2, use a different approach because the terms used above lose roll and yaw information
-            else
-            {
-                const float m21 = 2.0f * (m_y * m_z + m_x * m_w);
-                const float m11 = 1.0f - 2.0f * (m_x * m_x + m_z * m_z);
-                const float roll = Atan2(m21, m11);
-                return Vector3(roll, pitch, 0.0f);
-            }
-        }
+    AZ_MATH_INLINE Vector3 Quaternion::GetEulerDegreesZYX() const
+    {
+        return Vector3RadToDeg(GetEulerRadiansZYX());
     }
 
 

--- a/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/QuaternionTests.cpp
@@ -541,12 +541,45 @@ namespace UnitTest
     {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansXYZ(param.euler), IsClose(param.result));
+
+        // Test backwards computation Quaternion -> Tait-Brian angles
+        const auto sourceDegrees = Vector3RadToDeg(param.euler);
+        const bool isGimbleLock = fabs(fabs(sourceDegrees.GetY()) - 90.0f) < Constants::Tolerance;
+
+        const auto anglesTaitBryanRadiansXYZ = param.result.GetEulerRadiansXYZ();
+
+        const auto resultDegrees = Vector3RadToDeg(anglesTaitBryanRadiansXYZ);
+        auto succeeded = resultDegrees.IsClose(sourceDegrees);
+        EXPECT_TRUE((succeeded || isGimbleLock));
+
+        // O3DE_DEPRECATION_NOTICE(GHI-10929)
+        // Test backwards computation Quaternion -> Euler (actually Tait-Brian) angles
+        // with the method GetEulerRadians(), which is subject to deprecation,
+        // as methods to be deprecated are roughly equivalent in computations:
+        // - SetFromEulerRadians(), CreateFromEulerAnglesRadians(), ConvertEulerRadiansToQuaternion() - with CreateFromEulerRadiansXYZ();
+        // - SetFromEulerDegrees(), CreateFromEulerAnglesDegrees(), ConvertEulerDegreesToQuaternion() - with CreateFromEulerDegreesXYZ();
+        // - GetEulerRadians() - with GetEulerRadiansXYZ(), which is somewhat optimized;
+        // - GetEulerDegrees() - with GetEulerDegreesXYZ().
+        const auto anglesEulerRadians = param.result.GetEulerRadians();
+
+        const auto resultEulerDegrees = Vector3RadToDeg(anglesEulerRadians);
+        succeeded = succeeded && resultDegrees.IsClose(resultEulerDegrees);
+        EXPECT_TRUE((succeeded || isGimbleLock));
     }
 
     TEST_P(AngleRadianTestFixtureXYZ, EulerDegreesXYZ)
     {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
+        const auto sourceDegrees = Vector3RadToDeg(param.euler);
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesXYZ(sourceDegrees), IsClose(param.result));
+
+        // Test backwards computation Quaternion -> Tait-Brian angles
+        const bool isGimbleLock = fabs(fabs(sourceDegrees.GetY()) - 90.0f) < Constants::Tolerance;
+
+        const auto anglesTaitBryanDegreesXYZ = param.result.GetEulerDegreesXYZ();
+
+        auto succeeded = anglesTaitBryanDegreesXYZ.IsClose(sourceDegrees);
+        EXPECT_TRUE((succeeded || isGimbleLock));
     }
 
     INSTANTIATE_TEST_CASE_P(
@@ -566,20 +599,20 @@ namespace UnitTest
             EulerTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
             EulerTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi)},
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
                 
             EulerTestArgs{ AZ::Vector3(AZ::Constants::HalfPi, 0, AZ::Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationX(AZ::Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi)},
-            EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, -AZ::Constants::HalfPi, AZ::Constants::QuarterPi), 
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
+            EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, -AZ::Constants::HalfPi, AZ::Constants::QuarterPi),
                 AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(-AZ::Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi)},
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
             EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, AZ::Constants::HalfPi, AZ::Constants::TwoOverPi), 
                 AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(AZ::Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::TwoOverPi)}
-                ));
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::TwoOverPi) }
+        ));
 
     using AngleRadianTestFixtureYXZ = ::testing::TestWithParam<EulerTestArgs>;
 
@@ -587,12 +620,27 @@ namespace UnitTest
     {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansYXZ(param.euler), IsClose(param.result));
+
+        // Test backwards computation Quaternion -> Tait-Brian angles
+        const auto sourceDegrees = Vector3RadToDeg(param.euler);
+
+        const auto anglesTaitBryanRadiansYXZ = param.result.GetEulerRadiansYXZ();
+
+        const auto resultDegrees = Vector3RadToDeg(anglesTaitBryanRadiansYXZ);
+        EXPECT_TRUE(resultDegrees.IsClose(sourceDegrees));
     }
 
     TEST_P(AngleRadianTestFixtureYXZ, EulerDegreesYXZ)
     {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesYXZ(Vector3RadToDeg(param.euler)), IsClose(param.result));
+        const auto sourceDegrees = Vector3RadToDeg(param.euler);
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesYXZ(sourceDegrees), IsClose(param.result));
+
+        // Test backwards computation Quaternion -> Tait-Brian angles
+        const auto anglesTaitBryanRadiansYXZ = param.result.GetEulerRadiansYXZ();
+
+        const auto resultDegrees = Vector3RadToDeg(anglesTaitBryanRadiansYXZ);
+        EXPECT_TRUE(resultDegrees.IsClose(sourceDegrees));
     }
 
     INSTANTIATE_TEST_CASE_P(
@@ -612,34 +660,52 @@ namespace UnitTest
             EulerTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
             EulerTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi)},
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
 
             EulerTestArgs{ AZ::Vector3(AZ::Constants::HalfPi, 0, AZ::Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationX(AZ::Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi)},
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
             EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, -AZ::Constants::HalfPi, AZ::Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationY(-AZ::Constants::HalfPi) *
                 AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi)},
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) },
             EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, AZ::Constants::HalfPi, AZ::Constants::TwoOverPi), 
                 AZ::Quaternion::CreateRotationY(AZ::Constants::HalfPi) *
                 AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationZ(AZ::Constants::TwoOverPi)}
-                
+                AZ::Quaternion::CreateRotationZ(AZ::Constants::TwoOverPi) }
         ));
 
     using AngleRadianTestFixtureZYX = ::testing::TestWithParam<EulerTestArgs>;
 
-    TEST_P(AngleRadianTestFixtureZYX, EulerRadiansYXZ)
+    TEST_P(AngleRadianTestFixtureZYX, EulerRadiansZYX)
     {
         auto& param = GetParam();
         EXPECT_THAT(AZ::Quaternion::CreateFromEulerRadiansZYX(param.euler), IsClose(param.result));
+
+        // Test backwards computation Quaternion -> Tait-Brian angles
+        const auto sourceDegrees = Vector3RadToDeg(param.euler);
+        const bool isGimbleLock = fabs(fabs(sourceDegrees.GetY()) - 90.0f) < Constants::Tolerance;
+
+        const auto anglesTaitBryanRadiansZYX = param.result.GetEulerRadiansZYX();
+
+        const auto resultDegrees = Vector3RadToDeg(anglesTaitBryanRadiansZYX);
+        const auto succeeded = resultDegrees.IsClose(sourceDegrees);
+        EXPECT_TRUE((succeeded || isGimbleLock));
     }
 
-    TEST_P(AngleRadianTestFixtureZYX, EulerDegreesYXZ)
+    TEST_P(AngleRadianTestFixtureZYX, EulerDegreesZYX)
     {
         auto& param = GetParam();
-        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesZYX(Vector3RadToDeg(param.euler)), IsClose(param.result));
+        const auto sourceDegrees = Vector3RadToDeg(param.euler);
+        EXPECT_THAT(AZ::Quaternion::CreateFromEulerDegreesZYX(sourceDegrees), IsClose(param.result));
+
+        // Test backwards computation Quaternion -> Tait-Brian angles
+        const bool isGimbleLock = fabs(fabs(sourceDegrees.GetY()) - 90.0f) < Constants::Tolerance;
+
+        const auto anglesTaitBryanDegreesZYX = param.result.GetEulerDegreesZYX();
+
+        const auto succeeded = anglesTaitBryanDegreesZYX.IsClose(sourceDegrees);
+        EXPECT_TRUE((succeeded || isGimbleLock));
     }
 
     INSTANTIATE_TEST_CASE_P(
@@ -659,19 +725,19 @@ namespace UnitTest
             EulerTestArgs{ AZ::Vector3(0, AZ::Constants::QuarterPi, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(AZ::Constants::QuarterPi) },
             EulerTestArgs{ AZ::Vector3(AZ::Constants::QuarterPi, 0, AZ::Constants::QuarterPi), AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi)},
+                AZ::Quaternion::CreateRotationX(AZ::Constants::QuarterPi) },
                 
             EulerTestArgs{ AZ::Vector3(AZ::Constants::HalfPi, 0, AZ::Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
-                AZ::Quaternion::CreateRotationX(AZ::Constants::HalfPi)},
+                AZ::Quaternion::CreateRotationX(AZ::Constants::HalfPi) },
             EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, -AZ::Constants::HalfPi, AZ::Constants::QuarterPi), 
                 AZ::Quaternion::CreateRotationZ(AZ::Constants::QuarterPi) *
                 AZ::Quaternion::CreateRotationY(-AZ::Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi)},
+                AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) },
             EulerTestArgs{ AZ::Vector3(-AZ::Constants::QuarterPi, AZ::Constants::HalfPi, AZ::Constants::TwoOverPi), 
                 AZ::Quaternion::CreateRotationZ(AZ::Constants::TwoOverPi) *
                 AZ::Quaternion::CreateRotationY(AZ::Constants::HalfPi) *
-                AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi)}
+                AZ::Quaternion::CreateRotationX(-AZ::Constants::QuarterPi) }
         ));
 
 } // namespace UnitTest

--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
@@ -186,12 +186,14 @@ void CCompoundSplineTrack::GetValue(float time, AZ::Quaternion& value)
     AZ_Assert(m_nDimensions == 3, "mismatched dimension %d", m_nDimensions);
     if (m_nDimensions == 3)
     {
-        // Assume Euler Angles XYZ
+        // Euler Angles XYZ
         float angles[3] = {0, 0, 0};
         for (int i = 0; i < m_nDimensions; i++)
         {
             m_subTracks[i]->GetValue(time, angles[i]);
         }
+        // Use ZYX Euler (actually Tait-Bryan) rotation angles order instead of using CreateFromEulerDegreesXYZ(),
+        // in order to provide "pitch, roll, yaw" editing in TrackView
         value = AZ::Quaternion::CreateFromEulerDegreesZYX(AZ::Vector3(angles[0], angles[1], angles[2]));
     }
     else
@@ -233,8 +235,9 @@ void CCompoundSplineTrack::SetValue(float time, const AZ::Quaternion& value, boo
     AZ_Assert(m_nDimensions == 3, "mismatched dimension %d", m_nDimensions);
     if (m_nDimensions == 3)
     {
-        // Assume Euler Angles XYZ
-        AZ::Vector3 eulerAngle = value.GetEulerDegrees();
+        // Use ZYX Euler (actually Tait-Bryan) rotation angles order instead of using
+        // GetEulerDegrees() (or GetEulerDegreesXYZ()), in order to provide "pitch, roll, yaw" editing in TrackView.
+        AZ::Vector3 eulerAngle = value.GetEulerDegreesZYX();
         for (int i = 0; i < 3; i++)
         {
             float degree = eulerAngle.GetElement(i);
@@ -253,7 +256,7 @@ void CCompoundSplineTrack::SetValue(float time, const AZ::Quaternion& value, boo
 //////////////////////////////////////////////////////////////////////////
 void CCompoundSplineTrack::OffsetKeyPosition(const AZ::Vector3& offset)
 {
-    AZ_Assert(m_nDimensions == 3, "expect 3 subtracks found %d", m_nDimensions);
+    AZ_Assert(m_nDimensions == 3, "expect 3 sub-tracks found %d", m_nDimensions);
     if (m_nDimensions == 3)
     {
         for (int i = 0; i < 3; i++)

--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
@@ -183,12 +183,14 @@ namespace Maestro
         AZ_Assert(m_nDimensions == 3, "mismatched dimension %d", m_nDimensions);
         if (m_nDimensions == 3)
         {
-            // Assume Euler Angles XYZ
+            // Euler Angles XYZ
             float angles[3] = { 0, 0, 0 };
             for (int i = 0; i < m_nDimensions; i++)
             {
                 m_subTracks[i]->GetValue(time, angles[i]);
             }
+            // Use ZYX Euler (actually Tait-Bryan) rotation angles order instead of using CreateFromEulerDegreesXYZ(),
+            // in order to provide "pitch, roll, yaw" editing in TrackView
             value = AZ::Quaternion::CreateFromEulerDegreesZYX(AZ::Vector3(angles[0], angles[1], angles[2]));
         }
         else
@@ -226,8 +228,9 @@ namespace Maestro
         AZ_Assert(m_nDimensions == 3, "mismatched dimension %d", m_nDimensions);
         if (m_nDimensions == 3)
         {
-            // Assume Euler Angles XYZ
-            AZ::Vector3 eulerAngle = value.GetEulerDegrees();
+            // Use ZYX Euler (actually Tait-Bryan) rotation angles order instead of using
+            // GetEulerDegrees() (or GetEulerDegreesXYZ()), in order to provide "pitch, roll, yaw" editing in TrackView.
+            AZ::Vector3 eulerAngle = value.GetEulerDegreesZYX();
             for (int i = 0; i < 3; i++)
             {
                 float degree = eulerAngle.GetElement(i);


### PR DESCRIPTION
## What does this PR do?
Closes https://github.com/o3de/o3de/issues/18639

* Adds methods for `Quaternion` to Euler (actually Tait-Bryan) Angles computations for `XYZ`, `YXZ`, `ZYX` rotations:
* * Adds these new (and older but missed) `Quaternion` methods to behavior contex reflection; adds `AZ::Script::Attributes::Deprecated` attribute to old reflected methods which should be deprecated (but `AZ::Script::Attributes::ExcludeFrom` attribute is added as comment only for now).
* * Adds unit tests for these new methods and also adds comparing `XYZ` conversions to old "Euler" conversions (which are presumably to be deprecated, please see Issue https://github.com/o3de/o3de/issues/10929);
* * Adds missing comments to declarations of methods to be deprecated.
* * Moves the `Quaternion::GetEulerRadians()` method (which is supposed to be deprecated) from `Code\Framework\AzCore\AzCore\Math\Quaternion.inl` to `Code\Framework\AzCore\AzCore\Math\Quaternion.cpp`, adds deprecation comments.
* * The `GetEulerDegreesXYZ()` method is slighly optimized as compared to the old `GetEulerRadians()` method (to be deprecated), local variables names in the new code are made closer to relarted mathematics and O3DE code (e.g.  `Matrix3x3::SetRotationPartFromQuaternion()`).


* Fixes recording camera rotations in TrackView by substituting deprecated `GetEulerDegrees()` method with the new `GetEulerDegreesZYX()` method :
 As angles from "Rotation" sub-tracks of "Transform" tracks for cameras are converted to `Quaternion`s using `CreateFromEulerDegreesZYX()` method, initial setup of "computed" rotation angles being recorded is also to be made using the new `GetEulerDegreesZYX()` method.

This essentially provides support for user-friendly editing of "Rotation" sub-tracks' keys using "pitch=x, roll=y, yaw=z" interpretaion, with the benefit that "roll" usually remains zero (good for cameras), and "pitch" / "yaw" angles are edited directly.

## How was this PR tested?
* "Core/Math" UnitTests run with added checks for the new methods.
* Editor run under Windows, a cut-scene with animated camera created,
* * rotations for this camera recorded;
* * rotations for this camera edited in Track View ("pitch=x, roll=y==0, yaw=z") interpretaion noted;
* A level with this cut-scene saved and reloaded, playing / editing the animation went as expected.


