### PR TITLE
Allow GenericAssetHandler to load/save objects in custom ObjectStream format.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.h
@@ -91,12 +91,14 @@ namespace AzFramework
             const char* group,
             const char* extension,
             const AZ::Uuid& componentTypeId = AZ::Uuid::CreateNull(),
-            AZ::SerializeContext* serializeContext = nullptr)
+            AZ::SerializeContext* serializeContext = nullptr,
+            const AZ::DataStream::StreamType streamType = AZ::ObjectStream::ST_XML)
             : m_displayName(displayName)
             , m_group(group)
             , m_extension(extension)
             , m_componentTypeId(componentTypeId)
             , m_serializeContext(serializeContext)
+            , m_streamType(streamType)
         {
             AZ_Assert(extension, "Extension is required.");
             if (extension[0] == '.')
@@ -151,7 +153,7 @@ namespace AzFramework
             if (assetData && m_serializeContext)
             {
                 return AZ::Utils::SaveObjectToStream<AssetType>(*stream,
-                    AZ::ObjectStream::ST_XML,
+                    m_streamType,
                     assetData,
                     m_serializeContext);
             }
@@ -236,6 +238,7 @@ namespace AzFramework
         AZStd::string m_extension;
         AZ::Uuid m_componentTypeId = AZ::Uuid::CreateNull();
         AZ::SerializeContext* m_serializeContext;
+        AZ::DataStream::StreamType m_streamType;
         GenericAssetHandler(const GenericAssetHandler&) = delete;
     };
 } // namespace AzFramework


### PR DESCRIPTION
## What does this PR do?

GenericAssetHandler typically store assets in XML format. This PR allows GenericAssetHandler to load/save assets in a different ObjectStream format such as json/binary.

This can be applied all assets using GenericAssetHandler (editable in AssetEditor).

## How was this PR tested?

Pass a different streamType argument to GenericAssetHandler constructor.