### PR TITLE
Fixes issues with undo and redo and continuous edits

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -1291,24 +1291,19 @@ namespace AzToolsFramework
         }
 
         // if we are in an undo already, and its already the expected one, just return it.
-        if ((m_currentBatchUndo) && (m_currentBatchUndo == expected))
+        UndoSystem::URSequencePoint* searchNode = m_currentBatchUndo;
+        while (searchNode)
         {
-            if (m_undoStack->GetTop() == m_currentBatchUndo)
+            if (searchNode == expected)
             {
-                m_undoStack->PopTop();
+                return searchNode;
             }
-
-            return m_currentBatchUndo;
+            searchNode = searchNode->GetParent(); // walk up the tree.
         }
 
-        const auto ptr = m_undoStack->GetTop();
-        if (ptr && ptr == expected)
-        {
-            m_currentBatchUndo = ptr;
-            m_undoStack->PopTop();
-
-            return m_currentBatchUndo;
-        }
+        // note that when resuming an undo batch, we do not pop any values, this allows the node to
+        // continue adding data to nodes without creating new undos.
+        // we only create a new undo node if the one we are trying to resume is not anywhere in the current undo tree.
 
         return BeginUndoBatch(label);
     }


### PR DESCRIPTION
## What does this PR do?

fixes https://github.com/o3de/o3de/issues/18871
possibly others, if they have undo redo issues.

basically, any time you made a continuous edit, the two different property editor systems would fight each other.

Normal one-off edits were fine (checkbox, button, delete button, etc) But any continous edits (slider, color, transform) were broken.

example of the fighting, drag the color around in a color control

```ComponentAdapter
    PropertyColorCtrl::valueChanged => PropertyEditorGUIMessages::RequestWrite,
        PropertyManagerComponent::RequestWrite
            m_currentUndoBatch = BeginUndoBatch ("Modify Property")
                BeginUndoBatch: empty stack, so it creates one and returns it
        PropertyManagerComponent::RequestWrite (singleton) continues
            emits IndividualPropertyHandlerEditNotifications::Bus::Events::OnValueChanged ValueChangeType::InProgressEdit
                ComponentAdapter::HandleMessage handlePropertyEditorChanged in dpecomponentadapter
                    case Nodes::ValueChangeType::InProgressEdit:
                        m_currentUndoBatch = BeginUndoBatch ("Modify Entity Property")

// at the end of this,
BeginUndoBatch: non-empty stack so stack is now
0x00000221cfb0c5e8 "Modify Entity Property" (top of stack)
0x00000221cfb0fdf0 "Modify Property" (root), parent of above
```

now, suppose someone drags the color slider or value around, we try to resume the undo and append to it, instead of creating thousands of undos as the user slides the value around.

Same thing happens as above, except that
```cpp
PropertyManagerComponent::RequestWrite tries to invoke ResumeUndoBatch since it knows
its in the middle of the batch and this is a continuous edit.

But PropertyManagerComponent cached 0x00000221cfb0fdf0 (currently root of stack)

So instead of returning the existing live undo, it creates a new one.
now the stack has 3 elements in it.
```

then the other property handler (DPE Component adapter) does the same thing, trying to resume its undo, but again, now that value is no longer at the top of ths stack (the newly created one is) so it too creates a new one.

So now the stack is 4 deep.

every movement of the mouse increases the stack by 2 more.

When the editing operation finishes, it pops only the most recent 2 off the stack.

This change allows ResumeUndoBatch to continue the undo as long as the element in question is the most recent operation in the undo list, which means its in the most recent current stack.  (The undo system is a linked list of stacks).  It is okay to continue appending to the current undo operation as long it is the current one.  It cannot append once its closed.

## How was this PR tested?

Manual testing

* Tested with color and slider properties
* Tested with transform and boolean properties
* Tested with adding and removing components
* Tested with adding and removing elements to a vector, reordering vector, deleting elements in the vector.

The above was tested by hitting undo and redo after each operation to ensure that they made undo elements.
Then the above was tested again to make sure they all worked on prefabs (creating undoable / redoable overrides) and then tested again when in-place editing an open prefab.  

No issues discovered.
