### PR TITLE
Updated C++ ColorSpaceId to match the Shader.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/TransformColor.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/TransformColor.azsli
@@ -19,6 +19,7 @@
 #include "GeneratedTransforms/CalculateLuminance_LinearSrgb.azsli"
 #include "GeneratedTransforms/CalculateLuminance_AcesCg.azsli"
 
+// !! THIS ENUM MUST MATCH THE ONE IN: TransformColor.h !!
 // Removing enum class so that variables can be created using this type without causing compile errors.
 enum ColorSpaceId
 {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ColorManagement/TransformColor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ColorManagement/TransformColor.h
@@ -15,15 +15,16 @@ namespace AZ
 {
     namespace RPI
     {
+        // !! THIS ENUM MUST MATCH THE ONE IN: TransformColor.azsli !!
         enum class ColorSpaceId
         {
             SRGB = 0,
             LinearSRGB,
+            ACEScc,
             ACEScg,
             ACES2065,
             XYZ,
-
-            ColorSpaceIdCount
+            Invalid
         };
 
         ATOM_RPI_PUBLIC_API Color TransformColor(Color color, ColorSpaceId fromColorSpace, ColorSpaceId toColorSpace);


### PR DESCRIPTION
The ColorSpaceId enum in TransformColor.h was missing the ACEScc field.
Removed the ColorSpaceIdCount because it was never used, and wasn't present in the .azsli enum.
This fixed the bloom example in AtomSampleViewer, resolving:
https://github.com/o3de/o3de-atom-sampleviewer/issues/391