### PR TITLE
[TrackView] Refactor and fix camera switching  both in Editing and Play Game modes

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -851,13 +851,11 @@ void CAnimationContext::OnEditorNotifyEvent(EEditorNotifyEvent event)
     case eNotify_OnBeginGameMode:
         if (m_pSequence)
         {
-            // Restart sequence at the beginning
-            auto savedTime = m_currTime;
-            AnimateActiveSequence();
-            m_currTime = savedTime;
+            // Reset the sequence, so that changed camera positions are restored
+            m_pSequence->Reset(false);
 
             // Force recent changes made in TrackView, updating in-memory prefab using Undo/Redo framework
-            AzToolsFramework::ScopedUndoBatch undoBatch("Update TrackView Sequence");
+            AzToolsFramework::ScopedUndoBatch undoBatch("Update TrackView Sequence Before Playing Game");
             undoBatch.MarkEntityDirty(m_pSequence->GetSequenceComponentEntityId());
         }
         {
@@ -873,9 +871,18 @@ void CAnimationContext::OnEditorNotifyEvent(EEditorNotifyEvent event)
 
     case eNotify_OnBeginSceneSave:
     case eNotify_OnBeginLayerExport:
+        if (m_pSequence)
         {
-            constexpr const bool isSwitchingToGameMode = false;
+            // Reset the sequence, so that changed camera positions are restored
+            m_pSequence->Reset(false);
+
+            // Force recent changes made in TrackView, updating in-memory prefab using Undo/Redo framework
+            AzToolsFramework::ScopedUndoBatch undoBatch("Update TrackView Sequence Before Saving");
+            undoBatch.MarkEntityDirty(m_pSequence->GetSequenceComponentEntityId());
+        }
+        {
             // Store active sequence and camera Ids and drop this sequence.
+            constexpr const bool isSwitchingToGameMode = false;
             StoreSequenceOnExitingEditMode(isSwitchingToGameMode);
         }
         break;
@@ -907,7 +914,7 @@ void CAnimationContext::OnEditorNotifyEvent(EEditorNotifyEvent event)
         m_mostRecentSequenceTime = 0.0f;
         m_bSavedRecordingState = m_recording;
         SetRecordingInternal(false);
-        GetIEditor()->GetAnimation()->SetSequence(nullptr, false, false);
+        SetSequence(nullptr, false, false);
         break;
 
     case eNotify_OnEndLoad:

--- a/Code/Editor/TrackView/KeyUIControls.h
+++ b/Code/Editor/TrackView/KeyUIControls.h
@@ -466,7 +466,7 @@ private:
 
     void ResetCameraEntries();
 
-    const char* const defaulNoneKeyName = "<None>"; // Name used in menu when no camera is selected
+    static constexpr const char* defaultNoneKeyName = "<None>"; // Name used in menu when no camera is selected
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/KeyUIControls.h
+++ b/Code/Editor/TrackView/KeyUIControls.h
@@ -465,6 +465,8 @@ protected:
 private:
 
     void ResetCameraEntries();
+
+    const char* const defaulNoneKeyName = "<None>"; // Name used in menu when no camera is selected
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/SelectKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SelectKeyUIControls.cpp
@@ -101,7 +101,7 @@ void CSelectKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sele
                 QString entityIdString = mv_camera;
                 selectKey.cameraAzEntityId = AZ::EntityId(entityIdString.toULongLong());
                 selectKey.szSelection =  mv_camera.GetVar()->GetDisplayValue().toUtf8().data();
-                if (selectKey.szSelection == defaulNoneKeyName)
+                if (selectKey.szSelection == defaultNoneKeyName)
                 {
                     selectKey.szSelection.clear(); // Erase "<None>" got from menu for unassigned key 
                 }

--- a/Code/Editor/TrackView/SelectKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SelectKeyUIControls.cpp
@@ -42,7 +42,7 @@ bool CSelectKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selec
             // Get All cameras.
             mv_camera.SetEnumList(nullptr);
 
-            mv_camera->AddEnumItem(QObject::tr(defaulNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
+            mv_camera->AddEnumItem(QObject::tr(defaultNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
             // Find all Component Entity Cameras
             AZ::EBusAggregateResults<AZ::EntityId> cameraComponentEntities;

--- a/Code/Editor/TrackView/SelectKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SelectKeyUIControls.cpp
@@ -159,7 +159,7 @@ void CSelectKeyUIControls::OnCameraRemoved(const AZ::EntityId & cameraId)
     // still includes the deleted camera at this point. Reset the list anyway and filter out the
     // deleted camera.
     mv_camera->SetEnumList(nullptr);
-    mv_camera->AddEnumItem(QObject::tr(defaulNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
+    mv_camera->AddEnumItem(QObject::tr(defaultNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
     AZ::EBusAggregateResults<AZ::EntityId> cameraComponentEntities;
     Camera::CameraBus::BroadcastResult(cameraComponentEntities, &Camera::CameraRequests::GetCameras);

--- a/Code/Editor/TrackView/SelectKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SelectKeyUIControls.cpp
@@ -42,7 +42,7 @@ bool CSelectKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selec
             // Get All cameras.
             mv_camera.SetEnumList(nullptr);
 
-            mv_camera->AddEnumItem(QObject::tr("<None>"), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
+            mv_camera->AddEnumItem(QObject::tr(defaulNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
             // Find all Component Entity Cameras
             AZ::EBusAggregateResults<AZ::EntityId> cameraComponentEntities;
@@ -68,6 +68,7 @@ bool CSelectKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selec
 
             mv_BlendTime.GetVar()->SetLimits(0.0f, selectKey.fDuration > .0f ? selectKey.fDuration : 1.0f, 0.1f, true, false);
             mv_BlendTime = selectKey.fBlendTime;
+            mv_BlendTime->OnSetValue(false); // update dialog value
 
             bAssigned = true;        
         }
@@ -100,6 +101,10 @@ void CSelectKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sele
                 QString entityIdString = mv_camera;
                 selectKey.cameraAzEntityId = AZ::EntityId(entityIdString.toULongLong());
                 selectKey.szSelection =  mv_camera.GetVar()->GetDisplayValue().toUtf8().data();
+                if (selectKey.szSelection == defaulNoneKeyName)
+                {
+                    selectKey.szSelection.clear(); // Erase "<None>" got from menu for unassigned key 
+                }
             }
 
             if (pVar == mv_BlendTime.GetVar())
@@ -108,21 +113,11 @@ void CSelectKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sele
                 {
                     mv_BlendTime = 0.0f;
                 }
-
-                selectKey.fBlendTime = mv_BlendTime;
-            }
-
-            if (!selectKey.szSelection.empty())
-            {
-                IMovieSystem* movieSystem = AZ::Interface<IMovieSystem>::Get();
-                if (movieSystem)
+                else if ((selectKey.fDuration > AZ::Constants::Tolerance) && (mv_BlendTime > selectKey.fDuration))
                 {
-                    IAnimSequence* pSequence = movieSystem->FindLegacySequenceByName(selectKey.szSelection.c_str());
-                    if (pSequence)
-                    {
-                        selectKey.fDuration = pSequence->GetTimeRange().Length();
-                    }
+                    mv_BlendTime = selectKey.fDuration;
                 }
+                selectKey.fBlendTime = mv_BlendTime;
             }
 
             bool isDuringUndo = false;
@@ -164,7 +159,7 @@ void CSelectKeyUIControls::OnCameraRemoved(const AZ::EntityId & cameraId)
     // still includes the deleted camera at this point. Reset the list anyway and filter out the
     // deleted camera.
     mv_camera->SetEnumList(nullptr);
-    mv_camera->AddEnumItem(QObject::tr("<None>"), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
+    mv_camera->AddEnumItem(QObject::tr(defaulNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
     AZ::EBusAggregateResults<AZ::EntityId> cameraComponentEntities;
     Camera::CameraBus::BroadcastResult(cameraComponentEntities, &Camera::CameraRequests::GetCameras);
@@ -203,7 +198,7 @@ void CSelectKeyUIControls::OnEntityNameChanged(const AZ::EntityId & entityId, [[
 void CSelectKeyUIControls::ResetCameraEntries()
 {
     mv_camera.SetEnumList(nullptr);
-    mv_camera->AddEnumItem(QObject::tr("<None>"), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
+    mv_camera->AddEnumItem(QObject::tr(defaulNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
     // Find all Component Entity Cameras
     AZ::EBusAggregateResults<AZ::EntityId> cameraComponentEntities;

--- a/Code/Editor/TrackView/SelectKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SelectKeyUIControls.cpp
@@ -198,7 +198,7 @@ void CSelectKeyUIControls::OnEntityNameChanged(const AZ::EntityId & entityId, [[
 void CSelectKeyUIControls::ResetCameraEntries()
 {
     mv_camera.SetEnumList(nullptr);
-    mv_camera->AddEnumItem(QObject::tr(defaulNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
+    mv_camera->AddEnumItem(QObject::tr(defaultNoneKeyName), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
     // Find all Component Entity Cameras
     AZ::EBusAggregateResults<AZ::EntityId> cameraComponentEntities;

--- a/Code/Legacy/CryCommon/AnimKey.h
+++ b/Code/Legacy/CryCommon/AnimKey.h
@@ -231,7 +231,7 @@ struct ISequenceKey
         fStartTime = 0;
         fEndTime = 0;
         bOverrideTimes = false;
-        bDoNotStop = false; // default crisis behavior
+        bDoNotStop = false;
     }
 };
 

--- a/Code/Legacy/CryCommon/IMovieSystem.cpp
+++ b/Code/Legacy/CryCommon/IMovieSystem.cpp
@@ -115,16 +115,6 @@ SAnimContext::SAnimContext()
 }
 
 
-// SCameraParams member functions
-
-SCameraParams::SCameraParams()
-{
-    fov = 0.0f;
-    nearZ = DEFAULT_NEAR;
-    justActivated = false;
-}
-
-
 // IAnimTrack member definitions
 AZ_TYPE_INFO_WITH_NAME_IMPL(IAnimTrack, "IAnimTrack", "{AA0D5170-FB28-426F-BA13-7EFF6BB3AC67}");
 AZ_RTTI_NO_TYPE_INFO_IMPL(IAnimTrack);

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -195,24 +195,13 @@ struct SAnimContext
     float startTime;        //!< The start time of this playing sequence
 };
 
-/** Parameters for cut-scene cameras
-*/
-struct SCameraParams
-{
-    SCameraParams();
-    AZ::EntityId cameraEntityId;
-    float fov;
-    float nearZ;
-    bool justActivated;
-};
-
 //! Interface for movie-system implemented by user for advanced function-support
 struct IMovieUser
 {
     // <interfuscator:shuffle>
     virtual ~IMovieUser(){}
     //! Called when movie system requests a camera-change.
-    virtual void SetActiveCamera(const SCameraParams& Params) = 0;
+    virtual void SetActiveCamera(const AZ::EntityId& cameraEntityId) = 0;
     //! Called when movie system enters into cut-scene mode.
     virtual void BeginCutScene(IAnimSequence* pSeq, unsigned long dwFlags, bool bResetFX) = 0;
     //! Called when movie system exits from cut-scene mode.
@@ -318,7 +307,7 @@ struct IAnimTrack
     virtual void SetNumKeys(int numKeys) = 0;
 
     //! Remove specified key.
-    virtual void RemoveKey(int num) = 0;
+    virtual void RemoveKey(int index) = 0;
 
     //! Get key at specified location.
     //! @param key Must be valid pointer to compatible key structure, to be filled with specified key location.
@@ -372,9 +361,10 @@ struct IAnimTrack
     virtual int CopyKey(IAnimTrack* pFromTrack, int nFromKey) = 0;
 
     //! Get info about specified key.
-    //! @param Short human readable text description of this key.
-    //! @param duration of this key in seconds.
-    virtual void GetKeyInfo(int key, const char*& description, float& duration) = 0;
+    //! @param index The index specifying the this key.
+    //! @param description The short human readable text description of this key.
+    //! @param duration The duration of this key in seconds.
+    virtual void GetKeyInfo(int index, const char*& description, float& duration) = 0;
 
     //////////////////////////////////////////////////////////////////////////
     // Get track value at specified time.
@@ -1223,14 +1213,14 @@ struct IMovieSystem
 
     virtual IMovieCallback* GetCallback() = 0;
 
-    virtual const SCameraParams& GetCameraParams() const = 0;
-    virtual void SetCameraParams(const SCameraParams& Params) = 0;
+    virtual AZ::EntityId GetActiveCamera() const = 0;
+    virtual void SetActiveCamera(const AZ::EntityId& entityId) = 0;
     virtual void SendGlobalEvent(const char* pszEvent) = 0;
 
     // Gets the float time value for a sequence that is already playing
     virtual float GetPlayingTime(IAnimSequence* pSeq) = 0;
     virtual float GetPlayingSpeed(IAnimSequence* pSeq) = 0;
-    // Sets the time progression of an already playing cutscene.
+    // Sets the time progression of an already playing cut-scene.
     // If IAnimSequence:NO_SEEK flag is set on pSeq, this call is ignored.
     virtual bool SetPlayingTime(IAnimSequence* pSeq, float fTime) = 0;
     virtual bool SetPlayingSpeed(IAnimSequence* pSeq, float fSpeed) = 0;

--- a/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
@@ -326,7 +326,7 @@ namespace Maestro
         /** Get last key before specified time.
                 @return Index of key, or -1 if such key not exist.
         */
-        int GetActiveKey(float time, KeyType* key);
+        virtual int GetActiveKey(float time, KeyType* key);
 
 #ifdef MOVIESYSTEM_SUPPORT_EDITING
         ColorB GetCustomColor() const override

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.h
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.h
@@ -128,8 +128,8 @@ public:
     IMovieCallback* GetCallback() override { return m_pCallback; }
     void Callback(IMovieCallback::ECallbackReason Reason, IAnimNode* pNode);
 
-    const SCameraParams& GetCameraParams() const override { return m_ActiveCameraParams; }
-    void SetCameraParams(const SCameraParams& Params) override;
+    AZ::EntityId GetActiveCamera() const override { return m_ActiveCameraEntityId; }
+    void SetActiveCamera(const AZ::EntityId& entityId) override;
 
     void SendGlobalEvent(const char* pszEvent) override;
     void SetSequenceStopBehavior(ESequenceStopBehavior behavior) override;
@@ -171,11 +171,6 @@ public:
     void OnSequenceActivated(IAnimSequence* sequence) override;
 
     static void Reflect(AZ::ReflectContext* context);
-
-    static float GetCameraPrecacheTime()
-    {
-        return m_mov_cameraPrecacheTime;
-    }
 
 private:
 
@@ -233,7 +228,7 @@ private:
     bool    m_bPaused;
     bool    m_bCutscenesPausedInEditor;
 
-    SCameraParams m_ActiveCameraParams;
+    AZ::EntityId m_ActiveCameraEntityId;
 
     ESequenceStopBehavior m_sequenceStopBehavior;
 
@@ -279,7 +274,6 @@ private:
     void RegisterParamTypes();
 
 private:
-    static float m_mov_cameraPrecacheTime;
 #if !defined(_RELEASE)
     static int m_mov_DebugEvents;
     static int m_mov_debugCamShake;

--- a/Gems/Maestro/Code/Source/Cinematics/SceneNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/SceneNode.cpp
@@ -799,7 +799,8 @@ namespace Maestro
     {
         if (!m_movieSystem || !m_pSequence || !m_CurrentSelectTrack || !currKey.IsInitialized())
         {
-            const auto text = AZStd::string::format("ApplyCameraKey(%d, %s, time=%f)", currKeyIdx, currKey.cameraAzEntityId.ToString().c_str(), ec.time).c_str();
+            [[maybe_unused]] const auto text =
+                AZStd::string::format("ApplyCameraKey(%d, %s, time=%f)", currKeyIdx, currKey.cameraAzEntityId.ToString().c_str(), ec.time).c_str();
             AZ_Assert(m_movieSystem, "%s: invalid movie system pointer.", text);
             AZ_Assert(m_pSequence, "%s: invalid sequence pointer.", text);
             AZ_Assert(m_CurrentSelectTrack, "%s: invalid track pointer.", text);

--- a/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
@@ -28,30 +28,23 @@ namespace Maestro
         AZ_RTTI(CAnimSceneNode, "{659BB221-38D3-43C0-BEE4-7EAB49C8CB33}", CAnimNode);
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        // helper interface for a uniform interface to legacy and component entity cameras
+        // helper interface to component entity cameras
         class ISceneCamera
         {
         public:
             virtual ~ISceneCamera() = default;
 
-            virtual const Vec3& GetPosition() const = 0;
-            virtual const Quat& GetRotation() const = 0;
-            virtual void SetPosition(const Vec3& localPosition) = 0;
-            virtual void SetRotation(const Quat& localRotation) = 0;
+            virtual const AZ::Vector3 GetWorldPosition() const = 0;
+            virtual const AZ::Quaternion GetWorldRotation() const = 0;
 
             virtual float GetFoV() const = 0;
             virtual float GetNearZ() const = 0;
 
-            // includes check for changes
-            virtual void SetNearZAndFOVIfChanged(float fov, float nearZ) = 0;
-            virtual void TransformPositionFromLocalToWorldSpace(Vec3& position) = 0;
-            virtual void TransformPositionFromWorldToLocalSpace(Vec3& position) = 0;
-            virtual void TransformRotationFromLocalToWorldSpace(Quat& rotation) = 0;
-            // keeps existing world position
-            virtual void SetWorldRotation(const Quat& rotation) = 0;
-
-            // returns true if the camera has a parent
-            virtual bool HasParent() const = 0;
+            // Setting methods are supposed to check for needed changes.
+            virtual void SetWorldPosition(const AZ::Vector3& worldPosition) = 0;
+            // Keeps existing world position
+            virtual void SetWorldRotation(const AZ::Quaternion& worldRotation) = 0;
+            virtual void SetFovAndNearZ(float degreesFoV, float nearZ) = 0;
 
         protected:
             ISceneCamera() {}
@@ -98,7 +91,18 @@ namespace Maestro
         void ReleaseSounds(); // Stops audio
 
     private:
-        void ApplyCameraKey(ISelectKey& key, SAnimContext& ec);
+        // With a valid camera selection key, apply camera properties at ec.time,
+        // interpolating with a next key camera properties, if available
+        void ApplyCameraKey(int currKeyIdx, ISelectKey& currKey, const SAnimContext& ec);
+        // Initialize camera properties, if the key is valid (camera EntityId is valid), so that these can be restored after changes during interpolation.
+        // @return True, if the key is re-initialized.
+        bool InitializeCameraProperties(ISelectKey& key) const;
+        // Restore cameras' properties, if available, because these could be changed while playing the sequence having CSelectTrack.
+        void RestoreCameraProperties(ISelectKey& key) const;
+
+        bool OverrideCameraIdNeeded(); // Returns true if a previously active camera state is overridden by a camera properties set by ICVar in CMovieSystem.
+        bool RestoreOverriddenCameraIdNeeded(); // Returns true if a previously active camera state is restored after an override.
+
         void ApplyEventKey(IEventKey& key, SAnimContext& ec);
         void ApplyConsoleKey(IConsoleKey& key, SAnimContext& ec);
         void ApplyAudioKey(char const* const sTriggerName, bool const bPlay = true) override;
@@ -106,23 +110,17 @@ namespace Maestro
 
         void ApplyGotoKey(CGotoTrack* poGotoTrack, SAnimContext& ec);
 
-        // fill retInterpolatedCameraParams with interpolated camera data. If firstCameraId is a valid AZ::EntityId, it is used.
-        // should be non-null. Preference will be given to firstCamera if they are both non-null
-        void InterpolateCameras(
-            SCameraParams& retInterpolatedCameraParams, ISceneCamera* firstCamera, ISelectKey& firstKey, ISelectKey& secondKey, float time);
-
         void InitializeTrackDefaultValue(IAnimTrack* pTrack, const CAnimParamType& paramType) override;
 
         // Cached parameters of node at given time.
         float m_time = 0.0f;
 
         CSelectTrack* m_CurrentSelectTrack;
-        int m_CurrentSelectTrackKeyNumber;
-        IAnimNode* m_pCamNodeOnHoldForInterp;
-        float m_lastPrecachePoint;
 
-        //! Last animated key in track.
-        int m_lastCameraKey;
+        AZ::EntityId m_OverrideCamId; // A Camera Component EntityId to override camera selections, if set by ICVar in CMovieSystem.
+        ISelectKey m_overriddenCameraProperties; // In Play Game mode, properties of an overridden active camera.
+
+        //! Last animated key numbers in tracks.
         int m_lastEventKey;
         int m_lastConsoleKey;
         int m_lastSequenceKey;
@@ -130,19 +128,6 @@ namespace Maestro
         int m_lastCaptureKey;
         bool m_bLastCapturingEnded;
         int m_captureFrameCount;
-
-        struct InterpolatingCameraStartState
-        {
-            Vec3 m_interpolatedCamFirstPos;
-            Quat m_interpolatedCamFirstRot;
-            float m_FoV;
-            float m_nearZ;
-        };
-
-        using keyIdx = int;
-
-        // each camera key with a blend time > 0 needs a stashed initial xform for interpolation
-        AZStd::map<keyIdx, InterpolatingCameraStartState> m_InterpolatingCameraStartStates;
 
         AZStd::vector<SSoundInfo> m_SoundInfo;
 

--- a/Gems/Maestro/Code/Source/Cinematics/SelectTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/SelectTrack.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Serialization/SerializeContext.h>
+#include "SceneNode.h"
 #include "SelectTrack.h"
 #include "Maestro/Types/AnimValueType.h"
 
@@ -44,16 +45,171 @@ namespace Maestro
         return AnimValueType::Select;
     };
 
-    void CSelectTrack::GetKeyInfo(int key, const char*& description, float& duration)
+    void CSelectTrack::GetKeyInfo(int index, const char*& description, float& duration)
     {
-        AZ_Assert(key >= 0 && key < (int)m_keys.size(), "Key index %i is out of range", key);
+        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index %i is out of range", index);
         CheckValid();
-        description = 0;
-        duration = m_keys[key].fDuration;
-        if (!m_keys[key].szSelection.empty())
+        auto& key = m_keys[index];
+        if (key.CheckValid())
         {
-            description = m_keys[key].szSelection.c_str();
+            duration = key.fDuration;
+            description = key.szSelection.c_str();
         }
+        else
+        {
+            description = nullptr;
+            duration = 0;
+        }
+    }
+
+    void CSelectTrack::SetKey(int index, IKey* key)
+    {
+        const int numKeys = (int)m_keys.size();
+        if (index < 0 || index >= numKeys || !key)
+        {
+            AZ_Assert(index >= 0 && index < numKeys, "CSelectTrack::SetKey(%d): Key index is out of range", index);
+            AZ_Assert(key != 0, "CSelectTrack::SetKey(%d): Key cannot be null!", index);
+            return;
+        }
+
+        ISelectKey oldKey = m_keys[index];
+        ISelectKey newKey = *((ISelectKey*)key);
+        if (oldKey.cameraAzEntityId != newKey.cameraAzEntityId)
+        {
+            newKey.ResetCameraProperies(); // stored camera parameters are now probably invalid
+        }
+
+        m_keys[index] = newKey; // Store the key
+
+        CalculateDurationForEachKey(); // and sorted timeline
+
+        if(!newKey.IsValid() || newKey.IsInitialized())
+        {
+            return; // Invalid or already initialized key - no need to search for stored camera parameters.
+        }
+
+        // Try to find a valid key with same camera controller EntityId in order to copy stored camera parameters.
+        for (int idx = 0; idx < numKeys; ++idx)
+        {
+            if (idx != index)
+            {
+                ISelectKey& aKey = m_keys[idx];
+                if (aKey.IsInitialized() && (aKey.cameraAzEntityId == newKey.cameraAzEntityId))
+                {
+                    m_keys[index].CopyCameraProperies(aKey);
+                    return;
+                }
+            }
+        }
+        // Key keeps invalid camera properties, and until animation reset and re-activation,
+        // the needed camera properties cannot be requested (could have been changed while playing animation).
+    }
+
+    void CSelectTrack::CalculateDurationForEachKey()
+    {
+        const int numKeys = (int)m_keys.size();
+        if (numKeys < 1)
+        {
+            return;
+        }
+
+        SortKeys();
+
+        const auto timeRangeEnd =
+            (GetNode() && GetNode()->GetSequence())
+            ? GetNode()->GetSequence()->GetTimeRange().end : m_keys[numKeys - 1].time;
+
+        for (int currKeyIdx = 0; currKeyIdx < numKeys; ++currKeyIdx)
+        {
+            ISelectKey& currKey = m_keys[currKeyIdx];
+            // find a next valid key in timeline
+            int nextKeyNumber = -1;
+            ISelectKey nextKey;
+            for (int nextKeyIdx = currKeyIdx + 1; nextKeyIdx < numKeys; ++nextKeyIdx)
+            {
+                nextKey = m_keys[nextKeyIdx];
+                if (nextKey.IsValid())
+                {
+                    nextKeyNumber = nextKeyIdx;
+                    break;
+                }
+            }
+            if (nextKeyNumber > 0)
+            {
+                currKey.fDuration = nextKey.time - currKey.time;
+            }
+            else
+            {
+                currKey.fDuration = AZStd::max(timeRangeEnd - currKey.time, 0.0f);
+            }
+        }
+    }
+
+    int CSelectTrack::GetActiveKey(float time, ISelectKey* key)
+    {
+        if (key == nullptr)
+        {
+            return -1;
+        }
+
+        const int nkeys = static_cast<int>(m_keys.size());
+        if (nkeys == 0)
+        {
+            m_lastTime = time;
+            m_currKey = -1;
+            return m_currKey;
+        }
+        const int lastKeyIdx = nkeys - 1;
+
+        CheckValid();
+
+        m_lastTime = time;
+
+        if (m_keys[0].time > time)
+        {
+            m_currKey = -1;
+            return m_currKey; // Time is before first key.
+        }
+
+        if (m_currKey < 0)
+        {
+            m_currKey = 0;
+        }
+
+        // Start searching for a range between valid keys, containing given time, from the current key.
+        auto currSelectKey = m_keys[m_currKey];
+        if (currSelectKey.IsValid() && time >= currSelectKey.time)
+        {
+            for (int next = m_currKey + 1; next < nkeys; ++next)
+            {
+                auto nextSelectKey = m_keys[next];
+                if (nextSelectKey.IsValid() && time >= nextSelectKey.time)
+                {
+                    m_currKey = next;
+                    currSelectKey = nextSelectKey;
+                }
+                if ((next >= lastKeyIdx) || (nextSelectKey.IsValid() && (time <= nextSelectKey.time)))
+                {
+                    *key = currSelectKey;
+                    return m_currKey;
+                }
+            }
+        }
+
+        // If not found from the current middle || last key, restart searching from the beginning.
+        for (int idx = 0; idx < nkeys; ++idx)
+        {
+            auto& nextSelectKey = m_keys[idx];
+            if (nextSelectKey.IsValid() && (time >= nextSelectKey.time)) // skip invalid keys
+            {
+                m_currKey = idx;
+                *key = currSelectKey;
+                return m_currKey;
+            }
+        }
+
+        m_currKey = -1; // no valid keys in sequence
+        return m_currKey;
     }
 
     static bool SelectTrackVersionConverter(AZ::SerializeContext& serializeContext, AZ::SerializeContext::DataElementNode& rootElement)

--- a/Gems/Maestro/Code/Source/Cinematics/SelectTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/SelectTrack.h
@@ -24,7 +24,15 @@ namespace Maestro
 
         AnimValueType GetValueType() override;
 
-        void GetKeyInfo(int key, const char*& description, float& duration) override;
+        // TAnimTrack<ISelectKey> overrides
+        void GetKeyInfo(int index, const char*& description, float& duration) override;
+        void SetKey(int index, IKey* key) override; // Stores the key and fills fDuration.
+        int GetActiveKey(float time, ISelectKey* key) override; // Template specialization: skips invalid keys.
+
+        // For all keys, calculate a key duration for correct UI slider range, even for invalid keys,
+        // but ignoring next invalid keys time : these should not affect a previous valid key duration.
+        void CalculateDurationForEachKey();
+
         void SerializeKey(ISelectKey& key, XmlNodeRef& keyNode, bool bLoading) override;
 
         static void Reflect(AZ::ReflectContext* context);


### PR DESCRIPTION
## What does this PR do?
Closes https://github.com/o3de/o3de/issues/5361 - in the part related to Playing Game mode;
Closes https://github.com/o3de/o3de/issues/8486 - in the part related to Playing Game mode;

### Inrtroduction:
The legacy implementation of the Director -> Camera (switching) cut-scene track in `ISelectKey` / `ISelectTrack` / `CAnimSceneNode` classes has the following major problems:
* The `ApplyCameraKey()` code implements only editor viewport camera switching, but in Game mode camera switching is unsupported;
* This code does not evaluate **invalid** `ISelectKey`{s}, which were added by user but not initialized with correct camera controller `EntityId` and `Entity` name;
* As legacy implementation for the additional animation camera has been removed, this code still changes existing camera properties (FoV, near clipping distance, transform),
and in order to restore these, uses several incomplete / ambiguous legacy structures, maps and storing counters, which makes code rather complex and hardly readable;
* In this code, the `ISelectKey:fDuration`, needed for virtualization compatibility and correct display of` ISelectKey:fBlendTime` sliders in UI, - cannot be changed by user, and is never calculated, and thus is always zero.
Thus duration / blending bars in UI for Camera track bar are painted erratically, and sliders for fBlenTime have {0,1} range by default.
* Changing keys (adding, deleting, changing time) does not change in-memory DOM template, and thus are not saved to prefabs or applied in Play Game mode after such recent changes.

### Changes:
* The `struct ISelectKey` updated to store initial camera properties, and provide methods for checking validness of camera `EntityId` + `Name` and stored camera properties;

* The `class CSelectTrack` updated to correctly evaluate invalid keys plus recalculate fDuration data member in keys;

* The legacy (obsolete / incomplete / unused) `struct SCameraParams` and several legacy unneeded data members renoved from `Movie` interfaces and code;

* The UI code for for `CSelectTrack` updated: 
* * The `CSelectKeyUIControls::OnKeySelectionChange()`:  ambiguous code handling fDuration + cleanup of camera name when unassigned changed;
* * The `CTrackViewDialog` updated:  needed code updating buttons states added;
* * The `CTrackViewDopeSheetBase` upddated to correctly draw bars for `CSelectTrack`, draw invalid keys in **red**; plus some  comparisons of float values corrected;

* The `CTrackViewTrack` methods updated: missing `Undo-Batch`es for `CreateKey()`, `SlideKeys()` and `RemoveKey()` added, so that in-memory prefab DOM template is updated with these `TrackViewDialog` changes, and thus changes are applied when switching to Play Game and Save level / prefab modes..
The `SetKey()` methods do usually have `Undo-Batch`es in corresponding UI controls.

* The `ISceneCamera` helper interface and implementation `class CComponentEntitySceneCamera` refactored :
* * Obsolete `Quat` and `Vec3` classes substituted with `AZ::Quaternion` and` AZ::Vector3`;
* * Ambiguous conversions `Degrees <-> Radians` removed;
* * Needed checks for the valid camera `EntityId` and `FoV` and `nearZ` values added;
* * Transform setters now also check for actual changes before requesting component changes.
* * Unneeded methods removed;

* The `class CAnimSceneNode` refactored:

* * Valid `ISelectKey`{s} are initialized with initial camera properties at activation, and restore camera properties at deactivate and reset events.

* * Invalid `ISelectKey`{s} are skipped while animating;

* * The `ApplyCameraKey()` refactored to support emulation of camera switching in Game mode and correct interpolation;
* * * In game mode, cameras are not switched, instead the level active camera receives interpolated properties;
* * * Interpolation algorithm simplified and optimized, so that special method for interpolation is not needed now;
* * * Interpolation is made between camera properties stored in a pair of valid keys, while legacy code requested camera properties at each time step, and then tried to restore camera properties (in fact frequently tampering camera states);
* * * Thus several legacy data members storing indices of keys and camera properties, as well as corresponding code are removed;

* * The legacy mechanism for overriding camera by `ICVar`, now unused, further implemented ;

## How was this PR tested?
Under Windows Editor, a test scene was created, with 4 cameras (one was the default "Camera") and a Track View sequence, which was animating camera switches via Director track.
The sequence was played and scrubbed, new sequence was added / destroyed, etc.
Needed functionality observed both when editing keys and animating in Editor mode, and whern playing Game in editor.

### Note:
Cameras are switched when "Autostart" property (flag `IAnimSequence::eSeqFlags_PlayOnReset`) is **set** in the sequence.
Changing camera keys and camera states is to be made with the above property / flag **cleared**, so that partially animated / interpolated track does not interfere with user edits.

https://github.com/user-attachments/assets/036b1c5b-c87f-4ff2-bb4c-d0b83169719f


https://github.com/user-attachments/assets/2ffaf617-04a6-44fd-875f-d198e89ca5d0


