### PR TITLE
Add missing dereference operator in deque at() function

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/deque.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/deque.h
@@ -316,7 +316,7 @@ namespace AZStd
         AZ_FORCE_INLINE size_type max_size() const  { return AZStd::allocator_traits<allocator_type>::max_size(m_allocator) / sizeof(block_node_type); }
         AZ_FORCE_INLINE bool empty() const          { return m_size == 0; }
 
-        AZ_FORCE_INLINE const_reference at(size_type offset) const { return iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
+        AZ_FORCE_INLINE const_reference at(size_type offset) const { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
         AZ_FORCE_INLINE reference       at(size_type offset)       { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
         AZ_FORCE_INLINE const_reference operator[](size_type offset) const { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }
         AZ_FORCE_INLINE reference       operator[](size_type offset)       { return *iterator(AZSTD_CHECKED_ITERATOR_2(iterator, m_firstOffset + offset, this)); }


### PR DESCRIPTION
## What does this PR do?

This PR adds a missing dereference operator in the body of the function `AZStd::deque::at(size_t)`.

## How was this PR tested?

Try to use the function `deque::at(size_t) const`, which does not compile without this PR.
