### PR TITLE
TerrainSystemComponent: Add RPISytem as a dependency

### DIFF
--- a/Gems/Terrain/Code/Mocks/Terrain/MockTerrainRPISystemComponent.h
+++ b/Gems/Terrain/Code/Mocks/Terrain/MockTerrainRPISystemComponent.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RPI.Public/RPISystem.h>
+#include <AzCore/Component/Component.h>
+
+namespace UnitTest
+{
+    class MockTerrainRPISystemComponent : public AZ::Component
+    {
+    public:
+        AZ_COMPONENT(MockTerrainRPISystemComponent, "{1e42c9a8-a264-4b4f-aaa5-cc66558cce7f}");
+
+        static void Reflect([[maybe_unused]] AZ::ReflectContext* context)
+        {
+        }
+
+        void Activate() override
+        {
+            AZ::RPI::RPISystemDescriptor rpiSystemDescriptor;
+            m_rpiSystem = AZStd::make_unique<AZ::RPI::RPISystem>();
+            m_rpiSystem->Initialize(rpiSystemDescriptor);
+
+            AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
+            m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
+            m_imageSystem->Init(imageSystemDescriptor);
+        }
+
+        void Deactivate() override
+        {
+            m_imageSystem->Shutdown();
+            m_imageSystem = nullptr;
+            m_rpiSystem->Shutdown();
+            m_rpiSystem = nullptr;
+        }
+
+    private:
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& services)
+        {
+            services.push_back(AZ_CRC_CE("RPISystem"));
+        }
+
+        AZStd::unique_ptr<AZ::RPI::RPISystem> m_rpiSystem;
+        AZStd::unique_ptr<AZ::RPI::ImageSystem> m_imageSystem;
+    };
+
+} // namespace UnitTest

--- a/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainSystemComponent.cpp
@@ -49,6 +49,7 @@ namespace Terrain
 
     void TerrainSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
+        required.push_back(AZ_CRC_CE("RPISystem"));
     }
 
     void TerrainSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)

--- a/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainTestFixtures.cpp
@@ -11,7 +11,6 @@
 
 #include <Atom/RPI.Reflect/Image/ImageMipChainAsset.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAssetHandler.h>
-#include <Atom/RPI.Public/RPISystem.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Scene/SceneSystemComponent.h>
 #include <GradientSignal/Components/GradientSurfaceDataComponent.h>
@@ -38,6 +37,7 @@
 
 #include <MockAxisAlignedBoxShapeComponent.h>
 #include <Terrain/MockTerrainLayerSpawner.h>
+#include <Terrain/MockTerrainRPISystemComponent.h>
 
 extern "C" void CleanUpRpiPublicGenericClassInfo();
 
@@ -65,6 +65,7 @@ namespace UnitTest
 
             UnitTest::MockAxisAlignedBoxShapeComponent::CreateDescriptor(),
             UnitTest::MockTerrainLayerSpawnerComponent::CreateDescriptor(),
+            UnitTest::MockTerrainRPISystemComponent::CreateDescriptor(),
         });
     }
 
@@ -412,18 +413,10 @@ namespace UnitTest
         m_systemEntity = CreateEntity();
         m_systemEntity->CreateComponent<AzFramework::SceneSystemComponent>();
         m_systemEntity->CreateComponent<Terrain::TerrainSystemComponent>();
+        m_systemEntity->CreateComponent<MockTerrainRPISystemComponent>();
 
         // Create a stub RHI for use by Atom
         m_rhiFactory.reset(aznew UnitTest::StubRHI::Factory());
-
-        // Create the Atom RPISystem
-        AZ::RPI::RPISystemDescriptor rpiSystemDescriptor;
-        m_rpiSystem = AZStd::make_unique<AZ::RPI::RPISystem>();
-        m_rpiSystem->Initialize(rpiSystemDescriptor);
-
-        AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
-        m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
-        m_imageSystem->Init(imageSystemDescriptor);
 
         // Now that the RPISystem is activated, activate the system entity.
         m_systemEntity->Init();
@@ -432,9 +425,6 @@ namespace UnitTest
 
     void TerrainSystemTestFixture::TearDown()
     {
-        m_imageSystem->Shutdown();
-        m_rpiSystem->Shutdown();
-        m_rpiSystem = nullptr;
         m_rhiFactory = nullptr;
 
         m_systemEntity.reset();

--- a/Gems/Terrain/Code/Tests/TerrainTestFixtures.h
+++ b/Gems/Terrain/Code/Tests/TerrainTestFixtures.h
@@ -11,7 +11,6 @@
 #include <TerrainSystem/TerrainSystem.h>
 #include <Components/TerrainSurfaceGradientListComponent.h>
 
-#include <Atom/RPI.Public/RPISystem.h>
 #include <Atom/RPI.Public/Image/ImageSystem.h>
 #include <Common/RHI/Factory.h>
 #include <Common/RHI/Stubs.h>
@@ -135,8 +134,6 @@ namespace UnitTest
 
     private:
         AZStd::unique_ptr<UnitTest::StubRHI::Factory> m_rhiFactory;
-        AZStd::unique_ptr<AZ::RPI::RPISystem> m_rpiSystem;
-        AZStd::unique_ptr<AZ::RPI::ImageSystem> m_imageSystem;
 
         UnitTest::SetRestoreFileIOBaseRAII m_restoreFileIO;
         ::testing::NiceMock<AZ::IO::MockFileIOBase> m_fileIOMock;

--- a/Gems/Terrain/Code/terrain_mocks_files.cmake
+++ b/Gems/Terrain/Code/terrain_mocks_files.cmake
@@ -7,8 +7,9 @@
 #
 
 set(FILES
-    Mocks/Terrain/MockTerrainLayerSpawner.h
-    Mocks/Terrain/MockTerrainAreaSurfaceRequestBus.h
-    Mocks/Terrain/MockTerrainMacroMaterialBus.h
     Mocks/Terrain/MockTerrain.h
+    Mocks/Terrain/MockTerrainAreaSurfaceRequestBus.h
+    Mocks/Terrain/MockTerrainLayerSpawner.h
+    Mocks/Terrain/MockTerrainMacroMaterialBus.h
+    Mocks/Terrain/MockTerrainRPISystemComponent.h
 )


### PR DESCRIPTION
## What does this PR do?

The TerrainSystemComponent uses the `PassSystemInterface` in its Activate function, but does not depend on the RPISystem.
This PR adds this needed dependency.

## How was this PR tested?

Tested on windows with the startergame-assets project
