### PR TITLE
Fix lua script initialization properties (fixes #10076)

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -352,8 +352,9 @@ namespace AzToolsFramework
         /*!
          * Completes the current undo batch.
          * It's still possible to resume the batch as long as it's still the most recent one.
+         * Returns false if the undo batch was discarded because it was empty, true in all other cases.
          */
-        virtual void EndUndoBatch() = 0;
+        virtual bool EndUndoBatch() = 0;
 
         /*!
          * \return true if the entity (or entities) can be edited/modified.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -1336,12 +1336,13 @@ namespace AzToolsFramework
         return root->Changed() || changed;
     }
 
-    void ToolsApplication::EndUndoBatch()
+    bool ToolsApplication::EndUndoBatch()
     {
+        bool resultValue = true;
         AZ_Assert(m_currentBatchUndo, "Cannot end batch - no batch current");
         if (!m_currentBatchUndo)
         {
-            return; // let's not crash just becuase there's a programmer error.
+            return false; // let's not crash just becuase there's a programmer error.
         }
 
         if (m_currentBatchUndo->GetParent())
@@ -1371,6 +1372,7 @@ namespace AzToolsFramework
             }
             else
             {
+                resultValue = false; // we discarded it because it was empty
                 delete m_currentBatchUndo;
             }
 
@@ -1379,6 +1381,7 @@ namespace AzToolsFramework
 #endif
             m_currentBatchUndo = nullptr;
         }
+        return resultValue;
     }
 
     void ToolsApplication::OnPrefabInstancePropagationBegin()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
@@ -95,7 +95,7 @@ namespace AzToolsFramework
         void FlushRedo() override;
         UndoSystem::URSequencePoint* BeginUndoBatch(const char* label) override;
         UndoSystem::URSequencePoint* ResumeUndoBatch(UndoSystem::URSequencePoint* token, const char* label) override;
-        void EndUndoBatch() override;
+        bool EndUndoBatch() override;
 
         bool IsEntityEditable(AZ::EntityId entityId) override;
         bool AreEntitiesEditable(const EntityIdList& entityIds) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
@@ -108,6 +108,8 @@ namespace AzToolsFramework
             AZ::Data::Asset<AZ::ScriptAsset> m_scriptAsset;
 
             AZStd::string m_customName;
+
+            AzToolsFramework::UndoSystem::URSequencePoint* m_undoPoint = nullptr;
         };
     } // namespace Component
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
@@ -78,7 +78,7 @@ namespace AzToolsFramework
                 float m_sortOrder; // Sort order of the property as defined by using the "order" attribute, by default the order is FLT_MAX which means alphabetical sort will be used
             };
 
-            void LoadProperties();
+            bool LoadProperties(); // returns true if properties have changed.
             void LoadProperties(AZ::ScriptDataContext& sdc, AzFramework::ScriptPropertyGroup& group);
             void RemovedOldProperties(AzFramework::ScriptPropertyGroup& group);
             void SortProperties(AzFramework::ScriptPropertyGroup& group);
@@ -108,8 +108,7 @@ namespace AzToolsFramework
             AZ::Data::Asset<AZ::ScriptAsset> m_scriptAsset;
 
             AZStd::string m_customName;
-
-            AzToolsFramework::UndoSystem::URSequencePoint* m_undoPoint = nullptr;
+            bool m_loadingNewScript = false;
         };
     } // namespace Component
 } // namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?
fixes 
https://github.com/o3de/o3de/issues/10076 

Script properties would not initialize properly the first time a script is assigned.  They are expected to read the "Properties" block and then create a copy of that block in the component, to use as a cache.

The problem is that scripts load asynchronously, and the properties block is only created later, once the script loads, which is not inside the user-initiated "undo redo" block caused by assigning the script, and thus, is not saved.

This error also affected any file that was saved in such a state.  This fix retroactively causes those situations to repair themselves when the level is opened and warns the user when the fix is applied so that they can save the level again to permanently fix it.

## How was this PR tested?

Used the assets attached to the issue report

1. Made sure it fixes the assets
2. Made sure it fixes the assets if they are a sub-prefab of the level
3. Made sure saving it fixes it
4. Made sure saving it when they are a sub prefab fixes it
5. Made sure that PUSHING the changes to the prefab fixes it everywhere the prefab is loaded
6. Made sure that it works with new script components getting new scripts without showing the warning
7. Made sure the warning ONLY pops up if its a legacy fixup (from case 1,2, above) and not during normal editor operation

Note that in the longer term I'd like to see a better fix that relates to the asset builder.