### PR TITLE
ScriptCanvas breakpoint support : Allow to add breakpoint on node and stop execution when breakpoint is hit (disabled behind code)

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.h
@@ -213,7 +213,16 @@ namespace GraphCanvas
         {
         }
         ////
-        
+
+        //////////////////////////////////////
+        // Breakpoint handling
+
+        virtual void AddBreakpoints([[maybe_unused]] const AZStd::unordered_set<NodeId>& nodeIds)
+        {
+        }
+
+        //////////////////////////////////////
+
         //////////////////////////////////////
         // Node Wrapper Optional Overrides
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.h>
+
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuAction.h>
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.h>
+
+namespace GraphCanvas
+{
+    void BreakpointActionsMenuGroup::PopulateMenu(EditorContextMenu* contextMenu)
+    {
+        contextMenu->AddActionGroup(BreakpointContextMenuAction::GetBreakpointContextMenuActionGroupId());
+
+        m_addBreakpointAction = aznew AddBreakpointMenuAction(contextMenu);
+        contextMenu->AddMenuAction(m_addBreakpointAction);
+    }
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ContextMenuAction.h>
+#include <GraphCanvas/Widgets/EditorContextMenu/EditorContextMenu.h>
+
+namespace GraphCanvas
+{
+    class BreakpointActionsMenuGroup
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(BreakpointActionsMenuGroup, AZ::SystemAllocator);
+
+        BreakpointActionsMenuGroup() = default;
+        ~BreakpointActionsMenuGroup() = default;
+
+        void PopulateMenu(EditorContextMenu* contextMenu);
+
+    private:
+        ContextMenuAction* m_addBreakpointAction;
+    };
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuAction.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuAction.h
@@ -22,12 +22,17 @@ namespace GraphCanvas
         }
 
         using ContextMenuAction::RefreshAction;
-        void RefreshAction(const GraphId& graphId, [[maybe_unused]] const AZ::EntityId& targetId) override
+        void RefreshAction([[maybe_unused]] const GraphId& graphId, [[maybe_unused]] const AZ::EntityId& targetId) override
         {
+            /*
             bool hasSelectedItems = false;
             SceneRequestBus::EventResult(hasSelectedItems, graphId, &SceneRequests::HasSelectedItems);
 
             setEnabled(hasSelectedItems);
+            */
+
+            setEnabled(false);
+            setToolTip("Feature in development. Adding breakpoint works but will freeze the editor when breakpoint is hit.");
         }
 
     public:

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuAction.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuAction.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ContextMenuAction.h>
+
+#include <GraphCanvas/Components/SceneBus.h>
+
+namespace GraphCanvas
+{
+    class BreakpointContextMenuAction : public ContextMenuAction
+    {
+    protected:
+        BreakpointContextMenuAction(AZStd::string_view actionName, QObject* parent)
+            : ContextMenuAction(actionName, parent)
+        {
+        }
+
+        using ContextMenuAction::RefreshAction;
+        void RefreshAction(const GraphId& graphId, [[maybe_unused]] const AZ::EntityId& targetId) override
+        {
+            bool hasSelectedItems = false;
+            SceneRequestBus::EventResult(hasSelectedItems, graphId, &SceneRequests::HasSelectedItems);
+
+            setEnabled(hasSelectedItems);
+        }
+
+    public:
+        static ActionGroupId GetBreakpointContextMenuActionGroupId()
+        {
+            return AZ_CRC_CE("BreakpointActionGroup");
+        }
+
+        ActionGroupId GetActionGroupId() const override
+        {
+            return GetBreakpointContextMenuActionGroupId();
+        }
+    };
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.h>
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/std/containers/vector.h>
+#include <GraphCanvas/Components/Nodes/NodeBus.h>
+#include <GraphCanvas/Editor/GraphModelBus.h>
+
+namespace GraphCanvas
+{
+    //////////////////////////////
+    // AddBreakpointMenuAction
+    //////////////////////////////
+
+    AddBreakpointMenuAction::AddBreakpointMenuAction(QObject* parent)
+        : BreakpointContextMenuAction("Add Breakpoint", parent)
+    {
+    }
+
+    ContextMenuAction::SceneReaction AddBreakpointMenuAction::TriggerAction(
+        const GraphId& graphId, [[maybe_unused]] const AZ::Vector2& scenePos)
+    {
+        AZStd::vector<AZ::EntityId> selectedNodes;
+        SceneRequestBus::EventResult(selectedNodes, graphId, &SceneRequests::GetSelectedNodes);
+
+        if (selectedNodes.empty())
+        {
+            return SceneReaction::Nothing;
+        }
+
+        AZStd::unordered_set<NodeId> nodeIds;
+        for (const AZ::EntityId& nodeId : selectedNodes)
+        {
+            nodeIds.insert(nodeId);
+        }
+
+        GraphModelRequestBus::Event(graphId, &GraphModelRequests::AddBreakpoints, nodeIds);
+        return SceneReaction::PostUndo;
+    }
+
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuAction.h>
+
+namespace GraphCanvas
+{
+    class AddBreakpointMenuAction : public BreakpointContextMenuAction
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(AddBreakpointMenuAction, AZ::SystemAllocator);
+
+        AddBreakpointMenuAction(QObject* parent);
+        virtual ~AddBreakpointMenuAction() = default;
+
+        using BreakpointContextMenuAction::TriggerAction;
+        SceneReaction TriggerAction(const GraphId& graphId, const AZ::Vector2& scenePos) override;
+    };
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenus/NodeContextMenu.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenus/NodeContextMenu.cpp
@@ -20,6 +20,7 @@ namespace GraphCanvas
     {
         m_editActionGroup.PopulateMenu(this);
         m_nodeGroupActionGroup.PopulateMenu(this);
+        m_breakpointActionGroup.PopulateMenu(this);
         m_disableActionGroup.PopulateMenu(this);
         m_alignmentActionGroup.PopulateMenu(this);
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenus/NodeContextMenu.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenus/NodeContextMenu.h
@@ -10,27 +10,27 @@
 #include <GraphCanvas/Widgets/EditorContextMenu/EditorContextMenu.h>
 
 #include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/AlignmentMenuActions/AlignmentActionsMenuGroup.h>
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.h>
+#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/DisableMenuActions/DisableActionsMenuGroup.h>
 #include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/EditMenuActions/EditActionsMenuGroup.h>
 #include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/NodeGroupMenuActions/NodeGroupActionsMenuGroup.h>
-#include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/DisableMenuActions/DisableActionsMenuGroup.h>
 
 namespace GraphCanvas
 {
-    class NodeContextMenu
-        : public EditorContextMenu
+    class NodeContextMenu : public EditorContextMenu
     {
     public:
         AZ_CLASS_ALLOCATOR(NodeContextMenu, AZ::SystemAllocator)
         NodeContextMenu(EditorId editorId, QWidget* parent = nullptr);
         ~NodeContextMenu() override = default;
-        
+
     protected:
-    
         void OnRefreshActions(const GraphId& graphId, const AZ::EntityId& targetMemberId) override;
 
-        EditActionsMenuGroup        m_editActionGroup;
-        NodeGroupActionsMenuGroup   m_nodeGroupActionGroup;
-        DisableActionsMenuGroup     m_disableActionGroup;
-        AlignmentActionsMenuGroup   m_alignmentActionGroup;
+        EditActionsMenuGroup m_editActionGroup;
+        NodeGroupActionsMenuGroup m_nodeGroupActionGroup;
+        BreakpointActionsMenuGroup m_breakpointActionGroup;
+        DisableActionsMenuGroup m_disableActionGroup;
+        AlignmentActionsMenuGroup m_alignmentActionGroup;
     };
-}
+} // namespace GraphCanvas

--- a/Gems/GraphCanvas/Code/graphcanvas_staticlib_files.cmake
+++ b/Gems/GraphCanvas/Code/graphcanvas_staticlib_files.cmake
@@ -159,6 +159,11 @@ set(FILES
     StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/AlignmentMenuActions/AlignmentContextMenuAction.h
     StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/AlignmentMenuActions/AlignmentContextMenuActions.cpp
     StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/AlignmentMenuActions/AlignmentContextMenuActions.h
+    StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.cpp
+    StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointActionsMenuGroup.h
+    StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuAction.h
+    StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.cpp
+    StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/BreakpointMenuActions/BreakpointContextMenuActions.h
     StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ConstructMenuActions/BookmarkConstructMenuActions.cpp
     StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ConstructMenuActions/BookmarkConstructMenuActions.h
     StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/ConstructMenuActions/ConstructContextMenuAction.h

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -34,8 +34,10 @@ AZ_POP_DISABLE_WARNING
 #include <ScriptCanvas/Bus/RequestBus.h>
 #include <ScriptCanvas/Bus/EditorScriptCanvasBus.h>
 #include <ScriptCanvas/Core/ConnectionBus.h>
+#include <ScriptCanvas/Core/ExecutionNotificationsBus.h>
 #include <ScriptCanvas/Core/GraphScopedTypes.h>
 #include <ScriptCanvas/Core/NodeBus.h>
+#include <ScriptCanvas/Debugger/Bus.h>
 #include <ScriptCanvas/GraphCanvas/MappingBus.h>
 #include <ScriptCanvas/Libraries/Core/EBusEventHandler.h>
 #include <ScriptCanvas/Libraries/Core/FunctionDefinitionNode.h>
@@ -2586,6 +2588,19 @@ namespace ScriptCanvasEditor
             if (canvasNode)
             {
                 canvasNode->FinalizeExtension(extenderId);
+            }
+        }
+    }
+
+    void EditorGraph::AddBreakpoints(const AZStd::unordered_set<GraphCanvas::NodeId>& nodeIds)
+    {
+        for (const GraphCanvas::NodeId& nodeId : nodeIds)
+        {
+            AZ::EntityId scNodeId = ConvertToScriptCanvasNodeId(nodeId);
+            if (scNodeId.IsValid())
+            {
+                ScriptCanvas::Breakpoint breakpoint(scNodeId);
+                ScriptCanvas::Debugger::ClientRequestsBus::Broadcast(&ScriptCanvas::Debugger::ClientRequests::AddBreakpoint, breakpoint);
             }
         }
     }

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
@@ -205,6 +205,8 @@ namespace ScriptCanvasEditor
         void ExtensionCancelled(const GraphCanvas::NodeId& nodeId, const GraphCanvas::ExtenderId& extenderId) override;
         void FinalizeExtension(const GraphCanvas::NodeId& nodeId, const GraphCanvas::ExtenderId& extenderId) override;
 
+        void AddBreakpoints(const AZStd::unordered_set<GraphCanvas::NodeId>& nodeIds) override;
+
         bool ShouldWrapperAcceptDrop(const GraphCanvas::NodeId& wrapperNode, const QMimeData* mimeData) const override;
 
         void AddWrapperDropTarget(const GraphCanvas::NodeId& wrapperNode) override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
@@ -649,3 +649,16 @@ namespace ScriptCanvas
         visitor.Visit(*this);
     }
 } // namespace ScriptCanvas
+
+namespace AZStd
+{
+    template<>
+    struct hash<ScriptCanvas::Breakpoint>
+    {
+        AZ_FORCE_INLINE size_t operator()(const ScriptCanvas::Breakpoint& argument) const
+        {
+            // AZ::EntityId overloads the u64 cast to return the stored id
+            return static_cast<AZ::u64>(argument);
+        }
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
@@ -11,8 +11,8 @@
 #include "Core.h"
 #include "Core/Datum.h"
 #include "Core/Endpoint.h"
-#include "Variable/GraphVariable.h"
 #include "Core/NamedId.h"
+#include "Variable/GraphVariable.h"
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/std/time.h>
@@ -60,11 +60,12 @@ namespace ScriptCanvas
         VariableIdentifier(VariableId variableId, const GraphIdentifier& graphId)
             : m_variableId(variableId)
             , m_graphId(graphId)
-        {}
+        {
+        }
 
         AZStd::string ToString() const;
     };
-}
+} // namespace ScriptCanvas
 
 namespace AZStd
 {
@@ -97,7 +98,7 @@ namespace AZStd
             return graphInfoHash;
         }
     };
-}
+} // namespace AZStd
 
 namespace ScriptCanvas
 {
@@ -106,92 +107,146 @@ namespace ScriptCanvas
     struct BreakTag
     {
         AZ_TYPE_INFO(BreakTag, "{B1B0976D-E300-470B-B01C-8EED7571414A}");
-        static const char* ToString() { return "Break"; }
+        static const char* ToString()
+        {
+            return "Break";
+        }
     };
     struct BreakpointTag
     {
         AZ_TYPE_INFO(BreakpointTag, "{4915585E-9AF7-4414-87D4-F1EE31E04E4D}");
-        static const char* ToString() { return "Breakpoint"; }
+        static const char* ToString()
+        {
+            return "Breakpoint";
+        }
     };
     struct ContinueTag
     {
         AZ_TYPE_INFO(ContinueTag, "{611DF6CA-24CC-4F6B-89BF-4EDE56661040}");
-        static const char* ToString() { return "Continue"; }
+        static const char* ToString()
+        {
+            return "Continue";
+        }
     };
     struct ExecutionThreadBeginTag
     {
         AZ_TYPE_INFO(ExecutionThreadBeginTag, "{43C2F51D-17E9-4B4A-A1EF-3D5FD39857A4}");
-        static const char* ToString() { return "ExecutionThreadBegin"; }
+        static const char* ToString()
+        {
+            return "ExecutionThreadBegin";
+        }
     };
     struct ExecutionThreadEndTag
     {
         AZ_TYPE_INFO(ExecutionThreadEndTag, "{1BD155E9-ED07-4900-A6C9-04704A79424B}");
-        static const char* ToString() { return "ExecutionThreadEnd"; }
+        static const char* ToString()
+        {
+            return "ExecutionThreadEnd";
+        }
     };
     struct GetAvailableScriptTargetsTag
     {
         AZ_TYPE_INFO(GetAvailableScriptTargetsTag, "{D6B4D3FE-5975-4974-8DF4-CF823CCEEDB9}");
-        static const char* ToString() { return "GetAvailableScriptTargets"; }
+        static const char* ToString()
+        {
+            return "GetAvailableScriptTargets";
+        }
     };
     struct GetActiveEntitiesTag
     {
         AZ_TYPE_INFO(GetActiveEntitiesTag, "{F28305CE-7CC4-4481-BCAA-5347361496B1}");
-        static const char* ToString() { return "GetActiveEntities"; }
+        static const char* ToString()
+        {
+            return "GetActiveEntities";
+        }
     };
     struct GetActiveGraphsTag
     {
         AZ_TYPE_INFO(GetActiveGraphsTag, "{4AF50B18-87A7-45F0-925C-76D89DFC6DB6}");
-        static const char* ToString() { return "GetActiveGraphs"; }
+        static const char* ToString()
+        {
+            return "GetActiveGraphs";
+        }
     };
     struct GetVariableValueTag
     {
         AZ_TYPE_INFO(GetVariableValueTag, "{DBD77ADA-B8A5-423F-8524-5F2C765A1E46}");
-        static const char* ToString() { return "GetVariableValueTag"; }
+        static const char* ToString()
+        {
+            return "GetVariableValueTag";
+        }
     };
     struct GetVariableValuesTag
     {
         AZ_TYPE_INFO(GetVariableValuesTag, "{AEBE5DB8-DD6D-4B3F-AFDA-5A89010C21DF}");
-        static const char* ToString() { return "GetVariableValuesTag"; }
+        static const char* ToString()
+        {
+            return "GetVariableValuesTag";
+        }
     };
     struct GraphActivationTag
     {
         AZ_TYPE_INFO(GraphActivationTag, "{9DC4188F-52A1-4F95-A20C-FEFECDF48FEE}");
-        static const char* ToString() { return "GraphActivation"; }
+        static const char* ToString()
+        {
+            return "GraphActivation";
+        }
     };
     struct GraphDeactivationTag
     {
         AZ_TYPE_INFO(GraphDeactivationTag, "{FE4B8C6B-B8EE-4CA1-A4D4-DB559D977E22}");
-        static const char* ToString() { return "GraphDeactivation"; }
+        static const char* ToString()
+        {
+            return "GraphDeactivation";
+        }
     };
     struct InputSignalTag
     {
         AZ_TYPE_INFO(InputSignalTag, "{AFAE431F-4E4F-4AC6-8EBB-5D6A209280A4}");
-        static const char* ToString() { return "InputSignal"; }
+        static const char* ToString()
+        {
+            return "InputSignal";
+        }
     };
     struct OutputSignalTag
     {
         AZ_TYPE_INFO(OutputSignalTag, "{6E8D6FA8-92C5-4EEB-82DE-8CF4293F83E6}");
-        static const char* ToString() { return "OutputSignal"; }
+        static const char* ToString()
+        {
+            return "OutputSignal";
+        }
     };
     struct ReturnSignalTag
     {
         AZ_TYPE_INFO(ReturnSignalTag, "{CFA657CE-6073-4D3C-B5EF-B7BA624A4C19}");
-        static const char* ToString() { return "ReturnSignal"; }
+        static const char* ToString()
+        {
+            return "ReturnSignal";
+        }
     };
     struct AnnotateNodeSignalTag
     {
         AZ_TYPE_INFO(AnnotateNodeSignalTag, "{6F61974F-B1BB-4377-8903-B360C50A28EC}");
-        static const char* ToString() { return "AnnotateNodeSignal"; }
+        static const char* ToString()
+        {
+            return "AnnotateNodeSignal";
+        }
     };
     struct StepOverTag
     {
         AZ_TYPE_INFO(StepOverTag, "{44980605-0FF2-4A5C-870E-324B4184ADD6}");
-        static const char* ToString() { return "StepOver"; }
+        static const char* ToString()
+        {
+            return "StepOver";
+        }
     };
     struct VariableChangeTag
     {
         AZ_TYPE_INFO(VariableChangeTag, "{2936D848-1EA1-4B07-A462-F52F8A0ED395}");
-        static const char* ToString() { return "VariableChange"; }
+        static const char* ToString()
+        {
+            return "VariableChange";
+        }
     };
 
     class LoggableEventVisitor;
@@ -226,10 +281,7 @@ namespace ScriptCanvas
         {
             if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
-                serializeContext->Class<ThisType, t_Parent, LoggableEvent>()
-                    ->Version(0)
-                    ->Field("timestamp", &ThisType::m_timestamp)
-                    ;
+                serializeContext->Class<ThisType, t_Parent, LoggableEvent>()->Version(0)->Field("timestamp", &ThisType::m_timestamp);
             }
         }
 
@@ -237,12 +289,14 @@ namespace ScriptCanvas
 
         TaggedParent()
             : m_timestamp(AZStd::GetTimeUTCMilliSecond())
-        {}
+        {
+        }
 
         TaggedParent(const t_Parent& parent)
             : t_Parent(parent)
             , m_timestamp(AZStd::GetTimeUTCMilliSecond())
-        {}
+        {
+        }
 
         Timestamp GetTimestamp() const override
         {
@@ -267,12 +321,12 @@ namespace ScriptCanvas
         AZ_CLASS_ALLOCATOR(ActiveGraphStatus, AZ::SystemAllocator);
         AZ_TYPE_INFO(ActiveGraphStatus, "{6E251A99-EE03-4C12-9122-35A90CBB5891}");
 
-        int               m_instanceCounter = 0;
-        bool              m_isObserved = false;
+        int m_instanceCounter = 0;
+        bool m_isObserved = false;
     };
 
-    using ActiveGraphStatusMap = AZStd::unordered_map< AZ::Data::AssetId, ActiveGraphStatus >;
-    using EntityActiveGraphStatusMap = AZStd::unordered_map< GraphIdentifier, ActiveGraphStatus >;
+    using ActiveGraphStatusMap = AZStd::unordered_map<AZ::Data::AssetId, ActiveGraphStatus>;
+    using EntityActiveGraphStatusMap = AZStd::unordered_map<GraphIdentifier, ActiveGraphStatus>;
 
     struct ActiveEntityStatus final
     {
@@ -284,7 +338,7 @@ namespace ScriptCanvas
         EntityActiveGraphStatusMap m_activeGraphs;
     };
 
-    using ActiveEntityStatusMap = AZStd::unordered_map< AZ::EntityId, ActiveEntityStatus >;
+    using ActiveEntityStatusMap = AZStd::unordered_map<AZ::EntityId, ActiveEntityStatus>;
     using ActiveEntitiesAndGraphs = AZStd::pair<ActiveEntityStatusMap, ActiveGraphStatusMap>;
 
     struct DatumValue
@@ -308,12 +362,14 @@ namespace ScriptCanvas
         DatumValue(AZ::TypeId behaviorContextObjectType, const AZStd::string& toStringResult)
             : m_behaviorContextObjectType(behaviorContextObjectType)
             , m_datum(Datum(toStringResult))
-        {}
+        {
+        }
 
         DatumValue(const Datum& datum)
             : m_behaviorContextObjectType{}
             , m_datum(datum)
-        {}
+        {
+        }
 
         AZStd::string ToString() const;
     };
@@ -321,8 +377,7 @@ namespace ScriptCanvas
     using SlotDataMap = AZStd::unordered_map<NamedSlotId, DatumValue>;
     using VariableValues = AZStd::unordered_map<VariableId, AZStd::pair<AZStd::string, DatumValue>>;
 
-    struct ActivationInfo
-        : public GraphInfo
+    struct ActivationInfo : public GraphInfo
     {
         AZ_CLASS_ALLOCATOR(ActivationInfo, AZ::SystemAllocator);
         AZ_RTTI(ActivationInfo, "{9EBCB557-80D1-43CA-840E-BB8945BF13F4}", GraphInfo);
@@ -344,8 +399,7 @@ namespace ScriptCanvas
         AZStd::string ToString() const;
     };
 
-    struct Signal
-        : public GraphInfo
+    struct Signal : public GraphInfo
     {
         AZ_CLASS_ALLOCATOR(Signal, AZ::SystemAllocator);
         AZ_RTTI(Signal, "{F65B92D1-10D8-4065-90FA-8FD46A9B122A}", GraphInfo);
@@ -360,20 +414,23 @@ namespace ScriptCanvas
 
         Signal(const GraphInfo& graphInfo)
             : GraphInfo(graphInfo)
-        {}
+        {
+        }
 
         Signal(const GraphInfo& graphInfo, const NodeTypeIdentifier& nodeType, const NamedEndpoint& endpoint)
             : GraphInfo(graphInfo)
             , m_nodeType(nodeType)
             , m_endpoint(endpoint)
-        {}
+        {
+        }
 
         Signal(const GraphInfo& graphInfo, const NodeTypeIdentifier& nodeType, const NamedEndpoint& endpoint, const SlotDataMap& data)
             : GraphInfo(graphInfo)
             , m_nodeType(nodeType)
             , m_endpoint(endpoint)
             , m_data(data)
-        {}
+        {
+        }
 
         virtual ~Signal() = default;
 
@@ -398,10 +455,8 @@ namespace ScriptCanvas
         {
             if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
-                serializeContext->Class<ThisType, DatumValue, GraphInfo, LoggableEvent>()
-                    ->Version(0)
-                    ->Field("timestamp", &ThisType::m_timestamp)
-                    ;
+                serializeContext->Class<ThisType, DatumValue, GraphInfo, LoggableEvent>()->Version(0)->Field(
+                    "timestamp", &ThisType::m_timestamp);
             }
         }
 
@@ -409,7 +464,8 @@ namespace ScriptCanvas
 
         TaggedDataValue()
             : m_timestamp(AZStd::GetTimeUTCMilliSecond())
-        {}
+        {
+        }
 
         TaggedDataValue(const TaggedDataValue&) = default;
 
@@ -417,7 +473,8 @@ namespace ScriptCanvas
             : DatumValue(dataValue)
             , GraphInfo(graphInfo)
             , m_timestamp(AZStd::GetTimeUTCMilliSecond())
-        {}
+        {
+        }
 
         Timestamp GetTimestamp() const override
         {
@@ -437,7 +494,7 @@ namespace ScriptCanvas
         void Visit(LoggableEventVisitor& visitor) override;
     };
 
-    using Breakpoint = TaggedParent<BreakpointTag, Signal>;
+    using Breakpoint = TaggedParent<BreakpointTag, AZ::EntityId>; // NodeId
 
     struct ExecutionThreadBeginning
         : public GraphInfo
@@ -456,7 +513,8 @@ namespace ScriptCanvas
         ExecutionThreadBeginning(const GraphInfo& graphInfo, AZ::EntityId nodeId)
             : GraphInfo(graphInfo)
             , m_nodeId(nodeId)
-        {}
+        {
+        }
 
         virtual ~ExecutionThreadBeginning() = default;
 
@@ -494,8 +552,7 @@ namespace ScriptCanvas
         Timestamp m_timestamp;
     };
 
-    struct NodeStateChange
-        : public GraphInfoEventBase
+    struct NodeStateChange : public GraphInfoEventBase
     {
         AZ_CLASS_ALLOCATOR(NodeStateChange, AZ::SystemAllocator);
         AZ_RTTI(NodeStateChange, "{6D3B9C70-E6E9-4780-87C0-D74E7BFBE53D}", GraphInfoEventBase);
@@ -510,8 +567,7 @@ namespace ScriptCanvas
 
     using VariableChange = TaggedDataValue<VariableChangeTag>;
 
-    struct AnnotateNodeSignal
-        : public GraphInfoEventBase
+    struct AnnotateNodeSignal : public GraphInfoEventBase
     {
     public:
         AZ_CLASS_ALLOCATOR(AnnotateNodeSignal, AZ::SystemAllocator);
@@ -526,20 +582,20 @@ namespace ScriptCanvas
 
         AnnotateNodeSignal();
         AnnotateNodeSignal(const AnnotateNodeSignal&) = default;
-        AnnotateNodeSignal(const GraphInfo& graphInfo, AnnotationLevel annotationLevel, AZStd::string_view annotation, const AZ::NamedEntityId& assetId);
+        AnnotateNodeSignal(
+            const GraphInfo& graphInfo, AnnotationLevel annotationLevel, AZStd::string_view annotation, const AZ::NamedEntityId& assetId);
 
         AZStd::string ToString() const override;
 
         void Visit(LoggableEventVisitor& visitor) override;
 
         AnnotationLevel m_annotationLevel;
-        AZStd::string   m_annotation;
+        AZStd::string m_annotation;
 
         AZ::NamedEntityId m_assetNodeId;
     };
 
-    class ExecutionNotifications
-        : public AZ::EBusTraits
+    class ExecutionNotifications : public AZ::EBusTraits
     {
     public:
         virtual void AnnotateNode(const AnnotateNodeSignal&) = 0;
@@ -592,22 +648,4 @@ namespace ScriptCanvas
     {
         visitor.Visit(*this);
     }
-}
-
-namespace AZStd
-{
-    template<>
-    struct hash<ScriptCanvas::Breakpoint>
-    {
-        using argument_type = ScriptCanvas::Breakpoint;
-        using result_type = AZStd::size_t;
-
-        AZ_FORCE_INLINE size_t operator()(const argument_type& argument) const
-        {
-            result_type result = AZStd::hash<const AZ::u64>()(static_cast<AZ::u64>(argument.m_runtimeEntity));
-            AZStd::hash_combine(result, argument.m_graphIdentifier);
-            AZStd::hash_combine(result, argument.m_endpoint);
-            return result;
-        }
-    };
-}
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Debugger.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Debugger.h
@@ -13,14 +13,14 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 
-#include <AzFramework/Network/IRemoteTools.h>
 #include <AzFramework/Entity/EntityContextBus.h>
+#include <AzFramework/Network/IRemoteTools.h>
 
 #include <ScriptCanvas/Core/NodeBus.h>
 
-#include "Messages/Request.h"
-#include "Messages/Notify.h"
 #include "APIArguments.h"
+#include "Messages/Notify.h"
+#include "Messages/Request.h"
 
 namespace ScriptCanvas
 {
@@ -28,13 +28,13 @@ namespace ScriptCanvas
     {
         //! The ScriptCanvas debugger component, this is the runtime debugger code that directly controls the execution
         //! and provides insight into a running ScriptCanvas graph.
-        class ServiceComponent 
+        class ServiceComponent
             : public AZ::Component
             , public Message::RequestVisitor
             , public ExecutionNotificationsBus::Handler
             , public AZ::SystemTickBus::Handler
         {
-           using Lock = AZStd::lock_guard<AZStd::recursive_mutex>;
+            using Lock = AZStd::lock_guard<AZStd::recursive_mutex>;
 
         public:
             AZ_COMPONENT(ServiceComponent, "{794B1BA5-DE13-46C7-9149-74FFB02CB51B}");
@@ -83,7 +83,7 @@ namespace ScriptCanvas
             //////////////////////////////////////////////////////////////////////////
 
             bool IsAssetObserved(const AZ::Data::AssetId& assetId) const;
-            
+
             //////////////////////////////////////////////////////////////////////////
             // Message processing
             void Visit(Message::AddBreakpointRequest& request) override;
@@ -129,14 +129,14 @@ namespace ScriptCanvas
                 else if (m_state == SCDebugState_Attached)
                 {
                     const Signal& asSignal(nodeSignal);
-                    Breakpoint breakpoint(asSignal);
+                    Breakpoint breakpoint(asSignal.m_endpoint.GetNodeId());
 
                     if (m_breakpoints.find(breakpoint) != m_breakpoints.end())
                     {
                         SCRIPT_CANVAS_DEBUGGER_TRACE_SERVER("Hit breakpoint: %s", nodeSignal.ToString().data());
                         if (remoteToolsInterface)
                         {
-                            remoteToolsInterface->SendRemoteToolsMessage(m_client.m_info, Message::BreakpointHit(nodeSignal));
+                            remoteToolsInterface->SendRemoteToolsMessage(m_client.m_info, Message::BreakpointHit(breakpoint));
                         }
                         m_state = SCDebugState_Interactive;
                         Interact();
@@ -161,7 +161,7 @@ namespace ScriptCanvas
             void Interact();
             bool IsAttached() const;
             void ProcessMessages();
-            
+
         private:
             enum eSCDebugState
             {
@@ -186,16 +186,16 @@ namespace ScriptCanvas
             AZStd::atomic_uint m_state;
             AZStd::unordered_set<Breakpoint> m_breakpoints;
 
-            bool                    m_activeGraphStatusDirty;
-            ActiveGraphStatusMap    m_activeGraphs;
+            bool m_activeGraphStatusDirty;
+            ActiveGraphStatusMap m_activeGraphs;
 
-            bool                    m_activeEntityStatusDirty;
-            ActiveEntityStatusMap   m_activeEntities;
+            bool m_activeEntityStatusDirty;
+            ActiveEntityStatusMap m_activeEntities;
 
             AZStd::recursive_mutex m_msgMutex;
             AzFramework::RemoteToolsMessageQueue m_msgQueue;
             AzFramework::IRemoteTools* m_remoteTools = nullptr;
             AzFramework::RemoteToolsEndpointStatusEvent::Handler m_endpointLeftEventHandler;
         };
-    }
-}
+    } // namespace Debugger
+} // namespace ScriptCanvas


### PR DESCRIPTION
## What does this PR do?

Work on https://github.com/o3de/o3de/issues/9192. Last **pre-RFC work** for the full script canvas debugging pipeline (will release a document in a few days, and this PR helps to understand the core of said pipeline).

Upon right click on a node, display the option **"Add breakpoint"** which will register a breakpoint in the client debugger for this node (it is registered for all the runtime instances of this graph). 

Said option is **left always disabled** as we currently don't have a generic way to properly pause the logic without freezing the editor, this means that I will have to **extract scriptcanvas editor in a separate executable** via another PR once the RFC is approved.

Took the opportunity to apply clang-format on a few files which will be impacted by the RFC.

![change](https://github.com/user-attachments/assets/912046da-17f8-4c3b-a24f-f60b074fe5ac)

**Note:**
- You need to have the RemoteToolsDebugging gem enabled
- Only works if you resaved the graph during this editor session (else the node ids don't match, will have to look at it)
- You have to have the graph toggled on in the inspected graph list (won't be needed via a future change)

![image](https://github.com/user-attachments/assets/007150a2-3472-4eb6-b74b-a621fbe41a4f)

## How was this PR tested?

Local development build with the newspaper project
