### PR TITLE
Add recreation cache for `ResourceView` to `Resource`

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
@@ -50,9 +50,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        //! Returns true if the DeviceResourceView is in the cache of all single device buffers
-        bool IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
-
     protected:
         void SetDescriptor(const BufferDescriptor& descriptor);
 
@@ -61,64 +58,5 @@ namespace AZ::RHI
 
         //! The RHI descriptor for this Buffer.
         BufferDescriptor m_descriptor;
-    };
-
-    //! A BufferView is a light-weight representation of a view onto a multi-device buffer.
-    //! It holds a raw pointer to a multi-device buffer as well as a BufferViewDescriptor
-    //! Using both, single-device BufferViews can be retrieved
-    class BufferView : public ResourceView
-    {
-    public:
-        AZ_RTTI(BufferView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);
-        virtual ~BufferView() = default;
-
-        BufferView(const RHI::Buffer* buffer, BufferViewDescriptor descriptor, MultiDevice::DeviceMask deviceMask)
-            : m_buffer{ buffer }
-            , m_descriptor{ descriptor }
-            , m_deviceMask{ deviceMask }
-        {
-        }
-
-        //! Given a device index, return the corresponding DeviceBufferView for the selected device
-        const RHI::Ptr<RHI::DeviceBufferView> GetDeviceBufferView(int deviceIndex) const;
-
-        //! Return the contained multi-device buffer
-        const RHI::Buffer* GetBuffer() const
-        {
-            return m_buffer.get();
-        }
-
-        //! Return the contained BufferViewDescriptor
-        const BufferViewDescriptor& GetDescriptor() const
-        {
-            return m_descriptor;
-        }
-
-        AZStd::unordered_map<int, uint32_t> GetBindlessReadIndex() const;
-
-        const Resource* GetResource() const override
-        {
-            return m_buffer.get();
-        }
-
-        const DeviceResourceView* GetDeviceResourceView(int deviceIndex) const override
-        {
-            return GetDeviceBufferView(deviceIndex).get();
-        }
-
-    private:
-        //! Safe-guard access to DeviceBufferView cache during parallel access
-        mutable AZStd::mutex m_bufferViewMutex;
-        //! A raw pointer to a multi-device buffer
-        ConstPtr<RHI::Buffer> m_buffer;
-        //! The corresponding BufferViewDescriptor for this view.
-        BufferViewDescriptor m_descriptor;
-        //! The device mask of the buffer stored for comparison to figure out when cache entries need to be freed.
-        mutable MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
-        //! DeviceBufferView cache
-        //! This cache is necessary as the caller receives raw pointers from the ResourceCache, 
-        //! which now, with multi-device objects in use, need to be held in memory as long as
-        //! the multi-device view is held.
-        mutable AZStd::unordered_map<int, Ptr<RHI::DeviceBufferView>> m_cache;
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ #pragma once
+
+ #include <Atom/RHI.Reflect/BufferViewDescriptor.h>
+ #include <Atom/RHI/Resource.h>
+ #include <Atom/RHI/Buffer.h>
+
+ namespace AZ::RHI
+{
+    class DeviceBuffer;
+    class DeviceBufferView;
+
+    //! A BufferView is a light-weight representation of a view onto a multi-device buffer.
+    //! It holds a ConstPtr to a multi-device buffer as well as a BufferViewDescriptor
+    //! Using both, single-device BufferViews can be retrieved
+    class BufferView : public ResourceView
+    {
+    public:
+        AZ_RTTI(BufferView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);
+        virtual ~BufferView() = default;
+
+        BufferView(const RHI::Buffer* buffer, BufferViewDescriptor descriptor, MultiDevice::DeviceMask deviceMask)
+            : m_buffer{ buffer }
+            , m_descriptor{ descriptor }
+            , m_deviceMask{ deviceMask }
+        {
+        }
+
+        //! Given a device index, return the corresponding DeviceBufferView for the selected device
+        const RHI::Ptr<RHI::DeviceBufferView> GetDeviceBufferView(int deviceIndex) const;
+
+        //! Return the contained multi-device buffer
+        const RHI::Buffer* GetBuffer() const
+        {
+            return m_buffer.get();
+        }
+
+        //! Return the contained BufferViewDescriptor
+        const BufferViewDescriptor& GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        AZStd::unordered_map<int, uint32_t> GetBindlessReadIndex() const;
+
+        const Resource* GetResource() const override
+        {
+            return m_buffer.get();
+        }
+
+        const DeviceResourceView* GetDeviceResourceView(int deviceIndex) const override
+        {
+            return GetDeviceBufferView(deviceIndex).get();
+        }
+
+    private:
+        //! From RHI::Object
+        void Shutdown() final;
+
+        //! Safe-guard access to DeviceBufferView cache during parallel access
+        mutable AZStd::mutex m_bufferViewMutex;
+        //! A raw pointer to a multi-device buffer
+        ConstPtr<RHI::Buffer> m_buffer;
+        //! The corresponding BufferViewDescriptor for this view.
+        BufferViewDescriptor m_descriptor;
+        //! The device mask of the buffer stored for comparison to figure out when cache entries need to be freed.
+        mutable MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+        //! DeviceBufferView cache
+        //! This cache is necessary as the caller receives raw pointers from the ResourceCache, 
+        //! which now, with multi-device objects in use, need to be held in memory as long as
+        //! the multi-device view is held.
+        mutable AZStd::unordered_map<int, Ptr<RHI::DeviceBufferView>> m_cache;
+    };
+}

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
@@ -8,10 +8,13 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/FrameSchedulerEnums.h>
+#include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/Image.h>
+#include <Atom/RHI/ImageView.h>
 #include <Atom/RHI/Object.h>
 #include <Atom/RHI/ObjectCache.h>
-#include <Atom/RHI/Image.h>
-#include <Atom/RHI/Buffer.h>
+
 
 //! Struct used as a key for m_imageReverseLookupHash map below. The reason for using a struct instead of a hash directly is
 //! so that the map can handle hash collision correctly by using the == operator. This struct contains

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
@@ -93,9 +93,6 @@ namespace AZ::RHI
         //! Shuts down the resource by detaching it from its parent pool.
         void Shutdown() override final;
 
-        //! Returns true if the DeviceResourceView is in the cache of all single device images
-        bool IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
-
     protected:
         virtual void SetDescriptor(const ImageDescriptor& descriptor);
 
@@ -110,60 +107,4 @@ namespace AZ::RHI
         ImageAspectFlags m_aspectFlags = ImageAspectFlags::None;
     };
 
-    //! A ImageView is a light-weight representation of a view onto a multi-device image.
-    //! It holds a raw pointer to a multi-device image as well as an ImageViewDescriptor
-    //! Using both, single-device ImageViews can be retrieved
-    class ImageView : public ResourceView
-    {
-    public:
-        AZ_RTTI(ImageView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);
-        virtual ~ImageView() = default;
-
-        ImageView(const RHI::Image* image, ImageViewDescriptor descriptor, MultiDevice::DeviceMask deviceMask)
-            : m_image{ image }
-            , m_descriptor{ descriptor }
-            , m_deviceMask{ deviceMask }
-        {
-        }
-
-        //! Given a device index, return the corresponding DeviceImageView for the selected device
-        const RHI::Ptr<RHI::DeviceImageView> GetDeviceImageView(int deviceIndex) const;
-
-        //! Return the contained multi-device image
-        const RHI::Image* GetImage() const
-        {
-            return m_image.get();
-        }
-
-        //! Return the contained ImageViewDescriptor
-        const ImageViewDescriptor& GetDescriptor() const
-        {
-            return m_descriptor;
-        }
-
-        const Resource* GetResource() const override
-        {
-            return m_image.get();
-        }
-
-        const DeviceResourceView* GetDeviceResourceView(int deviceIndex) const override
-        {
-            return GetDeviceImageView(deviceIndex).get();
-        }
-
-    private:
-        //! Safe-guard access to DeviceImageView cache during parallel access
-        mutable AZStd::mutex m_imageViewMutex;
-        //! A raw pointer to a multi-device image
-        ConstPtr<RHI::Image> m_image;
-        //! The corresponding ImageViewDescriptor for this view.
-        ImageViewDescriptor m_descriptor;
-        //! The device mask of the image stored for comparison to figure out when cache entries need to be freed.
-        mutable MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
-        //! DeviceImageView cache
-        //! This cache is necessary as the caller receives raw pointers from the ResourceCache,
-        //! which now, with multi-device objects in use, need to be held in memory as long as
-        //! the multi-device view is held.
-        mutable AZStd::unordered_map<int, Ptr<RHI::DeviceImageView>> m_cache;
-    };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
@@ -9,6 +9,7 @@
 
 #include <Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h>
 #include <Atom/RHI/Image.h>
+#include <Atom/RHI/ImageView.h>
 #include <Atom/RHI/ScopeAttachment.h>
 #include <AzCore/Memory/PoolAllocator.h>
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageView.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ #pragma once
+
+ #include <Atom/RHI.Reflect/ImageViewDescriptor.h>
+ #include <Atom/RHI/Resource.h>
+ #include <Atom/RHI/Image.h>
+
+ namespace AZ::RHI
+{
+    class DeviceImage;
+
+    //! A ImageView is a light-weight representation of a view onto a multi-device image.
+    //! It holds a ConstPtr to a multi-device image as well as an ImageViewDescriptor
+    //! Using both, single-device ImageViews can be retrieved
+    class ImageView : public ResourceView
+    {
+    public:
+        AZ_RTTI(ImageView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);
+        virtual ~ImageView() = default;
+
+        ImageView(const RHI::Image* image, ImageViewDescriptor descriptor, MultiDevice::DeviceMask deviceMask)
+            : m_image{ image }
+            , m_descriptor{ descriptor }
+            , m_deviceMask{ deviceMask }
+        {
+        }
+
+        //! Given a device index, return the corresponding DeviceImageView for the selected device
+        const RHI::Ptr<RHI::DeviceImageView> GetDeviceImageView(int deviceIndex) const;
+
+        //! Return the contained multi-device image
+        const RHI::Image* GetImage() const
+        {
+            return m_image.get();
+        }
+
+        //! Return the contained ImageViewDescriptor
+        const ImageViewDescriptor& GetDescriptor() const
+        {
+            return m_descriptor;
+        }
+
+        const Resource* GetResource() const override
+        {
+            return m_image.get();
+        }
+
+        const DeviceResourceView* GetDeviceResourceView(int deviceIndex) const override
+        {
+            return GetDeviceImageView(deviceIndex).get();
+        }
+
+        void Shutdown() final;
+
+    private:
+        //! Safe-guard access to DeviceImageView cache during parallel access
+        mutable AZStd::mutex m_imageViewMutex;
+        //! A raw pointer to a multi-device image
+        ConstPtr<RHI::Image> m_image;
+        //! The corresponding ImageViewDescriptor for this view.
+        ImageViewDescriptor m_descriptor;
+        //! The device mask of the image stored for comparison to figure out when cache entries need to be freed.
+        mutable MultiDevice::DeviceMask m_deviceMask = MultiDevice::AllDevices;
+        //! DeviceImageView cache
+        //! This cache is necessary as the caller receives raw pointers from the ResourceCache,
+        //! which now, with multi-device objects in use, need to be held in memory as long as
+        //! the multi-device view is held.
+        mutable AZStd::unordered_map<int, Ptr<RHI::DeviceImageView>> m_cache;
+    };
+}

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
@@ -72,7 +72,7 @@ namespace AZ::RHI
     protected:
         Resource() = default;
 
-        //! Returns view based on the descriptor
+        //! Returns view based on the descriptor and keeps a raw pointer in a local cache
         Ptr<ImageView> GetResourceView(const ImageViewDescriptor& imageViewDescriptor) const;
         Ptr<BufferView> GetResourceView(const BufferViewDescriptor& bufferViewDescriptor) const;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
@@ -9,11 +9,14 @@
 
 #include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RHI.Reflect/ImageViewDescriptor.h>
-#include <Atom/RHI/ConstantsData.h>
 #include <Atom/RHI/Buffer.h>
-#include <Atom/RHI/Image.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/ConstantsData.h>
 #include <Atom/RHI/DeviceShaderResourceGroupData.h>
+#include <Atom/RHI/Image.h>
+#include <Atom/RHI/ImageView.h>
 #include <AzCore/std/containers/variant.h>
+
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -7,7 +7,9 @@
  */
 #include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/BufferFrameAttachment.h>
+#include <Atom/RHI/BufferView.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
+
 
 namespace AZ::RHI
 {
@@ -33,7 +35,7 @@ namespace AZ::RHI
 
     Ptr<BufferView> Buffer::BuildBufferView(const BufferViewDescriptor& bufferViewDescriptor)
     {
-        return aznew BufferView{ this, bufferViewDescriptor, GetDeviceMask() };
+        return Base::GetResourceView(bufferViewDescriptor);
     }
 
     const HashValue64 Buffer::GetHash() const
@@ -46,72 +48,5 @@ namespace AZ::RHI
     void Buffer::Shutdown()
     {
         Resource::Shutdown();
-    }
-
-    bool Buffer::IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor)
-    {
-        bool isInResourceCache{true};
-        IterateObjects<DeviceBuffer>([&isInResourceCache, &bufferViewDescriptor]([[maybe_unused]] auto deviceIndex, auto deviceBuffer)
-        {
-            isInResourceCache &= deviceBuffer->IsInResourceCache(bufferViewDescriptor);
-        });
-        return isInResourceCache;
-    }
-
-    //! Given a device index, return the corresponding DeviceBufferView for the selected device
-    const RHI::Ptr<RHI::DeviceBufferView> BufferView::GetDeviceBufferView(int deviceIndex) const
-    {
-        AZStd::lock_guard lock(m_bufferViewMutex);
-
-        if (m_buffer->GetDeviceMask() != m_deviceMask)
-        {
-            m_deviceMask = m_buffer->GetDeviceMask();
-
-            MultiDeviceObject::IterateDevices(
-                m_deviceMask,
-                [this](int deviceIndex)
-                {
-                    if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
-                    {
-                        m_cache.erase(it);
-                    }
-                    return true;
-                });
-        }
-
-        auto iterator{ m_cache.find(deviceIndex) };
-        if (iterator == m_cache.end())
-        {
-            //! Buffer view is not yet in the cache
-            auto [new_iterator, inserted]{ m_cache.insert(
-                AZStd::make_pair(deviceIndex, m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor))) };
-            if (inserted)
-            {
-                return new_iterator->second;
-            }
-        }
-        // TODO: Figure out why `iterator->second` is sometimes null given that `m_buffer` is non-null
-        // Add null check for `iterator->second` to avoid empty pointer
-        else if (!iterator->second || &iterator->second->GetBuffer() != m_buffer->GetDeviceBuffer(deviceIndex).get())
-        {
-            iterator->second = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor);
-        }
-
-        return iterator->second;
-    }
-
-    AZStd::unordered_map<int, uint32_t> BufferView::GetBindlessReadIndex() const
-    {
-        AZStd::unordered_map<int, uint32_t> result;
-
-        MultiDeviceObject::IterateDevices(
-            m_buffer->GetDeviceMask(),
-            [this, &result](int deviceIndex)
-            {
-                result[deviceIndex] = GetDeviceBufferView(deviceIndex)->GetBindlessReadIndex();
-                return true;
-            });
-
-        return result;
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferScopeAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferScopeAttachment.cpp
@@ -6,8 +6,9 @@
  *
  */
 
-#include <Atom/RHI/BufferScopeAttachment.h>
-#include <Atom/RHI/BufferFrameAttachment.h>
+ #include <Atom/RHI/BufferScopeAttachment.h>
+ #include <Atom/RHI/BufferFrameAttachment.h>
+ #include <Atom/RHI/BufferView.h>
 #include <Atom/RHI/DeviceBuffer.h>
 
 namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ #include <Atom/RHI/BufferView.h>
+ #include <Atom/RHI/Buffer.h>
+
+ namespace AZ::RHI
+ {
+    //! Given a device index, return the corresponding DeviceBufferView for the selected device
+    const RHI::Ptr<RHI::DeviceBufferView> BufferView::GetDeviceBufferView(int deviceIndex) const
+    {
+        AZStd::lock_guard lock(m_bufferViewMutex);
+
+        if (m_buffer->GetDeviceMask() != m_deviceMask)
+        {
+            m_deviceMask = m_buffer->GetDeviceMask();
+
+            MultiDeviceObject::IterateDevices(
+                m_deviceMask,
+                [this](int deviceIndex)
+                {
+                    if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
+                    {
+                        m_cache.erase(it);
+                    }
+                    return true;
+                });
+        }
+
+        auto iterator{ m_cache.find(deviceIndex) };
+        if (iterator == m_cache.end())
+        {
+            //! Buffer view is not yet in the cache
+            auto [new_iterator, inserted]{ m_cache.insert(
+                AZStd::make_pair(deviceIndex, m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor))) };
+            if (inserted)
+            {
+                return new_iterator->second;
+            }
+        }
+        // Add null check for `iterator->second` to avoid empty pointer
+        else if (!iterator->second || &iterator->second->GetBuffer() != m_buffer->GetDeviceBuffer(deviceIndex).get())
+        {
+            iterator->second = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor);
+        }
+
+        return iterator->second;
+    }
+
+    AZStd::unordered_map<int, uint32_t> BufferView::GetBindlessReadIndex() const
+    {
+        AZStd::unordered_map<int, uint32_t> result;
+
+        MultiDeviceObject::IterateDevices(
+            m_buffer->GetDeviceMask(),
+            [this, &result](int deviceIndex)
+            {
+                result[deviceIndex] = GetDeviceBufferView(deviceIndex)->GetBindlessReadIndex();
+                return true;
+            });
+
+        return result;
+    }
+
+    void BufferView::Shutdown()
+    {
+        if(m_buffer->IsInitialized())
+        {
+            m_buffer->EraseResourceView(static_cast<ResourceView*>(this));
+            m_buffer = nullptr;
+            ResourceView::Shutdown();
+        }
+    }
+ }

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
@@ -73,7 +73,6 @@
         {
             m_buffer->EraseResourceView(static_cast<ResourceView*>(this));
             m_buffer = nullptr;
-            ResourceView::Shutdown();
         }
     }
  }

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompileContext.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompileContext.cpp
@@ -5,12 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Atom/RHI/FrameGraphCompileContext.h>
-#include <Atom/RHI/FrameGraphAttachmentDatabase.h>
 #include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/FrameGraphAttachmentDatabase.h>
+#include <Atom/RHI/FrameGraphCompileContext.h>
 #include <Atom/RHI/Image.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
+#include <Atom/RHI/ImageView.h>
+
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -6,20 +6,22 @@
  *
  */
 
-#include <Atom/RHI/FrameGraphCompiler.h>
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
+#include <Atom/RHI/BufferView.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameGraph.h>
+#include <Atom/RHI/FrameGraphCompiler.h>
 #include <Atom/RHI/ImageFrameAttachment.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
+#include <Atom/RHI/ImageView.h>
 #include <Atom/RHI/RHIUtils.h>
 #include <Atom/RHI/Scope.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
 #include <Atom/RHI/TransientAttachmentPool.h>
 #include <AzCore/IO/SystemFile.h>
-#include <AzCore/std/sort.h>
 #include <AzCore/std/optional.h>
+#include <AzCore/std/sort.h>
 
 namespace AZ::RHI
 {
@@ -949,8 +951,20 @@ namespace AZ::RHI
                 {
                     const ImageViewDescriptor& imageViewDescriptor = node->GetDescriptor().m_imageViewDescriptor;
 
-                    // Multi device image views don't have a global cache, so we always cache them
-                    ImageView* imageView = GetImageViewFromLocalCache(image, imageViewDescriptor);
+                    ImageView* imageView = nullptr;
+                    // Check image's cache first as that contains views provided by higher level code.
+                    if (image->IsInResourceCache(imageViewDescriptor))
+                    {
+                        imageView = image->BuildImageView(imageViewDescriptor).get();
+                    }
+                    else
+                    {
+                        // If the higher level code has not provided a view, check local frame graph compiler's local cache.
+                        // The local cache is special and was mainly added to handle transient resources. This cache adds a dependency to
+                        // the resourceview ensuring they do not get deleted at the end of the frame and recreated at the start of the next
+                        // frame.
+                        imageView = GetImageViewFromLocalCache(image, imageViewDescriptor);
+                    }
 
                     node->SetImageView(imageView);
                 }
@@ -975,8 +989,20 @@ namespace AZ::RHI
                 {
                     const BufferViewDescriptor& bufferViewDescriptor = node->GetDescriptor().m_bufferViewDescriptor;
 
-                    // Multi device buffer views don't have a global cache, so we always cache them
-                    BufferView* bufferView = GetBufferViewFromLocalCache(buffer, bufferViewDescriptor);
+                    BufferView* bufferView = nullptr;
+                    // Check buffer's cache first as that contains views provided by higher level code.
+                    if (buffer->IsInResourceCache(bufferViewDescriptor))
+                    {
+                        bufferView = buffer->BuildBufferView(bufferViewDescriptor).get();
+                    }
+                    else
+                    {
+                        // If the higher level code has not provided a view, check local frame graph compiler's local cache.
+                        // The local cache is special and was mainly added to handle transient resources. This cache adds a dependency to
+                        // the resourceview ensuring they do not get deleted at the end of the frame and recreated at the start of the next
+                        // frame.
+                        bufferView = GetBufferViewFromLocalCache(buffer, bufferViewDescriptor);
+                    }
 
                     node->SetBufferView(bufferView);
                 }

--- a/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RHI/DeviceImageView.h>
 #include <Atom/RHI/Image.h>
 #include <Atom/RHI/ImageFrameAttachment.h>
+#include <Atom/RHI/ImageView.h>
 
 namespace AZ::RHI
 {
@@ -45,7 +46,7 @@ namespace AZ::RHI
 
     Ptr<ImageView> Image::BuildImageView(const ImageViewDescriptor& imageViewDescriptor)
     {
-        return aznew ImageView{ this, imageViewDescriptor, GetDeviceMask() };
+        return Base::GetResourceView(imageViewDescriptor);
     }
 
     uint32_t Image::GetResidentMipLevel() const
@@ -85,56 +86,6 @@ namespace AZ::RHI
     void Image::Shutdown()
     {
         Resource::Shutdown();
-    }
-
-    bool Image::IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor)
-    {
-        bool isInResourceCache{true};
-        IterateObjects<DeviceImage>([&isInResourceCache, &imageViewDescriptor]([[maybe_unused]] auto deviceIndex, auto deviceImage)
-        {
-            isInResourceCache &= deviceImage->IsInResourceCache(imageViewDescriptor);
-        });
-        return isInResourceCache;
-    }
-
-    //! Given a device index, return the corresponding DeviceBufferView for the selected device
-    const RHI::Ptr<RHI::DeviceImageView> ImageView::GetDeviceImageView(int deviceIndex) const
-    {
-        AZStd::lock_guard lock(m_imageViewMutex);
-
-        if (m_image->GetDeviceMask() != m_deviceMask)
-        {
-            m_deviceMask = m_image->GetDeviceMask();
-
-            MultiDeviceObject::IterateDevices(
-                m_deviceMask,
-                [this](int deviceIndex)
-                {
-                    if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
-                    {
-                        m_cache.erase(it);
-                    }
-                    return true;
-                });
-        }
-
-        auto iterator{ m_cache.find(deviceIndex) };
-        if (iterator == m_cache.end())
-        {
-            //! Image view is not yet in the cache
-            auto [new_iterator, inserted]{ m_cache.insert(
-                AZStd::make_pair(deviceIndex, m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor))) };
-            if (inserted)
-            {
-                return new_iterator->second;
-            }
-        }
-        else if (&iterator->second->GetImage() != m_image->GetDeviceImage(deviceIndex).get())
-        {
-            iterator->second = m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor);
-        }
-
-        return iterator->second;
     }
 
     void ImageSubresourceLayout::Init(MultiDevice::DeviceMask deviceMask, const DeviceImageSubresourceLayout &deviceLayout)

--- a/Gems/Atom/RHI/Code/Source/RHI/ImageScopeAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImageScopeAttachment.cpp
@@ -8,7 +8,7 @@
 
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ImageFrameAttachment.h>
-#include <Atom/RHI/DeviceImageView.h>
+#include <Atom/RHI/ImageView.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
 #include <Atom/RHI/Scope.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImageView.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ #include <Atom/RHI/ImageView.h>
+ #include <Atom/RHI/Image.h>
+
+ namespace AZ::RHI
+{
+        //! Given a device index, return the corresponding DeviceBufferView for the selected device
+        const RHI::Ptr<RHI::DeviceImageView> ImageView::GetDeviceImageView(int deviceIndex) const
+        {
+            AZStd::lock_guard lock(m_imageViewMutex);
+    
+            if (m_image->GetDeviceMask() != m_deviceMask)
+            {
+                m_deviceMask = m_image->GetDeviceMask();
+    
+                MultiDeviceObject::IterateDevices(
+                    m_deviceMask,
+                    [this](int deviceIndex)
+                    {
+                        if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
+                        {
+                            m_cache.erase(it);
+                        }
+                        return true;
+                    });
+            }
+    
+            auto iterator{ m_cache.find(deviceIndex) };
+            if (iterator == m_cache.end())
+            {
+                //! Image view is not yet in the cache
+                auto [new_iterator, inserted]{ m_cache.insert(
+                    AZStd::make_pair(deviceIndex, m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor))) };
+                if (inserted)
+                {
+                    return new_iterator->second;
+                }
+            }
+            else if (&iterator->second->GetImage() != m_image->GetDeviceImage(deviceIndex).get())
+            {
+                iterator->second = m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor);
+            }
+    
+            return iterator->second;
+        }
+
+        void ImageView::Shutdown()
+        {
+            if(m_image->IsInitialized())
+            {
+                m_image->EraseResourceView(static_cast<ResourceView*>(this));
+                m_image = nullptr;
+                ResourceView::Shutdown();
+            }
+        }
+}

--- a/Gems/Atom/RHI/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImageView.cpp
@@ -57,7 +57,6 @@
             {
                 m_image->EraseResourceView(static_cast<ResourceView*>(this));
                 m_image = nullptr;
-                ResourceView::Shutdown();
             }
         }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/Resource.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Resource.cpp
@@ -7,12 +7,12 @@
  */
 #include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RHI.Reflect/ImageViewDescriptor.h>
-#include <Atom/RHI/DeviceBufferView.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/DeviceResourceView.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/DeviceImageView.h>
+#include <Atom/RHI/ImageView.h>
 #include <Atom/RHI/Resource.h>
 #include <Atom/RHI/ResourcePool.h>
-#include <Atom/RHI/DeviceResourceView.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/hash.h>
 
@@ -119,5 +119,154 @@ namespace AZ::RHI
             m_pool->ShutdownResource(this);
         }
         MultiDeviceObject::Shutdown();
+    }
+
+    Ptr<ImageView> Resource::GetResourceView(const ImageViewDescriptor& imageViewDescriptor) const
+    {
+        const HashValue64 hash = imageViewDescriptor.GetHash();
+        AZStd::lock_guard<AZStd::mutex> registryLock(m_cacheMutex);
+        auto it = m_resourceViewCache.find(static_cast<uint64_t>(hash));
+        if (it == m_resourceViewCache.end())
+        {
+            return InsertNewImageView(hash, imageViewDescriptor);
+        }
+        else
+        {
+            // We've found a matching ResourceView in the cache, but another thread may be releasing the last intrusive_ptr while
+            // we are in this function, dropping the refcount to 0 (and forcing it to -1 for good measure) then deleting it.
+            //
+            //  There are 2 scenarios:
+            //
+            // m_useCount is -1. The other thread is already on the path to deleting it. We need to make a new one here
+            // and replace the old one.
+            //
+            // m_useCount is >=0. We cannot guarantee another thread won't drop the refcount to 0 after we check the value here
+            // so before we create a new intrusive_ptr, we need to use fetch_add to increment the refcount as we check the value to
+            // prevent a race
+            int useCount = it->second->m_useCount.fetch_add(2);
+            if (useCount == -1)
+            {
+                // The useCount was -1 before we incremented.
+                // Another thread is going to come along and delete the one we just found.
+                // Go ahead and erase it and insert a new one instead
+                m_resourceViewCache.erase(it);
+
+                return InsertNewImageView(hash, imageViewDescriptor);
+            }
+            else
+            {
+                // Create the new Ptr, increasing the refcount
+                Ptr<ImageView> result = static_cast<ImageView*>(it->second);
+
+                // Before we checked the value we artificially incremented the refcount to prevent another
+                // thread from letting it go to 0 again. Get rid of that artificial increase now that we have
+                // our new Ptr to hold on to the refcount
+                it->second->m_useCount.fetch_sub(2);
+                return result;
+            }
+        }
+    }
+
+    Ptr<BufferView> Resource::GetResourceView(const BufferViewDescriptor& bufferViewDescriptor) const
+    {
+        const HashValue64 hash = bufferViewDescriptor.GetHash();
+        AZStd::lock_guard<AZStd::mutex> registryLock(m_cacheMutex);
+        auto it = m_resourceViewCache.find(static_cast<uint64_t>(hash));
+        if (it == m_resourceViewCache.end())
+        {
+            return InsertNewBufferView(hash, bufferViewDescriptor);
+        }
+        else
+        {
+            // We've found a matching ResourceView in the cache, but another thread may be releasing the last intrusive_ptr while
+            // we are in this function, dropping the refcount to 0 (and forcing it to -1 for good measure) then deleting it.
+            //
+            //  There are 2 scenarios:
+            //
+            // m_useCount is -1. The other thread is already on the path to deleting it. We need to make a new one here
+            // and replace the old one.
+            //
+            // m_useCount is >=0. We cannot guarantee another thread won't drop the refcount to 0 after we check the value here
+            // so before we create a new intrusive_ptr, we need to use fetch_add to increment the refcount as we check the value to prevent
+            // a race
+            int useCount = it->second->m_useCount.fetch_add(2);
+            if (useCount == -1)
+            {
+                // The useCount was -1 before we incremented.
+                // Another thread is going to come along and delete the one we just found.
+                // Go ahead and erase it and insert a new one instead
+                m_resourceViewCache.erase(it);
+
+                return InsertNewBufferView(hash, bufferViewDescriptor);
+            }
+            else
+            {
+                // Create the new Ptr, increasing the refcount
+                Ptr<BufferView> result = static_cast<BufferView*>(it->second);
+
+                // Before we checked the value we artificially incremented the refcount to prevent another
+                // thread from letting it go to 0 again. Get rid of that artificial increase now that we have
+                // our new Ptr to hold on to the refcount
+                it->second->m_useCount.fetch_sub(2);
+                return result;
+            }
+        }
+    }
+
+    Ptr<ImageView> Resource::InsertNewImageView(HashValue64 hash, const ImageViewDescriptor& imageViewDescriptor) const
+    {
+        Ptr<ImageView> imageViewPtr = aznew ImageView{ static_cast<const RHI::Image*>(this), imageViewDescriptor, GetDeviceMask() };
+        if (imageViewPtr)
+        {
+            m_resourceViewCache[static_cast<uint64_t>(hash)] = static_cast<ResourceView*>(imageViewPtr.get());
+            return imageViewPtr;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    Ptr<BufferView> Resource::InsertNewBufferView(HashValue64 hash, const BufferViewDescriptor& bufferViewDescriptor) const
+    {
+        Ptr<BufferView> bufferViewPtr = aznew BufferView{static_cast<const RHI::Buffer*>(this), bufferViewDescriptor, GetDeviceMask()};
+        if (bufferViewPtr)
+        {
+            m_resourceViewCache[static_cast<uint64_t>(hash)] = static_cast<ResourceView*>(bufferViewPtr.get());
+            return bufferViewPtr;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    void Resource::EraseResourceView(ResourceView* resourceView) const
+    {
+        AZStd::lock_guard<AZStd::mutex> registryLock(m_cacheMutex);
+        auto itr = m_resourceViewCache.begin();
+        while (itr != m_resourceViewCache.end())
+        {
+            if (itr->second == resourceView)
+            {
+                m_resourceViewCache.erase(itr->first);
+                break;
+            }
+            itr++;
+        }
+    }
+
+    bool Resource::IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor)
+    {
+        const HashValue64 hash = imageViewDescriptor.GetHash();
+        auto it = m_resourceViewCache.find(static_cast<uint64_t>(hash));
+        return it != m_resourceViewCache.end();
+    }
+
+    bool Resource::IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor)
+    {
+        const HashValue64 hash = bufferViewDescriptor.GetHash();
+        auto it = m_resourceViewCache.find(static_cast<uint64_t>(hash));
+        return it != m_resourceViewCache.end();
     }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -18,6 +18,7 @@ set(FILES
     Include/Atom/RHI/DeviceBuffer.h
     Include/Atom/RHI/Buffer.h
     Include/Atom/RHI/DeviceBufferView.h
+    Include/Atom/RHI/BufferView.h
     Include/Atom/RHI/DeviceIndexBufferView.h
     Include/Atom/RHI/IndexBufferView.h
     Include/Atom/RHI/DeviceStreamBufferView.h
@@ -25,6 +26,7 @@ set(FILES
     Source/RHI/DeviceBuffer.cpp
     Source/RHI/Buffer.cpp
     Source/RHI/DeviceBufferView.cpp
+    Source/RHI/BufferView.cpp
     Source/RHI/DeviceIndexBufferView.cpp
     Source/RHI/IndexBufferView.cpp
     Source/RHI/DeviceStreamBufferView.cpp
@@ -124,9 +126,11 @@ set(FILES
     Include/Atom/RHI/DeviceImage.h
     Include/Atom/RHI/Image.h
     Include/Atom/RHI/DeviceImageView.h
+    Include/Atom/RHI/ImageView.h
     Source/RHI/DeviceImage.cpp
     Source/RHI/Image.cpp
     Source/RHI/DeviceImageView.cpp
+    Source/RHI/ImageView.cpp
     Include/Atom/RHI/DeviceImagePool.h
     Include/Atom/RHI/ImagePool.h
     Include/Atom/RHI/DeviceImagePoolBase.h

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -6,17 +6,19 @@
  *
  */
 
+#include <Atom/RHI/DeviceImageView.h>
+#include <Atom/RHI/Image.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
+#include <Atom/RHI/ImageView.h>
+#include <Atom/RHI/Resource.h>
 #include <Atom/RHI/Scope.h>
 #include <Atom/RHI/ScopeAttachment.h>
-#include <Atom/RHI/Image.h>
-#include <Atom/RHI/Resource.h>
-#include <Atom/RHI/DeviceImageView.h>
-#include <RHI/Vulkan.h>
 #include <RHI/Conversion.h>
 #include <RHI/Device.h>
 #include <RHI/Image.h>
 #include <RHI/PhysicalDevice.h>
+#include <RHI/Vulkan.h>
+
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
@@ -12,7 +12,9 @@
 
 #include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/BufferView.h>
 #include <Atom/RHI/Fence.h>
+
 
 #include <Atom/RHI.Reflect/AttachmentId.h>
 #include <Atom/RHI.Reflect/Base.h>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.h
@@ -7,11 +7,12 @@
  */
 #pragma once
 
+#include <Atom/RHI/ImageView.h>
 #include <Atom/RPI.Public/Configuration.h>
-#include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Public/Pass/ComputePass.h>
-#include <Atom/RHI/Image.h>
+#include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Reflect/Pass/PassDescriptor.h>
+
 
 namespace AZ::RPI
 {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
@@ -10,9 +10,11 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 
+#include <Atom/RHI/DeviceImageView.h>
 #include <Atom/RHI/Image.h>
 #include <Atom/RHI/ImagePool.h>
-#include <Atom/RHI/DeviceImageView.h>
+#include <Atom/RHI/ImageView.h>
+
 
 #include <Atom/RPI.Reflect/Configuration.h>
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 
-#include <Atom/RHI/DeviceImageView.h>
 #include <Atom/RHI/Image.h>
 #include <Atom/RHI/ImagePool.h>
 #include <Atom/RHI/ImageView.h>


### PR DESCRIPTION
## What does this PR try to fix?

As surfaced in https://github.com/o3de/o3de/issues/18706, there is an issue with the change in implementation that happened during the transition to multi-device resources.
The initial goal was not to have a two-layer cache hierarchy for `ResourceView`s and `DeviceResourceView`s, but leave the lower level as is and re-create `ResourceView` s on demand.

`DeviceResource`s have a "recreation" cache, a cache that does not actually cache the resource by holding its memory, but a cache that holds raw pointers to the memory.
I.e., if some other code (for example `DeviceShaderResourceGroupData`) already requested a `DeviceResourceView` on a `DeviceResource` and was holding a smart pointer to this object, then the cache in the `DeviceResource` would be able to provide access to this as well, without the need to re-create the `DeviceResourceView`.

The `FrameGraphCompiler` has an additional cache to handle all cases where higher-level code does not already cache the view and hence is necessary for the lifetime of the `Resource`.
Unfortunately, this cache has no way of clearing items, items are only evicted once the cache is full.

This lead to the memory leak behaviour described in https://github.com/o3de/o3de/issues/18706, where resizing a buffer would leave the old buffer in the cache (as the cache checks for name and descriptor (which changes during a resize)).

## What does this PR do?
This PR adds back the ability of `Resource`s to "cache" their `ResourceView`s. This way `ResourceView`s are only created once initially and as long as the lifetime is extended by someone, repeat calls to `GetResourceView` resulted in hits in the cache and no newly build `ResourceView`s.

## How was this PR tested?

This was tested by resizing a buffer every 100 frames and comparing the usage of dedicated GPU memory.

### Previous Behaviour
![Cache_broken](https://github.com/user-attachments/assets/be19dd56-07c1-4fe0-9813-412064202b4e)

### New Behaviour
![Cache_fixed](https://github.com/user-attachments/assets/c029a1e7-bb52-4de1-9925-934342bf3adb)

