### PR TITLE
Revert "Assimp importer use DCC (Y-Up) coordinate system by default. …

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -167,7 +167,7 @@ namespace AZ
 
         AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> AssImpSceneWrapper::GetUpVectorAndSign() const
         {
-            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Y, 1);
+            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Z, 1);
             int32_t upVectorRead(static_cast<int32_t>(result.first));
             m_assImpScene->mMetaData->Get("UpAxis", upVectorRead);
             m_assImpScene->mMetaData->Get("UpAxisSign", result.second);
@@ -177,7 +177,7 @@ namespace AZ
 
         AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> AssImpSceneWrapper::GetFrontVectorAndSign() const
         {
-            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Z, -1);
+            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::Y, 1);
             int32_t frontVectorRead(static_cast<int32_t>(result.first));
             m_assImpScene->mMetaData->Get("FrontAxis", frontVectorRead);
             m_assImpScene->mMetaData->Get("FrontAxisSign", result.second);

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -67,7 +67,8 @@ namespace AZ
 
             AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> frontAxisAndSign = assImpScene->GetFrontVectorAndSign();
 
-            if (upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Z)
+            if (upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Z &&
+                upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Unknown)
             {
                 AZ::Matrix4x4 currentCoordMatrix = AZ::Matrix4x4::CreateIdentity();
                 //(UpVector = +Z, FrontVector = +Y, CoordSystem = -X(RightHanded))


### PR DESCRIPTION
…(#18627)"

Upon further investigation, this behavior shall be reverted for the following reasons:

* Assimp internally applies transform to scene root that converts the coordinate system automatically to Y-up even if the original models are specified a different one.

* This change breaks the models and prefabs in the existing projects where transforms are manually applied to the assets to accommodate o3de's behavior.

This reverts commit 8fff90124e4c64fec58062b7af292594a8deaecb.

## What does this PR do?

Revert to the old assimp behavior

## How was this PR tested?

N/A
