### PR TITLE
Move the registration of property handlers to LyShineEditorSystemComponent so that they can be handled by Asset Editor.

### DIFF
--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -146,8 +146,6 @@ EditorWindow::EditorWindow(QWidget* parent, Qt::WindowFlags flags)
     // value while using the UI Editor.
     SaveStartupLocalizationFolderSetting();
 
-    PropertyHandlers::Register();
-
     setAcceptDrops(true);
 
     // Store local copy of startup localization value

--- a/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
+++ b/Gems/LyShine/Code/Editor/LyShineEditorSystemComponent.cpp
@@ -9,6 +9,7 @@
 #include "LyShineEditorSystemComponent.h"
 #include "EditorWindow.h"
 #include "PropertyHandlerCanvasAsset.h"
+#include "PropertyHandlers.h"
 
 // UI_ANIMATION_REVISIT, added includes so that we can register the UI Animation system on startup
 #include "Animation/UiAnimViewSequenceManager.h"
@@ -147,6 +148,7 @@ namespace LyShineEditor
         CUiAnimViewSequenceManager::Create();
 
         AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
+        PropertyHandlers::Register();
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

LyShine has implemented property handlers for some of asset types it uses such as sprites, however, the handlers only gets registered when UI editor window starts. This PR moves their registration to LyShineEditorSystemComponent::Activate() so that other editors such as Asset Editor can use the handlers.

## How was this PR tested?

Define a custom generic asset type that has a member as AzFramework::SimpleAssetReference<LmbrCentral::TextureAsset> and set its DataElement as "Sprite". Create and edit such asset in AssetEditor.