### PR TITLE
Add SmoothCriticallyDamped function to MathUtils.h

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/MathUtils.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathUtils.h
@@ -408,6 +408,45 @@ namespace AZ
         return IsClose(a, b, AZStd::numeric_limits<double>::epsilon()) ? 0.0 : (value - a) / (b - a);
     }
 
+    //! Smooths a value towards a target using a critically damped spring system.
+    //! This function adjusts `value` towards `target` while maintaining continuity of `value` and its rate of change (`valueRate`).
+    //! The smoothing is controlled by `smoothTime`, with `timeDelta` representing the time since the last update.
+    //!
+    //! @param[in,out] value      The value to be smoothed.
+    //! @param[in,out] valueRate  The rate of change of the value.
+    //! @param[in]     timeDelta  The time interval since the last update (in seconds).
+    //! @param[in]     target     The target value to smooth towards.
+    //! @param[in]     smoothTime The timescale for smoothing (lag time or 2/omega, where omega is the spring frequency).
+    //!
+    //! @note This implements a critically damped spring system for smooth ease-in/ease-out behavior.
+    //! @note Uses a polynomial approximation to the exponential function for performance, accurate within 0.1% when
+    //!       smoothTime > 2 * timeDelta. For stiff springs or large frame spikes, accuracy may degrade slightly.
+    //! @note Based on "Critically Damped Ease-In/Ease-Out Smoothing" by Thomas Lowe, Game Programming Gems IV.
+    template<typename T>
+    AZ_MATH_INLINE void SmoothCriticallyDamped(T& value, T& valueRate, float timeDelta, const T& target, float smoothTime)
+    {
+        if (smoothTime > 0.0f)
+        {
+            const float omega = 2.0f / smoothTime;
+            const float x = omega * timeDelta;
+            const float exp = 1.0f / (1.0f + x + 0.48f * x * x + 0.235f * x * x * x);
+            const T change = value - target;
+            const T temp = static_cast<T>((valueRate + change * omega) * timeDelta);
+            valueRate = static_cast<T>((valueRate - temp * omega) * exp);
+            value = static_cast<T>(target + (change + temp) * exp);
+        }
+        else if (timeDelta > 0.0f)
+        {
+            valueRate = static_cast<T>((target - value) / timeDelta);
+            value = target;
+        }
+        else
+        {
+            value = target;
+            valueRate = T(0); // Zero the rate
+        }
+    }
+
     //! Returns true if the number provided is even.
     template<typename T>
     constexpr AZStd::enable_if_t<AZStd::is_integral<T>::value, bool> IsEven(T a)


### PR DESCRIPTION
### What does this PR do?
This PR implements #14490. It introduces a template function, `SmoothCriticallyDamped()`, to `AzCore/Math/MathUtils.h`. It implements a critically damped ease-in/ease-out function for smoothly interpolating values toward a target over time.

https://github.com/user-attachments/assets/24fc7970-e98d-47a9-a482-6b79a70c2c74

### Why is this change needed?
O3DE currently offers linear interpolation via `AZ::Lerp()`, but lacks a built-in utility for critically damped smoothing.

The code is directly copied over from an older commit in the O3DE codebase, which should be covered under Apache 2.0 and MIT licenses:

https://github.com/o3de/o3de/blob/b4a2edec6a36381b85d3118608543e7535961d36/Code/Legacy/CryCommon/Cry_Math.h#L605-L662

See further discussion here: https://github.com/o3de/o3de/issues/14490#issuecomment-1472857858

### How was this PR tested?
On Windows 11. Tested in the editor comparing AZ::SmoothCriticallyDamped() to AZ::Lerp() by interpolating two spheres back and forth across a 10-meter distance (see above video).

**Example usage:**
```cpp
float position = 0.0f, velocity = 0.0f;
AZ::SmoothCriticallyDamped(position, velocity, 0.016f, 10.0f, 0.5f); // Smooths position toward 10 over time
