### PR TITLE
Update Linux build presets to strip debug symbols and reduce CPU utilization

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -125,7 +125,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build/linux",
-      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4",
+      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4 -DLY_STRIP_DEBUG_SYMBOLS=ON",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "all"
     }
@@ -154,7 +154,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build/linux",
-      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4",
+      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4" ,
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "all"
     }
@@ -182,7 +182,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build/linux",
-      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4",
+      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4 -DLY_STRIP_DEBUG_SYMBOLS=ON",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "all",
       "CTEST_OPTIONS": "-L (SUITE_smoke|SUITE_main) -LE (REQUIRES_gpu) --no-tests=error -T Test",
@@ -246,7 +246,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build/linux",
-      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4",
+      "CMAKE_OPTIONS": "-G 'Ninja Multi-Config' -DLY_PARALLEL_LINK_JOBS=4 -DLY_STRIP_DEBUG_SYMBOLS=ON",
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "AssetProcessorBatch",
       "ASSET_PROCESSOR_BINARY": "bin/profile/AssetProcessorBatch",

--- a/scripts/build/Platform/Linux/build_linux.sh
+++ b/scripts/build/Platform/Linux/build_linux.sh
@@ -62,7 +62,8 @@ if [[ "${LY_MIN_MEMORY_PER_CORE:-0}" -gt 0 ]]; then
     CORE_COUNT=$((CALCULATED_MAX_CORE_USAGE > TOTAL_CORE_COUNT ? TOTAL_CORE_COUNT :  CALCULATED_MAX_CORE_USAGE))
     echo "Max Usable Cores    : $CORE_COUNT"
 else
-    CORE_COUNT=$TOTAL_CORE_COUNT
+    # Reserve at least 1 core to reduce IO contention
+    CORE_COUNT=$(expr $TOTAL_CORE_COUNT - 1)
 fi
 
 # Split the configuration on semi-colon and use the cmake --build wrapper to run the underlying build command for each


### PR DESCRIPTION
## What does this PR do?
- Updates the Linux build presets for profile to use `LY_STRIP_DEBUG_SYMBOLS=ON` to reduce the artifact size for AR Linux builds

- Reduces the Linux build core count usage by (total cores - 1) to reduce IO contention during builds. Without this, the GHA agent will fail to respond to pings during AR runs.

## How was this PR tested?

Tested in the my AR branch. Test run here: https://github.com/amzn-changml/o3de/actions/runs/14160266382
