### PR TITLE
Don't recreate device TLAS every frame

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RayTracingAccelerationStructure.cpp
@@ -302,13 +302,16 @@ namespace AZ::RHI
             [this, &descriptor, &rayTracingBufferPools, &resultCode](int deviceIndex)
             {
                 auto device = RHISystemInterface::Get()->GetDevice(deviceIndex);
-                auto deviceRayTracingTlas{Factory::Get().CreateRayTracingTlas()};
-                this->m_deviceObjects[deviceIndex] = deviceRayTracingTlas;
+                if (!m_deviceObjects.contains(deviceIndex))
+                {
+                    this->m_deviceObjects[deviceIndex] = Factory::Get().CreateRayTracingTlas().get();
+                }
 
                 auto deviceDescriptor{ descriptor->GetDeviceRayTracingTlasDescriptor(deviceIndex) };
 
-                resultCode = deviceRayTracingTlas->CreateBuffers(
-                    *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get());
+                resultCode = GetDeviceRayTracingTlas(deviceIndex)
+                                 ->CreateBuffers(
+                                     *device, &deviceDescriptor, *rayTracingBufferPools.GetDeviceRayTracingBufferPools(deviceIndex).get());
                 return resultCode == ResultCode::Success;
             });
 


### PR DESCRIPTION
## What does this PR do?

Currently the `DeviceRayTracingTlas` of the multi device `RayTracingTlas` are recreated every time the `CreateBuffers` function is called. This leads to some problems as the acceleration structure buffers of the Tlas are in a `FrameCountMaxRingBuffer` to ensure they are valid until the current frame was actually rendered.
This manifested as validation errors like this in Vulkan:
```
[Error] (vkDebugMessage) - [ERROR][Validation] Validation Error: [ VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02442 ] Object 0: handle = 0x20dc0d80070, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xaf03fd73 | Cannot call vkDestroyAccelerationStructureKHR on VkAccelerationStructureKHR 0xf353c500000dbf4f[] that is currently in use by a command buffer. The Vulkan spec states: All submitted commands that refer to accelerationStructure must have completed execution (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02442)
```

It probably also might result in device lost errors when the pipeline is GPU bound, I did however not see anything like this on my machine.

## How was this PR tested?

Tested on Windows with Vulkan/DX12, Debug Raytracing and Raytraced Reflections
