### PR TITLE
Ensure for-each loops with AZ::RPI::Pass::m_attachmentBindings use the correct attachment binding count

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -448,10 +448,7 @@ namespace AZ
             const Name PipelineGlobalKeyword{"PipelineGlobal"};
 
             // List of input, output and input/output attachment bindings
-            // [GFX TODO][GHI-18438] Using a deque here that is not cleared, since pointers are held to the bindings for connections and are
-            // not expected to be changed even during a rebuild
-            int m_attachmentBindingsSize{ 0 };
-            AZStd::deque<PassAttachmentBinding> m_attachmentBindings;
+            PassAttachmentBindingList m_attachmentBindings;
 
             // List of attachments owned by this pass.
             // It includes both transient attachments and imported attachments

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -215,9 +215,41 @@ namespace AZ
             Ptr<PassAttachment> m_originalAttachment = nullptr;
         };
 
-        using PassAttachmentBindingList = AZStd::deque<PassAttachmentBinding>;
-        using PassAttachmentBindingListView = const AZStd::deque<PassAttachmentBinding>;
+        //! A convenience class for storing pass attachment bindings which ensures existing pointers to already added pass attachment
+        //! bindings are not invalidated when new pass attachment bindings are added, as well as ensuring pass attachment bindings are
+        //! stored at the same addresses when a pass is rebuilt.
+        //! @see [GFX TODO][GHI-18438]
+        class ATOM_RPI_PUBLIC_API PassAttachmentBindingList final
+        {
+            using ContainerType = AZStd::deque<PassAttachmentBinding>;
+
+        public:
+            using size_type = ContainerType::size_type;
+            using iterator = ContainerType::iterator;
+            using const_iterator = ContainerType::const_iterator;
+
+            // clang-format off
+            size_type size()  const noexcept { return m_attachmentBindingCount; }
+            bool      empty() const noexcept { return size() == 0; }
+            PassAttachmentBinding&       operator[](size_type index)       { return m_attachmentBindings[index]; }
+            const PassAttachmentBinding& operator[](size_type index) const { return m_attachmentBindings[index]; }
+            iterator       begin()        noexcept { return m_attachmentBindings.begin(); }
+            iterator       end()          noexcept { return m_attachmentBindings.begin() + m_attachmentBindingCount; }
+            const_iterator begin()  const noexcept { return m_attachmentBindings.begin(); }
+            const_iterator end()    const noexcept { return m_attachmentBindings.begin() + m_attachmentBindingCount; }
+            const_iterator cbegin() const noexcept { return m_attachmentBindings.cbegin(); }
+            const_iterator cend()   const noexcept { return m_attachmentBindings.cbegin() + m_attachmentBindingCount; }
+            // clang-format on
+
+            void push_back(const PassAttachmentBinding& attachmentBinding);
+            void clear();
+
+        private:
+            ContainerType m_attachmentBindings;
+            size_type m_attachmentBindingCount{ 0 };
+        };
+
+        using PassAttachmentBindingListView = const PassAttachmentBindingList&;
 
     }   // namespace RPI
-
 }   // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -96,10 +96,10 @@ namespace AZ
                 GetOutputCount());
 
             AZ_Assert(
-                (m_attachmentBindingsSize == 2) || (m_inputOutputCopy && m_attachmentBindingsSize == 1),
+                (m_attachmentBindings.size() == 2) || (m_inputOutputCopy && m_attachmentBindings.size() == 1),
                 "CopyPass must have exactly 2 bindings: 1 input and 1 output. %s has %d bindings.",
                 GetPathName().GetCStr(),
-                m_attachmentBindingsSize);
+                m_attachmentBindings.size());
 
             bool sameDevice = (m_data.m_sourceDeviceIndex == -1 && m_data.m_destinationDeviceIndex == -1) ||
                 m_data.m_sourceDeviceIndex == m_data.m_destinationDeviceIndex;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -404,5 +404,27 @@ namespace AZ
             m_originalAttachment.reset();
         }
 
+        void PassAttachmentBindingList::push_back(const PassAttachmentBinding& attachmentBinding)
+        {
+            if (m_attachmentBindingCount < m_attachmentBindings.size())
+            {
+                m_attachmentBindings[m_attachmentBindingCount] = attachmentBinding;
+            }
+            else
+            {
+                m_attachmentBindings.push_back(attachmentBinding);
+            }
+            ++m_attachmentBindingCount;
+        }
+
+        void PassAttachmentBindingList::clear()
+        {
+            // Clear all entries but do not clear the underlying container itself. @see [GFX TODO][GHI-18438]
+            for (auto& attachmentBinding : *this)
+            {
+                attachmentBinding.Clear();
+            }
+            m_attachmentBindingCount = 0;
+        }
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -83,9 +83,10 @@ namespace AZ
                 ReplaceSubpassInputs(RHI::SubpassInputSupportType::None);
             }
 
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
+            int slotIndex = -1;
+            for (const auto& binding : m_attachmentBindings)
             {
-                const PassAttachmentBinding& binding = m_attachmentBindings[slotIndex];
+                slotIndex++;
 
                 if (!binding.GetAttachment())
                 {
@@ -179,9 +180,8 @@ namespace AZ
         {
             RHI::MultisampleState outputMultiSampleState;
             bool wasSet = false;
-            for (size_t slotIndex = 0; slotIndex < m_attachmentBindingsSize; ++slotIndex)
+            for (const auto& binding : m_attachmentBindings)
             {
-                const PassAttachmentBinding& binding = m_attachmentBindings[slotIndex];
                 if (binding.m_slotType != PassSlotType::Output && binding.m_slotType != PassSlotType::InputOutput)
                 {
                     continue;


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new `PassAttachmentBindingList` class which is used instead of the (`int m_attachmentBindingsSize`,`AZStd::deque<PassAttachmentBinding> m_attachmentBindings`)-pair to store pass attachment bindings with the same guarantees about pointer validity as before.

I introduced this class since the original approach does not guard against iteration over `m_attachmentBindings`, which is not allowed since it contains only valid entries in the range [0..`m_attachmentBindingsSize`]. In the original [PR18673](https://github.com/o3de/o3de/pull/18673) some instances of this iteration were missed, which were fixed in [PR18698](https://github.com/o3de/o3de/pull/18698); and now I found some more instances where such illegal iterations are still present (eg. in `RenderPass::InitializeInternal()`), which lead to errors when rebuilding passes in some cases.

Therefore, I introduced this class, which does not require usages of `m_attachmentBindings` in derived pass classes to be updated, which eliminates the potential for this error entirely.

## How was this PR tested?

The errors when rebuilding passes (from asserts in RenderPass::InitializeInternal()) no longer occur with this PR.
Run the editor with some small test scenes, test some samples in AtomSampleViewer.
