### PR TITLE
Update slot names if the referenced variable is renamed

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -180,7 +180,7 @@ namespace ScriptCanvasEditor
         GeneralEditorNotificationBus::Handler::BusConnect(scriptCanvasId);
 
         ScriptCanvas::Graph::Activate();
-        PostActivate();
+
         m_undoHelper.SetSource(this);
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -391,10 +391,7 @@ namespace ScriptCanvas
 
             if (m_variable)
             {
-                if (VariableNotificationBus::MultiHandler::BusIsConnectedId(m_variable->GetGraphScopedId()))
-                {
-                    VariableNotificationBus::MultiHandler::BusDisconnect(m_variable->GetGraphScopedId());
-                }
+                DisconnectVariableNotificationBus();
 
                 VariableNotificationBus::MultiHandler::BusConnect(m_variable->GetGraphScopedId());
             }
@@ -964,10 +961,7 @@ namespace ScriptCanvas
 
     void Slot::OnVariableRenamed(AZStd::string_view variableName)
     {
-        if (VariableNotificationBus::MultiHandler::BusIsConnectedId(m_variable->GetGraphScopedId()))
-        {
-            VariableNotificationBus::MultiHandler::BusDisconnect(m_variable->GetGraphScopedId());
-        }
+        DisconnectVariableNotificationBus();
 
         Rename(variableName);
     }
@@ -982,5 +976,12 @@ namespace ScriptCanvas
         m_isVisible = isVisible;
     }
 
+    void Slot::DisconnectVariableNotificationBus()
+    {
+        if (VariableNotificationBus::MultiHandler::BusIsConnectedId(m_variable->GetGraphScopedId()))
+        {
+            VariableNotificationBus::MultiHandler::BusDisconnect(m_variable->GetGraphScopedId());
+        }
+    }
 }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -961,8 +961,6 @@ namespace ScriptCanvas
 
     void Slot::OnVariableRenamed(AZStd::string_view variableName)
     {
-        DisconnectVariableNotificationBus();
-
         Rename(variableName);
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -516,7 +516,6 @@ namespace ScriptCanvas
 
         m_variableReference = variableId;
         m_variable = nullptr;
-        VariableNotificationBus::Handler::BusDisconnect();
 
         if (IsDynamicSlot())
         {
@@ -798,7 +797,7 @@ namespace ScriptCanvas
             {
                 return AZ::Failure(AZStd::string::format("%s is a Container type and not a Value type.", ScriptCanvas::Data::GetName(otherType).c_str()));
             }
-        }        
+        }
 
         if (otherSlot.IsDynamicSlot())
         {
@@ -958,6 +957,11 @@ namespace ScriptCanvas
         return m_node->ConstructTransientIdentifier((*this));
     }
 
+    void Slot::OnVariableRenamed(AZStd::string_view variableName)
+    {
+        Rename(variableName);
+    }
+
     void Slot::SetDynamicGroup(const AZ::Crc32& dynamicGroup)
     {
         m_dynamicGroup = dynamicGroup;
@@ -969,3 +973,4 @@ namespace ScriptCanvas
     }
 
 }
+

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -302,7 +302,7 @@ namespace ScriptCanvas
 
     Slot::~Slot()
     {
-        VariableNotificationBus::Handler::BusDisconnect();
+        VariableNotificationBus::MultiHandler::BusDisconnect();
     }
 
     Slot& Slot::operator=(const Slot& slot)
@@ -391,7 +391,12 @@ namespace ScriptCanvas
 
             if (m_variable)
             {
-                VariableNotificationBus::Handler::BusConnect(m_variable->GetGraphScopedId());
+                if (VariableNotificationBus::MultiHandler::BusIsConnectedId(m_variable->GetGraphScopedId()))
+                {
+                    VariableNotificationBus::MultiHandler::BusDisconnect(m_variable->GetGraphScopedId());
+                }
+
+                VariableNotificationBus::MultiHandler::BusConnect(m_variable->GetGraphScopedId());
             }
             else if (m_node)
             {
@@ -959,6 +964,11 @@ namespace ScriptCanvas
 
     void Slot::OnVariableRenamed(AZStd::string_view variableName)
     {
+        if (VariableNotificationBus::MultiHandler::BusIsConnectedId(m_variable->GetGraphScopedId()))
+        {
+            VariableNotificationBus::MultiHandler::BusDisconnect(m_variable->GetGraphScopedId());
+        }
+
         Rename(variableName);
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -235,6 +235,8 @@ namespace ScriptCanvas
         void OnVariableRenamed(AZStd::string_view /*newVariableName*/) override;
         ///
 
+        void DisconnectVariableNotificationBus();
+
         bool m_isOverload = false;
         bool m_isVisible = true;
         bool m_isUserAdded = false;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -230,6 +230,11 @@ namespace ScriptCanvas
         ////
 
     protected:
+
+        // VariableNotificationBus...
+        void OnVariableRenamed(AZStd::string_view /*newVariableName*/) override;
+        ///
+
         bool m_isOverload = false;
         bool m_isVisible = true;
         bool m_isUserAdded = false;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -43,7 +43,7 @@ namespace ScriptCanvas
     };
 
     class Slot final
-        : public VariableNotificationBus::Handler
+        : public VariableNotificationBus::MultiHandler
     {
         friend class Node;
     public:


### PR DESCRIPTION
## What does this PR do?

When a variable is renamed the Slot class was not handing the rename. While fixing this I noticed that `PostActivate` was being called twice which didn't appear to cause any side effects but was not correct. 

Changed the handler for `VariableNotificationBus` to MultiHandler, a graph can have multiple nodes which have slots with different VariableId, but same graph Id. It's possible we should change the `GraphScopedId` to use the Node ID, Graph ID, and Variable ID to be more accurate. 

Closes #7996 

