### PR TITLE
Reduce pre-allocated memory for vulkan descriptor sets

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
@@ -319,7 +319,7 @@ namespace AZ
                 // Reserve memory for the acceleration structures descriptors
                 // We need t a pointer to the entries which may be invalidated in push_back without reserving memory
                 size_t numAccelerationStructureEntries = 0;
-                for (const WriteDescriptorData& updateData : m_updateData.span())
+                for (const WriteDescriptorData& updateData : m_updateData)
                 {
                     const VkDescriptorType descType = layout.GetDescriptorType(updateData.m_layoutIndex);
                     if (descType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR)
@@ -330,7 +330,7 @@ namespace AZ
                 writeAccelerationStructureDescs.reserve(numAccelerationStructureEntries);
             }
 
-            for (const WriteDescriptorData& updateData : m_updateData.span())
+            for (const WriteDescriptorData& updateData : m_updateData)
             {
                 const VkDescriptorType descType = layout.GetDescriptorType(updateData.m_layoutIndex);
 
@@ -432,7 +432,7 @@ namespace AZ
             uint32_t unboundedArraySize = 0;
 
             // find the unbounded array in the update data
-            for (const WriteDescriptorData& updateData : m_updateData.span())
+            for (const WriteDescriptorData& updateData : m_updateData)
             {
                 if ((layout.GetNativeBindingFlags()[updateData.m_layoutIndex] & VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT) != 0)
                 {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.h
@@ -39,7 +39,7 @@ namespace AZ
             using Base = RHI::DeviceObject;
             friend class DescriptorPool;
 
-            static constexpr size_t ViewsFixedsize = 16;
+            static constexpr size_t ViewsFixedsize = 2;
 
         public:
             
@@ -73,6 +73,9 @@ namespace AZ
             RHI::Ptr<BufferView> GetConstantDataBufferView() const;
 
         private:
+            // we use the small_vector to speed up SRG compilation, but we have to be a bit careful with the size of the pre-allocation:
+            // e.g. the StarterGame - Level has about 8000 objects (~4000 meshes with 2 LODs) that get a unique Draw-Srgs for
+            // each pass. And with 2 Material-Pipelines we have about 20 passes, so we end up with 160.000 unique Draw-Srgs
             struct WriteDescriptorData
             {
                 uint32_t m_layoutIndex = 0;
@@ -107,7 +110,7 @@ namespace AZ
             Descriptor m_descriptor;
 
             VkDescriptorSet m_nativeDescriptorSet = VK_NULL_HANDLE;
-            AZStd::small_vector<WriteDescriptorData, ViewsFixedsize> m_updateData;
+            AZStd::vector<WriteDescriptorData> m_updateData;
             RHI::Ptr<Buffer> m_constantDataBuffer;
             RHI::Ptr<BufferView> m_constantDataBufferView;
             bool m_nullDescriptorSupported = false;


### PR DESCRIPTION
## What does this PR do?

The SinglePlayer - Level in the [StarterGame-Assets](https://github.com/o3de/startergame-assets/tree/main) has about 8000 draw-items for each raster-pass (roughly 5000 objects, and most object have 2 LODs). With the passes of two material-pipelines active (MainPipeline and LowEndPipeline, total about 20 Passes), this results in about 160.000 unique Draw-SRGs alone, and with the pre-allocation of the small_vector optimization for the descriptor sets in Vulkan, the entire level needs about 66 GB of RAM, compared to the 6 GB of DX12.    

This PR reduces the RAM requirements to about 10 GB, which is still a lot, but at least manageable.

I've tested this with the Malloc Allocator, since the level is also quite unstable with the HPHA - allocator, 

## How was this PR tested?

Windows, using Vulkan