### PR TITLE
(stabilization) BUGFIX - Crash on CTRL+G if SC is open.

### DIFF
--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -16,6 +16,10 @@ set(SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES
     $<$<NOT:$<CONFIG:Release>>:SC_EXECUTION_TRACE_ENABLED> # this is REQUIRED for debugging/execution logging
 )
 
+# note that the above define controls whether the debug static library has member variables in its classes, in its API,
+# and thus must be transmitted to all users of the static library or else the sizeof the structs will mismatch.
+# It must thus be an INTERFACE or PUBLIC compile definition
+
 set(SCRIPT_CANVAS_DEBUG_DEBUGGER_DEFINES
 $<$<NOT:$<CONFIG:Release>>:
 #   SCRIPT_CANVAS_DEBUGGER_IS_ALWAYS_OBSERVING # for aggressive logging that ignores filtering (probably only for debug/development purposes)
@@ -36,10 +40,10 @@ ly_add_target(
     COMPILE_DEFINITIONS
         PUBLIC
             SCRIPTCANVAS_ERRORS_ENABLED
+            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
         PRIVATE
             ${SCRIPT_CANVAS_COMMON_DEFINES}
             ${SCRIPT_CANVAS_DEBUG_DEBUGGER_DEFINES}
-            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AzCore
@@ -86,10 +90,10 @@ ly_add_target(
     COMPILE_DEFINITIONS
         PUBLIC
             SCRIPTCANVAS_ERRORS_ENABLED
+            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
         PRIVATE
             ${SCRIPT_CANVAS_COMMON_DEFINES}
             ${SCRIPT_CANVAS_DEBUG_DEBUGGER_DEFINES}
-            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::ScriptEvents.Static


### PR DESCRIPTION
## What does this PR do?

Fixes bug https://github.com/o3de/o3de/issues/18790


  

>   Script canvas would crash (debug) or perform
>     undefined behavior when you pressed CTRL+G and the
>     script canvas window was open.
> 
>     This was because the CMake file applied a preprocessor
>     definition to targets in ScriptCanvas as PRIVATE, and that
>     preprocessor definition changed the size of a type
>     (It removed a member variable).
> 
>     The problem is, that header also contains a templated
>     function from a static library that will be compiled in other
>     compile units, not just the private target in ScriptCanvas,
>     causing undefined behavior.
> 

## How was this PR tested?

Its a 100% crash in debug, 0% crash after fixing.  So just run it in debug and make sure it doesn't crash anymore.
