### PR TITLE
ScriptCanvas : Enable debug information in scriptcanvas to luac build

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
@@ -64,7 +64,7 @@ namespace ScriptComponentCpp
             AZ_TracePrintf(errorWindow.data(), "Top of stack is not function!");
         }
 
-        const int stripBinaryRepresentation = 1;
+        const int stripBinaryRepresentation = 0;
         return lua_dump(l, LuaStreamWriter, &stream, stripBinaryRepresentation) == 0;
     }
 }

--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorkerUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorkerUtility.cpp
@@ -235,10 +235,12 @@ namespace ScriptCanvasBuilder
         AZStd::string vmFullPath = input.request->m_fullPath;
         AzFramework::StringFunc::Path::StripExtension(vmFullPath);
         vmFullPath += ScriptCanvas::Grammar::k_internalRuntimeSuffix;
+
+        compileRequest.m_errorWindow = s_scriptCanvasBuilder;
+        compileRequest.m_sourceFile = input.request->m_sourceFile;
         compileRequest.m_fullPath = vmFullPath;
         compileRequest.m_fileName = input.fileNameOnly;
         compileRequest.m_tempDirPath = input.request->m_tempDirPath;
-        compileRequest.m_errorWindow = s_scriptCanvasBuilder;
         compileRequest.m_input = &inputStream;
         AzFramework::ConstructScriptAssetPaths(compileRequest);
 


### PR DESCRIPTION
## What does this PR do?

Preparation work to support breakpoint on scriptcanvas, related to issue #9192

Allow `LuaHook()` defined in `ScriptContextDebug.cpp` to get line and filename when calling `lua_getinfo` in a running luac originating from scriptcanvas (is already working for standart luac files as compilation is another codepath via `LuaBuilderWorker`).

The lua hook is currently only enabled when the LuaEditor is attached to the Editor (rely on **RemoteToolsGem**). It is used to know when a line match a user breakpoint and stop the execution if it matches. The scriptcanvas will rely on this system in the near future for its breakpoint support

![change](https://github.com/user-attachments/assets/2f92148c-8a88-409a-b8dc-9f732e3a0796)

## How was this PR tested?

Windows build on development branch, using the newspapper sample project with RemoteToolsGem enabled
