### PR TITLE
Disable TIAF from Windows build_config.json (Point-Release)

### DIFF
--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -75,9 +75,7 @@
     "steps": [
       "profile",
       "asset_profile",
-      "test_cpu_profile",
-      "test_impact_analysis_profile_native",
-      "test_impact_analysis_profile_python"
+      "test_cpu_profile"
     ]
   },
   "scrubbing": {


### PR DESCRIPTION
## What does this PR do?

Disables the Windows TIAF build phase from Jenkins

## How was this PR tested?

Tested in a Sandbox Jenkins instance
