### PR TITLE
(Stabilization)Fixes an additional ASan detection in settings registry.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistrar.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistrar.cpp
@@ -34,25 +34,24 @@ namespace AZ::DocumentPropertyEditor
 
         AZ::IO::FixedMaxPath fullSettingsPath = AZ::Utils::GetProjectPath();
         fullSettingsPath /= relativeFilepath;
-        const char* posixSettingsPath = fullSettingsPath.AsPosix().c_str();
+        AZ::IO::FixedMaxPath posixSettingsPath = fullSettingsPath.AsPosix().c_str();
 
         AZStd::string stringBuffer;
         AZ::IO::ByteContainerStream stringStream(&stringBuffer);
         if (!AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(*registry, anchorKey, stringStream, dumperSettings))
         {
             return AZ::Failure(AZStd::string::format(
-                "Failed to save settings to file '%s': failed to retrieve settings from registry", posixSettingsPath));
+                "Failed to save settings to file '%s': failed to retrieve settings from registry", posixSettingsPath.c_str()));
         }
 
         constexpr auto openMode = AZ::IO::SystemFile::SF_OPEN_CREATE
             | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH
             | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
-        if (AZ::IO::SystemFile outputFile; outputFile.Open(posixSettingsPath, openMode))
+        if (AZ::IO::SystemFile outputFile; outputFile.Open(posixSettingsPath.c_str(), openMode))
         {
             if(outputFile.Write(stringBuffer.data(), stringBuffer.size()) != stringBuffer.size())
             {
-                return AZ::Failure(AZStd::string::format(
-                    "Failed to save settings to file '%s': incomplete contents written", posixSettingsPath));
+                return AZ::Failure(AZStd::string::format("Failed to save settings to file '%s': incomplete contents written", posixSettingsPath.c_str()));
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a potential stack buffer overflow error, detected by Address Sanitizer.
This one happens every time you change the view in the Property Editor and it tries to save the expansion state
of properties.

The use-after free occurs because the AZ::IO::FixedMaxPath function ".AsPosix()" returns a temporary object.

This temporary object was being cached in a char* pointer, and then used after the original call site of AsPosix() resolved.

## How was this PR tested?

This is an Address Sanitizer (ASan) Detection.  It detects it 100% of the time when clicking around in the property editor.  The detection goes away when the bug is fixed.