### PR TITLE
(Cherry pick from Stab) Fix lua script initialization properties

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -352,8 +352,9 @@ namespace AzToolsFramework
         /*!
          * Completes the current undo batch.
          * It's still possible to resume the batch as long as it's still the most recent one.
+         * Returns false if the undo batch was discarded because it was empty, true in all other cases.
          */
-        virtual void EndUndoBatch() = 0;
+        virtual bool EndUndoBatch() = 0;
 
         /*!
          * \return true if the entity (or entities) can be edited/modified.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -1285,7 +1285,13 @@ namespace AzToolsFramework
 
     UndoSystem::URSequencePoint* ToolsApplication::ResumeUndoBatch(UndoSystem::URSequencePoint* expected, const char* label)
     {
-        if (m_currentBatchUndo)
+        if ((!m_undoStack) || (!expected))
+        {
+            return BeginUndoBatch(label);
+        }
+
+        // if we are in an undo already, and its already the expected one, just return it.
+        if ((m_currentBatchUndo) && (m_currentBatchUndo == expected))
         {
             if (m_undoStack->GetTop() == m_currentBatchUndo)
             {
@@ -1295,16 +1301,13 @@ namespace AzToolsFramework
             return m_currentBatchUndo;
         }
 
-        if (m_undoStack)
+        const auto ptr = m_undoStack->GetTop();
+        if (ptr && ptr == expected)
         {
-            const auto ptr = m_undoStack->GetTop();
-            if (ptr && ptr == expected)
-            {
-                m_currentBatchUndo = ptr;
-                m_undoStack->PopTop();
+            m_currentBatchUndo = ptr;
+            m_undoStack->PopTop();
 
-                return m_currentBatchUndo;
-            }
+            return m_currentBatchUndo;
         }
 
         return BeginUndoBatch(label);
@@ -1333,9 +1336,14 @@ namespace AzToolsFramework
         return root->Changed() || changed;
     }
 
-    void ToolsApplication::EndUndoBatch()
+    bool ToolsApplication::EndUndoBatch()
     {
+        bool resultValue = true;
         AZ_Assert(m_currentBatchUndo, "Cannot end batch - no batch current");
+        if (!m_currentBatchUndo)
+        {
+            return false; // let's not crash just becuase there's a programmer error.
+        }
 
         if (m_currentBatchUndo->GetParent())
         {
@@ -1364,6 +1372,7 @@ namespace AzToolsFramework
             }
             else
             {
+                resultValue = false; // we discarded it because it was empty
                 delete m_currentBatchUndo;
             }
 
@@ -1372,6 +1381,7 @@ namespace AzToolsFramework
 #endif
             m_currentBatchUndo = nullptr;
         }
+        return resultValue;
     }
 
     void ToolsApplication::OnPrefabInstancePropagationBegin()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
@@ -95,7 +95,7 @@ namespace AzToolsFramework
         void FlushRedo() override;
         UndoSystem::URSequencePoint* BeginUndoBatch(const char* label) override;
         UndoSystem::URSequencePoint* ResumeUndoBatch(UndoSystem::URSequencePoint* token, const char* label) override;
-        void EndUndoBatch() override;
+        bool EndUndoBatch() override;
 
         bool IsEntityEditable(AZ::EntityId entityId) override;
         bool AreEntitiesEditable(const EntityIdList& entityIds) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
@@ -13,11 +13,13 @@
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzFramework/Asset/AssetCatalogBus.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <AzToolsFramework/Undo/UndoSystem.h>
 #include <AzCore/std/sort.h>
 #include <AzCore/Script/ScriptContextDebug.h>
 
@@ -772,9 +774,20 @@ namespace AzToolsFramework
                 pausedBreakpoints = true;
             }
 
+            AzToolsFramework::UndoSystem::URSequencePoint* undoPoint = nullptr;
+            bool wasInsideAnotherUndo = false;
             if (m_scriptComponent.LoadInContext())
             {
-                LoadProperties();
+                if (LoadProperties()) // returns true if changed.
+                {
+                    ToolsApplicationRequests::Bus::BroadcastResult(undoPoint, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "Update Script Properties");
+                    wasInsideAnotherUndo = (undoPoint) && (undoPoint->GetParent());
+                    ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, GetEntityId());
+                    // If the undo point has a parent, it means its part of a bigger undo that was likely user-initiated like assigning
+                    // the script, in which case, there is no need to notify the user as they will expect the change and will save the
+                    // level. If it has no parent, this means it is a spontaneous fixup that happens during level loading or prefab loading,
+                    // and the user will need notification.
+                }
             }
 
             if (pausedBreakpoints)
@@ -783,12 +796,43 @@ namespace AzToolsFramework
             }
 
             InvalidatePropertyDisplay(Refresh_EntireTree);
-            ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, GetEntityId());
+            if (undoPoint)
+            {
+                bool wasKept = false;
+                ToolsApplicationRequests::Bus::BroadcastResult(wasKept, &ToolsApplicationRequests::Bus::Events::EndUndoBatch);
+
+                // Empty undos are discarded.  If this happens it means that there were no changes applied, we don't need to tell the user
+                // We also don't have to tell them if we asynchronously update the script properties when loading a new script from asset assignment
+                // since the entity will already be marked dirty / for save.
+                if ((wasKept)&&(!wasInsideAnotherUndo)&&(!m_loadingNewScript))
+                {
+                    AZ_Warning(
+                        "ScriptComponent",
+                        false,
+                        "While loading a Lua Script Component, some properties (from the Properties section in the assigned lua script file) were\n"
+                        "missing or incorrect in the saved file.  (Entity:  %s)\n"
+                        "This has automatically been repaired.\nPlease save the level, to apply it permanently.\n"
+                        "If the problem was inside a prefab inside the level, the fix has been applied as an override.  If you want to apply it to\n"
+                        "every instance of the prefab, push these overrides to the prefab file itself by left clicking the Script component's icon in\n"
+                        "the component inspector for this entity.",
+                        GetEntity()->GetName().c_str());
+                }
+            }
+
+            m_loadingNewScript = false;
         }
 
-        void ScriptEditorComponent::LoadProperties()
+        bool ScriptEditorComponent::LoadProperties()
         {
             ClearDataElements();
+
+            // cache the old properties for comparison.
+            AZStd::string oldProperties;
+            oldProperties.reserve(1024);
+            {
+                AZ::IO::ByteContainerStream<AZStd::string> byteStream(&oldProperties);
+                AZ::JsonSerializationUtils::SaveObjectToStream(&m_scriptComponent.m_properties, byteStream);
+            }
 
             AZ::ScriptContext* context = m_scriptComponent.m_context;
             LSV_BEGIN(context->NativeContext(), -1);
@@ -798,7 +842,7 @@ namespace AzToolsFramework
 
             if (!success)
             {
-                return;
+                return false;
             }
 
             AZ::ScriptDataContext stackContext;
@@ -842,7 +886,20 @@ namespace AzToolsFramework
 
             SortProperties(m_scriptComponent.m_properties);
 
-            InvalidatePropertyDisplay(Refresh_EntireTree);
+            // compare with the old properties.
+            AZStd::string newProperties;
+            newProperties.reserve(1024);
+            {
+                AZ::IO::ByteContainerStream<AZStd::string> byteStream(&newProperties);
+                AZ::JsonSerializationUtils::SaveObjectToStream(&m_scriptComponent.m_properties, byteStream);
+            }
+
+            if (oldProperties.compare(newProperties) != 0)
+            {
+                InvalidatePropertyDisplay(Refresh_EntireTree);
+                return true;
+            }
+            return false;
         }
 
         void ScriptEditorComponent::ClearDataElements()
@@ -913,6 +970,7 @@ namespace AzToolsFramework
 
             // Only clear properties and data elements if the asset we're changing to is not the same one we already had set on our scriptComponent
             // The only time we shouldn't do this is when someone has set the same script on the component through the editor
+            m_loadingNewScript = true;
             if (m_scriptAsset != m_scriptComponent.GetScript())
             {
                 m_scriptComponent.m_properties.Clear();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
@@ -78,7 +78,7 @@ namespace AzToolsFramework
                 float m_sortOrder; // Sort order of the property as defined by using the "order" attribute, by default the order is FLT_MAX which means alphabetical sort will be used
             };
 
-            void LoadProperties();
+            bool LoadProperties(); // returns true if properties have changed.
             void LoadProperties(AZ::ScriptDataContext& sdc, AzFramework::ScriptPropertyGroup& group);
             void RemovedOldProperties(AzFramework::ScriptPropertyGroup& group);
             void SortProperties(AzFramework::ScriptPropertyGroup& group);
@@ -108,6 +108,7 @@ namespace AzToolsFramework
             AZ::Data::Asset<AZ::ScriptAsset> m_scriptAsset;
 
             AZStd::string m_customName;
+            bool m_loadingNewScript = false;
         };
     } // namespace Component
 } // namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?
This is a cherry-pick of 
 https://github.com/o3de/o3de/pull/18771 from stabilization into dev.

(fixes #10076)

* Fixes lua not initializing properties
* Makes sure that the user is warned when the fixup happens. Makes sure that the fixup only informs the user when something actually changes in the level, that requires their attention, and not when they are just changing scripts via properties and such.
