### PR TITLE
(OPTIONAL POINT RELEASE FIX) Fixes a bad cherry-pick merge that would prevent ASAN working

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
@@ -147,7 +147,7 @@ namespace AZ
         {
             byteSize = MemorySizeAdjustedDown(byteSize); // restore original size
         }
-
+#endif
         AZ_Assert(
             address != nullptr, "SystemAllocator: Failed to allocate %zu bytes aligned on %zu!", byteSize,
             alignment);
@@ -205,7 +205,6 @@ namespace AZ
 
         AZ_PROFILE_MEMORY_ALLOC(MemoryReserved, newAddress, newSize, "SystemAllocator realloc");
         AZ_MEMORY_PROFILE(ProfileReallocation(ptr, newAddress, allocatedSize, newAlignment));
-#endif
 
         return newAddress;
     }
@@ -216,8 +215,12 @@ namespace AZ
     //=========================================================================
     auto SystemAllocator::get_allocated_size(pointer ptr, align_type alignment) const -> size_type
     {
-        size_type allocSize = MemorySizeAdjustedDown(m_subAllocator->get_allocated_size(ptr, alignment));
-        return allocSize;
+        #if (AZCORE_SYSTEM_ALLOCATOR == AZCORE_SYSTEM_ALLOCATOR_MALLOC)
+            return AZ_OS_MSIZE(ptr, alignment);
+        #else
+            size_type allocSize = MemorySizeAdjustedDown(m_subAllocator->get_allocated_size(ptr, alignment));
+            return allocSize;
+        #endif
     }
 
 } // namespace AZ


### PR DESCRIPTION
## What does this PR do?

The cherry-pick merge of ASAN fixes from dev to 24092.2 caused an ifdef to shift around and produce bad
code when ASAN is enabled (which is not the default).

Note that the ifdef shifted around in exactly a way that meant that not having ASAN enabled (which is the default) worked just fine and behaved normally and didn't cause any actual changes to the code as compiled or executed, which is why AR passed.

But if you turn on ASAN, it won't compile since it switches to malloc allocator and this ifdef eats most of the file.

Only people compiling O3DE from source AND turning on ASAN or manually changing the code to change to malloc will encounter this problem.  The installer will be unaffected.

## How was this PR tested?

Just compilation.  
I made sure its more or less identical to dev systemallocator and tested the functions using clear-box-testing.
the problem is fairly obvious once you see it.  (See the diff)