### PR TITLE
MaterialPipeline assets can customize DrawSrg

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR.azsli
@@ -97,6 +97,20 @@ option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opa
         return output;
     }
 
+    // Added this version to make it compatible with the number of arguments in BasePBR.
+    // Avoids compilation errors for compute shaders, listed in a materialpipeline,
+    // that call EvaluateVertexGeometry().
+    VsOutput EvaluateVertexGeometry_StandardMultilayerPBR(
+        float3 position,
+        float3 normal,
+        float4 tangent,
+        float2 uv0_tiled,
+        float2 uv1_unwrapped,
+        uint instanceId)
+    {
+        return EvaluateVertexGeometry_StandardMultilayerPBR(position, normal, tangent, uv0_tiled, uv1_unwrapped, float3(0, 0, 0), instanceId, false);
+    }
+
     VsOutput EvaluateVertexGeometry_StandardMultilayerPBR(VsInput IN, VsSystemValues SV)
     {
         return EvaluateVertexGeometry_StandardMultilayerPBR(

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
@@ -427,7 +427,11 @@ void LtcQuadEvaluate(
 
             // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
             const float clearCoatSpecularF0 = 0.04;
+        #ifdef CS_SAMPLERS
+            float2 schlickCc = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoordsCc, 0).xy;
+        #else
             float2 schlickCc = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoordsCc).xy;
+        #endif
             float F = schlickCc.x * clearCoatSpecularF0 + (1.0 - clearCoatSpecularF0) * schlickCc.y;
             F *= surface.clearCoat.factor;
 
@@ -679,7 +683,11 @@ void LtcPolygonEvaluate(
 
             // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
             const float clearCoatSpecularF0 = 0.04;
+        #ifdef CS_SAMPLERS
+            float2 schlickCc = ltcAmpMatrix.SampleLevel(SceneSrg::LtcSampler, ltcCoordsCc, 0).xy;
+        #else
             float2 schlickCc = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoordsCc).xy;
+        #endif
             float F = clearCoatSpecularF0 * schlickCc.x + (1.0 - clearCoatSpecularF0) * schlickCc.y;
             F *= surface.clearCoat.factor;
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/ClearCoatInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/ClearCoatInput.azsli
@@ -49,7 +49,11 @@ void GetClearCoatInputs(Texture2D influenceMap, float2 influenceUV, real clearCo
         }
         else
         {
+        #ifdef CS_SAMPLERS
+            clearCoatFactor *= real(influenceMap.SampleLevel(mapSampler, influenceUV, 0).r);
+        #else
             clearCoatFactor *= real(influenceMap.Sample(mapSampler, influenceUV).r);
+        #endif
         }
     }
     
@@ -61,7 +65,11 @@ void GetClearCoatInputs(Texture2D influenceMap, float2 influenceUV, real clearCo
         }
         else
         {
+        #ifdef CS_SAMPLERS
+            roughness *= real(roughnessMap.SampleLevel(mapSampler, roughnessUV, 0).r);
+        #else
             roughness *= real(roughnessMap.Sample(mapSampler, roughnessUV).r);
+        #endif
         }
     }
     
@@ -74,7 +82,11 @@ void GetClearCoatInputs(Texture2D influenceMap, float2 influenceUV, real clearCo
         }
         else
         {
+        #ifdef CS_SAMPLERS
+            sampledValue = real2(normalMap.SampleLevel(mapSampler, normalUV, 0).xy);
+        #else
             sampledValue = real2(normalMap.Sample(mapSampler, normalUV).xy);
+        #endif
         }
         clearCoatNormal = GetWorldSpaceNormal(sampledValue.xy, normal, tangent, bitangent, uvMatrix, normalStrength);
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SubsurfaceInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SubsurfaceInput.azsli
@@ -20,7 +20,11 @@ real GetSubsurfaceInput(Texture2D map, sampler mapSampler, float2 uv, real surfa
         }
         else
         {
+        #ifdef CS_SAMPLERS
+            surfaceScatteringFactor *= real(map.SampleLevel(mapSampler, uv, 0).r);
+        #else
             surfaceScatteringFactor *= real(map.Sample(mapSampler, uv).r);
+        #endif
         }
     }
     return surfaceScatteringFactor;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Common.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MultilayerPBR/StandardMultilayerPBR_Common.azsli
@@ -199,7 +199,11 @@ real3 GetApplicableBlendMaskValues(LayerBlendSource blendSource, float2 blendMas
                 }
                 else
                 {
+                #ifdef CS_SAMPLERS
+                    blendSourceValues = real3(MaterialSrg::m_blendMaskTexture.SampleLevel(MaterialSrg::m_sampler, blendMaskUv, 0).rgb);
+                #else
                     blendSourceValues = real3(MaterialSrg::m_blendMaskTexture.Sample(MaterialSrg::m_sampler, blendMaskUv).rgb);
+                #endif
                 }
                 break;
             case LayerBlendSource::BlendMaskVertexColors:

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -319,6 +319,12 @@ namespace AZ
                 const RHI::DrawFilterMask materialPipelineFilter,
                 DispatchArgumentsSetupCB dispatchArgumentsSetupCB) const = 0;
 
+            //! Returns the DrawSrg from the first DrawItem that matches @drawListTag
+            //! and its material pipeline matches @materialPipelineMask.
+            //! The search is done only within the DrawItems of the subMesh identifiable by the tuple (@meshHandle, @lodIndex, @subMeshIndex). 
+            virtual Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(const MeshHandle& meshHandle, uint32_t lodIndex, uint32_t subMeshIndex,
+                RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) = 0;
+
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
@@ -289,6 +289,10 @@ namespace AZ
 
             MeshInstanceManager& GetMeshInstanceManager();
             bool IsMeshInstancingEnabled() const;
+
+            Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(const MeshHandle& meshHandle, uint32_t lodIndex, uint32_t subMeshIndex,
+                RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) override;
+
         private:
             MeshFeatureProcessor(const MeshFeatureProcessor&) = delete;
 

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli
@@ -18,6 +18,10 @@
 #define USE_DRAWSRG_MESHLOD_MESHINDEX 0
 #endif
 
+#ifndef MATERIAL_PIPELINE_DRAW_SRG_MEMBERS
+#define MATERIAL_PIPELINE_DRAW_SRG_MEMBERS
+#endif
+
 #if USE_CUSTOM_DRAW_SRG
 #else
 ShaderResourceGroup DrawSrg : SRG_PerDraw
@@ -34,6 +38,7 @@ ShaderResourceGroup DrawSrg : SRG_PerDraw
     {
         return (m_uvStreamTangentBitmask >> (4 * uvIndex)) & 0xF;
     }
+
+    MATERIAL_PIPELINE_DRAW_SRG_MEMBERS
 }
 #endif
-

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPipelineSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPipelineSourceData.h
@@ -66,9 +66,9 @@ namespace AZ
 
             // A list of members to be added to the Object SRG. For example, writing:
             // 
-            // "objectSrg": [
-            //     "float4 m_myCustomVar1",
-            //     "uint   m_myCustomVar2"
+            // "objectSrgAdditions": [
+            //     "float4 m_myCustomVar1;",
+            //     "uint   m_myCustomVar2;"
             // ],
             // 
             // in your .materialpipeline file will add m_myCustomVar1 and m_myCustomVar2
@@ -76,6 +76,19 @@ namespace AZ
             // NOTE: this feature currently only supports "type variableName" entries and
             // doesn't support arbitrary strings, which may cause shader compilation failure
             AZStd::vector<AZStd::string> m_objectSrgAdditions;
+
+            // A list of members to be added to the Draw SRG. For example, writing:
+            //
+            // "drawSrgAdditions": [
+            //     "float4 m_myCustomVar1;",
+            //     "uint   m_myCustomVar2;"
+            // ],
+            //
+            // in your .materialpipeline file will add m_myCustomVar1 and m_myCustomVar2
+            // to the DrawSrg of all materials rendered in your material pipeline.
+            // NOTE: this feature currently only supports "type variableName" entries and
+            // doesn't support arbitrary strings, which may cause shader compilation failure
+            AZStd::vector<AZStd::string> m_drawSrgAdditions;
 
             //! Relative path to a lua script to configure shader compilation
             AZStd::string m_pipelineScript;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -60,6 +60,8 @@ namespace AZ
             AZ_DEFAULT_COPY(MeshDrawPacket);
             AZ_DEFAULT_MOVE(MeshDrawPacket);
 
+            static Data::Instance<RPI::ShaderResourceGroup> InvalidSrg;
+
             bool Update(const Scene& parentScene, bool forceUpdate = false);
 
             RHI::DrawPacket* GetRHIDrawPacket() { return m_drawPacket.get(); }
@@ -84,6 +86,9 @@ namespace AZ
             const ShaderList& GetActiveShaderList() const { return m_activeShaders; }
 
             void DebugOutputShaderVariants();
+
+            //! Returns the DrawSrg from the DrawItem that corresponds to @drawItemIndex.
+            Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(uint32_t drawItemIndex);
 
         private:
             bool DoUpdate(const Scene& parentScene);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -75,6 +75,8 @@ namespace AZ
             /// Returns whether the group is currently queued for compilation.
             bool IsQueuedForCompile() const;
 
+            bool IsInitialized() const;
+
             /// Finds the shader input index from the shader input name for each type of resource.
             RHI::ShaderInputBufferIndex    FindShaderInputBufferIndex(const Name& name) const;
             RHI::ShaderInputImageIndex     FindShaderInputImageIndex(const Name& name) const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -399,13 +399,13 @@ namespace AZ
             const AZStd::vector<AZStd::string>& srgAdditionsFromMaterialPipelines,
             const AZStd::unordered_map<AZStd::string, uint32_t>& objectSrgAdditionsRedundancyMap)
         {
-            AZ_Warning(MaterialTypeBuilderName, false, "List of redundant additions to '%s':\n", srgName);
+            AZ_Printf(MaterialTypeBuilderName, "List of redundant additions to '%s':\n", srgName);
             for (const auto& addition : srgAdditionsFromMaterialPipelines)
             {
                 uint32_t count = objectSrgAdditionsRedundancyMap.at(addition);
                 if (count > 1)
                 {
-                    AZ_Warning(MaterialTypeBuilderName, false, "\t'%s' found in %u material pipelines:\n", addition.c_str(), count);
+                    AZ_Printf(MaterialTypeBuilderName, "\t'%s' found in %u material pipelines:\n", addition.c_str(), count);
                 }
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPipelineSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPipelineSourceData.cpp
@@ -34,11 +34,12 @@ namespace AZ
                     ;
 
                 serializeContext->Class<MaterialPipelineSourceData>()
-                    ->Version(4)    // Object Srg Additions
+                    ->Version(5)    // Draw Srg Additions
                     ->Field("shaderTemplates", &MaterialPipelineSourceData::m_shaderTemplates)
                     ->Field("runtime", &MaterialPipelineSourceData::m_runtimeControls)
                     ->Field("pipelineScript", &MaterialPipelineSourceData::m_pipelineScript)
                     ->Field("objectSrgAdditions", &MaterialPipelineSourceData::m_objectSrgAdditions)
+                    ->Field("drawSrgAdditions", &MaterialPipelineSourceData::m_drawSrgAdditions)
                     ;
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -21,6 +21,8 @@ namespace AZ
 {
     namespace RPI
     {
+        Data::Instance<RPI::ShaderResourceGroup> MeshDrawPacket::InvalidSrg;
+
         AZ_CVAR(bool,
             r_forceRootShaderVariantUsage,
             false,
@@ -243,6 +245,15 @@ namespace AZ
                 AZ_TracePrintf("MeshDrawPacket", "%d: %s", index++, variant.data());
             }
 #endif
+        }
+
+        Data::Instance<RPI::ShaderResourceGroup>& MeshDrawPacket::GetDrawSrg(uint32_t drawItemIndex)
+        {
+            if (drawItemIndex >= aznumeric_cast<uint32_t>(m_perDrawSrgs.size()))
+            {
+                return InvalidSrg;
+            }
+            return m_perDrawSrgs[drawItemIndex];
         }
 
         bool MeshDrawPacket::DoUpdate(const Scene& parentScene)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -140,6 +140,11 @@ namespace AZ
             return m_shaderResourceGroup->IsQueuedForCompile();
         }
 
+        bool ShaderResourceGroup::IsInitialized() const
+        {
+            return m_isInitialized;
+        }
+
         RHI::ShaderInputBufferIndex ShaderResourceGroup::FindShaderInputBufferIndex(const Name& name) const
         {
             return m_layout->FindShaderInputBufferIndex(name);


### PR DESCRIPTION
## What does this PR do?

This commit adds the ability to `*.materialpipeline` assets to add custom shader constants to DrawSrg.

The mechanism is implemented with json property `"drawSrgAdditions"`, which operationally works identical to the existing `"objectSrgAdditions"`.

Both consists as arrays of lines, where each line typically represents the data type and name of a shader constant that should be added to DrawSrg. Example:
```
"drawSrgAdditions": [
    "float4 m_vector;",
    "uint2 m_counters;"
]
```

Added API to MeshFeatureProcessor to query DrawSrgs from a given subMesh:
```
//! Returns the DrawSrg from the first DrawItem that matches @drawListTag
//! and its material pipeline matches @materialPipelineMask.
//! The search is done only within the DrawItems of the subMesh identifiable by the tuple (@meshHandle, @lodIndex, @subMeshIndex).
virtual Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(const MeshHandle& meshHandle, uint32_t lodIndex, uint32_t subMeshIndex,
    RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) = 0;
```

Added a few more `#ifdef CS_SAMPLERS` blocks in some Shaders to avoid compilation errors when using Compute shaders.

## How was this PR tested?

Validated on PC (Win11) and Quest3 with custom material pipeline. 
