### PR TITLE
Fix error message condition about pass state in Pass::FrameBegin

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1485,7 +1485,7 @@ namespace AZ
                 return;
             }
 
-            AZ_Error("PassSystem", m_state == PassState::Idle,
+            AZ_Error("PassSystem", m_state == PassState::Idle || m_state == PassState::Queued,
                 "Pass::FrameBegin - Pass [%s] is attempting to render, and should be in the 'Idle' or 'Queued' state, but is in the '%s' state.",
                 m_path.GetCStr(), ToString(m_state).data());
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes an `AZ_Error` condition in `AZ::RPI::Pass::FrameBegin(...)` which checks if the pass is in the correct state. The condition only allows a pass to be in the `Idle` state, but the error message suggests `Queued` is also allowed. According to the discussion in #18752, the error message is correct and `Queued` is also allowed, so I changed the condition.

This was not a problem in the MainPipeline, but in a internal gem I was calling `Pass::QueueForBuildAndInitialization()` from `FeatureProcessor::Render`, which lead to this error message.

## How was this PR tested?

Tested using an internal gem, which ran into this error message. The same message does no longer occur, and as far as I can tell nothing else broke as a result.