### PR TITLE
Rename AZ::Log2 function to "RequiredBitsForValue"

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/MathUtils.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathUtils.h
@@ -72,8 +72,8 @@ namespace AZ
         return (testValue & (testValue - 1)) == 0;
     }
 
-    //! Calculates at compile-time the integral log base 2 of the input value.
-    constexpr uint32_t Log2(uint64_t maxValue)
+    //! Calculates at compile-time the number of bits required to represent the given max value.
+    constexpr uint32_t RequiredBitsForValue(uint64_t maxValue)
     {
         uint32_t bits = 0;
         do

--- a/Code/Framework/AzNetworking/AzNetworking/DataStructures/FixedSizeBitset.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/DataStructures/FixedSizeBitset.inl
@@ -85,8 +85,8 @@ namespace AzNetworking
     inline void FixedSizeBitset<SIZE, ElementType>::SetBit(uint32_t index, bool value)
     {
         AZ_Assert(index < SIZE, "Out of bounds access (requested %u, size %u)", index, SIZE);
-        constexpr uint32_t ElementTypeBitsLogTwo = AZ::Log2(ElementTypeBits - 1);
-        const uint32_t    element = index >> ElementTypeBitsLogTwo;
+        constexpr uint32_t ElementTypeBitCount = AZ::RequiredBitsForValue(ElementTypeBits - 1);
+        const uint32_t    element = index >> ElementTypeBitCount;
         const ElementType offset  = index &  (ElementTypeBits - 1);
         const ElementType mask    = static_cast<ElementType>(0x01) << offset;
         const ElementType current = m_container[element];
@@ -97,8 +97,8 @@ namespace AzNetworking
     inline bool FixedSizeBitset<SIZE, ElementType>::GetBit(uint32_t index) const
     {
         AZ_Assert(index < SIZE, "Out of bounds access (requested %u, size %u)", index, SIZE);
-        constexpr uint32_t ElementTypeBitsLogTwo = AZ::Log2(ElementTypeBits - 1);
-        const uint32_t    element = index >> ElementTypeBitsLogTwo;
+        constexpr uint32_t ElementTypeBitCount = AZ::RequiredBitsForValue(ElementTypeBits - 1);
+        const uint32_t    element = index >> ElementTypeBitCount;
         const ElementType offset  = index &  (ElementTypeBits - 1);
         return (static_cast<ElementType>(m_container[element] >> offset) & static_cast<ElementType>(0x01)) ? true : false;
     }

--- a/Code/Framework/AzNetworking/AzNetworking/DataStructures/RingBufferBitset.h
+++ b/Code/Framework/AzNetworking/AzNetworking/DataStructures/RingBufferBitset.h
@@ -23,7 +23,7 @@ namespace AzNetworking
     {
     public:
 
-        static constexpr uint32_t NumBitsetChunkedBits = AZ::Log2(BitsetChunk(~0));
+        static constexpr uint32_t NumBitsetChunkedBits = AZ::RequiredBitsForValue(BitsetChunk(~0));
         static constexpr uint32_t RingbufferContainerSize = SIZE / NumBitsetChunkedBits;
         static_assert((SIZE % NumBitsetChunkedBits) == 0, "RingbufferBitset must be a multiple of NumBitsetChunkedBits");
 

--- a/Code/Framework/AzNetworking/AzNetworking/DataStructures/RingBufferBitset.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/DataStructures/RingBufferBitset.inl
@@ -122,14 +122,14 @@ namespace AzNetworking
     template <typename TYPE>
     inline bool GetBitHelper(TYPE element, uint32_t bitIndex)
     {
-        AZ_Assert(bitIndex < AZ::Log2(TYPE(~0)), "Out of bounds access (requested %u, size %u)", bitIndex, AZ::Log2(TYPE(~0)));
+        AZ_Assert(bitIndex < AZ::RequiredBitsForValue(TYPE(~0)), "Out of bounds access (requested %u, size %u)", bitIndex, AZ::RequiredBitsForValue(TYPE(~0)));
         return ((element >> bitIndex) & 0x01) ? true : false;
     }
 
     template <typename TYPE>
     inline void SetBitHelper(TYPE &element, uint32_t bitIndex, bool value)
     {
-        AZ_Assert(bitIndex < AZ::Log2(TYPE(~0)), "Out of bounds access (requested %u, size %u)", bitIndex, AZ::Log2(TYPE(~0)));
+        AZ_Assert(bitIndex < AZ::RequiredBitsForValue(TYPE(~0)), "Out of bounds access (requested %u, size %u)", bitIndex, AZ::RequiredBitsForValue(TYPE(~0)));
         const TYPE mask = TYPE(0x01 << bitIndex);
         element = (value) ? (element | mask) : (element & (TYPE)(~mask));
     }


### PR DESCRIPTION
## What does this PR do?

This PR renames the function `AZ::Log2(uint64_t maxValue)` to `AZ::RequiredBitsForValue(uint64_t maxValue)`, since this what the function actually calculates (see #18653). The new function name is derived from the `RequiredBytesForValue<MAX_VALUE>()` function a few lines further down in the same file.

## How was this PR tested?

AR
