### PR TITLE
Fixes an assert that occurs if you undo/redo prefab focus

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -365,41 +365,47 @@ namespace AzToolsFramework
         EntityIdList newlyDeselected;
         ExtractEntityIdsFromSelection(deselected, newlyDeselected);
 
-        ScopedUndoBatch undo("Select Entity");
+        // This function could be called during undo/redo, in which case, we don't want to MAKE new undo/redo commands
+        // but we still want to update our own internal state.
+        AZStd::unique_ptr<ScopedUndoBatch> undo;
+        AZStd::unique_ptr<SelectionCommand> selectionCommand;
+        if (!m_isDuringUndoRedo)
+        {
+            // initialize the selection command here to store the current selection before
+            // new entities are selected or deselected below
+            // (SelectionCommand calls GetSelectedEntities in the constructor)
 
-        // initialize the selection command here to store the current selection before
-        // new entities are selected or deselected below
-        // (SelectionCommand calls GetSelectedEntities in the constructor)
-        auto selectionCommand =
-            AZStd::make_unique<SelectionCommand>(AZStd::vector<AZ::EntityId>{}, "");
+            undo = AZStd::make_unique<ScopedUndoBatch>("Select Entity");
+            selectionCommand = AZStd::make_unique<SelectionCommand>(AZStd::vector<AZ::EntityId>{}, "");
+        }
 
+    
         // Add the newly selected and deselected entities from the outliner to the appropriate selection buffer.
         for (const AZ::EntityId& entityId : newlySelected)
         {
             m_entitiesSelectedByOutliner.insert(entityId);
         }
 
-        ToolsApplicationRequestBus::Broadcast(
-            &ToolsApplicationRequests::MarkEntitiesSelected, newlySelected);
+        ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::MarkEntitiesSelected, newlySelected);
 
         for (const AZ::EntityId& entityId : newlyDeselected)
         {
             m_entitiesDeselectedByOutliner.insert(entityId);
         }
 
-        ToolsApplicationRequestBus::Broadcast(
-            &ToolsApplicationRequests::MarkEntitiesDeselected, newlyDeselected);
+        ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::MarkEntitiesDeselected, newlyDeselected);
 
         // call GetSelectedEntities again after all changes, and then update the selection
         // command  so the 'after' state is valid and up to date
         EntityIdList selectedEntities;
-        ToolsApplicationRequests::Bus::BroadcastResult(
-            selectedEntities, &ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
+        ToolsApplicationRequests::Bus::BroadcastResult(selectedEntities, &ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
 
-        selectionCommand->UpdateSelection(selectedEntities);
-
-        selectionCommand->SetParent(undo.GetUndoBatch());
-        selectionCommand.release();
+        if ((undo) && (selectionCommand))
+        {
+            selectionCommand->UpdateSelection(selectedEntities);
+            selectionCommand->SetParent(undo->GetUndoBatch());
+            selectionCommand.release(); // SetParent is an ownership transfer, the undo batch will now own deletion of this memory.
+        }
 
         m_entitiesDeselectedByOutliner.clear();
         m_entitiesSelectedByOutliner.clear();
@@ -1239,6 +1245,16 @@ namespace AzToolsFramework
         }
 
         QueueScrollToNewContent(GetEntityIdFromIndex(firstSelectedEntityIndex));
+    }
+
+    // ToolsApplicationEventBus handler
+    void EntityOutlinerWidget::BeforeUndoRedo()
+    {
+        m_isDuringUndoRedo = true;
+    }
+    void EntityOutlinerWidget::AfterUndoRedo()
+    {
+        m_isDuringUndoRedo = false;
     }
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.hxx
@@ -136,6 +136,10 @@ namespace AzToolsFramework
         EntityOutlinerSortFilterProxyModel* m_proxyModel;
         AZStd::vector<AZ::EntityId> m_selectedEntityIds;
 
+        // ToolsApplicationEventBus handler
+        void BeforeUndoRedo() override;
+        void AfterUndoRedo() override;
+
         void PrepareSelection();
         void DoCreateEntity();
         void DoCreateEntityWithParent(const AZ::EntityId& parentId);
@@ -193,6 +197,8 @@ namespace AzToolsFramework
 
         QIcon m_emptyIcon;
         QIcon m_clearIcon;
+
+        bool m_isDuringUndoRedo = false;
 
         void QueueContentUpdateSort(const AZ::EntityId& entityId);
         void SortContent();


### PR DESCRIPTION
## What does this PR do?

Fixes issue #4864 - https://github.com/o3de/o3de/issues/4864

Turns out that the outliner was creating undo/redo on selection change, which is fine, but not if the selection change is BECAUSE of an undo/redo.

## How was this PR tested?

Tested by undoing and redoing many slice edits and operations including opening and closing.