### PR TITLE
Add an option for assimp importer to extract embedded textures from model files.

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -29,11 +29,13 @@ namespace AZ
         AssImpSceneWrapper::AssImpSceneWrapper()
             : m_assImpScene(nullptr)
             , m_importer(AZStd::make_unique<Assimp::Importer>())
+            , m_extractEmbeddedTextures(false)
         {
         }
         AssImpSceneWrapper::AssImpSceneWrapper(aiScene* aiScene)
             : m_assImpScene(aiScene)
             , m_importer(AZStd::make_unique<Assimp::Importer>())
+            , m_extractEmbeddedTextures(false)
         {
         }
 
@@ -105,6 +107,8 @@ namespace AZ
             }
 
             CalculateAABBandVertices(m_assImpScene, m_aabb, m_vertices);
+
+            m_extractEmbeddedTextures = importSettings.m_extractEmbeddedTextures;
 
             return true;
         }

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
@@ -48,6 +48,9 @@ namespace AZ
             AZStd::string GetSceneFileName() const { return m_sceneFileName; }
             aiAABB GetAABB() const { return m_aabb; }
             uint32_t GetVertices() const { return m_vertices; }
+
+            bool GetExtractEmbeddedTextures() const { return m_extractEmbeddedTextures; }
+
         protected:
             const aiScene* m_assImpScene = nullptr;
             AZStd::unique_ptr<Assimp::Importer> m_importer;

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
@@ -57,6 +57,7 @@ namespace AZ
             AZStd::string m_sceneFileName;
             aiAABB m_aabb;
             uint32_t m_vertices;
+            bool m_extractEmbeddedTextures;
         };
 
     } // namespace AssImpSDKWrapper

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
@@ -184,16 +184,16 @@ namespace AZ
             {
                 if (textureFilePath.empty())
                 {
-                    AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "Material %.*s has no associated texture.", AZ_STRING_ARG(materialName));
+                    AZ_Info(AZ::SceneAPI::Utilities::LogWindow, "Material %.*s has no associated texture.", AZ_STRING_ARG(materialName));
                     return textureFilePath;
                 }
                 const AZStd::string& sceneFilePath = scene.GetSceneFileName();
-                const aiTexture* embeddedTexture = scene.GetAssImpScene()->GetEmbeddedTexture(textureFilePath.c_str())
+                const aiTexture* embeddedTexture = scene.GetAssImpScene()->GetEmbeddedTexture(textureFilePath.c_str());
                 if (scene.GetExtractEmbeddedTextures() && embeddedTexture != nullptr)
                 {
                     if (embeddedTexture->mHeight == 0)
                     {
-                        AZ_TracePrintf(
+                        AZ_Info(
                             AZ::SceneAPI::Utilities::LogWindow,
                             "Material %.*s has an embedded texture compressed as %s format",
                             AZ_STRING_ARG(materialName), embeddedTexture->achFormatHint);
@@ -204,7 +204,7 @@ namespace AZ
                             sceneFilePath.c_str(), relativeTexturePath, rootPath);
 
                         AZStd::string textureFileName;
-                        if (embeddedTexture->mFileName.length == 0)
+                        if (embeddedTexture->mFilename.length == 0)
                         {
                             // Set texture path as ${relative scene folder}/${scene filename}_${embedded texture index}
                             // for embedded texture, path starts with asterisk (like *1, *2, ...).
@@ -214,15 +214,9 @@ namespace AZ
                         }
                         else
                         {
-                            AZ::StringFunc::Path::GetFileName(embeddedTexture->mFileName.C_Str(), textureFileName);
+                            AZ::StringFunc::Path::GetFileName(embeddedTexture->mFilename.C_Str(), textureFileName);
                         }
                         AZ::StringFunc::Path::ReplaceFullName(relativeTexturePath, textureFileName.c_str(), embeddedTexture->achFormatHint);
-                        AZ_TracePrintf(
-                            AZ::SceneAPI::Utilities::LogWindow,
-                            "Material %.*s has a compressed texture that shall be saved at '%.*s'",
-                            AZ_STRING_ARG(materialName),
-                            AZ_STRING_ARG(relativeTexturePath));
-
                         // Save the texture
                         IO::FileIOBase* fileIO = IO::FileIOBase::GetInstance();
                         AZStd::string fullTexturePath;
@@ -230,7 +224,7 @@ namespace AZ
 
                         if (fileIO->Exists(fullTexturePath.c_str()))
                         {
-                            // don't override if the file already exists.
+                            // don't overwrite if the file already exists.
                             return relativeTexturePath;
                         }
 
@@ -260,8 +254,9 @@ namespace AZ
                     }
                     else
                     {
-                        AZ_TracePrintf(
-                            AZ::SceneAPI::Utilities::LogWindow,
+                        AZ_Warning(
+                            "AtomFeatureCommon",
+                            false,
                             "Material %.*s has a uncompressed texture with absolute path '%.*s', which is not supported",
                             AZ_STRING_ARG(materialName),
                             AZ_STRING_ARG(textureFilePath));

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.h
@@ -29,9 +29,6 @@ namespace AZ
                 static void Reflect(ReflectContext* context);
 
                 Events::ProcessingResult ImportMaterials(AssImpSceneNodeAppendedContext& context);
-
-            private:
-                AZStd::string ResolveTexturePath(const AZStd::string& materialName, const AZStd::string& sceneFilePath, const AZStd::string& textureFilePath) const;
             };
         } // namespace SceneBuilder
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneCore/Import/SceneImportSettings.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Import/SceneImportSettings.cpp
@@ -16,9 +16,10 @@ namespace AZ::SceneAPI
         if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context); serializeContext)
         {
             serializeContext->Class<SceneImportSettings>()
-                ->Version(0)
+                ->Version(1)
                 ->Field("OptimizeScene", &SceneImportSettings::m_optimizeScene)
-                ->Field("OptimizeMeshes", &SceneImportSettings::m_optimizeMeshes);
+                ->Field("OptimizeMeshes", &SceneImportSettings::m_optimizeMeshes)
+                ->Field("ExtractEmbeddedTextures", &SceneImportSettings::m_extractEmbeddedTextures);
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext(); editContext)
             {
@@ -39,7 +40,12 @@ namespace AZ::SceneAPI
                         &SceneImportSettings::m_optimizeMeshes,
                         "Merge Duplicate Meshes",
                         "Non-instanced unskinned meshes with the same vertices and faces are merged into instanced meshes. "
-                        "This will reduce the number of draw calls in the scene.");
+                        "This will reduce the number of draw calls in the scene.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SceneImportSettings::m_extractEmbeddedTextures,
+                        "Extract Embedded Textures",
+                        "Extract textures embedded in the scene file and write them into the directory of the source scene.");
             }
         }
     }

--- a/Code/Tools/SceneAPI/SceneCore/Import/SceneImportSettings.h
+++ b/Code/Tools/SceneAPI/SceneCore/Import/SceneImportSettings.h
@@ -26,5 +26,6 @@ namespace AZ::SceneAPI
 
         bool m_optimizeScene = false;
         bool m_optimizeMeshes = false;
+        bool m_extractEmbeddedTextures = false;
     };
 } //namespace AZ::SceneAPI


### PR DESCRIPTION
## What does this PR do?

FBX and GLTF files can have texture files embedded. This PR adds a option to allow assimp importer to extract such textures into the model directory.

Should solve https://github.com/o3de/o3de/issues/2430

## How was this PR tested?

WIP