### PR TITLE
Fix buffer clear action clearing whole buffer instead of buffer view on Vulkan

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -1398,9 +1398,8 @@ namespace AZ
                     buffer.GetBufferMemoryView()->GetNativeBuffer(),
                     buffer.GetBufferMemoryView()->GetOffset() +
                         static_cast<size_t>(bufferViewDesc.m_elementOffset) * bufferViewDesc.m_elementSize,
-                    buffer.GetBufferMemoryView()->GetSize(),
+                    static_cast<size_t>(bufferViewDesc.m_elementCount) * bufferViewDesc.m_elementSize,
                     vkClearValue.i);
         }
-
     }
 }


### PR DESCRIPTION
## What does this PR do?

When declaring a buffer view with a clear action in a pass file, the buffer view is not taken into account when performing the clear action and the whole buffer is cleared instead in Vulkan (DX12 does not do this).

## How was this PR tested?

Test with an internal gem which uses this specific configuration for a slot (Bufferview of 1 uint from a larger buffer, the clear action should only clear this single uint):
```
"Name": "SomeBuffer",
"ShaderInputName": "m_someBuffer",
"SlotType": "InputOutput",
"ScopeAttachmentUsage": "Shader",
"BufferViewDesc": {
    "m_elementOffset": "0",
    "m_elementCount": "1",
    "m_elementSize": "4",
    "m_elementFormat": "R32_UINT"
},
"LoadStoreAction": {
    "LoadAction": "Clear",
    "StoreAction": "Store"
}
```
This code does not work correctly on Vulkan (works fine with DX12), and works as expected with Vulkan with this PR.