### PR TITLE
ScriptCanvas: Fix default file path when saving a new graph

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1710,43 +1710,19 @@ namespace ScriptCanvasEditor
 
             QString localSelectedFilter;
             QFileDialog::Options options;
-            QString filePath1 = QFileDialog::getSaveFileName(this, QObject::tr("Save As..."), fullPath.c_str(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"), &localSelectedFilter, options);
+            QString filePath = AzQtComponents::FileDialog::GetSaveFileName(this, QObject::tr("Save As..."), fullPath.c_str(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"), &localSelectedFilter, options);
 
-            selectedFile = filePath1.toUtf8().toStdString().c_str();
+            selectedFile = filePath.toUtf8().toStdString().c_str();
 
             // If the selected file is empty that means we just cancelled.
             // So we want to break out.
-            if (!selectedFile.isEmpty())
+            if (selectedFile.isEmpty())
             {
-                AZStd::string filePath = selectedFile.toUtf8().data();
-
-                if (!AZ::StringFunc::EndsWith(filePath, SourceDescription::GetFileExtension(), false))
-                {
-                    filePath += SourceDescription::GetFileExtension();
-                }
-
-                AZStd::string fileName;
-
-                if (AzFramework::StringFunc::Path::GetFileName(filePath.c_str(), fileName))
-                {
-                    isValidFileName = !(fileName.empty());
-                    if (isValidFileName)
-                    {
-                        if (AzFramework::StringFunc::FirstCharacter(fileName.c_str()) >= '0' &&
-                            AzFramework::StringFunc::FirstCharacter(fileName.c_str()) <= '9')
-                        {
-                            QMessageBox::warning(this, QObject::tr("Unable to Save"), QObject::tr("File name cannot start with a number"));
-                            return false;
-                        }
-                    }
-                }
-                else
-                {
-                    QMessageBox::information(this, "Unable to Save", "File name cannot be empty");
-                }
+                QMessageBox::information(this, "Unable to Save", "File name cannot be empty");
             }
             else
             {
+                isValidFileName = true;
                 break;
             }
         }
@@ -1754,7 +1730,6 @@ namespace ScriptCanvasEditor
         if (isValidFileName)
         {
             AZStd::string internalStringFile = selectedFile.toUtf8().data();
-
 
             if (!AZ::StringFunc::EndsWith(internalStringFile, SourceDescription::GetFileExtension(), false))
             {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
@@ -197,6 +197,7 @@ namespace ScriptCanvas
         , m_id(source.Id())
         , m_relativePath(source.m_relativePath)
         , m_absolutePath(source.m_absolutePath)
+        , m_suggestedFileName(source.m_suggestedFileName)
     {
         SanitizePath();
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
@@ -238,6 +238,16 @@ namespace ScriptCanvas
         return m_absolutePath;
     }
 
+    void SourceHandle::SetSuggestedFileName(const AZStd::string_view suggestedFileName)
+    {
+        m_suggestedFileName = suggestedFileName;
+    }
+
+    AZStd::string SourceHandle::GetSuggestedFileName() const
+    {
+        return m_suggestedFileName;
+    }
+
     bool SourceHandle::AnyEquals(const SourceHandle& other) const
     {
         return m_data && m_data == other.m_data

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
@@ -393,6 +393,9 @@ namespace ScriptCanvas
 
         AZStd::string ToString() const;
 
+        AZStd::string GetSuggestedFileName() const;
+        void SetSuggestedFileName(const AZStd::string_view suggestedFileName);
+
     private:
         SourceHandle(const SourceHandle& data, const AZ::Uuid& id, const AZ::IO::Path& path);
 
@@ -406,6 +409,7 @@ namespace ScriptCanvas
         AZ::Uuid m_id = AZ::Uuid::CreateNull();
         AZ::IO::Path m_relativePath;
         AZ::IO::Path m_absolutePath;
+        AZStd::string m_suggestedFileName;
 
         void SanitizePath();
     };


### PR DESCRIPTION
## What does this PR do?

When saving a new file in ScriptCanvas it would sometimes go to the executable's folder instead of the project's root folder. The problem was that we'd send `AzQtComponents::FileDialog::GetSaveFileName` an invalid filename and the function would handle that by returning the executable's folder.

This change stores the suggested filename that was used when creating the new asset and using it for the open save file dialog but also it ensures that the folder that we specify exists.

Also removed some additional file name validation, the `AzQtComponents::FileDialog::GetSaveFileName` already verifies that the filename is valid.

Closes #13616 
Closes #13163
