### PR TITLE
Fix Remote Tools Spam and restore SC live window

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.cpp
@@ -157,7 +157,11 @@ namespace AzNetworking
         if (::bind(aznumeric_cast<int32_t>(m_socketFd), (const sockaddr*)&hints, sizeof(hints)) != 0)
         {
             const int32_t error = GetLastNetworkError();
-            AZLOG_WARN("Failed to bind TCP socket to port %u (%d:%s)", uint32_t(port), error, GetNetworkErrorDesc(error));
+            if (m_warnedBindForPortFailure != port)
+            {
+                m_warnedBindForPortFailure = port;
+                AZLOG_WARN("Failed to bind TCP listen socket to port %u (%d:%s)", uint32_t(port), error, GetNetworkErrorDesc(error));
+            }
             return false;
         }
 
@@ -183,8 +187,12 @@ namespace AzNetworking
 
             if (::bind(aznumeric_cast<int32_t>(m_socketFd), (const sockaddr*)&hints, sizeof(hints)) != 0)
             {
-                const int32_t error = GetLastNetworkError();
-                AZLOG_WARN("Failed to bind TCP socket to port %u (%d:%s)", uint32_t(localPort), error, GetNetworkErrorDesc(error));
+                if (m_warnedBindForPortFailure != localPort)
+                {
+                    m_warnedBindForPortFailure = localPort;
+                    const int32_t error = GetLastNetworkError();
+                    AZLOG_WARN("Failed to bind TCP connect socket to port %u (%d:%s)", uint32_t(localPort), error, GetNetworkErrorDesc(error));
+                }
                 return false;
             }
         }

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.h
@@ -86,6 +86,12 @@ namespace AzNetworking
         bool SocketCreateInternal();
 
         SocketFd m_socketFd;
+
+        // prevent warning spam for bind failure, if something is sitting on the port.
+        // These threads usually try 100x a second or faster, so warning for every bind failure is bad
+        // We'll remember the last warned port so that if the app layer responds to a listen failure
+        // by trying another port, that will show up.
+        uint16_t m_warnedBindForPortFailure = 0; //! Which port have we most recently warned for?
     };
 }
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
@@ -25,7 +25,6 @@ namespace ScriptCanvasEditor
         , m_ui(new Ui::LoggingWindow)
     {
         m_ui->setupUi(this);
-        m_ui->emptyCapture->setParent(this);
 
         // Hack to hide the close button on the first tab. Since we always want it open.
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/ScriptCanvasConstants.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/ScriptCanvasConstants.h
@@ -14,5 +14,5 @@ namespace ScriptCanvas
 {
     static const AZ::Name RemoteToolsName = AZ::Name::FromStringLiteral("ScriptCanvasRemoteTools", nullptr);
     static constexpr AZ::Crc32 RemoteToolsKey("ScriptCanvasRemoteTools");
-    static constexpr uint16_t RemoteToolsPort = 6787;
+    static constexpr uint16_t RemoteToolsPort = 45641;
 }


### PR DESCRIPTION
## What does this PR do?
A couple fixes related to Remote Tools system.

Fixes https://github.com/o3de/o3de/issues/18812
Does not fix, but improves https://github.com/o3de/o3de/issues/17643

1. Change the remote tools port to be something that's far less likely to be camped on by another service.
2. Makes it so that the Remote Tools system only reports once per port that it cannot bind.
3. Restores the "LIVE" tab in SC (which uses Remote Tools)

The third point above was caused by a previous PR, https://github.com/o3de/o3de/pull/18734
After that PR was submitted, I went back with ASan and fixed several SC issues to resolve crashes, and that line that calls SetParent is no longer necessary.

The Live tab disappeared because it was reparented as a child of the docking window, which removes it from the tab view, which closes and erases the tabs, making them always blank.  The docking window itself had its own layout, and the child was never added to that layout, which means, it rendered at 0,0 underneath everything.

With these fixes, you can connect and list targets in the SC Live View, and as the game runs, you can see the entity tree update, so connection is now established.  

The actual breakpoint and log panels do not fill up, because the lua execution mode is not emitting any events.

## Testing

Tested in both debug and profile with the following permutations
* Opening and closing the SC Window
* The above, but with a level loaded
* The above, but with no level loaded
* The above, after switching levels
* The above, with live attached, with and without a SC loaded
* The above, with having run in ctrl+g mode with sc entities in a level.

No crashes or ASAN warnings in debug, no crashes in Profile.