### PR TITLE
[Track View] Fix Compound Tracks Keys evaluation (selection, editing, addition).

### DIFF
--- a/Code/Editor/TrackView/KeyUIControls.h
+++ b/Code/Editor/TrackView/KeyUIControls.h
@@ -648,7 +648,7 @@ class CStringKeyUIControls
 {
 public:
     CSmartVariableArray mv_table;
-    CSmartVariableEnum<QString> mv_value;
+    CSmartVariable<QString> mv_value;
 
     void OnCreateVars() override
     {
@@ -670,4 +670,203 @@ public:
         static const GUID guid = { 0xe056f001, 0xa2df, 0x4e87, { 0x8d, 0xbb, 0x98, 0x0a, 0x65, 0x19, 0x40, 0xdc } };
         return guid;
     }
+};
+
+////////////////////// Compound tracks UI handlers
+
+/**
+ * Base class template of Key UI Controls for Compound (Vector?) tracks.
+ * @param V AZ::Vector3 or AZ::Vector4.
+ */
+template <class V> class CVectorKeyUIControlsBase
+{
+    CVectorKeyUIControlsBase() {}
+public:
+    /**
+     * Template ctor: 
+     * @param T AnimValueType type, supported: Vector, RGB, Quat, Vector4.
+     */
+    explicit CVectorKeyUIControlsBase(AnimValueType valueType) : m_valueType(valueType) { }
+
+    /**
+    * Get Compound animation track for a set of selected keys.
+    * @param selectedKeys Bundle of selected keys.
+    * @return Pointer to existing Compound animation track satisfying conditions, or nullptr.
+    */
+    IAnimTrack* GetCompoundTrackFromKeys(const CTrackViewKeyBundle& selectedKeys);
+
+    AnimValueType m_valueType;
+    V m_Vector;
+};
+
+/**
+ * Get and Set values for a Vector3 compound track key via track properties dialog.
+ */
+class CVectorKeyUIControls
+    : public CTrackViewKeyUIControls
+    , public CVectorKeyUIControlsBase<AZ::Vector3>
+{
+protected:
+
+    explicit CVectorKeyUIControls(AnimValueType valueType) : CVectorKeyUIControlsBase(valueType) {}
+
+public:
+
+    CVectorKeyUIControls() : CVectorKeyUIControlsBase<AZ::Vector3>(AnimValueType::Vector) {}
+
+    CSmartVariableArray mv_table;
+    CSmartVariable<float> mv_x;
+    CSmartVariable<float> mv_y;
+    CSmartVariable<float> mv_z;
+
+    void OnCreateVars() override
+    {
+        AddVariable(mv_table, "Key Properties");
+        AddVariable(mv_table, mv_x, "X");
+        AddVariable(mv_table, mv_y, "Y");
+        AddVariable(mv_table, mv_z, "Z");
+    }
+
+    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
+    {
+        return valueType == AnimValueType::Vector;
+    }
+
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
+
+    unsigned int GetPriority() const override
+    {
+        return 1;
+    }
+
+    static const GUID& GetClassID()
+    {
+        // {1F432CD8-D6FA-4C83-B174-55AB4F3D9785}
+        static const GUID guid = { 0x1f432cd8, 0xd6fa, 0x4c83, { 0xb1, 0x74, 0x55, 0xab, 0x4f, 0x3d, 0x97, 0x85 } };
+        return guid;
+    }
+
+protected:
+    bool m_skipOnUIChange = false;
+};
+
+/**
+ * Get and Set values for a Vector3 compound track key treated as RGB via track properties dialog.
+ */
+class CRgbKeyUIControls
+    : public CVectorKeyUIControls
+{
+public:
+
+    CRgbKeyUIControls() : CVectorKeyUIControls(AnimValueType::RGB) {}
+
+    void OnCreateVars() override
+    {
+        AddVariable(mv_table, "Key Properties");
+        AddVariable(mv_table, mv_x, "Red");
+        AddVariable(mv_table, mv_y, "Green");
+        AddVariable(mv_table, mv_z, "Blue");
+    }
+
+    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
+    {
+        return valueType == AnimValueType::RGB;
+    }
+
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
+
+    static const GUID& GetClassID()
+    {
+        // {8D8EC4F6-7C3A-4DEC-863D-C67D9A0645B9}
+        static const GUID guid = { 0x8d8ec4f6, 0x7c3a, 0x4dec, { 0x86, 0x3d, 0xc6, 0x7d, 0x9a, 0x06, 0x45, 0xb9 } };
+        return guid;
+    }
+};
+
+/**
+ * Get and Set values (in degrees) for a Vector3 compound track key treated as set of Euler (actually Tait-Bryan) angles of a Quaternion
+ * via track properties dialog.
+ */
+class CQuatKeyUIControls
+    : public CVectorKeyUIControls
+{
+public:
+
+    CQuatKeyUIControls() : CVectorKeyUIControls(AnimValueType::Quat) {}
+
+    void OnCreateVars() override
+    {
+        AddVariable(mv_table, "Key Properties");
+        // Names correspond to ZXY order in [Quaternion] <-> [Tait-Bryan angles in Degrees] conversions in <Transform::Rotation> tracks.
+        AddVariable(mv_table, mv_x, "Pitch");
+        AddVariable(mv_table, mv_y, "Roll");
+        AddVariable(mv_table, mv_z, "Yaw");
+    }
+
+    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
+    {
+        return valueType == AnimValueType::Quat;
+    }
+
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
+
+    static const GUID& GetClassID()
+    {
+        // {273EBFD3-BED5-41C9-8E2C-F2C0DF53F807}
+        static const GUID guid = { 0x273ebfd3, 0xbed5, 0x41c9, { 0x8e, 0x2c, 0xf2, 0xc0, 0xdf, 0x53, 0xf8, 0x07 } };
+        return guid;
+    }
+};
+
+/**
+ * Get and Set values for a Vector4 compound track key via track properties dialog.
+ */
+class CVector4KeyUIControls
+    : public CTrackViewKeyUIControls
+    , CVectorKeyUIControlsBase<AZ::Vector4>
+{
+protected:
+    explicit CVector4KeyUIControls(AnimValueType valueType) : CVectorKeyUIControlsBase(valueType) { }
+
+public:
+    CVector4KeyUIControls() : CVectorKeyUIControlsBase<AZ::Vector4>(AnimValueType::Vector4) {}
+
+    CSmartVariableArray mv_table;
+    CSmartVariable<float> mv_x;
+    CSmartVariable<float> mv_y;
+    CSmartVariable<float> mv_z;
+    CSmartVariable<float> mv_w;
+
+    void OnCreateVars() override
+    {
+        AddVariable(mv_table, "Key Properties");
+        AddVariable(mv_table, mv_x, "X");
+        AddVariable(mv_table, mv_y, "Y");
+        AddVariable(mv_table, mv_z, "Z");
+        AddVariable(mv_table, mv_z, "W");
+    }
+
+    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
+    {
+        return valueType == AnimValueType::Vector4;
+    }
+
+    bool OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
+
+    unsigned int GetPriority() const override
+    {
+        return 1;
+    }
+
+    static const GUID& GetClassID()
+    {
+        // {C83EFDC1-927A-4112-8F66-BD53B205E589}                                                       
+        static const GUID guid = { 0xc83efdc1, 0x927a, 0x4112, { 0x8f, 0x66, 0xbd, 0x53, 0xb2, 0x05, 0xe5, 0x89 } };
+        return guid;
+    }
+
+private:
+    bool m_skipOnUIChange = false;
 };

--- a/Code/Editor/TrackView/KeyUIControls.h
+++ b/Code/Editor/TrackView/KeyUIControls.h
@@ -696,7 +696,7 @@ public:
     IAnimTrack* GetCompoundTrackFromKeys(const CTrackViewKeyBundle& selectedKeys);
 
     AnimValueType m_valueType;
-    V m_Vector;
+    V m_vector;
 };
 
 /**

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -642,6 +642,11 @@ void CTrackViewAnimNode::RemoveTrack(CTrackViewTrack* track)
     }
 }
 
+void CTrackViewAnimNode::UpdateTrackDefaultValue(float time, IAnimTrack* pTrack)
+{
+    GetAnimNode()->UpdateTrackDefaultValue(time, pTrack);
+}
+
 bool CTrackViewAnimNode::SnapTimeToPrevKey(float& time) const
 {
     const float startTime = time;

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -644,6 +644,12 @@ void CTrackViewAnimNode::RemoveTrack(CTrackViewTrack* track)
 
 void CTrackViewAnimNode::UpdateTrackDefaultValue(float time, IAnimTrack* pTrack)
 {
+    if (!pTrack)
+    {
+        AZ_Assert(pTrack, "Invalid Track");
+        return;
+    }
+
     GetAnimNode()->UpdateTrackDefaultValue(time, pTrack);
 }
 

--- a/Code/Editor/TrackView/TrackViewAnimNode.h
+++ b/Code/Editor/TrackView/TrackViewAnimNode.h
@@ -106,6 +106,9 @@ public:
     virtual CTrackViewTrack* CreateTrack(const CAnimParamType& paramType);
     virtual void RemoveTrack(CTrackViewTrack* pTrack);
 
+    // Updates track default values before adding a new key at time, so that animated entity is not affected by adding a key
+    void UpdateTrackDefaultValue(float time, IAnimTrack* pTrack);
+
     // Add selected entities from scene to group node
     virtual CTrackViewAnimNodeBundle AddSelectedEntities(const AZStd::vector<AnimParamType>& tracks);
 

--- a/Code/Editor/TrackView/TrackViewCurveEditor.cpp
+++ b/Code/Editor/TrackView/TrackViewCurveEditor.cpp
@@ -350,7 +350,7 @@ void CTrackViewCurveEditor::OnKeyAdded(CTrackViewKeyHandle& addedKeyHandle)
     };
 
     const auto numSubTracks = pTrack->GetChildCount();
-    if (!numSubTracks || pTrack->IsSubTrack()) // Simple track owning Bezier Keys
+    if (numSubTracks <= 0 || pTrack->IsSubTrack()) // Simple track owning Bezier Keys
     {
         updateKeyFlags(addedKeyHandle);
         return;

--- a/Code/Editor/TrackView/TrackViewCurveEditor.cpp
+++ b/Code/Editor/TrackView/TrackViewCurveEditor.cpp
@@ -321,11 +321,23 @@ void CTrackViewCurveEditor::OnKeysChanged([[maybe_unused]] CTrackViewSequence* p
 
 void CTrackViewCurveEditor::OnKeyAdded(CTrackViewKeyHandle& addedKeyHandle)
 {
-    EAnimCurveType trType = addedKeyHandle.GetTrack()->GetCurveType();
-    if (trType == eAnimCurveType_BezierFloat)
+    const auto pTrack = addedKeyHandle.GetTrack();
+    if (!pTrack)
     {
+        return;
+    }
+
+    EAnimCurveType trType = addedKeyHandle.GetTrack()->GetCurveType();
+    if (trType != eAnimCurveType_BezierFloat)
+    {
+        return;
+    }
+
+    auto updateKeyFlags = [](CTrackViewKeyHandle& addedKeyHandle)
+    {
+        const auto pTrack = addedKeyHandle.GetTrack();
         // we query the added key's track to find the default tangent flags to use for newly created keys
-        const int tangentFlagsForNewKeys = addedKeyHandle.GetTrack()->GetAnimNode()->GetDefaultKeyTangentFlags();
+        const int tangentFlagsForNewKeys = pTrack->GetAnimNode()->GetDefaultKeyTangentFlags();
         I2DBezierKey bezierKey;
         addedKeyHandle.GetKey(&bezierKey);
 
@@ -335,6 +347,21 @@ void CTrackViewCurveEditor::OnKeyAdded(CTrackViewKeyHandle& addedKeyHandle)
         // set tangent flags to the default tangent flags used for the track's animNode and save them
         bezierKey.flags |= tangentFlagsForNewKeys;
         addedKeyHandle.SetKey(&bezierKey);
+    };
+
+    const auto numSubTracks = pTrack->GetChildCount();
+    if (!numSubTracks || pTrack->IsSubTrack()) // Simple track owning Bezier Keys
+    {
+        updateKeyFlags(addedKeyHandle);
+        return;
+    }
+
+    // Compound track with sub-tracks owning Bezier Keys
+    for (unsigned int i = 0; i < numSubTracks; ++i)
+    {
+        const auto pSubTrack = static_cast<CTrackViewTrack*>(pTrack->GetChild(i));
+        CTrackViewKeyHandle subTrackHandle(pSubTrack, addedKeyHandle.GetIndex());
+        updateKeyFlags(subTrackHandle);
     }
 }
 

--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -31,8 +31,9 @@
 #include <AzQtComponents/Utilities/Conversions.h>
 
 // CryCommon
-#include <CryCommon/Maestro/Types/AnimValueType.h>
+#include <CryCommon/Maestro/Types/AnimNodeType.h>
 #include <CryCommon/Maestro/Types/AnimParamType.h>
+#include <CryCommon/Maestro/Types/AnimValueType.h>
 #include <CryCommon/Maestro/Types/AssetBlendKey.h>
 
 // Editor
@@ -1842,14 +1843,46 @@ void CTrackViewDopeSheetBase::LButtonDownOnTimeAdjustBar([[maybe_unused]] const 
 void CTrackViewDopeSheetBase::LButtonDownOnKey([[maybe_unused]] const QPoint& point, CTrackViewKeyHandle& keyHandle, Qt::KeyboardModifiers modifiers)
 {
     CTrackViewSequence* sequence = GetIEditor()->GetAnimation()->GetSequence();
+    const auto pTrack = keyHandle.GetTrack();
     AZ_Assert(sequence, "Expected a valid sequence.");
-
-    if (!sequence)
+    AZ_Assert(pTrack, "Expected a valid track.");
+    if (!sequence || !pTrack)
     {
         return;
     }
 
-    if (!keyHandle.IsSelected() && !(modifiers & Qt::ControlModifier))
+    auto isSelected = keyHandle.IsSelected();
+
+    if (isSelected && pTrack->IsSubTrack())
+    {
+        // Allow selecting keys in Sub-tracks when "a logical key" in a parent Compound track was selected.
+        if (const auto parentNode = pTrack->GetParentNode())
+        {
+            if (parentNode->IsSelected())
+            {
+                isSelected = false; // Allow to select a key in sub-track...
+                parentNode->SetSelected(false); // ... and deselect the parent node.
+            }
+            else
+            {
+                for (unsigned int subTrackIdx = 0; isSelected && subTrackIdx < parentNode->GetChildCount(); ++subTrackIdx)
+                {
+                    const auto pSubTrack = parentNode->GetChild(subTrackIdx);
+                    const auto selectedKeysBundle = pSubTrack->GetSelectedKeys();
+                    for (unsigned int keyIdx = 0; isSelected && keyIdx < selectedKeysBundle.GetKeyCount(); ++keyIdx)
+                    {
+                        const auto key = selectedKeysBundle.GetKey(keyIdx);
+                        if (key != keyHandle) // If there is another key selected in the parent Compound track ? ...
+                        {
+                            isSelected = false; // ... regard this key unselected, and thus allow selecting it.
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (!isSelected && !(modifiers & Qt::ControlModifier))
     {
         CTrackViewSequenceNotificationContext context(sequence);
         AzToolsFramework::ScopedUndoBatch undoBatch("Select keys");
@@ -2255,74 +2288,92 @@ void CTrackViewDopeSheetBase::AddKeys(const QPoint& point, const bool bTryAddKey
     float keyTime = TimeFromPoint(point);
     bool inRange = m_timeRange.IsInside(keyTime);
 
-    if (pTrack && inRange)
+    if (!(pNode && pTrack && inRange))
     {
-        if (bTryAddKeysInGroup && pNode->GetParentNode())       // Add keys in group
-        {
-            CTrackViewTrackBundle tracksInGroup = pNode->GetTracksByParam(pTrack->GetParameterType());
-            for (int i = 0; i < (int)tracksInGroup.GetCount(); ++i)
-            {
-                CTrackViewTrack* pCurrTrack = tracksInGroup.GetTrack(i);
+        return;
+    }
 
-                if (pCurrTrack->GetChildCount() == 0)   // A simple track
-                {
-                    if (IsOkToAddKeyHere(pCurrTrack, keyTime))
-                    {
-                        AzToolsFramework::ScopedUndoBatch undoBatch("Create Key");
-                        pCurrTrack->CreateKey(keyTime);
-                        undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
-                    }
-                }
-                else                                                                            // A compound track
-                {
-                    for (unsigned int k = 0; k < pCurrTrack->GetChildCount(); ++k)
-                    {
-                        CTrackViewTrack* pSubTrack = static_cast<CTrackViewTrack*>(pCurrTrack->GetChild(k));
-                        if (IsOkToAddKeyHere(pSubTrack, keyTime))
-                        {
-                            AzToolsFramework::ScopedUndoBatch undoBatch("Create Key");
-                            pSubTrack->CreateKey(keyTime);
-                            undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
-                        }
-                    }
-                }
-            }
-        }
-        else if (pTrack->GetChildCount() == 0)          // A simple track
+    if (bTryAddKeysInGroup && pNode->GetParentNode())       // Add keys in group
+    {
+        CTrackViewTrackBundle tracksInGroup = pNode->GetTracksByParam(pTrack->GetParameterType());
+        for (int i = 0; i < (int)tracksInGroup.GetCount(); ++i)
         {
-            if (pTrack->GetValueType() == AnimValueType::String)
+            CTrackViewTrack* pCurrTrack = tracksInGroup.GetTrack(i);
+            if (!IsOkToAddKeyHere(pCurrTrack, keyTime))
             {
-                CreateStringKey(pTrack, keyTime);
-                return;
+                continue;
             }
 
-            if (IsOkToAddKeyHere(pTrack, keyTime))
+            if (pCurrTrack->GetChildCount() == 0)   // A simple track
             {
+                if (pTrack->GetValueType() == AnimValueType::String)
+                {
+                    CreateStringKey(pTrack, keyTime);
+                    continue;
+                }
+
                 AzToolsFramework::ScopedUndoBatch undoBatch("Create Key");
+                pCurrTrack->CreateKey(keyTime);
+                undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+            }
+            else                                    // A compound track
+            {
+                if (pTrack->GetValueType() == AnimValueType::RGB)
+                {
+                    CreateColorKey(pTrack, keyTime);
+                    continue;
+                }
+
+                // Update track default values before adding a new key at time, so that animated entity properties are not affected by adding a key
+                {
+                    AzToolsFramework::ScopedUndoBatch undoBatchUpdate("Update Track Defaults");
+                    pNode->UpdateTrackDefaultValue(keyTime, pTrack->GetAnimTrack());
+                    undoBatchUpdate.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+                }
+
+                AzToolsFramework::ScopedUndoBatch undoBatchCreate("Create Key");
                 pTrack->CreateKey(keyTime);
-                undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+                undoBatchCreate.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
             }
         }
-        else                                                                                // A compound track
+        return;
+    }
+
+    if (!IsOkToAddKeyHere(pTrack, keyTime))
+    {
+        return;
+    }
+
+    if (pTrack->GetChildCount() == 0)   // A simple track
+    {
+        if (pTrack->GetValueType() == AnimValueType::String)
         {
-            if (pTrack->GetValueType() == AnimValueType::RGB)
-            {
-                CreateColorKey(pTrack, keyTime);
-            }
-            else
-            {
-                AzToolsFramework::ScopedUndoBatch undoBatch("Create Key");
-                for (unsigned int i = 0; i < pTrack->GetChildCount(); ++i)
-                {
-                    CTrackViewTrack* pSubTrack = static_cast<CTrackViewTrack*>(pTrack->GetChild(i));
-                    if (IsOkToAddKeyHere(pSubTrack, keyTime))
-                    {
-                        pSubTrack->CreateKey(keyTime);
-                    }
-                }
-                undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
-            }
+            CreateStringKey(pTrack, keyTime);
+            return;
         }
+
+        AzToolsFramework::ScopedUndoBatch undoBatch("Create Key");
+        pTrack->CreateKey(keyTime);
+        undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+    }
+    else                                // A compound track
+    {
+        if (pTrack->GetValueType() == AnimValueType::RGB)
+        {
+            CreateColorKey(pTrack, keyTime);
+            return;
+        }
+
+        // Update track default values before adding a new key at time, so that animated entity properties are not affected by adding a key
+        {
+            AzToolsFramework::ScopedUndoBatch undoBatchUpdate("Update Track Defaults");
+            pNode->UpdateTrackDefaultValue(keyTime, pTrack->GetAnimTrack());
+            undoBatchUpdate.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+        }
+
+        AzToolsFramework::ScopedUndoBatch undoBatchCreate("Create Key");
+        pTrack->CreateKey(keyTime);
+        undoBatchCreate.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
     }
 }
 
@@ -2455,7 +2506,7 @@ void CTrackViewDopeSheetBase::DrawTrack(CTrackViewTrack* pTrack, QPainter* paint
     bool bLightAnimationSetActive = pSequence->GetFlags() & IAnimSequence::eSeqFlags_LightAnimationSet;
     if (bLightAnimationSetActive && pTrack->GetKeyCount() > 0)
     {
-        // In the case of the light animation set, the time of of the last key
+        // In the case of the light animation set, the time of the last key
         // determines the end of the track.
         float lastKeyTime = pTrack->GetKey(pTrack->GetKeyCount() - 1).GetTime();
         rcInner.setRight(min(rcInner.right(), TimeToClient(lastKeyTime)));
@@ -2846,11 +2897,32 @@ void CTrackViewDopeSheetBase::DrawKeys(CTrackViewTrack* pTrack, QPainter* painte
             continue;
         }
 
-        if (pTrack->GetChildCount() == 0 // At compound tracks, keys are all green.
-            && abs(x - prevKeyPixel) < 2)
+        if (pTrack->GetChildCount() == 0 && abs(x - prevKeyPixel) < 2)
         {
-            // If multiple keys on the same time.
+            // If multiple keys on the same time at a simple track, keys are red
             painter->drawPixmap(QPoint(x - 6, rect.top() + 2), QPixmap(":/Trackview/trackview_keys_02.png")); // red
+        }
+        else if (pTrack->IsCompoundTrack()) // A key at a compound track is regarded as selected if all keys at the same time are selected
+        {
+            bool areAllSubKeysSelected = true;
+            for (int n = 0; n < numKeys; ++n)
+            {
+                CTrackViewKeyHandle aKeyHandle = sortedKeys[n];
+                const auto aKeyTime = aKeyHandle.GetTime();
+                if ((AZStd::abs(aKeyTime - time) < AZ::Constants::Tolerance) && !aKeyHandle.IsSelected())
+                {
+                    areAllSubKeysSelected = false;
+                    break;
+                }
+            }
+            if (areAllSubKeysSelected)
+            {
+                painter->drawPixmap(QPoint(x - 6, rect.top() + 2), QPixmap(":/Trackview/trackview_keys_01.png")); // white
+            }
+            else
+            {
+                painter->drawPixmap(QPoint(x - 6, rect.top() + 2), QPixmap(":/Trackview/trackview_keys_00.png")); // green
+            }
         }
         else
         {

--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -1851,7 +1851,7 @@ void CTrackViewDopeSheetBase::LButtonDownOnKey([[maybe_unused]] const QPoint& po
         return;
     }
 
-    auto isSelected = keyHandle.IsSelected();
+    bool isSelected = keyHandle.IsSelected();
 
     if (isSelected && pTrack->IsSubTrack())
     {
@@ -2285,10 +2285,10 @@ void CTrackViewDopeSheetBase::AddKeys(const QPoint& point, const bool bTryAddKey
     CTrackViewSequenceNotificationContext context(sequence);
 
     CTrackViewAnimNode* pNode = pTrack->GetAnimNode();
-    float keyTime = TimeFromPoint(point);
-    bool inRange = m_timeRange.IsInside(keyTime);
+    const float keyTime = TimeFromPoint(point);
+    const bool inRange = m_timeRange.IsInside(keyTime);
 
-    if (!(pNode && pTrack && inRange))
+    if (!(pNode && inRange))
     {
         return;
     }

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
@@ -146,7 +146,8 @@ void CTrackViewKeyPropertiesDlg::OnKeysChanged(CTrackViewSequence* pSequence)
             return;
         }
 
-        if ((numSelectedKeys > 1) && pTrack->IsSubTrack()) // A Compound track selected with keys selected in sub-tracks?
+        const bool areSubTrackKeysSelected = (numSelectedKeys > 1) && pTrack->IsSubTrack();
+        if (areSubTrackKeysSelected)
         {
             if (const auto pParentNode = pTrack->GetParentNode())
             {
@@ -336,7 +337,7 @@ bool CTrackViewTrackPropsDlg::OnKeySelectionChange(const CTrackViewKeyBundle& se
     m_keyHandle = CTrackViewKeyHandle();
 
     const auto keysCount = selectedKeys.GetKeyCount();
-    if ((keysCount == 1) || ((keysCount > 1) && selectedKeys.AreAllKeysOfSameType()))
+    if (keysCount == 1 || ((keysCount > 1) && selectedKeys.AreAllKeysOfSameType()))
     {
         m_keyHandle = selectedKeys.GetKey(0);
     }

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
@@ -61,6 +61,12 @@ CTrackViewKeyPropertiesDlg::CTrackViewKeyPropertiesDlg(QWidget* hParentWnd)
     m_pVarBlock = new CVarBlock;
 
     // Add key UI classes
+    // Compound tracks
+    m_keyControls.push_back(new CQuatKeyUIControls());
+    m_keyControls.push_back(new CRgbKeyUIControls());
+    m_keyControls.push_back(new CVectorKeyUIControls());
+    m_keyControls.push_back(new CVector4KeyUIControls());
+    // Simple tracks
     m_keyControls.push_back(new C2DBezierKeyUIControls());
     m_keyControls.push_back(new CAssetBlendKeyUIControls());
     m_keyControls.push_back(new CCaptureKeyUIControls());
@@ -131,9 +137,25 @@ void CTrackViewKeyPropertiesDlg::OnKeysChanged(CTrackViewSequence* pSequence)
 {
     const CTrackViewKeyBundle& selectedKeys = pSequence->GetSelectedKeys();
 
-    if (selectedKeys.GetKeyCount() > 0 && selectedKeys.AreAllKeysOfSameType())
+    const auto numSelectedKeys = selectedKeys.GetKeyCount();
+    if (numSelectedKeys > 0 && selectedKeys.AreAllKeysOfSameType())
     {
-        const CTrackViewTrack* pTrack = selectedKeys.GetKey(0).GetTrack();
+        auto pTrack = selectedKeys.GetKey(0).GetTrack();
+        if (!pTrack)
+        {
+            return;
+        }
+
+        if ((numSelectedKeys > 1) && pTrack->IsSubTrack()) // A Compound track selected with keys selected in sub-tracks?
+        {
+            if (const auto pParentNode = pTrack->GetParentNode())
+            {
+                if (pParentNode->GetNodeType() == ETrackViewNodeType::eTVNT_Track)
+                {
+                    pTrack = static_cast<CTrackViewTrack*>(pParentNode);
+                }
+            }
+        }
 
         const CAnimParamType paramType = pTrack->GetParameterType();
         const EAnimCurveType trackType = pTrack->GetCurveType();
@@ -152,39 +174,60 @@ void CTrackViewKeyPropertiesDlg::OnKeysChanged(CTrackViewSequence* pSequence)
 
 void CTrackViewKeyPropertiesDlg::OnKeySelectionChanged(CTrackViewSequence* sequence)
 {
-    m_sequence = sequence;
-
-    if (nullptr == sequence)
+    auto cleanup = [this]()
     {
         m_wndProps->ClearSelection();
         m_pVarBlock->DeleteAllVariables();
         m_wndProps->setEnabled(false);
         m_wndTrackProps->setEnabled(false);
+        m_pLastTrackSelected = nullptr;
+    };
+
+    m_sequence = sequence;
+    if (!sequence)
+    {
+        cleanup();
         return;
     }
 
     const CTrackViewKeyBundle& selectedKeys = sequence->GetSelectedKeys();
+    const auto numSelectedKeys = selectedKeys.GetKeyCount();
+    if (numSelectedKeys < 1 || !selectedKeys.AreAllKeysOfSameType())
+    {
+        cleanup();
+        return;
+    }
 
     m_wndTrackProps->OnKeySelectionChange(selectedKeys);
 
-    const bool bSelectChangedInSameTrack
-        = m_pLastTrackSelected
-            && selectedKeys.GetKeyCount() == 1
-            && selectedKeys.GetKey(0).GetTrack() == m_pLastTrackSelected;
+    const auto pFirstTrack = selectedKeys.GetKey(0).GetTrack();
+    if (!pFirstTrack)
+    {
+        cleanup();
+        return;
+    }
+
+    auto pTrack = pFirstTrack;
+    // Check if a Compound track is selected with keys selected in sub-tracks?
+    if ((numSelectedKeys > 1) && pFirstTrack->IsSubTrack())
+    {
+        if (const auto pParentNode = pFirstTrack->GetParentNode())
+        {
+            if (pParentNode->GetNodeType() == ETrackViewNodeType::eTVNT_Track)
+            {
+                pTrack = static_cast<CTrackViewTrack*>(pParentNode);
+            }
+        }
+    }
+
+    const bool bSelectChangedInSameTrack = m_pLastTrackSelected && pTrack == m_pLastTrackSelected;
 
     // Every Key in an Asset Blend track can have different min/max values on the float sliders
     // because it's based on the duration of the motion that is set. So don't try to
     // reuse the controls when the selection changes, otherwise the tooltips may be wrong.
     const bool reuseControls = bSelectChangedInSameTrack && m_pLastTrackSelected && (m_pLastTrackSelected->GetValueType() != AnimValueType::AssetBlend);
 
-    if (selectedKeys.GetKeyCount() == 1)
-    {
-        m_pLastTrackSelected = selectedKeys.GetKey(0).GetTrack();
-    }
-    else
-    {
-        m_pLastTrackSelected = nullptr;
-    }
+    m_pLastTrackSelected = pTrack;
 
     if (reuseControls)
     {
@@ -201,11 +244,9 @@ void CTrackViewKeyPropertiesDlg::OnKeySelectionChanged(CTrackViewSequence* seque
     {
         if (!reuseControls)
         {
-            const CTrackViewTrack* pTrack = selectedKeys.GetKey(0).GetTrack();
-
             const CAnimParamType paramType = pTrack->GetParameterType();
             const EAnimCurveType trackType = pTrack->GetCurveType();
-            const AnimValueType valueType = pTrack->GetValueType();
+            const AnimValueType  valueType = pTrack->GetValueType();
 
             for (const auto& keyControl : m_keyControls)
             {
@@ -294,7 +335,8 @@ bool CTrackViewTrackPropsDlg::OnKeySelectionChange(const CTrackViewKeyBundle& se
 {
     m_keyHandle = CTrackViewKeyHandle();
 
-    if (selectedKeys.GetKeyCount() == 1)
+    const auto keysCount = selectedKeys.GetKeyCount();
+    if ((keysCount == 1) || ((keysCount > 1) && selectedKeys.AreAllKeysOfSameType()))
     {
         m_keyHandle = selectedKeys.GetKey(0);
     }

--- a/Code/Editor/TrackView/TrackViewTrack.cpp
+++ b/Code/Editor/TrackView/TrackViewTrack.cpp
@@ -269,7 +269,7 @@ CTrackViewKeyHandle CTrackViewTrack::CreateKey(const float time)
     CTrackViewKeyHandle keyHandle;
 
     const auto sequence = GetSequence();
-    if (!(m_pAnimTrack && sequence))
+    if (!m_pAnimTrack || !sequence)
     {
         AZ_Assert(m_pAnimTrack, "CreateKey(%f): no animation track");
         AZ_Assert(sequence, "CreateKey(%f): no sequence", time);

--- a/Code/Editor/TrackView/VectorKeyUIControls.cpp
+++ b/Code/Editor/TrackView/VectorKeyUIControls.cpp
@@ -15,7 +15,7 @@
 
 ///////////////////////////////////////////////////////
 template<class V>
-IAnimTrack* CVectorKeyUIControlsBase<typename V>::GetCompoundTrackFromKeys(const CTrackViewKeyBundle& selectedKeys)
+IAnimTrack* CVectorKeyUIControlsBase<V>::GetCompoundTrackFromKeys(const CTrackViewKeyBundle& selectedKeys)
 {
     if ((selectedKeys.GetKeyCount() < 1) || !selectedKeys.AreAllKeysOfSameType())
     {

--- a/Code/Editor/TrackView/VectorKeyUIControls.cpp
+++ b/Code/Editor/TrackView/VectorKeyUIControls.cpp
@@ -62,8 +62,8 @@ bool CVectorKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selec
     }
 
     const auto keyTime = selectedKeys.GetKey(0).GetTime();
-    m_Vector = AZ::Vector3::CreateZero();
-    pAnimTrack->GetValue(keyTime, m_Vector, false);
+    m_vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_vector, false);
 
     float fMin = -1.0f;
     float fMax = 1.0f;
@@ -72,17 +72,17 @@ bool CVectorKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selec
     // updating the start/end ui elements, not the user setting new values.
     m_skipOnUIChange = true;
 
-    mv_x = m_Vector.GetX();
+    mv_x = m_vector.GetX();
     pAnimTrack->GetSubTrack(0)->GetKeyValueRange(fMin, fMax);
     float step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_x->SetLimits(fMin, fMax, step, false, false);
 
-    mv_y = m_Vector.GetY();
+    mv_y = m_vector.GetY();
     pAnimTrack->GetSubTrack(1)->GetKeyValueRange(fMin, fMax);
     step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_y->SetLimits(fMin, fMax, step, false, false);
 
-    mv_z = m_Vector.GetZ();
+    mv_z = m_vector.GetZ();
     pAnimTrack->GetSubTrack(2)->GetKeyValueRange(fMin, fMax);
     step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_z->SetLimits(fMin, fMax, step, false, false);
@@ -93,8 +93,8 @@ bool CVectorKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selec
 
 void CVectorKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys)
 {
-    CTrackViewSequence* sequence = GetIEditor()->GetAnimation()->GetSequence();
-    if (m_skipOnUIChange || !sequence || !selectedKeys.AreAllKeysOfSameType())
+    auto pSequence = GetIEditor()->GetAnimation()->GetSequence();
+    if (m_skipOnUIChange || !pSequence || !selectedKeys.AreAllKeysOfSameType())
     {
         return;
     }
@@ -106,10 +106,10 @@ void CVectorKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sele
     }
 
     const auto keyTime = selectedKeys.GetKey(0).GetTime();
-    m_Vector = AZ::Vector3::CreateZero();
-    pAnimTrack->GetValue(keyTime, m_Vector, false);
+    m_vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_vector, false);
 
-    AZ::Vector3 newVector(m_Vector);
+    AZ::Vector3 newVector(m_vector);
     if (pVar == mv_x.GetVar())
     {
         newVector.SetX(mv_x);
@@ -123,7 +123,7 @@ void CVectorKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sele
         newVector.SetZ(mv_z);
     }
 
-    if (newVector.IsClose(m_Vector, AZ::Constants::Tolerance))
+    if (newVector.IsClose(m_vector, AZ::Constants::Tolerance))
     {
         return;
     }
@@ -139,7 +139,7 @@ void CVectorKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sele
     {
         AzToolsFramework::ScopedUndoBatch undoBatch("Set Key Value");
         pAnimTrack->SetValue(keyTime, newVector, false);
-        undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+        undoBatch.MarkEntityDirty(pSequence->GetSequenceComponentEntityId());
     }
 }
 
@@ -153,8 +153,8 @@ bool CRgbKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selected
     }
 
     const auto keyTime = selectedKeys.GetKey(0).GetTime();
-    m_Vector = AZ::Vector3::CreateZero();
-    pAnimTrack->GetValue(keyTime, m_Vector, false);
+    m_vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_vector, false);
 
     float fMin = -1.0f;
     float fMax = 1.0f;
@@ -165,13 +165,13 @@ bool CRgbKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selected
     // updating the start/end ui elements, not the user setting new values.
     m_skipOnUIChange = true;
 
-    mv_x = m_Vector.GetX();
+    mv_x = m_vector.GetX();
     mv_x.GetVar()->SetLimits(fMin, fMax, step, true, true);
 
-    mv_y = m_Vector.GetY();
+    mv_y = m_vector.GetY();
     mv_y.GetVar()->SetLimits(fMin, fMax, step, true, true);
 
-    mv_z = m_Vector.GetZ();
+    mv_z = m_vector.GetZ();
     mv_z.GetVar()->SetLimits(fMin, fMax, step, true, true);
 
     m_skipOnUIChange = false;
@@ -189,8 +189,8 @@ bool CQuatKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selecte
     }
 
     const auto keyTime = selectedKeys.GetKey(0).GetTime();
-    m_Vector = AZ::Vector3::CreateZero();
-    pAnimTrack->GetValue(keyTime, m_Vector, false);
+    m_vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_vector, false);
 
     float fMin = -1.0f;
     float fMax = 1.0f;
@@ -199,17 +199,17 @@ bool CQuatKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selecte
     // updating the start/end ui elements, not the user setting new values.
     m_skipOnUIChange = true;
 
-    mv_x = m_Vector.GetX();
+    mv_x = m_vector.GetX();
     pAnimTrack->GetSubTrack(0)->GetKeyValueRange(fMin, fMax);
     float step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_x->SetLimits(fMin, fMax, step, true, true);
 
-    mv_y = m_Vector.GetY();
+    mv_y = m_vector.GetY();
     pAnimTrack->GetSubTrack(1)->GetKeyValueRange(fMin, fMax);
     step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_y->SetLimits(fMin, fMax, step, true, true);
 
-    mv_z = m_Vector.GetZ();
+    mv_z = m_vector.GetZ();
     pAnimTrack->GetSubTrack(2)->GetKeyValueRange(fMin, fMax);
     step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_y->SetLimits(fMin, fMax, step, true, true);
@@ -230,8 +230,8 @@ bool CVector4KeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& sele
     }
 
     const auto keyTime = selectedKeys.GetKey(0).GetTime();
-    m_Vector = AZ::Vector4::CreateZero();
-    pAnimTrack->GetValue(keyTime, m_Vector, false);
+    m_vector = AZ::Vector4::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_vector, false);
 
     float fMin = -1.0f;
     float fMax = 1.0f;
@@ -240,22 +240,22 @@ bool CVector4KeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& sele
     // updating the start/end ui elements, not the user setting new values.
     m_skipOnUIChange = true;
 
-    mv_x = m_Vector.GetX();
+    mv_x = m_vector.GetX();
     pAnimTrack->GetSubTrack(0)->GetKeyValueRange(fMin, fMax);
     float step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_x->SetLimits(fMin, fMax, step, false, false);
 
-    mv_y = m_Vector.GetY();
+    mv_y = m_vector.GetY();
     pAnimTrack->GetSubTrack(1)->GetKeyValueRange(fMin, fMax);
     step = AZStd::max((fMax - fMin) / 100.f, 0.01f);
     mv_y->SetLimits(fMin, fMax, step, false, false);
 
-    mv_z = m_Vector.GetZ();
+    mv_z = m_vector.GetZ();
     pAnimTrack->GetSubTrack(2)->GetKeyValueRange(fMin, fMax);
     step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_z->SetLimits(fMin, fMax, step, false, false);
 
-    mv_w = m_Vector.GetW();
+    mv_w = m_vector.GetW();
     pAnimTrack->GetSubTrack(3)->GetKeyValueRange(fMin, fMax);
     step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
     mv_w->SetLimits(fMin, fMax, step, false, false);
@@ -267,8 +267,8 @@ bool CVector4KeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& sele
 
 void CVector4KeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys)
 {
-    CTrackViewSequence* sequence = GetIEditor()->GetAnimation()->GetSequence();
-    if (m_skipOnUIChange || !sequence || !selectedKeys.AreAllKeysOfSameType())
+    auto pSequence = GetIEditor()->GetAnimation()->GetSequence();
+    if (m_skipOnUIChange || !pSequence || !selectedKeys.AreAllKeysOfSameType())
     {
         return;
     }
@@ -280,10 +280,10 @@ void CVector4KeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sel
     }
 
     const auto keyTime = selectedKeys.GetKey(0).GetTime();
-    m_Vector = AZ::Vector4::CreateZero();
-    pAnimTrack->GetValue(keyTime, m_Vector, false);
+    m_vector = AZ::Vector4::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_vector, false);
 
-    AZ::Vector4 newVector(m_Vector);
+    AZ::Vector4 newVector(m_vector);
     if (pVar == mv_x.GetVar())
     {
         newVector.SetX(mv_x);
@@ -300,7 +300,7 @@ void CVector4KeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sel
     {
         newVector.SetW(mv_w);
     }
-    if (newVector.IsClose(m_Vector, AZ::Constants::Tolerance))
+    if (newVector.IsClose(m_vector, AZ::Constants::Tolerance))
     {
         return;
     }
@@ -317,6 +317,6 @@ void CVector4KeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& sel
     {
         AzToolsFramework::ScopedUndoBatch undoBatch("Set Key Value");
         pAnimTrack->SetValue(keyTime, newVector, false);
-        undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+        undoBatch.MarkEntityDirty(pSequence->GetSequenceComponentEntityId());
     }
 }

--- a/Code/Editor/TrackView/VectorKeyUIControls.cpp
+++ b/Code/Editor/TrackView/VectorKeyUIControls.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "EditorDefs.h"
+
+#include "KeyUIControls.h"
+
+#include "Controls/ReflectedPropertyControl/ReflectedPropertyItem.h"
+#include "TrackViewKeyPropertiesDlg.h"
+
+///////////////////////////////////////////////////////
+template<class V>
+IAnimTrack* CVectorKeyUIControlsBase<typename V>::GetCompoundTrackFromKeys(const CTrackViewKeyBundle& selectedKeys)
+{
+    if ((selectedKeys.GetKeyCount() < 1) || !selectedKeys.AreAllKeysOfSameType())
+    {
+        return nullptr;
+    }
+
+    const CTrackViewKeyHandle& keyHandle = selectedKeys.GetKey(0);
+    auto pTrack = keyHandle.GetTrack();
+    if (!pTrack)
+    {
+        return nullptr;
+    }
+
+    if (!pTrack->IsCompoundTrack())
+    {
+        if (!pTrack->IsSubTrack())
+        {
+            return nullptr; // Simple track
+        }
+        if (const auto pParentNode = pTrack->GetParentNode())
+        {
+            if (pParentNode->GetNodeType() == ETrackViewNodeType::eTVNT_Track)
+            {
+                pTrack = static_cast<CTrackViewTrack*>(pParentNode);
+            }
+        }
+    }
+
+    if ((pTrack->GetValueType() != m_valueType) || !pTrack->GetAnimTrack())
+    {
+        return nullptr;
+    }
+
+    return pTrack->GetAnimTrack();
+}
+
+////////////////////////////////////////////////////////////////
+bool CVectorKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
+{
+    auto pAnimTrack = GetCompoundTrackFromKeys(selectedKeys);
+    if (!pAnimTrack)
+    {
+        return false;
+    }
+
+    const auto keyTime = selectedKeys.GetKey(0).GetTime();
+    m_Vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_Vector, false);
+
+    float fMin = -1.0f;
+    float fMax = 1.0f;
+
+    // Don't trigger an OnUIChange event, since this code is the one
+    // updating the start/end ui elements, not the user setting new values.
+    m_skipOnUIChange = true;
+
+    mv_x = m_Vector.GetX();
+    pAnimTrack->GetSubTrack(0)->GetKeyValueRange(fMin, fMax);
+    float step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_x->SetLimits(fMin, fMax, step, false, false);
+
+    mv_y = m_Vector.GetY();
+    pAnimTrack->GetSubTrack(1)->GetKeyValueRange(fMin, fMax);
+    step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_y->SetLimits(fMin, fMax, step, false, false);
+
+    mv_z = m_Vector.GetZ();
+    pAnimTrack->GetSubTrack(2)->GetKeyValueRange(fMin, fMax);
+    step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_z->SetLimits(fMin, fMax, step, false, false);
+
+    m_skipOnUIChange = false;
+    return true;
+}
+
+void CVectorKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys)
+{
+    CTrackViewSequence* sequence = GetIEditor()->GetAnimation()->GetSequence();
+    if (m_skipOnUIChange || !sequence || !selectedKeys.AreAllKeysOfSameType())
+    {
+        return;
+    }
+
+    auto pAnimTrack = GetCompoundTrackFromKeys(selectedKeys);
+    if (!pAnimTrack)
+    {
+        return;
+    }
+
+    const auto keyTime = selectedKeys.GetKey(0).GetTime();
+    m_Vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_Vector, false);
+
+    AZ::Vector3 newVector(m_Vector);
+    if (pVar == mv_x.GetVar())
+    {
+        newVector.SetX(mv_x);
+    }
+    else if (pVar == mv_y.GetVar())
+    {
+        newVector.SetY(mv_y);
+    }
+    else if (pVar == mv_z.GetVar())
+    {
+        newVector.SetZ(mv_z);
+    }
+
+    if (newVector.IsClose(m_Vector, AZ::Constants::Tolerance))
+    {
+        return;
+    }
+
+    bool isDuringUndo = false;
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(isDuringUndo, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsDuringUndoRedo);
+
+    if (isDuringUndo)
+    {
+        pAnimTrack->SetValue(keyTime, newVector, false);
+    }
+    else
+    {
+        AzToolsFramework::ScopedUndoBatch undoBatch("Set Key Value");
+        pAnimTrack->SetValue(keyTime, newVector, false);
+        undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+    }
+}
+
+///////////////////////////////////////////////////
+bool CRgbKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
+{
+    auto pAnimTrack = GetCompoundTrackFromKeys(selectedKeys);
+    if (!pAnimTrack)
+    {
+        return false;
+    }
+
+    const auto keyTime = selectedKeys.GetKey(0).GetTime();
+    m_Vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_Vector, false);
+
+    float fMin = -1.0f;
+    float fMax = 1.0f;
+    pAnimTrack->GetKeyValueRange(fMin, fMax);
+    float step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+
+    // Don't trigger an OnUIChange event, since this code is the one
+    // updating the start/end ui elements, not the user setting new values.
+    m_skipOnUIChange = true;
+
+    mv_x = m_Vector.GetX();
+    mv_x.GetVar()->SetLimits(fMin, fMax, step, true, true);
+
+    mv_y = m_Vector.GetY();
+    mv_y.GetVar()->SetLimits(fMin, fMax, step, true, true);
+
+    mv_z = m_Vector.GetZ();
+    mv_z.GetVar()->SetLimits(fMin, fMax, step, true, true);
+
+    m_skipOnUIChange = false;
+
+    return true;
+}
+
+///////////////////////////////////////////////////
+bool CQuatKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
+{
+    auto pAnimTrack = GetCompoundTrackFromKeys(selectedKeys);
+    if (!pAnimTrack)
+    {
+        return false;
+    }
+
+    const auto keyTime = selectedKeys.GetKey(0).GetTime();
+    m_Vector = AZ::Vector3::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_Vector, false);
+
+    float fMin = -1.0f;
+    float fMax = 1.0f;
+
+    // Don't trigger an OnUIChange event, since this code is the one
+    // updating the start/end ui elements, not the user setting new values.
+    m_skipOnUIChange = true;
+
+    mv_x = m_Vector.GetX();
+    pAnimTrack->GetSubTrack(0)->GetKeyValueRange(fMin, fMax);
+    float step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_x->SetLimits(fMin, fMax, step, true, true);
+
+    mv_y = m_Vector.GetY();
+    pAnimTrack->GetSubTrack(1)->GetKeyValueRange(fMin, fMax);
+    step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_y->SetLimits(fMin, fMax, step, true, true);
+
+    mv_z = m_Vector.GetZ();
+    pAnimTrack->GetSubTrack(2)->GetKeyValueRange(fMin, fMax);
+    step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_y->SetLimits(fMin, fMax, step, true, true);
+
+    m_skipOnUIChange = false;
+
+    return true;
+}
+
+
+///////////////////////////////////////////////////
+bool CVector4KeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
+{
+    auto pAnimTrack = GetCompoundTrackFromKeys(selectedKeys);
+    if (!pAnimTrack)
+    {
+        return false;
+    }
+
+    const auto keyTime = selectedKeys.GetKey(0).GetTime();
+    m_Vector = AZ::Vector4::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_Vector, false);
+
+    float fMin = -1.0f;
+    float fMax = 1.0f;
+
+    // Don't trigger an OnUIChange event, since this code is the one
+    // updating the start/end ui elements, not the user setting new values.
+    m_skipOnUIChange = true;
+
+    mv_x = m_Vector.GetX();
+    pAnimTrack->GetSubTrack(0)->GetKeyValueRange(fMin, fMax);
+    float step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_x->SetLimits(fMin, fMax, step, false, false);
+
+    mv_y = m_Vector.GetY();
+    pAnimTrack->GetSubTrack(1)->GetKeyValueRange(fMin, fMax);
+    step = AZStd::max((fMax - fMin) / 100.f, 0.01f);
+    mv_y->SetLimits(fMin, fMax, step, false, false);
+
+    mv_z = m_Vector.GetZ();
+    pAnimTrack->GetSubTrack(2)->GetKeyValueRange(fMin, fMax);
+    step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_z->SetLimits(fMin, fMax, step, false, false);
+
+    mv_w = m_Vector.GetW();
+    pAnimTrack->GetSubTrack(3)->GetKeyValueRange(fMin, fMax);
+    step = ReflectedPropertyItem::ComputeSliderStep(fMin, fMax);
+    mv_w->SetLimits(fMin, fMax, step, false, false);
+
+    m_skipOnUIChange = false;
+
+    return true;
+}
+
+void CVector4KeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys)
+{
+    CTrackViewSequence* sequence = GetIEditor()->GetAnimation()->GetSequence();
+    if (m_skipOnUIChange || !sequence || !selectedKeys.AreAllKeysOfSameType())
+    {
+        return;
+    }
+
+    auto pAnimTrack = GetCompoundTrackFromKeys(selectedKeys);
+    if (!pAnimTrack)
+    {
+        return;
+    }
+
+    const auto keyTime = selectedKeys.GetKey(0).GetTime();
+    m_Vector = AZ::Vector4::CreateZero();
+    pAnimTrack->GetValue(keyTime, m_Vector, false);
+
+    AZ::Vector4 newVector(m_Vector);
+    if (pVar == mv_x.GetVar())
+    {
+        newVector.SetX(mv_x);
+    }
+    else if (pVar == mv_y.GetVar())
+    {
+        newVector.SetY(mv_y);
+    }
+    else if (pVar == mv_z.GetVar())
+    {
+        newVector.SetZ(mv_z);
+    }
+    else if (pVar == mv_w.GetVar())
+    {
+        newVector.SetW(mv_w);
+    }
+    if (newVector.IsClose(m_Vector, AZ::Constants::Tolerance))
+    {
+        return;
+    }
+
+    bool isDuringUndo = false;
+    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+        isDuringUndo, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsDuringUndoRedo);
+
+    if (isDuringUndo)
+    {
+        pAnimTrack->SetValue(keyTime, newVector, false);
+    }
+    else
+    {
+        AzToolsFramework::ScopedUndoBatch undoBatch("Set Key Value");
+        pAnimTrack->SetValue(keyTime, newVector, false);
+        undoBatch.MarkEntityDirty(sequence->GetSequenceComponentEntityId());
+    }
+}

--- a/Code/Editor/editor_lib_files.cmake
+++ b/Code/Editor/editor_lib_files.cmake
@@ -523,6 +523,7 @@ set(FILES
     TrackView/TrackViewEventNode.h
     TrackView/TrackViewMessageBox.cpp
     TrackView/TrackViewMessageBox.h
+    TrackView/VectorKeyUIControls.cpp
     Util/AffineParts.h
     Util/AutoLogTime.cpp
     Util/AutoLogTime.h

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -636,6 +636,9 @@ public:
     // Initializes track default values after de-serialization / user creation. Only called in editor.
     virtual void InitializeTrackDefaultValue(IAnimTrack* pTrack, const CAnimParamType& paramType, AnimValueType remapValueType = AnimValueType::Unknown) = 0;
 
+    // Updates track default values before adding a new key at time, so that animated entity is not affected by adding a key
+    virtual void UpdateTrackDefaultValue(float time, IAnimTrack* pTrack) = 0;
+
     // Assign animation track to parameter.
     // if track parameter is NULL track with parameter id param will be removed.
     virtual void SetTrack(const CAnimParamType& paramType, IAnimTrack* track) = 0;

--- a/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.h
@@ -90,6 +90,8 @@ namespace Maestro
         IAnimTrack* CreateTrack(const CAnimParamType& paramType, AnimValueType remapValueType = AnimValueType::Unknown) override;
         bool RemoveTrack(IAnimTrack* pTrack) override;
 
+        void UpdateTrackDefaultValue(float time, IAnimTrack* pTrack) override;
+
         //////////////////////////////////////////////////////////////////////////
         // EditorSequenceAgentComponentNotificationBus::Handler Interface
         void OnSequenceAgentConnected() override;

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
@@ -975,9 +975,6 @@ namespace Maestro
             subTrackParamTypes[1] = AnimParamType::ColorG;
             subTrackParamTypes[2] = AnimParamType::ColorB;
             IAnimTrack* pTrack = aznew CCompoundSplineTrack(3, AnimValueType::RGB, subTrackParamTypes, false);
-            pTrack->SetSubTrackName(0, "Red");
-            pTrack->SetSubTrackName(1, "Green");
-            pTrack->SetSubTrackName(2, "Blue");
             return pTrack;
         }
 

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
@@ -222,6 +222,8 @@ namespace Maestro
             [[maybe_unused]] AnimValueType remapValueType = AnimValueType::Unknown) override
         {
         }
+        void UpdateTrackDefaultValue([[maybe_unused]] float time, [[maybe_unused]] IAnimTrack* pTrack) override {};
+
         void SetTimeRange(Range timeRange) override;
         void AddTrack(IAnimTrack* pTrack) override;
         bool RemoveTrack(IAnimTrack* pTrack) override;

--- a/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack.h
@@ -203,26 +203,46 @@ namespace Maestro
 
         float GetKeyTime(int index) const override
         {
-            AZ_Assert(index >= 0 && index < GetNumKeys(), "Key index %i is out of range", index);
+            if (index < 0 || index >= GetNumKeys())
+            {
+                AZ_Assert(false, "Key index %i is out of range (0-%d)", index, GetNumKeys());
+                return 0.0f;
+            }
+
             return m_spline->time(index);
         }
 
         void SetKeyTime(int index, float time) override
         {
-            AZ_Assert(index >= 0 && index < GetNumKeys(), "Key index %i is out of range", index);
+            if (index < 0 || index >= GetNumKeys())
+            {
+                AZ_Assert(false, "Key index %i is out of range (0-%d)", index, GetNumKeys());
+                return;
+            }
+
             m_spline->SetKeyTime(index, time);
             Invalidate();
         }
 
         int GetKeyFlags(int index) override
         {
-            AZ_Assert(index >= 0 && index < GetNumKeys(), "Key index %i is out of range", index);
+            if (index < 0 || index >= GetNumKeys())
+            {
+                AZ_Assert(false, "Key index %i is out of range (0-%d)", index, GetNumKeys());
+                return 0;
+            }
+
             return m_spline->key(index).flags;
         }
 
         void SetKeyFlags(int index, int flags) override
         {
-            AZ_Assert(index >= 0 && index < GetNumKeys(), "Key index %i is out of range", index);
+            if (index < 0 || index >= GetNumKeys())
+            {
+                AZ_Assert(false, "Key index %i is out of range (0-%d)", index, GetNumKeys());
+                return;
+            }
+
             m_spline->key(index).flags = flags;
         }
 

--- a/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack_Vec2Specialization.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack_Vec2Specialization.cpp
@@ -391,8 +391,7 @@ namespace Maestro
 
         static char str[64];
         description = str;
-        const int numKeys = GetNumKeys();
-        AZ_Assert(index >= 0 && index < numKeys, "Key index %i is out of range", index);
+        AZ_Assert(index >= 0 && index < GetNumKeys(), "Key index %i is out of range", index);
         Spline::key_type& k = m_spline->key(index);
         azsprintf(str, "%.2f", k.value.y);
     }

--- a/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
@@ -87,8 +87,8 @@ namespace Maestro
 
         bool IsKeySelected(int key) const override
         {
-            bool valid = (key >= 0 && key < (int)m_keys.size());
-            AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(key), static_cast<int>(m_keys.size()));
+            bool valid = (key >= 0 && key < static_cast<int>(m_keys.size()));
+            AZ_Assert(valid, "Key index (%i) is out of range (%i)", key, static_cast<int>(m_keys.size()));
             if (!valid)
             {
                 return false;
@@ -103,8 +103,8 @@ namespace Maestro
 
         void SelectKey(int key, bool select) override
         {
-            bool valid = (key >= 0 && key < (int)m_keys.size());
-            AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(key), static_cast<int>(m_keys.size()));
+            bool valid = (key >= 0 && key < static_cast<int>(m_keys.size()));
+            AZ_Assert(valid, "Key index (%i) is out of range (%i)", key, static_cast<int>(m_keys.size()));
             if (!valid)
             {
                 return;
@@ -355,6 +355,12 @@ namespace Maestro
         */
         virtual void SerializeKey(KeyType& key, XmlNodeRef& keyNode, bool bLoading) = 0;
 
+
+        void InitPostLoad([[maybe_unused]] IAnimSequence* sequence) override
+        {
+            AZ_Assert(false, "Not expected to be used");
+        }
+
         //////////////////////////////////////////////////////////////////////////
         //////////////////////////////////////////////////////////////////////////
         /** Get last key before specified time.
@@ -550,8 +556,8 @@ namespace Maestro
     template<class KeyType>
     inline float TAnimTrack<KeyType>::GetKeyTime(int index) const
     {
-        bool valid = (index >= 0 && index < (int)m_keys.size());
-        AZ_Assert(valid, "Key index (%i) is out of range (%i)", static_cast<int>(index), static_cast<int>(m_keys.size()));
+        bool valid = (index >= 0 && index < static_cast<int> (m_keys.size()));
+        AZ_Assert(valid, "Key index (%i) is out of range (%i)", index, static_cast<int>(m_keys.size()));
         if (!valid)
         {
             return 0.0f;

--- a/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimTrack.h
@@ -355,11 +355,7 @@ namespace Maestro
         */
         virtual void SerializeKey(KeyType& key, XmlNodeRef& keyNode, bool bLoading) = 0;
 
-
-        void InitPostLoad([[maybe_unused]] IAnimSequence* sequence) override
-        {
-            AZ_Assert(false, "Not expected to be used");
-        }
+        void InitPostLoad([[maybe_unused]] IAnimSequence* sequence) override { }
 
         //////////////////////////////////////////////////////////////////////////
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
@@ -535,22 +535,20 @@ namespace Maestro
         // The key at m_subTracks[firstIdx][key] maybe active or inactive.
         // A "logical key" for a compound track is regarded as selected when all keys at the same timeline are selected
         const auto firtsKeyTime = m_subTracks[firstIdx]->GetKeyTime(key);
-        bool areAllKeysActive = true;
-        for (int subTrackIdx = 0; areAllKeysActive && subTrackIdx < GetSubTrackCount(); ++subTrackIdx)
+        for (int subTrackIdx = 0; subTrackIdx < GetSubTrackCount(); ++subTrackIdx)
         {
             const auto pSubTrack = m_subTracks[subTrackIdx];
-            for (int keyIdx = 0; areAllKeysActive && keyIdx < pSubTrack->GetNumKeys(); ++keyIdx)
+            for (int keyIdx = 0; keyIdx < pSubTrack->GetNumKeys(); ++keyIdx)
             {
                 const auto subKeyTime = pSubTrack->GetKeyTime(keyIdx);
-                if (AZStd::abs(firtsKeyTime - subKeyTime) < AZ::Constants::Tolerance)
+                if ((AZStd::abs(firtsKeyTime - subKeyTime) < AZ::Constants::Tolerance) && !pSubTrack->IsKeySelected(keyIdx))
                 {
-                    areAllKeysActive = pSubTrack->IsKeySelected(keyIdx);
-                    break;
+                    return false;
                 }
             }
         }
 
-        return areAllKeysActive;
+        return true;
     }
 
     void CCompoundSplineTrack::SelectKey(int key, bool select)

--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
@@ -35,11 +35,6 @@ namespace Maestro
         {
             m_subTracks[i].reset(aznew C2DSplineTrack());
             m_subTracks[i]->SetParameterType(subTrackParamTypes[i]);
-
-            if (inValueType == AnimValueType::RGB)
-            {
-                m_subTracks[i]->SetKeyValueRange(0.0f, 255.f);
-            }
         }
 
         m_subTrackNames.resize(MaxSubtracks);
@@ -47,6 +42,9 @@ namespace Maestro
         m_subTrackNames[1] = "Y";
         m_subTrackNames[2] = "Z";
         m_subTrackNames[3] = "W";
+
+        SetKeyValueRanges();
+        RenameSubTracksIfNeeded();
 
 #ifdef MOVIESYSTEM_SUPPORT_EDITING
         m_bCustomColorSet = false;
@@ -146,6 +144,11 @@ namespace Maestro
             m_subTracks[i]->SerializeSelection(subTrackNode, bLoading, bCopySelected, fTimeOffset);
         }
         return true;
+    }
+
+    void CCompoundSplineTrack::InitPostLoad([[maybe_unused]] IAnimSequence* sequence)
+    {
+        SetKeyValueRanges();
     }
 
     void CCompoundSplineTrack::GetValue(float time, float& value, bool applyMultiplier)
@@ -401,7 +404,11 @@ namespace Maestro
 
     int CCompoundSplineTrack::GetSubTrackIndex(int& key) const
     {
-        AZ_Assert(key >= 0 && key < GetNumKeys(), "Key index %i is invalid", key);
+        if (key < 0 || key >= GetNumKeys())
+        {
+            AZ_Assert(false, "Key index %i is invalid (0-%d))", key, GetNumKeys());
+            return -1;
+        }
         int count = 0;
         for (int i = 0; i < m_nDimensions; i++)
         {
@@ -425,6 +432,17 @@ namespace Maestro
             return;
         }
         m_subTracks[i]->RemoveKey(num);
+    }
+
+    int CCompoundSplineTrack::CreateKey(float time)
+    {
+        int keyIdx = -1;
+        for (int i = 0; i < m_nDimensions; ++i)
+        {
+            const int keyIdxInSubTrack = m_subTracks[i]->CreateKey(time);
+            keyIdx = AZStd::max(keyIdx, keyIdxInSubTrack);
+        }
+        return keyIdx;
     }
 
     void CCompoundSplineTrack::GetKeyInfo(int key, const char*& description, float& duration)
@@ -500,14 +518,39 @@ namespace Maestro
 
     bool CCompoundSplineTrack::IsKeySelected(int key) const
     {
-        AZ_Assert(key >= 0 && key < GetNumKeys(), "Key index %i is invalid", key);
-        int i = GetSubTrackIndex(key);
-        AZ_Assert(i >= 0, "No subtrack for index %i is found", key);
-        if (i < 0)
+        if (key < 0 || key >= GetNumKeys())
         {
+            AZ_Assert(false, "Key index %i is invalid, total keys=%d", key, GetNumKeys());
             return false;
         }
-        return m_subTracks[i]->IsKeySelected(key);
+
+        // Initial key index is belonging to the set of all keys in all sub-tracks
+        int firstIdx = GetSubTrackIndex(key);
+        if (firstIdx < 0)
+        {
+            AZ_Assert(false, "No subtrack for key index %i is found", key);
+            return false;
+        }
+
+        // The key at m_subTracks[firstIdx][key] maybe active or inactive.
+        // A "logical key" for a compound track is regarded as selected when all keys at the same timeline are selected
+        const auto firtsKeyTime = m_subTracks[firstIdx]->GetKeyTime(key);
+        bool areAllKeysActive = true;
+        for (int subTrackIdx = 0; areAllKeysActive && subTrackIdx < GetSubTrackCount(); ++subTrackIdx)
+        {
+            const auto pSubTrack = m_subTracks[subTrackIdx];
+            for (int keyIdx = 0; areAllKeysActive && keyIdx < pSubTrack->GetNumKeys(); ++keyIdx)
+            {
+                const auto subKeyTime = pSubTrack->GetKeyTime(keyIdx);
+                if (AZStd::abs(firtsKeyTime - subKeyTime) < AZ::Constants::Tolerance)
+                {
+                    areAllKeysActive = pSubTrack->IsKeySelected(keyIdx);
+                    break;
+                }
+            }
+        }
+
+        return areAllKeysActive;
     }
 
     void CCompoundSplineTrack::SelectKey(int key, bool select)
@@ -522,12 +565,11 @@ namespace Maestro
         float keyTime = m_subTracks[i]->GetKeyTime(key);
         // In the case of compound tracks, animators want to
         // select all keys of the same time in the sub-tracks together.
-        const float timeEpsilon = 0.001f;
         for (int k = 0; k < m_nDimensions; ++k)
         {
             for (int m = 0; m < m_subTracks[k]->GetNumKeys(); ++m)
             {
-                if (fabs(m_subTracks[k]->GetKeyTime(m) - keyTime) < timeEpsilon)
+                if (fabs(m_subTracks[k]->GetKeyTime(m) - keyTime) < AZ::Constants::Tolerance)
                 {
                     m_subTracks[k]->SelectKey(m, select);
                     break;
@@ -560,6 +602,115 @@ namespace Maestro
             count += m_subTracks[i]->GetNumKeys();
         }
         return result;
+    }
+
+    void CCompoundSplineTrack::RenameSubTracksIfNeeded()
+    {
+        switch (m_valueType)
+        {
+        case AnimValueType::RGB:
+            {
+                if (m_nDimensions != 3)
+                {
+                    AZ_Assert(false, "Invalid dimensions %d for RGB track", m_nDimensions);
+                    return;
+                }
+                m_subTrackNames[0] = "Red";
+                m_subTrackNames[1] = "Green";
+                m_subTrackNames[2] = "Blue";
+            }
+            return;
+        case AnimValueType::Quat:
+            {
+                if (m_nDimensions != 3)
+                {
+                    AZ_Assert(false, "Invalid dimensions %d for Quaternion track", m_nDimensions);
+                    return;
+                }
+                m_subTrackNames[0] = "Pitch";
+                m_subTrackNames[1] = "Roll";
+                m_subTrackNames[2] = "Yaw";
+            }
+            return;
+        default:
+            // Do nothing, a specific factory method should handle this.
+            return;
+        }
+    }
+
+    void CCompoundSplineTrack::SetKeyValueRanges()
+    {
+        switch (m_valueType)
+        {
+        case AnimValueType::RGB:
+            {
+                SetKeyValueRange(0.0f, 255.f);
+                return;
+            }
+        case AnimValueType::Quat:
+            {
+                if (m_nDimensions != 3)
+                {
+                    AZ_Assert(false, "Invalid dimensions %d for Quaternion track", m_nDimensions);
+                    return;
+                }
+                m_subTracks[0]->SetKeyValueRange(-90.0f, 90.0f);
+                m_subTracks[1]->SetKeyValueRange(-180.0f, 180.0f);
+                m_subTracks[2]->SetKeyValueRange(-180.0f, 180.0f);
+                return;
+            }
+        case AnimValueType::Vector:
+            {
+                for (int i = 0; i < m_nDimensions; ++i)
+                {
+                    switch (m_subTracks[i]->GetParameterType().GetType())
+                    {
+                    case AnimParamType::PositionX:
+                    case AnimParamType::PositionY:
+                    case AnimParamType::PositionZ:
+                        {
+                            m_subTracks[i]->SetKeyValueRange(-100.0f, 100.0f);
+                            break;
+                        }
+                    case AnimParamType::ScaleX:
+                    case AnimParamType::ScaleY:
+                    case AnimParamType::ScaleZ:
+                        {
+                            m_subTracks[i]->SetKeyValueRange(0.01f, 100.0f);
+                            break;
+                        }
+                    case AnimParamType::DepthOfField: // Do nothing, DepthOfField handled in factory methods.
+                    default: // Do nothing, rotations were handled above, others should be handled in factory methods or added here.
+                        break;
+                    }
+                }
+                return;
+            }
+        case AnimValueType::Float:
+        case AnimValueType::DiscreteFloat:
+            {
+                for (int i = 0; i < GetSubTrackCount(); i++)
+                {
+                    float fMinKeyValue = 0;
+                    float fMaxKeyValue = 0;
+                    m_subTracks[i]->GetKeyValueRange(fMinKeyValue, fMaxKeyValue);
+                    if (fMaxKeyValue - fMinKeyValue < AZ::Constants::Tolerance)
+                    {
+                        m_subTracks[i]->SetKeyValueRange(-1.0f, 1.0f);
+                    }
+                }
+                return;
+            }
+        case AnimValueType::Vector4:
+            {
+                return; // Do nothing, a specific factory method should handle this.
+            }
+        default:
+            {
+                AZ_Error("CompoundSplineTrack", false, "ResetKeyValueRanges(): Unexpected ValueType %d.", static_cast<int>(m_valueType));
+                return;
+            }
+        }
     }
 
     void CCompoundSplineTrack::SetExpanded(bool expanded)

--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.h
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.h
@@ -78,11 +78,7 @@ namespace Maestro
         void RemoveKey(int num) override;
 
         void GetKeyInfo(int key, const char*& description, float& duration) override;
-        int CreateKey([[maybe_unused]] float time) override
-        {
-            AZ_Assert(false, "Not expected to be used");
-            return 0;
-        }
+        int CreateKey(float time) override;
 
         int CloneKey([[maybe_unused]] int fromKey) override
         {
@@ -207,6 +203,8 @@ namespace Maestro
 
         bool SerializeSelection(XmlNodeRef& xmlNode, bool bLoading, bool bCopySelected = false, float fTimeOffset = 0) override;
 
+        void InitPostLoad([[maybe_unused]] IAnimSequence* sequence) override;
+
         int NextKeyByTime(int key) const override;
 
         void SetSubTrackName(const int i, const AZStd::string& name)
@@ -271,6 +269,10 @@ namespace Maestro
         static void Reflect(AZ::ReflectContext* context);
 
     protected:
+        void RenameSubTracksIfNeeded(); // Called in ctor, and then sub-track names are serialized.
+        void SetKeyValueRanges(); // Key Value Range in a sub-track is not serialized, set it depending on the m_valueType and sub-track's m_nParamType.
+
+
         int m_refCount;
         AnimValueType m_valueType;
         int m_nDimensions;


### PR DESCRIPTION
## What does this PR do?

Closes: https://github.com/o3de/o3de/issues/18640
Closes: https://github.com/o3de/o3de/issues/18575

##### PR mainly addresses 4 problems:
* Previously many glitches were noted, when users could not select a Sub-Key, if a Compond Key was selected, and vice-versa.
* There was no UI representing Compound Keys for editing in Key Properties Dialogs (both stationary in TrackVewDialog "Key" tab and "On Spot", - by  left button double click or right-button click-sub-menu) .
* UI sliders (i.e. min/max key value ranges) were not set in accordance with sub-track target properties.
* Manually adding keys to "Position" and "Rotation" Transform sub-tracks -> shifted / rotated animated entity from the last user-set positiion / orientation.


#### So, PR fixes Compound Tracks Keys evaluation (selection, editing, addition):
* Adds support for Key Editing UI with 3 or 4 values, stored in Compound Tracks.
Fully implemented for Vector3 keys: this includes common `AnimValueType::Vector` (e.g. Transform->"`Position`" track) and `AnimValueType::Vector4` tracks, and specializations for `AnimValueType::RGB` and `AnimValueType::Quat` (e.g. Transform ->"`Rotation`" track).
* * New classes use a base template, and hence minimize code base, and thus implemented in the single Code\Editor\TrackView\VectorKeyUIControls.cpp.
* * The `AnimValueType::Quat` controls for "Rotation" track fully follow ZYX order convention for Quaternion <-> Tait-Bryan Angles (in degrees) conversions, and thus sub-tracks are renamed "Pitch", "Roll" and "Yaw".

* Adds support for Updating Tracks'  Default Values before adding a key, - to use actual Entity properties if changed by user.
Thus adding a key in transform compound track does not shift / rotate the animated entity from the last user-set position / roration.

* Provides means in Compound Tracks to: Create keys, Rename sub-tracks, set Key Value Ranges (which correctly sets UI sliders in the above mentioned Key Editing UI controls.

* Fixes selecting Compound Keys / Sub-Keys, and adding Keys to Compound Tracks.

## How was this PR tested?

Release and Profile Editors were run under Windows, desired functionality observed:
Keys are selected / edited / added / deleted as desired.

#### Notes:
Track names are serialized into prefabs, and thus only newly created tracks are receiving new names.
Extended editing support is available for old prefabs.

https://github.com/user-attachments/assets/1f6b517d-82d6-4745-af02-2f9eaa9dadec

