### PR TITLE
(stabilization) Compile fix - Fixes pythontestcoverage compile error if tests are disabled

### DIFF
--- a/AutomatedTesting/Gem/PythonCoverage/Code/Source/PythonCoverageEditorSystemComponent.cpp
+++ b/AutomatedTesting/Gem/PythonCoverage/Code/Source/PythonCoverageEditorSystemComponent.cpp
@@ -71,6 +71,8 @@ namespace PythonCoverage
     PythonCoverageEditorSystemComponent::CoverageState PythonCoverageEditorSystemComponent::ParseCoverageOutputDirectory()
     {
         m_coverageState = CoverageState::Disabled;
+
+#if defined(LY_TEST_IMPACT_DEFAULT_CONFIG_FILE)
         const AZStd::string configFilePath = LY_TEST_IMPACT_DEFAULT_CONFIG_FILE;
 
         if (configFilePath.empty())
@@ -106,6 +108,7 @@ namespace PythonCoverage
 
         // Everything is good to go, await the first python test case
         m_coverageState = CoverageState::Idle;
+#endif
         return m_coverageState;
     }
     


### PR DESCRIPTION
## What does this PR do?

If you try to compile with LY_DISABLE_TEST_MODULES=ON, the test coverage system (related to the Test Impact Analysis Framework) will not define any symbols, and the PythonCoverageEditorSystemComponent.cpp will
fail to compile due to a missing define.

## How was this PR tested?
Build and run the editor with `-DLY_DISABLE_TEST_MODULES=ON`

Without this fix, it cannot actually build (AutomatedTesting project).
