### PR TITLE
[Track View] Fix switching camera while in Undo / Redo

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -856,7 +856,7 @@ namespace AzToolsFramework
             if (!owningInstance.has_value())
             {
                 AZ_Warning("Prefab", false, "GenerateUndoNodesForEntityChangeAndUpdateCache - "
-                    "The dirty entity has no owning instance.");
+                    "The dirty entity %s has no owning instance.", entityId.ToString().c_str());
                 return AZ::Success();
             }
 


### PR DESCRIPTION
## What does this PR do?

This is a follow-up to PR #18766.

When a sequence has Director with Camera Selection track, cameras are being switched during Undo / Redo.
Same happens when the Instance Update Executor is cleaning the prefab in-memory DOM Template after Undo / Redo.
Marking camera Entities as dirty in both cases rises redundant warnings and could break Undo / Redo operation.

So this PR disables marking camera Entities as dirty while Undo / Redo or DOM Template clean-up is in progress.

## How was this PR tested?

Profile and Release Editors run, expected behaviour noted: no redundant warnings noted.

