### PR TITLE
Refactor ResourceView and rename Build*View to Get*View

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ACES/AcesDisplayMapperFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ACES/AcesDisplayMapperFeatureProcessor.cpp
@@ -384,7 +384,7 @@ namespace AZ::Render
         }
 
         lutResource.m_lutImageViewDescriptor = RHI::ImageViewDescriptor::Create(LutFormat, 0, 0);
-        lutResource.m_lutImageView = lutResource.m_lutImage->BuildImageView(lutResource.m_lutImageViewDescriptor);
+        lutResource.m_lutImageView = lutResource.m_lutImage->GetImageView(lutResource.m_lutImageViewDescriptor);
         if (!lutResource.m_lutImageView.get())
         {
             AZ_Error("AcesDisplayMapperFeatureProcessor", false, "Failed to initialize LUT image view.");

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2370,18 +2370,21 @@ namespace AZ
                 RayTracingFeatureProcessor::SubMeshMaterial& subMeshMaterial = subMesh.m_material;
                 subMesh.m_positionFormat = PositionStreamFormat;
                 subMesh.m_positionVertexBufferView = streamIter[0];
-                subMesh.m_positionShaderBufferView = const_cast<RHI::Buffer*>(streamIter[0].GetBuffer())->BuildBufferView(positionBufferDescriptor);
+                subMesh.m_positionShaderBufferView =
+                    const_cast<RHI::Buffer*>(streamIter[0].GetBuffer())->GetBufferView(positionBufferDescriptor);
 
                 subMesh.m_normalFormat = NormalStreamFormat;
                 subMesh.m_normalVertexBufferView = streamIter[1];
-                subMesh.m_normalShaderBufferView = const_cast<RHI::Buffer*>(streamIter[1].GetBuffer())->BuildBufferView(normalBufferDescriptor);
+                subMesh.m_normalShaderBufferView =
+                    const_cast<RHI::Buffer*>(streamIter[1].GetBuffer())->GetBufferView(normalBufferDescriptor);
 
                 if (tangentBufferByteCount > 0)
                 {
                     subMesh.m_bufferFlags |= RayTracingSubMeshBufferFlags::Tangent;
                     subMesh.m_tangentFormat = TangentStreamFormat;
                     subMesh.m_tangentVertexBufferView = streamIter[2];
-                    subMesh.m_tangentShaderBufferView = const_cast<RHI::Buffer*>(streamIter[2].GetBuffer())->BuildBufferView(tangentBufferDescriptor);
+                    subMesh.m_tangentShaderBufferView =
+                        const_cast<RHI::Buffer*>(streamIter[2].GetBuffer())->GetBufferView(tangentBufferDescriptor);
                 }
 
                 if (bitangentBufferByteCount > 0)
@@ -2389,7 +2392,8 @@ namespace AZ
                     subMesh.m_bufferFlags |= RayTracingSubMeshBufferFlags::Bitangent;
                     subMesh.m_bitangentFormat = BitangentStreamFormat;
                     subMesh.m_bitangentVertexBufferView = streamIter[3];
-                    subMesh.m_bitangentShaderBufferView = const_cast<RHI::Buffer*>(streamIter[3].GetBuffer())->BuildBufferView(bitangentBufferDescriptor);
+                    subMesh.m_bitangentShaderBufferView =
+                        const_cast<RHI::Buffer*>(streamIter[3].GetBuffer())->GetBufferView(bitangentBufferDescriptor);
                 }
 
                 if (uvBufferByteCount > 0)
@@ -2397,11 +2401,12 @@ namespace AZ
                     subMesh.m_bufferFlags |= RayTracingSubMeshBufferFlags::UV;
                     subMesh.m_uvFormat = UVStreamFormat;
                     subMesh.m_uvVertexBufferView = streamIter[4];
-                    subMesh.m_uvShaderBufferView = const_cast<RHI::Buffer*>(streamIter[4].GetBuffer())->BuildBufferView(uvBufferDescriptor);
+                    subMesh.m_uvShaderBufferView = const_cast<RHI::Buffer*>(streamIter[4].GetBuffer())->GetBufferView(uvBufferDescriptor);
                 }
 
                 subMesh.m_indexBufferView = mesh.GetIndexBufferView();
-                subMesh.m_indexShaderBufferView = const_cast<RHI::Buffer*>(mesh.GetIndexBufferView().GetBuffer())->BuildBufferView(indexBufferDescriptor);
+                subMesh.m_indexShaderBufferView =
+                    const_cast<RHI::Buffer*>(mesh.GetIndexBufferView().GetBuffer())->GetBufferView(indexBufferDescriptor);
 
                 // add material data
                 if (material)

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
@@ -159,7 +159,7 @@ namespace AZ
                 AZ::RHI::Buffer* rhiBuffer = const_cast<AZ::RHI::Buffer*>(streamIter[streamIdx].GetBuffer());
                 uint32_t streamByteCount = static_cast<uint32_t>(rhiBuffer->GetDescriptor().m_byteCount);
                 auto bufferViewDescriptor = AZ::RHI::BufferViewDescriptor::CreateRaw(0, streamByteCount);
-                auto ptrBufferView = rhiBuffer->BuildBufferView(bufferViewDescriptor);
+                auto ptrBufferView = rhiBuffer->GetBufferView(bufferViewDescriptor);
                 shaderStreamBufferViews->m_streamViewsBySemantic.emplace(AZStd::move(shaderSemantic), ptrBufferView);
             }
 
@@ -203,7 +203,7 @@ namespace AZ
                 indexBufferView.GetIndexFormat() == AZ::RHI::IndexFormat::Uint16 ? AZ::RHI::Format::R16_UINT : AZ::RHI::Format::R32_UINT;
             auto* rhiBuffer = const_cast<AZ::RHI::Buffer*>(indexBufferView.GetBuffer());
 
-            return rhiBuffer->BuildBufferView(indexBufferDescriptor);
+            return rhiBuffer->GetBufferView(indexBufferDescriptor);
         }
 
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetInputBuffers.cpp
@@ -29,7 +29,7 @@ namespace AZ
             m_vertexDeltaBuffer = RPI::Buffer::FindOrCreate(bufferAssetView.GetBufferAsset());
             if (m_vertexDeltaBuffer)
             {
-                m_vertexDeltaBufferView = m_vertexDeltaBuffer->GetRHIBuffer()->BuildBufferView(bufferAssetView.GetBufferViewDescriptor());
+                m_vertexDeltaBufferView = m_vertexDeltaBuffer->GetRHIBuffer()->GetBufferView(bufferAssetView.GetBufferViewDescriptor());
                 m_vertexDeltaBufferView->SetName(Name(bufferNamePrefix + "MorphTargetVertexDeltaView"));
             }
         }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -1221,7 +1221,7 @@ namespace AZ
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
 
             bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_scene"));
-            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_tlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor).get());
+            m_rayTracingSceneSrg->SetBufferView(bufferIndex, m_tlas->GetTlasBuffer()->GetBufferView(bufferViewDescriptor).get());
 
             // directional lights
             const auto directionalLightFP = GetParentScene()->GetFeatureProcessor<DirectionalLightFeatureProcessor>();

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
@@ -124,7 +124,8 @@ namespace AZ
                     RHI::BufferViewDescriptor descriptor =
                         CreateInputViewDescriptor(streamInfo->m_enum, streamInfo->m_elementFormat, streamBufferView);
 
-                    AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView = const_cast<RHI::Buffer*>(streamBufferView.GetBuffer())->BuildBufferView(descriptor);
+                    AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView =
+                        const_cast<RHI::Buffer*>(streamBufferView.GetBuffer())->GetBufferView(descriptor);
                     {
                         // Initialize the buffer view
                         AZStd::string bufferViewName = AZStd::string::format(

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
@@ -42,7 +42,7 @@ namespace AZ::RHI
         //! Returns the buffer frame attachment if the buffer is currently attached.
         const BufferFrameAttachment* GetFrameAttachment() const;
 
-        Ptr<BufferView> BuildBufferView(const BufferViewDescriptor& bufferViewDescriptor);
+        Ptr<BufferView> GetBufferView(const BufferViewDescriptor& bufferViewDescriptor);
 
         //! Get the hash associated with the Buffer
         const HashValue64 GetHash() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResource.h
@@ -31,6 +31,7 @@ namespace AZ::RHI
         : public DeviceObject
     {
         friend class Resource;
+        friend class ResourceView;
         friend class DeviceResourcePool;
     public:
         AZ_RTTI(DeviceResource, "{9D02CDAC-80EB-4B77-8E62-849AC6E69206}", DeviceObject);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResource.h
@@ -8,9 +8,7 @@
 #pragma once
 
 #include <Atom/RHI/DeviceObject.h>
-#include <AzCore/std/containers/unordered_set.h>
-#include <AzCore/std/containers/unordered_map.h>
-
+#include <Atom/RHI/ResourceViewCache.h>
 
 namespace AZ::RHI
 {
@@ -91,12 +89,6 @@ namespace AZ::RHI
 
         /// Called by the frame attachment at frame building time.
         void SetFrameAttachment(FrameAttachment* frameAttachment);
-
-        /// Called by GetResourceView to insert a new image view
-        Ptr<DeviceImageView> InsertNewImageView(HashValue64 hash, const ImageViewDescriptor& imageViewDescriptor) const;
-
-        /// Called by GetResourceView to insert a new buffer view
-        Ptr<DeviceBufferView> InsertNewBufferView(HashValue64 hash, const BufferViewDescriptor& bufferViewDescriptor) const;
                                     
         /// The parent pool this resource is registered with.
         DeviceResourcePool* m_pool = nullptr;
@@ -113,8 +105,6 @@ namespace AZ::RHI
         // Cache the resourceViews in order to avoid re-creation
         // Since DeviceResourceView has a dependency to DeviceResource this cache holds raw pointers here in order to ensure there
         // is no circular dependency between the resource and it's resourceview.
-        mutable AZStd::unordered_map<size_t, DeviceResourceView*> m_resourceViewCache;
-        // This should help provide thread safe access to resourceView cache
-        mutable AZStd::mutex m_cacheMutex;
+        mutable ResourceViewCache<DeviceResource> m_resourceViewCache;
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
@@ -51,7 +51,7 @@ namespace AZ::RHI
         const ImageDescriptor& GetDescriptor() const;
 
         //! Returns the multi-device DeviceImageView
-        Ptr<ImageView> BuildImageView(const ImageViewDescriptor& imageViewDescriptor);
+        Ptr<ImageView> GetImageView(const ImageViewDescriptor& imageViewDescriptor);
 
         //! Computes the subresource layouts and total size of the image contents, if represented linearly. Effectively,
         //! this data represents how to store the image in a buffer resource. Naturally, if the image contents

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -30,6 +30,7 @@ namespace AZ::RHI
     class MultiDeviceObject : public Object
     {
         friend struct UnitTest::MultiDeviceDrawPacketData;
+        friend class ResourceView;
 
     public:
         AZ_RTTI(MultiDeviceObject, "{17D34F71-944C-4AF5-9823-627474C4C0A6}", Object);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
@@ -39,6 +39,8 @@ namespace AZ::RHI
         // IntrusivePtrCountPolicy overrides
         template<typename Type>
         friend struct AZStd::IntrusivePtrCountPolicy;
+        template<typename ResourceType>
+        friend struct ResourceViewCache;
         void add_ref() const;
 
         //! All objects have an explicit Init / Shutdown path in addition to

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
@@ -7,8 +7,10 @@
  */
 #pragma once
 
+#include <Atom/RHI/DeviceResource.h>
 #include <Atom/RHI/MultiDeviceObject.h>
 #include <AzCore/std/containers/unordered_map.h>
+
 
 namespace AZ::RHI
 {
@@ -33,6 +35,7 @@ namespace AZ::RHI
     public:
         AZ_RTTI(Resource, "{613AED98-48FD-4453-98F8-6956D2133489}", MultiDeviceObject);
         virtual ~Resource();
+        AZ_RHI_MULTI_DEVICE_OBJECT_GETTER(Resource);
 
         //! Returns whether the resource is currently an attachment on a frame graph.
         bool IsAttachment() const;
@@ -113,24 +116,4 @@ namespace AZ::RHI
     class Image;
     class DeviceResourceView;
 
-    //! ResourceView is a base class for multi-device buffer and image views for
-    //! polymorphic usage of views in a generic way.
-    class ResourceView : public Object
-    {
-    public:
-        // The resource owns a cache of resource views, and it needs access to the refcount
-        // of the resource views to prevent threading issues.
-        friend class Resource;
-
-        virtual ~ResourceView() = default;
-
-        //! Returns the resource associated with this view.
-        virtual const Resource* GetResource() const = 0;
-        virtual const DeviceResourceView* GetDeviceResourceView(int deviceIndex) const = 0;
-
-        AZ_RTTI(ResourceView, "{D7442960-531D-4DCC-B60D-FD26FF75BE51}", Object);
-
-    protected:
-        void Shutdown() override{};
-    };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
@@ -9,7 +9,7 @@
 
 #include <Atom/RHI/DeviceResource.h>
 #include <Atom/RHI/MultiDeviceObject.h>
-#include <AzCore/std/containers/unordered_map.h>
+#include <Atom/RHI/ResourceViewCache.h>
 
 
 namespace AZ::RHI
@@ -69,7 +69,6 @@ namespace AZ::RHI
         bool IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
         bool IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
 
-        //! Removes the provided ResourceView from the cache
         void EraseResourceView(ResourceView* resourceView) const;
 
     protected:
@@ -89,12 +88,6 @@ namespace AZ::RHI
         //! Called by the frame attachment at frame building time.
         void SetFrameAttachment(FrameAttachment* frameAttachment, int deviceIndex = MultiDevice::InvalidDeviceIndex);
 
-        //! Called by GetResourceView to insert a new image view
-        Ptr<ImageView> InsertNewImageView(HashValue64 hash, const ImageViewDescriptor& imageViewDescriptor) const;
-
-        //! Called by GetResourceView to insert a new buffer view
-        Ptr<BufferView> InsertNewBufferView(HashValue64 hash, const BufferViewDescriptor& bufferViewDescriptor) const;
-
         //! The parent pool this resource is registered with.
         ResourcePool* m_pool = nullptr;
 
@@ -107,9 +100,7 @@ namespace AZ::RHI
         //! Cache the resourceViews in order to avoid re-creation
         //! Since ResourceView has a dependency to Resource this cache holds raw pointers here in order to ensure there
         //! is no circular dependency between the resource and it's resourceview.
-        mutable AZStd::unordered_map<size_t, ResourceView*> m_resourceViewCache;
-        //! This should help provide thread safe access to resourceView cache
-        mutable AZStd::mutex m_cacheMutex;
+        mutable ResourceViewCache<Resource> m_resourceViewCache;
     };
 
     class Buffer;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceView.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ #pragma once
+
+ #include <Atom/RHI/MultiDeviceObject.h>
+ #include <Atom/RHI/DeviceResourceView.h>
+
+ namespace AZ::RHI
+{
+    class Resource;
+
+    //! ResourceView is a base class for multi-device buffer and image views for
+    //! polymorphic usage of views in a generic way.
+    //! As the handling of the device-specific ResourceViews is more elaborate,
+    //! this does not inherit from MultiDeviceObject but manages the DeviceResourceViews on its own
+    class ResourceView : public Object
+    {
+    public:
+        // The resource owns a cache of resource views, and it needs access to the refcount
+        // of the resource views to prevent threading issues.
+        friend class Resource;
+
+        AZ_RTTI(ResourceView, "{D7442960-531D-4DCC-B60D-FD26FF75BE51}", Object);
+
+        ResourceView(const RHI::Resource* resource, MultiDevice::DeviceMask deviceMask)
+            : m_resource{ resource }
+            , m_deviceMask{ deviceMask }
+        {
+        }
+        virtual ~ResourceView() = default;
+
+        //! Returns the resource associated with this view.
+        const Resource* GetResource() const;
+        //! Interface for the two derived classes to return a DeviceResourceView
+        virtual const DeviceResourceView* GetDeviceResourceView(int deviceIndex) const = 0;
+
+    protected:
+        //! Templated method for both DeviceImageView and DeviceBufferView that either creates and caches
+        //! or return the corresponding DeviceResourceView
+        template<typename View, typename ViewDescriptor>
+        const RHI::Ptr<View> GetDeviceResourceView(int deviceIndex, const ViewDescriptor& viewDescriptor) const;
+
+    private:
+        //////////////////////////////////////////////////////////////////////////
+        //! RHI::Object
+        void Shutdown() final;
+
+        //! A ConstPtr pointer to a Resource which extends its lifetime
+        ConstPtr<RHI::Resource> m_resource;
+        //! The device mask of the Resource stored for comparison to figure out when cache entries need to be freed.
+        mutable MultiDevice::DeviceMask m_deviceMask{ MultiDevice::AllDevices};
+        //! Safe-guard access to DeviceResourceView objects during parallel access
+        mutable AZStd::mutex m_resourceViewMutex;
+        //! DeviceResourceView cache
+        //! This cache is necessary as the caller receives raw pointers from the ResourceCache, 
+        //! which now, with multi-device objects in use, need to be held in memory as long as
+        //! the multi-device view is held.
+        mutable AZStd::unordered_map<int, Ptr<RHI::DeviceResourceView>> m_cache;
+    };
+}

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceViewCache.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceViewCache.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ #pragma once
+
+#include <AzCore/Utils/TypeHash.h>
+#include <Atom/RHI.Reflect/Base.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/containers/unordered_map.h>
+
+ namespace AZ::RHI
+{
+    class DeviceResourceView;
+    struct ImageViewDescriptor;
+    struct BufferViewDescriptor;
+    class DeviceImageView;
+    class DeviceBufferView;
+    class DeviceResource;
+    class Resource;
+    class ResourceView;
+    class ImageView;
+    class BufferView;
+    
+    //! ResourceViewCache is used by both Resource and DeviceResource to cache raw pointers to ResourceView and DeviceResourceView respectively.
+    //! As ResourceViewType has a strong dependency (by holding a ConstrPtr) to ResourceType, this cache holds raw pointers to 
+    //! ensure no circular dependency arises.
+    //! As it can be accessed in parallel, access to the cache is protected by a mutex.
+    template <typename ResourceType>
+    struct ResourceViewCache
+    {
+        //! Helper struct to provide correct Type and creatio method for (Device)Image/Bufferview
+        template <typename Type, typename DescriptorType>
+        struct ResourceViewTypeHelper;
+
+        template<>
+        struct ResourceViewTypeHelper<DeviceResource, ImageViewDescriptor>
+        {
+            using ViewType = DeviceImageView;
+            static Ptr<DeviceImageView> CreateView(const DeviceResource* resource, const ImageViewDescriptor& imageViewDescriptor);
+        };
+
+        template<>
+        struct ResourceViewTypeHelper<DeviceResource, BufferViewDescriptor>
+        {
+            using ViewType = DeviceBufferView;
+            static Ptr<DeviceBufferView> CreateView(const DeviceResource* resource, const BufferViewDescriptor& bufferViewDescriptor);
+        };
+
+        template<>
+        struct ResourceViewTypeHelper<Resource, ImageViewDescriptor>
+        {
+            using ViewType = ImageView;
+            static Ptr<ImageView> CreateView(const Resource* resource, const ImageViewDescriptor& imageViewDescriptor);
+        };
+
+        template<>
+        struct ResourceViewTypeHelper<Resource, BufferViewDescriptor>
+        {
+            using ViewType = BufferView;
+            static Ptr<BufferView> CreateView(const Resource* resource, const BufferViewDescriptor& bufferViewDescriptor);
+        };
+
+        //! Helper struct to select (Device)ResourceView based on (Device)Resource and the corresponding views for Buffers and Images
+        template <typename Type>
+        struct ResourceTypeHelper;
+
+        template <>
+        struct ResourceTypeHelper<DeviceResource>
+        {
+            using ResourceViewType = DeviceResourceView;
+            template <typename DescriptorType>
+            using ViewType = typename ResourceViewTypeHelper<DeviceResource, DescriptorType>::ViewType;
+        };
+
+        template <>
+        struct ResourceTypeHelper<Resource>
+        {
+            using ResourceViewType = ResourceView;
+            template <typename DescriptorType>
+            using ViewType = typename ResourceViewTypeHelper<Resource, DescriptorType>::ViewType;
+        };
+
+        //! Returns true if the ResourceViewType is in the cache
+        template <typename DescriptorType>
+        bool IsInResourceCache(const DescriptorType& viewDescriptor);
+
+        //! Removes the provided ResourceViewType from the cache
+        void EraseResourceView(typename ResourceTypeHelper<ResourceType>::ResourceViewType* resourceView) const;
+
+        //! Returns view based on the descriptor
+        template <typename DescriptorType>
+        auto GetResourceView(const ResourceType* resource, const DescriptorType& viewDescriptor) const -> Ptr<typename ResourceTypeHelper<ResourceType>::template ViewType<DescriptorType>>;
+
+        //! Called by GetResourceView to insert a new view
+        template <typename DescriptorType>
+        auto InsertNewView(
+                     const ResourceType* resource, HashValue64 hash, const DescriptorType& viewDescriptor)
+                     const->Ptr<typename ResourceTypeHelper<ResourceType>::template ViewType<DescriptorType>>;
+
+        //! Cache the ResourceViewTypes in order to avoid re-creation
+        mutable AZStd::unordered_map<size_t, typename ResourceTypeHelper<ResourceType>::ResourceViewType*> m_resourceViewCache;
+        //! This provides thread-safe access to the m_resourceViewCache
+        mutable AZStd::mutex m_cacheMutex;
+    };
+}

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -33,7 +33,7 @@ namespace AZ::RHI
         return static_cast<const BufferFrameAttachment*>(Resource::GetFrameAttachment());
     }
 
-    Ptr<BufferView> Buffer::BuildBufferView(const BufferViewDescriptor& bufferViewDescriptor)
+    Ptr<BufferView> Buffer::GetBufferView(const BufferViewDescriptor& bufferViewDescriptor)
     {
         return Base::GetResourceView(bufferViewDescriptor);
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
@@ -14,42 +14,7 @@
     //! Given a device index, return the corresponding DeviceBufferView for the selected device
     const RHI::Ptr<RHI::DeviceBufferView> BufferView::GetDeviceBufferView(int deviceIndex) const
     {
-        AZStd::lock_guard lock(m_bufferViewMutex);
-
-        if (m_buffer->GetDeviceMask() != m_deviceMask)
-        {
-            m_deviceMask = m_buffer->GetDeviceMask();
-
-            MultiDeviceObject::IterateDevices(
-                m_deviceMask,
-                [this](int deviceIndex)
-                {
-                    if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
-                    {
-                        m_cache.erase(it);
-                    }
-                    return true;
-                });
-        }
-
-        auto iterator{ m_cache.find(deviceIndex) };
-        if (iterator == m_cache.end())
-        {
-            //! Buffer view is not yet in the cache
-            auto [new_iterator, inserted]{ m_cache.insert(
-                AZStd::make_pair(deviceIndex, m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor))) };
-            if (inserted)
-            {
-                return new_iterator->second;
-            }
-        }
-        // Add null check for `iterator->second` to avoid empty pointer
-        else if (!iterator->second || &iterator->second->GetBuffer() != m_buffer->GetDeviceBuffer(deviceIndex).get())
-        {
-            iterator->second = m_buffer->GetDeviceBuffer(deviceIndex)->GetBufferView(m_descriptor);
-        }
-
-        return iterator->second;
+        return ResourceView::GetDeviceResourceView<DeviceBufferView>(deviceIndex, m_descriptor);
     }
 
     AZStd::unordered_map<int, uint32_t> BufferView::GetBindlessReadIndex() const
@@ -57,7 +22,7 @@
         AZStd::unordered_map<int, uint32_t> result;
 
         MultiDeviceObject::IterateDevices(
-            m_buffer->GetDeviceMask(),
+            GetResource()->GetDeviceMask(),
             [this, &result](int deviceIndex)
             {
                 result[deviceIndex] = GetDeviceBufferView(deviceIndex)->GetBindlessReadIndex();
@@ -65,14 +30,5 @@
             });
 
         return result;
-    }
-
-    void BufferView::Shutdown()
-    {
-        if(m_buffer->IsInitialized())
-        {
-            m_buffer->EraseResourceView(static_cast<ResourceView*>(this));
-            m_buffer = nullptr;
-        }
     }
  }

--- a/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
@@ -5,21 +5,23 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Atom/RHI.Reflect/PipelineLayoutDescriptor.h>
+#include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/CommandListValidator.h>
-#include <Atom/RHI/Scope.h>
-#include <Atom/RHI/DeviceShaderResourceGroup.h>
-#include <Atom/RHI/DeviceShaderResourceGroupPool.h>
-#include <Atom/RHI/DeviceResourcePool.h>
 #include <Atom/RHI/DeviceImagePoolBase.h>
 #include <Atom/RHI/DeviceImageView.h>
-#include <Atom/RHI/Buffer.h>
-#include <Atom/RHI/Image.h>
-#include <Atom/RHI/DeviceResourceView.h>
 #include <Atom/RHI/DeviceResource.h>
-#include <Atom/RHI/FrameGraph.h>
-#include <Atom/RHI/ScopeAttachment.h>
+#include <Atom/RHI/DeviceResourcePool.h>
+#include <Atom/RHI/DeviceResourceView.h>
+#include <Atom/RHI/DeviceShaderResourceGroup.h>
+#include <Atom/RHI/DeviceShaderResourceGroupPool.h>
 #include <Atom/RHI/FrameAttachment.h>
-#include <Atom/RHI.Reflect/PipelineLayoutDescriptor.h>
+#include <Atom/RHI/FrameGraph.h>
+#include <Atom/RHI/Image.h>
+#include <Atom/RHI/ResourceView.h>
+#include <Atom/RHI/Scope.h>
+#include <Atom/RHI/ScopeAttachment.h>
+
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -891,7 +891,7 @@ namespace AZ::RHI
             const ImageResourceViewData imageResourceViewData = ImageResourceViewData{ image->GetName(), imageViewDescriptor };
             RemoveFromCache(imageResourceViewData, m_imageReverseLookupHash, m_imageViewCache);
             // Create a new image view instance and insert it into the cache.
-            Ptr<ImageView> imageViewPtr = image->BuildImageView(imageViewDescriptor);
+            Ptr<ImageView> imageViewPtr = image->GetImageView(imageViewDescriptor);
             imageView = imageViewPtr.get();
             m_imageViewCache.Insert(static_cast<uint64_t>(hash), AZStd::move(imageViewPtr));
             if (!image->GetName().IsEmpty())
@@ -919,7 +919,7 @@ namespace AZ::RHI
             RemoveFromCache(bufferResourceViewData, m_bufferReverseLookupHash, m_bufferViewCache);
                 
             // Create a new buffer view instance and insert it into the cache.
-            Ptr<BufferView> bufferViewPtr = buffer->BuildBufferView(bufferViewDescriptor);
+            Ptr<BufferView> bufferViewPtr = buffer->GetBufferView(bufferViewDescriptor);
             bufferView = bufferViewPtr.get();
             m_bufferViewCache.Insert(static_cast<uint64_t>(hash), AZStd::move(bufferViewPtr));
             if (!buffer->GetName().IsEmpty())
@@ -955,7 +955,7 @@ namespace AZ::RHI
                     // Check image's cache first as that contains views provided by higher level code.
                     if (image->IsInResourceCache(imageViewDescriptor))
                     {
-                        imageView = image->BuildImageView(imageViewDescriptor).get();
+                        imageView = image->GetImageView(imageViewDescriptor).get();
                     }
                     else
                     {
@@ -993,7 +993,7 @@ namespace AZ::RHI
                     // Check buffer's cache first as that contains views provided by higher level code.
                     if (buffer->IsInResourceCache(bufferViewDescriptor))
                     {
-                        bufferView = buffer->BuildBufferView(bufferViewDescriptor).get();
+                        bufferView = buffer->GetBufferView(bufferViewDescriptor).get();
                     }
                     else
                     {

--- a/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
@@ -44,7 +44,7 @@ namespace AZ::RHI
         return static_cast<const ImageFrameAttachment*>(Resource::GetFrameAttachment());
     }
 
-    Ptr<ImageView> Image::BuildImageView(const ImageViewDescriptor& imageViewDescriptor)
+    Ptr<ImageView> Image::GetImageView(const ImageViewDescriptor& imageViewDescriptor)
     {
         return Base::GetResourceView(imageViewDescriptor);
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ImageView.cpp
@@ -14,49 +14,6 @@
         //! Given a device index, return the corresponding DeviceBufferView for the selected device
         const RHI::Ptr<RHI::DeviceImageView> ImageView::GetDeviceImageView(int deviceIndex) const
         {
-            AZStd::lock_guard lock(m_imageViewMutex);
-    
-            if (m_image->GetDeviceMask() != m_deviceMask)
-            {
-                m_deviceMask = m_image->GetDeviceMask();
-    
-                MultiDeviceObject::IterateDevices(
-                    m_deviceMask,
-                    [this](int deviceIndex)
-                    {
-                        if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
-                        {
-                            m_cache.erase(it);
-                        }
-                        return true;
-                    });
-            }
-    
-            auto iterator{ m_cache.find(deviceIndex) };
-            if (iterator == m_cache.end())
-            {
-                //! Image view is not yet in the cache
-                auto [new_iterator, inserted]{ m_cache.insert(
-                    AZStd::make_pair(deviceIndex, m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor))) };
-                if (inserted)
-                {
-                    return new_iterator->second;
-                }
-            }
-            else if (&iterator->second->GetImage() != m_image->GetDeviceImage(deviceIndex).get())
-            {
-                iterator->second = m_image->GetDeviceImage(deviceIndex)->GetImageView(m_descriptor);
-            }
-    
-            return iterator->second;
-        }
-
-        void ImageView::Shutdown()
-        {
-            if(m_image->IsInitialized())
-            {
-                m_image->EraseResourceView(static_cast<ResourceView*>(this));
-                m_image = nullptr;
-            }
+            return ResourceView::GetDeviceResourceView<DeviceImageView>(deviceIndex, m_descriptor);
         }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/ResourceView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ResourceView.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ #include <Atom/RHI/ResourceView.h>
+ #include <Atom/RHI/Resource.h>
+ #include <Atom/RHI/DeviceImageView.h>
+ #include <Atom/RHI/DeviceBufferView.h>
+
+ namespace AZ::RHI
+{
+    void ResourceView::Shutdown()
+        {
+            if(m_resource->IsInitialized())
+            {
+                m_resource->EraseResourceView(static_cast<ResourceView*>(this));
+                m_resource = nullptr;
+            }
+        }
+
+        const Resource* ResourceView::GetResource() const
+        {
+            return m_resource.get();
+        }
+
+        template<typename View, typename ViewDescriptor>
+        const RHI::Ptr<View> ResourceView::GetDeviceResourceView(int deviceIndex, const ViewDescriptor& viewDescriptor) const
+        {
+            // As this can be called concurrently and the cache is potentially manipulated, need to lock this scope
+            AZStd::lock_guard lock(m_resourceViewMutex);
+
+            // As the view keeps the device resources alive (by keeping the views alive in the cache),
+            // we need to check if they are still required by the resource, otherwise delete the corresponding views from the cache
+            if (m_resource->GetDeviceMask() != m_deviceMask)
+            {
+                m_deviceMask = m_resource->GetDeviceMask();
+
+                MultiDeviceObject::IterateDevices(
+                    m_deviceMask,
+                    [this](int deviceIndex)
+                    {
+                        if (auto it{ m_cache.find(deviceIndex) }; it != m_cache.end())
+                        {
+                            m_cache.erase(it);
+                        }
+                        return true;
+                    });
+            }
+
+            auto iterator{ m_cache.find(deviceIndex) };
+            if (iterator == m_cache.end())
+            {
+                // ResourceView is not yet in the cache
+                const auto& deviceResourceView{ m_resource->GetDeviceResource(deviceIndex)->GetResourceView(viewDescriptor) };
+                auto [new_iterator, inserted]{ m_cache.insert(
+                    AZStd::make_pair(deviceIndex, static_cast<DeviceResourceView*>(deviceResourceView.get()))) };
+                if (inserted)
+                {
+                    return deviceResourceView;
+                }
+            }
+            else if (&iterator->second->GetResource() != m_resource->GetDeviceResource(deviceIndex).get())
+            {
+                iterator->second =
+                    static_cast<DeviceResourceView*>(m_resource->GetDeviceResource(deviceIndex)->GetResourceView(viewDescriptor).get());
+            }
+
+            return static_cast<View*>(iterator->second.get());
+        }
+
+        // Explicit instantiations for DeviceImageView and DeviceBufferView
+        template const RHI::Ptr<RHI::DeviceImageView> ResourceView::GetDeviceResourceView<RHI::DeviceImageView, RHI::ImageViewDescriptor>(
+            int, const RHI::ImageViewDescriptor&) const;
+        template const RHI::Ptr<RHI::DeviceBufferView> ResourceView::
+            GetDeviceResourceView<RHI::DeviceBufferView, RHI::BufferViewDescriptor>(int, const RHI::BufferViewDescriptor&) const;
+}

--- a/Gems/Atom/RHI/Code/Source/RHI/ResourceViewCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ResourceViewCache.cpp
@@ -15,27 +15,34 @@
 
  namespace AZ::RHI
  {
-    Ptr<DeviceImageView> ResourceViewCache<DeviceResource>::ResourceViewTypeHelper<DeviceResource, ImageViewDescriptor>::CreateView(const DeviceResource* resource, const ImageViewDescriptor& imageViewDescriptor)
-    {
-        Ptr<DeviceImageView> imageViewPtr = RHI::Factory::Get().CreateImageView();
-        return (imageViewPtr->Init(static_cast<const DeviceImage&>(*resource), imageViewDescriptor) == RHI::ResultCode::Success) ? imageViewPtr : nullptr;
-    }
+     namespace ResourceViewCacheHelper
+     {
+         Ptr<DeviceImageView> CreateView(const DeviceResource* resource, const ImageViewDescriptor& imageViewDescriptor)
+         {
+             Ptr<DeviceImageView> imageViewPtr = RHI::Factory::Get().CreateImageView();
+             return (imageViewPtr->Init(static_cast<const DeviceImage&>(*resource), imageViewDescriptor) == RHI::ResultCode::Success)
+                 ? imageViewPtr
+                 : nullptr;
+         }
 
-    Ptr<DeviceBufferView> ResourceViewCache<DeviceResource>::ResourceViewTypeHelper<DeviceResource, BufferViewDescriptor>::CreateView(const DeviceResource* resource, const BufferViewDescriptor& bufferViewDescriptor)
-    {
-        Ptr<DeviceBufferView> bufferViewPtr = RHI::Factory::Get().CreateBufferView();
-        return (bufferViewPtr->Init(static_cast<const DeviceBuffer&>(*resource), bufferViewDescriptor) == RHI::ResultCode::Success) ? bufferViewPtr : nullptr;
-    }
+         Ptr<DeviceBufferView> CreateView(const DeviceResource* resource, const BufferViewDescriptor& bufferViewDescriptor)
+         {
+             Ptr<DeviceBufferView> bufferViewPtr = RHI::Factory::Get().CreateBufferView();
+             return (bufferViewPtr->Init(static_cast<const DeviceBuffer&>(*resource), bufferViewDescriptor) == RHI::ResultCode::Success)
+                 ? bufferViewPtr
+                 : nullptr;
+         }
 
-    Ptr<ImageView> ResourceViewCache<Resource>::ResourceViewTypeHelper<Resource, ImageViewDescriptor>::CreateView(const Resource* resource, const ImageViewDescriptor& imageViewDescriptor)
-    {
-        return aznew ImageView{static_cast<const Image*>(resource), imageViewDescriptor, resource->GetDeviceMask()};
-    }
+         Ptr<ImageView> CreateView(const Resource* resource, const ImageViewDescriptor& imageViewDescriptor)
+         {
+             return aznew ImageView{ static_cast<const Image*>(resource), imageViewDescriptor, resource->GetDeviceMask() };
+         }
 
-    Ptr<BufferView> ResourceViewCache<Resource>::ResourceViewTypeHelper<Resource, BufferViewDescriptor>::CreateView(const Resource* resource, const BufferViewDescriptor& bufferViewDescriptor)
-    {
-        return aznew BufferView{static_cast<const Buffer*>(resource), bufferViewDescriptor, resource->GetDeviceMask()};
-    }
+         Ptr<BufferView> CreateView(const Resource* resource, const BufferViewDescriptor& bufferViewDescriptor)
+         {
+             return aznew BufferView{ static_cast<const Buffer*>(resource), bufferViewDescriptor, resource->GetDeviceMask() };
+         }
+     } // namespace ResourceViewCacheHelper
 
     template <typename ResourceType>
     template <typename DescriptorType>
@@ -89,7 +96,7 @@
     template <typename DescriptorType>
     auto ResourceViewCache<ResourceType>::InsertNewView(const ResourceType* resource,  HashValue64 hash, const DescriptorType& viewDescriptor) const -> Ptr<typename ResourceViewCache<ResourceType>::ResourceTypeHelper<ResourceType>::template ViewType<DescriptorType>>
     {
-        auto viewPtr{ResourceViewTypeHelper<ResourceType, DescriptorType>::CreateView(resource, viewDescriptor)};
+        auto viewPtr{ ResourceViewCacheHelper::CreateView(resource, viewDescriptor) };
         if (viewPtr)
         {
             m_resourceViewCache[static_cast<uint64_t>(hash)] = static_cast<typename ResourceTypeHelper<ResourceType>::ResourceViewType*>(viewPtr.get());

--- a/Gems/Atom/RHI/Code/Source/RHI/ResourceViewCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ResourceViewCache.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ #include <Atom/RHI/ResourceViewCache.h>
+ #include <Atom/RHI/ImageView.h>
+ #include <Atom/RHI/BufferView.h>
+ #include <Atom/RHI/Factory.h>
+ #include <Atom/RHI/DeviceResource.h>
+ #include <Atom/RHI/Resource.h>
+
+ namespace AZ::RHI
+ {
+    Ptr<DeviceImageView> ResourceViewCache<DeviceResource>::ResourceViewTypeHelper<DeviceResource, ImageViewDescriptor>::CreateView(const DeviceResource* resource, const ImageViewDescriptor& imageViewDescriptor)
+    {
+        Ptr<DeviceImageView> imageViewPtr = RHI::Factory::Get().CreateImageView();
+        return (imageViewPtr->Init(static_cast<const DeviceImage&>(*resource), imageViewDescriptor) == RHI::ResultCode::Success) ? imageViewPtr : nullptr;
+    }
+
+    Ptr<DeviceBufferView> ResourceViewCache<DeviceResource>::ResourceViewTypeHelper<DeviceResource, BufferViewDescriptor>::CreateView(const DeviceResource* resource, const BufferViewDescriptor& bufferViewDescriptor)
+    {
+        Ptr<DeviceBufferView> bufferViewPtr = RHI::Factory::Get().CreateBufferView();
+        return (bufferViewPtr->Init(static_cast<const DeviceBuffer&>(*resource), bufferViewDescriptor) == RHI::ResultCode::Success) ? bufferViewPtr : nullptr;
+    }
+
+    Ptr<ImageView> ResourceViewCache<Resource>::ResourceViewTypeHelper<Resource, ImageViewDescriptor>::CreateView(const Resource* resource, const ImageViewDescriptor& imageViewDescriptor)
+    {
+        return aznew ImageView{static_cast<const Image*>(resource), imageViewDescriptor, resource->GetDeviceMask()};
+    }
+
+    Ptr<BufferView> ResourceViewCache<Resource>::ResourceViewTypeHelper<Resource, BufferViewDescriptor>::CreateView(const Resource* resource, const BufferViewDescriptor& bufferViewDescriptor)
+    {
+        return aznew BufferView{static_cast<const Buffer*>(resource), bufferViewDescriptor, resource->GetDeviceMask()};
+    }
+
+    template <typename ResourceType>
+    template <typename DescriptorType>
+    auto ResourceViewCache<ResourceType>::GetResourceView(const ResourceType* resource, const DescriptorType& viewDescriptor) const -> Ptr<typename ResourceViewCache<ResourceType>::ResourceTypeHelper<ResourceType>::template ViewType<DescriptorType>>
+    {
+        const HashValue64 hash = viewDescriptor.GetHash();
+        AZStd::lock_guard<AZStd::mutex> registryLock(m_cacheMutex);
+        auto it = m_resourceViewCache.find(static_cast<uint64_t>(hash));
+        if (it == m_resourceViewCache.end())
+        {
+            return InsertNewView(resource, hash, viewDescriptor);
+        }
+        else
+        {
+            // We've found a matching ResourceViewType in the cache, but another thread may be releasing the last intrusive_ptr while
+            // we are in this function, dropping the refcount to 0 (and forcing it to -1 for good measure) then deleting it.
+            //
+            //  There are 2 scenarios:
+            //
+            // m_useCount is -1. The other thread is already on the path to deleting it. We need to make a new one here
+            // and replace the old one.
+            //
+            // m_useCount is >=0. We cannot guarantee another thread won't drop the refcount to 0 after we check the value here
+            // so before we create a new intrusive_ptr, we need to use fetch_add to increment the refcount as we check the value to
+            // prevent a race
+            int useCount = it->second->m_useCount.fetch_add(2);
+            if (useCount == -1)
+            {
+                // The useCount was -1 before we incremented.
+                // Another thread is going to come along and delete the one we just found.
+                // Go ahead and erase it and insert a new one instead
+                m_resourceViewCache.erase(it);
+
+                return InsertNewView(resource, hash, viewDescriptor);
+            }
+            else
+            {
+                // Create the new Ptr, increasing the refcount
+                Ptr<typename ResourceTypeHelper<ResourceType>::template ViewType<DescriptorType>> result = static_cast<typename ResourceTypeHelper<ResourceType>::template ViewType<DescriptorType>*>(it->second);
+
+                // Before we checked the value we artificially incremented the refcount to prevent another
+                // thread from letting it go to 0 again. Get rid of that artificial increase now that we have
+                // our new Ptr to hold on to the refcount
+                it->second->m_useCount.fetch_sub(2);
+                return result;
+            }
+        }       
+    }
+
+    template <typename ResourceType>
+    template <typename DescriptorType>
+    auto ResourceViewCache<ResourceType>::InsertNewView(const ResourceType* resource,  HashValue64 hash, const DescriptorType& viewDescriptor) const -> Ptr<typename ResourceViewCache<ResourceType>::ResourceTypeHelper<ResourceType>::template ViewType<DescriptorType>>
+    {
+        auto viewPtr{ResourceViewTypeHelper<ResourceType, DescriptorType>::CreateView(resource, viewDescriptor)};
+        if (viewPtr)
+        {
+            m_resourceViewCache[static_cast<uint64_t>(hash)] = static_cast<typename ResourceTypeHelper<ResourceType>::ResourceViewType*>(viewPtr.get());
+            return viewPtr;
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    template <typename ResourceType>
+    void ResourceViewCache<ResourceType>::EraseResourceView(typename ResourceTypeHelper<ResourceType>::ResourceViewType* resourceView) const
+    {
+        AZStd::lock_guard<AZStd::mutex> registryLock(m_cacheMutex);
+        auto itr = m_resourceViewCache.begin();
+        while (itr != m_resourceViewCache.end())
+        {
+            if (itr->second == resourceView)
+            {
+                m_resourceViewCache.erase(itr->first);
+                break;
+            }
+            itr++;
+        }
+    }
+    
+    template <typename ResourceType> 
+    template <typename DescriptorType>
+    bool ResourceViewCache<ResourceType>::IsInResourceCache(const DescriptorType& viewDescriptor)
+    {
+        const HashValue64 hash = viewDescriptor.GetHash();
+        auto it = m_resourceViewCache.find(static_cast<uint64_t>(hash));
+        return it != m_resourceViewCache.end();
+    }
+
+    // Explicit instantiations for DeviceResource
+    template 
+    Ptr<DeviceImageView> ResourceViewCache<DeviceResource>::GetResourceView(const DeviceResource* resource, const ImageViewDescriptor& imageViewDescriptor) const;
+    template
+    Ptr<DeviceBufferView> ResourceViewCache<DeviceResource>::GetResourceView(const DeviceResource* resource, const BufferViewDescriptor& bufferViewDescriptor) const;
+    template
+    Ptr<DeviceImageView> ResourceViewCache<DeviceResource>::InsertNewView(const DeviceResource* resource,  HashValue64 hash, const ImageViewDescriptor& imageViewDescriptor) const;
+    template
+    Ptr<DeviceBufferView> ResourceViewCache<DeviceResource>::InsertNewView(const DeviceResource* resource,  HashValue64 hash, const BufferViewDescriptor& bufferViewDescriptor) const;
+    template
+    void ResourceViewCache<DeviceResource>::EraseResourceView(DeviceResourceView* resourceView) const;
+    template
+    bool ResourceViewCache<DeviceResource>::IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
+    template
+    bool ResourceViewCache<DeviceResource>::IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
+
+    // Explicit instantiations for Resource
+    template 
+    Ptr<ImageView> ResourceViewCache<Resource>::GetResourceView(const Resource* resource, const ImageViewDescriptor& imageViewDescriptor) const;
+    template
+    Ptr<BufferView> ResourceViewCache<Resource>::GetResourceView(const Resource* resource, const BufferViewDescriptor& bufferViewDescriptor) const;
+    template
+    Ptr<ImageView> ResourceViewCache<Resource>::InsertNewView(const Resource* resource,  HashValue64 hash, const ImageViewDescriptor& imageViewDescriptor) const;
+    template
+    Ptr<BufferView> ResourceViewCache<Resource>::InsertNewView(const Resource* resource,  HashValue64 hash, const BufferViewDescriptor& bufferViewDescriptor) const;
+    template
+    void ResourceViewCache<Resource>::EraseResourceView(ResourceView* resourceView) const;
+    template
+    bool ResourceViewCache<Resource>::IsInResourceCache(const ImageViewDescriptor& imageViewDescriptor);
+    template
+    bool ResourceViewCache<Resource>::IsInResourceCache(const BufferViewDescriptor& bufferViewDescriptor);
+}

--- a/Gems/Atom/RHI/Code/Source/RHI/ScopeAttachment.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ScopeAttachment.cpp
@@ -6,9 +6,11 @@
  *
  */
 
+#include <Atom/RHI/FrameAttachment.h>
+#include <Atom/RHI/ResourceView.h>
 #include <Atom/RHI/ScopeAttachment.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
-#include <Atom/RHI/FrameAttachment.h>
+
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -189,10 +189,12 @@ set(FILES
     Source/RHI/QueryPoolSubAllocator.cpp
     Include/Atom/RHI/DeviceResource.h
     Include/Atom/RHI/Resource.h
+    Include/Atom/RHI/ResourceView.h
     Include/Atom/RHI/ResourceInvalidateBus.h
     Include/Atom/RHI/DeviceResourceView.h
     Source/RHI/DeviceResource.cpp
     Source/RHI/Resource.cpp
+    Source/RHI/ResourceView.cpp
     Source/RHI/DeviceResourceView.cpp
     Include/Atom/RHI/DeviceResourcePool.h
     Include/Atom/RHI/ResourcePool.h

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -190,11 +190,13 @@ set(FILES
     Include/Atom/RHI/DeviceResource.h
     Include/Atom/RHI/Resource.h
     Include/Atom/RHI/ResourceView.h
+    Include/Atom/RHI/ResourceViewCache.h
     Include/Atom/RHI/ResourceInvalidateBus.h
     Include/Atom/RHI/DeviceResourceView.h
     Source/RHI/DeviceResource.cpp
     Source/RHI/Resource.cpp
     Source/RHI/ResourceView.cpp
+    Source/RHI/ResourceViewCache.cpp
     Source/RHI/DeviceResourceView.cpp
     Include/Atom/RHI/DeviceResourcePool.h
     Include/Atom/RHI/ResourcePool.h

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -235,7 +235,7 @@ namespace AZ
                 return;
             }
 
-            m_bufferView = m_rhiBuffer->BuildBufferView(m_bufferViewDescriptor);
+            m_bufferView = m_rhiBuffer->GetBufferView(m_bufferViewDescriptor);
 
             if(!m_bufferView.get())
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
@@ -141,7 +141,7 @@ namespace AZ
             if (resultCode == RHI::ResultCode::Success)
             {
                 m_imagePool = pool;
-                m_imageView = m_image->BuildImageView(imageAsset.GetImageViewDescriptor());
+                m_imageView = m_image->GetImageView(imageAsset.GetImageViewDescriptor());
                 if(!m_imageView.get())
                 {
                     AZ_Error("AttachmentImage", false, "AttachmentImage::Init() failed to initialize RHI image view.");

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -153,7 +153,7 @@ namespace AZ
                 // Set rhi image name
                 m_imageAsset = { &imageAsset, AZ::Data::AssetLoadBehavior::PreLoad };
                 m_image->SetName(Name(m_imageAsset.GetHint()));
-                m_imageView = m_image->BuildImageView(imageAsset.GetImageViewDescriptor());
+                m_imageView = m_image->GetImageView(imageAsset.GetImageViewDescriptor());
                 if(!m_imageView.get())
                 {
                    AZ_Error("Image", false, "Failed to initialize RHI image view. This is not a recoverable error and is likely a bug.");

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
@@ -89,7 +89,7 @@ namespace AZ::RPI
         {
             imageViewDescriptor.m_mipSliceMin = static_cast<uint16_t>(mipIndex);
             imageViewDescriptor.m_mipSliceMax = static_cast<uint16_t>(mipIndex);
-            Ptr<RHI::ImageView> imageView = const_cast<RHI::Image*>(rhiImage)->BuildImageView(imageViewDescriptor);
+            Ptr<RHI::ImageView> imageView = const_cast<RHI::Image*>(rhiImage)->GetImageView(imageViewDescriptor);
             srg.SetImageView(m_imageDestinationIndex, imageView.get(), mipIndex);
             m_imageViews[mipIndex] = imageView;
         }

--- a/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupBufferTests.cpp
@@ -111,9 +111,9 @@ namespace UnitTest
             m_longBuffer = Buffer::FindOrCreate(m_longBufferAsset);
 
             m_threeBuffers = { m_shortBuffer, m_mediumBuffer, m_longBuffer };
-            m_bufferViewA = m_longBuffer->GetRHIBuffer()->BuildBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6));
-            m_bufferViewB = m_longBuffer->GetRHIBuffer()->BuildBufferView(RHI::BufferViewDescriptor::CreateRaw(15, 4));
-            m_bufferViewC = m_longBuffer->GetRHIBuffer()->BuildBufferView(RHI::BufferViewDescriptor::CreateRaw(22, 18));
+            m_bufferViewA = m_longBuffer->GetRHIBuffer()->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(5, 6));
+            m_bufferViewB = m_longBuffer->GetRHIBuffer()->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(15, 4));
+            m_bufferViewC = m_longBuffer->GetRHIBuffer()->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(22, 18));
 
             m_threeBufferViews = { m_bufferViewA.get(), m_bufferViewB.get(), m_bufferViewC.get() };
         }

--- a/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupImageTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/ShaderResourceGroup/ShaderResourceGroupImageTests.cpp
@@ -66,14 +66,14 @@ namespace UnitTest
             m_threeImages = { m_whiteImage, m_blackImage, m_greyImage };
 
             RHI::ImageViewDescriptor imageViewDescA = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 1, 1);
-            m_imageViewA = m_whiteImage->GetRHIImage()->BuildImageView(imageViewDescA);
+            m_imageViewA = m_whiteImage->GetRHIImage()->GetImageView(imageViewDescA);
 
             RHI::ImageViewDescriptor imageViewDescB = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 2, 2);
-            m_imageViewB = m_whiteImage->GetRHIImage()->BuildImageView(imageViewDescB);
+            m_imageViewB = m_whiteImage->GetRHIImage()->GetImageView(imageViewDescB);
 
             RHI::ImageViewDescriptor imageViewDescC = RHI::ImageViewDescriptor::Create(RHI::Format::Unknown, 3, 3);
-            m_imageViewC = m_whiteImage->GetRHIImage()->BuildImageView(imageViewDescC);
-            
+            m_imageViewC = m_whiteImage->GetRHIImage()->GetImageView(imageViewDescC);
+
             m_threeImageViews = { m_imageViewA.get(), m_imageViewB.get(), m_imageViewC.get() };
         }
 

--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
@@ -124,7 +124,7 @@ namespace AZ
                         streamDesc.m_elementFormat, RHI::BufferBindFlags::ShaderRead    // No need for ReadWrite in the raster fill
                     );
 
-                    m_readBuffersViews[index] = rhiBuffer->BuildBufferView(viewDescriptor);
+                    m_readBuffersViews[index] = rhiBuffer->GetBufferView(viewDescriptor);
 
                     // Buffer binding into the raster srg
                     RHI::ShaderInputBufferIndex indexHandle = m_simSrgForRaster->FindShaderInputBufferIndex(streamDesc.m_paramNameInSrg);
@@ -253,7 +253,7 @@ namespace AZ
                         streamDesc.m_elementFormat, RHI::BufferBindFlags::ShaderReadWrite
                     );
 
-                    m_dynamicBuffersViews[stream] = rhiBuffer->BuildBufferView(viewDescriptor);
+                    m_dynamicBuffersViews[stream] = rhiBuffer->GetBufferView(viewDescriptor);
                 }
 
                 m_initialized = true;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGrid.cpp
@@ -492,7 +492,9 @@ namespace AZ
             uint32_t packed3 = 0;
             uint32_t packed4 = (m_scrolling << 16) | (1 << 17) | (1 << 18) | (1 << 19) | (1 << 20); // scrolling, rayFormat, irradianceFormat, relocation, classification
 
-            m_prepareSrg->SetBufferView(m_renderData->m_prepareSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_prepareSrg->SetBufferView(
+                m_renderData->m_prepareSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgGridDataInitializedNameIndex, m_gridDataInitialized);
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgProbeGridOriginNameIndex, m_transform.GetTranslation());
             m_prepareSrg->SetConstant(m_renderData->m_prepareSrgProbeGridProbeHysteresisNameIndex, m_probeHysteresis);
@@ -524,11 +526,21 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_rayTraceSrg.get(), "Failed to create RayTrace shader resource group");
             }
 
-            m_rayTraceSrg->SetBufferView(m_renderData->m_rayTraceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_rayTraceSrg->SetImageView(m_renderData->m_rayTraceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_rayTraceSrg->SetBufferView(
+                m_renderData->m_rayTraceSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(
+                m_renderData->m_rayTraceSrgProbeRayTraceNameIndex,
+                m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(
+                m_renderData->m_rayTraceSrgProbeIrradianceNameIndex,
+                m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(
+                m_renderData->m_rayTraceSrgProbeDistanceNameIndex,
+                m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_rayTraceSrg->SetImageView(
+                m_renderData->m_rayTraceSrgProbeDataNameIndex,
+                m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgAmbientMultiplierNameIndex, m_ambientMultiplier);
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgGiShadowsNameIndex, m_giShadows);
             m_rayTraceSrg->SetConstant(m_renderData->m_rayTraceSrgUseDiffuseIblNameIndex, m_useDiffuseIbl);
@@ -546,10 +558,18 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_blendIrradianceSrg.get(), "Failed to create BlendIrradiance shader resource group");
             }
 
-            m_blendIrradianceSrg->SetBufferView(m_renderData->m_blendIrradianceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeIrradianceNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_blendIrradianceSrg->SetImageView(m_renderData->m_blendIrradianceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetBufferView(
+                m_renderData->m_blendIrradianceSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(
+                m_renderData->m_blendIrradianceSrgProbeRayTraceNameIndex,
+                m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(
+                m_renderData->m_blendIrradianceSrgProbeIrradianceNameIndex,
+                m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_blendIrradianceSrg->SetImageView(
+                m_renderData->m_blendIrradianceSrgProbeDataNameIndex,
+                m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_blendIrradianceSrg->SetConstant(m_renderData->m_blendIrradianceSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_blendIrradianceSrg->SetConstant(m_renderData->m_blendIrradianceSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -562,10 +582,18 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_blendDistanceSrg.get(), "Failed to create BlendDistance shader resource group");
             }
 
-            m_blendDistanceSrg->SetBufferView(m_renderData->m_blendDistanceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDistanceNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_blendDistanceSrg->SetImageView(m_renderData->m_blendDistanceSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_blendDistanceSrg->SetBufferView(
+                m_renderData->m_blendDistanceSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(
+                m_renderData->m_blendDistanceSrgProbeRayTraceNameIndex,
+                m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(
+                m_renderData->m_blendDistanceSrgProbeDistanceNameIndex,
+                m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_blendDistanceSrg->SetImageView(
+                m_renderData->m_blendDistanceSrgProbeDataNameIndex,
+                m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_blendDistanceSrg->SetConstant(m_renderData->m_blendDistanceSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_blendDistanceSrg->SetConstant(m_renderData->m_blendDistanceSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -582,7 +610,9 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateRowIrradianceSrg.get(), "Failed to create BorderUpdateRowIrradiance shader resource group");
                 }
 
-                m_borderUpdateRowIrradianceSrg->SetImageView(m_renderData->m_borderUpdateRowIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+                m_borderUpdateRowIrradianceSrg->SetImageView(
+                    m_renderData->m_borderUpdateRowIrradianceSrgProbeTextureNameIndex,
+                    m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
                 m_borderUpdateRowIrradianceSrg->SetConstant(m_renderData->m_borderUpdateRowIrradianceSrgNumTexelsNameIndex, DefaultNumIrradianceTexels);
             }
 
@@ -594,7 +624,9 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateColumnIrradianceSrg.get(), "Failed to create BorderUpdateColumnRowIrradiance shader resource group");
                 }
 
-                m_borderUpdateColumnIrradianceSrg->SetImageView(m_renderData->m_borderUpdateColumnIrradianceSrgProbeTextureNameIndex, m_irradianceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+                m_borderUpdateColumnIrradianceSrg->SetImageView(
+                    m_renderData->m_borderUpdateColumnIrradianceSrgProbeTextureNameIndex,
+                    m_irradianceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
                 m_borderUpdateColumnIrradianceSrg->SetConstant(m_renderData->m_borderUpdateColumnIrradianceSrgNumTexelsNameIndex, DefaultNumIrradianceTexels);
             }
 
@@ -606,7 +638,9 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateRowDistanceSrg.get(), "Failed to create BorderUpdateRowDistance shader resource group");
                 }
 
-                m_borderUpdateRowDistanceSrg->SetImageView(m_renderData->m_borderUpdateRowDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+                m_borderUpdateRowDistanceSrg->SetImageView(
+                    m_renderData->m_borderUpdateRowDistanceSrgProbeTextureNameIndex,
+                    m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
                 m_borderUpdateRowDistanceSrg->SetConstant(m_renderData->m_borderUpdateRowDistanceSrgNumTexelsNameIndex, DefaultNumDistanceTexels);
             }
 
@@ -618,7 +652,9 @@ namespace AZ
                     AZ_Error("DiffuseProbeGrid", m_borderUpdateColumnDistanceSrg.get(), "Failed to create BorderUpdateColumnRowDistance shader resource group");
                 }
 
-                m_borderUpdateColumnDistanceSrg->SetImageView(m_renderData->m_borderUpdateColumnDistanceSrgProbeTextureNameIndex, m_distanceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+                m_borderUpdateColumnDistanceSrg->SetImageView(
+                    m_renderData->m_borderUpdateColumnDistanceSrgProbeTextureNameIndex,
+                    m_distanceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
                 m_borderUpdateColumnDistanceSrg->SetConstant(m_renderData->m_borderUpdateColumnDistanceSrgNumTexelsNameIndex, DefaultNumDistanceTexels);
             }
         }
@@ -631,9 +667,15 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_relocationSrg.get(), "Failed to create Relocation shader resource group");
             }
 
-            m_relocationSrg->SetBufferView(m_renderData->m_relocationSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_relocationSrg->SetImageView(m_renderData->m_relocationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_relocationSrg->SetBufferView(
+                m_renderData->m_relocationSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_relocationSrg->SetImageView(
+                m_renderData->m_relocationSrgProbeRayTraceNameIndex,
+                m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_relocationSrg->SetImageView(
+                m_renderData->m_relocationSrgProbeDataNameIndex,
+                m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_relocationSrg->SetConstant(m_renderData->m_relocationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_relocationSrg->SetConstant(m_renderData->m_relocationSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -646,9 +688,15 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_classificationSrg.get(), "Failed to create Classification shader resource group");
             }
 
-            m_classificationSrg->SetBufferView(m_renderData->m_classificationSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeRayTraceNameIndex, m_rayTraceImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
-            m_classificationSrg->SetImageView(m_renderData->m_classificationSrgProbeDataNameIndex, m_probeDataImage[m_currentImageIndex]->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_classificationSrg->SetBufferView(
+                m_renderData->m_classificationSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_classificationSrg->SetImageView(
+                m_renderData->m_classificationSrgProbeRayTraceNameIndex,
+                m_rayTraceImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeRayTraceImageViewDescriptor).get());
+            m_classificationSrg->SetImageView(
+                m_renderData->m_classificationSrgProbeDataNameIndex,
+                m_probeDataImage[m_currentImageIndex]->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_classificationSrg->SetConstant(m_renderData->m_classificationSrgFrameUpdateCountNameIndex, m_frameUpdateCount);
             m_classificationSrg->SetConstant(m_renderData->m_classificationSrgFrameUpdateIndexNameIndex, m_frameUpdateIndex);
         }
@@ -666,7 +714,9 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_renderObjectSrg.get(), "Failed to create render shader resource group");
             }
 
-            m_renderObjectSrg->SetBufferView(m_renderData->m_renderSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_renderObjectSrg->SetBufferView(
+                m_renderData->m_renderSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
 
             AZ::Matrix3x4 modelToWorld = AZ::Matrix3x4::CreateFromTransform(m_transform) * AZ::Matrix3x4::CreateScale(m_renderExtents);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgModelToWorldNameIndex, modelToWorld);
@@ -678,9 +728,15 @@ namespace AZ
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgEnableDiffuseGiNameIndex, m_enabled);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgAmbientMultiplierNameIndex, m_ambientMultiplier);
             m_renderObjectSrg->SetConstant(m_renderData->m_renderSrgEdgeBlendIblNameIndex, m_edgeBlendIbl);
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeIrradianceNameIndex, GetIrradianceImage()->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDistanceNameIndex, GetDistanceImage()->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_renderObjectSrg->SetImageView(m_renderData->m_renderSrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(
+                m_renderData->m_renderSrgProbeIrradianceNameIndex,
+                GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(
+                m_renderData->m_renderSrgProbeDistanceNameIndex,
+                GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_renderObjectSrg->SetImageView(
+                m_renderData->m_renderSrgProbeDataNameIndex,
+                GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
 
             m_updateRenderObjectSrg = false;
 
@@ -698,10 +754,16 @@ namespace AZ
 
             uint32_t tlasInstancesBufferByteCount = aznumeric_cast<uint32_t>(m_visualizationTlas->GetTlasInstancesBuffer()->GetDescriptor().m_byteCount);
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateStructured(0, tlasInstancesBufferByteCount / RayTracingTlasInstanceElementSize, RayTracingTlasInstanceElementSize);
-            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex, m_visualizationTlas->GetTlasInstancesBuffer()->BuildBufferView(bufferViewDescriptor).get());
+            m_visualizationPrepareSrg->SetBufferView(
+                m_renderData->m_visualizationPrepareSrgTlasInstancesNameIndex,
+                m_visualizationTlas->GetTlasInstancesBuffer()->GetBufferView(bufferViewDescriptor).get());
 
-            m_visualizationPrepareSrg->SetBufferView(m_renderData->m_visualizationPrepareSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_visualizationPrepareSrg->SetImageView(m_renderData->m_visualizationPrepareSrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_visualizationPrepareSrg->SetBufferView(
+                m_renderData->m_visualizationPrepareSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_visualizationPrepareSrg->SetImageView(
+                m_renderData->m_visualizationPrepareSrgProbeDataNameIndex,
+                GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_visualizationPrepareSrg->SetConstant(m_renderData->m_visualizationPrepareSrgProbeSphereRadiusNameIndex, m_visualizationSphereRadius);
         }
 
@@ -715,12 +777,22 @@ namespace AZ
 
             uint32_t tlasBufferByteCount = aznumeric_cast<uint32_t>(m_visualizationTlas->GetTlasBuffer()->GetDescriptor().m_byteCount);
             RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
-            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgTlasNameIndex, m_visualizationTlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetBufferView(
+                m_renderData->m_visualizationRayTraceSrgTlasNameIndex,
+                m_visualizationTlas->GetTlasBuffer()->GetBufferView(bufferViewDescriptor).get());
 
-            m_visualizationRayTraceSrg->SetBufferView(m_renderData->m_visualizationRayTraceSrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex, GetIrradianceImage()->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDistanceNameIndex, GetDistanceImage()->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetBufferView(
+                m_renderData->m_visualizationRayTraceSrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(
+                m_renderData->m_visualizationRayTraceSrgProbeIrradianceNameIndex,
+                GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(
+                m_renderData->m_visualizationRayTraceSrgProbeDistanceNameIndex,
+                GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_visualizationRayTraceSrg->SetImageView(
+                m_renderData->m_visualizationRayTraceSrgProbeDataNameIndex,
+                GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_visualizationRayTraceSrg->SetConstant(m_renderData->m_visualizationRayTraceSrgShowInactiveProbesNameIndex, m_visualizationShowInactiveProbes);
             m_visualizationRayTraceSrg->SetImageView(m_renderData->m_visualizationRayTraceSrgOutputNameIndex, outputImageView);
         }
@@ -733,10 +805,18 @@ namespace AZ
                 AZ_Error("DiffuseProbeGrid", m_querySrg.get(), "Failed to create Query shader resource group");
             }
 
-            m_querySrg->SetBufferView(m_renderData->m_querySrgGridDataNameIndex, m_gridDataBuffer->BuildBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeIrradianceNameIndex, GetIrradianceImage()->BuildImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDistanceNameIndex, GetDistanceImage()->BuildImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
-            m_querySrg->SetImageView(m_renderData->m_querySrgProbeDataNameIndex, GetProbeDataImage()->BuildImageView(m_renderData->m_probeDataImageViewDescriptor).get());
+            m_querySrg->SetBufferView(
+                m_renderData->m_querySrgGridDataNameIndex,
+                m_gridDataBuffer->GetBufferView(m_renderData->m_gridDataBufferViewDescriptor).get());
+            m_querySrg->SetImageView(
+                m_renderData->m_querySrgProbeIrradianceNameIndex,
+                GetIrradianceImage()->GetImageView(m_renderData->m_probeIrradianceImageViewDescriptor).get());
+            m_querySrg->SetImageView(
+                m_renderData->m_querySrgProbeDistanceNameIndex,
+                GetDistanceImage()->GetImageView(m_renderData->m_probeDistanceImageViewDescriptor).get());
+            m_querySrg->SetImageView(
+                m_renderData->m_querySrgProbeDataNameIndex,
+                GetProbeDataImage()->GetImageView(m_renderData->m_probeDataImageViewDescriptor).get());
             m_querySrg->SetConstant(m_renderData->m_querySrgAmbientMultiplierNameIndex, m_ambientMultiplier);
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
@@ -228,7 +228,7 @@ namespace AZ
                 RHI::ShaderInputBufferIndex bufferIndex = m_srgLayout->FindShaderInputBufferIndex(AZ::Name("m_irradianceQueries"));
                 RHI::Ptr<RHI::Buffer> buffer = diffuseProbeGridFeatureProcessor->GetQueryBuffer()->GetRHIBuffer();
                 RHI::BufferViewDescriptor bufferViewDescriptor = diffuseProbeGridFeatureProcessor->GetQueryBufferViewDescriptor();
-                diffuseProbeGrid->GetQuerySrg()->SetBufferView(bufferIndex, buffer->BuildBufferView(bufferViewDescriptor).get());
+                diffuseProbeGrid->GetQuerySrg()->SetBufferView(bufferIndex, buffer->GetBufferView(bufferViewDescriptor).get());
 
                 // bind output UAV
                 bufferIndex = m_srgLayout->FindShaderInputBufferIndex(AZ::Name("m_output"));

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsUtilities.cpp
@@ -173,7 +173,7 @@ namespace AZ
             viewDescriptor.m_ignoreFrameAttachmentValidation = true;
 
             RHI::Buffer* rhiBuffer = Meshlets::SharedBufferInterface::Get()->GetBuffer()->GetRHIBuffer();
-            return rhiBuffer->BuildBufferView(viewDescriptor);
+            return rhiBuffer->GetBufferView(viewDescriptor);
         }
 
         bool UtilityClass::BindBufferViewToSrg(

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -408,10 +408,10 @@ namespace Terrain
 
             subMesh.m_positionFormat = positionsBufferFormat;
             subMesh.m_positionVertexBufferView = positionsVertexBufferView;
-            subMesh.m_positionShaderBufferView = rhiPositionsBuffer.BuildBufferView(positionsBufferDescriptor);
+            subMesh.m_positionShaderBufferView = rhiPositionsBuffer.GetBufferView(positionsBufferDescriptor);
             subMesh.m_normalFormat = normalsBufferFormat;
             subMesh.m_normalVertexBufferView = normalsVertexBufferView;
-            subMesh.m_normalShaderBufferView = rhiNormalsBuffer.BuildBufferView(normalsBufferDescriptor);
+            subMesh.m_normalShaderBufferView = rhiNormalsBuffer.GetBufferView(normalsBufferDescriptor);
             subMesh.m_indexBufferView = AZ::RHI::IndexBufferView(rhiIndexBuffer, indexBufferByteOffset, indexBufferByteCount, indexBufferFormat);
             subMesh.m_material.m_baseColor = AZ::Color::CreateFromVector3(AZ::Vector3(0.18f));
 
@@ -421,7 +421,7 @@ namespace Terrain
             indexBufferDescriptor.m_elementSize = indexElementSize;
             indexBufferDescriptor.m_elementFormat = AZ::RHI::Format::R32_UINT;
 
-            subMesh.m_indexShaderBufferView = rhiIndexBuffer.BuildBufferView(indexBufferDescriptor);
+            subMesh.m_indexShaderBufferView = rhiIndexBuffer.GetBufferView(indexBufferDescriptor);
 
             meshGroup.m_mesh.m_assetId = AZ::Data::AssetId(meshGroup.m_id);
             float xyScale = (m_gridSize * m_sampleSpacing) * (1 << lodLevel);


### PR DESCRIPTION
## What does this PR do?

Refactor `ResourceView` into a proper base class for `ImageView` and `BufferView` and rename `Build*View` to `Get*View`.
This means moving the `ConstPtr<Resource>` into the `ResourceView` as well as the cache, deduplicating the code that can be shared between `BufferView` and `ImageView`.
Furthermore, since https://github.com/o3de/o3de/pull/18715, `Build*View` no longer always builds but may return a pointer to an already created and now cached view, so we propose reverting the rename that took place in the initial multiGPU version.


This refactor changes the structure as follows:

### Previous structure
![PreviousUML simplified](https://github.com/user-attachments/assets/0e3629eb-d150-426e-830c-efc2dac1c08c)
### New structure
![NewUML simplified](https://github.com/user-attachments/assets/75d25a1f-a1a6-4118-a86a-7460854bcaa1)

With more detail added (adding dependencies) this would result in:
### Previous structure
![Previous UML](https://github.com/user-attachments/assets/34b98ac8-a6b6-45c2-89e3-95fdf09ec1d0)
### New structure
![NewUML](https://github.com/user-attachments/assets/b012b845-18cb-4f44-b3ba-9454d41ef591)

