### PR TITLE
[TrackView] Block adding a sequence to self.

### DIFF
--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -287,7 +287,8 @@ bool CAnimationContext::IsInGameMode() const
 bool CAnimationContext::IsInEditingMode() const
 {
     const auto editor = GetIEditor();
-    const bool isNotEditing = !editor || editor->IsInConsolewMode() || editor->IsInTestMode() || editor->IsInLevelLoadTestMode() || editor->IsInPreviewMode();
+    const bool isNotEditing = !editor || editor->IsInConsolewMode() || editor->IsInTestMode() || editor->IsInLevelLoadTestMode() ||
+        editor->IsInPreviewMode() || editor->IsInSimulationMode();
     return !m_bIsInGameMode && !isNotEditing;
 }
 

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -351,7 +351,7 @@ bool CTrackViewAnimNode::IsBoundToEditorObjects() const
     {
         if (m_animNode->GetType() == AnimNodeType::AzEntity)
         {
-            // check if bound to comoponent entity
+            // check if bound to component entity
             return m_animNode->GetAzEntityId().IsValid();
         }
         else
@@ -382,7 +382,7 @@ CTrackViewAnimNode* CTrackViewAnimNode::CreateSubNode(
     AZ::ComponentId componentId)
 {
     const bool isGroupNode = IsGroupNode();
-    AZ_Assert(isGroupNode, "Expected CreateSubNode to be called on a group capible node.");
+    AZ_Assert(isGroupNode, "Expected CreateSubNode to be called on a group capable node.");
     if (!isGroupNode)
     {
         return nullptr;
@@ -1236,14 +1236,37 @@ CTrackViewAnimNodeBundle CTrackViewAnimNode::AddSelectedEntities(const AZStd::ve
     AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
         entityIds, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
 
+    IMovieSystem* movieSystem = AZ::Interface<IMovieSystem>::Get();
+    if (!movieSystem)
+    {
+        AZ_Assert(false, "AddSelectedEntities(): invalid movie system.");
+        return addedNodes;
+    }
+
+    const auto pSequence = GetSequence();
+    if (!pSequence)
+    {
+        movieSystem->LogUserNotificationMsg("Could not add selected entity, because sequence is invalid.");
+        return addedNodes;
+    }
+        
     // Add selected nodes.
     for (const AZ::EntityId& entityId : entityIds)
     {
+
+        // Check if object is not the same sequence, to avoid cyclic dependencies
+        if (pSequence->GetSequenceComponentEntityId() == entityId)
+        {
+            movieSystem->LogUserNotificationMsg("Could not add self to self.");
+            continue;
+        }
+
         AZ::Entity* entity = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
 
         if (entity == nullptr)
         {
+            movieSystem->LogUserNotificationMsg("Could not add selected entity, because could not find the entity.");
             continue;
         }
 
@@ -1253,12 +1276,8 @@ CTrackViewAnimNodeBundle CTrackViewAnimNode::AddSelectedEntities(const AZStd::ve
             // If it has the same director than the current node, reject it
             if (existingNode->GetDirector() == GetDirector())
             {
-                IMovieSystem* movieSystem = AZ::Interface<IMovieSystem>::Get();
-                if (movieSystem)
-                {
-                    movieSystem->LogUserNotificationMsg(AZStd::string::format(
-                        "'%s' was already added to '%s', skipping...", entity->GetName().c_str(), GetDirector()->GetName().c_str()));
-                }
+                movieSystem->LogUserNotificationMsg(AZStd::string::format("'%s' was already added to '%s', skipping...",
+                    entity->GetName().c_str(), GetDirector()->GetName().c_str()));
 
                 continue;
             }

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -882,7 +882,10 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
             {
                 AzToolsFramework::ScopedUndoBatch undoBatch("Add Entities to Track View");
                 CTrackViewAnimNodeBundle addedNodes = groupNode->AddSelectedEntities(m_pTrackViewDialog->GetDefaultTracksForEntityNode());
-                undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
+                if (addedNodes.GetCount() > 0)
+                {
+                    undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
+                }
 
                 int selectedEntitiesCount = 0;
                 AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
@@ -921,7 +924,10 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                         shortMessages = messages;
                     }
 
-                    QMessageBox::information(this, tr("Track View Warning"), tr(shortMessages.c_str()));
+                    if (!shortMessages.empty())
+                    {
+                        QMessageBox::information(this, tr("Track View Warning"), tr(shortMessages.c_str()));
+                    }
 
                     // clear the notification log now that we've consumed and presented them.
                     movieSystem->ClearUserNotificationMsgs();


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/o3de/o3de/issues/6643

In fact, issue #6643 was mostly fixed earlier, so this PR just updates `CAnimationContext` to fix determination of "Editing Mode", excluding "Simulation Mode" from modes where editing features are enabled.

While analysing repro steps of #6643, I noted that Track View Dialog allows to add a sequence entitty as a Node to itself, 
so this PR also disables this troublesome feature, whichg may lead to unexpected cycled dependencies.


## How was this PR tested?

Profile and Release Editors run, expected behaviour noted.
