### PR TITLE
Move Aftermath crash tracker into namespaces

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
@@ -15,278 +15,258 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 
 #if defined(USE_NSIGHT_AFTERMATH)   // To enable nsight aftermath, download and install Nsight AfterMath and add 'ATOM_AFTERMATH_PATH=%path_to_the_install_folder%' to environment variables
-GpuCrashTracker::~GpuCrashTracker()
+namespace AZ::DX12
 {
-    // If initialized, disable GPU crash dumps
-    if (m_initialized)
+    GpuCrashTracker::~GpuCrashTracker()
     {
-        GFSDK_Aftermath_DisableGpuCrashDumps();
-    }
-}
-
-void GpuCrashTracker::AddContext(GFSDK_Aftermath_ContextHandle cntxHndl)
-{
-    m_contextHandles.push_back(cntxHndl);
-}
-
-void GpuCrashTracker::EnableGPUCrashDumps()
-{
-    // Enable GPU crash dumps and set up the callbacks for crash dump notifications,
-    // shader debug information notifications, and providing additional crash
-    // dump description data.Only the crash dump callback is mandatory. The other two
-    // callbacks are optional and can be omitted, by passing nullptr, if the corresponding
-    // functionality is not used.
-    // The DeferDebugInfoCallbacks flag enables caching of shader debug information data
-    // in memory. If the flag is set, ShaderDebugInfoCallback will be called only
-    // in the event of a crash, right before GpuCrashDumpCallback. If the flag is not set,
-    // ShaderDebugInfoCallback will be called for every shader that is compiled.
-    GFSDK_Aftermath_Result result = GFSDK_Aftermath_EnableGpuCrashDumps(
-        GFSDK_Aftermath_Version_API,
-        GFSDK_Aftermath_GpuCrashDumpWatchedApiFlags_DX,
-        GFSDK_Aftermath_GpuCrashDumpFeatureFlags_DeferDebugInfoCallbacks, // Let the Nsight Aftermath library cache shader debug information.
-        GpuCrashDumpCallback,                                             // Register callback for GPU crash dumps.
-        ShaderDebugInfoCallback,                                          // Register callback for shader debug information.
-        CrashDumpDescriptionCallback,                                     // Register callback for GPU crash dump description.
-        ResolveMarkerCallback,                                            // Register callback for mark resolution
-        this);                                                           // Set the GpuCrashTracker object as user data for the above callbacks.
-    
-    m_initialized = GFSDK_Aftermath_SUCCEED(result);
-
-    char executableFolder[AZ::IO::MaxPathLength];
-    AZ::Utils::GetExecutableDirectory(executableFolder, AZ::IO::MaxPathLength);
-    m_executableFolder = executableFolder;
-    m_projectName = AZ::Utils::GetProjectName();
-}
-
-void GpuCrashTracker::OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
-{
-    if (!m_initialized)
-    {
-        return;
+        // If initialized, disable GPU crash dumps
+        if (m_initialized)
+        {
+            GFSDK_Aftermath_DisableGpuCrashDumps();
+        }
     }
 
-    // Make sure only one thread at a time...
-    AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
-    // Write to file for later in-depth analysis with Nsight Graphics.
-    WriteGpuCrashDumpToFile(pGpuCrashDump, gpuCrashDumpSize);
-}
-
-void GpuCrashTracker::OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize)
-{
-    if (!m_initialized)
+    void GpuCrashTracker::AddContext(GFSDK_Aftermath_ContextHandle cntxHndl)
     {
-        return;
-    }
-        
-    // Get shader debug information identifier
-    GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier = {};
-    if (GFSDK_Aftermath_SUCCEED(GFSDK_Aftermath_GetShaderDebugInfoIdentifier(
-        GFSDK_Aftermath_Version_API,
-        pShaderDebugInfo,
-        shaderDebugInfoSize,
-        &identifier)))
-    {
-        // Store information for decoding of GPU crash dumps with shader address mapping
-        // from within the application.
-        std::vector<uint8_t> data((uint8_t*)pShaderDebugInfo, (uint8_t*)pShaderDebugInfo + shaderDebugInfoSize);
-
-        // Write to file for later in-depth analysis of crash dumps with Nsight Graphics
-        WriteShaderDebugInformationToFile(identifier, pShaderDebugInfo, shaderDebugInfoSize);
-    }
-    else
-    {
-        AZ_TracePrintf("Aftermath", "Failed to get shader debug info\n");
-    }
-}
-
-void GpuCrashTracker::OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription)
-{
-    if (!m_initialized)
-    {
-        return;
+        m_contextHandles.push_back(cntxHndl);
     }
 
-    // Add some basic description about the crash. This is called after the GPU crash happens, but before
-    // the actual GPU crash dump callback. The provided data is included in the crash dump and can be
-    // retrieved using GFSDK_Aftermath_GpuCrashDump_GetDescription().
-    addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationName, m_projectName.c_str());
-    addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationVersion, "v1.0");
-    addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_UserDefined, "GPU crash related dump for nv aftermath");
-}
-
-void GpuCrashTracker::WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
-{
-    if (!m_initialized)
+    void GpuCrashTracker::EnableGPUCrashDumps()
     {
-        return;
+        // Enable GPU crash dumps and set up the callbacks for crash dump notifications,
+        // shader debug information notifications, and providing additional crash
+        // dump description data.Only the crash dump callback is mandatory. The other two
+        // callbacks are optional and can be omitted, by passing nullptr, if the corresponding
+        // functionality is not used.
+        // The DeferDebugInfoCallbacks flag enables caching of shader debug information data
+        // in memory. If the flag is set, ShaderDebugInfoCallback will be called only
+        // in the event of a crash, right before GpuCrashDumpCallback. If the flag is not set,
+        // ShaderDebugInfoCallback will be called for every shader that is compiled.
+        GFSDK_Aftermath_Result result = GFSDK_Aftermath_EnableGpuCrashDumps(
+            GFSDK_Aftermath_Version_API,
+            GFSDK_Aftermath_GpuCrashDumpWatchedApiFlags_DX,
+            GFSDK_Aftermath_GpuCrashDumpFeatureFlags_DeferDebugInfoCallbacks, // Let the Nsight Aftermath library cache shader debug
+                                                                              // information.
+            GpuCrashDumpCallback, // Register callback for GPU crash dumps.
+            ShaderDebugInfoCallback, // Register callback for shader debug information.
+            CrashDumpDescriptionCallback, // Register callback for GPU crash dump description.
+            ResolveMarkerCallback, // Register callback for mark resolution
+            this); // Set the GpuCrashTracker object as user data for the above callbacks.
+
+        m_initialized = GFSDK_Aftermath_SUCCEED(result);
+
+        char executableFolder[AZ::IO::MaxPathLength];
+        AZ::Utils::GetExecutableDirectory(executableFolder, AZ::IO::MaxPathLength);
+        m_executableFolder = executableFolder;
+        m_projectName = AZ::Utils::GetProjectName();
     }
-    // Create a GPU crash dump decoder object for the GPU crash dump.
-    GFSDK_Aftermath_GpuCrashDump_Decoder decoder = {};
-    GFSDK_Aftermath_Result result = GFSDK_Aftermath_GpuCrashDump_CreateDecoder(
-        GFSDK_Aftermath_Version_API,
-        pGpuCrashDump,
-        gpuCrashDumpSize,
-        &decoder);
-    AssertOnError(result);
 
-    // Use the decoder object to read basic information, like application
-    // name, PID, etc. from the GPU crash dump.
-    GFSDK_Aftermath_GpuCrashDump_BaseInfo baseInfo = {};
-    result = GFSDK_Aftermath_GpuCrashDump_GetBaseInfo(decoder, &baseInfo);
-    AssertOnError(result);
-
-     // Create a unique file name for writing the crash dump data to a file.
-    // Note: due to an Nsight Aftermath bug (will be fixed in an upcoming
-    // driver release) we may see redundant crash dumps. As a workaround,
-    // attach a unique count to each generated file name.
-    static int count = 0;
-    const AZStd::string baseFileName = AZStd::string::format("%s/%s-%i-%i", m_executableFolder.c_str(), m_projectName.c_str(), baseInfo.pid, ++count);
-
-    const AZStd::string crashDumpFileName = baseFileName + ".nv-gpudmp";
-    AZ::IO::SystemFile dumpFile;
-    dumpFile.Open(crashDumpFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
-    dumpFile.Write(static_cast<const char*>(pGpuCrashDump), gpuCrashDumpSize);
-    dumpFile.Close();
-
-    // Decode the crash dump to a JSON string.
-    // Step 1: Generate the JSON and get the size.
-    uint32_t jsonSize = 0;
-    result = GFSDK_Aftermath_GpuCrashDump_GenerateJSON(
-        decoder,
-        GFSDK_Aftermath_GpuCrashDumpDecoderFlags_ALL_INFO,
-        GFSDK_Aftermath_GpuCrashDumpFormatterFlags_NONE,
-        ShaderDebugInfoLookupCallback,
-        ShaderLookupCallback,
-        ShaderSourceDebugInfoLookupCallback,
-        this,
-        &jsonSize);
-    AssertOnError(result);
-    
-    // Step 2: Allocate a buffer and fetch the generated JSON.
-    AZStd::unique_ptr<char[]> json = AZStd::make_unique<char[]>(jsonSize);
-    result = GFSDK_Aftermath_GpuCrashDump_GetJSON(
-        decoder,
-        jsonSize,
-        json.get());
-    AssertOnError(result);
-
-    // Write the the crash dump data as JSON to a file.
-    const AZStd::string jsonFileName = crashDumpFileName + ".json";
-    AZ::IO::SystemFile jsonFile;
-    jsonFile.Open(jsonFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
-    jsonFile.Write(json.get(), jsonSize - 1);
-    jsonFile.Close();
-
-    // Destroy the GPU crash dump decoder object.
-    result = GFSDK_Aftermath_GpuCrashDump_DestroyDecoder(decoder);
-    AssertOnError(result);
-}
-
-void GpuCrashTracker::WriteShaderDebugInformationToFile(
-    GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier,
-    const void* pShaderDebugInfo,
-    const uint32_t shaderDebugInfoSize)
-{
-    if (!m_initialized)
+    void GpuCrashTracker::OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
     {
-        return;
+        if (!m_initialized)
+        {
+            return;
+        }
+
+        // Make sure only one thread at a time...
+        AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
+        // Write to file for later in-depth analysis with Nsight Graphics.
+        WriteGpuCrashDumpToFile(pGpuCrashDump, gpuCrashDumpSize);
     }
-     // Create an unique file name from identifier
-    const AZStd::string fileName = AZStd::string::format("%s/%016llX-%016llX.nvdbg", m_executableFolder.c_str(), identifier.id[0], identifier.id[1]);
-    
-    AZ::IO::SystemFile shaderDebugFile;
-    shaderDebugFile.Open(fileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
-    shaderDebugFile.Write(pShaderDebugInfo, shaderDebugInfoSize);
-}
 
-void GpuCrashTracker::OnShaderDebugInfoLookup(
-    [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier,
-    [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const
-{
-    // [GFX TODO][ATOM-14662] Add support for debug shader symbols
-}
+    void GpuCrashTracker::OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize)
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
 
-void GpuCrashTracker::OnShaderLookup(
-    [[maybe_unused]] const GFSDK_Aftermath_ShaderBinaryHash& shaderHash,
-    [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
-{
-    // [GFX TODO][ATOM-14662] Add support for debug shader symbols
-}
+        // Get shader debug information identifier
+        GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier = {};
+        if (GFSDK_Aftermath_SUCCEED(GFSDK_Aftermath_GetShaderDebugInfoIdentifier(
+                GFSDK_Aftermath_Version_API, pShaderDebugInfo, shaderDebugInfoSize, &identifier)))
+        {
+            // Store information for decoding of GPU crash dumps with shader address mapping
+            // from within the application.
+            std::vector<uint8_t> data((uint8_t*)pShaderDebugInfo, (uint8_t*)pShaderDebugInfo + shaderDebugInfoSize);
 
-void GpuCrashTracker::OnResolveMarker(
-    [[maybe_unused]] const void* pMarker, [[maybe_unused]] const uint32_t markerDataSize, [[maybe_unused]] void** resolvedMarkerData, [[maybe_unused]] uint32_t* markerSize) const
-{
-}
+            // Write to file for later in-depth analysis of crash dumps with Nsight Graphics
+            WriteShaderDebugInformationToFile(identifier, pShaderDebugInfo, shaderDebugInfoSize);
+        }
+        else
+        {
+            AZ_TracePrintf("Aftermath", "Failed to get shader debug info\n");
+        }
+    }
 
-void GpuCrashTracker::OnShaderSourceDebugInfoLookup(
-    [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugName& shaderDebugName,
-    [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
-{
-    // [GFX TODO][ATOM-14662] Add support for debug shader symbols
-}
+    void GpuCrashTracker::OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription)
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
 
-void GpuCrashTracker::GpuCrashDumpCallback(
-    const void* pGpuCrashDump,
-    const uint32_t gpuCrashDumpSize,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnCrashDump(pGpuCrashDump, gpuCrashDumpSize);
-}
+        // Add some basic description about the crash. This is called after the GPU crash happens, but before
+        // the actual GPU crash dump callback. The provided data is included in the crash dump and can be
+        // retrieved using GFSDK_Aftermath_GpuCrashDump_GetDescription().
+        addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationName, m_projectName.c_str());
+        addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationVersion, "v1.0");
+        addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_UserDefined, "GPU crash related dump for nv aftermath");
+    }
 
-void GpuCrashTracker::ShaderDebugInfoCallback(
-    const void* pShaderDebugInfo,
-    const uint32_t shaderDebugInfoSize,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderDebugInfo(pShaderDebugInfo, shaderDebugInfoSize);
-}
+    void GpuCrashTracker::WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
+        // Create a GPU crash dump decoder object for the GPU crash dump.
+        GFSDK_Aftermath_GpuCrashDump_Decoder decoder = {};
+        GFSDK_Aftermath_Result result =
+            GFSDK_Aftermath_GpuCrashDump_CreateDecoder(GFSDK_Aftermath_Version_API, pGpuCrashDump, gpuCrashDumpSize, &decoder);
+        AssertOnError(result);
 
-void GpuCrashTracker::CrashDumpDescriptionCallback(
-    PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnDescription(addDescription);
-}
+        // Use the decoder object to read basic information, like application
+        // name, PID, etc. from the GPU crash dump.
+        GFSDK_Aftermath_GpuCrashDump_BaseInfo baseInfo = {};
+        result = GFSDK_Aftermath_GpuCrashDump_GetBaseInfo(decoder, &baseInfo);
+        AssertOnError(result);
 
-void GpuCrashTracker::ShaderDebugInfoLookupCallback(
-    const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier,
-    PFN_GFSDK_Aftermath_SetData setShaderDebugInfo,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderDebugInfoLookup(*pIdentifier, setShaderDebugInfo);
-}
+        // Create a unique file name for writing the crash dump data to a file.
+        // Note: due to an Nsight Aftermath bug (will be fixed in an upcoming
+        // driver release) we may see redundant crash dumps. As a workaround,
+        // attach a unique count to each generated file name.
+        static int count = 0;
+        const AZStd::string baseFileName =
+            AZStd::string::format("%s/%s-%i-%i", m_executableFolder.c_str(), m_projectName.c_str(), baseInfo.pid, ++count);
 
-void GpuCrashTracker::ShaderLookupCallback(
-    const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash,
-    PFN_GFSDK_Aftermath_SetData setShaderBinary,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderLookup(*pShaderHash, setShaderBinary);
-}
+        const AZStd::string crashDumpFileName = baseFileName + ".nv-gpudmp";
+        AZ::IO::SystemFile dumpFile;
+        dumpFile.Open(crashDumpFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+        dumpFile.Write(static_cast<const char*>(pGpuCrashDump), gpuCrashDumpSize);
+        dumpFile.Close();
 
-void GpuCrashTracker::ResolveMarkerCallback(
-    const void* pMarker,
-    const uint32_t markerDataSize,
-    void* pUserData,
-    void** resolvedMarkerData,
-    uint32_t* markerSize)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnResolveMarker(pMarker, markerDataSize, resolvedMarkerData, markerSize);
-}
+        // Decode the crash dump to a JSON string.
+        // Step 1: Generate the JSON and get the size.
+        uint32_t jsonSize = 0;
+        result = GFSDK_Aftermath_GpuCrashDump_GenerateJSON(
+            decoder,
+            GFSDK_Aftermath_GpuCrashDumpDecoderFlags_ALL_INFO,
+            GFSDK_Aftermath_GpuCrashDumpFormatterFlags_NONE,
+            ShaderDebugInfoLookupCallback,
+            ShaderLookupCallback,
+            ShaderSourceDebugInfoLookupCallback,
+            this,
+            &jsonSize);
+        AssertOnError(result);
 
-void GpuCrashTracker::ShaderSourceDebugInfoLookupCallback(
-    const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName,
-    PFN_GFSDK_Aftermath_SetData setShaderBinary,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderSourceDebugInfoLookup(*pShaderDebugName, setShaderBinary);
-}
+        // Step 2: Allocate a buffer and fetch the generated JSON.
+        AZStd::unique_ptr<char[]> json = AZStd::make_unique<char[]>(jsonSize);
+        result = GFSDK_Aftermath_GpuCrashDump_GetJSON(decoder, jsonSize, json.get());
+        AssertOnError(result);
+
+        // Write the the crash dump data as JSON to a file.
+        const AZStd::string jsonFileName = crashDumpFileName + ".json";
+        AZ::IO::SystemFile jsonFile;
+        jsonFile.Open(jsonFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+        jsonFile.Write(json.get(), jsonSize - 1);
+        jsonFile.Close();
+
+        // Destroy the GPU crash dump decoder object.
+        result = GFSDK_Aftermath_GpuCrashDump_DestroyDecoder(decoder);
+        AssertOnError(result);
+    }
+
+    void GpuCrashTracker::WriteShaderDebugInformationToFile(
+        GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier, const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize)
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
+        // Create an unique file name from identifier
+        const AZStd::string fileName =
+            AZStd::string::format("%s/%016llX-%016llX.nvdbg", m_executableFolder.c_str(), identifier.id[0], identifier.id[1]);
+
+        AZ::IO::SystemFile shaderDebugFile;
+        shaderDebugFile.Open(fileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+        shaderDebugFile.Write(pShaderDebugInfo, shaderDebugInfoSize);
+    }
+
+    void GpuCrashTracker::OnShaderDebugInfoLookup(
+        [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier,
+        [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const
+    {
+        // [GFX TODO][ATOM-14662] Add support for debug shader symbols
+    }
+
+    void GpuCrashTracker::OnShaderLookup(
+        [[maybe_unused]] const GFSDK_Aftermath_ShaderBinaryHash& shaderHash,
+        [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
+    {
+        // [GFX TODO][ATOM-14662] Add support for debug shader symbols
+    }
+
+    void GpuCrashTracker::OnResolveMarker(
+        [[maybe_unused]] const void* pMarker,
+        [[maybe_unused]] const uint32_t markerDataSize,
+        [[maybe_unused]] void** resolvedMarkerData,
+        [[maybe_unused]] uint32_t* markerSize) const
+    {
+    }
+
+    void GpuCrashTracker::OnShaderSourceDebugInfoLookup(
+        [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugName& shaderDebugName,
+        [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
+    {
+        // [GFX TODO][ATOM-14662] Add support for debug shader symbols
+    }
+
+    void GpuCrashTracker::GpuCrashDumpCallback(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnCrashDump(pGpuCrashDump, gpuCrashDumpSize);
+    }
+
+    void GpuCrashTracker::ShaderDebugInfoCallback(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderDebugInfo(pShaderDebugInfo, shaderDebugInfoSize);
+    }
+
+    void GpuCrashTracker::CrashDumpDescriptionCallback(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnDescription(addDescription);
+    }
+
+    void GpuCrashTracker::ShaderDebugInfoLookupCallback(
+        const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier, PFN_GFSDK_Aftermath_SetData setShaderDebugInfo, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderDebugInfoLookup(*pIdentifier, setShaderDebugInfo);
+    }
+
+    void GpuCrashTracker::ShaderLookupCallback(
+        const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderLookup(*pShaderHash, setShaderBinary);
+    }
+
+    void GpuCrashTracker::ResolveMarkerCallback(
+        const void* pMarker, const uint32_t markerDataSize, void* pUserData, void** resolvedMarkerData, uint32_t* markerSize)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnResolveMarker(pMarker, markerDataSize, resolvedMarkerData, markerSize);
+    }
+
+    void GpuCrashTracker::ShaderSourceDebugInfoLookupCallback(
+        const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderSourceDebugInfoLookup(*pShaderDebugName, setShaderBinary);
+    }
+} // namespace AZ::DX12
 #endif
 

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
@@ -16,154 +16,129 @@
 #if defined(USE_NSIGHT_AFTERMATH)
 #include <RHI/NsightAftermathHelpers.h>
 
-//! Implements GPU crash dump tracking using the Nsight
-//! Aftermath API. It lets you add markers which can be used to identify
-//! the scope that was executing on the GPU at the time of TDR/crash
-class GpuCrashTracker
+namespace AZ::DX12
 {
-public:
-    GpuCrashTracker() = default;
-    ~GpuCrashTracker();
+    //! Implements GPU crash dump tracking using the Nsight
+    //! Aftermath API. It lets you add markers which can be used to identify
+    //! the scope that was executing on the GPU at the time of TDR/crash
+    class GpuCrashTracker
+    {
+    public:
+        GpuCrashTracker() = default;
+        ~GpuCrashTracker();
 
-    //! Initialize the GPU crash dump tracker.
-    void EnableGPUCrashDumps();
+        //! Initialize the GPU crash dump tracker.
+        void EnableGPUCrashDumps();
 
-    //! Cache all context handles which can be used to check the status of them in case of a gpu crash/TDR
-    void AddContext(GFSDK_Aftermath_ContextHandle cntxHndl);
+        //! Cache all context handles which can be used to check the status of them in case of a gpu crash/TDR
+        void AddContext(GFSDK_Aftermath_ContextHandle cntxHndl);
 
-    //! Return the handles
-    const AZStd::vector<GFSDK_Aftermath_ContextHandle>& GetContextHandles() { return m_contextHandles; }
+        //! Return the handles
+        const AZStd::vector<GFSDK_Aftermath_ContextHandle>& GetContextHandles()
+        {
+            return m_contextHandles;
+        }
 
-private:
+    private:
+        //! *********************************************************
+        //! Callback handlers for GPU crash dumps and related data.
+        //!
 
-    //! *********************************************************
-    //! Callback handlers for GPU crash dumps and related data.
-    //!
+        //! Handler for GPU crash dump callbacks.
+        void OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
 
-    //! Handler for GPU crash dump callbacks.
-    void OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
+        //! Handler for shader debug information callbacks.
+        void OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize);
 
-    //! Handler for shader debug information callbacks.
-    void OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize);
+        //! Handler for GPU crash dump description callbacks.
+        void OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription);
 
-    //! Handler for GPU crash dump description callbacks.
-    void OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription);
+        //! *********************************************************
+        //! Helpers for writing a GPU crash dump and debug information
+        //! data to files.
+        //!
 
-    //! *********************************************************
-    //! Helpers for writing a GPU crash dump and debug information
-    //! data to files.
-    //!
+        //! Helper for writing a GPU crash dump to a file.
+        void WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
 
-    //! Helper for writing a GPU crash dump to a file.
-    void WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
+        //! Helper for writing shader debug information to a file
+        void WriteShaderDebugInformationToFile(
+            GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier, const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize);
 
-    //! Helper for writing shader debug information to a file
-    void WriteShaderDebugInformationToFile(
-        GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier,
-        const void* pShaderDebugInfo,
-        const uint32_t shaderDebugInfoSize);
+        //! *********************************************************
+        //! Helpers for decoding GPU crash dump to JSON.
+        //!
 
-    //! *********************************************************
-    //! Helpers for decoding GPU crash dump to JSON.
-    //!
+        //! Handler for shader debug information lookup callbacks.
+        //! This is used by the JSON decoder for mapping shader instruction
+        //! addresses to DXIL lines or HLSl source lines.
+        void OnShaderDebugInfoLookup(
+            const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier, PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const;
 
-    //! Handler for shader debug information lookup callbacks.
-    //! This is used by the JSON decoder for mapping shader instruction
-    //! addresses to DXIL lines or HLSl source lines.
-    void OnShaderDebugInfoLookup(
-        const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier,
-        PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const;
+        //! Handler for shader lookup callbacks.
+        //! This is used by the JSON decoder for mapping shader instruction
+        //! addresses to DXIL lines or HLSL source lines.
+        //! NOTE: If the application loads stripped shader binaries (-Qstrip_debug),
+        //! Aftermath will require access to both the stripped and the not stripped
+        //! shader binaries.
+        void OnShaderLookup(const GFSDK_Aftermath_ShaderBinaryHash& shaderHash, PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
 
-    //! Handler for shader lookup callbacks.
-    //! This is used by the JSON decoder for mapping shader instruction
-    //! addresses to DXIL lines or HLSL source lines.
-    //! NOTE: If the application loads stripped shader binaries (-Qstrip_debug),
-    //! Aftermath will require access to both the stripped and the not stripped
-    //! shader binaries.
-    void OnShaderLookup(
-        const GFSDK_Aftermath_ShaderBinaryHash& shaderHash,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
+        //! Marker resolve callback
+        void OnResolveMarker(const void* pMarker, const uint32_t markerDataSize, void** resolvedMarkerData, uint32_t* markerSize) const;
 
-    //! Marker resolve callback
-    void OnResolveMarker(
-        const void* pMarker,
-        const uint32_t markerDataSize,
-        void** resolvedMarkerData,
-        uint32_t* markerSize) const;
+        //! Handler for shader source debug info lookup callbacks.
+        //! This is used by the JSON decoder for mapping shader instruction addresses to
+        //! HLSL source lines, if the shaders used by the application were compiled with
+        //! separate debug info data files.
+        void OnShaderSourceDebugInfoLookup(
+            const GFSDK_Aftermath_ShaderDebugName& shaderDebugName, PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
 
+        //! *********************************************************
+        //! Static callback wrappers.
+        //!
 
-    //! Handler for shader source debug info lookup callbacks.
-    //! This is used by the JSON decoder for mapping shader instruction addresses to
-    //! HLSL source lines, if the shaders used by the application were compiled with
-    //! separate debug info data files.
-    void OnShaderSourceDebugInfoLookup(
-        const GFSDK_Aftermath_ShaderDebugName& shaderDebugName,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
+        //! GPU crash dump callback.
+        static void GpuCrashDumpCallback(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize, void* pUserData);
 
-    //! *********************************************************
-    //! Static callback wrappers.
-    //!
+        //! Shader debug information callback.
+        static void ShaderDebugInfoCallback(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize, void* pUserData);
 
-    //! GPU crash dump callback.
-    static void GpuCrashDumpCallback(
-        const void* pGpuCrashDump,
-        const uint32_t gpuCrashDumpSize,
-        void* pUserData);
+        //! GPU crash dump description callback.
+        static void CrashDumpDescriptionCallback(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription, void* pUserData);
 
-    //! Shader debug information callback.
-    static void ShaderDebugInfoCallback(
-        const void* pShaderDebugInfo,
-        const uint32_t shaderDebugInfoSize,
-        void* pUserData);
+        //! Shader debug information lookup callback.
+        static void ShaderDebugInfoLookupCallback(
+            const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier, PFN_GFSDK_Aftermath_SetData setShaderDebugInfo, void* pUserData);
 
-    //! GPU crash dump description callback.
-    static void CrashDumpDescriptionCallback(
-        PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription,
-        void* pUserData);
+        //! Shader lookup callback.
+        static void ShaderLookupCallback(
+            const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData);
 
-    //! Shader debug information lookup callback.
-    static void ShaderDebugInfoLookupCallback(
-        const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier,
-        PFN_GFSDK_Aftermath_SetData setShaderDebugInfo,
-        void* pUserData);
+        //! Marker resolve callback
+        static void ResolveMarkerCallback(
+            const void* pMarker, const uint32_t markerDataSize, void* pUserData, void** resolvedMarkerData, uint32_t* markerSize);
 
-    //! Shader lookup callback.
-    static void ShaderLookupCallback(
-        const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary,
-        void* pUserData);
+        //! Shader source debug info lookup callback.
+        static void ShaderSourceDebugInfoLookupCallback(
+            const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData);
 
-    //! Marker resolve callback
-    static void ResolveMarkerCallback(
-        const void* pMarker,
-        const uint32_t markerDataSize,
-        void* pUserData,
-        void** resolvedMarkerData,
-        uint32_t* markerSize);
+        //! *********************************************************
+        //! GPU crash tracker state.
+        //!
 
-    //! Shader source debug info lookup callback.
-    static void ShaderSourceDebugInfoLookupCallback(
-        const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary,
-        void* pUserData);
+        //! Is the GPU crash dump tracker initialized?
+        bool m_initialized = false;
 
-    //! *********************************************************
-    //! GPU crash tracker state.
-    //!
+        //! For thread-safe access of GPU crash tracker state.
+        mutable AZStd::mutex m_mutex;
 
-    //! Is the GPU crash dump tracker initialized?
-    bool m_initialized = false;
+        // cache executable folder and project name
+        AZStd::string m_executableFolder;
+        AZStd::string m_projectName;
 
-    //! For thread-safe access of GPU crash tracker state.
-    mutable AZStd::mutex m_mutex;
-
-    // cache executable folder and project name
-    AZStd::string m_executableFolder;
-    AZStd::string m_projectName;
-
-    //! Cache the handles which can be used to output the name of the last executing scope
-    AZStd::vector<GFSDK_Aftermath_ContextHandle> m_contextHandles;
-
-};
+        //! Cache the handles which can be used to output the name of the last executing scope
+        AZStd::vector<GFSDK_Aftermath_ContextHandle> m_contextHandles;
+    };
+} // namespace AZ::DX12
 
 #endif

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermath_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermath_Windows.cpp
@@ -73,7 +73,7 @@ namespace Aftermath
         // Create an Nsight Aftermath context handle for setting Aftermath event markers in this command list.
         GFSDK_Aftermath_Result result = GFSDK_Aftermath_DX12_CreateContextHandle(commandList, &aftermathCntHndl);
         AssertOnError(result);
-        static_cast<GpuCrashTracker*>(crashTracker)->AddContext(aftermathCntHndl);
+        static_cast<AZ::DX12::GpuCrashTracker*>(crashTracker)->AddContext(aftermathCntHndl);
         return static_cast<void*>(aftermathCntHndl);
 #else
         return nullptr;
@@ -83,7 +83,8 @@ namespace Aftermath
     void OutputLastScopeExecutingOnGPU([[maybe_unused]] void* crashTracker)
     {
 #if defined(USE_NSIGHT_AFTERMATH)
-        AZStd::vector<GFSDK_Aftermath_ContextHandle> cntxtHandles = static_cast<GpuCrashTracker*>(crashTracker)->GetContextHandles();
+        AZStd::vector<GFSDK_Aftermath_ContextHandle> cntxtHandles =
+            static_cast<AZ::DX12::GpuCrashTracker*>(crashTracker)->GetContextHandles();
         GFSDK_Aftermath_ContextData* outContextData = new GFSDK_Aftermath_ContextData[cntxtHandles.size()];
         GFSDK_Aftermath_Result result = GFSDK_Aftermath_GetData(static_cast<uint32_t>(cntxtHandles.size()), cntxtHandles.data(), outContextData);
         AssertOnError(result);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.cpp
@@ -15,269 +15,249 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 
 #if defined(USE_NSIGHT_AFTERMATH)   // To enable nsight aftermath, download and install Nsight AfterMath and add 'ATOM_AFTERMATH_PATH=%path_to_the_install_folder%' to environment variables (or alternatively set LY_AFTERMATH_PATH in CMake options)
-GpuCrashTracker::~GpuCrashTracker()
+namespace AZ::Vulkan
 {
-    // If initialized, disable GPU crash dumps
-    if (m_initialized)
+    GpuCrashTracker::~GpuCrashTracker()
     {
-        GFSDK_Aftermath_DisableGpuCrashDumps();
-    }
-}
-
-void GpuCrashTracker::EnableGPUCrashDumps()
-{
-    // Enable GPU crash dumps and set up the callbacks for crash dump notifications,
-    // shader debug information notifications, and providing additional crash
-    // dump description data.Only the crash dump callback is mandatory. The other two
-    // callbacks are optional and can be omitted, by passing nullptr, if the corresponding
-    // functionality is not used.
-    // The DeferDebugInfoCallbacks flag enables caching of shader debug information data
-    // in memory. If the flag is set, ShaderDebugInfoCallback will be called only
-    // in the event of a crash, right before GpuCrashDumpCallback. If the flag is not set,
-    // ShaderDebugInfoCallback will be called for every shader that is compiled.
-    GFSDK_Aftermath_Result result = GFSDK_Aftermath_EnableGpuCrashDumps(
-        GFSDK_Aftermath_Version_API,
-        GFSDK_Aftermath_GpuCrashDumpWatchedApiFlags_Vulkan,
-        GFSDK_Aftermath_GpuCrashDumpFeatureFlags_DeferDebugInfoCallbacks, // Let the Nsight Aftermath library cache shader debug information.
-        GpuCrashDumpCallback,                                             // Register callback for GPU crash dumps.
-        ShaderDebugInfoCallback,                                          // Register callback for shader debug information.
-        CrashDumpDescriptionCallback,                                     // Register callback for GPU crash dump description.
-        ResolveMarkerCallback,                                            // Register callback for mark resolution
-        this);                                                           // Set the GpuCrashTracker object as user data for the above callbacks.
-    
-    m_initialized = GFSDK_Aftermath_SUCCEED(result);
-
-    char executableFolder[AZ::IO::MaxPathLength];
-    AZ::Utils::GetExecutableDirectory(executableFolder, AZ::IO::MaxPathLength);
-    m_executableFolder = executableFolder;
-    m_projectName = AZ::Utils::GetProjectName();
-}
-
-void GpuCrashTracker::OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
-{
-    if (!m_initialized)
-    {
-        return;
+        // If initialized, disable GPU crash dumps
+        if (m_initialized)
+        {
+            GFSDK_Aftermath_DisableGpuCrashDumps();
+        }
     }
 
-    // Make sure only one thread at a time...
-    AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
-    // Write to file for later in-depth analysis with Nsight Graphics.
-    WriteGpuCrashDumpToFile(pGpuCrashDump, gpuCrashDumpSize);
-}
-
-void GpuCrashTracker::OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize)
-{
-    if (!m_initialized)
+    void GpuCrashTracker::EnableGPUCrashDumps()
     {
-        return;
+        // Enable GPU crash dumps and set up the callbacks for crash dump notifications,
+        // shader debug information notifications, and providing additional crash
+        // dump description data.Only the crash dump callback is mandatory. The other two
+        // callbacks are optional and can be omitted, by passing nullptr, if the corresponding
+        // functionality is not used.
+        // The DeferDebugInfoCallbacks flag enables caching of shader debug information data
+        // in memory. If the flag is set, ShaderDebugInfoCallback will be called only
+        // in the event of a crash, right before GpuCrashDumpCallback. If the flag is not set,
+        // ShaderDebugInfoCallback will be called for every shader that is compiled.
+        GFSDK_Aftermath_Result result = GFSDK_Aftermath_EnableGpuCrashDumps(
+            GFSDK_Aftermath_Version_API,
+            GFSDK_Aftermath_GpuCrashDumpWatchedApiFlags_Vulkan,
+            GFSDK_Aftermath_GpuCrashDumpFeatureFlags_DeferDebugInfoCallbacks, // Let the Nsight Aftermath library cache shader debug
+                                                                              // information.
+            GpuCrashDumpCallback, // Register callback for GPU crash dumps.
+            ShaderDebugInfoCallback, // Register callback for shader debug information.
+            CrashDumpDescriptionCallback, // Register callback for GPU crash dump description.
+            ResolveMarkerCallback, // Register callback for mark resolution
+            this); // Set the GpuCrashTracker object as user data for the above callbacks.
+
+        m_initialized = GFSDK_Aftermath_SUCCEED(result);
+
+        char executableFolder[AZ::IO::MaxPathLength];
+        AZ::Utils::GetExecutableDirectory(executableFolder, AZ::IO::MaxPathLength);
+        m_executableFolder = executableFolder;
+        m_projectName = AZ::Utils::GetProjectName();
     }
 
-    // Get shader debug information identifier
-    GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier = {};
-    if (GFSDK_Aftermath_SUCCEED(GFSDK_Aftermath_GetShaderDebugInfoIdentifier(
-        GFSDK_Aftermath_Version_API,
-        pShaderDebugInfo,
-        shaderDebugInfoSize,
-        &identifier)))
+    void GpuCrashTracker::OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
     {
-        // Write to file for later in-depth analysis of crash dumps with Nsight Graphics
-        WriteShaderDebugInformationToFile(identifier, pShaderDebugInfo, shaderDebugInfoSize);
-    }
-    else
-    {
-        AZ_TracePrintf("Aftermath", "Failed to get shader debug info\n");
-    }
-}
+        if (!m_initialized)
+        {
+            return;
+        }
 
-void GpuCrashTracker::OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription)
-{
-    if (!m_initialized)
-    {
-        return;
+        // Make sure only one thread at a time...
+        AZStd::unique_lock<AZStd::mutex> lock(m_mutex);
+        // Write to file for later in-depth analysis with Nsight Graphics.
+        WriteGpuCrashDumpToFile(pGpuCrashDump, gpuCrashDumpSize);
     }
 
-    // Add some basic description about the crash. This is called after the GPU crash happens, but before
-    // the actual GPU crash dump callback. The provided data is included in the crash dump and can be
-    // retrieved using GFSDK_Aftermath_GpuCrashDump_GetDescription().
-    addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationName, m_projectName.c_str());
-    addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationVersion, "v1.0");
-    addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_UserDefined, "GPU crash related dump for nv aftermath");
-}
-
-void GpuCrashTracker::WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
-{
-    if (!m_initialized)
+    void GpuCrashTracker::OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize)
     {
-        return;
+        if (!m_initialized)
+        {
+            return;
+        }
+
+        // Get shader debug information identifier
+        GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier = {};
+        if (GFSDK_Aftermath_SUCCEED(GFSDK_Aftermath_GetShaderDebugInfoIdentifier(
+                GFSDK_Aftermath_Version_API, pShaderDebugInfo, shaderDebugInfoSize, &identifier)))
+        {
+            // Write to file for later in-depth analysis of crash dumps with Nsight Graphics
+            WriteShaderDebugInformationToFile(identifier, pShaderDebugInfo, shaderDebugInfoSize);
+        }
+        else
+        {
+            AZ_TracePrintf("Aftermath", "Failed to get shader debug info\n");
+        }
     }
-    // Create a GPU crash dump decoder object for the GPU crash dump.
-    GFSDK_Aftermath_GpuCrashDump_Decoder decoder = {};
-    GFSDK_Aftermath_Result result = GFSDK_Aftermath_GpuCrashDump_CreateDecoder(
-        GFSDK_Aftermath_Version_API,
-        pGpuCrashDump,
-        gpuCrashDumpSize,
-        &decoder);
-    AssertOnError(result);
 
-    // Use the decoder object to read basic information, like application
-    // name, PID, etc. from the GPU crash dump.
-    GFSDK_Aftermath_GpuCrashDump_BaseInfo baseInfo = {};
-    result = GFSDK_Aftermath_GpuCrashDump_GetBaseInfo(decoder, &baseInfo);
-    AssertOnError(result);
-
-     // Create a unique file name for writing the crash dump data to a file.
-    // Note: due to an Nsight Aftermath bug (will be fixed in an upcoming
-    // driver release) we may see redundant crash dumps. As a workaround,
-    // attach a unique count to each generated file name.
-    static int count = 0;
-    const AZStd::string baseFileName = AZStd::string::format("%s/%s-%i-%i", m_executableFolder.c_str(), m_projectName.c_str(), baseInfo.pid, ++count);
-
-    const AZStd::string crashDumpFileName = baseFileName + ".nv-gpudmp";
-    AZ::IO::SystemFile dumpFile;
-    dumpFile.Open(crashDumpFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
-    dumpFile.Write(static_cast<const char*>(pGpuCrashDump), gpuCrashDumpSize);
-    dumpFile.Close();
-
-    // Decode the crash dump to a JSON string.
-    // Step 1: Generate the JSON and get the size.
-    uint32_t jsonSize = 0;
-    result = GFSDK_Aftermath_GpuCrashDump_GenerateJSON(
-        decoder,
-        GFSDK_Aftermath_GpuCrashDumpDecoderFlags_ALL_INFO,
-        GFSDK_Aftermath_GpuCrashDumpFormatterFlags_NONE,
-        ShaderDebugInfoLookupCallback,
-        ShaderLookupCallback,
-        ShaderSourceDebugInfoLookupCallback,
-        this,
-        &jsonSize);
-    AssertOnError(result);
-
-    // Step 2: Allocate a buffer and fetch the generated JSON.
-    AZStd::unique_ptr<char[]> json = AZStd::make_unique<char[]>(jsonSize);
-    result = GFSDK_Aftermath_GpuCrashDump_GetJSON(
-        decoder,
-        jsonSize,
-        json.get());
-    AssertOnError(result);
-
-    // Write the the crash dump data as JSON to a file.
-    const AZStd::string jsonFileName = crashDumpFileName + ".json";
-    AZ::IO::SystemFile jsonFile;
-    jsonFile.Open(jsonFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
-    jsonFile.Write(json.get(), jsonSize - 1);
-    jsonFile.Close();
-
-    // Destroy the GPU crash dump decoder object.
-    result = GFSDK_Aftermath_GpuCrashDump_DestroyDecoder(decoder);
-    AssertOnError(result);
-}
-
-void GpuCrashTracker::WriteShaderDebugInformationToFile(
-    GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier,
-    const void* pShaderDebugInfo,
-    const uint32_t shaderDebugInfoSize)
-{
-    if (!m_initialized)
+    void GpuCrashTracker::OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription)
     {
-        return;
+        if (!m_initialized)
+        {
+            return;
+        }
+
+        // Add some basic description about the crash. This is called after the GPU crash happens, but before
+        // the actual GPU crash dump callback. The provided data is included in the crash dump and can be
+        // retrieved using GFSDK_Aftermath_GpuCrashDump_GetDescription().
+        addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationName, m_projectName.c_str());
+        addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_ApplicationVersion, "v1.0");
+        addDescription(GFSDK_Aftermath_GpuCrashDumpDescriptionKey_UserDefined, "GPU crash related dump for nv aftermath");
     }
-     // Create an unique file name from identifier
-    const AZStd::string fileName = AZStd::string::format("%s/%016llX-%016llX.nvdbg", m_executableFolder.c_str(), identifier.id[0], identifier.id[1]);
-    
-    AZ::IO::SystemFile shaderDebugFile;
-    shaderDebugFile.Open(fileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
-    shaderDebugFile.Write(pShaderDebugInfo, shaderDebugInfoSize);
-}
 
-void GpuCrashTracker::OnShaderDebugInfoLookup(
-    [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier,
-    [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const
-{
-    // [GFX TODO][ATOM-14662] Add support for debug shader symbols
-}
+    void GpuCrashTracker::WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize)
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
+        // Create a GPU crash dump decoder object for the GPU crash dump.
+        GFSDK_Aftermath_GpuCrashDump_Decoder decoder = {};
+        GFSDK_Aftermath_Result result =
+            GFSDK_Aftermath_GpuCrashDump_CreateDecoder(GFSDK_Aftermath_Version_API, pGpuCrashDump, gpuCrashDumpSize, &decoder);
+        AssertOnError(result);
 
-void GpuCrashTracker::OnShaderLookup(
-    [[maybe_unused]] const GFSDK_Aftermath_ShaderBinaryHash& shaderHash,
-    [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
-{
-    // [GFX TODO][ATOM-14662] Add support for debug shader symbols
-}
+        // Use the decoder object to read basic information, like application
+        // name, PID, etc. from the GPU crash dump.
+        GFSDK_Aftermath_GpuCrashDump_BaseInfo baseInfo = {};
+        result = GFSDK_Aftermath_GpuCrashDump_GetBaseInfo(decoder, &baseInfo);
+        AssertOnError(result);
 
-void GpuCrashTracker::OnResolveMarker(
-    [[maybe_unused]] const void* pMarker, [[maybe_unused]] const uint32_t markerDataSize,[[maybe_unused]] void** resolvedMarkerData, [[maybe_unused]] uint32_t* markerSize) const
-{
-}
+        // Create a unique file name for writing the crash dump data to a file.
+        // Note: due to an Nsight Aftermath bug (will be fixed in an upcoming
+        // driver release) we may see redundant crash dumps. As a workaround,
+        // attach a unique count to each generated file name.
+        static int count = 0;
+        const AZStd::string baseFileName =
+            AZStd::string::format("%s/%s-%i-%i", m_executableFolder.c_str(), m_projectName.c_str(), baseInfo.pid, ++count);
 
-void GpuCrashTracker::OnShaderSourceDebugInfoLookup(
-    [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugName& shaderDebugName,
-    [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
-{
-    // [GFX TODO][ATOM-14662] Add support for debug shader symbols
-}
+        const AZStd::string crashDumpFileName = baseFileName + ".nv-gpudmp";
+        AZ::IO::SystemFile dumpFile;
+        dumpFile.Open(crashDumpFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+        dumpFile.Write(static_cast<const char*>(pGpuCrashDump), gpuCrashDumpSize);
+        dumpFile.Close();
 
-void GpuCrashTracker::GpuCrashDumpCallback(
-    const void* pGpuCrashDump,
-    const uint32_t gpuCrashDumpSize,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnCrashDump(pGpuCrashDump, gpuCrashDumpSize);
-}
+        // Decode the crash dump to a JSON string.
+        // Step 1: Generate the JSON and get the size.
+        uint32_t jsonSize = 0;
+        result = GFSDK_Aftermath_GpuCrashDump_GenerateJSON(
+            decoder,
+            GFSDK_Aftermath_GpuCrashDumpDecoderFlags_ALL_INFO,
+            GFSDK_Aftermath_GpuCrashDumpFormatterFlags_NONE,
+            ShaderDebugInfoLookupCallback,
+            ShaderLookupCallback,
+            ShaderSourceDebugInfoLookupCallback,
+            this,
+            &jsonSize);
+        AssertOnError(result);
 
-void GpuCrashTracker::ShaderDebugInfoCallback(
-    const void* pShaderDebugInfo,
-    const uint32_t shaderDebugInfoSize,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderDebugInfo(pShaderDebugInfo, shaderDebugInfoSize);
-}
+        // Step 2: Allocate a buffer and fetch the generated JSON.
+        AZStd::unique_ptr<char[]> json = AZStd::make_unique<char[]>(jsonSize);
+        result = GFSDK_Aftermath_GpuCrashDump_GetJSON(decoder, jsonSize, json.get());
+        AssertOnError(result);
 
-void GpuCrashTracker::CrashDumpDescriptionCallback(
-    PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnDescription(addDescription);
-}
+        // Write the the crash dump data as JSON to a file.
+        const AZStd::string jsonFileName = crashDumpFileName + ".json";
+        AZ::IO::SystemFile jsonFile;
+        jsonFile.Open(jsonFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+        jsonFile.Write(json.get(), jsonSize - 1);
+        jsonFile.Close();
 
-void GpuCrashTracker::ShaderDebugInfoLookupCallback(
-    const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier,
-    PFN_GFSDK_Aftermath_SetData setShaderDebugInfo,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderDebugInfoLookup(*pIdentifier, setShaderDebugInfo);
-}
+        // Destroy the GPU crash dump decoder object.
+        result = GFSDK_Aftermath_GpuCrashDump_DestroyDecoder(decoder);
+        AssertOnError(result);
+    }
 
-void GpuCrashTracker::ShaderLookupCallback(
-    const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash,
-    PFN_GFSDK_Aftermath_SetData setShaderBinary,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderLookup(*pShaderHash, setShaderBinary);
-}
+    void GpuCrashTracker::WriteShaderDebugInformationToFile(
+        GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier, const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize)
+    {
+        if (!m_initialized)
+        {
+            return;
+        }
+        // Create an unique file name from identifier
+        const AZStd::string fileName =
+            AZStd::string::format("%s/%016llX-%016llX.nvdbg", m_executableFolder.c_str(), identifier.id[0], identifier.id[1]);
 
-void GpuCrashTracker::ResolveMarkerCallback(
-    const void* pMarker,
-    const uint32_t markerDataSize,
-    void* pUserData,
-    void** resolvedMarkerData,
-    uint32_t* markerSize)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnResolveMarker(pMarker, markerDataSize, resolvedMarkerData, markerSize);
-}
+        AZ::IO::SystemFile shaderDebugFile;
+        shaderDebugFile.Open(fileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY);
+        shaderDebugFile.Write(pShaderDebugInfo, shaderDebugInfoSize);
+    }
 
-void GpuCrashTracker::ShaderSourceDebugInfoLookupCallback(
-    const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName,
-    PFN_GFSDK_Aftermath_SetData setShaderBinary,
-    void* pUserData)
-{
-    GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
-    pGpuCrashTracker->OnShaderSourceDebugInfoLookup(*pShaderDebugName, setShaderBinary);
-}
+    void GpuCrashTracker::OnShaderDebugInfoLookup(
+        [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier,
+        [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const
+    {
+        // [GFX TODO][ATOM-14662] Add support for debug shader symbols
+    }
+
+    void GpuCrashTracker::OnShaderLookup(
+        [[maybe_unused]] const GFSDK_Aftermath_ShaderBinaryHash& shaderHash,
+        [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
+    {
+        // [GFX TODO][ATOM-14662] Add support for debug shader symbols
+    }
+
+    void GpuCrashTracker::OnResolveMarker(
+        [[maybe_unused]] const void* pMarker,
+        [[maybe_unused]] const uint32_t markerDataSize,
+        [[maybe_unused]] void** resolvedMarkerData,
+        [[maybe_unused]] uint32_t* markerSize) const
+    {
+    }
+
+    void GpuCrashTracker::OnShaderSourceDebugInfoLookup(
+        [[maybe_unused]] const GFSDK_Aftermath_ShaderDebugName& shaderDebugName,
+        [[maybe_unused]] PFN_GFSDK_Aftermath_SetData setShaderBinary) const
+    {
+        // [GFX TODO][ATOM-14662] Add support for debug shader symbols
+    }
+
+    void GpuCrashTracker::GpuCrashDumpCallback(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnCrashDump(pGpuCrashDump, gpuCrashDumpSize);
+    }
+
+    void GpuCrashTracker::ShaderDebugInfoCallback(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderDebugInfo(pShaderDebugInfo, shaderDebugInfoSize);
+    }
+
+    void GpuCrashTracker::CrashDumpDescriptionCallback(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnDescription(addDescription);
+    }
+
+    void GpuCrashTracker::ShaderDebugInfoLookupCallback(
+        const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier, PFN_GFSDK_Aftermath_SetData setShaderDebugInfo, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderDebugInfoLookup(*pIdentifier, setShaderDebugInfo);
+    }
+
+    void GpuCrashTracker::ShaderLookupCallback(
+        const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderLookup(*pShaderHash, setShaderBinary);
+    }
+
+    void GpuCrashTracker::ResolveMarkerCallback(
+        const void* pMarker, const uint32_t markerDataSize, void* pUserData, void** resolvedMarkerData, uint32_t* markerSize)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnResolveMarker(pMarker, markerDataSize, resolvedMarkerData, markerSize);
+    }
+
+    void GpuCrashTracker::ShaderSourceDebugInfoLookupCallback(
+        const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData)
+    {
+        GpuCrashTracker* pGpuCrashTracker = reinterpret_cast<GpuCrashTracker*>(pUserData);
+        pGpuCrashTracker->OnShaderSourceDebugInfoLookup(*pShaderDebugName, setShaderBinary);
+    }
+} // namespace AZ::Vulkan
 #endif
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/RHI/NsightAftermathGpuCrashTracker_Windows.h
@@ -15,145 +15,117 @@
 #if defined(USE_NSIGHT_AFTERMATH)
 #include <RHI/NsightAftermathHelpers.h>
 
-//! Implements GPU crash dump tracking using the Nsight
-//! Aftermath API. It lets you add markers which can be used to identify
-//! the scope that was executing on the GPU at the time of TDR/crash
-class GpuCrashTracker
+namespace AZ::Vulkan
 {
-public:
-    GpuCrashTracker() = default;
-    ~GpuCrashTracker();
+    //! Implements GPU crash dump tracking using the Nsight
+    //! Aftermath API. It lets you add markers which can be used to identify
+    //! the scope that was executing on the GPU at the time of TDR/crash
+    class GpuCrashTracker
+    {
+    public:
+        GpuCrashTracker() = default;
+        ~GpuCrashTracker();
 
-    //! Initialize the GPU crash dump tracker.
-    void EnableGPUCrashDumps();
+        //! Initialize the GPU crash dump tracker.
+        void EnableGPUCrashDumps();
 
-private:
+    private:
+        //! *********************************************************
+        //! Callback handlers for GPU crash dumps and related data.
+        //!
 
-    //! *********************************************************
-    //! Callback handlers for GPU crash dumps and related data.
-    //!
+        //! Handler for GPU crash dump callbacks.
+        void OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
 
-    //! Handler for GPU crash dump callbacks.
-    void OnCrashDump(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
+        //! Handler for shader debug information callbacks.
+        void OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize);
 
-    //! Handler for shader debug information callbacks.
-    void OnShaderDebugInfo(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize);
+        //! Handler for GPU crash dump description callbacks.
+        void OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription);
 
-    //! Handler for GPU crash dump description callbacks.
-    void OnDescription(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription);
+        //! *********************************************************
+        //! Helpers for writing a GPU crash dump and debug information
+        //! data to files.
+        //!
 
-    //! *********************************************************
-    //! Helpers for writing a GPU crash dump and debug information
-    //! data to files.
-    //!
+        //! Helper for writing a GPU crash dump to a file.
+        void WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
 
-    //! Helper for writing a GPU crash dump to a file.
-    void WriteGpuCrashDumpToFile(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize);
+        //! Helper for writing shader debug information to a file
+        void WriteShaderDebugInformationToFile(
+            GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier, const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize);
 
-    //! Helper for writing shader debug information to a file
-    void WriteShaderDebugInformationToFile(
-        GFSDK_Aftermath_ShaderDebugInfoIdentifier identifier,
-        const void* pShaderDebugInfo,
-        const uint32_t shaderDebugInfoSize);
+        //! *********************************************************
+        //! Helpers for decoding GPU crash dump to JSON.
+        //!
 
-    //! *********************************************************
-    //! Helpers for decoding GPU crash dump to JSON.
-    //!
+        //! Handler for shader debug information lookup callbacks.
+        //! This is used by the JSON decoder for mapping shader instruction
+        //! addresses to SPIR-V lines or HLSl source lines.
+        void OnShaderDebugInfoLookup(
+            const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier, PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const;
 
-    //! Handler for shader debug information lookup callbacks.
-    //! This is used by the JSON decoder for mapping shader instruction
-    //! addresses to SPIR-V lines or HLSl source lines.
-    void OnShaderDebugInfoLookup(
-        const GFSDK_Aftermath_ShaderDebugInfoIdentifier& identifier,
-        PFN_GFSDK_Aftermath_SetData setShaderDebugInfo) const;
+        //! Handler for shader lookup callbacks.
+        //! This is used by the JSON decoder for mapping shader instruction
+        //! addresses to SPIR-V lines or HLSL source lines.
+        //! NOTE: If the application loads stripped shader binaries (-Qstrip_debug),
+        //! Aftermath will require access to both the stripped and the not stripped
+        //! shader binaries.
+        void OnShaderLookup(const GFSDK_Aftermath_ShaderBinaryHash& shaderHash, PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
 
-    //! Handler for shader lookup callbacks.
-    //! This is used by the JSON decoder for mapping shader instruction
-    //! addresses to SPIR-V lines or HLSL source lines.
-    //! NOTE: If the application loads stripped shader binaries (-Qstrip_debug),
-    //! Aftermath will require access to both the stripped and the not stripped
-    //! shader binaries.
-    void OnShaderLookup(
-        const GFSDK_Aftermath_ShaderBinaryHash& shaderHash,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
+        //! Marker resolve callback
+        void OnResolveMarker(const void* pMarker, const uint32_t markerDataSize, void** resolvedMarkerData, uint32_t* markerSize) const;
 
+        //! Handler for shader source debug info lookup callbacks.
+        //! This is used by the JSON decoder for mapping shader instruction addresses to
+        //! HLSL source lines, if the shaders used by the application were compiled with
+        //! separate debug info data files.
+        void OnShaderSourceDebugInfoLookup(
+            const GFSDK_Aftermath_ShaderDebugName& shaderDebugName, PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
 
-    //! Marker resolve callback
-    void OnResolveMarker(
-        const void* pMarker,
-        const uint32_t markerDataSize,
-        void** resolvedMarkerData,
-        uint32_t* markerSize) const;
+        //! *********************************************************
+        //! Static callback wrappers.
+        //!
 
+        //! GPU crash dump callback.
+        static void GpuCrashDumpCallback(const void* pGpuCrashDump, const uint32_t gpuCrashDumpSize, void* pUserData);
 
-    //! Handler for shader source debug info lookup callbacks.
-    //! This is used by the JSON decoder for mapping shader instruction addresses to
-    //! HLSL source lines, if the shaders used by the application were compiled with
-    //! separate debug info data files.
-    void OnShaderSourceDebugInfoLookup(
-        const GFSDK_Aftermath_ShaderDebugName& shaderDebugName,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary) const;
+        //! Shader debug information callback.
+        static void ShaderDebugInfoCallback(const void* pShaderDebugInfo, const uint32_t shaderDebugInfoSize, void* pUserData);
 
-    //! *********************************************************
-    //! Static callback wrappers.
-    //!
+        //! GPU crash dump description callback.
+        static void CrashDumpDescriptionCallback(PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription, void* pUserData);
 
-    //! GPU crash dump callback.
-    static void GpuCrashDumpCallback(
-        const void* pGpuCrashDump,
-        const uint32_t gpuCrashDumpSize,
-        void* pUserData);
+        //! Shader debug information lookup callback.
+        static void ShaderDebugInfoLookupCallback(
+            const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier, PFN_GFSDK_Aftermath_SetData setShaderDebugInfo, void* pUserData);
 
-    //! Shader debug information callback.
-    static void ShaderDebugInfoCallback(
-        const void* pShaderDebugInfo,
-        const uint32_t shaderDebugInfoSize,
-        void* pUserData);
+        //! Shader lookup callback.
+        static void ShaderLookupCallback(
+            const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData);
 
-    //! GPU crash dump description callback.
-    static void CrashDumpDescriptionCallback(
-        PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription addDescription,
-        void* pUserData);
+        //! Marker resolve callback
+        static void ResolveMarkerCallback(
+            const void* pMarker, const uint32_t markerDataSize, void* pUserData, void** resolvedMarkerData, uint32_t* markerSize);
 
-    //! Shader debug information lookup callback.
-    static void ShaderDebugInfoLookupCallback(
-        const GFSDK_Aftermath_ShaderDebugInfoIdentifier* pIdentifier,
-        PFN_GFSDK_Aftermath_SetData setShaderDebugInfo,
-        void* pUserData);
+        //! Shader source debug info lookup callback.
+        static void ShaderSourceDebugInfoLookupCallback(
+            const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName, PFN_GFSDK_Aftermath_SetData setShaderBinary, void* pUserData);
 
-    //! Shader lookup callback.
-    static void ShaderLookupCallback(
-        const GFSDK_Aftermath_ShaderBinaryHash* pShaderHash,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary,
-        void* pUserData);
+        //! *********************************************************
+        //! GPU crash tracker state.
+        //!
 
-    //! Marker resolve callback
-    static void ResolveMarkerCallback(
-        const void* pMarker,
-        const uint32_t markerDataSize,
-        void* pUserData,
-        void** resolvedMarkerData,
-        uint32_t* markerSize);
+        //! Is the GPU crash dump tracker initialized?
+        bool m_initialized = false;
 
-    //! Shader source debug info lookup callback.
-    static void ShaderSourceDebugInfoLookupCallback(
-        const GFSDK_Aftermath_ShaderDebugName* pShaderDebugName,
-        PFN_GFSDK_Aftermath_SetData setShaderBinary,
-        void* pUserData);
+        //! For thread-safe access of GPU crash tracker state.
+        mutable AZStd::mutex m_mutex;
 
-    //! *********************************************************
-    //! GPU crash tracker state.
-    //!
-
-    //! Is the GPU crash dump tracker initialized?
-    bool m_initialized = false;
-
-    //! For thread-safe access of GPU crash tracker state.
-    mutable AZStd::mutex m_mutex;
-
-    // cache executable folder and project name
-    AZStd::string m_executableFolder;
-    AZStd::string m_projectName;
-};
+        // cache executable folder and project name
+        AZStd::string m_executableFolder;
+        AZStd::string m_projectName;
+    };
+} // namespace AZ::Vulkan
 
 #endif


### PR DESCRIPTION
## What does this PR do?

Moved  the `GpuCrashTracker` class to `AZ::DX12`/`AZ::Vulkan` namespaces.

Previously the crash trackers for DX12 and Vulkan were in the global namespace leading to linker errors in some situations. E.g. when a Gem uses the APIs introduced in https://github.com/o3de/o3de/pull/18450 for both Vulkan and DX12. This Gem needs to link to to both RHI backends linking both crash trackers.

## How was this PR tested?

Tested on Windows with and without aftermath with a Gem that links to both Vulkan and DX12
