### PR TITLE
Potential fix for NaN summing in `BloomCompositeCS.azsl`

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomCompositeCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomCompositeCS.azsl
@@ -102,7 +102,11 @@ void MainCS(uint3 dID : SV_DispatchThreadID)
         PassSrg::m_inputTexture.SampleLevel(PassSrg::LinearSampler, sourceUv, PassSrg::m_sourceMipLevel).rgb;    
     float3 color1 = PassSrg::m_outputTexture[dID.xy].xyz;
 
-    float3 color = color0 * PassSrg::m_intensity * PassSrg::m_tint + color1;
+    float3 color = color1;
+    if (color0.x == color0.x && color0.y == color0.y && color0.z == color0.z )
+    {
+        color += color0 * PassSrg::m_intensity * PassSrg::m_tint;
+    }
 
     PassSrg::m_outputTexture[dID.xy] = float4(color, 1.0);
 }


### PR DESCRIPTION
## What does this PR do?

This is a proposed, fix for NaN that appears in final render when quad lights are used with bloom.
It is not the greatest solution since it introduced branching to shader, but seems to resolve isse.


## How was this PR tested?

I've reproduced issue https://github.com/o3de/o3de/issues/18683, after fix issue is not reproducible