### PR TITLE
Merge from stabilization 25050 to development branch

### DIFF
--- a/AutomatedTesting/Gem/PythonCoverage/Code/Source/PythonCoverageEditorSystemComponent.cpp
+++ b/AutomatedTesting/Gem/PythonCoverage/Code/Source/PythonCoverageEditorSystemComponent.cpp
@@ -71,6 +71,8 @@ namespace PythonCoverage
     PythonCoverageEditorSystemComponent::CoverageState PythonCoverageEditorSystemComponent::ParseCoverageOutputDirectory()
     {
         m_coverageState = CoverageState::Disabled;
+
+#if defined(LY_TEST_IMPACT_DEFAULT_CONFIG_FILE)
         const AZStd::string configFilePath = LY_TEST_IMPACT_DEFAULT_CONFIG_FILE;
 
         if (configFilePath.empty())
@@ -106,6 +108,7 @@ namespace PythonCoverage
 
         // Everything is good to go, await the first python test case
         m_coverageState = CoverageState::Idle;
+#endif
         return m_coverageState;
     }
     

--- a/Code/Framework/AzCore/AzCore/Script/ScriptPropertySerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptPropertySerializer.cpp
@@ -81,6 +81,25 @@ namespace AZ
             return context.Report(JSR::Tasks::WriteValue, JSR::Outcomes::DefaultsUsed, "ScriptPropertySerializer Store used defaults for DynamicSerializableField");
         }
 
+        if (defaultScriptDataPtr && defaultScriptDataPtr->m_typeId != inputScriptDataPtr->m_typeId)
+        {
+            // Edge Case here, where the stored types don't match:
+            // example:
+            // inputScriptdataPtr has
+            //   m_value{ m_data = 0x000012d2be18d820 m_typeId = 0xA96A5037 - 0xAD0D43B6 - 0x9948ED63 - 0x438C4A52 } AZ::DynamicSerializableField
+            //
+            // defaultScriptDataPtr has
+            //   m_value{ m_data = 0x0000000000000000 m_typeId = 0x00000000 - 0x00000000 - 0x00000000 - 0x00000000 } AZ::DynamicSerializableField
+            // 
+            // if the script data and the default data hold a different type entirely from each other, you cannot pass the default
+            // down into any further JSON functions, because all of those functions (Store, ContinueStoring, etc)
+            // only take 3 params related to these objects - namely,
+            //    *  the void* thing to store
+            //    *  typeid of thing to store
+            //    *  optional void* of default value, ASSUMED TO BE THE SAME TYPE
+            defaultFieldPtr = nullptr;
+        }
+
         JSR::ResultCode result(JSR::Tasks::WriteValue);
         outputValue.SetObject();
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistrar.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistrar.cpp
@@ -34,25 +34,24 @@ namespace AZ::DocumentPropertyEditor
 
         AZ::IO::FixedMaxPath fullSettingsPath = AZ::Utils::GetProjectPath();
         fullSettingsPath /= relativeFilepath;
-        const char* posixSettingsPath = fullSettingsPath.AsPosix().c_str();
+        AZ::IO::FixedMaxPath posixSettingsPath = fullSettingsPath.AsPosix().c_str();
 
         AZStd::string stringBuffer;
         AZ::IO::ByteContainerStream stringStream(&stringBuffer);
         if (!AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(*registry, anchorKey, stringStream, dumperSettings))
         {
             return AZ::Failure(AZStd::string::format(
-                "Failed to save settings to file '%s': failed to retrieve settings from registry", posixSettingsPath));
+                "Failed to save settings to file '%s': failed to retrieve settings from registry", posixSettingsPath.c_str()));
         }
 
         constexpr auto openMode = AZ::IO::SystemFile::SF_OPEN_CREATE
             | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH
             | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
-        if (AZ::IO::SystemFile outputFile; outputFile.Open(posixSettingsPath, openMode))
+        if (AZ::IO::SystemFile outputFile; outputFile.Open(posixSettingsPath.c_str(), openMode))
         {
             if(outputFile.Write(stringBuffer.data(), stringBuffer.size()) != stringBuffer.size())
             {
-                return AZ::Failure(AZStd::string::format(
-                    "Failed to save settings to file '%s': incomplete contents written", posixSettingsPath));
+                return AZ::Failure(AZStd::string::format("Failed to save settings to file '%s': incomplete contents written", posixSettingsPath.c_str()));
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -520,9 +520,19 @@ namespace AzToolsFramework
             const auto& selectedIndexes = selected.indexes();
             if (!selectedIndexes.empty())
             {
-                auto newRootIndex = m_tableViewProxyModel->mapFromSource(
-                    m_assetFilterModel->mapFromSource(treeViewFilterModel->mapToSource(selectedIndexes[0])));
-                m_tableViewWidget->setRootIndex(newRootIndex);
+                auto indexInTreeView = treeViewFilterModel->mapToSource(selectedIndexes[0]);
+                auto indexInFilterModel = m_assetFilterModel->mapFromSource(indexInTreeView);
+                if (m_tableViewProxyModel->sourceModel() == m_treeToTableProxyModel)
+                {
+                    auto indexInProxyModel = m_treeToTableProxyModel->mapFromSource(indexInFilterModel);
+                    auto newRootIndex = m_tableViewProxyModel->mapFromSource(indexInProxyModel);
+                    m_tableViewWidget->setRootIndex(newRootIndex);
+                }
+                else
+                {
+                    auto newRootIndex = m_tableViewProxyModel->mapFromSource(indexInFilterModel);
+                    m_tableViewWidget->setRootIndex(newRootIndex);
+                }
             }
             else
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -425,8 +425,9 @@ namespace AzToolsFramework
             const auto& selectedIndexes = selected.indexes();
             if (!selectedIndexes.empty())
             {
-                const auto newRootIndex = m_thumbnailViewProxyModel->mapFromSource(
-                    m_assetFilterModel->mapFromSource(treeViewFilterModel->mapToSource(selectedIndexes[0])));
+                const auto indexInSourceModel = treeViewFilterModel->mapToSource(selectedIndexes[0]);
+                const auto indexInFilterModel = m_assetFilterModel->mapFromSource(indexInSourceModel);
+                const auto newRootIndex = m_thumbnailViewProxyModel->mapFromSource(indexInFilterModel);
                 m_thumbnailViewWidget->setRootIndex(newRootIndex);
             }
             else

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -108,8 +108,8 @@ namespace AzToolsFramework::Prefab
         };
 
         message.Match(PrefabPropertyEditorNodes::PrefabOverrideLabel::RevertOverride, handleRevertOverride);
-
-        return ReflectionAdapter::HandleMessage(message);
+        
+        return ComponentAdapter::HandleMessage(message);
     }
 
     void PrefabComponentAdapter::UpdateDomContents(const PropertyChangeInfo& propertyChangeInfo)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
@@ -102,12 +102,12 @@
             m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
             m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());
 
-            // Queue a refresh of the property display in case the overrides contain only default values.
-            // Otherwise, when overrides don't trigger changes in the template dom, the entity won't be
-            // recreated on propagation and the inspector won't be updated to reflect override icon changes
+            // We have to refresh the entire tree when you revert overrides, because reverting overrides
+            // respawns (as in, deletes and recreates) any entities that have the overrides.  The inspector
+            // MUST drop its references to those entities which are about to be destroyed!
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
                 &AzToolsFramework::ToolsApplicationEvents::Bus::Events::InvalidatePropertyDisplay,
-                AzToolsFramework::Refresh_AttributesAndValues);
+                AzToolsFramework::Refresh_EntireTree); 
 
             return true;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.cpp
@@ -121,7 +121,7 @@ namespace AzToolsFramework
             void UpdateEntitiesAsOverrides(
                 const AZStd::vector<const AZ::Entity*>& entityList,
                 Instance& owningInstance,
-                const Instance& focusedInstance,
+                Instance& focusedInstance,
                 UndoSystem::URSequencePoint* undoBatch)
             {
                 PrefabUndoEntityOverrides* state = aznew PrefabUndoEntityOverrides("Undo Updating Entity List As Override");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoHelpers.h
@@ -84,7 +84,7 @@ namespace AzToolsFramework
             void UpdateEntitiesAsOverrides(
                 const AZStd::vector<const AZ::Entity*>& entityList,
                 Instance& owningInstance,
-                const Instance& focusedInstance,
+                Instance& focusedInstance,
                 UndoSystem::URSequencePoint* undoBatch);
 
             //! Helper function for deleting entities and update parents to prefab template with undo-redo support.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -9,6 +9,7 @@
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
 #include <AzToolsFramework/Prefab/Link/Link.h>
 #include <AzToolsFramework/Prefab/Overrides/PrefabOverridePublicInterface.h>
+#include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabInstanceUtils.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h>
@@ -40,7 +41,7 @@ namespace AzToolsFramework
         void PrefabUndoEntityOverrides::CaptureAndRedo(
             const AZStd::vector<const AZ::Entity*>& entityList,
             Instance& owningInstance,
-            const Instance& focusedInstance)
+            Instance& focusedInstance)
         {
             AZ_Assert(
                 &owningInstance != &focusedInstance,
@@ -62,6 +63,7 @@ namespace AzToolsFramework
             }
 
             PrefabDomReference cachedOwningInstanceDom = owningInstance.GetCachedInstanceDom();
+            PrefabDomReference cachedFocusedInstanceDom = focusedInstance.GetCachedInstanceDom();
 
             const AZStd::string overridePatchPathToOwningInstance = PrefabInstanceUtils::GetRelativePathFromClimbedInstances(
                 climbUpResult.m_climbedInstances, true); // skip top instance
@@ -124,12 +126,29 @@ namespace AzToolsFramework
                 {
                     PrefabUndoUtils::UpdateEntityInPrefabDom(cachedOwningInstanceDom, entityDomAfterUpdate, entityAliasPath);
                 }
+                // Preemptively update the cached DOM in the focused instance, too, since it will be skipped on update
+                if (cachedFocusedInstanceDom.has_value())
+                {
+                    AZStd::string pathInsideFocusedInstance = AZStd::string::format(
+                        "/%s/%s%s",
+                        PrefabDomUtils::InstancesName,
+                        link->get().GetInstanceName().c_str(),
+                        entityPathFromTopInstance.c_str());
+                    PrefabUndoUtils::UpdateEntityInPrefabDom(cachedFocusedInstanceDom, entityDomAfterUpdate, pathInsideFocusedInstance);
+                } 
             }
 
             // Redo - Update target template of the link.
             link->get().UpdateTarget();
             m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
-            m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());
+
+            // If we get into this function, it means that we are reading from a realized set of actual C++ entities in memory
+            // as the "Source of Truth", and calling GenerateEntityDomBySerializing to write the changes that have already been applied
+            // to those c++ entities into an override patch, comparing before/after.  This implies that the instance we have focused
+            // has already got the changes applied to its c++ entities, and does not need template propogation.  All OTHER instances
+            // besides that one do need propogation.  If we do not skip the focusedInstance, we will be modifying the instance
+            // and possibly despawning/respawning it while the user is actually still editing/dragging/typing/looking at properties of it.
+            m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId(), focusedInstance);
         }
 
         void PrefabUndoEntityOverrides::Undo()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.h
@@ -36,7 +36,7 @@ namespace AzToolsFramework::Prefab
         void CaptureAndRedo(
             const AZStd::vector<const AZ::Entity*>& entityList,
             Instance& owningInstance,
-            const Instance& focusedInstance);
+            Instance& focusedInstance);
 
     private:
         // The function to update link during undo and redo.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -470,6 +470,11 @@ namespace AzToolsFramework
 
     bool ComponentEditor::AreAnyComponentsDisabled() const
     {
+        if (m_preventDataAccess) // are we during some sort of full ui rebuild?
+        {
+            return false;
+        }
+
         for (auto component : m_components)
         {
             auto entity = component->GetEntity();
@@ -605,6 +610,11 @@ namespace AzToolsFramework
 
     void ComponentEditor::QueuePropertyEditorInvalidationForComponent(AZ::EntityComponentIdPair entityComponentIdPair, PropertyModificationRefreshLevel refreshLevel)
     {
+        if (m_preventDataAccess) // are we during some sort of full ui rebuild?
+        {
+            return;
+        }
+
         for (const auto component : m_components)
         {
             if ((component->GetId() == entityComponentIdPair.GetComponentId()) 
@@ -623,6 +633,7 @@ namespace AzToolsFramework
 
     void ComponentEditor::PreventRefresh(bool shouldPrevent)
     {
+        m_preventDataAccess = shouldPrevent;
         GetPropertyEditor()->PreventDataAccess(shouldPrevent);
     }
 
@@ -979,6 +990,11 @@ namespace AzToolsFramework
 
     bool ComponentEditor::HasComponentWithId(AZ::ComponentId componentId)
     {
+        if (m_preventDataAccess) // are we during some sort of full ui rebuild?
+        {
+            return false;
+        }
+
         for (AZ::Component* component : m_components)
         {
             if (component->GetId() == componentId)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
@@ -184,6 +184,8 @@ namespace AzToolsFramework
         AZ::Crc32 m_savedKeySeed;
 
         AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeEvent::Handler m_propertyChangeHandler;
+
+        bool m_preventDataAccess = false;
     };
 
 } // namespace AzToolsFramework

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
@@ -423,8 +423,8 @@ namespace ImageProcessingAtom
                     callback(asset);
                 }
 
-                m_assetCallbackMap.erase(itr);
                 AZ::Data::AssetBus::MultiHandler::BusDisconnect(itr->first);
+                m_assetCallbackMap.erase(itr);
              }
         }
     } // namespace Utils

--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -16,6 +16,10 @@ set(SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES
     $<$<NOT:$<CONFIG:Release>>:SC_EXECUTION_TRACE_ENABLED> # this is REQUIRED for debugging/execution logging
 )
 
+# note that the above define controls whether the debug static library has member variables in its classes, in its API,
+# and thus must be transmitted to all users of the static library or else the sizeof the structs will mismatch.
+# It must thus be an INTERFACE or PUBLIC compile definition
+
 set(SCRIPT_CANVAS_DEBUG_DEBUGGER_DEFINES
 $<$<NOT:$<CONFIG:Release>>:
 #   SCRIPT_CANVAS_DEBUGGER_IS_ALWAYS_OBSERVING # for aggressive logging that ignores filtering (probably only for debug/development purposes)
@@ -36,10 +40,10 @@ ly_add_target(
     COMPILE_DEFINITIONS
         PUBLIC
             SCRIPTCANVAS_ERRORS_ENABLED
+            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
         PRIVATE
             ${SCRIPT_CANVAS_COMMON_DEFINES}
             ${SCRIPT_CANVAS_DEBUG_DEBUGGER_DEFINES}
-            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AzCore
@@ -86,10 +90,10 @@ ly_add_target(
     COMPILE_DEFINITIONS
         PUBLIC
             SCRIPTCANVAS_ERRORS_ENABLED
+            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
         PRIVATE
             ${SCRIPT_CANVAS_COMMON_DEFINES}
             ${SCRIPT_CANVAS_DEBUG_DEBUGGER_DEFINES}
-            ${SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES}
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::ScriptEvents.Static


### PR DESCRIPTION

Normally I'd individually cherrypick these but it turns out that there is nothing currently in stabilization yet (such as version changes or "do not merge" commits) so I can just merge the whole branch.

Merges the following pull requests:

* Fixes an additional ASan detection in settings registry. ([#18822](https://github.com/o3de/o3de/pull/18822))
* Fix a few ASan and other corruption errors found. ([#18819](https://github.com/o3de/o3de/pull/18819))
* Fixes a buffer overrun ASan error in LUA Script Properties ([#18807](https://github.com/o3de/o3de/pull/18807))
* Fixes compilation if test modules are disabled. ([#18786](https://github.com/o3de/o3de/pull/18786))
* Fixes containers (vectors, maps, etc) not saving state or undos when modified in the inspector ([#18802](https://github.com/o3de/o3de/pull/18802))
* BUGFIX: Fixes a crash when editing overrides on a prefab instance. ([#18795](https://github.com/o3de/o3de/pull/18795))
* Fix lua editor connectivty with ringbuffer error message ([#18782](https://github.com/o3de/o3de/pull/18782))
* Fixes intermittent test failures ([#18760](https://github.com/o3de/o3de/pull/18760)) ([#18797](https://github.com/o3de/o3de/pull/18797))
* BUGFIX - Crash on CTRL+G if SC is open. ([#18791](https://github.com/o3de/o3de/pull/18791))
* Fix lua script initialization properties ([#18771](https://github.com/o3de/o3de/pull/18771))

Note that the below commits are included, but were already merged from dev to stabilization/25050, and applied no changes
to to dev when merging back:

* Cherry-Pick recent Track View Changes from development to stabilization/25050. ([#18788](https://github.com/o3de/o3de/pull/18788))
* ScriptCanvas: Fix crash on SC editor close ([#18758](https://github.com/o3de/o3de/pull/18758))
* Fixes a issue (vulkan malloc crash) and compile error ([#18736](https://github.com/o3de/o3de/pull/18736))


## Testing

Ran the CI tests locally.