### PR TITLE
Do not buffer cmake Assets build logs

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -69,6 +69,7 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME launcher_gener
         if(PAL_TRAIT_BUILD_HOST_TOOLS)
             add_custom_target(${project_name}.Assets
                 COMMENT "Processing ${project_name} assets..."
+                USES_TERMINAL # Do not buffer output of run command
                 COMMAND "${CMAKE_COMMAND}"
                     -DLY_LOCK_FILE=$<GENEX_EVAL:$<TARGET_FILE_DIR:AZ::AssetProcessorBatch>>/project_assets.lock
                     -P ${LY_ROOT_FOLDER}/cmake/CommandExecution.cmake


### PR DESCRIPTION
## What does this PR do?

This PR changes behavior when triggering Assets build via cmake.

Currently, when running 
```bash
cmake --build ${build_path} --target ${project_name}.Assets
```
AssetProcessorBatch is triggered in the backgroud, all logs are gathered and only when the process exits, all logs are dumped at once. This behavior makes it really hard to monitor Asset build process.

This PR changes this behavior to make all stdout from run command to be available in the parent stdout as soon as it is published.

### CMake option references

- [add_custom_command](https://cmake.org/cmake/help/v3.10/command/add_custom_command.html)
- [console job pool](https://cmake.org/cmake/help/v3.10/prop_gbl/JOB_POOLS.html#prop_gbl:JOB_POOLS)

## How was this PR tested?

Tested with Ninja Multi-Config generator

Build was split to 2 phases:
1. Build AssetProcessorBatch
  ```bash
  cmake --build ${build_path} --target AssetProcessorBatch
  ```
2. Build Assets
  ```bash
  cmake --build ${build_path} --target ${project_name}.Assets
  ```

After the change, logs started coming as soon as AssetProcessorBatch was started, not after processing all assets.

Change is also propagated to o3de sdk engine after install build.