### PR TITLE
Fix some pass attachment binding-related functions not being updated to the new deque-based storage method

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -346,8 +346,9 @@ namespace AZ
 
         PassAttachmentBinding* Pass::FindAttachmentBinding(const Name& slotName)
         {
-            for (PassAttachmentBinding& binding : m_attachmentBindings)
+            for (int slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
             {
+                auto& binding = m_attachmentBindings[slotIndex];
                 if (slotName == binding.m_name)
                 {
                     return &binding;
@@ -358,8 +359,9 @@ namespace AZ
 
         const PassAttachmentBinding* Pass::FindAttachmentBinding(const Name& slotName) const
         {
-            for (const PassAttachmentBinding& binding : m_attachmentBindings)
+            for (int slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
             {
+                const auto& binding = m_attachmentBindings[slotIndex];
                 if (slotName == binding.m_name)
                 {
                     return &binding;
@@ -1164,8 +1166,9 @@ namespace AZ
         {
             // Depending on whether a pass is enabled or not, it may switch it's bindings to become a pass-through
             // For this reason we update connecting bindings on a per-frame basis
-            for (PassAttachmentBinding& binding : m_attachmentBindings)
+            for (int slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
             {
+                auto& binding = m_attachmentBindings[slotIndex];
                 UpdateConnectedBinding(binding);
             }
         }
@@ -1670,8 +1673,9 @@ namespace AZ
                 return false;
             }
             uint32_t bindingIndex = 0;
-            for (auto& binding : m_attachmentBindings)
+            for (int slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
             {
+                auto& binding = m_attachmentBindings[slotIndex];
                 if (slotName == binding.m_name)
                 {
                     RHI::AttachmentType type = binding.GetAttachment()->GetAttachmentType();
@@ -1867,8 +1871,9 @@ namespace AZ
                 AZStd::string stringOutput;
                 PrintPassName(stringOutput);
 
-                for (const PassAttachmentBinding& binding : m_attachmentBindings)
+                for (int slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
                 {
+                    const auto& binding = m_attachmentBindings[slotIndex];
                     uint32_t bindingMask = (1 << uint32_t(binding.m_slotType));
                     if ((bindingMask & slotTypeMask) && (binding.GetAttachment() == nullptr))
                     {


### PR DESCRIPTION
## What does this PR do?

#18673 changed how attachment bindings are stored in the pass class, but not all functions which access these were updated correctly. For example, the function `FindAttachmentBinding` would iterate over all entires in `m_attachmentBindings` and return a potentially invalid value, as the number of valid entires is stored separately in `m_attachmentBindingsSize`. 

## How was this PR tested?

AR + Test with an internal gem, which crashes due to the previous behavior, and does no longer crash with this PR.
