### PR TITLE
Add missing include in DX12/ShaderResourceGroupPool.h

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderResourceGroupPool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderResourceGroupPool.h
@@ -9,10 +9,10 @@
 
 #include <Atom/RHI/DeviceShaderResourceGroupPool.h>
 #include <Atom/RHI/FrameEventBus.h>
+#include <AtomCore/std/containers/small_vector.h>
 #include <RHI/Descriptor.h>
 #include <RHI/MemorySubAllocator.h>
 #include <RHI/ShaderResourceGroup.h>
-
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

This PR adds a missing include in `RHI/DX12/.../ShaderResourceGroupPool.h`, which fixes a compile error when building the engine on Windows without unity build.

## How was this PR tested?

Compile with `-DLY_UNITY_BUILD=OFF` on Windows.
