### PR TITLE
Force SliceBuilderWorker to unconditionally produce dynamic slices.

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderComponent.cpp
@@ -43,7 +43,7 @@ namespace SliceBuilder
 
         AssetBuilderSDK::AssetBuilderDesc builderDescriptor;
         builderDescriptor.m_name = "Slice Builder";
-        builderDescriptor.m_version = 8;
+        builderDescriptor.m_version = 9;
         builderDescriptor.m_analysisFingerprint = builderAnalysisFingerprint;
         builderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZ::SliceAsset::GetFileFilter(), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
         builderDescriptor.m_busId = SliceBuilderWorker::GetUUID();

--- a/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
@@ -195,7 +195,6 @@ namespace SliceBuilder
 
         bool requiresUpgrade = m_sliceHasLegacyDataPatches;
         bool sliceWritable = AZ::IO::SystemFile::IsWritable(fullPath.c_str());
-        bool createDynamicSlice = sourcePrefab->IsDynamic();
 
         AZ::SerializeContext* context = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
@@ -254,10 +253,7 @@ namespace SliceBuilder
                 requiresUpgrade = false;
             }
 
-            if (createDynamicSlice)
-            {
-                jobDescriptor.m_jobParameters.insert(AZStd::make_pair(AZ::u32(AZ_CRC_CE("JobParam_MakeDynamicSlice")), AZStd::string("Create Dynamic Slice")));
-            }
+            jobDescriptor.m_jobParameters.insert(AZStd::make_pair(AZ::u32(AZ_CRC_CE("JobParam_MakeDynamicSlice")), AZStd::string("Create Dynamic Slice")));
 
             response.m_createJobOutputs.push_back(jobDescriptor);
 


### PR DESCRIPTION
This fix is to make sure dynamicslices are unconditionally built and can be used by UiSpawner.

## What does this PR do?

For historical reasons the IsDynamic field in slices can not be set to true and prevents the dynamicslice asset (required by UiSpawner component) from being built. This PR ought to fix it by forcing SliceBuilderWorker to ignore IsDynamic value and always build dynamicslices.

## How was this PR tested?

Draft, not tested yet.
