### PR TITLE
Clang 19 fixes.

### DIFF
--- a/Code/Editor/Util/EditorUtils.h
+++ b/Code/Editor/Util/EditorUtils.h
@@ -115,9 +115,9 @@ namespace EditorUtils
         // Move constructor: needed to use CreateScopedVariable, and transfers ownership.
         TScopedVariableValue(TScopedVariableValue&& tInput)
         {
-            std::move(m_pVariable, tInput.m_tVariable);
-            std::move(m_tConstructValue, tInput.m_tConstructValue);
-            std::move(m_tDestructValue, tInput.m_tDestructtValue);
+            m_pVariable = tInput.m_pVariable;
+            m_tConstructValue = tInput.m_tConstructValue;
+            m_tDestructValue = tInput.m_tDestructValue;
         }
 
         // Applies the scoping exit, if the variable is valid.

--- a/Code/Framework/AzCore/AzCore/std/string/regex.h
+++ b/Code/Framework/AzCore/AzCore/std/string/regex.h
@@ -2295,10 +2295,6 @@ namespace AZStd
             {
                 m_regEx = 0;
             }
-            else
-            {
-                this->_Adopt(m_regEx);
-            }
         }
 
         bool operator==(const this_type& right) const

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/TitleBarOverdrawScreenHandler_win.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/TitleBarOverdrawScreenHandler_win.cpp
@@ -65,7 +65,7 @@ bool TitleBarOverdrawScreenHandler::eventFilter(QObject *watched, QEvent *event)
         // Intentional fall-through
         case QEvent::Show:
         {
-            if (QWindow* window = qobject_cast<QWindow*>(watched))
+            if (qobject_cast<QWindow*>(watched))
             {
                 applyOverdrawMargins();
             }

--- a/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Artifact/Factory/TestImpactTestRunSuiteFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Common/Code/Source/Artifact/Factory/TestImpactTestRunSuiteFactory.cpp
@@ -99,7 +99,7 @@ namespace TestImpact
 
                         const auto getResult = [](const AZ::rapidxml::xml_node<>* node)
                         {
-                            if (auto child_node = node->first_node("failure"))
+                            if (node->first_node("failure"))
                             {
                                 return TestRunResult::Failed;
                             }

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicArray.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicArray.inl
@@ -447,7 +447,7 @@ namespace AZ
     auto StableDynamicArray<T, ElementsPerPage, Allocator>::iterator::operator++(int) -> this_type
     {
         this_type temp = *this;
-        ++this;
+        ++*this;
         return temp;
     }
 
@@ -517,7 +517,7 @@ namespace AZ
     auto StableDynamicArray<T, ElementsPerPage, Allocator>::const_iterator::operator++(int) -> this_type
     {
         this_type temp = *this;
-        ++this;
+        ++*this;
         return temp;
     }
 
@@ -582,7 +582,7 @@ namespace AZ
     auto StableDynamicArray<T, ElementsPerPage, Allocator>::pageIterator::operator++(int) -> this_type
     {
         this_type temp = *this;
-        ++this;
+        ++*this;
         return temp;
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -4872,7 +4872,7 @@ namespace ScriptCanvas
 
         void AbstractCodeModel::ParseOutputData(ExecutionTreePtr execution, ExecutionChild& executionChild)
         {
-            if (const auto nodeling = azrtti_cast<const Nodes::Core::FunctionDefinitionNode*>(execution->GetId().m_node))
+            if (azrtti_cast<const Nodes::Core::FunctionDefinitionNode*>(execution->GetId().m_node))
             {
                 // this nodeling will always be the Execution-In part of the function definition
                 // since a call to a user out does not enter this path

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -33,6 +33,8 @@ ly_append_configurations_options(
         -Wno-reorder
         -Wno-switch
         -Wno-undefined-var-template
+        -fno-relaxed-template-template-args
+        -Wno-deprecated-no-relaxed-template-template-args
 
         ###################
         # Enabled warnings (that are disabled by default)


### PR DESCRIPTION
See https://github.com/o3de/o3de/issues/18470 w.r.t. compiler flags. However, this should be fixed properly in the code at some point to avoid those depricated flags.

## What does this PR do?

Multiple errors need to be fixed in order to get o3de to compile with clang 19. Many (rather serious/obvious) errors are within template functions that are never instantiated but which clang 19 seems to at least compile partially.

## How was this PR tested?

Compiling o3de with clang 19.
