### PR TITLE
Clear build results before each compilation

### DIFF
--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderDataSystem.cpp
@@ -97,6 +97,8 @@ namespace ScriptCanvasBuilder
     {
         using namespace ScriptCanvasBuilder;
 
+        m_buildResultsByHandle.clear();
+
         BuilderSourceStorage result;
 
         AZ::ApplicationTypeQuery appType;


### PR DESCRIPTION
## What does this PR do?

When a Script Canvas graph is processed by AP, the `DataSystem` class stores the results of processing a source file for both editor-configurable properties and for runtime ready assets for faster retrieval when many are being simultaneously processed.
The map that stores the processed data `m_buildResultsByHandle` was not being cleared between uses of this system which was leaving it with invalid (e.g. deleted) variable data.

This change ensures that the `m_buildResultsByHandle` map is cleared before each compilation so that no stale data is present when compiling the graph.

Closes #16010