### PR TITLE
Cherrypick from stab: Fixes a issue #18720 (vulkan malloc crash) and compile error

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
@@ -168,6 +168,13 @@ namespace AZ
     //=========================================================================
     auto SystemAllocator::deallocate(pointer ptr, size_type byteSize, [[maybe_unused]] size_type alignment) -> size_type
     {
+        // It is valid to call "free" on a nullptr and it should produce no action.
+        // Early out here to avoid calling something like AZ_OS_MSIZE, which may not be valid on nullptr.
+        if (!ptr)
+        {
+            return 0;
+        }
+
         #if (AZCORE_SYSTEM_ALLOCATOR == AZCORE_SYSTEM_ALLOCATOR_MALLOC)
             AZ_PROFILE_MEMORY_FREE(MemoryReserved, ptr);
             byteSize = byteSize == 0 ? AZ_OS_MSIZE(ptr, alignment) : byteSize;

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -1010,6 +1010,14 @@ namespace UnitTest
         EXPECT_NEAR(matrix2.GetTranspose3x3().GetDeterminant3x3(), expected2, 1e-3f);
     }
 
+    // Use of INFINITY in newer Windows SDKs trigger a math overflow warning because it redefines INFINITY
+    // as (huge number * huge number) instead of the previous definition of just (huge number).  The multiplication
+    // operation triggers the overflow warning.
+
+    // We still want that warning globally in the code but we don't want it in this test, specifically, which uses it
+    // to validate that we can detect infinite matrices that come about from runtime operations.
+    AZ_PUSH_DISABLE_WARNING(4756, "-Wunknown-warning-option")  //warning C4756: overflow in constant arithmetic
+
     TEST(MATH_Matrix3x4, IsFinite)
     {
         AZ::Matrix3x4 matrix = AZ::Matrix3x4::CreateFromQuaternionAndTranslation(
@@ -1040,4 +1048,5 @@ namespace UnitTest
             }
         }
     }
+    AZ_POP_DISABLE_WARNING
 } // namespace UnitTest


### PR DESCRIPTION
(Cherrypicking from stabilization branch)

See the original https://github.com/o3de/o3de/pull/18736

* Fixes a issue #18720 and a compile error with latest Windows SDK

Fixes:
https://github.com/o3de/o3de/issues/18720

I was unable to test this without also fixing a compiler error introduced by the latest windows SDK.

The latest windows SDK changed the basic definition of the macro `INFINITY` from being a huge number on its own, to be two huge numbers multiplied by each other.  This causes the compiler to error out with a 'math overflow' whenever INFINITY is used anywhere.

One of our tests uses it as an input number to test whether it can detect an infinite matrix.  I've bracketed the test with a push and pop for that warning.  It only happens on MSVC and only with latest SDK.
