### PR TITLE
Fixes #18687

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -58,6 +58,15 @@ namespace AZ
             //! @returns Map of material assigned data including materials, property overrides, and other parameters.
             virtual const MaterialAssignmentMap& GetMaterialMap() const = 0;
 
+            //! Similar as above, but returns a deep copy of all materials.
+            //! This "Copy" function is useful for Lua because GetMaterialMap()
+            //! returns a reference and Lua treats it a as a reference too.
+            //! Making further chages to the material component, for example by calling SetMaterialAssetId()
+            //! would indirectly affect the MaterialAssignmentMap that was returned by reference.
+            //! To avoid this scenario, a Lua script can call this function to get an actual copy that remains
+            //! unaffected by calling functions like SetMaterialAssetId().
+            virtual MaterialAssignmentMap GetMaterialMapCopy() const = 0;
+
             //! Clears all overridden materials and properties from the material component.
             virtual void ClearMaterialMap() = 0;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -131,7 +131,6 @@ namespace AZ
 
         void MaterialComponentController::Deactivate()
         {
-            AZ::Data::AssetBus::MultiHandler::BusDisconnect();
             MaterialComponentRequestBus::Handler::BusDisconnect();
             MaterialConsumerNotificationBus::Handler::BusDisconnect();
 
@@ -568,13 +567,6 @@ namespace AZ
                     materialIt->second.m_propertyOverrides.empty() &&
                     materialIt->second.m_matModUvOverrides.empty())
                 {
-                    // TODO: Although this works, we need to make sure that the previous material AssetId
-                    // is not being used in other slots before Disconnecting from the AssetBus.
-                    //const auto& prevAssetId = materialIt->second.m_materialAsset.GetId();
-                    //if (prevAssetId.IsValid())
-                    //{
-                    //    AZ::Data::AssetBus::MultiHandler::BusDisconnect(prevAssetId);
-                    //}
                     m_configuration.m_materials.erase(materialAssignmentId);
                     QueueMaterialsUpdatedNotification();
                     return;
@@ -583,13 +575,6 @@ namespace AZ
                 // If the asset ID is different than what's already assigned then replace it
                 if (materialIt->second.m_materialAsset.GetId() != materialAssetId)
                 {
-                    // TODO: Although this works, we need to make sure that the previous material AssetId
-                    // is not being used in other slots before Disconnecting from the AssetBus.
-                    //const auto& prevAssetId = materialIt->second.m_materialAsset.GetId();
-                    //if (prevAssetId.IsValid())
-                    //{
-                    //    AZ::Data::AssetBus::MultiHandler::BusDisconnect(prevAssetId);
-                    //}
                     materialIt->second.m_materialAsset =
                         AZ::Data::Asset<AZ::RPI::MaterialAsset>(materialAssetId, AZ::AzTypeInfo<AZ::RPI::MaterialAsset>::Uuid());
                     QueueLoadMaterials();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -53,6 +53,7 @@ namespace AZ
             AZStd::string GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const override;
             void SetMaterialMap(const MaterialAssignmentMap& materials) override;
             const MaterialAssignmentMap& GetMaterialMap() const override;
+            MaterialAssignmentMap GetMaterialMapCopy() const override;
             void ClearMaterialMap() override;
             void ClearMaterialsOnModelSlots() override;
             void ClearMaterialsOnLodSlots() override;


### PR DESCRIPTION
## What does this PR do?
Fixes #18687 

`MaterialComponentController::OnSystemTick()` was missing the
additional check that `m_notifiedMaterialAssets` must be empty in order to call
`SystemTickBus::BusDisconnect()`.

Also added `GetMaterialMapCopy()` function to `MaterialComponentRequestBus`
so Lua scripts can actually make a copy of the current MaterialMap.

## How was this PR tested?

Validated on Win11 with Lua script that follows the steps as reported by Reverb. The Lua Script is available as an attachment in GHI #18687 .
