### PR TITLE
Fixes #18687 (#18688)

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -53,6 +53,15 @@ namespace AZ
             //! @returns Map of material assigned data including materials, property overrides, and other parameters.
             virtual const MaterialAssignmentMap& GetMaterialMap() const = 0;
 
+            //! Similar as above, but returns a deep copy of all materials.
+            //! This "Copy" function is useful for Lua because GetMaterialMap()
+            //! returns a reference and Lua treats it a as a reference too.
+            //! Making further chages to the material component, for example by calling SetMaterialAssetId()
+            //! would indirectly affect the MaterialAssignmentMap that was returned by reference.
+            //! To avoid this scenario, a Lua script can call this function to get an actual copy that remains
+            //! unaffected by calling functions like SetMaterialAssetId().
+            virtual MaterialAssignmentMap GetMaterialMapCopy() const = 0;
+
             //! Clears all overridden materials and properties from the material component.
             virtual void ClearMaterialMap() = 0;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -44,6 +44,7 @@ namespace AZ
                     ->Event("GetMaterialLabel", &MaterialComponentRequestBus::Events::GetMaterialLabel, "GetMaterialSlotLabel")
                     ->Event("SetMaterialMap", &MaterialComponentRequestBus::Events::SetMaterialMap, "SetMaterialOverrides")
                     ->Event("GetMaterialMap", &MaterialComponentRequestBus::Events::GetMaterialMap, "GetMaterialOverrides")
+                    ->Event("GetMaterialMapCopy", &MaterialComponentRequestBus::Events::GetMaterialMapCopy)
                     ->Event("ClearMaterialMap", &MaterialComponentRequestBus::Events::ClearMaterialMap, "ClearAllMaterialOverrides")
                     ->Event("SetMaterialAssetIdOnDefaultSlot", &MaterialComponentRequestBus::Events::SetMaterialAssetIdOnDefaultSlot, "SetDefaultMaterialOverride")
                     ->Event("GetMaterialAssetIdOnDefaultSlot", &MaterialComponentRequestBus::Events::GetMaterialAssetIdOnDefaultSlot, "GetDefaultMaterialOverride")
@@ -237,7 +238,8 @@ namespace AZ
             if (!m_queuedLoadMaterials &&
                 !m_queuedMaterialsCreatedNotification &&
                 !m_queuedMaterialsUpdatedNotification &&
-                m_materialsWithDirtyProperties.empty())
+                m_materialsWithDirtyProperties.empty() &&
+                m_notifiedMaterialAssets.empty())
             {
                 SystemTickBus::Handler::BusDisconnect();
             }
@@ -409,6 +411,11 @@ namespace AZ
         }
 
         const MaterialAssignmentMap& MaterialComponentController::GetMaterialMap() const
+        {
+            return m_configuration.m_materials;
+        }
+
+        MaterialAssignmentMap MaterialComponentController::GetMaterialMapCopy() const
         {
             return m_configuration.m_materials;
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -52,6 +52,7 @@ namespace AZ
             AZStd::string GetMaterialLabel(const MaterialAssignmentId& materialAssignmentId) const override;
             void SetMaterialMap(const MaterialAssignmentMap& materials) override;
             const MaterialAssignmentMap& GetMaterialMap() const override;
+            MaterialAssignmentMap GetMaterialMapCopy() const override;
             void ClearMaterialMap() override;
             void ClearMaterialsOnModelSlots() override;
             void ClearMaterialsOnLodSlots() override;


### PR DESCRIPTION
## What does this PR do?

Cherry-pick #18688 

* Fixes #18687

Inside MaterialComponentController::OnSystemTick was missing the additional check that `m_notifiedMaterialAssets` must be empty in order to call `SystemTickBus::BusDisconnect()`.

Also added `GetMaterialMapCopy()` function to `MaterialComponentRequestBus` so Lua scripts can actually make a copy of the current MaterialMap.

## How was this PR tested?

Validated on Windows with Lua Script attached to #18687 
