### PR TITLE
Fixes Material Previews are not showing actual material

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/PreviewRenderer/PreviewContent.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/PreviewRenderer/PreviewContent.h
@@ -36,5 +36,9 @@ namespace AtomToolsFramework
 
         //! Prepare or pose content before rendering
         virtual void Update() = 0;
+
+        //! Returns true when it is guaranteed that the content is in GPU memory
+        //! and ready to render.
+        virtual bool IsReadyToRender() = 0;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -209,11 +209,17 @@ namespace AtomToolsFramework
         m_currentCaptureRequest.m_content->Update();
     }
 
+    bool PreviewRenderer::IsContentReadyToRender()
+    {
+        return m_currentCaptureRequest.m_content->IsReadyToRender();
+    }
+
     AZ::Render::FrameCaptureId PreviewRenderer::StartCapture()
     {
         auto captureCompleteCallback = m_currentCaptureRequest.m_captureCompleteCallback;
         auto captureFailedCallback = m_currentCaptureRequest.m_captureFailedCallback;
-        auto captureCallback = [captureCompleteCallback, captureFailedCallback](const AZ::RPI::AttachmentReadback::ReadbackResult& result)
+        auto captureCallback =
+            [captureCompleteCallback, captureFailedCallback](const AZ::RPI::AttachmentReadback::ReadbackResult& result)
         {
             if (result.m_dataBuffer)
             {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.h
@@ -50,6 +50,7 @@ namespace AtomToolsFramework
 
         void PoseContent();
 
+        bool IsContentReadyToRender();
         AZ::Render::FrameCaptureId StartCapture();
         void EndCapture();
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.cpp
@@ -39,7 +39,7 @@ namespace AtomToolsFramework
             return;
         }
 
-        if (AZStd::chrono::steady_clock::now() > m_captureTime)
+        if (m_renderer->IsContentReadyToRender())
         {
             if (!AZ::Render::FrameCaptureNotificationBus::Handler::BusIsConnected())
             {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRendererCaptureState.h
@@ -29,7 +29,6 @@ namespace AtomToolsFramework
 
         //! Track the amount of time since the capture request was initiated
         AZStd::chrono::steady_clock::time_point m_startTime = AZStd::chrono::steady_clock::now();
-        AZStd::chrono::steady_clock::time_point m_captureTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(5);
         AZStd::chrono::steady_clock::time_point m_abortTime = AZStd::chrono::steady_clock::now() + AZStd::chrono::milliseconds(5000);
         bool m_captureComplete = false;
     };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewContent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewContent.h
@@ -13,6 +13,7 @@
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialAssignment.h>
+#include <AtomLyIntegration/CommonFeatures/Mesh/MeshHandleStateBus.h>
 #include <AtomToolsFramework/PreviewRenderer/PreviewContent.h>
 
 namespace AZ
@@ -20,7 +21,7 @@ namespace AZ
     namespace LyIntegration
     {
         //! Creates a simple scene used for most previews and thumbnails
-        class SharedPreviewContent final : public AtomToolsFramework::PreviewContent
+        class SharedPreviewContent final : public AtomToolsFramework::PreviewContent, public AZ::Render::MeshHandleStateNotificationBus::Handler
         {
         public:
             AZ_CLASS_ALLOCATOR(SharedPreviewContent, AZ::SystemAllocator);
@@ -41,11 +42,22 @@ namespace AZ
             bool IsError() const override;
             void ReportErrors() override;
             void Update() override;
+            bool IsReadyToRender() override;
 
         private:
             void UpdateModel();
             void UpdateLighting();
             void UpdateCamera();
+
+            ///////////////////////////////////////////////////////////////
+            //AZ::Render::MeshHandleStateNotificationBus::Handler overrides
+            void OnMeshHandleSet(const AZ::Render::MeshFeatureProcessorInterface::MeshHandle* meshHandle) override;
+            ///////////////////////////////////////////////////////////////
+
+            // Called by @m_meshUpdatedHandler
+            void OnMeshDrawPacketUpdated(
+                const AZ::Render::ModelDataInstanceInterface& meshHandleIface,
+                uint32_t lodIndex, uint32_t meshIndex, const AZ::RPI::MeshDrawPacket& meshDrawPacket);
 
             static constexpr float AspectRatio = 1.0f;
             static constexpr float NearDist = 0.001f;
@@ -62,6 +74,13 @@ namespace AZ
             Data::Asset<RPI::MaterialAsset> m_materialAsset;
             Data::Asset<RPI::AnyAsset> m_lightingPresetAsset;
             Render::MaterialPropertyOverrideMap m_materialPropertyOverrides;
+
+            // We need @m_meshHandle to be able to register for MeshDrawPacketUpdatedEvent(s).
+            // These events are the signals we need to have assurance that the scene is fully available
+            // on GPU and we are ready to render and generate the Thumbnail.
+            const AZ::Render::MeshFeatureProcessorInterface::MeshHandle* m_meshHandle = nullptr;
+            AZ::Render::ModelDataInstanceInterface::MeshDrawPacketUpdatedEvent::Handler m_meshUpdatedHandler;
+            uint32_t m_meshDrawPacketUpdateCount = 0;
         };
     } // namespace LyIntegration
 } // namespace AZ


### PR DESCRIPTION
## What does this PR do?

Fixes #18646

It was found that the PreviewRenderer was not allowing itself enough time for the scene to be loaded in GPU and ready to render.

Instead of simply increasing the wait time, this fix uses a more reliable signal from the MeshFeatureProcessor that notifies us when the MeshDrawPacket has been updated in GPU memory and ready to render:
AZ::Render::ModelDataInstanceInterface::MeshDrawPacketUpdatedEvent

## How was this PR tested?

Validated on PC (Debug & Profile builds) with a large scene from KitBash3D. See attached video:
<video src="https://github.com/user-attachments/assets/c4b76ee2-bdb4-4c00-aed4-c2a4bc63cd55" controls></video>

![image](https://github.com/user-attachments/assets/71fbb7ca-2071-4ee8-89bc-ef7a60e2db4c)

