### PR TITLE
Update the variable's property tree on rename

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -870,6 +870,19 @@ namespace ScriptCanvasEditor
         }
     }
 
+    void GraphVariablesModel::OnVariableRenamed(AZStd::string_view /*newVariableName*/)
+    {
+        const ScriptCanvas::GraphScopedVariableId* variableId = ScriptCanvas::VariableNotificationBus::GetCurrentBusId();
+
+        int index = FindRowForVariableId((*variableId).m_identifier);
+
+        if (index >= 0)
+        {
+            QModelIndex modelIndex = createIndex(index, ColumnIndex::Name, nullptr);
+            dataChanged(modelIndex, modelIndex);
+        }
+    }
+
     QVariant GraphVariablesModel::headerData(int section, Qt::Orientation orientation, int role /*= Qt::DisplayRole*/) const
     {
         if (orientation == Qt::Horizontal && role == Qt::DisplayRole)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
@@ -88,7 +88,7 @@ namespace ScriptCanvasEditor
         ////
 
         // VariableNotificationBus
-        void OnVariableRenamed(AZStd::string_view /*newVariableName*/) override;
+        void OnVariableRenamed(AZStd::string_view newVariableName) override;
         ///
 
         QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
@@ -87,6 +87,10 @@ namespace ScriptCanvasEditor
         void OnVariablePriorityChanged() override;
         ////
 
+        // VariableNotificationBus
+        void OnVariableRenamed(AZStd::string_view /*newVariableName*/) override;
+        ///
+
         QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariableDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariableDockWidget.cpp
@@ -163,7 +163,7 @@ namespace ScriptCanvasEditor
 
     void VariablePropertiesComponent::OnVariableRemoved()
     {
-        ScriptCanvas::VariableNotificationBus::Handler::BusDisconnect();        
+        ScriptCanvas::VariableNotificationBus::Handler::BusDisconnect();
 
         m_variableName = AZStd::string();
         m_variable = nullptr;
@@ -179,7 +179,10 @@ namespace ScriptCanvasEditor
     void VariablePropertiesComponent::OnVariableRenamed(AZStd::string_view variableName)
     {
         m_variableName = variableName;
-        PropertyGridRequestBus::Broadcast(&PropertyGridRequests::RefreshPropertyGrid);
+
+        m_variable->ModDatum().SetLabel(m_variableName);
+
+        PropertyGridRequestBus::Broadcast(&PropertyGridRequests::RebuildPropertyGrid);
     }
 
     void VariablePropertiesComponent::OnVariableScopeChanged()
@@ -781,7 +784,7 @@ namespace ScriptCanvasEditor
 
             if (propertiesComponent)
             {
-                ScriptCanvas::GraphVariable* graphVariable = owningGraph->FindVariableById(varId);;
+                ScriptCanvas::GraphVariable* graphVariable = owningGraph->FindVariableById(varId);
                 propertiesComponent->SetVariable(graphVariable);
 
                 selection.push_back(propertiesComponent->GetEntityId());
@@ -1018,4 +1021,3 @@ namespace ScriptCanvasEditor
 
 #include <Editor/View/Widgets/VariablePanel/moc_VariableDockWidget.cpp>
 }
-

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariableDockWidget.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariableDockWidget.h
@@ -81,7 +81,7 @@ namespace ScriptCanvasEditor
 
         // VariableNotificationBus::Handler
         void OnVariableRemoved() override;
-        void OnVariableRenamed(AZStd::string_view variableName) override;        
+        void OnVariableRenamed(AZStd::string_view variableName) override;
         void OnVariableScopeChanged() override;
 
         void OnVariableValueChanged() override;


### PR DESCRIPTION
## What does this PR do?

When variables got renamed the variable's datum label was not being updated, since that's a serialized field, not updating it meant that the data saved to the source file was out of sync with what was actually present in the editor.

Also found that the GraphModel was not notifying of a data change on rename.

Closes #11397 