### PR TITLE
(Stabilization) BUGFIX: Fixes a crash when editing overrides on a prefab instance.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
@@ -121,7 +121,7 @@ namespace AzToolsFramework
             void UpdateEntitiesAsOverrides(
                 const AZStd::vector<const AZ::Entity*>& entityList,
                 Instance& owningInstance,
-                const Instance& focusedInstance,
+                Instance& focusedInstance,
                 UndoSystem::URSequencePoint* undoBatch)
             {
                 PrefabUndoEntityOverrides* state = aznew PrefabUndoEntityOverrides("Undo Updating Entity List As Override");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
@@ -84,7 +84,7 @@ namespace AzToolsFramework
             void UpdateEntitiesAsOverrides(
                 const AZStd::vector<const AZ::Entity*>& entityList,
                 Instance& owningInstance,
-                const Instance& focusedInstance,
+                Instance& focusedInstance,
                 UndoSystem::URSequencePoint* undoBatch);
 
             //! Helper function for deleting entities and update parents to prefab template with undo-redo support.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -129,7 +129,14 @@ namespace AzToolsFramework
             // Redo - Update target template of the link.
             link->get().UpdateTarget();
             m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
-            m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());
+
+            // If we get into this function, it means that we are reading from a realized set of actual C++ entities in memory
+            // as the "Source of Truth", and calling GenerateEntityDomBySerializing to write the changes that have already been applied
+            // to those c++ entities into an override patch, comparing before/after.  This implies that the instance we have focused
+            // has already got the changes applied to its c++ entities, and does not need template propogation.  All OTHER instances
+            // besides that one do need propogation.  If we do not skip the focusedInstance, we will be modifying the instance
+            // and possibly despawning/respawning it while the user is actually still editing/dragging/typing/looking at properties of it.
+            m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId(), focusedInstance);
         }
 
         void PrefabUndoEntityOverrides::Undo()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h
@@ -36,7 +36,7 @@ namespace AzToolsFramework::Prefab
         void CaptureAndRedo(
             const AZStd::vector<const AZ::Entity*>& entityList,
             Instance& owningInstance,
-            const Instance& focusedInstance);
+            Instance& focusedInstance);
 
     private:
         // The function to update link during undo and redo.


### PR DESCRIPTION
## What does this PR do?
fixes issue:
https://github.com/o3de/o3de/issues/18794

The crash was caused by the current focused Instance being queued for reload (and then reloaded, which involves it being deleted and recreated) while the property system was still live editing it and still had messages in the queue for it, causing use-after-free.

The issue has more information on how to repro.

The fix here is to make sure that the instance being edited is in the list of instances NOT to respawn, since it is already updated by the inspector.

## Tested how?

I Created a level that had the following structure which not only has prefabs, but prefabs-in-prefabs, and more than 1 of each.
 
![image](https://github.com/user-attachments/assets/9989b053-0912-4f1b-a28e-61402623a738)
Each of the entities have a "Debug Text" component on them, which provides a color picker and a text field to type in to try to repro the bug.

Did every possible prefab operation I could think of, including,
* Modifying the innermost prefab itself - seeing the changes propogate to all others
* Modifying the middle prefab
    * Modifying entity1 as an override - it propogates correctly to the other instance
    * Modifying the "real" entity - it propogates correctly to the other instance.
 * Modifying the level (applying overrides to each of the 4 entity1's and the 2 'entityoutsides' - works as expected
 * Mixed modification - making the base entity different colors and different texts, eg, making entity1 red, then making the first entity1 in the bigger group green as an override, then making the first entity 1 in the first group in the level blue as an override.  ENsuring that all overrides applied as expected.
 * Performing repeated undo and redo of all of the above.
 * Saving and loading at various states to ensure that it sticks.

At this point, I can't think of what else to try to find edge cases, so if you have ideas, let me know.