### PR TITLE
Script Canvas: Fixed issue with promoting variables from a node's slot

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -2428,7 +2428,7 @@ namespace ScriptCanvasEditor
 
         AZ::Outcome<ScriptCanvas::VariableId, AZStd::string> addOutcome;
 
-        ScriptCanvas::GraphVariableManagerRequestBus::EventResult(addOutcome, GetScriptCanvasId(), &ScriptCanvas::GraphVariableManagerRequests::AddVariable, variableName, variableDatum, true);
+        ScriptCanvas::GraphVariableManagerRequestBus::EventResult(addOutcome, GetScriptCanvasId(), &ScriptCanvas::GraphVariableManagerRequests::AddVariable, variableName, variableDatum, false);
 
         if (addOutcome.IsSuccess())
         {

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -2371,7 +2371,11 @@ namespace ScriptCanvasEditor
             ScriptCanvas::GraphVariableManagerRequestBus::EventResult(hasValidDefault, GetScriptCanvasId(), &ScriptCanvas::GraphVariableManagerRequests::IsNameValid, defaultName);
         } while (!hasValidDefault);
 
-        bool nameAvailable = false;
+        bool nameAvailable = hasValidDefault.IsSuccess();
+        if (nameAvailable)
+        {
+            variableName = defaultName;
+        }
 
         QWidget* mainWindow = nullptr;
         UIRequestBus::BroadcastResult(mainWindow, &UIRequests::GetMainWindow);

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -2428,7 +2428,8 @@ namespace ScriptCanvasEditor
 
         AZ::Outcome<ScriptCanvas::VariableId, AZStd::string> addOutcome;
 
-        ScriptCanvas::GraphVariableManagerRequestBus::EventResult(addOutcome, GetScriptCanvasId(), &ScriptCanvas::GraphVariableManagerRequests::AddVariable, variableName, variableDatum, false);
+        constexpr bool functionScope = false; // Promoted variables are used as references, thus they need to be a member variable
+        ScriptCanvas::GraphVariableManagerRequestBus::EventResult(addOutcome, GetScriptCanvasId(), &ScriptCanvas::GraphVariableManagerRequests::AddVariable, variableName, variableDatum, functionScope);
 
         if (addOutcome.IsSuccess())
         {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -627,8 +627,8 @@ namespace ScriptCanvasEditor
 
             if (graphVariable->GetScope() != ScriptCanvas::VariableFlags::Scope::FunctionReadOnly)
             {
-            itemFlags |= Qt::ItemIsEditable;
-        }
+                itemFlags |= Qt::ItemIsEditable;
+            }
 
         }
         else if (index.column() == ColumnIndex::InitialValueSource)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -231,10 +231,7 @@ namespace ScriptCanvas
             AZStd::set<const GraphVariable*, GraphVariable::Comparator> sortedVariables;
             for (const auto& variablePair : sourceVariables)
             {
-                if (variablePair.second.GetScope() != VariableFlags::Scope::FunctionReadOnly)
-                {
-                    sortedVariables.insert(&variablePair.second);
-                }
+                sortedVariables.insert(&variablePair.second);
 
                 if (auto datum = variablePair.second.GetDatum())
                 {
@@ -5561,3 +5558,4 @@ namespace ScriptCanvas
         }
     }
 }
+

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -231,7 +231,10 @@ namespace ScriptCanvas
             AZStd::set<const GraphVariable*, GraphVariable::Comparator> sortedVariables;
             for (const auto& variablePair : sourceVariables)
             {
-                sortedVariables.insert(&variablePair.second);
+                if (variablePair.second.GetScope() != VariableFlags::Scope::FunctionReadOnly)
+                {
+                    sortedVariables.insert(&variablePair.second);
+                }
 
                 if (auto datum = variablePair.second.GetDatum())
                 {
@@ -246,7 +249,7 @@ namespace ScriptCanvas
                 AZ_Assert(datum != nullptr, "the datum must be valid");
 
                 // #functions2 slot<->variable check to verify if it is a member variable
-                auto variable = sourceVariable->GetScope() == VariableFlags::Scope::Graph
+                auto variable = (sourceVariable->GetScope() == VariableFlags::Scope::Graph)
                     ? AddMemberVariable(*datum, sourceVariable->GetVariableName(), sourceVariable->GetVariableId())
                     : AddVariable(*datum, sourceVariable->GetVariableName(), sourceVariable->GetVariableId());
 


### PR DESCRIPTION
## What does this PR do?

The name of the variable selected when promoting a node's slot was incorrectly set to "(1) (1)", even though an effort was made to determine a viable name, it wasn't being used. This change uses the name if it was determined.

The other change fixes the AP error that would happen after promoting the variable. When a variable was promoted it was being added to the Abstract Code Model as a function scope variable, however, a promoted variable is used as a variable reference, for this to work correctly the variable should be a member variable, otherwise the behavior would be undefined since the variable would be within the function's scope and not actually a reference.

Closes #3101 