### PR TITLE
[Track View] Fix for the issue #15023: Force recent changes made in TrackView when switching to Play Game mode

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -851,7 +851,14 @@ void CAnimationContext::OnEditorNotifyEvent(EEditorNotifyEvent event)
     case eNotify_OnBeginGameMode:
         if (m_pSequence)
         {
-            m_pSequence->Resume();
+            // Restart sequence at the beginning
+            auto savedTime = m_currTime;
+            AnimateActiveSequence();
+            m_currTime = savedTime;
+
+            // Force recent changes made in TrackView, updating in-memory prefab using Undo/Redo framework
+            AzToolsFramework::ScopedUndoBatch undoBatch("Update TrackView Sequence");
+            undoBatch.MarkEntityDirty(m_pSequence->GetSequenceComponentEntityId());
         }
         {
             // This notification arrives before even the OnStartPlayInEditorBegin and later OnStartPlayInEditor events


### PR DESCRIPTION
## What does this PR do?
Closes https://github.com/o3de/o3de/issues/15023
Partially fixes https://github.com/o3de/o3de/issues/8486:
 The  `CSelectTrack` track is animated in TrackView, but is not properly animated in Play Game mode.

Adds forcing recent changes made in TrackView, - updating in-memory prefab using Undo/Redo framework, - when switching into Play Game mode.
Also ensures that the active sequence restarts from the beginning.

## How was this PR tested?
Editor run under Windows, a cut-scene with reproduction steps from the issue https://github.com/o3de/o3de/issues/15023 created.
When playing game after adding transform keys, without any other actions, sequence is properly animated. 