### PR TITLE
[WIP] Add a setting registry that allows AssImp to change behavior when importing coordinates

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
 #include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
@@ -28,6 +29,12 @@ namespace AZ
 
         void SceneSystem::Set(const SDKScene::SceneWrapperBase* scene)
         {
+            static constexpr const char* s_UseNewAssimpBehaviorKey = "/O3DE/Preferences/SceneAPI/AssImpReadRootTransform";
+            bool useNewAssimpBehavior{ false };
+            if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get())
+            {
+                settingsRegistry->Get(useNewAssimpBehavior, s_UseNewAssimpBehaviorKey);
+            }
             // Get unit conversion factor to meter.
             if (!azrtti_istypeof<AssImpSDKWrapper::AssImpSceneWrapper>(scene))
             {
@@ -35,7 +42,7 @@ namespace AZ
             }
 
             const AssImpSDKWrapper::AssImpSceneWrapper* assImpScene = azrtti_cast<const AssImpSDKWrapper::AssImpSceneWrapper*>(scene);
-
+            DataTypes::MatrixType rootTransform = AssImpSDKWrapper::AssImpTypeConverter::ToTransform(assImpScene->GetAssImpScene()->mRootNode->mTransformation);
             /* Check if metadata has information about "UnitScaleFactor" or "OriginalUnitScaleFactor". 
              * This particular metadata is FBX format only. */
             if (assImpScene->GetAssImpScene()->mMetaData->HasKey("UnitScaleFactor") ||
@@ -52,9 +59,21 @@ namespace AZ
             else
             {
                 // Some file formats (like DAE) embed the scale in the root transformation, so extract that scale from here.
-                auto rootTransform = 
-                    AssImpSDKWrapper::AssImpTypeConverter::ToTransform(assImpScene->GetAssImpScene()->mRootNode->mTransformation);
                 m_unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
+                rootTransform /= m_unitSizeInMeters;
+            }
+
+            if (useNewAssimpBehavior)
+            {
+                // AssImp SDK internally uses a Y-up coordinate system, so we need to adjust the coordinate system to match the O3DE coordinate system (Z-up).
+                AZ::Matrix3x4 adjustmatrix = AZ::Matrix3x4::CreateFromRows(
+                    AZ::Vector4(1, 0, 0, 0),
+                    AZ::Vector4(0, 0, -1, 0),
+                    AZ::Vector4(0, 1, 0, 0)
+                );
+                m_adjustTransform.reset(new DataTypes::MatrixType(adjustmatrix * rootTransform));
+                m_adjustTransformInverse.reset(new DataTypes::MatrixType(m_adjustTransform->GetInverseFull()));
+                return;
             }
 
             AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> upAxisAndSign = assImpScene->GetUpVectorAndSign();

--- a/Templates/DefaultProject/Template/Registry/assimp_settings.setreg
+++ b/Templates/DefaultProject/Template/Registry/assimp_settings.setreg
@@ -1,0 +1,9 @@
+{
+    "O3DE": {
+        "Preferences": {
+            "SceneAPI": {
+                "AssImpReadRootTransform": true
+            }
+        }
+    }
+}

--- a/Templates/DefaultProject/template.json
+++ b/Templates/DefaultProject/template.json
@@ -191,6 +191,10 @@
             "isTemplated": true
         },
         {
+            "file": "Registry/assimp_settings.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Registry/load_level.setreg",
             "isTemplated": false
         },

--- a/Templates/MinimalProject/Template/Registry/assimp_settings.setreg
+++ b/Templates/MinimalProject/Template/Registry/assimp_settings.setreg
@@ -1,0 +1,9 @@
+{
+    "O3DE": {
+        "Preferences": {
+            "SceneAPI": {
+                "AssImpReadRootTransform": true
+            }
+        }
+    }
+}

--- a/Templates/MinimalProject/template.json
+++ b/Templates/MinimalProject/template.json
@@ -191,6 +191,10 @@
             "isTemplated": true
         },
         {
+            "file": "Registry/assimp_settings.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Resources/Splash.bmp",
             "isTemplated": false
         },

--- a/Templates/ScriptOnlyProject/Template/Registry/assimp_settings.setreg
+++ b/Templates/ScriptOnlyProject/Template/Registry/assimp_settings.setreg
@@ -1,0 +1,9 @@
+{
+    "O3DE": {
+        "Preferences": {
+            "SceneAPI": {
+                "AssImpReadRootTransform": true
+            }
+        }
+    }
+}

--- a/Templates/ScriptOnlyProject/template.json
+++ b/Templates/ScriptOnlyProject/template.json
@@ -87,6 +87,10 @@
             "isTemplated": true
         },
         {
+            "file": "Registry/assimp_settings.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Resources/GameSDK.ico",
             "isTemplated": false
         },


### PR DESCRIPTION
## What does this PR do?

The new behavior shall assume AssImp's transform is always Y-up. The new behavior can be enabled by setting registry /O3DE/Preferences/SceneAPI/AssImpReadRootTransform, which is disabled by default.

## How was this PR tested?

Not yet tested
