### PR TITLE
Fix RT-instanceMask for Terrain ray tracing meshes not being set

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -427,6 +427,8 @@ namespace Terrain
             float xyScale = (m_gridSize * m_sampleSpacing) * (1 << lodLevel);
             meshGroup.m_mesh.m_transform = AZ::Transform::CreateIdentity();
             meshGroup.m_mesh.m_nonUniformScale = AZ::Vector3(xyScale, xyScale, m_worldHeightBounds.m_max - m_worldHeightBounds.m_min);
+            meshGroup.m_mesh.m_instanceMask |=
+                static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::STATIC_MESH);
         };
 
         createMesh(rtSector.m_meshGroups[0], 0, totalIndexBufferByteCount);


### PR DESCRIPTION
## What does this PR do?

The TerrainMeshManager of the Terrain gem adds meshes to the ray tracing scene via `RayTracingFeatureProcessorInterface::AddMesh`, but does not set `m_instanceMask` on the `RayTracingFeatureProcessorInterface::Mesh` parameter (which has the default value 0), which leads to the terrain not being visible to ray tracing at all.

## How was this PR tested?

Create a small test scene with a terrain, and add the DebugRayTracing component. Without this PR, the terrain is not visible at all in the debug visualization; with this PR it shows up as expected.

* Left image: Terrain without ray tracing
* Middle image: RT debug visualization without this PR (only the groundplane and the shaderball are visible)
* Right image: RT debug visualization with this PR

![terrain-rt-small](https://github.com/user-attachments/assets/6a5a3edf-786b-4bbb-8e5c-56749fbeaf61)

Special thanks to @kh-huawei for finding this problem and for providing the test level.