### PR TITLE
Galibzon/material mesh index

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/AlphaUtils.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/AlphaUtils.azsli
@@ -12,6 +12,9 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
 
 void CheckClipping(real alpha, real opacityFactor)
 {
+#ifdef CS_SAMPLERS
+    // In compute shaders the clip() intrinsic is not allowed.
+#else
     switch(o_opacity_mode)
     {
         case OpacityMode::Cutout:
@@ -29,4 +32,5 @@ void CheckClipping(real alpha, real opacityFactor)
         default:
             break;
     }
+#endif //ifdef CS_SAMPLERS
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
@@ -129,8 +129,12 @@ struct ParallaxOffset
 ParallaxOffset BasicParallaxMapping(float depthFactor, float2 uv, float3 dirToCameraTS)
 {
     // the amount to shift
+#ifdef CS_SAMPLERS
+    float2 delta = dirToCameraTS.xy * GetNormalizedDepth(0, depthFactor, uv, float2(0, 0), float2(0, 0)) * depthFactor;
+#else
     float2 delta = dirToCameraTS.xy * GetNormalizedDepth(0, depthFactor, uv, ddx_fine(uv), ddy_fine(uv)) * depthFactor;
-    
+#endif
+
     ParallaxOffset result;
 
     result.m_offsetTS = float3(0,0,0);
@@ -161,8 +165,13 @@ ParallaxOffset AdvancedParallaxMapping(float depthFactor, float depthOffset, flo
     // the amount to shift per step, shift in the inverse direction of dirToCameraTS
     float3 delta = -dirToCameraTS.xyz * depthFactor * dirToCameraZInverse * step;
 
+#ifdef CS_SAMPLERS
+    float2 ddx_uv = float2(0, 0);
+    float2 ddy_uv = float2(0, 0);
+#else
     float2 ddx_uv = ddx_fine(uv);
     float2 ddy_uv = ddy_fine(uv);
+#endif
 
     float depthSearchStart = depthOffset;
     float depthSearchEnd = depthSearchStart + depthFactor;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/AlphaInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/AlphaInput.azsli
@@ -26,7 +26,11 @@ real SampleAlpha(Texture2D baseColorMap, Texture2D opacityMap, float2 baseColorU
             }
             else
             {
+            #ifdef CS_SAMPLERS
+                alpha = real(baseColorMap.SampleLevel(mapSampler, baseColorUv, 0).a);
+            #else
                 alpha = real(baseColorMap.Sample(mapSampler, baseColorUv).a);
+            #endif
             }
             break;
         }
@@ -38,7 +42,11 @@ real SampleAlpha(Texture2D baseColorMap, Texture2D opacityMap, float2 baseColorU
             }
             else
             {
+            #ifdef CS_SAMPLERS
+                alpha = real(opacityMap.SampleLevel(mapSampler, opacityUv, 0).r);
+            #else
                 alpha = real(opacityMap.Sample(mapSampler, opacityUv).r);
+            #endif
             }
             break;
         }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/EmissiveInput.azsli
@@ -42,7 +42,11 @@ real3 GetEmissiveInput(Texture2D map, sampler mapSampler, float2 uv, real factor
             }
             else
             {
-                sampledValue = real3(map.Sample(mapSampler, uv).rgb);
+                #ifdef CS_SAMPLERS
+                    sampledValue = real3(map.SampleLevel(mapSampler, uv, 0).rgb);
+                #else
+                    sampledValue = real3(map.Sample(mapSampler, uv).rgb);
+                #endif
             }
             emissive *= TransformColor(sampledValue, ColorSpaceId::LinearSRGB, ColorSpaceId::ACEScg);
         }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/MetallicInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/MetallicInput.azsli
@@ -40,7 +40,11 @@ real GetMetallicInput(Texture2D map, sampler mapSampler, float2 uv, real factor,
        }
        else
        {
+        #ifdef CS_SAMPLERS
+           return real(map.SampleLevel(mapSampler, uv, 0).r);
+        #else
            return real(map.Sample(mapSampler, uv).r);
+        #endif
        }
     }
     return factor;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAAEdgeDetection.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAAEdgeDetection.azsl
@@ -71,7 +71,13 @@ option enum class EdgeDetectionMode { Depth, Luma, Color } o_edgeDetectionMode =
 
 // This macro being defined before being included in SMAA.azsli, we can control which function is enabled in SMAA.azsli
 // This macro is intended to enable the edge detection functions only.
-#define ATOM_SMAA_EDGE_DETECTION_PASS_IMPLEMENTATION_ENABLE
+#ifdef CS_SAMPLERS
+    // When using Compute shaders, the "discard" intrinsic is not available (only valid for Fragment shaders).
+    // ATOM_SMAA_EDGE_DETECTION_PASS_IMPLEMENTATION_ENABLE in "SMAA.azsli" uses "discard".
+    #define ATOM_SMAA_BLENDING_WEIGHT_CALCULATION_PASS_IMPLEMENTATION_ENABLE
+#else
+    #define ATOM_SMAA_EDGE_DETECTION_PASS_IMPLEMENTATION_ENABLE
+#endif
 
 // Defining the elements below before including SMAA.azsli as they'll be used in it.
 // - PassSrg SRG to be used for the edge detection implementation.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h
@@ -29,13 +29,16 @@ namespace AZ
             //! REMARK: If the BindlessSrg is enabled, which typically is, this buffer view is already bound
             //! as a ByteAddressBuffer
             virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetVertexIndicesBufferView() const = 0;
-            //! Returns the StreamBufferView from the Vertex Indices, which is useful to know the actual
+            //! Returns the IndexBufferView from the Vertex Indices, which is useful to know the actual
             //! byte offset, byte count, etc related to the sub mesh(Mesh Index). 
             virtual const AZ::RHI::IndexBufferView& GetVertexIndicesIndexBufferView() const = 0;
             //! A shortcut to get the Read Index from the BindlessSrg for the IndexBufferView.
             //! Alternatively, you could get the same index by getting it directly from the AZ::RHI::BufferView
             //! returned by GetIndexBufferView()
             virtual uint32_t GetVertexIndicesBindlessReadIndex(int deviceIndex) const = 0;
+            //! Same as above, but conveniently returns all the indices across all available devices
+            //! in an unordered_map.
+            virtual AZStd::unordered_map<int, uint32_t> GetVertexIndicesBindlessReadIndex() const = 0;
 
             //! Returns the Shader-bindable RHI::BufferView for a Vertex Stream, identifiable by @shaderSemantic, from a particular mesh.
             virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetBufferView(const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
@@ -54,6 +57,12 @@ namespace AZ
             //! returned by GetBufferView().
             virtual uint32_t GetStreamBufferViewBindlessReadIndex(int deviceIndex, const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
             virtual uint32_t GetStreamBufferViewBindlessReadIndex(int deviceIndex, const char* semanticName) const = 0;
+            //! Same as above, but conveniently returns all the indices across all available devices
+            //! in an unordered_map.
+            virtual AZStd::unordered_map<int, uint32_t> GetStreamBufferViewBindlessReadIndex(
+                const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
+            virtual AZStd::unordered_map<int, uint32_t> GetStreamBufferViewBindlessReadIndex(
+                const char* semanticName) const = 0;
 
             //! For informational purposes. Returns the LOD Index of the Mesh.
             virtual uint32_t GetLodIndex() const = 0;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/StreamBufferViewsBuilderInterface.h
@@ -8,13 +8,14 @@
 
 #pragma once
 
+#include <Atom/RHI/StreamBufferView.h>
+
 #include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
 
 namespace AZ
 {
     namespace Render
     {
-
         // An Interface that contains all Stream BufferViews (AZ::RHI::BufferView)
         // requested to @StreamBufferViewsBuilderInterface.
         // This is useful to manually bind Mesh Stream Buffers in a Compute or RayTracing Shader.
@@ -24,12 +25,36 @@ namespace AZ
             AZ_RTTI(AZ::Render::ShaderStreamBufferViewsInterface, "{3A80C85C-DD3A-4A1D-B564-291EB463CD0B}");
             virtual ~ShaderStreamBufferViewsInterface() = default;
 
-            //! Returns the Shader-bindable RHI::BufferView for the Vertex Indices from a particular mesh. 
-            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetIndexBufferView() const = 0;
+            //! Returns the Shader-bindable RHI::BufferView for the Vertex Indices from a particular mesh.
+            //! REMARK: If the BindlessSrg is enabled, which typically is, this buffer view is already bound
+            //! as a ByteAddressBuffer
+            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetVertexIndicesBufferView() const = 0;
+            //! Returns the StreamBufferView from the Vertex Indices, which is useful to know the actual
+            //! byte offset, byte count, etc related to the sub mesh(Mesh Index). 
+            virtual const AZ::RHI::IndexBufferView& GetVertexIndicesIndexBufferView() const = 0;
+            //! A shortcut to get the Read Index from the BindlessSrg for the IndexBufferView.
+            //! Alternatively, you could get the same index by getting it directly from the AZ::RHI::BufferView
+            //! returned by GetIndexBufferView()
+            virtual uint32_t GetVertexIndicesBindlessReadIndex(int deviceIndex) const = 0;
+
             //! Returns the Shader-bindable RHI::BufferView for a Vertex Stream, identifiable by @shaderSemantic, from a particular mesh.
-            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetStreamBufferView(const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
+            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetBufferView(const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
             //! Same as above, but provides the convenience of finding the vertex stream by name, like "POSITION" or "UV1", etc.
-            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetStreamBufferView(const char* semanticName) const = 0;
+            virtual const AZ::RHI::Ptr<AZ::RHI::BufferView>& GetBufferView(const char* semanticName) const = 0;
+
+            //! Returns the StreamBufferView for a Vertex Stream, identifiable by @shaderSemantic, from a particular mesh.
+            //! This is useful to know the actual byte offset, byte count, etc related to the sub mesh(Mesh Index).
+            //! if the semantic is not fund, it returns nullptr.
+            virtual const AZ::RHI::StreamBufferView* GetStreamBufferView(const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
+            //! Same as above, but provides the convenience of finding the vertex stream by name, like "POSITION" or "UV1", etc.
+            virtual const AZ::RHI::StreamBufferView* GetStreamBufferView(const char* semanticName) const = 0;
+
+            //! A shortcut to get the Read Index from the BindlessSrg for a particular BufferView identifiable by its shader semantic.
+            //! Alternatively, you could get the same index by getting it directly from the AZ::RHI::BufferView
+            //! returned by GetBufferView().
+            virtual uint32_t GetStreamBufferViewBindlessReadIndex(int deviceIndex, const AZ::RHI::ShaderSemantic& shaderSemantic) const = 0;
+            virtual uint32_t GetStreamBufferViewBindlessReadIndex(int deviceIndex, const char* semanticName) const = 0;
+
             //! For informational purposes. Returns the LOD Index of the Mesh.
             virtual uint32_t GetLodIndex() const = 0;
             // For informational purposes. Returns the Mesh Index (Within the current LOD index) of the Mesh.

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.h
@@ -39,7 +39,8 @@ namespace AZ
 
         private:
             void FinalizeShaderInputContract();
-            AZ::RHI::Ptr<AZ::RHI::BufferView> BuildShaderIndexBufferView(const AZ::RPI::ModelLod::Mesh& modelLodMesh) const;
+            AZ::RHI::Ptr<AZ::RHI::BufferView> BuildShaderIndexBufferView(
+                const AZ::RPI::ModelLod::Mesh& modelLodMesh, AZ::RHI::IndexBufferView& indexBufferViewOut) const;
 
             static constexpr char LogWindow[] = "ShaderStreamBufferViewsBuilder";
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- #pragma once
+#pragma once
 
 #include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RHI/Buffer.h>
@@ -53,6 +53,12 @@ namespace AZ::RHI
         {
             return GetDeviceBufferView(deviceIndex).get();
         }
+
+        // Convenient helper function to get both of the indices (Read and ReadWrite) in the BindlessSrg for a given device:
+        //     - If @outReadWriteIndex != nullptr, it will get the shader index (ReadWrite) in Bindless::m_RWByteAddressBuffer[].
+        //     See "/o3de/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features\Bindless.azsli" for details.
+        // Returns the shader index (READ) in Bindless::m_ByteAddressBuffer[].
+        uint32_t GetBindlessIndices(int deviceIndex, uint32_t* outReadWriteIndex = nullptr) const;
 
     private:
         //! The corresponding BufferViewDescriptor for this view.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
@@ -55,10 +55,11 @@ namespace AZ::RHI
         }
 
         // Convenient helper function to get both of the indices (Read and ReadWrite) in the BindlessSrg for a given device:
+        //     - If @outReadIndex != nullptr, it will get the shader index (READ) in Bindless::m_ByteAddressBuffer[].
         //     - If @outReadWriteIndex != nullptr, it will get the shader index (ReadWrite) in Bindless::m_RWByteAddressBuffer[].
         //     See "/o3de/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features\Bindless.azsli" for details.
-        // Returns the shader index (READ) in Bindless::m_ByteAddressBuffer[].
-        uint32_t GetBindlessIndices(int deviceIndex, uint32_t* outReadWriteIndex = nullptr) const;
+        // Returns true if @deviceIndex is valid, otherwise returns false.
+        bool GetBindlessIndices(int deviceIndex, uint32_t* outReadIndex, uint32_t* outReadWriteIndex = nullptr) const;
 
     private:
         //! The corresponding BufferViewDescriptor for this view.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferView.h
@@ -23,7 +23,7 @@ namespace AZ::RHI
         AZ_RTTI(DeviceBufferView, "{3012F770-1DD7-4CEC-A5D0-E2FC807548C1}", DeviceResourceView);
         virtual ~DeviceBufferView() = default;
 
-        static constexpr uint32_t InvalidBindlessIndex = 0xFFFFFFFF;
+        static constexpr uint32_t InvalidBindlessIndex = static_cast<uint32_t>(-1);
 
         //! Initializes the buffer view with the provided buffer and view descriptor.
         ResultCode Init(const DeviceBuffer& buffer, const BufferViewDescriptor& viewDescriptor);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
@@ -44,16 +44,20 @@ namespace AZ::RHI
         //! Returns the number of draw items stored in the packet.
         size_t GetDrawItemCount() const;
 
-        //! Returns the index associated with the given DrawListTag
-        s32 GetDrawListIndex(DrawListTag drawListTag) const;
+        //! Returns the index of the first DrawItem that matches the given DrawListTag, and the given DrawFilterMask.
+        //! REMARK: When more than one MaterialPipelines are active, they may have Shaders with the same DrawListTag.
+        //!         In these cases there will be one DrawItem for each MaterialPipeline.
+        s32 GetDrawListIndex(DrawListTag drawListTag, DrawFilterMask materialPipelineMask = DrawFilterMaskDefaultValue) const;
 
         //! Returns the DeviceDrawItem at the given index
         DrawItem* GetDrawItem(size_t index);
         const DrawItem* GetDrawItem(size_t index) const;
 
-        //! Returns the DeviceDrawItem associated with the given DrawListTag
-        DrawItem* GetDrawItem(DrawListTag drawListTag);
-        const DrawItem* GetDrawItem(DrawListTag drawListTag) const;
+        //! Returns the first DrawItem that matches the given DrawListTag, and the given DrawFilterMask.
+        //! REMARK: When more than one MaterialPipelines are active, they may have Shaders with the same DrawListTag.
+        //!         In these cases there will be one DrawItem for each MaterialPipeline.
+        DrawItem* GetDrawItem(DrawListTag drawListTag, DrawFilterMask materialPipelineMask = DrawFilterMaskDefaultValue);
+        const DrawItem* GetDrawItem(DrawListTag drawListTag, DrawFilterMask materialPipelineMask = DrawFilterMaskDefaultValue) const;
 
         //! Returns the draw item and its properties associated with the provided index.
         DrawItemProperties GetDrawItemProperties(size_t index) const;

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
@@ -6,21 +6,21 @@
  *
  */
 
- #include <Atom/RHI/BufferView.h>
- #include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferView.h>
+#include <Atom/RHI/Buffer.h>
 
- namespace AZ::RHI
- {
+namespace AZ::RHI
+{
     //! Given a device index, return the corresponding DeviceBufferView for the selected device
     const RHI::Ptr<RHI::DeviceBufferView> BufferView::GetDeviceBufferView(int deviceIndex) const
     {
         return ResourceView::GetDeviceResourceView<DeviceBufferView>(deviceIndex, m_descriptor);
     }
-
+    
     AZStd::unordered_map<int, uint32_t> BufferView::GetBindlessReadIndex() const
     {
         AZStd::unordered_map<int, uint32_t> result;
-
+    
         MultiDeviceObject::IterateDevices(
             GetResource()->GetDeviceMask(),
             [this, &result](int deviceIndex)
@@ -28,7 +28,21 @@
                 result[deviceIndex] = GetDeviceBufferView(deviceIndex)->GetBindlessReadIndex();
                 return true;
             });
-
+    
         return result;
     }
- }
+    
+    uint32_t BufferView::GetBindlessIndices(int deviceIndex, uint32_t* outReadWriteIndex) const
+    {
+        const auto& deviceBufferView = GetDeviceBufferView(deviceIndex);
+        if (!deviceBufferView)
+        {
+            return DeviceBufferView::InvalidBindlessIndex;
+        }
+        if (outReadWriteIndex != nullptr)
+        {
+            *outReadWriteIndex = deviceBufferView->GetBindlessReadWriteIndex();
+        }
+        return deviceBufferView->GetBindlessReadIndex();
+    }
+}

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferView.cpp
@@ -16,11 +16,11 @@ namespace AZ::RHI
     {
         return ResourceView::GetDeviceResourceView<DeviceBufferView>(deviceIndex, m_descriptor);
     }
-    
+
     AZStd::unordered_map<int, uint32_t> BufferView::GetBindlessReadIndex() const
     {
         AZStd::unordered_map<int, uint32_t> result;
-    
+
         MultiDeviceObject::IterateDevices(
             GetResource()->GetDeviceMask(),
             [this, &result](int deviceIndex)
@@ -28,21 +28,25 @@ namespace AZ::RHI
                 result[deviceIndex] = GetDeviceBufferView(deviceIndex)->GetBindlessReadIndex();
                 return true;
             });
-    
+
         return result;
     }
     
-    uint32_t BufferView::GetBindlessIndices(int deviceIndex, uint32_t* outReadWriteIndex) const
+    bool BufferView::GetBindlessIndices(int deviceIndex, uint32_t* outReadIndex, uint32_t* outReadWriteIndex) const
     {
         const auto& deviceBufferView = GetDeviceBufferView(deviceIndex);
         if (!deviceBufferView)
         {
-            return DeviceBufferView::InvalidBindlessIndex;
+            return false;
+        }
+        if (outReadIndex != nullptr)
+        {
+            *outReadIndex = deviceBufferView->GetBindlessReadIndex();
         }
         if (outReadWriteIndex != nullptr)
         {
             *outReadWriteIndex = deviceBufferView->GetBindlessReadWriteIndex();
         }
-        return deviceBufferView->GetBindlessReadIndex();
+        return true;
     }
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/DrawPacket.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DrawPacket.cpp
@@ -20,11 +20,11 @@ namespace AZ::RHI
         return m_drawItems.size();
     }
 
-    s32 DrawPacket::GetDrawListIndex(DrawListTag drawListTag) const
+    s32 DrawPacket::GetDrawListIndex(DrawListTag drawListTag, DrawFilterMask materialPipelineMask) const
     {
         for (size_t i = 0; i < m_drawItems.size(); ++i)
         {
-            if (GetDrawListTag(i) == drawListTag)
+            if ((GetDrawListTag(i) == drawListTag) && (GetDrawFilterMask(i) & materialPipelineMask))
             {
                 return s32(i);
             }
@@ -42,9 +42,9 @@ namespace AZ::RHI
         return (index < m_drawItems.size()) ? &m_drawItems[index] : nullptr;
     }
 
-    DrawItem* DrawPacket::GetDrawItem(DrawListTag drawListTag)
+    DrawItem* DrawPacket::GetDrawItem(DrawListTag drawListTag, DrawFilterMask materialPipelineMask)
     {
-        s32 index = GetDrawListIndex(drawListTag);
+        s32 index = GetDrawListIndex(drawListTag, materialPipelineMask);
         if (index > -1)
         {
             return GetDrawItem(index);
@@ -52,9 +52,9 @@ namespace AZ::RHI
         return nullptr;
     }
 
-    const DrawItem* DrawPacket::GetDrawItem(DrawListTag drawListTag) const
+    const DrawItem* DrawPacket::GetDrawItem(DrawListTag drawListTag, DrawFilterMask materialPipelineMask) const
     {
-        s32 index = GetDrawListIndex(drawListTag);
+        s32 index = GetDrawListIndex(drawListTag, materialPipelineMask);
         if (index > -1)
         {
             return GetDrawItem(index);

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli
@@ -14,12 +14,21 @@
 #define USE_CUSTOM_DRAW_SRG 0
 #endif
 
+#ifndef USE_DRAWSRG_MESHLOD_MESHINDEX
+#define USE_DRAWSRG_MESHLOD_MESHINDEX 0
+#endif
+
 #if USE_CUSTOM_DRAW_SRG
 #else
 ShaderResourceGroup DrawSrg : SRG_PerDraw
 {
     // This SRG is unique per draw packet
     uint m_uvStreamTangentBitmask;
+
+#if USE_DRAWSRG_MESHLOD_MESHINDEX
+    // See MeshDrawPacket.h
+    uint m_modelLodMeshIndex;
+#endif
 
     uint GetTangentAtUv(uint uvIndex)
     {

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/TangentSpace.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/TangentSpace.azsli
@@ -215,8 +215,13 @@ void SurfaceGradientNormalMapping_Init(real3 normalWS, float3 posWS, bool isBack
     float fs = (isBackface && backfaceMode != BACKFACE_MODE_NONE) ? -1.0 : 1.0;
     g_nrmBaseNormal = (fs*renormFactor) * normalWS;
     g_resolveSign = (isBackface && backfaceMode == BACKFACE_MODE_FLIP) ? -1.0 : 1.0; 
+#ifdef CS_SAMPLERS
+    g_dPdx = float3(0, 0, 0);
+    g_dPdy = float3(0, 0, 0);
+#else
     g_dPdx = ddx_fine(posWS);
     g_dPdy = ddy_fine(posWS);
+#endif
 
     //already in world space
     g_sigmaX = g_dPdx - dot(g_dPdx, g_nrmBaseNormal)*g_nrmBaseNormal;
@@ -227,8 +232,13 @@ void SurfaceGradientNormalMapping_Init(real3 normalWS, float3 posWS, bool isBack
 //! Utility function to generate a tangent basis without using explicit tangent/bitangent vectors.
 void SurfaceGradientNormalMapping_GenerateTB(float2 uv, out real3 tangentWS, out real3 bitangentWS)
 {
+#ifdef CS_SAMPLERS
+    float2 dUVdx = float2(0, 0); 
+    float2 dUVdy = float2(0, 0);
+#else
     float2 dUVdx = ddx_fine(uv); 
     float2 dUVdy = ddy_fine(uv);
+#endif
     float det = dot(dUVdx , float2(dUVdy.y, -dUVdy.x)); 
     float signDet = det < 0 ? -1 : 1;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -14,6 +14,7 @@
 #include <Atom/RPI.Public/Model/ModelLod.h>
 #include <Atom/RHI/DrawPacket.h>
 #include <Atom/RHI/DrawPacketBuilder.h>
+#include <Atom/RHI.Reflect/ShaderInputNameIndex.h>
 
 #include <AzCore/Math/Obb.h>
 #include <AzCore/std/containers/fixed_vector.h>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -94,7 +94,7 @@ namespace AZ
             // By default it is NOT defined.
             // When defined, the value of @m_modelLodMeshIndex (aka subMesh index) is written
             // to the shader constant.
-            static constexpr AZStd::string_view DrawSrgModelLodMeshIndex = "m_modelLodMeshIndex";
+            RHI::ShaderInputNameIndex m_drawSrgModelLodMeshIndex = "m_modelLodMeshIndex";
 
             Ptr<RHI::DrawPacket> m_drawPacket;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -89,6 +89,13 @@ namespace AZ
             bool DoUpdate(const Scene& parentScene);
             void ForValidShaderOptionName(const Name& shaderOptionName, const AZStd::function<bool(const ShaderCollection::Item&, ShaderOptionIndex)>& callback);
 
+            // To enable this shader constant in DrawSrg, a shader must:
+            // #define USE_DRAWSRG_MESHLOD_MESHINDEX 1
+            // By default it is NOT defined.
+            // When defined, the value of @m_modelLodMeshIndex (aka subMesh index) is written
+            // to the shader constant.
+            static constexpr AZStd::string_view DrawSrgModelLodMeshIndex = "m_modelLodMeshIndex";
+
             Ptr<RHI::DrawPacket> m_drawPacket;
 
             // Note, many of the following items are held locally in the MeshDrawPacket solely to keep them resident in memory as long as they are needed

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -14,7 +14,6 @@
 #include <Atom/RPI.Public/Model/ModelLod.h>
 #include <Atom/RHI/DrawPacket.h>
 #include <Atom/RHI/DrawPacketBuilder.h>
-#include <Atom/RHI.Reflect/ShaderInputNameIndex.h>
 
 #include <AzCore/Math/Obb.h>
 #include <AzCore/std/containers/fixed_vector.h>
@@ -95,7 +94,9 @@ namespace AZ
             // By default it is NOT defined.
             // When defined, the value of @m_modelLodMeshIndex (aka subMesh index) is written
             // to the shader constant.
-            RHI::ShaderInputNameIndex m_drawSrgModelLodMeshIndex = "m_modelLodMeshIndex";
+            // REMARK: Unfortunately can't use RHI::ShaderInputNameIndex as it would cause
+            //         a crash in the UnitTest: MeshInstanceManagerTestFixture.AddInstance
+            static constexpr char DrawSrgModelLodMeshIndex[] = "m_modelLodMeshIndex";
 
             Ptr<RHI::DrawPacket> m_drawPacket;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -519,7 +519,7 @@ namespace AZ
                 {
                     for (const AZStd::string& objectSrgAddition : *perMaterialPipelineAdditions)
                     {
-                        generatedAzsl += AZStd::string::format("%s;   \\\n", objectSrgAddition.c_str());
+                        generatedAzsl += AZStd::string::format("%s   \\\n", objectSrgAddition.c_str());
                     }
                 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -422,13 +422,14 @@ namespace AZ
                         drawSrg->SetConstant(index, uvStreamTangentBitmask.GetFullTangentBitmask());
                     }
 
-                    AZ::Name shaderModelLodMeshIndex = AZ::Name(DrawSrgModelLodMeshIndex);
-                    index = drawSrg->FindShaderInputConstantIndex(shaderModelLodMeshIndex);
-                    if (index.IsValid())
-                    {
-                        drawSrg->SetConstant(index, aznumeric_cast<uint32_t>(m_modelLodMeshIndex));
-                    }
+                    // We need to call Reset for each ShaderItem, because not all shader have
+                    // the DrawSrg::m_modelLodMeshIndex constant defined in them.
+                    m_drawSrgModelLodMeshIndex.Reset();
+                    drawSrg->SetConstant(m_drawSrgModelLodMeshIndex, aznumeric_cast<uint32_t>(m_modelLodMeshIndex));
 
+                    // TODO: Does it make sense to call Compile() in the case where both SetConstant() calls above fail?
+                    // Leaving it as always calling Compile() as precaution that there's code somewhere else that assumes
+                    // Compile() was already called on DrawSrg.
                     drawSrg->Compile();
                 };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -422,6 +422,13 @@ namespace AZ
                         drawSrg->SetConstant(index, uvStreamTangentBitmask.GetFullTangentBitmask());
                     }
 
+                    AZ::Name shaderModelLodMeshIndex = AZ::Name(DrawSrgModelLodMeshIndex);
+                    index = drawSrg->FindShaderInputConstantIndex(shaderModelLodMeshIndex);
+                    if (index.IsValid())
+                    {
+                        drawSrg->SetConstant(index, aznumeric_cast<uint32_t>(m_modelLodMeshIndex));
+                    }
+
                     drawSrg->Compile();
                 };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -422,10 +422,13 @@ namespace AZ
                         drawSrg->SetConstant(index, uvStreamTangentBitmask.GetFullTangentBitmask());
                     }
 
-                    // We need to call Reset for each ShaderItem, because not all shader have
-                    // the DrawSrg::m_modelLodMeshIndex constant defined in them.
-                    m_drawSrgModelLodMeshIndex.Reset();
-                    drawSrg->SetConstant(m_drawSrgModelLodMeshIndex, aznumeric_cast<uint32_t>(m_modelLodMeshIndex));
+                    AZ::Name drawSrgModelLodMeshIndex = AZ::Name(DrawSrgModelLodMeshIndex);
+                    index = drawSrg->FindShaderInputConstantIndex(drawSrgModelLodMeshIndex);
+
+                    if (index.IsValid())
+                    {
+                        drawSrg->SetConstant(index, aznumeric_cast<uint32_t>(m_modelLodMeshIndex));
+                    }
 
                     // TODO: Does it make sense to call Compile() in the case where both SetConstant() calls above fail?
                     // Leaving it as always calling Compile() as precaution that there's code somewhere else that assumes

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -247,10 +247,16 @@ namespace AZ
                 EditorMeshStatsForLod stats;
                 const auto& meshes = lodAsset->GetMeshes();
                 stats.m_meshCount = static_cast<AZ::u32>(meshes.size());
+                stats.m_subMeshStatsForLod.reserve(stats.m_meshCount);
                 for (const auto& mesh : meshes)
                 {
-                    stats.m_vertCount += mesh.GetVertexCount();
-                    stats.m_triCount += mesh.GetIndexCount() / 3;
+                    const auto vertexCount = mesh.GetVertexCount();
+                    const auto triCount = mesh.GetIndexCount() / 3;
+                    stats.m_subMeshStatsForLod.push_back({});
+                    stats.m_subMeshStatsForLod.back().m_vertCount = vertexCount;
+                    stats.m_subMeshStatsForLod.back().m_triCount = triCount;
+                    stats.m_vertCount += vertexCount;
+                    stats.m_triCount += triCount;
                 }
                 m_stats.m_meshStatsForLod.emplace_back(AZStd::move(stats));
             }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshStats.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshStats.cpp
@@ -17,14 +17,39 @@ namespace AZ
 {
     namespace Render
     {
+        void EditorSubMeshStatsForLod::Reflect(ReflectContext* context)
+        {
+            if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<EditorSubMeshStatsForLod>()
+                    ->Field("vertCount", &EditorSubMeshStatsForLod::m_vertCount)
+                    ->Field("triCount", &EditorSubMeshStatsForLod::m_triCount);
+
+                if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+                {
+                    editContext->Class<EditorSubMeshStatsForLod>("EditorSubMeshStatsForLod", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorSubMeshStatsForLod::m_vertCount, "Vert Count", "")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorSubMeshStatsForLod::m_triCount, "Tri Count", "")
+                        ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ;
+                }
+            }
+        }
+
         void EditorMeshStatsForLod::Reflect(ReflectContext* context)
         {
+            EditorSubMeshStatsForLod::Reflect(context);
+
             if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<EditorMeshStatsForLod>()
                     ->Field("meshCount", &EditorMeshStatsForLod::m_meshCount)
                     ->Field("vertCount", &EditorMeshStatsForLod::m_vertCount)
                     ->Field("triCount", &EditorMeshStatsForLod::m_triCount)
+                    ->Field("subMeshInfo", &EditorMeshStatsForLod::m_subMeshStatsForLod)
                 ;
 
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -37,6 +62,8 @@ namespace AZ
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMeshStatsForLod::m_vertCount, "Vert Count", "")
                             ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMeshStatsForLod::m_triCount, "Tri Count", "")
+                            ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &EditorMeshStatsForLod::m_subMeshStatsForLod, "Mesh Stats", "")
                             ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                     ;
                 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshStats.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshStats.h
@@ -17,6 +17,17 @@ namespace AZ
 {
     namespace Render
     {
+        struct EditorSubMeshStatsForLod final
+        {
+            AZ_RTTI(EditorSubMeshStatsForLod, "{1B1DD151-237A-486E-A9A1-A652FE3D4CA8}");
+            AZ_CLASS_ALLOCATOR(EditorSubMeshStatsForLod, SystemAllocator);
+
+            static void Reflect(ReflectContext* context);
+
+            AZ::u32 m_vertCount = 0;
+            AZ::u32 m_triCount = 0;
+        };
+
         struct EditorMeshStatsForLod final
         {
             AZ_RTTI(EditorMeshStatsForLod, "{626E3AEB-0F7A-4777-BAF1-2BBA8C1857ED}");
@@ -27,6 +38,7 @@ namespace AZ
             AZ::u32 m_meshCount = 0;
             AZ::u32 m_vertCount = 0;
             AZ::u32 m_triCount = 0;
+            AZStd::vector<EditorSubMeshStatsForLod> m_subMeshStatsForLod;
         };
 
         struct EditorMeshStats final


### PR DESCRIPTION
## What does this PR do?

Improved ShaderStreamBufferViewsInterface
by adding the ability to query for
the `IndexBufferView` and `StreamBufferView` which
will help the developer find the actual Offsets
and ByteCounts for each BufferView which can be use
in shader constants to find the correct data
in the ByteAddressBuffers.

Added convenient API to BufferView to get
the BindlessSrg indices for READ and RW (optional).

Added opt-in `DrawSrg::m_modelLodMeshIndex` shader
constant. To opt-in the developer must enable
the shader macro `USE_DRAWSRG_MESHLOD_MESHINDEX`
and MeshDrawPacket will set its value to the
subMesh index. By default it is disabled so it doesn't
affect material pipelines. This is useful for
Texture Space Shading techniques where it can
be important to know which subMesh index a DrawItem
is referring to.

Extended EditorMeshComponent.cpp to list
the number of Triangles and Vertices per subMesh
in the readonly Mesh statistics.

Improved MaterialTypeBuilder.cpp by removing the
";" extra character per line in "objectSrgAddtion".
This enables materialpipeline files to add
custom structs to ObjectSrg. This also implies
that it is up to the developer to manually add ";"
where needed.

Add more macro protections in *.azsl* files
to prevent usage of functions only available to
 fragment shaders like ddx_fine or clip() or discard
 with help of `#ifdef CS_SAMPLERS` which means
 the shader being compiled is a Compute shader.

## How was this PR tested?

Validated with AutomatedTesting (Windows), OpenXRTest (Windows  and Quest3), and proprietary project where We are doing Texture Space Shading techniques. 
