### PR TITLE
MaterialComponentRequestBus::IsMaterialAssetReady

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -40,6 +40,11 @@ namespace AZ
             //! @returns Default asset ID associated with the material assignment ID, otherwise an invalid asset ID.
             virtual AZ::Data::AssetId GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const = 0;
 
+            //! @param materialAssignmentId ID of material assignment slot for which the information is being requested.
+            //! @returns Asset<MaterialAsset>::IsReady() state of the material asset associated with the source model
+            //!          or object prior to overrides being applied.
+            virtual bool IsDefaultMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
             //! Get the material asset associated with the source model or object prior to overrides being applied.
             //! @param materialAssignmentId ID of material assignment slot for which the information is being requested.
             //! @returns String corresponding to the display name of the material slot.
@@ -97,6 +102,10 @@ namespace AZ
             //! @param materialAssignmentId ID of material slot.
             //! @returns The current material asset ID is found, otherwise invalid asset ID .
             virtual AZ::Data::AssetId GetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const = 0;
+
+            //! @param materialAssignmentId ID of material assignment slot for which the information is being requested.
+            //! @returns Asset<MaterialAsset>::IsReady() state of the material asset associated with the material assignment ID.
+            virtual bool IsMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId) const = 0;
 
             //! Removes the material asset associated with the material assignment ID
             //! @param materialAssignmentId ID of material slot.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -41,6 +41,7 @@ namespace AZ
                     ->Event("FindMaterialAssignmentId", &MaterialComponentRequestBus::Events::FindMaterialAssignmentId)
                     ->Event("GetActiveMaterialAssetId", &MaterialComponentRequestBus::Events::GetMaterialAssetId) // This function is now redundant but cannot be marked deprecated or removed in case it's still referenced in script
                     ->Event("GetDefaultMaterialAssetId", &MaterialComponentRequestBus::Events::GetDefaultMaterialAssetId)
+                    ->Event("IsDefaultMaterialAssetReady", &MaterialComponentRequestBus::Events::IsDefaultMaterialAssetReady)
                     ->Event("GetMaterialLabel", &MaterialComponentRequestBus::Events::GetMaterialLabel, "GetMaterialSlotLabel")
                     ->Event("SetMaterialMap", &MaterialComponentRequestBus::Events::SetMaterialMap, "SetMaterialOverrides")
                     ->Event("GetMaterialMap", &MaterialComponentRequestBus::Events::GetMaterialMap, "GetMaterialOverrides")
@@ -56,6 +57,7 @@ namespace AZ
                     ->Event("RepairMaterialsWithRenamedProperties", &MaterialComponentRequestBus::Events::RepairMaterialsWithRenamedProperties, "ApplyAutomaticPropertyUpdates")
                     ->Event("SetMaterialAssetId", &MaterialComponentRequestBus::Events::SetMaterialAssetId, "SetMaterialOverride")
                     ->Event("GetMaterialAssetId", &MaterialComponentRequestBus::Events::GetMaterialAssetId, "GetMaterialOverride")
+                    ->Event("IsMaterialAssetReady", &MaterialComponentRequestBus::Events::IsMaterialAssetReady)
                     ->Event("ClearMaterialAssetId", &MaterialComponentRequestBus::Events::ClearMaterialAssetId, "ClearMaterialOverride")
                     ->Event("IsMaterialAssetIdOverridden", &MaterialComponentRequestBus::Events::IsMaterialAssetIdOverridden)
                     ->Event("HasPropertiesOverridden", &MaterialComponentRequestBus::Events::HasPropertiesOverridden)
@@ -392,6 +394,12 @@ namespace AZ
             return materialIt != m_defaultMaterialMap.end() ? materialIt->second.m_materialAsset.GetId() : AZ::Data::AssetId();
         }
 
+        bool MaterialComponentController::IsDefaultMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId) const
+        {
+            const auto materialIt = m_defaultMaterialMap.find(materialAssignmentId);
+            return (materialIt != m_defaultMaterialMap.end()) && materialIt->second.m_materialAsset.IsReady();
+        }
+
         AZStd::string MaterialComponentController::GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const
         {
             MaterialAssignmentLabelMap labels;
@@ -583,6 +591,12 @@ namespace AZ
 
             // Otherwise return the cached default material asset ID
             return GetDefaultMaterialAssetId(materialAssignmentId);
+        }
+
+        bool MaterialComponentController::IsMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId) const
+        {
+            const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
+            return (materialIt != m_configuration.m_materials.end()) && materialIt->second.m_materialAsset.IsReady();
         }
 
         void MaterialComponentController::ClearMaterialAssetId(const MaterialAssignmentId& materialAssignmentId)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -49,6 +49,7 @@ namespace AZ
             MaterialAssignmentMap GetDefaultMaterialMap() const override;
             MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             AZ::Data::AssetId GetDefaultMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
+            bool IsDefaultMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId) const override;
             AZStd::string GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const override;
             void SetMaterialMap(const MaterialAssignmentMap& materials) override;
             const MaterialAssignmentMap& GetMaterialMap() const override;
@@ -64,6 +65,7 @@ namespace AZ
             void ClearMaterialAssetIdOnDefaultSlot() override;
             void SetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId, const AZ::Data::AssetId& materialAssetId) override;
             AZ::Data::AssetId GetMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) const override;
+            bool IsMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId) const override;
             void ClearMaterialAssetId(const MaterialAssignmentId& materialAssignmentId) override;
             bool IsMaterialAssetIdOverridden(const MaterialAssignmentId& materialAssignmentId) const override;
             bool HasPropertiesOverridden(const MaterialAssignmentId& materialAssignmentId) const override;


### PR DESCRIPTION
## What does this PR do?

Added two new methods to MaterialComponentRequestBus:
1. IsMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId);
2. IsDefaultMaterialAssetReady(const MaterialAssignmentId& materialAssignmentId);

This is useful because at runtime you may not get the actual value of a particular material property if the MaterialAsset associated to a particular MaterialAssignmentId has not been loaded in memory.

For a Lua or Python script, once IsMaterialAssetReady() returns `true`. it is guaranteed that any of the GetPropertyValueXXX() methods will actually return a non-default value.

## How was this PR tested?

Validated with a Lua Script that, upon entering Game mode, printed the states of  `IsDefaultMaterialAssetReady`  and `IsMaterialAssetReady` during `OnTick` events, along with the value of `baseColor.color` property for a particular Material component. It can be seen in the log snippet below, that only at Frame 5,  `IsMaterialAssetReady` became `true` and reading `baseColor.color` got the expected value:
```
(Script) - OnTick 1: isDefaultReady=true, isReady=false
(Script) - baseColor.color =(r=0.8000000,g=0.8000000,b=0.8000000,a=1.0000000)
(Script) - OnTick 2: isDefaultReady=true, isReady=false
(Script) - baseColor.color =(r=0.8000000,g=0.8000000,b=0.8000000,a=1.0000000)
(Script) - OnTick 3: isDefaultReady=true, isReady=false
(Script) - baseColor.color =(r=0.8000000,g=0.8000000,b=0.8000000,a=1.0000000)
(Script) - OnTick 4: isDefaultReady=true, isReady=false
(Script) - baseColor.color =(r=0.8000000,g=0.8000000,b=0.8000000,a=1.0000000)
(Script) - OnTick 5: isDefaultReady=true, isReady=true
(Script) - baseColor.color =(r=0.0000000,g=0.2462043,b=0.3813230,a=1.0000000) 
``` 
