### PR TITLE
Project Manager: Clear the gem model on refresh to avoid duplicates

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -310,6 +310,9 @@ namespace O3DE::ProjectManager
     {
         QSet<QPersistentModelIndex> validIndexes;
 
+        // Clear the model to avoid duplicated entries that may cause incompatibilities
+        m_gemModel->Clear();
+
         if (const auto& outcome = PythonBindingsInterface::Get()->GetAllGemInfos(m_projectPath); outcome.IsSuccess())
         {
             const auto& indexes = m_gemModel->AddGems(outcome.GetValue(), /*updateExisting=*/true);


### PR DESCRIPTION
When refreshing the gem catalog in the project manager, the Gem model needs to be cleared up, otherwise duplicate entries are added which can lead to incompatibilities with gems that are no longer valid. As in the case of changing the version of a gem and refreshing the catalog.

Fixes #18796 