### PR TITLE
DeferredFog: Don't reload the noise texture every frame

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
@@ -110,7 +110,10 @@ namespace AZ
         {
             // Remove outdated level settings aggregate
             m_globalAggregateLevelSettings = AZStd::make_unique<PostProcessSettings>(this);
-            m_blendedPerViewSettings.clear();
+            for (auto& [view, settings] : m_blendedPerViewSettings)
+            {
+                m_globalAggregateLevelSettings->ApplySettingsTo(&settings);
+            }
             // Apply settings from priority sorted list of level settings
             AZStd::vector_set<const RPI::View*> activeViews;
             for (auto& settings : m_sortedFrameSettings)

--- a/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogPass.cpp
@@ -138,9 +138,12 @@ namespace AZ
 #include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
 
 #undef  AZ_GFX_TEXTURE2D_PARAM
-#define AZ_GFX_TEXTURE2D_PARAM(Name, MemberName, DefaultValue)                  \
-                fogSettings->MemberName##Image =                                \
-                    fogSettings->LoadStreamingImage( fogSettings->MemberName.c_str(), "DeferredFogSettings" );  \
+#define AZ_GFX_TEXTURE2D_PARAM(Name, MemberName, DefaultValue)                                                                                 \
+                if (fogSettings->MemberName##CurrentlyLoaded != fogSettings->MemberName)                                                       \
+                {                                                                                                                              \
+                    fogSettings->MemberName##Image = fogSettings->LoadStreamingImage(fogSettings->MemberName.c_str(), "DeferredFogSettings");  \
+                    fogSettings->MemberName##CurrentlyLoaded  = fogSettings->MemberName;                                                       \
+                }
 
 #include <Atom/Feature/ScreenSpace/DeferredFogParams.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>

--- a/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogSettings.h
@@ -126,8 +126,9 @@ namespace AZ
 
             // Macro to replace only the image macro for defining only image resources
 #undef  AZ_GFX_TEXTURE2D_PARAM
-#define AZ_GFX_TEXTURE2D_PARAM(Name, MemberName, DefaultValue)                \
-            Data::Instance<AZ::RPI::Image> MemberName##Image;                 \
+#define AZ_GFX_TEXTURE2D_PARAM(Name, MemberName, DefaultValue)            \
+            Data::Instance<AZ::RPI::Image> MemberName##Image;             \
+            AZStd::string MemberName##CurrentlyLoaded;
 
 #include <Atom/Feature/ScreenSpace/DeferredFogParams.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>


### PR DESCRIPTION
## What does this PR do?

When the DeferredFog component is present in a level, the noise texture for the fog was reloaded every frame. This took about 0.75ms every frame on my machine.

This PR fixes two things for the fog settings:
1. The `m_blendedPerViewSettings` in the PostProcesFeatureProcessor were deleted every frame and created anew. Thus a potentially loaded image was also deleted. We now reset the settings per view instead of clearing the whole map.
2. The noise texture was reloaded every time a settings changed in the DeferredFogSettings. Added a variable to remember which images is currently loaded.

## How was this PR tested?

Tested on Windows with Vulkan/DX12 in a level with fog
