### PR TITLE
Enable common test utility targets for sdk

### DIFF
--- a/Code/Framework/AzCore/CMakeLists.txt
+++ b/Code/Framework/AzCore/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 # and will ignore all overrides in release builds.
 # This behavior can be overridden by passing -DALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES=0, 1, 2, 3 or 4 when generating the build files.
 # The override can be removed by passing -UALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES when generating the build files.
-set(ALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES "" CACHE STRING 
+set(ALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES "" CACHE STRING
 "Forces the Settings Registry development overrides to be used or ignored.
   If unset, development overrides are used in development builds and ignored in release builds.
   0 disables the development overrides in all builds.
@@ -152,8 +152,7 @@ endif()
 ################################################################################
 # Tests
 ################################################################################
-if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
-
+if(PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
     ly_add_target(
         NAME AzCoreTestCommon STATIC
         NAMESPACE AZ
@@ -197,52 +196,54 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzCore
     )
 
-    o3de_pal_dir(pal_tests_dir ${CMAKE_CURRENT_LIST_DIR}/Tests/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
-    ly_add_target(
-        NAME AzCore.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
-        NAMESPACE AZ
-        FILES_CMAKE
-            Tests/azcoretests_files.cmake
-            ${pal_tests_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
-        PLATFORM_INCLUDE_FILES
-            ${pal_tests_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}.cmake
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Tests
-        COMPILE_DEFINITIONS
-            PRIVATE
-                AZ_NUMERICCAST_ENABLED
-        BUILD_DEPENDENCIES
-            PRIVATE
-                AZ::AzCore
-                AZ::AzCoreTestCommon
-                AZ::AzTestShared
-                AZ::AzTest
-        RUNTIME_DEPENDENCIES
-            AZ::AzCoreTestDLL
-    )
-    ly_add_googletest(
-        NAME AZ::AzCore.Tests
-        LABELS REQUIRES_tiaf
-    )
-    ly_add_googletest(
-        NAME AZ::AzCore.Tests
-        TEST_SUITE sandbox
-    )
-    ly_add_googlebenchmark(
-        NAME AZ::AzCore.Benchmarks
-        TARGET AZ::AzCore.Tests
-    )
-    ly_add_source_properties(
-        SOURCES Tests/Debug.cpp
-        PROPERTY COMPILE_DEFINITIONS
-        VALUES AZCORETEST_DLL_NAME=\"$<TARGET_FILE_NAME:AzCore.Tests>\"
-    )
-    ly_add_target_files(
-        TARGETS AzCore.Tests
-        FILES ${CMAKE_CURRENT_SOURCE_DIR}/Tests/Memory/AllocatorBenchmarkRecordings.bin
-        OUTPUT_SUBDIRECTORY Tests/AzCore/Memory
-    )
+    if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+        o3de_pal_dir(pal_tests_dir ${CMAKE_CURRENT_LIST_DIR}/Tests/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+        ly_add_target(
+            NAME AzCore.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+            NAMESPACE AZ
+            FILES_CMAKE
+                Tests/azcoretests_files.cmake
+                ${pal_tests_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+            PLATFORM_INCLUDE_FILES
+                ${pal_tests_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}.cmake
+            INCLUDE_DIRECTORIES
+                PRIVATE
+                    Tests
+            COMPILE_DEFINITIONS
+                PRIVATE
+                    AZ_NUMERICCAST_ENABLED
+            BUILD_DEPENDENCIES
+                PRIVATE
+                    AZ::AzCore
+                    AZ::AzCoreTestCommon
+                    AZ::AzTestShared
+                    AZ::AzTest
+            RUNTIME_DEPENDENCIES
+                AZ::AzCoreTestDLL
+        )
+        ly_add_googletest(
+            NAME AZ::AzCore.Tests
+            LABELS REQUIRES_tiaf
+        )
+        ly_add_googletest(
+            NAME AZ::AzCore.Tests
+            TEST_SUITE sandbox
+        )
+        ly_add_googlebenchmark(
+            NAME AZ::AzCore.Benchmarks
+            TARGET AZ::AzCore.Tests
+        )
+        ly_add_source_properties(
+            SOURCES Tests/Debug.cpp
+            PROPERTY COMPILE_DEFINITIONS
+            VALUES AZCORETEST_DLL_NAME=\"$<TARGET_FILE_NAME:AzCore.Tests>\"
+        )
+        ly_add_target_files(
+            TARGETS AzCore.Tests
+            FILES ${CMAKE_CURRENT_SOURCE_DIR}/Tests/Memory/AllocatorBenchmarkRecordings.bin
+            OUTPUT_SUBDIRECTORY Tests/AzCore/Memory
+        )
+    endif()
 
 endif()
 

--- a/Code/Framework/AzManipulatorTestFramework/CMakeLists.txt
+++ b/Code/Framework/AzManipulatorTestFramework/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 #
 
-if(NOT PAL_TRAIT_BUILD_TESTS_SUPPORTED OR NOT PAL_TRAIT_BUILD_HOST_TOOLS)
+if(NOT PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED OR NOT PAL_TRAIT_BUILD_HOST_TOOLS)
     return()
 endif()
 
@@ -29,6 +29,10 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
 )
+
+if(NOT PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+    return()
+endif()
 
 ly_add_target(
     NAME AzManipulatorTestFramework.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}

--- a/Code/Framework/AzToolsFramework/CMakeLists.txt
+++ b/Code/Framework/AzToolsFramework/CMakeLists.txt
@@ -50,7 +50,7 @@ ly_add_target(
 ################################################################################
 # Tests
 ################################################################################
-if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+if(PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
 
     ly_add_target(
         NAME AzToolsFrameworkTestCommon STATIC
@@ -71,39 +71,41 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzTest
     )
 
-    ly_add_target(
-        NAME AzToolsFramework.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
-        NAMESPACE AZ
-        AUTOMOC
-        FILES_CMAKE
-            Tests/aztoolsframeworktests_files.cmake
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Tests
-        COMPILE_DEFINITIONS
-            PRIVATE
-                O3DE_PYTHON_SITE_PACKAGE_SUBPATH="${LY_PYTHON_VENV_SITE_PACKAGES}"
-        BUILD_DEPENDENCIES
-            PUBLIC
-                AZ::AzTestShared
-            PRIVATE
+    if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+        ly_add_target(
+            NAME AzToolsFramework.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+            NAMESPACE AZ
+            AUTOMOC
+            FILES_CMAKE
+                Tests/aztoolsframeworktests_files.cmake
+            INCLUDE_DIRECTORIES
+                PRIVATE
+                    Tests
+            COMPILE_DEFINITIONS
+                PRIVATE
+                    O3DE_PYTHON_SITE_PACKAGE_SUBPATH="${LY_PYTHON_VENV_SITE_PACKAGES}"
+            BUILD_DEPENDENCIES
+                PUBLIC
+                    AZ::AzTestShared
+                PRIVATE
+                    3rdParty::Qt::Test
+                    AZ::AzFrameworkTestShared
+                    AZ::AzToolsFramework
+                    AZ::AzToolsFrameworkTestCommon
+                    AZ::AzManipulatorTestFramework.Static
+                    AZ::AzCoreTestCommon
+                    AZ::AzTest
+                    AZ::AzQtComponents
+            RUNTIME_DEPENDENCIES
                 3rdParty::Qt::Test
-                AZ::AzFrameworkTestShared
-                AZ::AzToolsFramework
-                AZ::AzToolsFrameworkTestCommon
-                AZ::AzManipulatorTestFramework.Static
-                AZ::AzCoreTestCommon
-                AZ::AzTest
-                AZ::AzQtComponents
-        RUNTIME_DEPENDENCIES
-            3rdParty::Qt::Test
-    )
-    ly_add_googletest(
-        NAME AZ::AzToolsFramework.Tests
-        LABELS REQUIRES_tiaf
-    )
-    ly_add_googlebenchmark(
-        NAME AZ::AzToolsFramework.Benchmarks
-        TARGET AZ::AzToolsFramework.Tests
-    )
+        )
+        ly_add_googletest(
+            NAME AZ::AzToolsFramework.Tests
+            LABELS REQUIRES_tiaf
+        )
+        ly_add_googlebenchmark(
+            NAME AZ::AzToolsFramework.Benchmarks
+            TARGET AZ::AzToolsFramework.Tests
+        )
+    endif()
 endif()


### PR DESCRIPTION
## What does this PR do?

This PR enables several targets to be available to projects / gems that use prebuilt SDK.
Those targets are
- AzCoreTestCommon
- AzTestShared
- AzCoreTestDLL
- AzManipulatorTestFramework.Static
- AzToolsFrameworkTestCommon
Without this change, some outside gems that are built with the project fail on configure step because some targets are not available if engine was built with `-DLY_DISABLE_TEST_MODULES=ON`

It changes usage of `PAL_TRAIT_BUILD_TESTS_SUPPORTED` to `PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED` for targets that aren't tests themselves.
Affected targets `*.Tests` are available only if `(PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)` 

## How was this PR tested?

1. Built SDK engine after change.
2. Use engine with `MinimalProject` project and `ROS2` gem enabled
3. Build tests from ROS2 gem
