### PR TITLE
Fixes containers (vectors, maps, etc) not saving state or undos when modified in the inspector

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -31,6 +31,26 @@ namespace AZ::DocumentPropertyEditor
         using OnChangedCallbackPrefixTree = AZ::Dom::DomPrefixTree<AZStd::function<Dom::Value(const Dom::Value&)>>;
         OnChangedCallbackPrefixTree m_onChangedCallbacks;
 
+        // Given a container node (The PropertyEditor node that represents the root of a container)
+        // get a AZ::Dom::Value that represents its contents.
+        AZ::Dom::Value GetContainerValue(void* containerInstance, const AZ::Dom::Value& containerNode)
+        {
+            AZ::Dom::Value resultValue;
+            auto typeIdAttribute = containerNode.FindMember(Nodes::PropertyEditor::ValueType.GetName());
+            if (typeIdAttribute != containerNode.MemberEnd())
+            {
+                AZ::TypeId typeId = AZ::Dom::Utils::DomValueToTypeId(typeIdAttribute->second);
+                if (const AZ::SerializeContext::ClassData* classData = m_serializeContext->FindClassData(typeId))
+                {
+                    AZ::JsonSerializerSettings storeSettings;
+                    // Defaults must be kept to make sure a complete object is written to the Dom::Value
+                    storeSettings.m_keepDefaults = true;
+                    AZ::Dom::Utils::StoreViaJsonSerialization(containerInstance, nullptr, typeId, resultValue, storeSettings);
+                }
+            }
+            return resultValue;
+        }
+
         //! This represents a container or associative container instance and has methods
         //! for interacting with the container.
         struct BoundContainer
@@ -134,19 +154,30 @@ namespace AZ::DocumentPropertyEditor
 
             void OnClear(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path)
             {
+                auto containerNode = GetContainerNode(impl, path);
+
                 m_container->ClearElements(m_containerInstance, impl->m_serializeContext);
 
-                auto containerNode = GetContainerNode(impl, path);
-                Nodes::PropertyEditor::ChangeNotify.InvokeOnDomNode(containerNode);
+                // notify the new value in the container so that listeners can update dom / store overrides / undo redo
+                AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
+
                 impl->m_adapter->NotifyResetDocument();
             }
 
             void StoreReservedInstance(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path)
             {
-                m_container->StoreElement(m_containerInstance, m_reservedElementInstance);
                 auto containerNode = GetContainerNode(impl, path);
-                Nodes::PropertyEditor::ChangeNotify.InvokeOnDomNode(containerNode);
-                impl->m_adapter->NotifyResetDocument();
+
+                m_container->StoreElement(m_containerInstance, m_reservedElementInstance);
+
+                // Notify that the document has changed with the new value in the container:
+                AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
+
+                impl->m_adapter->NotifyResetDocument(); // rebuild the view based on the new contents, which could be many rows
                 m_reservedElementInstance = nullptr;
             }
 
@@ -430,21 +461,30 @@ namespace AZ::DocumentPropertyEditor
 
             void OnRemoveElement(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path)
             {
-                const AZ::SerializeContext::ClassElement* containerClassElement =
-                    m_container->GetElement(m_container->GetDefaultElementNameCrc());
+                auto containerNode = GetContainerNode(impl, path);
+                const AZ::SerializeContext::ClassElement* containerClassElement = m_container->GetElement(m_container->GetDefaultElementNameCrc());
                 auto elementInstance = m_container->GetElementByIndex(m_containerInstance, containerClassElement, m_elementIndex);
                 [[maybe_unused]] const bool elementRemoved = m_container->RemoveElement(m_containerInstance, elementInstance, impl->m_serializeContext);
                 AZ_Assert(elementRemoved, "could not remove element!");
-                auto containerNode = GetContainerNode(impl, path);
-                Nodes::PropertyEditor::ChangeNotify.InvokeOnDomNode(containerNode);
+
+                // notify about the new values in the container:
+                AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
+
                 impl->m_adapter->NotifyResetDocument();
             }
 
             void OnMoveElement(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path, bool moveForward)
             {
-                m_container->SwapElements(m_containerInstance, m_elementIndex, (moveForward ? m_elementIndex + 1 : m_elementIndex - 1));
                 auto containerNode = GetContainerNode(impl, path);
-                Nodes::PropertyEditor::ChangeNotify.InvokeOnDomNode(containerNode);
+                m_container->SwapElements(m_containerInstance, m_elementIndex, (moveForward ? m_elementIndex + 1 : m_elementIndex - 1));
+
+                //  notify about the new values in the container:
+                AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
+
                 impl->m_adapter->NotifyResetDocument();
             }
 
@@ -647,7 +687,10 @@ namespace AZ::DocumentPropertyEditor
                     else
                     {
                         // Otherwise use Json Serialization to copy the Dom Value directly into the valuePointer address
-                        resultCode = AZ::Dom::Utils::LoadViaJsonSerialization(valuePointer, valueType, newValue);
+                        // containers will always show their full value, so clear them
+                        JsonDeserializerSettings settings;
+                        settings.m_clearContainers = true;
+                        resultCode = AZ::Dom::Utils::LoadViaJsonSerialization(valuePointer, valueType, newValue, settings);
                         if (resultCode.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
                         {
                             AZ_Error(
@@ -1318,6 +1361,7 @@ namespace AZ::DocumentPropertyEditor
         m_impl->m_builder.AddMessageHandler(this, Nodes::Adapter::SetNodeDisabled);
         m_impl->m_builder.AddMessageHandler(this, Nodes::Adapter::QuerySubclass);
         m_impl->m_builder.AddMessageHandler(this, Nodes::Adapter::AddContainerSubclass);
+
         m_impl->m_onChangedCallbacks.Clear();
         m_impl->m_containers.Clear();
         if (m_instance != nullptr)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -108,8 +108,8 @@ namespace AzToolsFramework::Prefab
         };
 
         message.Match(PrefabPropertyEditorNodes::PrefabOverrideLabel::RevertOverride, handleRevertOverride);
-
-        return ReflectionAdapter::HandleMessage(message);
+        
+        return ComponentAdapter::HandleMessage(message);
     }
 
     void PrefabComponentAdapter::UpdateDomContents(const PropertyChangeInfo& propertyChangeInfo)


### PR DESCRIPTION
## What does this PR do?

Fixes Issue
https://github.com/o3de/o3de/issues/18603
"Changing order in AZStd::vector in Editor does not effect anything"

Fixes Issue
https://github.com/o3de/o3de/issues/16911
"DPE Inspector: Changes are not detected when adding new elements in the Asset Editor and those cannot be saved"

Basically, any container-related operation
* adding a new element
* Deleting elements
* Reordering elements
* Clearing the container

Would not trigger undo or redo, not trigger prefab updates, and would not send any message up to the actual system that things had been changed.

This change fixes this behavior by making container edits behave pretty much like any other normal edit, that is, calculating the new value and sending the new value up the event stack for things to serialize them into undo/redo and so on.

## How was this PR tested?

* Adding an element to container (ie, click the + button in the inspector in a vector.  I'm using the Simple State component in the inspector on an entity)
* Removing an element (trash can button)
* Moving an element (up and down button)
* Clearing (trash can button in the container row)
* Doing the 4 above tests in a container that itself is in a container (so e.g. the list of entities in the Simple State container's state container)

Then repeating the 5 above tests, but on an entity inside a prefab instead of a loose entity:
* with the component  already existing in the prefab with data already in it, so the above are overrides
* with the component not already existing in the prefab, so the component being added itself is an override

Then repeating the two test cases above, with a prefab-inside-a-prefab-inside-a-prefab!

*  Doing undo and redo at each step of the above to make sure it undoes and redoes. 

* Running CI tests.