### PR TITLE
(stabilization) Fix a few ASan and other corruption errors found.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -520,9 +520,19 @@ namespace AzToolsFramework
             const auto& selectedIndexes = selected.indexes();
             if (!selectedIndexes.empty())
             {
-                auto newRootIndex = m_tableViewProxyModel->mapFromSource(
-                    m_assetFilterModel->mapFromSource(treeViewFilterModel->mapToSource(selectedIndexes[0])));
-                m_tableViewWidget->setRootIndex(newRootIndex);
+                auto indexInTreeView = treeViewFilterModel->mapToSource(selectedIndexes[0]);
+                auto indexInFilterModel = m_assetFilterModel->mapFromSource(indexInTreeView);
+                if (m_tableViewProxyModel->sourceModel() == m_treeToTableProxyModel)
+                {
+                    auto indexInProxyModel = m_treeToTableProxyModel->mapFromSource(indexInFilterModel);
+                    auto newRootIndex = m_tableViewProxyModel->mapFromSource(indexInProxyModel);
+                    m_tableViewWidget->setRootIndex(newRootIndex);
+                }
+                else
+                {
+                    auto newRootIndex = m_tableViewProxyModel->mapFromSource(indexInFilterModel);
+                    m_tableViewWidget->setRootIndex(newRootIndex);
+                }
             }
             else
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -425,8 +425,9 @@ namespace AzToolsFramework
             const auto& selectedIndexes = selected.indexes();
             if (!selectedIndexes.empty())
             {
-                const auto newRootIndex = m_thumbnailViewProxyModel->mapFromSource(
-                    m_assetFilterModel->mapFromSource(treeViewFilterModel->mapToSource(selectedIndexes[0])));
+                const auto indexInSourceModel = treeViewFilterModel->mapToSource(selectedIndexes[0]);
+                const auto indexInFilterModel = m_assetFilterModel->mapFromSource(indexInSourceModel);
+                const auto newRootIndex = m_thumbnailViewProxyModel->mapFromSource(indexInFilterModel);
                 m_thumbnailViewWidget->setRootIndex(newRootIndex);
             }
             else

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
@@ -102,12 +102,12 @@
             m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
             m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());
 
-            // Queue a refresh of the property display in case the overrides contain only default values.
-            // Otherwise, when overrides don't trigger changes in the template dom, the entity won't be
-            // recreated on propagation and the inspector won't be updated to reflect override icon changes
+            // We have to refresh the entire tree when you revert overrides, because reverting overrides
+            // respawns (as in, deletes and recreates) any entities that have the overrides.  The inspector
+            // MUST drop its references to those entities which are about to be destroyed!
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
                 &AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay,
-                AzToolsFramework::Refresh_AttributesAndValues);
+                AzToolsFramework::Refresh_EntireTree); 
 
             return true;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -470,6 +470,11 @@ namespace AzToolsFramework
 
     bool ComponentEditor::AreAnyComponentsDisabled() const
     {
+        if (m_preventDataAccess) // are we during some sort of full ui rebuild?
+        {
+            return false;
+        }
+
         for (auto component : m_components)
         {
             auto entity = component->GetEntity();
@@ -605,6 +610,11 @@ namespace AzToolsFramework
 
     void ComponentEditor::QueuePropertyEditorInvalidationForComponent(AZ::EntityComponentIdPair entityComponentIdPair, PropertyModificationRefreshLevel refreshLevel)
     {
+        if (m_preventDataAccess) // are we during some sort of full ui rebuild?
+        {
+            return;
+        }
+
         for (const auto component : m_components)
         {
             if ((component->GetId() == entityComponentIdPair.GetComponentId()) 
@@ -623,6 +633,7 @@ namespace AzToolsFramework
 
     void ComponentEditor::PreventRefresh(bool shouldPrevent)
     {
+        m_preventDataAccess = shouldPrevent;
         GetPropertyEditor()->PreventDataAccess(shouldPrevent);
     }
 
@@ -979,6 +990,11 @@ namespace AzToolsFramework
 
     bool ComponentEditor::HasComponentWithId(AZ::ComponentId componentId)
     {
+        if (m_preventDataAccess) // are we during some sort of full ui rebuild?
+        {
+            return false;
+        }
+
         for (AZ::Component* component : m_components)
         {
             if (component->GetId() == componentId)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
@@ -184,6 +184,8 @@ namespace AzToolsFramework
         AZ::Crc32 m_savedKeySeed;
 
         AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeEvent::Handler m_propertyChangeHandler;
+
+        bool m_preventDataAccess = false;
     };
 
 } // namespace AzToolsFramework

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
@@ -423,8 +423,8 @@ namespace ImageProcessingAtom
                     callback(asset);
                 }
 
-                m_assetCallbackMap.erase(itr);
                 AZ::Data::AssetBus::MultiHandler::BusDisconnect(itr->first);
+                m_assetCallbackMap.erase(itr);
              }
         }
     } // namespace Utils


### PR DESCRIPTION
## What does this PR do?

During investigation of the Physics Material Slots issue, I was running in Debug with Address Sanitizer Enabled.

These changes fix a few of the errors that were found alongside CRT or Qt or AZ Asserts.

1. Wrong index used in AssetrBrowserTableView.  The table View has 2 different filter models depending on whether the user is searching for something via the text search field or not. When it is using the text search field it has to use a slightly different approach to reading the data or it will be pulling it from the wrong model.

2. AssetBrowserThumbnailView updated to match 1) above.

3. PrefabOverrideHandler.cpp - The Prefab Override Handler needs to refresh the entire property grid when overrides are reverted.  Refreshing only attributes and values does not work since reverting overrides deletes and recreates entities.

4. ComponentEditor.cpp - There are situations in which the entities in the component editor are invalid and its in between being told to refresh, and actually refreshing.  The parent owner class sends a "Prevent Data Access" signal to it, but it was not correctly using it to prevent data access of its own functions that may be called during refresh, leading to use-after-free

5. Atom Image Processing - use-after-free of an iterator variable calling erase on it, which invalidates it.

6. Phyics material asset being modified and updated during prefab respawn or before the asset is even loaded.

This does not "FIX" the Physics Material Slots issue, as nothing is actually broken in the code, but it does fix a few of the errors that were found during investigation.

## Testing:
Running the code with debug + ASAN and seeing that
* No more Qt spam
* No more debug check spam
* No more AZ_Assert spam
* No more ASan breaks

at least when modifying prefabs, editing material slot properties, reverting undos, etc.