### PR TITLE
ImGuiGpuProfiler: Ignore idle pipelines

### DIFF
--- a/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
+++ b/Gems/Atom/Utils/Code/Source/ImGuiGpuProfiler.cpp
@@ -2242,6 +2242,12 @@ namespace AZ
             // NOTE: Write it all out, can't have recursive functions for lambdas.
             const AZStd::function<void(const RPI::Pass*, PassEntry*)> getPassEntryRecursive = [&addPassEntry, &getPassEntryRecursive](const RPI::Pass* pass, PassEntry* parent) -> void
             {
+                if (pass->GetRenderPipeline() && pass->GetRenderPipeline()->GetRenderMode() == RPI::RenderPipeline::RenderMode::NoRender)
+                {
+                    // Ignore passes from render pipelines that are currently not rendering
+                    // E.g. the Preview pipeline
+                    return;
+                }
                 // Add new entry to the timestamp map.
                 if (pass->IsEnabled())
                 {


### PR DESCRIPTION
## What does this PR do?

The ImGui GPU profiler currently collects passes from all pipelines, even ones that are not active.
E.g. when the Preview Pipeline runs for one frame the pass timings are written, but then never updated again.
This leads to passes from past renderings still showing up in the Profiler:

https://github.com/user-attachments/assets/d41bb210-32ac-4483-a397-a085c49e306f

This commit adds a check while collecting the passes and ignores passes from render pipelines that are don't render this frame.

## How was this PR tested?

Tested on Windows
