### PR TITLE
Fixes intermittent test failures

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
@@ -162,7 +162,13 @@ def BasicEditorWorkflows_LevelEntityComponentCRUD():
 
         # 5) Verify the save/export of the level
         level_prefab_path = os.path.join(paths.products, "levels", lvl_name, f"{lvl_name}.spawnable")
-        success = await pyside_utils.wait_for_condition(lambda: os.path.exists(level_prefab_path), 10.0)
+
+        # In normal conditions this should be a few milliseconds but if AP is busy processing other files, or whatever
+        # it might take longer.  Make it a really long timer, like 30 minutes, so that if this does die, its 99.99%
+        # because it is broken, not because it is slow.  In normal tests, this should run instantly anyway and stops waiting
+        # as soon as its condition is met.
+        success = await pyside_utils.wait_for_condition(lambda: os.path.exists(level_prefab_path), 60.0 * 30.0)
+
         Report.result(Tests.saved_and_exported, success)
 
     run_test()

--- a/Code/Framework/AzCore/Tests/AZStd/String.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/String.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/std/string/wildcard.h>
 #include <AzCore/std/string/fixed_string.h>
 #include <AzCore/std/typetraits/is_convertible.h>
+#include <AzCore/Serialization/Locale.h> // for locale-independent string to float conversions
 
 // we need this for AZ_TEST_FLOAT compare
 #include <cinttypes>
@@ -629,6 +630,7 @@ namespace UnitTest
 
     TEST_F(String, Algorithms)
     {
+        AZ::Locale::ScopedSerializationLocale scopedLocale; // use the "C" locale for reading/writing floats with "." in them
         AZStd::string str = AZStd::string::format("%s %d", "BlaBla", 5);
         AZ_TEST_VALIDATE_STRING(str, 8);
 

--- a/Gems/LyShine/Code/Source/TextMarkup.cpp
+++ b/Gems/LyShine/Code/Source/TextMarkup.cpp
@@ -6,6 +6,7 @@
  *
  */
 #include "TextMarkup.h"
+#include <AzCore/Serialization/Locale.h>
 #include <AzCore/std/containers/stack.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/regex.h>
@@ -206,6 +207,7 @@ namespace
             float leftPadding = 0.0f;
             float rightPadding = 0.0f;
 
+            AZ::Locale::ScopedSerializationLocale scopedLocale; // use the "C" locale for stof()
             for (int i = 0, count = node->getNumAttributes(); i < count; ++i)
             {
                 const char* key = "";

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/Locale.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/regex.h>
@@ -406,6 +407,7 @@ namespace
             }
             else if (!pImageTag->m_height.empty())
             {
+                AZ::Locale::ScopedSerializationLocale scopedLocale; // use the "C" locale for reading/writing floats with "." in them
                 imageHeight = AZ::GetMax(0.0f, AZStd::stof(pImageTag->m_height));
             }
 

--- a/Gems/MotionMatching/Code/Source/CsvSerializers.cpp
+++ b/Gems/MotionMatching/Code/Source/CsvSerializers.cpp
@@ -326,6 +326,7 @@ namespace EMotionFX::MotionMatching
 
             auto LoadVector3FromString = [&valueTokens](size_t& valueIndex, AZ::Vector3& outVec)
             {
+                AZ::Locale::ScopedSerializationLocale scopedLocale; // use the "C" locale for reading/writing floats with "." in them
                 outVec.SetX(AZStd::stof(valueTokens[valueIndex + 0]));
                 outVec.SetY(AZStd::stof(valueTokens[valueIndex + 1]));
                 outVec.SetZ(AZStd::stof(valueTokens[valueIndex + 2]));


### PR DESCRIPTION
## What does this PR do?

Some conversions from string to float, or float to string for tests or for serialize/deserialize 

... were not being done in the invariant ("C") locale and would fail if on a machine that had comma set as the decimal separator.

## How was this PR tested?

Ran the CI build locally.
