### PR TITLE
TAP fix

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
@@ -54,9 +54,7 @@ namespace AZ::RHI
         //! This is called at the beginning of the compile phase for the current frame,
         //! before any allocations occur. The user should clear the backing allocator to
         //! a fresh state.
-        void Begin(
-            const TransientAttachmentPoolCompileFlags flags = TransientAttachmentPoolCompileFlags::None,
-            const TransientAttachmentStatistics::MemoryUsage* memoryHint = nullptr);
+        void Begin(const TransientAttachmentPoolCompileFlags flags = TransientAttachmentPoolCompileFlags::None);
 
         //! Called when a new scope is being allocated. Scopes are allocated in submission order.
         void BeginScope(Scope& scopeBase);

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -690,15 +690,15 @@ namespace AZ::RHI
 
         AZStd::sort(commands.begin(), commands.end());
 
-        auto processCommands = [&](int deviceIndex,
-                                   TransientAttachmentPoolCompileFlags compileFlags,
-                                   TransientAttachmentStatistics::MemoryUsage* memoryHint = nullptr)
+        auto processCommands =
+            [&](TransientAttachmentPoolCompileFlags compileFlags, AZStd::bitset<sizeof(MultiDevice::DeviceMask) * 8> memoryHints)
         {
-            transientAttachmentPool.Begin(compileFlags, memoryHint);
+            bool allocateResources = !CheckBitsAny(compileFlags, TransientAttachmentPoolCompileFlags::DontAllocateResources);
+            transientAttachmentPool.Begin(compileFlags);
 
             uint32_t currentScopeIndex = static_cast<uint32_t>(-1);
 
-            bool allocateResources = !CheckBitsAny(compileFlags, TransientAttachmentPoolCompileFlags::DontAllocateResources);
+            
             bool beganScope = false;
 
             for (Command command : commands)
@@ -707,8 +707,10 @@ namespace AZ::RHI
                 const uint32_t attachmentIndex = command.m_bits.m_attachmentIndex;
                 const Action action = (Action)command.m_bits.m_action;
 
-                if (scopes[scopeIndex]->GetDeviceIndex() != deviceIndex)
+                if (!allocateResources && !memoryHints.test(scopes[scopeIndex]->GetDeviceIndex()))
                 {
+                    // We can skip scopes in the exploratory phase if they run on a device that does not use the MemoryHint strategy for
+                    // allocation
                     continue;
                 }
 
@@ -717,11 +719,6 @@ namespace AZ::RHI
                 while (currentScopeIndex != scopeIndex)
                 {
                     const uint32_t nextScope = ++currentScopeIndex;
-
-                    if (scopes[nextScope]->GetDeviceIndex() != deviceIndex)
-                    {
-                        continue;
-                    }
 
                     // End the previous scope (if there is one).
                     if (beganScope)
@@ -826,29 +823,31 @@ namespace AZ::RHI
             transientAttachmentPool.End();
         };
 
+        AZStd::bitset<sizeof(MultiDevice::DeviceMask) * 8> memoryHintStrategy{};
         for (auto& [deviceIndex, descriptor] : transientAttachmentPool.GetDescriptor())
         {
-            AZStd::optional<TransientAttachmentStatistics::MemoryUsage> memoryUsage;
-
-            // Check if we need to do two passes (one for calculating the size and the second one for allocating the resources)
             if (descriptor.m_heapParameters.m_type == HeapAllocationStrategy::MemoryHint)
             {
-                // First pass to calculate size needed.
-                processCommands(
-                    deviceIndex,
-                    TransientAttachmentPoolCompileFlags::GatherStatistics | TransientAttachmentPoolCompileFlags::DontAllocateResources);
-                auto statistics = transientAttachmentPool.GetDeviceTransientAttachmentPool(deviceIndex)->GetStatistics();
-                memoryUsage = statistics.m_reservedMemory;
+                memoryHintStrategy.set(deviceIndex);
             }
-
-            // Second pass uses the information about memory usage
-            TransientAttachmentPoolCompileFlags poolCompileFlags = TransientAttachmentPoolCompileFlags::None;
-            if (CheckBitsAny(statisticsFlags, FrameSchedulerStatisticsFlags::GatherTransientAttachmentStatistics))
-            {
-                poolCompileFlags |= TransientAttachmentPoolCompileFlags::GatherStatistics;
-            }
-            processCommands(deviceIndex, poolCompileFlags, memoryUsage ? &memoryUsage.value() : nullptr);
         }
+
+        // Check if we need to do two passes (one for calculating the size and the second one for allocating the resources)
+        if (memoryHintStrategy.any())
+        {
+            // First pass to calculate size needed.
+            processCommands(
+                TransientAttachmentPoolCompileFlags::GatherStatistics | TransientAttachmentPoolCompileFlags::DontAllocateResources,
+                memoryHintStrategy);
+        }
+
+        // Second pass uses the information about memory usage
+        TransientAttachmentPoolCompileFlags poolCompileFlags = TransientAttachmentPoolCompileFlags::None;
+        if (CheckBitsAny(statisticsFlags, FrameSchedulerStatisticsFlags::GatherTransientAttachmentStatistics))
+        {
+            poolCompileFlags |= TransientAttachmentPoolCompileFlags::GatherStatistics;
+        }
+        processCommands(poolCompileFlags, memoryHintStrategy);
 
         for (auto& [deviceIndex, attachmentIndex] : removeImages)
         {


### PR DESCRIPTION
## Problem Description
### TL;DR
[PR #18140 ](https://github.com/o3de/o3de/pull/18140) introduced a loop over the device-specific `PlatformLimitsDescriptor`s in `FrameGraphCompiler::CompileTransientAttachments`, which called `TransientAttachmentPool::End()` multiple times (once per device)
This wrongly increased the `collectLatency` on all devices, which lead to a sudden large drop in performance once the `--device-count x` was larger than the collect latency of the heap, leading to clearing the heap and reallocating everything every frame.
### Description
During testing of multi-device pipelines, we realized that there was a sharp drop in performance when increasing the number of devices past a certain point (specifically, when going from 3 to 4 devices). After extensive testing, we realized that this was also the case for the `MainPipeline` without any multi-device work, but just initializing multiple devices.
In `vulkan`, this showed up as grossly increased timings for `ObjectCollector::Collect()` in `FrameBegin()` and `CommandQueue::FlushCommands`, while on `Dx12` the main slow down was visible in `FrameGraphCompiler::CompileTransientAttachments`, followed by `ObjectCollector::Collect` in `FrameEnd()`.
We noticed that, going from 3 to 4 devices, the amount of objects being collected by the `ObjectCollector` rose sharply (a few to more than hundred).
A complicating additional fact was that increasing the `CollectLatency` of the heap (which he need for the multi-device pipelines) also changed, when this drop in performance happened (a collect latency of 2 lead to the drop between 4 and 5, a latency of 3 moved it to between 5 and 6).
We finally narrowed it down to the Heap in the `TransientAttachmentPool`, which always return different pages every frame with 4 devices, while the same page was returned with 3 devices.
This was due to `void AliasedAttachmentAllocator<Heap>::CompactHeapPages()` suddenly releasing all pages every frame, which was due to increasing the collectIteration `if ((heapPage.m_collectIteration++) > collectLatency)` more often with 4 devices compared to 3 devices, while with 3 devices, this was reset to `0` again before the page was released.
And this happened due to a change introduced in [PR #18140 ](https://github.com/o3de/o3de/pull/18140).
This PR introduced device-specific `PlatformLimitsDescriptor`s, which lead to a loop being added in `FrameGraphCompiler::CompileTransientAttachments`, which processes the `Activate/Deactivate Buffer/Image` commands and might need a different allocation strategy based on `descriptor.m_heapParameters.m_type` (`HeapAllocationStrategy::MemoryHint` processes twice, once to query the memory requirements).
This meant that `processCommands` was called in a loop over the `deviceIndex`. As the activations/deactivations need to happen on multi-device `Buffer/Image`s, this code calls methods of `TransientAttachmentPool` and cannot directly call for each `DeviceTransientAttachmentPool` directly, although a device index is available.
This lead to `TransientAttachmentPool::End()` being called `device_count` times, and this is relayed to all `DeviceTransientAttachmentPool`s, this also called `DeviceTransientAttachmentPool::End()` `device_count` times, which at some point iterates over all `HeapPage`s and while doing so increases the `m_collectIteration`, which should only increase once per frame.
This then lead to releasing all pages every frame.
## Solution
This is solved by calling `ProcessCommands` only once (or twice in case of `HeapAllocationStrategy::MemoryHint`) as was the case before, calling `TransientAttachmentPool::End()` only once (or twice with `DontAllocateResources`).
A `AZStd::bitset` is generated which holds a bit for each device that runs with `MemoryHint` as its allocation strategy.
The correct `MemoryUsage` is simply chosen in `TransientAttachmentPool::Begin()` (passing in `nullptr` in the exploratory stage as well as for devices with a different allocation strategy and passing in the computed `MemoryUsage` during the actual run on devices with `MemoryHint`).
### Timings
These frame timings are for running the `GameLauncher` (built in `profile` mode) with the basic test level scene with the Shaderball, running on (2) RTX 4090, virtualizing the additional devices alternatingly.
Note, that, except for the `BRDFTexturePipeline`, no work should be executing on the other devices, the `MainPipeline` runs just on device 0, this was captured for `collectLatency = 1`, so the drop in performance happens between 3 and 4 devices.

| Device Count | Vulkan - Before | Vulkan - After | Dx12 - Before | Dx12 - After |
| ------------ | --------------- | -------------- | ------------- | ------------ |
| 1            | $2.2$ ms        | $2.2$ ms       | $2.3$ ms      | $2.2$ ms     |
| 2            | $2.5$ ms        | $2.5$ ms       | $3.1$ ms      | $3.0$ ms     |
| 3            | $2.9$ ms        | $2.9$ ms       | $3.9$ ms      | $3.9$ ms     |
| 4            | $44$ ms 💥         | $3.2$ ms       | $20$ ms  💥      | $4.7$ ms     |
| 5            | $45$ ms         | $3.6$ ms       | $20$ ms       | $5.4$ ms     |
| 6            | $45$ ms         | $3.9$ ms       | $21$ ms       | $6.1$ ms     |
| 7            | $45$ ms         | $4.3$ ms       | $21$ ms       | $7.0$ ms     |
| 8            | $46$ ms         | $4.6$ ms       | $23$ ms       | $7.8$ ms     |

## CPU Profiler Dx12
### Before
![Pasted image 20250403100838](https://github.com/user-attachments/assets/2db3b4e8-92bd-4aee-983f-4d7c653a8b07)
### After 
![Pasted image 20250403105707](https://github.com/user-attachments/assets/9b675755-e465-43d0-916b-7199e4e094a7)
## CPU Profiler Vulkan
### Before
![Pasted image 20250403100933](https://github.com/user-attachments/assets/248bca82-f7ee-4c82-b0cb-ba8195337285)
### After
![Pasted image 20250403105832](https://github.com/user-attachments/assets/32f9cb8d-0367-4fa8-a7cc-b30bf4dac939)


