### PR TITLE
Enable usage of unicode asset names

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/std/functional.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/Settings/CommandLine.h>
+#include <AzCore/Settings/CommandLineParser_Platform.h>
 #include <AzCore/StringFunc/StringFunc.h>
 
 namespace AZ
@@ -96,6 +97,9 @@ namespace AZ
             ParseArgument(argument.m_option, argument.m_value);
             return true;
         };
+
+        // Make sure utf-8 commandline parameters can be used on all platforms
+        Settings::Platform::CommandLineConverter converter(argc, argv);
 
         // For legacy reasons, the executable name argument(arg0) has not been parsed by this overload
         // of the command line class

--- a/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/CommandLine.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/std/functional.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/Settings/CommandLine.h>
-#include <AzCore/Settings/CommandLineParser_Platform.h>
 #include <AzCore/StringFunc/StringFunc.h>
 
 namespace AZ
@@ -97,9 +96,6 @@ namespace AZ
             ParseArgument(argument.m_option, argument.m_value);
             return true;
         };
-
-        // Make sure utf-8 commandline parameters can be used on all platforms
-        Settings::Platform::CommandLineConverter converter(argc, argv);
 
         // For legacy reasons, the executable name argument(arg0) has not been parsed by this overload
         // of the command line class

--- a/Code/Framework/AzCore/Platform/Android/AzCore/Settings/CommandLineParser_Platform.h
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/Settings/CommandLineParser_Platform.h
@@ -1,0 +1,12 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "../../../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h"

--- a/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzCore/Platform/Android/platform_android_files.cmake
@@ -28,6 +28,7 @@ set(FILES
     ../Common/UnixLike/AzCore/Platform_UnixLike.cpp
     AzCore/PlatformIncl_Platform.h
     AzCore/Serialization/Locale_Platform.h
+    AzCore/Settings/CommandLineParser_Platform.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.cpp
     ../Common/UnixLike/AzCore/Process/ProcessInfo_UnixLike.cpp
@@ -58,6 +59,7 @@ set(FILES
     AzCore/Module/DynamicModuleHandle_Android.cpp
     AzCore/NativeUI/NativeUISystemComponent_Android.cpp
     ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include "CommandLineParser_UnixLike.h"
 #include <AzCore/Settings/CommandLineParser.h>
 
 namespace AZ::Settings::Platform
@@ -17,4 +18,11 @@ namespace AZ::Settings::Platform
     {
         return CommandLineOptionPrefixArray{ "--", "-" };
     }
-}
+
+    CommandLineConverter::CommandLineConverter(int& argc, char**& argv)
+    {
+        // Do nothing, arguments are already in utf-8 encoding
+        AZ_UNUSED(argc);
+        AZ_UNUSED(argv);
+    }
+} // namespace AZ::Settings::Platform

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AZ::Settings::Platform
+{
+    //! A class to ensure command-line parameters are in utf-8 encoding.
+    //! On non-Windows platforms, it is assumed that utf-8 is used by default, so no further processing is required.
+    class CommandLineConverter
+    {
+    public:
+        CommandLineConverter(int& argc, char**& argv);
+    };
+} // namespace AZ::Settings::Platform

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
@@ -6,7 +6,11 @@
  *
  */
 
+#include "CommandLineParser_WinAPI.h"
 #include <AzCore/Settings/CommandLineParser.h>
+#include <AzCore/std/string/conversions.h>
+#include <Windows.h>
+#include <shellapi.h>
 
 namespace AZ::Settings::Platform
 {
@@ -17,4 +21,26 @@ namespace AZ::Settings::Platform
     {
         return CommandLineOptionPrefixArray{ "--", "-", "/" };
     }
-}
+
+    CommandLineConverter::CommandLineConverter(int& argc, char**& argv)
+    {
+        // Read arguments form GetCommandLineW(), convert them to utf-8, and write them back to argc+argv. This is the most convenient way
+        // on Windows to get the arguments as utf-8 encoded strings.
+
+        int argcW;
+        LPWSTR* argvW{ CommandLineToArgvW(GetCommandLineW(), &argcW) };
+
+        m_convertedArguments.resize(argcW);
+        m_convertedArgumentPointers.resize(argcW);
+
+        for (int i{ 0 }; i < argcW; i++)
+        {
+            AZStd::to_string(m_convertedArguments[i], argvW[i]); // Convert wchar to utf-8 char
+            m_convertedArgumentPointers[i] = m_convertedArguments[i].data();
+        }
+
+        LocalFree(argvW);
+        argc = argcW;
+        argv = m_convertedArgumentPointers.data();
+    }
+} // namespace AZ::Settings::Platform

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
@@ -24,14 +24,6 @@ namespace AZ::Settings::Platform
 
     CommandLineConverter::CommandLineConverter(int& argc, char**& argv)
     {
-        // Some test cases create an instance of ToolsTestApplication with new commandline parameters, which are different than the
-        // application commandline parameters retrieved by GetCommandLineW(). These test cases also set the argv[0] to nullptr, so it can be
-        // detected here.
-        if (argc >= 1 && argv[0] == nullptr)
-        {
-            return;
-        }
-
         // Read arguments form GetCommandLineW(), convert them to utf-8, and write them back to argc+argv. This is the most convenient way
         // on Windows to get the arguments as utf-8 encoded strings.
 

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
@@ -24,6 +24,14 @@ namespace AZ::Settings::Platform
 
     CommandLineConverter::CommandLineConverter(int& argc, char**& argv)
     {
+        // Some test cases create an instance of ToolsTestApplication with new commandline parameters, which are different than the
+        // application commandline parameters retrieved by GetCommandLineW(). These test cases also set the argv[0] to nullptr, so it can be
+        // detected here.
+        if (argc >= 1 && argv[0] == nullptr)
+        {
+            return;
+        }
+
         // Read arguments form GetCommandLineW(), convert them to utf-8, and write them back to argc+argv. This is the most convenient way
         // on Windows to get the arguments as utf-8 encoded strings.
 

--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.h
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+
+namespace AZ::Settings::Platform
+{
+    //! A class to ensure command-line parameters are in utf-8 encoding.
+    //! On Windows installations without utf-8 commandline arguments, the passed argc and argv arguments are overwritten. This class may
+    //! allocate and stores additional strings, therefore it needs to stay in scope until the arguments are no longer needed.
+    class CommandLineConverter
+    {
+        AZStd::vector<AZStd::string> m_convertedArguments;
+        AZStd::vector<char*> m_convertedArgumentPointers;
+
+    public:
+        CommandLineConverter(int& argc, char**& argv);
+    };
+} // namespace AZ::Settings::Platform

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/Settings/CommandLineParser_Platform.h
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/Settings/CommandLineParser_Platform.h
@@ -1,0 +1,12 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "../../../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h"

--- a/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
+++ b/Code/Framework/AzCore/Platform/Linux/platform_linux_files.cmake
@@ -59,9 +59,11 @@ set(FILES
     ../Common/UnixLike/AzCore/Platform_UnixLike.cpp
     AzCore/PlatformIncl_Platform.h
     AzCore/Serialization/Locale_Platform.h
+    AzCore/Settings/CommandLineParser_Platform.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.cpp
     ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Mac/AzCore/Settings/CommandLineParser_Platform.h
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/Settings/CommandLineParser_Platform.h
@@ -1,0 +1,12 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "../../../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h"

--- a/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
+++ b/Code/Framework/AzCore/Platform/Mac/platform_mac_files.cmake
@@ -61,9 +61,11 @@ set(FILES
     AzCore/Platform_Mac.cpp
     AzCore/PlatformIncl_Platform.h
     AzCore/Serialization/Locale_Platform.h
+    AzCore/Settings/CommandLineParser_Platform.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.cpp
     ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/Settings/CommandLineParser_Platform.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/Settings/CommandLineParser_Platform.h
@@ -1,0 +1,12 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "../../../Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.h"

--- a/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
@@ -64,9 +64,11 @@ set(FILES
     AzCore/PlatformIncl_Platform.h
     AzCore/PlatformIncl_Windows.h
     AzCore/Serialization/Locale_Platform.h
+    AzCore/Settings/CommandLineParser_Platform.h
     ../Common/WinAPI/AzCore/Serialization/Locale_WinAPI.h
     ../Common/WinAPI/AzCore/Serialization/Locale_WinAPI.cpp
     ../Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.cpp
+    ../Common/WinAPI/AzCore/Settings/CommandLineParser_WinAPI.h
     ../Common/WinAPI/AzCore/Socket/AzSocket_fwd_WinAPI.h
     ../Common/WinAPI/AzCore/Socket/AzSocket_WinAPI.cpp
     ../Common/WinAPI/AzCore/Socket/AzSocket_WinAPI.h

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/Settings/CommandLineParser_Platform.h
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/Settings/CommandLineParser_Platform.h
@@ -1,0 +1,12 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "../../../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h"

--- a/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
+++ b/Code/Framework/AzCore/Platform/iOS/platform_ios_files.cmake
@@ -59,9 +59,11 @@ set(FILES
     ../Common/UnixLike/AzCore/Platform_UnixLike.cpp
     AzCore/PlatformIncl_Platform.h
     AzCore/Serialization/Locale_Platform.h
+    AzCore/Settings/CommandLineParser_Platform.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.h
     ../Common/UnixLike/AzCore/Serialization/Locale_UnixLike.cpp
     ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.cpp
+    ../Common/UnixLike/AzCore/Settings/CommandLineParser_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_fwd_UnixLike.h
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.cpp
     ../Common/UnixLike/AzCore/Socket/AzSocket_UnixLike.h

--- a/Code/Framework/AzFramework/Platform/Common/WinAPI/AzFramework/IO/LocalFileIO_WinAPI.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/WinAPI/AzFramework/IO/LocalFileIO_WinAPI.cpp
@@ -94,7 +94,11 @@ namespace AZ
             for (AZ::IO::PathView pathSegment : resolvedPath.RelativePath())
             {
                 directoryPath /= pathSegment;
-                CreateDirectoryA(directoryPath.c_str(), nullptr);
+
+                AZStd::fixed_wstring<AZ::IO::MaxPathLength> directoryPathW;
+                AZStd::to_wstring(directoryPathW, directoryPath.String());
+                CreateDirectoryW(directoryPathW.c_str(), nullptr);
+
                 if (!IsDirectory(directoryPath.c_str()))
                 {
                     return ResultCode::Error;

--- a/Code/Tools/AssetProcessor/AssetBuilder/main.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilder/main.cpp
@@ -8,6 +8,7 @@
 #include "AssetBuilderApplication.h"
 #include "TraceMessageHook.h"
 #include "AssetBuilderComponent.h"
+#include <AzCore/Settings/CommandLineParser_Platform.h>
 
 // the user is not expected to interact with the AssetBuilderApplication directly,
 // so it can be always running in the culture-invariant locale.
@@ -23,6 +24,9 @@ int main(int argc, char** argv)
     // other invariant locale files, setting it to the invariant locale means that individual builders
     // don't need to keep track of locale, change it, set it, etc.
     setlocale(LC_ALL, "C"); 
+
+    // Make sure utf-8 commandline parameters can be used on all platforms
+    AZ::Settings::Platform::CommandLineConverter converter(argc, argv);
 
     const AZ::Debug::Trace tracer;
     AssetBuilderApplication app(&argc, &argv);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -2991,31 +2991,6 @@ namespace AssetProcessor
                         // keep track of its parent folder so that if it is deleted later we know it is a folder
                         // delete and not a file delete.
                         AddKnownFoldersRecursivelyForFile(normalizedPath, sourceAssetReference.ScanFolderPath().c_str());
-
-                        if (normalizedPath.toUtf8().length() > normalizedPath.length())
-                        {
-                            // if we are here it implies that the source file path contains non ascii characters
-                            AutoFailJob(
-                                AZStd::string::format(
-                                    "ProcessFilesToExamineQueue: source file path ( %s ) contains non ascii characters.\n",
-                                    normalizedPath.toUtf8().constData()),
-                                AZStd::string::format(
-                                    "Source file ( %s ) contains non ASCII characters.\n"
-                                    "O3DE currently only supports file paths having ASCII characters and therefore asset processor will not be able to process this file.\n"
-                                    "Please rename the source file to fix this error.\n",
-                                    normalizedPath.toUtf8().constData()),
-                                JobEntry(
-                                    sourceAssetReference,
-                                    AZ::Uuid::CreateNull(),
-                                    { "all", {} },
-                                    QString("PreCreateJobs"),
-                                    0,
-                                    GenerateNewJobRunKey(),
-                                    AZ::Uuid::CreateNull())
-                                );
-
-                            continue;
-                        }
                     }
                     else
                     {

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -4815,7 +4815,7 @@ TEST_F(AssetProcessorManagerTest, JobDependencyOrderOnly_MultipleJobs_EmitOK)
 }
 
 
-TEST_F(AssetProcessorManagerTest, SourceFile_With_NonASCII_Characters_Fail_Job_OK)
+TEST_F(AssetProcessorManagerTest, SourceFile_With_NonASCII_Characters_Job_OK)
 {
     // This test ensures that asset processor manager detects a source file that has non-ASCII characters
     // and sends a notification for a dummy autofail job.
@@ -4839,15 +4839,15 @@ TEST_F(AssetProcessorManagerTest, SourceFile_With_NonASCII_Characters_Fail_Job_O
     const ScanFolderInfo* scanFolder = m_config->GetScanFolderByPath(watchFolderPath);
     ASSERT_NE(scanFolder, nullptr);
 
-    QString folderPath(m_assetRootDir.absoluteFilePath("subfolder1/Test\xD0"));
+    QString folderPath(m_assetRootDir.absoluteFilePath(u8"subfolder1/Test\u2133")); // u+2133 -> "Script Capital M" unicode character
     QDir folderPathDir(folderPath);
-    QString absPath(folderPathDir.absoluteFilePath("Test.txt"));
+    QString absPath(folderPathDir.absoluteFilePath(u8"Test\u21334.txt"));
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(absPath, QString("test\n")));
 
     m_assetProcessorManager.get()->AssessAddedFile(absPath);
 
     ASSERT_TRUE(BlockUntilIdle(5000));
-    EXPECT_EQ(failedjobDetails.m_autoFail, true);
+    EXPECT_EQ(failedjobDetails.m_autoFail, false);
     EXPECT_EQ(failedjobDetails.m_jobEntry.GetAbsoluteSourcePath(), absPath);
 
     // folder delete notification


### PR DESCRIPTION
## What does this PR do?

This MR enables adding assets with unicode filenames or from unicode subfolders on Windows machines without enabled `Beta: Use Unicode UTF-8 for worldwide language support` (Windows 10) setting.

The only real production change for this was to remove the explicit check and error message in `assetProcessorManager.cpp`, and the change in `LocalFileIO::CreatePath` to enable creation of unicode folders. Everything else just seems to work™. The other changes were primarily for testing the AssetBuilder with the `-debug` flag from the commandline for these assets, which is also a nice thing to have.

Screenshot of the Asset, the Mesh component and the Material comonent:
![editorwindows](https://github.com/user-attachments/assets/7c36b35c-1bbd-4bce-ba08-6faab83215e2)


## How was this PR tested?

Create some test FBX files with various non-latin characters (including material names).
All assets process successfully and can be selected in the Mesh component, materials can be changed in the Material component, just as with assets with only latin characters.
