### PR TITLE
[WIP] Skip inserting skin weight that is less than epsilon during importing process.

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/string/conversions.h>
+#include <AzCore/Math/MathUtils.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
@@ -100,6 +101,11 @@ namespace AZ
                         int boneId = skinWeightData->GetBoneId(sanitizedName);
                         for (unsigned weight = 0; weight < bone->mNumWeights; ++weight)
                         {
+                            if (bone->mWeights[weight].mWeight <= AZ::Constants::FloatEpsilon)
+                            {
+                                continue;
+                            }
+
                             DataTypes::ISkinWeightData::Link link;
                             link.boneId = boneId;
                             link.weight = bone->mWeights[weight].mWeight;


### PR DESCRIPTION
## What does this PR do?

Certain skinned models lose vertices when displayed as Emfx actors. Further investigation indicates some of the skin weight values are INF (possibly a result of being divided by 0 during the optimization process). While the root cause of it is uncertain, this PR aims to mitigate that by skipping near-zero skin weights during importing.

This fix should also be able to reduce the memory usage for the importer.

## How was this PR tested?

WIP, not tested yet.
