### PR TITLE
Fix issue #14746: expose Enable controls of DeferredFog to TrackView sequence

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ScreenSpace/DeferredFogParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ScreenSpace/DeferredFogParams.inl
@@ -32,3 +32,8 @@ AZ_GFX_VEC2_PARAM(NoiseTexCoord2Velocity, m_noiseVelocityUV2, Vector2(0.00275f, 
 
 // Amount of blend between octaves: noise = (1 - blend) * octave1 + blend * octave2
 AZ_GFX_FLOAT_PARAM(OctavesBlendFactor, m_octavesBlendFactor, 0.4f)
+
+// Unified bool flags, moved here from DeferredFogSettings.h and DeferredFogComponentConfig.h.
+AZ_GFX_BOOL_PARAM(Enabled, m_enabled, true)
+AZ_GFX_BOOL_PARAM(UseNoiseTextureShaderOption, m_useNoiseTextureShaderOption, true)
+AZ_GFX_BOOL_PARAM(EnableFogLayerShaderOption, m_enableFogLayerShaderOption, true)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ScreenSpace/DeferredFogSettingsInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ScreenSpace/DeferredFogSettingsInterface.h
@@ -34,14 +34,6 @@ namespace AZ
             virtual void SetInitialized(bool isInitialized) = 0;
             virtual bool IsInitialized() = 0;
 
-            virtual void SetEnabled(bool value) = 0;
-            virtual bool GetEnabled() const = 0;
-
-            virtual void SetUseNoiseTextureShaderOption(bool value)= 0;
-            virtual bool GetUseNoiseTextureShaderOption()= 0;
-            virtual void SetEnableFogLayerShaderOption(bool value)= 0;
-            virtual bool GetEnableFogLayerShaderOption()= 0;
-
             // Auto-gen virtual getter and setter functions...
 #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                  \
         virtual ValueType Get##Name() const = 0;                                                        \

--- a/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogSettings.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogSettings.cpp
@@ -37,12 +37,6 @@ namespace AZ
             m_needUpdate = true;   // even if disabled, mark it for when it'll become enabled
         }
 
-        void DeferredFogSettings::SetEnabled(bool value) 
-        {
-            m_enabled = value;
-            OnSettingsChanged();
-        }
-
         //-------------------------------------------
         // Getters / setters macro
 #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                              \

--- a/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogSettings.h
@@ -66,12 +66,6 @@ namespace AZ
                 m_needUpdate = needUpdate;
             }
 
-            void SetEnabled(bool value) override;
-            bool GetEnabled() const override
-            {
-                return m_enabled;
-            }
-
             void SetInitialized(bool isInitialized) override
             {
                 m_isInitialized = isInitialized;
@@ -79,24 +73,6 @@ namespace AZ
             bool IsInitialized() override
             {
                 return m_isInitialized;
-            }
-
-            void SetUseNoiseTextureShaderOption(bool value) override
-            {
-                m_useNoiseTextureShaderOption = value;
-            }
-            bool GetUseNoiseTextureShaderOption() override
-            {
-                return m_useNoiseTextureShaderOption;
-            }
-
-            void SetEnableFogLayerShaderOption(bool value) override
-            {
-                m_enableFogLayerShaderOption = value;
-            }
-            bool GetEnableFogLayerShaderOption() override
-            {
-                return m_enableFogLayerShaderOption;
             }
 
             // Called by the post effects feature processor for doing per frame prep if required
@@ -158,20 +134,16 @@ namespace AZ
 
             PostProcessSettings* m_parentSettings = nullptr;
 
-            // 'm_enabled' indicates if the pass should be enabled. By default this is set to true since if the
+            // The 'm_enabled' member indicates if the pass should be enabled. By default this is set to true since if the
             // pass is data driven enabled, the default settings should not disable it.  If it is driven by
             // an engine component, these settings will be replaced by the component's settings controlled by
-            // the user.
-            bool m_enabled = true;
+            // the user. Defined using DeferredFogParams.inl, along with others.
 
             // Indication if the SRG indices were set
             bool m_isInitialized = false;
 
             // Indicates that the srg indices were set
             bool m_needUpdate = true;
-
-            bool m_useNoiseTextureShaderOption = true;
-            bool m_enableFogLayerShaderOption = true;
 
         };
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/ScreenSpace/DeferredFogComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/ScreenSpace/DeferredFogComponentConfig.h
@@ -44,34 +44,6 @@ namespace AZ
             void CopySettingsFrom(DeferredFogSettingsInterface* settings);
             void CopySettingsTo(DeferredFogSettingsInterface* settings);
 
-            // DeferredFogComponentConfigInterface overrides...
-            void SetEnabled(bool value)
-            {
-                m_enabled = value;
-            }
-            bool GetIsEnabled()
-            {
-                return m_enabled;
-            }
-
-            void SetUseNoiseTextureShaderOption(bool value)
-            {
-                m_useNoiseTextureShaderOption = value;
-            }
-            bool GetUseNoiseTextureShaderOption()
-            {
-                return m_useNoiseTextureShaderOption;
-            }
-
-            void SetEnableFogLayerShaderOption(bool value)
-            {
-                m_enableFogLayerShaderOption = value;
-            }
-            bool GetEnableFogLayerShaderOption()
-            {
-                return m_enableFogLayerShaderOption;
-            }
-
             bool SupportsFogDensity()
             {
                 return m_fogMode == FogMode::Exponential || m_fogMode == FogMode::ExponentialSquared;
@@ -100,9 +72,6 @@ namespace AZ
 #include <Atom/Feature/ScreenSpace/DeferredFogParams.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 
-            bool m_enabled = true;
-            bool m_useNoiseTextureShaderOption = false;
-            bool m_enableFogLayerShaderOption = false;
         };
 
     }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/DeferredFogComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/DeferredFogComponentConfig.cpp
@@ -30,9 +30,6 @@ namespace AZ
 #include <Atom/Feature/ScreenSpace/DeferredFogParams.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 #undef SERIALIZE_CLASS
-                    ->Field("IsEnabled", &DeferredFogComponentConfig::m_enabled)
-                    ->Field("UseNoiseTextureShaderOption", &DeferredFogComponentConfig::m_useNoiseTextureShaderOption)
-                    ->Field("EnableFogLayerShaderOption", &DeferredFogComponentConfig::m_enableFogLayerShaderOption)
                     ;
             }
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/DeferredFogComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ScreenSpace/DeferredFogComponentController.cpp
@@ -119,14 +119,6 @@ namespace AZ
             {
                 // Set SRG constants
                 m_configuration.CopySettingsTo(m_settingsInterface);
-
-                // Set the shader options bits
-                m_settingsInterface->SetEnableFogLayerShaderOption(m_configuration.GetEnableFogLayerShaderOption());
-                m_settingsInterface->SetUseNoiseTextureShaderOption(m_configuration.GetUseNoiseTextureShaderOption());
-
-                // Enable / disable the pass
-                m_settingsInterface->SetEnabled(m_configuration.GetIsEnabled());
-
                 m_settingsInterface->OnSettingsChanged();
             }
         }


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/o3de/o3de/issues/14746

Unifies generation of boolean 'Enable' attributes in `DeferredFogRequestsBus`, `class DeferredFogSettingsInterface`, `class DeferredFogSettings`, `class DeferredFogComponentConfig`, `class DeferredFogComponentController`:
removing legacy definitions and usage or these atributes in above mentioned classes and adding `AZ_GFX_BOOL_PARAM()` macros to `DeferredFogParams.inl`.

This exposes missing boolean 'Enable' attributes of DeferredFog to the bus  and behavior reflections.

## How was this PR tested?

Release and Profile Editors were run under Windows, desired functionality observed:

https://github.com/user-attachments/assets/84b3a2ed-2181-4430-9f41-47120268b3f9


