### PR TITLE
Fix crash when using "Debug Ray Tracing" component on non-RTX GPU

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h>
+#include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Debug/RayTracingDebugComponentController.h>
 
@@ -48,6 +49,11 @@ namespace AZ::Render
 
     void RayTracingDebugComponentController::Activate(EntityId entityId)
     {
+        if (!IsRayTracingSupported())
+        {
+            return;
+        }
+
         m_entityId = entityId;
 
         auto fp{ RPI::Scene::GetFeatureProcessorForEntity<RayTracingDebugFeatureProcessorInterface>(m_entityId) };
@@ -65,6 +71,11 @@ namespace AZ::Render
 
     void RayTracingDebugComponentController::Deactivate()
     {
+        if (!IsRayTracingSupported())
+        {
+            return;
+        }
+
         auto fp{ RPI::Scene::GetFeatureProcessorForEntity<RayTracingDebugFeatureProcessorInterface>(m_entityId) };
         if (fp)
         {
@@ -90,6 +101,16 @@ namespace AZ::Render
     void RayTracingDebugComponentController::OnConfigurationChanged()
     {
         m_configuration.CopySettingsTo(m_rayTracingDebugSettingsInterface);
+    }
+
+    bool RayTracingDebugComponentController::IsRayTracingSupported() const
+    {
+        return RHI::RHISystemInterface::Get()->GetRayTracingSupport() != RHI::MultiDevice::NoDevices;
+    }
+
+    bool RayTracingDebugComponentController::IsRayTracingNotSupported() const
+    {
+        return !IsRayTracingSupported();
     }
 
     // clang-format off

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugComponentController.h
@@ -38,6 +38,8 @@ namespace AZ::Render
 
     private:
         void OnConfigurationChanged();
+        bool IsRayTracingSupported() const;
+        bool IsRayTracingNotSupported() const;
 
         RayTracingDebugSettingsInterface* m_rayTracingDebugSettingsInterface{ nullptr };
         EntityId m_entityId{ EntityId::InvalidEntityId };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
@@ -38,7 +38,9 @@ namespace AZ::Render
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                         ->Attribute(Edit::Attributes::AutoExpand, true)
                     ->DataElement(Edit::UIHandlers::Default, &RayTracingDebugComponentController::m_configuration, "Configuration", "")
-                        ->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::ShowChildrenOnly)
+                        ->Attribute(Edit::Attributes::Visibility, &RayTracingDebugComponentController::IsRayTracingSupported)
+                    ->UIElement(Edit::UIHandlers::LineEdit, "Ray Tracing is not supported on this device.")
+                        ->Attribute(Edit::Attributes::Visibility, &RayTracingDebugComponentController::IsRayTracingNotSupported)
                 ;
 
                 editContext->Class<RayTracingDebugComponentConfig>("RayTracingDebugComponentConfig", "")


### PR DESCRIPTION
## What does this PR do?

This PR fixes a crash when adding the "Debug Ray Tracing" component to a level on a device which does not have RTX support or opening a level which contains this component on such a device (#18841).

## How was this PR tested?

Since I do not have access to a non-RTX GPU or non-RTX iGPU, I commented out the ray-tracing related extensions in RHI/Vulkan, which yielded the same error message and crash as in the linked issue, and with the changes for this PR the crash was resolved.

The "Debug Ray Tracing" component now also shows whether ray tracing is supported on the current device or not (left: RTX not supported, right: RTX supported):
![rtdebugcomponent](https://github.com/user-attachments/assets/50a0746c-6218-4500-93a5-820b2a52994d)

