### PR TITLE
Fixes a buffer overrun ASan error in LUA Script Properties

### DIFF
--- a/Code/Framework/AzCore/AzCore/Script/ScriptPropertySerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptPropertySerializer.cpp
@@ -81,6 +81,25 @@ namespace AZ
             return context.Report(JSR::Tasks::WriteValue, JSR::Outcomes::DefaultsUsed, "ScriptPropertySerializer Store used defaults for DynamicSerializableField");
         }
 
+        if (defaultScriptDataPtr && defaultScriptDataPtr->m_typeId != inputScriptDataPtr->m_typeId)
+        {
+            // Edge Case here, where the stored types don't match:
+            // example:
+            // inputScriptdataPtr has
+            //   m_value{ m_data = 0x000012d2be18d820 m_typeId = 0xA96A5037 - 0xAD0D43B6 - 0x9948ED63 - 0x438C4A52 } AZ::DynamicSerializableField
+            //
+            // defaultScriptDataPtr has
+            //   m_value{ m_data = 0x0000000000000000 m_typeId = 0x00000000 - 0x00000000 - 0x00000000 - 0x00000000 } AZ::DynamicSerializableField
+            // 
+            // if the script data and the default data hold a different type entirely from each other, you cannot pass the default
+            // down into any further JSON functions, because all of those functions (Store, ContinueStoring, etc)
+            // only take 3 params related to these objects - namely,
+            //    *  the void* thing to store
+            //    *  typeid of thing to store
+            //    *  optional void* of default value, ASSUMED TO BE THE SAME TYPE
+            defaultFieldPtr = nullptr;
+        }
+
         JSR::ResultCode result(JSR::Tasks::WriteValue);
         outputValue.SetObject();
 


### PR DESCRIPTION
## What does this PR do?

Fixes a problem with Script Properties serialization that Address Sanitizer (ASAN) found live.

Its unclear what problems this cause, since its going to be reading from uninitialized memory.  Problems range from mystery crashes to debug checks and so on.  In profile, it probably blows on through.

See the comment in code for the case example and justification.

Without this change, the JSON serializer would continue down the serialization stack, not knowing that the actual types of the "default" and the "value" ptrs differ and eventually it would static cast the "default" ptr given into the same typeid as the "value" ptr and then compare them.  For example, it would assume that since a the ScriptAssetRef (containing an assetId) was the type of the value, it could convert the "default" to a ScriptAssetRef too, and crash.

There didn't seem to be any other place to put this check, as the call stack more or less looks like
```
(Custom Asset Serializer calling AssetID operator== on bogus default value)
(internal non-type specific JSON Serializer code)
(internal non-type specific JSON Serializer code)
(internal non-type specific JSON Serializer code)
(internal non-type specific JSON Serializer code)
(internal non-type specific JSON Serializer code)
(This Script property serialize function)
```

With the internal non-type specific JSON serializer not really doing anything but offsetting the passed in `default` field by the `value` typeid's field offsets within the class, unaware that the types are not at all the same.

## How was this PR tested?

This was a 100% ASan failure each time you open the script spawner level.

Fixing it results in a 0% repro but the level still works.

