### PR TITLE
DPE: Don't request a size update for every Dom change

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1665,7 +1665,6 @@ namespace AzToolsFramework
             else
             {
                 updateGeometry();
-                emit RequestSizeUpdate();
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/16415

The `DocumentPropertyEditor` requested a size update for every change in the Dom, even just a changed numerical value. This led to a performance problem when moving objects around the scene as a stylesheet was repolished every frame. On my machine this took around 14ms per frame, though it was significantly slower on other machines (see the linked issue)

The size update request was introduced in https://github.com/o3de/o3de/pull/16394 to fix issue https://github.com/o3de/o3de/issues/15945
Since then the DPE has changed quite a bit, and the size update request in `HandleReset` of the DPE is probably enough. I tried to reproduce the issue with my fix and could not do so.

See also the discussion on Discord: https://discordapp.com/channels/805939474655346758/816043601754325023/1342449227573362780

## How was this PR tested?

Tested on Windows.
Tested with the same components as the videos in https://github.com/o3de/o3de/issues/15945 show. The sizing of the components is correct for me.
