### PR TITLE
Make the number of potential PassAttachments variable.

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -29,6 +29,7 @@
 #include <AzCore/std/containers/span.h>
 
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
@@ -453,8 +454,10 @@ namespace AZ
 
             // List of input, output and input/output attachment bindings
             // Fixed size for performance and so we can hold pointers to the bindings for connections
-            AZStd::fixed_vector<PassAttachmentBinding, PassAttachmentBindingCountMax> m_attachmentBindings;
-            
+            int m_attachmentBindingIndex{ 0 };
+            AZStd::deque<PassAttachmentBinding> m_attachmentBindings;
+            AZStd::vector<PassAttachmentBinding*> m_attachmentBindingPtrs;
+
             // List of attachments owned by this pass.
             // It includes both transient attachments and imported attachments
             AZStd::vector<Ptr<PassAttachment>> m_ownedAttachments;
@@ -667,13 +670,13 @@ namespace AZ
             // --- Private Members ---
 
             // List of attachment binding indices for all the input bindings
-            AZStd::fixed_vector<uint8_t, PassInputBindingCountMax> m_inputBindingIndices;
+            AZStd::vector<uint8_t> m_inputBindingIndices;
 
             // List of attachment binding indices for all the input/output bindings
-            AZStd::fixed_vector<uint8_t, PassInputOutputBindingCountMax> m_inputOutputBindingIndices;
+            AZStd::vector<uint8_t> m_inputOutputBindingIndices;
 
             // List of attachment binding indices for all the output bindings
-            AZStd::fixed_vector<uint8_t, PassOutputBindingCountMax> m_outputBindingIndices;
+            AZStd::vector<uint8_t> m_outputBindingIndices;
 
             // Used to maintain references to imported attachments so they're underlying
             // buffers and images don't get deleted during attachment build phase

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -68,11 +68,6 @@ namespace AZ
 
         using PassesByDrawList = AZStd::map<RHI::DrawListTag, const Pass*>;
 
-        const uint32_t PassAttachmentBindingCountMax = 32;
-        const uint32_t PassInputBindingCountMax = PassAttachmentBindingCountMax;
-        const uint32_t PassInputOutputBindingCountMax = PassInputBindingCountMax;
-        const uint32_t PassOutputBindingCountMax = PassInputBindingCountMax;
-                
         enum class PassAttachmentReadbackOption : uint8_t
         {
             Input = 0,
@@ -453,10 +448,10 @@ namespace AZ
             const Name PipelineGlobalKeyword{"PipelineGlobal"};
 
             // List of input, output and input/output attachment bindings
-            // Fixed size for performance and so we can hold pointers to the bindings for connections
-            int m_attachmentBindingIndex{ 0 };
+            // [GFX TODO][GHI-18438] Using a deque here that is not cleared, since pointers are held to the bindings for connections and are
+            // not expected to be changed even during a rebuild
+            int m_attachmentBindingsSize{ 0 };
             AZStd::deque<PassAttachmentBinding> m_attachmentBindings;
-            AZStd::vector<PassAttachmentBinding*> m_attachmentBindingPtrs;
 
             // List of attachments owned by this pass.
             // It includes both transient attachments and imported attachments

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -158,6 +158,9 @@ namespace AZ
             //! Updates the set attachment from the binding connection
             void UpdateConnection(bool useFallback);
 
+            //! Clears the smart pointers within to holding the memory too long.
+            void Clear();
+
             //! Name of the attachment binding so we can find it in a list of attachment binding
             Name m_name;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -13,6 +13,8 @@
 #include <Atom/RHI.Reflect/ShaderInputNameIndex.h>
 #include <Atom/RPI.Reflect/Pass/PassAttachmentReflect.h>
 
+#include <AzCore/std/containers/deque.h>
+
 namespace AZ
 {
     namespace RPI
@@ -210,8 +212,8 @@ namespace AZ
             Ptr<PassAttachment> m_originalAttachment = nullptr;
         };
 
-        using PassAttachmentBindingList = AZStd::vector<PassAttachmentBinding>;
-        using PassAttachmentBindingListView = AZStd::span<const PassAttachmentBinding>;
+        using PassAttachmentBindingList = AZStd::deque<PassAttachmentBinding>;
+        using PassAttachmentBindingListView = const AZStd::deque<PassAttachmentBinding>;
 
     }   // namespace RPI
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -96,10 +96,10 @@ namespace AZ
                 GetOutputCount());
 
             AZ_Assert(
-                (m_attachmentBindingIndex == 2) || (m_inputOutputCopy && m_attachmentBindingIndex == 1),
+                (m_attachmentBindingsSize == 2) || (m_inputOutputCopy && m_attachmentBindingsSize == 1),
                 "CopyPass must have exactly 2 bindings: 1 input and 1 output. %s has %d bindings.",
                 GetPathName().GetCStr(),
-                m_attachmentBindingIndex);
+                m_attachmentBindingsSize);
 
             bool sameDevice = (m_data.m_sourceDeviceIndex == -1 && m_data.m_destinationDeviceIndex == -1) ||
                 m_data.m_sourceDeviceIndex == m_data.m_destinationDeviceIndex;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -96,10 +96,10 @@ namespace AZ
                 GetOutputCount());
 
             AZ_Assert(
-                (m_attachmentBindings.size() == 2) || (m_inputOutputCopy && m_attachmentBindings.size() == 1),
+                (m_attachmentBindingIndex == 2) || (m_inputOutputCopy && m_attachmentBindingIndex == 1),
                 "CopyPass must have exactly 2 bindings: 1 input and 1 output. %s has %d bindings.",
                 GetPathName().GetCStr(),
-                m_attachmentBindings.size());
+                m_attachmentBindingIndex);
 
             bool sameDevice = (m_data.m_sourceDeviceIndex == -1 && m_data.m_destinationDeviceIndex == -1) ||
                 m_data.m_sourceDeviceIndex == m_data.m_destinationDeviceIndex;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -253,25 +253,28 @@ namespace AZ
 
         PassAttachmentBinding& Pass::GetInputBinding(uint32_t index)
         {
+            AZ_Assert(m_inputBindingIndices.size() > index, "Index out of bounds.");
             uint32_t bindingIndex = m_inputBindingIndices[index];
             return m_attachmentBindings[bindingIndex];
         }
 
         PassAttachmentBinding& Pass::GetInputOutputBinding(uint32_t index)
         {
+            AZ_Assert(m_inputOutputBindingIndices.size() > index, "Index out of bounds.");
             uint32_t bindingIndex = m_inputOutputBindingIndices[index];
             return m_attachmentBindings[bindingIndex];
         }
 
         PassAttachmentBinding& Pass::GetOutputBinding(uint32_t index)
         {
+            AZ_Assert(m_outputBindingIndices.size() > index, "Index out of bounds.");
             uint32_t bindingIndex = m_outputBindingIndices[index];
             return m_attachmentBindings[bindingIndex];
         }
 
         void Pass::AddAttachmentBinding(PassAttachmentBinding attachmentBinding)
         {
-            auto index = static_cast<uint8_t>(m_attachmentBindings.size());
+            auto index = static_cast<uint8_t>(m_attachmentBindingIndex);
             if (attachmentBinding.m_scopeAttachmentStage == RHI::ScopeAttachmentStage::Uninitialized)
             {
                 attachmentBinding.m_scopeAttachmentStage = attachmentBinding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::Shader
@@ -280,7 +283,18 @@ namespace AZ
             }
 
             // Add the binding. This will assert if the fixed size array is full.
-            m_attachmentBindings.push_back(attachmentBinding);
+
+            if (m_attachmentBindingIndex < m_attachmentBindings.size())
+            {
+                m_attachmentBindings[m_attachmentBindingIndex] = attachmentBinding;
+                m_attachmentBindingPtrs.push_back(&m_attachmentBindings[m_attachmentBindingIndex]);
+            }
+            else
+            {
+                m_attachmentBindings.push_back(attachmentBinding);
+                m_attachmentBindingPtrs.push_back(&m_attachmentBindings.back());
+            }
+            ++m_attachmentBindingIndex;
 
             // Add the index of the binding to the input, output or input/output list based on the slot type
             switch (attachmentBinding.m_slotType)
@@ -888,7 +902,7 @@ namespace AZ
         void Pass::DeclareAttachmentsToFrameGraph(
             RHI::FrameGraphInterface frameGraph, PassSlotType slotType, RHI::ScopeAttachmentAccess accessMask) const
         {
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindings.size(); ++slotIndex)
+            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingIndex; ++slotIndex)
             {
                 const auto& attachmentBinding = m_attachmentBindings[slotIndex];
                 if(slotType == PassSlotType::Uninitialized || slotType == attachmentBinding.m_slotType)
@@ -1097,7 +1111,7 @@ namespace AZ
             // An example of this could be reading from and writing to different mips of the same texture
 
             // Loop over all attachments bound to this pass
-            size_t size = m_attachmentBindings.size();
+            size_t size = m_attachmentBindingIndex;
             for (size_t i = 0; i < size; ++i)
             {
                 PassAttachmentBinding& binding01 = m_attachmentBindings[i];
@@ -1295,7 +1309,9 @@ namespace AZ
             m_inputBindingIndices.clear();
             m_inputOutputBindingIndices.clear();
             m_outputBindingIndices.clear();
-            m_attachmentBindings.clear();
+            // [GFX TODO][GHI-18438] we cannot clear the attamentBindings here (m_attachmentBindings.clear();)
+            m_attachmentBindingIndex = 0;
+            m_attachmentBindingPtrs.clear();
             m_ownedAttachments.clear();
             m_executeAfterPasses.clear();
             m_executeBeforePasses.clear();
@@ -1761,7 +1777,7 @@ namespace AZ
         void Pass::ReplaceSubpassInputs(RHI::SubpassInputSupportType supportedTypes)
         {
             m_flags.m_hasSubpassInput = false;
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindings.size(); ++slotIndex)
+            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingIndex; ++slotIndex)
             {
                 PassAttachmentBinding& binding = m_attachmentBindings[slotIndex];
                 if (binding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::SubpassInput)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -398,5 +398,11 @@ namespace AZ
             SetAttachment(targetAttachment);
         }
 
+        void PassAttachmentBinding::Clear()
+        {
+            m_attachment.reset();
+            m_originalAttachment.reset();
+        }
+
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -83,7 +83,7 @@ namespace AZ
                 ReplaceSubpassInputs(RHI::SubpassInputSupportType::None);
             }
 
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindings.size(); ++slotIndex)
+            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingIndex; ++slotIndex)
             {
                 const PassAttachmentBinding& binding = m_attachmentBindings[slotIndex];
 
@@ -179,7 +179,7 @@ namespace AZ
         {
             RHI::MultisampleState outputMultiSampleState;
             bool wasSet = false;
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindings.size(); ++slotIndex)
+            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingIndex; ++slotIndex)
             {
                 const PassAttachmentBinding& binding = m_attachmentBindings[slotIndex];
                 if (binding.m_slotType != PassSlotType::Output && binding.m_slotType != PassSlotType::InputOutput)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -83,7 +83,7 @@ namespace AZ
                 ReplaceSubpassInputs(RHI::SubpassInputSupportType::None);
             }
 
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingIndex; ++slotIndex)
+            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
             {
                 const PassAttachmentBinding& binding = m_attachmentBindings[slotIndex];
 
@@ -179,7 +179,7 @@ namespace AZ
         {
             RHI::MultisampleState outputMultiSampleState;
             bool wasSet = false;
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingIndex; ++slotIndex)
+            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
             {
                 const PassAttachmentBinding& binding = m_attachmentBindings[slotIndex];
                 if (binding.m_slotType != PassSlotType::Output && binding.m_slotType != PassSlotType::InputOutput)


### PR DESCRIPTION
## What does this PR do?

Since pointers are kept to the PassAttachments we need a container that doesn't change location when reallocating, i.e., a deque, and due to the pointers being kept even during a rebuild, we need to not clear the container.

See GHI #18438

## How was this PR tested?

ASV
