### PR TITLE
ScriptCanvas: Fix crash on SC editor close

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphOutliner/GraphOutlinerDockWidget.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphOutliner/GraphOutlinerDockWidget.cpp
@@ -91,6 +91,7 @@ namespace GraphCanvas
         verticalLayout->addWidget(m_nodelistTable);
 
         this->setWindowTitle("Graph Outliner");
+        this->setObjectName("GraphOutlinerDockWidget");
         this->setWidget(dockWidgetContents);
 
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingDataAggregator.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingDataAggregator.cpp
@@ -117,7 +117,7 @@ namespace ScriptCanvasEditor
         RemoveStaticRegistration(namedEntityId, oldGraphIdentifier);
     }
 
-    void LiveLoggingDataAggregator::Connected([[maybe_unused]] const ScriptCanvas::Debugger::Target& target)
+    void LiveLoggingDataAggregator::Connected([[maybe_unused]] ScriptCanvas::Debugger::Target& target)
     {
         AZStd::lock(m_notificationMutex);
         SetupExternalEntities();

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingDataAggregator.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingDataAggregator.h
@@ -30,7 +30,7 @@ namespace ScriptCanvasEditor
     public:
         AZ_CLASS_ALLOCATOR(LiveLoggingDataAggregator, AZ::SystemAllocator);
         LiveLoggingDataAggregator();
-        ~LiveLoggingDataAggregator();
+        ~LiveLoggingDataAggregator() override;
 
         // ClientUINotificationBus
         void OnCurrentTargetChanged() override;
@@ -50,7 +50,7 @@ namespace ScriptCanvasEditor
 
         // ServiceNotifications
         //// Logging Notifications
-        void Connected(const ScriptCanvas::Debugger::Target& target) override;
+        void Connected(ScriptCanvas::Debugger::Target& target) override;
         void GraphActivated(const ScriptCanvas::GraphActivation& activatedSignal) override;
         void GraphDeactivated(const ScriptCanvas::GraphDeactivation& deactivatedSignal) override;
         

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.cpp
@@ -348,7 +348,7 @@ namespace ScriptCanvasEditor
         }
     }
 
-    void LiveLoggingWindowSession::Connected([[maybe_unused]] const ScriptCanvas::Debugger::Target& target)
+    void LiveLoggingWindowSession::Connected([[maybe_unused]] ScriptCanvas::Debugger::Target& target)
     {
         if (m_userSettings->IsAutoCaptureEnabled() && isVisible())
         {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.h
@@ -100,7 +100,7 @@ namespace ScriptCanvasEditor
         ////
 
         // ScriptCavnas::Debugger::ServiceNotificationsBus
-        void Connected(const ScriptCanvas::Debugger::Target& target) override;
+        void Connected(ScriptCanvas::Debugger::Target& target) override;
         ////
         
     protected:

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
@@ -25,6 +25,7 @@ namespace ScriptCanvasEditor
         , m_ui(new Ui::LoggingWindow)
     {
         m_ui->setupUi(this);
+        m_ui->emptyCapture->setParent(this);
 
         // Hack to hide the close button on the first tab. Since we always want it open.
         
@@ -48,6 +49,7 @@ namespace ScriptCanvasEditor
 
         OnActiveTabChanged(m_ui->tabWidget->currentIndex());
         PivotOnEntities();
+
     }
 
     LoggingWindow::~LoggingWindow()

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
@@ -54,8 +54,6 @@ namespace ScriptCanvasEditor
 
     LoggingWindow::~LoggingWindow()
     {
-        // The tabWidget destruction is handled by its parent, if we don't clear the parent, this results in a double deletion
-        m_ui->tabWidget->setParent(nullptr);
     }
 
     void LoggingWindow::OnActiveTabChanged([[maybe_unused]] int index)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
@@ -27,6 +27,7 @@ namespace ScriptCanvasEditor
         m_ui->setupUi(this);
 
         // Hack to hide the close button on the first tab. Since we always want it open.
+        
         m_ui->tabWidget->setTabsClosable(true);
         m_ui->tabWidget->tabBar()->setTabButton(0, QTabBar::ButtonPosition::RightSide, nullptr);
         m_ui->tabWidget->tabBar()->setTabButton(0, QTabBar::ButtonPosition::LeftSide, nullptr);
@@ -51,7 +52,8 @@ namespace ScriptCanvasEditor
 
     LoggingWindow::~LoggingWindow()
     {
-
+        // The tabWidget destruction is handled by its parent, if we don't clear the parent, this results in a double deletion
+        m_ui->tabWidget->setParent(nullptr);
     }
 
     void LoggingWindow::OnActiveTabChanged([[maybe_unused]] int index)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.h
@@ -49,11 +49,11 @@ namespace ScriptCanvasEditor
 
         PivotTreeWidget* GetActivePivotWidget() const;
 
-        AZStd::unique_ptr<Ui::LoggingWindow> m_ui;
+        QScopedPointer<Ui::LoggingWindow> m_ui;
 
         QButtonGroup m_pivotGroup;
 
-        LoggingDataId m_activeDataId;        
+        LoggingDataId m_activeDataId;
 
         int m_entityPageIndex;
         int m_graphPageIndex;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <QButtonGroup>
+#include <QScopedPointer>
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzQtComponents/Components/StyledDockWidget.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/ExecutionLogAsset.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/ExecutionLogAsset.cpp
@@ -24,7 +24,6 @@ namespace ScriptCanvas
 
     void ExecutionLogData::Clear()
     {
-        m_events.resize(0);
         m_events.clear();
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/ExecutionLogAsset.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/ExecutionLogAsset.cpp
@@ -16,27 +16,18 @@ namespace ScriptCanvas
     {
         *this = source;
     }
-    
-    ExecutionLogData::ExecutionLogData(ExecutionLogData&& other)
-        : m_events(AZStd::move(other.m_events))
-    {
-    }
-        
+
     ExecutionLogData::~ExecutionLogData()
     {
         Clear();
     }
-    
+
     void ExecutionLogData::Clear()
     {
-        for (auto entry : m_events)
-        {
-            delete entry;
-        }
-
         m_events.resize(0);
+        m_events.clear();
     }
-    
+
     ExecutionLogData& ExecutionLogData::operator=(const ExecutionLogData& source)
     {
         Clear();
@@ -45,18 +36,7 @@ namespace ScriptCanvas
     
         for (auto entry : source.m_events)
         {
-            AZ_Assert(entry, "there should never bee a nullptr entry in an event log");
-            m_events.push_back(entry->Duplicate());
-        }
-
-        return *this;
-    }
-    
-    ExecutionLogData& ExecutionLogData::operator=(ExecutionLogData&& other)
-    {
-        if (this != &other)
-        {
-            m_events = AZStd::move(other.m_events);
+            m_events.push_back(entry);
         }
 
         return *this;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/ExecutionLogAsset.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/ExecutionLogAsset.h
@@ -14,8 +14,6 @@
 
 namespace ScriptCanvas
 {
-    struct LoggableEvent;
-
     struct ExecutionLogData
     {
         AZ_TYPE_INFO(ExecutionLogData, "{8813C6D6-7FC6-4A41-B77B-5B8BFC9C4C01}");
@@ -23,17 +21,15 @@ namespace ScriptCanvas
                 
         static void Reflect(AZ::ReflectContext* reflectContext);
         
-        AZStd::vector<LoggableEvent*> m_events;
-        
-        
+        AZStd::vector<LoggableEvent> m_events;
+
         ExecutionLogData() = default;
         ExecutionLogData(const ExecutionLogData& source);
-        ExecutionLogData(ExecutionLogData&&);
+        ExecutionLogData(ExecutionLogData&&) = delete;
         ~ExecutionLogData();
-                
+
         void Clear();
         ExecutionLogData& operator=(const ExecutionLogData& source);
-        ExecutionLogData& operator=(ExecutionLogData&&);
     };
 
     class ExecutionLogAsset

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.cpp
@@ -153,11 +153,6 @@ namespace ScriptCanvas
     ExecutionThreadBeginning::ExecutionThreadBeginning()
     {}
 
-    LoggableEvent* ExecutionThreadBeginning::Duplicate() const
-    {
-        return aznew ExecutionThreadBeginning(*this);
-    }
-
     Timestamp ExecutionThreadBeginning::GetTimestamp() const
     {
         return m_timestamp;
@@ -221,14 +216,8 @@ namespace ScriptCanvas
     NodeStateChange::NodeStateChange()
     {}
 
-    LoggableEvent* NodeStateChange::Duplicate() const
-    {
-        return aznew NodeStateChange(*this);
-    }
-
     AZStd::string NodeStateChange::ToString() const
     {
-        // \todo I think....this should get...cut...it's not actually a script canvas level feature
         return "NodeStateChange";
     }
 
@@ -270,11 +259,6 @@ namespace ScriptCanvas
         , m_annotation(annotation)
         , m_assetNodeId(assetId)
     {
-    }
-
-    LoggableEvent* AnnotateNodeSignal::Duplicate() const
-    {
-        return aznew AnnotateNodeSignal((*this));
     }
 
     AZStd::string AnnotateNodeSignal::ToString() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.h
@@ -204,11 +204,13 @@ namespace ScriptCanvas
 
         virtual ~LoggableEvent() = default;
 
-        virtual LoggableEvent* Duplicate() const = 0;
-        virtual Timestamp GetTimestamp() const = 0;
-        virtual void SetTimestamp(Timestamp) = 0;
-        virtual AZStd::string ToString() const = 0;
-        virtual void Visit(LoggableEventVisitor& visitor) = 0;
+        LoggableEvent() = default;
+        LoggableEvent(const LoggableEvent& rhs) = default;
+
+        virtual Timestamp GetTimestamp() const { return Timestamp(); }
+        virtual void SetTimestamp(Timestamp) {}
+        virtual AZStd::string ToString() const { return {}; }
+        virtual void Visit(LoggableEventVisitor&) {}
     };
 
     template<typename t_Tag, typename t_Parent>
@@ -241,11 +243,6 @@ namespace ScriptCanvas
             : t_Parent(parent)
             , m_timestamp(AZStd::GetTimeUTCMilliSecond())
         {}
-
-        LoggableEvent* Duplicate() const override
-        {
-            return aznew ThisType(*this);
-        }
 
         Timestamp GetTimestamp() const override
         {
@@ -422,16 +419,6 @@ namespace ScriptCanvas
             , m_timestamp(AZStd::GetTimeUTCMilliSecond())
         {}
 
-        //TaggedDataValue(const Signal& signal)
-        //    : Signal(signal)
-        //    , m_timestamp(AZStd::GetTimeUTCMilliSecond())
-        //{}
-
-        LoggableEvent* Duplicate() const override
-        {
-            return aznew TaggedDataValue<t_Tag>(*this);
-        }
-
         Timestamp GetTimestamp() const override
         {
             return m_timestamp;
@@ -472,8 +459,6 @@ namespace ScriptCanvas
         {}
 
         virtual ~ExecutionThreadBeginning() = default;
-
-        LoggableEvent* Duplicate() const override;
 
         Timestamp GetTimestamp() const override;
 
@@ -518,7 +503,6 @@ namespace ScriptCanvas
         NodeStateChange();
         NodeStateChange(const NodeStateChange&) = default;
 
-        LoggableEvent* Duplicate() const override;
         AZStd::string ToString() const override;
 
         void Visit(LoggableEventVisitor& visitor) override;
@@ -543,8 +527,6 @@ namespace ScriptCanvas
         AnnotateNodeSignal();
         AnnotateNodeSignal(const AnnotateNodeSignal&) = default;
         AnnotateNodeSignal(const GraphInfo& graphInfo, AnnotationLevel annotationLevel, AZStd::string_view annotation, const AZ::NamedEntityId& assetId);
-
-        LoggableEvent* Duplicate() const override;
 
         AZStd::string ToString() const override;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Bus.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Bus.h
@@ -27,7 +27,7 @@ namespace ScriptCanvas
             virtual void BecameUnavailable(const Target&) {}
             virtual void BecameAvailable(const Target&) {}
 
-            virtual void Connected(const Target&) {}
+            virtual void Connected(Target&) {}
             virtual void ConnectionRefused(const Target&) {}
             virtual void Disconnected() {}
             

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.cpp
@@ -35,7 +35,7 @@ namespace ScriptCanvas
         void Logger::ClearLog()
         {
 #if defined(SC_EXECUTION_TRACE_ENABLED)
-            m_logAsset.GetData().Clear();
+            m_logData.m_events.clear();
 #endif // SC_EXECUTION_TRACE_ENABLED
         }
 
@@ -44,9 +44,9 @@ namespace ScriptCanvas
             m_logExecutionOverrideEnabled = false;
         }
 
-        void Logger::Connected(const ScriptCanvas::Debugger::Target& target)
+        void Logger::Connected(ScriptCanvas::Debugger::Target& target)
         {
-            m_target = target;
+            m_target = &target;
         }
 
         AZ::Data::Asset<ExecutionLogAsset> Logger::LoadFromRelativePath([[maybe_unused]] AZStd::string_view path)
@@ -87,7 +87,10 @@ namespace ScriptCanvas
 #if defined(SC_EXECUTION_TRACE_ENABLED) 
             AZ::IO::FixedMaxPath fullpath = ExecutionLogAsset::GetDefaultDirectoryPath() / path;
 
-            AZ_VerifyError("ScriptCanvas", AZ::Utils::SaveObjectToFile(fullpath.String(), AZ::DataStream::ST_XML, &m_logAsset),
+            ExecutionLogAsset logAsset;
+            logAsset.SetData(m_logData);
+
+            AZ_VerifyError("ScriptCanvas", AZ::Utils::SaveObjectToFile(fullpath.String(), AZ::DataStream::ST_XML, &logAsset),
                 "File failed to save: %s", fullpath.c_str());
 #endif
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
@@ -34,7 +34,7 @@ namespace ScriptCanvas
             AZ_RTTI(Logger, "{BBA556C4-973B-4B2F-B2B9-357188086F78}");
             
             Logger();
-            virtual ~Logger();
+            ~Logger() override;
                 
             //////////////////////////////////////////////////////////////////////////
             // ServiceNotificationsBus::Handler
@@ -80,7 +80,7 @@ namespace ScriptCanvas
 
 #if defined(SC_EXECUTION_TRACE_ENABLED)
             ExecutionLogData m_logData;
-
+#endif
             ScriptCanvas::Debugger::Target* m_target;
         };
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Debugger/Logger.h
@@ -34,11 +34,11 @@ namespace ScriptCanvas
             AZ_RTTI(Logger, "{BBA556C4-973B-4B2F-B2B9-357188086F78}");
             
             Logger();
-            ~Logger();
+            virtual ~Logger();
                 
             //////////////////////////////////////////////////////////////////////////
             // ServiceNotificationsBus::Handler
-            void Connected(const ScriptCanvas::Debugger::Target&) override;
+            void Connected(ScriptCanvas::Debugger::Target&) override;
             void GraphActivated(const ScriptCanvas::GraphActivation&) override;
             void GraphDeactivated(const ScriptCanvas::GraphDeactivation&) override;
             void NodeStateChanged(const ScriptCanvas::NodeStateChange&) override;
@@ -59,7 +59,7 @@ namespace ScriptCanvas
         protected:
             AZ_FORCE_INLINE bool IsLoggingExecution() const 
             {
-                return m_target.m_script.m_logExecution
+                return m_target->m_script.m_logExecution
                     || (m_logExecutionOverrideEnabled && m_logExecutionOverride);
             }
 
@@ -68,7 +68,7 @@ namespace ScriptCanvas
             {
 #if defined(SC_EXECUTION_TRACE_ENABLED)
                 SCRIPT_CANVAS_DEBUGGER_TRACE_CLIENT("Logging: %s", loggableEvent.ToString().data());
-                m_logAsset.GetData().m_events.emplace_back(loggableEvent.Duplicate());
+                m_logData.m_events.push_back(loggableEvent);
 #endif
             }
 
@@ -79,9 +79,9 @@ namespace ScriptCanvas
             bool m_logExecutionOverride = false;
 
 #if defined(SC_EXECUTION_TRACE_ENABLED)
-            ExecutionLogAsset m_logAsset;
-#endif
-            ScriptCanvas::Debugger::Target m_target;
+            ExecutionLogData m_logData;
+
+            ScriptCanvas::Debugger::Target* m_target;
         };
     }
 }


### PR DESCRIPTION
## What does this PR do?

When closing the Script Canvas editor, there is a double delete because the tabWidget created during initialization is tracked and destroyed by the parent, if we don't clear out the parent, the owning widget will attempt to delete it which results in a double deletion.

Also simplified the code that tracks the logging, one of the causes for the crash is that a member variable of AssetData class was being kept, this data would get deleted by the asset at some point which left it in an undefined state, when the owning object got deleted it would try to invoke the dtor for the ExecutionLogAsset which was already invalid resulting in the crash.

Closes #18724 