### PR TITLE
Fixes all remaining Address Sanitizer issues in gem tests

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -644,11 +644,14 @@ namespace AZ::Data
 
     void AssetManager::WaitForActiveJobsAndStreamerRequestsToFinish()
     {
-        while (HasActiveJobsOrStreamerRequests())
+        do
         {
+            // this must happen at least once in case events are in the queue and the
+            // previous streamer requests or jobs just went to 0 after putting the last event in the queue.
+
             DispatchEvents();
             AZStd::this_thread::yield();
-        }
+        } while (HasActiveJobsOrStreamerRequests());
     }
 
     //=========================================================================

--- a/Code/Framework/AzCore/AzCore/EBus/EventSchedulerSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/EBus/EventSchedulerSystemComponent.cpp
@@ -62,6 +62,8 @@ namespace AZ
         m_freeEvents.clear();
         m_handles.clear();
         m_freeHandles.clear();
+        m_queue = {};
+        m_pendingQueue = {};
     }
 
     void EventSchedulerSystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)

--- a/Gems/EMotionFX/Code/Tests/InitSceneAPIFixture.h
+++ b/Gems/EMotionFX/Code/Tests/InitSceneAPIFixture.h
@@ -49,22 +49,10 @@ namespace EMotionFX
 
         ~InitSceneAPIFixture() override
         {
-            // Deactivate the system entity first, releasing references to SceneAPI
-            if (this->GetSystemEntity()->GetState() == AZ::Entity::State::Active)
-            {
-                this->GetSystemEntity()->Deactivate();
-            }
-
-            // Remove SceneAPI components before the DLL is uninitialized
-            (([&]() {
-                auto component = this->GetSystemEntity()->template FindComponent<Components>();
-                if (component)
-                {
-                    this->GetSystemEntity()->RemoveComponent(component);
-                    delete component;
-                }
-            })(), ...);
-
+            // Note to maintainers:
+            // The System entity is automatically deactivated, cleared, and destroyed, as well as all components in it,
+            // as part of app.stop(), which is called by the baseclass.  It is not necessary to manually tear them down here.
+            
             // Now tear down SceneAPI
             for (DynamicModuleHandlePtr& module : m_modules)
             {

--- a/Gems/EMotionFX/Code/Tests/MotionExtractionBusTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MotionExtractionBusTests.cpp
@@ -108,7 +108,8 @@ namespace EMotionFX
         void TearDown() override
         {
             m_motionSet->Clear();
-            m_motion->Destroy();
+            // note to maintainers
+            // clearing a motionset calls "delete" on all the motions in it, so m_motion will already be destroyed
             delete m_motionSet;
             m_entity.reset();
             EntityComponentFixture::TearDown();

--- a/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
+++ b/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
@@ -155,10 +155,8 @@ namespace EMotionFX
 
         ~ComponentFixture() override
         {
-            if (GetSystemEntity()->GetState() == AZ::Entity::State::Active)
-            {
-                GetSystemEntity()->Deactivate();
-            }
+            // note to future maintainers, 
+            // The System Entity is destroyed in m_app.Stop(), no need to manually destroy it here.
         }
 
         AZ::SerializeContext* GetSerializeContext()

--- a/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
@@ -87,7 +87,13 @@ namespace Maestro
 
         bool IsKeySelected(int key) const override
         {
-            AZ_Assert(key >= 0 && key < (int)m_keys.size(), "Key index is out of range");
+            bool valid = (key >= 0 && key < (int)m_keys.size());
+            AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(key), static_cast<int>(m_keys.size()));
+            if (!valid)
+            {
+                return false;
+            }
+
             if (m_keys[key].flags & AKEY_SELECTED)
             {
                 return true;
@@ -97,7 +103,13 @@ namespace Maestro
 
         void SelectKey(int key, bool select) override
         {
-            AZ_Assert(key >= 0 && key < (int)m_keys.size(), "Key index is out of range");
+            bool valid = (key >= 0 && key < (int)m_keys.size());
+            AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(key), static_cast<int>(m_keys.size()));
+            if (!valid)
+            {
+                return;
+            }
+
             if (select)
             {
                 m_keys[key].flags |= AKEY_SELECTED;
@@ -110,7 +122,13 @@ namespace Maestro
 
         bool IsSortMarkerKey(unsigned int key) const override
         {
-            AZ_Assert(key < m_keys.size(), "key index is out of range");
+            bool valid = (key < (int)m_keys.size());
+            AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(key), static_cast<int>(m_keys.size()));
+            if (!valid)
+            {
+                return false;
+            }
+
             if (m_keys[key].flags & AKEY_SORT_MARKER)
             {
                 return true;
@@ -120,7 +138,13 @@ namespace Maestro
 
         void SetSortMarkerKey(unsigned int key, bool enabled) override
         {
-            AZ_Assert(key < m_keys.size(), "key index is out of range");
+            bool valid = (key < (int)m_keys.size());
+            AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(key), static_cast<int>(m_keys.size()));
+            if (!valid)
+            {
+                return;
+            }
+
             if (enabled)
             {
                 m_keys[key].flags |= AKEY_SORT_MARKER;
@@ -470,7 +494,13 @@ namespace Maestro
     template<class KeyType>
     inline void TAnimTrack<KeyType>::RemoveKey(int index)
     {
-        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index is out of range");
+        bool valid = (index >= 0 && index < (int)m_keys.size());
+        AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(index), static_cast<int>(m_keys.size()));
+        if (!valid)
+        {
+            return;
+        }
+
         m_keys.erase(m_keys.begin() + index);
         Invalidate();
     }
@@ -479,8 +509,13 @@ namespace Maestro
     template<class KeyType>
     inline void TAnimTrack<KeyType>::GetKey(int index, IKey* key) const
     {
-        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index is out of range");
-        AZ_Assert(key != 0, "Key cannot be null!");
+        bool valid = key && (index >= 0 && index < (int)m_keys.size());
+        AZ_Assert(valid, "Key index (%i) is out of range (%i) or key (%p) is nullptr", static_cast<int>(index), static_cast<int>(m_keys.size()), key);
+        if (!valid)
+        {
+            return;
+        }
+
         *(KeyType*)key = m_keys[index];
     }
 
@@ -488,8 +523,12 @@ namespace Maestro
     template<class KeyType>
     inline void TAnimTrack<KeyType>::SetKey(int index, IKey* key)
     {
-        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index is out of range");
-        AZ_Assert(key != 0, "Key cannot be null!");
+        bool valid = key && (index >= 0 && index < (int)m_keys.size());
+        AZ_Assert(valid, "Key index (%i) is out of range (%i) or key (%p) is nullptr", static_cast<int>(index), static_cast<int>(m_keys.size()), key);
+        if (!valid)
+        {
+            return;
+        }
         m_keys[index] = *(KeyType*)key;
         Invalidate();
     }
@@ -498,7 +537,12 @@ namespace Maestro
     template<class KeyType>
     inline float TAnimTrack<KeyType>::GetKeyTime(int index) const
     {
-        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index is out of range");
+        bool valid = (index >= 0 && index < (int)m_keys.size());
+        AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(index), static_cast<int>(m_keys.size()));
+        if (!valid)
+        {
+            return 0.0f;
+        }
         return m_keys[index].time;
     }
 
@@ -506,7 +550,13 @@ namespace Maestro
     template<class KeyType>
     inline void TAnimTrack<KeyType>::SetKeyTime(int index, float time)
     {
-        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index is out of range");
+        bool valid = (index >= 0 && index < (int)m_keys.size());
+        AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(index), static_cast<int>(m_keys.size()));
+        if (!valid)
+        {
+            return;
+        }
+
         m_keys[index].time = time;
         Invalidate();
     }
@@ -529,7 +579,13 @@ namespace Maestro
     template<class KeyType>
     inline int TAnimTrack<KeyType>::GetKeyFlags(int index)
     {
-        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index is out of range");
+        bool valid = (index >= 0 && index < (int)m_keys.size());
+        AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(index), static_cast<int>(m_keys.size()));
+        if (!valid)
+        {
+            return 0;
+        }
+
         return m_keys[index].flags;
     }
 
@@ -537,7 +593,12 @@ namespace Maestro
     template<class KeyType>
     inline void TAnimTrack<KeyType>::SetKeyFlags(int index, int flags)
     {
-        AZ_Assert(index >= 0 && index < (int)m_keys.size(), "Key index is out of range");
+        bool valid = (index >= 0 && index < (int)m_keys.size());
+        AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(index), static_cast<int>(m_keys.size()));
+        if (!valid)
+        {
+            return;
+        }
         m_keys[index].flags = flags;
         Invalidate();
     }

--- a/Gems/Maestro/Code/Tests/Tracks/AnimTrackTest.cpp
+++ b/Gems/Maestro/Code/Tests/Tracks/AnimTrackTest.cpp
@@ -97,9 +97,7 @@ namespace Maestro
         {
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.IsKeySelected(-1);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, IsKeySelected_UnselectedKey_ExpectFalse)
@@ -120,9 +118,7 @@ namespace Maestro
         {
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.SelectKey(-1, true);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, SelectKey_UnselectedKey_Select)
@@ -169,9 +165,7 @@ namespace Maestro
         {
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.IsSortMarkerKey(5);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, IsSortMarkerKey_UnmarkedKey_ExpectFalse)
@@ -192,9 +186,7 @@ namespace Maestro
         {
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.SetSortMarkerKey(5, true);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, SetSortMarkerKey_UnsetKey_Set)
@@ -257,9 +249,7 @@ namespace Maestro
             IKey result;
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.GetKey(-1, &result);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, GetKey_ValidInputs_ExpectSuccess)
@@ -274,9 +264,7 @@ namespace Maestro
             ITestKey testKey;
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.SetKey(-1, &testKey);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, SetKey_ValidKey_ExpectSuccess)
@@ -293,9 +281,7 @@ namespace Maestro
         {
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.GetKeyTime(-1);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, GetKeyTime_ValidInputs_ExpectSuccess)
@@ -309,9 +295,7 @@ namespace Maestro
         {
             AZ_TEST_START_TRACE_SUPPRESSION;
             m_testTrackA.SetKeyTime(-1, 5.0f);
-            // We are expecting 2 asserts as the function does not early-out, so the bad input asserts in both
-            // the TrackView code and the AZStd code that gets called. Early-outs should probably be added in the future.
-            AZ_TEST_STOP_TRACE_SUPPRESSION(2);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
 
         TEST_F(TAnimTrackTest, SetKeyTime)

--- a/Gems/Multiplayer/Code/Tests/CommonHierarchySetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonHierarchySetup.h
@@ -173,6 +173,8 @@ namespace Multiplayer
             AZ::Interface<IMultiplayer>::Unregister(m_mockMultiplayer.get());
             AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(m_mockComponentApplicationRequests.get());
 
+            m_eventScheduler->Deactivate();
+
             m_eventScheduler.reset();
             m_mockTime.reset();
 

--- a/Gems/Multiplayer/Code/Tests/CommonNetworkEntitySetup.h
+++ b/Gems/Multiplayer/Code/Tests/CommonNetworkEntitySetup.h
@@ -132,10 +132,13 @@ namespace Multiplayer
             AZ::Interface<IMultiplayer>::Unregister(m_mockMultiplayer.get());
             AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(m_mockComponentApplicationRequests.get());
 
+            m_networkEntityManager->Reset();
+            m_networkEntityManager.reset();
+
+            m_eventScheduler->Deactivate();
             m_eventScheduler.reset();
             m_mockTime.reset();
 
-            m_networkEntityManager.reset();
             m_mockMultiplayer.reset();
             m_visisbilitySystem->Disconnect();
             m_visisbilitySystem.reset();

--- a/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkEntityTests.cpp
@@ -186,11 +186,14 @@ namespace Multiplayer
 
         EXPECT_TRUE(netEntityTracker->Exists(netId));
 
-        NetworkEntityTracker::iterator it = netEntityTracker->begin();
-        AZ::Entity* entity = netEntityTracker->Move(it);
+        // Move() will destroy the iterator.  This code has been changed
+        // to avoid keeping an object in scope that would otherwise be invalid (the iterator)
+        NetEntityId movedEntityId = netEntityTracker->begin()->first;
+        AZ::Entity* entity = netEntityTracker->Move(netEntityTracker->begin());
+
         EXPECT_NE(entity, nullptr);
-        netEntityTracker->Add(it->first, entity);
-        netEntityTracker->erase(it->first);
+        netEntityTracker->Add(movedEntityId, entity);
+        netEntityTracker->erase(movedEntityId);
         EXPECT_FALSE(netEntityTracker->Exists(netId));
     }
 

--- a/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
@@ -154,7 +154,7 @@ namespace Multiplayer
             m_netRigidBodyDescriptor->Reflect(m_serializeContext.get());
 
             m_rigidBody = AZStd::make_unique<PhysX::RigidBody>();
-            m_mockSceneInterface = AZStd::make_unique<Multiplayer::MockSceneInterface>();
+            m_mockSceneInterface = AZStd::make_unique<testing::NiceMock<Multiplayer::MockSceneInterface>>();
             ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _))
                 .WillByDefault(Invoke(
                     [this](AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle)

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventSystem.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventSystem.cpp
@@ -36,7 +36,6 @@ namespace ScriptEvents
         return m_scriptEvents[key];
     }
 
-
     void ScriptEventsSystemComponentImpl::RegisterScriptEventFromDefinition(const ScriptEvents::ScriptEvent& definition)
     {
         AZ::BehaviorContext* behaviorContext = nullptr;
@@ -162,5 +161,10 @@ namespace ScriptEvents
         {
             return AZ::Success();
         }
+    }
+
+    void ScriptEventsSystemComponentImpl::CleanUp()
+    {
+        m_scriptEvents.clear(); // invoking this will cause event busses to activate as destructors are called.
     }
 }

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventSystem.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventSystem.h
@@ -32,6 +32,11 @@ namespace ScriptEvents
         virtual void RegisterAssetHandler() = 0;
         virtual void UnregisterAssetHandler() = 0;
 
+        // It is required to call Cleanup before the module is being unloaded, so that the refcounted
+        // script event handles can be unwound correctly, while the system is still actually able to respond to bus calls
+        // made by its destructor.  Best place is during Deactivate of the System Component that invoked RegisterAssetHandler in the first place.
+        virtual void CleanUp();
+
         ////////////////////////////////////////////////////////////////////////
         // ScriptEvents::ScriptEventBus::Handler
         AZStd::intrusive_ptr<Internal::ScriptEventRegistration> RegisterScriptEvent(const AZ::Data::AssetId& assetId, AZ::u32 version) override;

--- a/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
+++ b/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
@@ -243,6 +243,7 @@ namespace ScriptEventsEditor
         if (moduleConfiguration)
         {
             moduleConfiguration->UnregisterAssetHandler();
+            moduleConfiguration->CleanUp();
         }
     }
 }

--- a/Gems/ScriptEvents/Code/Source/ScriptEventsSystemComponent.cpp
+++ b/Gems/ScriptEvents/Code/Source/ScriptEventsSystemComponent.cpp
@@ -101,6 +101,7 @@ namespace ScriptEvents
         if (moduleConfiguration)
         {
             moduleConfiguration->UnregisterAssetHandler();
+            moduleConfiguration->CleanUp();
         }
 
     }

--- a/Gems/SurfaceData/Code/Tests/MixedAllocatorTest.cpp
+++ b/Gems/SurfaceData/Code/Tests/MixedAllocatorTest.cpp
@@ -106,20 +106,24 @@ namespace UnitTest
         ASSERT_NE(data, nullptr);
 
         // Resize to something smaller than the allocated stack buffer. This should succeed.
-        auto reallocatedData = allocator.reallocate(data, allocResizeSmallerSize);
-        EXPECT_NE(reallocatedData, nullptr);
+        auto reallocatedDataSucceeds = allocator.reallocate(data, allocResizeSmallerSize);
+        EXPECT_NE(reallocatedDataSucceeds, nullptr);
 
         // Resize to something larger than the allocated stack buffer. This should return 0, as it isn't suported.
-        reallocatedData = allocator.reallocate(data, allocResizeLargerSize);
-        EXPECT_EQ(reallocatedData, nullptr);
+        auto reallocatedDataFails = allocator.reallocate(data, allocResizeLargerSize);
+        EXPECT_EQ(reallocatedDataFails, nullptr);
 
         auto numAllocatedBytesAfter = AZ::AllocatorInstance<AZ::SystemAllocator>::Get().NumAllocatedBytes();
 
         // Verify that all of the data came from the stack.
-        EXPECT_GE(numAllocatedBytesAfter - numAllocatedBytesBefore, 0);
+        EXPECT_EQ(numAllocatedBytesAfter, numAllocatedBytesBefore);
 
         // Verify that a deallocation is successful.
-        allocator.deallocate(reallocatedData, allocSize, allocAlignment);
+        allocator.deallocate(reallocatedDataSucceeds, allocSize, allocAlignment);
+
+        // verify that it came from the stack, not the heap
+        numAllocatedBytesAfter = AZ::AllocatorInstance<AZ::SystemAllocator>::Get().NumAllocatedBytes();
+        EXPECT_GE(numAllocatedBytesAfter,numAllocatedBytesBefore);
     }
 
 } // namespace UnitTest


### PR DESCRIPTION

## What does this PR do?

Fixes every ASAN issue that I found while running every gem's googletest/googlemock tests with debug + Address Sanitizer.

## What does this PR not do?

This does NOT fix ASAN issues that might be lurking in the actual editor, runtime, tools that are not exposed by their tests, or changes required 3rd party libraries, or our use of them.  I intend to follow up with corrections for MCPP and OpenMesh both of which need work for ASAN.

## How was this PR tested?

Running through the tests in question.
Basic smoke test of the editor and tools.
