### PR TITLE
(Stabilization) Fix compile error when building with a monolithic-nounity-configuration

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
@@ -8,8 +8,6 @@
 
 #if !defined(AZ_MONOLITHIC_BUILD)
 
-#include <Atom/RPI.Public/SceneBus.h>
-#include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 #include <AzCore/PlatformDef.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
@@ -19,6 +17,9 @@ extern "C" AZ_DLL_EXPORT void CleanUpRpiPublicGenericClassInfo()
 }
 
 #endif
+
+#include <Atom/RPI.Public/SceneBus.h>
+#include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 
 DECLARE_EBUS_INSTANTIATION_DLL_MULTI_ADDRESS(RPI::SceneNotification);
 DECLARE_EBUS_INSTANTIATION_DLL_MULTI_ADDRESS(RPI::ShaderReloadNotifications);


### PR DESCRIPTION
## What does this PR do?

This PR fixes a compile error in `Atom/RPI.Public/DllMain.cpp` when building the engine with a monolithic-nounity configuration (see #18813).
The EBus instantiation calls need to be outside of the `#if !defined(AZ_MONOLITHIC_BUILD)` region, since they are not related to monolithic/non-monolithic mode, but rather just need to exist in one of the cpp files built by the Gem::Atom_RPI.Public target.

## How was this PR tested?

Compile the GameLauncher with a monolithic+nounity configuraiton.
