### PR TITLE
Improves the performance of making trivial edits in a large level

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1023,7 +1023,8 @@ namespace AzToolsFramework
             PrefabDom& afterState, InstanceOptionalConstReference instanceToSkipUpdateQueue )
         {
             // Update the state of the entity
-            PrefabUndoHelpers::UpdateEntity(beforeState, afterState, entityId, undoBatch, true, instanceToSkipUpdateQueue);
+            constexpr bool updateCache = true;
+            PrefabUndoHelpers::UpdateEntity(beforeState, afterState, entityId, undoBatch, updateCache, instanceToSkipUpdateQueue);
         }
 
         void PrefabPublicHandler::Internal_HandleInstanceChange(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -989,7 +989,12 @@ namespace AzToolsFramework
                 else
                 {
                     // Source Template Editing
-                    Internal_HandleEntityChange(parentUndoBatch, entityId, beforeState, afterState);
+                    // If we're editing the source template directly (meaning, we are basically just moving an entity around or something like that)
+                    // and we are not reparenting it or anything, it means that we can skip over instance updates of the owning instance
+                    // We can do this because handleEntityChange will take care of updating both the instance's cached dom as well as the template,
+                    // and the AZ::Entity itself is already up to date due to this, because it was created by serializing, so only OTHER instances
+                    // of the same prefab need an update.
+                    Internal_HandleEntityChange(parentUndoBatch, entityId, beforeState, afterState, owningInstance);
 
                     if (isNewParentOwnedByDifferentInstance)
                     {
@@ -1015,11 +1020,10 @@ namespace AzToolsFramework
 
         void PrefabPublicHandler::Internal_HandleEntityChange(
             UndoSystem::URSequencePoint* undoBatch, AZ::EntityId entityId, PrefabDom& beforeState,
-            PrefabDom& afterState)
+            PrefabDom& afterState, InstanceOptionalConstReference instanceToSkipUpdateQueue )
         {
             // Update the state of the entity
-            PrefabUndoHelpers::UpdateEntity(beforeState, afterState,
-                entityId, undoBatch);
+            PrefabUndoHelpers::UpdateEntity(beforeState, afterState, entityId, undoBatch, true, instanceToSkipUpdateQueue);
         }
 
         void PrefabPublicHandler::Internal_HandleInstanceChange(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -184,9 +184,14 @@ namespace AzToolsFramework
             static void Internal_HandleContainerOverride(
                 UndoSystem::URSequencePoint* undoBatch, AZ::EntityId entityId, const PrefabDom& patch,
                 const LinkId linkId);
+
+            // if a non-nullopt const reference is sent to HandleEntityChange, it essentially means that the instance in question
+            // will be fully updated by this function (as in, the template it came from will be updated, as well as the instance in question)
+            // and thus, it can skip the instance update queue that happens later.
             static void Internal_HandleEntityChange(
                 UndoSystem::URSequencePoint* undoBatch, AZ::EntityId entityId, PrefabDom& beforeState,
-                PrefabDom& afterState);
+                PrefabDom& afterState, InstanceOptionalConstReference instanceToSkipUpdateQueue = AZStd::nullopt);
+
             void Internal_HandleInstanceChange(UndoSystem::URSequencePoint* undoBatch, AZ::Entity* entity, AZ::EntityId beforeParentId, AZ::EntityId afterParentId);
 
             void UpdateLinkPatchesWithNewEntityAliases(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
@@ -109,12 +109,13 @@ namespace AzToolsFramework
                 const PrefabDomValue& entityDomAfterUpdatingEntity,
                 AZ::EntityId entityId,
                 UndoSystem::URSequencePoint* undoBatch,
-                bool updateCache)
+                bool updateCache,
+                InstanceOptionalConstReference instanceToSkipInUpdate)
             {
                 PrefabUndoEntityUpdate* state = aznew PrefabUndoEntityUpdate("Undo Updating Entity");
                 state->SetParent(undoBatch);
                 state->Capture(entityDomBeforeUpdatingEntity, entityDomAfterUpdatingEntity, entityId, updateCache);
-                state->Redo();
+                state->Redo(instanceToSkipInUpdate);
             }
 
             void UpdateEntitiesAsOverrides(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
@@ -65,12 +65,16 @@ namespace AzToolsFramework
             //! @param entityId The id of the entity.
             //! @param undoBatch The undo batch node to register the update-entity undo node to.
             //! @param updateCache Flag that determines if the cached instance DOM is updated to avoid reloading in next tick.
+            //! @param instanceToSkipInUpdate - if not nullopt, it indicates to this function that it can skip this entity
+            //!                                 in the "propagate to other instances" queue, as this instance will have already been manually updated.
             void UpdateEntity(
                 const PrefabDomValue& entityDomBeforeUpdatingEntity,
                 const PrefabDomValue& entityDomAfterUpdatingEntity,
                 AZ::EntityId entityId,
                 UndoSystem::URSequencePoint* undoBatch,
-                bool updateCache = true);
+                bool updateCache = true,
+                InstanceOptionalConstReference instanceToSkipInUpdate = AZStd::nullopt
+            );
 
             //! Helper function for updating entities as overrides to focused template with undo-redo support.
             //! @param entityList Entity list for entities to be updated in focused template.


### PR DESCRIPTION
## What does this PR do?

Improves
https://github.com/o3de/o3de/issues/18656

It turns out that when you make a trivial edit, so for example, modifying a simple entity property like a property field or a transform, the system already 
1. updates the instance being edited (its cached json DOM) when it captures the undo
2. updates the template it belongs to (the prefab file in memory that the instance came from) as part of the commit op.
3. updates the actual entity being modified (this happens as you drag the entity around or modify its properties)
4. adds instances of this prefab being modified to the queue to propagate to other instances in the level.

The problem is, it adds the instance being edited to that queue *as well as* any other instances in the scene of that same prefab.

The main thing that this does is skip the already-updated instance from being added to that propagation queue.  It is already up to date.  It only adds the other instances like it did before, minus the one that was already done explicitly.

This reduces all of the time seen in the profile capture on the reported issue, to zero.  There is no longer any kind of delay I can notice when you move an entity around on the moment you "let go" of the entity, instead of a 2-5s delay.

It only does this for simple edits, that is, when its not a reparenting or override creation or something like that which would need more complex handling.  We could investigate that next if its still a problem of course.

The side effect of this is that when you have a large level and you are modifying individual entities in them, what would previously happen is that it would add **all** instances to the update queue, including the *one that was just updated*... 

 And in the case of a large level, the one that was just updated *is the level itself* leading to a respawn of the entire level, unnecessarily, and thus the huge freeze or delay.

## How was this PR tested?

Tested with both a custom level that had prefabs-in-prefabs as well as the startergame assets.
Tests:
* All the CI tests that already exist for this
* Manual testing:
   * Modifying entity properties in the level (incl transform)
   * Modifying entity properties as an override 
   * Modifying entity properties in a prefab and allowing propogation to other instances of the same prefab in the level
   * Overriding entity properties and then modifying the base prefab to result in propogation.
   * Undo and redo of all the above.  Note that another bug https://github.com/o3de/o3de/pull/18659 was found and fixed during this, but is unrelated.
 * Transparent-box testing - that is, opening the prefab files and examining their contents
 * Saving and loading at each step above, making sure that no data loss occurred.

