### PR TITLE
Add material type name definition in material pipeline generated shader

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -531,6 +531,9 @@ namespace AZ
                 // the project would require a rebuild of the cache anyway.
                 const AZ::IO::PathView materialAzsliFilePathView{ materialAzsliFilePath };
                 generatedAzsl += AZStd::string::format("#define MATERIAL_TYPE_AZSLI_FILE_PATH \"%s\" \n", materialAzsliFilePathView.StringAsPosix().c_str());
+                auto materialTypeNameUpper = materialTypeName;
+                AZStd::to_upper(materialTypeNameUpper);
+                generatedAzsl += AZStd::string::format("#define MATERIAL_TYPE_%s 1 \n", materialTypeNameUpper.c_str());
                 generatedAzsl += AZStd::string::format("#include \"%s\" \n", shaderTemplate.m_azsli.c_str());
 
                 AZ::IO::Path shaderName = shaderTemplate.m_shader;


### PR DESCRIPTION
## What does this PR do?

Material type builder is now iteratively combines materialtypes-materialpipelines-shadertemplates and generated the shaders for all cases, and **all material types are going through the same `VertexAndPixel` logic**. When writing the shading logics inside a `XXXVertexAndPixel.azsli` for a customize material pipeline, the developer has no way to know what material type is going to compile with, if someone wants to customize the shading for some specific material types it becomes impossible, especially some material types are sharing the same lighting model.

This PR automatically adds a macro definition before including the shader template's shader:

e.g.:

standardpbr_customized/material/pipeline_customized/shader.azsl

```
#define MATERIAL_PIPELINE_OBJECT_SRG_MEMBERS \
#define MATERIAL_TYPE_AZSLI_FILE_PATH "Path/to/StandardPBR.azsli"
#define MATERIAL_TYPE_NAME_STANDARDPBR 1
#include "Path/to/StandardPBR_CustomizedShader.azsli"
```

therefore the shading codes have a chance to know some context of material type. It should not have any other side effects since it is merely adding a macro definition.

## How was this PR tested?

Tested in windows and CI build.
