### PR TITLE
Remove OnRenderPipelineChanged override from RayTracingDebugFeatureProcessor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.cpp
@@ -68,11 +68,6 @@ namespace AZ::Render
         m_settings.reset();
     }
 
-    void RayTracingDebugFeatureProcessor::OnRenderPipelineChanged(RPI::RenderPipeline* pipeline, [[maybe_unused]] RPI::SceneNotification::RenderPipelineChangeType changeType)
-    {
-        m_pipeline = pipeline;
-    }
-
     void RayTracingDebugFeatureProcessor::AddRenderPasses(RPI::RenderPipeline* pipeline)
     {
         m_pipeline = pipeline;

--- a/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Debug/RayTracingDebugFeatureProcessor.h
@@ -29,9 +29,6 @@ namespace AZ::Render
         void OnRayTracingDebugComponentAdded() override;
         void OnRayTracingDebugComponentRemoved() override;
 
-        // SceneNotificationBus overrides
-        void OnRenderPipelineChanged(RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
-
         // FeatureProcessor overrides
         void Activate() override;
         void Deactivate() override;


### PR DESCRIPTION
## What does this PR do?

This PR removes the `OnRenderPipelineChanged` override from `RayTracingDebugFeatureProcessor`, which leads to problems when more than one pipeline is used in the scene.
For example, in the AtomSampleViewer with samples derived from `CommonSampleComponentBase` there are two pipelines (`RPISamplePipeline` and `BRDFTexturePipeline`), and `OnRenderPipelineChanged` is called for both pipelines in this order, which later leads to the debug pass only being added to the latter one. `AddRenderPasses` is only called for `RPISamplePipeline`, and works as expected.

## How was this PR tested?

Open a small test scene and a scene with terrain and enable the debug ray tracing pass, check if it shows up as expected.
