### PR TITLE
Fix compiling in Visual Studio 2019

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -503,6 +503,7 @@ namespace AZ
                 // the callback is executed
                 request.m_completeCallback = [=, thisPtr = RHI::Ptr<StreamingImage>(this)]()
                 {
+                    AZ_UNUSED(thisPtr);
 #ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG
                     AZ_TracePrintf("StreamingImage", "Upload mipchain done [%s]\n", mipChainAsset.GetHint().c_str());
 #endif


### PR DESCRIPTION
## What does this PR do?

/We5233 is enabled in `Configurations_msvc.cmake`, somehow this one is not caught by the CI which is using `MSVC 19.36.32532.0`, but it would be caught compiling in visual studio 2019.

This PR fixes it.

## How was this PR tested?

Running in Windows
