### PR TITLE
Don't check the LoadStoreAction for the pipelineStatesLookup

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -161,7 +161,6 @@ namespace AZ
         void ShadowmapPass::SetClearShadowDrawPacket(AZ::RHI::ConstPtr<RHI::DrawPacket> clearShadowDrawPacket)
         {
             m_clearShadowDrawPacket = clearShadowDrawPacket;
-            m_clearShadowDrawItemProperties = clearShadowDrawPacket->GetDrawItemProperties(0);
         }
 
         void ShadowmapPass::UpdatePipelineViewTag(const RPI::PipelineViewTag& viewTag)
@@ -172,6 +171,9 @@ namespace AZ
         void ShadowmapPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
         {
             Base::SetupFrameGraphDependencies(frameGraph);
+
+            // Report + 1 to make room for the clear draw packet.
+            uint32_t estimatedItemCount = static_cast<uint32_t>(m_drawListView.size() + 1);
 
             // Override the estimated item count set by the base class. Draw item count is compared against
             // the last frame to detect cases where a moving object leaves the shadow frustum. It wouldn't
@@ -185,15 +187,11 @@ namespace AZ
                     if (view && (view->GetOrFlags() & m_casterMovedBit.GetIndex()) == 0)
                     {
                         // Shadow is static and no casters moved since last frame.
-                        frameGraph.SetEstimatedItemCount(0);
+                        estimatedItemCount = 0;
                     }
                 }
             }
-            else
-            {
-                // Report + 1 to make room for the clear draw packet.
-                frameGraph.SetEstimatedItemCount(static_cast<uint32_t>(m_drawListView.size() + 1));
-            }
+            frameGraph.SetEstimatedItemCount(estimatedItemCount);
         }
 
         void ShadowmapPass::SubmitDrawItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex, uint32_t offset) const

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
@@ -84,7 +84,6 @@ namespace AZ
             uint32_t GetNumDraws() const;
 
             RHI::ConstPtr<RHI::DrawPacket> m_clearShadowDrawPacket;
-            RHI::DrawItemProperties m_clearShadowDrawItemProperties;
             RHI::Handle<uint32_t> m_casterMovedBit;
             uint16_t m_arraySlice = 0;
             bool m_clearEnabled = true;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderAttachmentLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderAttachmentLayout.h
@@ -40,6 +40,7 @@ namespace AZ::RHI
 
         bool operator==(const RenderAttachmentDescriptor& other) const;
         bool operator!=(const RenderAttachmentDescriptor& other) const;
+        bool IsEqual(const RenderAttachmentDescriptor& other, const bool compareLoadStoreAction) const;
 
         //! Position of the attachment in the layout.
         uint32_t m_attachmentIndex = InvalidRenderAttachmentIndex;
@@ -95,6 +96,7 @@ namespace AZ::RHI
 
         bool operator==(const SubpassRenderAttachmentLayout& other) const;
         bool operator!=(const SubpassRenderAttachmentLayout& other) const;
+        bool IsEqual(const SubpassRenderAttachmentLayout& other, const bool compareLoadStoreAction) const;
 
         //! Number of render targets in the subpass.
         uint32_t m_rendertargetCount = 0;
@@ -126,6 +128,7 @@ namespace AZ::RHI
         HashValue64 GetHash() const;
 
         bool operator==(const RenderAttachmentLayout& other) const;
+        bool IsEqual(const RenderAttachmentLayout& other, const bool compareLoadStoreAction) const;
 
         //! Number of total attachments in the list.
         uint32_t m_attachmentCount = 0;
@@ -148,6 +151,7 @@ namespace AZ::RHI
         HashValue64 GetHash() const;
 
         bool operator==(const RenderAttachmentConfiguration& other) const;
+        bool IsEqual(const RenderAttachmentConfiguration& other, const bool compareLoadStoreAction) const;
 
         //! Returns the format of a render target in the subpass being used.
         Format GetRenderTargetFormat(uint32_t index) const;

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderAttachmentLayout.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderAttachmentLayout.cpp
@@ -33,12 +33,18 @@ namespace AZ::RHI
 
     bool RenderAttachmentDescriptor::operator==(const RenderAttachmentDescriptor& other) const
     {
-        return (m_attachmentIndex == other.m_attachmentIndex)
-            && (m_resolveAttachmentIndex == other.m_resolveAttachmentIndex)
-            && (m_loadStoreAction == other.m_loadStoreAction)
-            && (m_scopeAttachmentAccess == other.m_scopeAttachmentAccess)
-            && (m_scopeAttachmentStage == other.m_scopeAttachmentStage)
-            ;
+        return IsEqual(other, true);
+    }
+
+    bool RenderAttachmentDescriptor::IsEqual(const RenderAttachmentDescriptor& other, const bool compareLoadStoreAction) const
+    {
+        // clang-format off
+        return (m_attachmentIndex == other.m_attachmentIndex) && 
+               (m_resolveAttachmentIndex == other.m_resolveAttachmentIndex) &&
+               (!compareLoadStoreAction || (m_loadStoreAction == other.m_loadStoreAction)) && 
+               (m_scopeAttachmentAccess == other.m_scopeAttachmentAccess) &&
+               (m_scopeAttachmentStage == other.m_scopeAttachmentStage);
+        // clang-format on
     }
 
     bool RenderAttachmentDescriptor::operator!=(const RenderAttachmentDescriptor& other) const
@@ -65,16 +71,20 @@ namespace AZ::RHI
 
     bool SubpassRenderAttachmentLayout::operator==(const SubpassRenderAttachmentLayout& other) const
     {
-        if ((m_rendertargetCount != other.m_rendertargetCount)
-            || (m_subpassInputCount != other.m_subpassInputCount)
-            || (m_depthStencilDescriptor != other.m_depthStencilDescriptor))
+        return IsEqual(other, true);
+    }
+
+    bool SubpassRenderAttachmentLayout::IsEqual(const SubpassRenderAttachmentLayout& other, const bool compareLoadStoreAction) const
+    {
+        if ((m_rendertargetCount != other.m_rendertargetCount) || (m_subpassInputCount != other.m_subpassInputCount) ||
+            (!m_depthStencilDescriptor.IsEqual(other.m_depthStencilDescriptor, compareLoadStoreAction)))
         {
             return false;
         }
 
         for (uint32_t i = 0; i < m_rendertargetCount; ++i)
         {
-            if (m_rendertargetDescriptors[i] != other.m_rendertargetDescriptors[i])
+            if (!m_rendertargetDescriptors[i].IsEqual(other.m_rendertargetDescriptors[i], compareLoadStoreAction))
             {
                 return false;
             }
@@ -118,8 +128,12 @@ namespace AZ::RHI
 
     bool RenderAttachmentLayout::operator==(const RenderAttachmentLayout& other) const
     {
-        if ((m_attachmentCount != other.m_attachmentCount)
-            || (m_subpassCount != other.m_subpassCount))
+        return IsEqual(other, true);
+    }
+
+    bool RenderAttachmentLayout::IsEqual(const RenderAttachmentLayout& other, const bool compareLoadStoreAction) const
+    {
+        if ((m_attachmentCount != other.m_attachmentCount) || (m_subpassCount != other.m_subpassCount))
         {
             return false;
         }
@@ -134,7 +148,7 @@ namespace AZ::RHI
 
         for (uint32_t i = 0; i < m_subpassCount; ++i)
         {
-            if(m_subpassLayouts[i] != other.m_subpassLayouts[i])
+            if (!m_subpassLayouts[i].IsEqual(other.m_subpassLayouts[i], compareLoadStoreAction))
             {
                 return false;
             }
@@ -209,7 +223,13 @@ namespace AZ::RHI
 
     bool RenderAttachmentConfiguration::operator==(const RenderAttachmentConfiguration& other) const
     {
-        return (m_renderAttachmentLayout == other.m_renderAttachmentLayout) && (m_subpassIndex == other.m_subpassIndex);
+        return IsEqual(other, true);
+    }
+
+    bool RenderAttachmentConfiguration::IsEqual(const RenderAttachmentConfiguration& other, const bool compareLoadStoreAction) const
+    {
+        return m_renderAttachmentLayout.IsEqual(other.m_renderAttachmentLayout, compareLoadStoreAction) &&
+            (m_subpassIndex == other.m_subpassIndex);
     }
 
     void SubpassInputDescriptor::Reflect(ReflectContext* context)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -1116,8 +1116,18 @@ namespace AZ
                                 for (; index < size; ++index)
                                 {
                                     PipelineStateData stateData = pipelineStateList[index];
-                                    if (stateData.m_multisampleState == multisampleState
-                                        && stateData.m_renderAttachmentConfiguration == renderAttachmentConfg)
+
+                                    // don't compare the loadStoreAction of the renderAttachmentConfiguration here for two reasons:
+                                    //
+                                    // - The FrameGraph takes the actual LoadStoreAction from the Pass (or more exactly from the scope), and
+                                    //   not from the Renderattachment - config here
+                                    //
+                                    // - The ShadowMap - Passes are used for both CSM and projected Shadowmaps with the same drawListTag,
+                                    //   but they use different LoadStoreActions, which would cause two separate entries for the same
+                                    //   drawListTag here.
+                                    if (stateData.m_multisampleState == multisampleState &&
+                                        stateData.m_renderAttachmentConfiguration.IsEqual(
+                                            renderAttachmentConfg, false /* compareLoadStoreAction */))
                                     {
                                         break;
                                     }


### PR DESCRIPTION
## What does this PR do?

This fix adds the function `IsEqual(..., const bool compareLoadStoreAction)` to the `RenderAttachmentConfiguration` and some other classes, and uses it during `Scene::RebuildPipelineStatesLookup()` to avoid duplicating the PipelineState caused only by the `LoadStoreAction`.
This works because the actual `LoadStoreAction` used by the GPU is controlled by the FrameGraph and taken from the Scope (i.e. the Pass), and not from the draw-item.   

Concretely this fixes issue [18727](https://github.com/o3de/o3de/issues/18727), where the `ShadowMap` - passes use the same drawlist tag, but can have different clearing actions depending on a shadow-cache setting.
Previously this resulted in multiple Pipeline - States in the PipelineStatesLookup in the Scene, and an error message (and a fallback to the first found entry) from the MeshFeatureProcessor when building MeshDrawPackets for a shadow-map, or specifically in the function `Scene::ConfigurePipelineState(drawListTag, pipelineStateDescriptorDraw)` which didn't know which pipeline state to use.

## How was this PR tested?

Windows on Vulkan and DX12, verify framebuffer clearing modes with nsight.
