### PR TITLE
Allows O3DE to compile with cmake v4.xx

### DIFF
--- a/Gems/RecastNavigation/Code/CMakeLists.txt
+++ b/Gems/RecastNavigation/Code/CMakeLists.txt
@@ -19,14 +19,26 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${
 # is supported by this platform.
 include(${pal_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
+# If you change these, please change the copy of them below in the installer 
+# section.  That installer section is the ONLY part of the file that is shipped in the installer
+# (SDK) version of the package, the rest of this file is not, so it must be duplicated there.
+set(RECAST_GIT_REPO "https://github.com/recastnavigation/recastnavigation.git")
+set(RECAST_GIT_TAG 5a870d4)
+set(RECAST_GIT_PATCH "${CMAKE_CURRENT_LIST_DIR}/recast-o3de.patch")
+
 # Add RecastNavigation dependency using FetchContent
 # Note: RecastNavigation::Detour requires lowering of the warning level to compile.
 include(FetchContent)
 FetchContent_Declare(
         RecastNavigation
-        GIT_REPOSITORY "https://github.com/recastnavigation/recastnavigation"
-        GIT_TAG "5a870d427e47abd4a8e4ce58a95582ec049434d5" # main branch
+        GIT_REPOSITORY ${RECAST_GIT_REPO}
+        GIT_TAG ${RECAST_GIT_TAG} # main branch as of March 17, 2022
+        PATCH_COMMAND cmake -P "${LY_ROOT_FOLDER}/cmake/PatchIfNotAlreadyPatched.cmake" ${RECAST_GIT_PATCH}
 )
+
+# please always be really clear about what third parties your gem uses.
+message(STATUS "RecastNavigation Gem uses ${RECAST_GIT_REPO} commit 5a870d4 (License: Zlib)")
+
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 set(RECASTNAVIGATION_DEMO OFF)
 set(RECASTNAVIGATION_TESTS OFF)
@@ -71,7 +83,14 @@ foreach(recastLibrary ${recastLibraries})
 endforeach()
 
 # Export external recast navigation targets for installers.
+# Note that the following property in the square brackets is the only part of this entire file
+# that gets included in installers.  This is why we need to duplicate the github repo from above
+# and cannot reuse the variables above.  The rest of this file won't be there to refer to.
 set_property(DIRECTORY APPEND PROPERTY O3DE_SUBDIRECTORY_INSTALL_CODE [[
+    set(RECAST_GIT_REPO "https://github.com/recastnavigation/recastnavigation.git")
+    set(RECAST_GIT_TAG 5a870d4)
+    message(STATUS "RecastNavigation Gem uses ${RECAST_GIT_REPO} commit 5a870d4 (License: Zlib)")
+    
     set(recastLibraries DebugUtils;Detour;DetourCrowd;DetourTileCache;Recast)
     foreach(recastLibrary ${recastLibraries})
         add_library(RecastNavigation::${recastLibrary} STATIC IMPORTED GLOBAL)

--- a/Gems/RecastNavigation/Code/recast-o3de.patch
+++ b/Gems/RecastNavigation/Code/recast-o3de.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c3121c6..f4b8e73 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.22)
+ 
+ project(RecastNavigation)
+ 

--- a/cmake/PatchIfNotAlreadyPatched.cmake
+++ b/cmake/PatchIfNotAlreadyPatched.cmake
@@ -1,0 +1,53 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# This file is used to patch a file only if it has not already been patched.
+# This is useful for patching a file that is fetched by FetchContent, which
+# does not have a built-in way to only apply a patch if it has not already been
+# applied.
+
+# Usage:
+# cmake -P PatchIfNotAlreadyPatched.cmake <patchfile>
+# it expects the current working directory to be in the root of the repository
+# for which the patch applies and uses `git apply` to patch it.
+
+# note that CMAKE_ARGV0 will be the cmake executable
+#  and that CMAKE_ARGV1 will be -P to enable the script mode
+#  and that CMAKE_ARGV2 will be the name of this script file itself,
+# so we start at CMAKE_ARGV3 to get the first argument passed to this script.
+
+set(PATCH_FILE_NAME "${CMAKE_ARGV3}")
+set(PATCH_ALREADY_APPLIED "")
+
+# Check if the patch has already been applied.
+# if this command returns 0 it means that reversing the patch was successful
+# which means the patch was already applied.
+execute_process(
+    COMMAND git apply --check --reverse "${PATCH_FILE_NAME}"
+    RESULT_VARIABLE PATCH_ALREADY_APPLIED
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if (PATCH_ALREADY_APPLIED STREQUAL "0")
+    message(STATUS "Skipping already applied patch ${PATCH_FILE_NAME} in dir ${CMAKE_BINARY_DIR}")
+else()
+    message(STATUS "Cleaning directory before patch...")
+    execute_process(COMMAND git restore .)
+    execute_process(COMMAND git clean -fdx)
+    message(STATUS "Applying patch ${PATCH_FILE_NAME} at ${CMAKE_BINARY_DIR}...")
+    execute_process(
+        COMMAND git apply --ignore-whitespace "${PATCH_FILE_NAME}"
+        RESULT_VARIABLE PATCH_RESULT
+    )
+    if (NOT PATCH_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to apply patch")
+    else()
+        message(STATUS "Patch applied successfully")
+    endif()
+endif()


### PR DESCRIPTION
## What does this PR do?

fixes issue https://github.com/o3de/o3de/issues/18878

CMake 4.xx will issue a fatal error if it encounters a cmake file that requests a cmake version under 3.5.

cmake.org now has 4.xx as the recommended latest stable release, and `winget install cmake` will install 4.x

Recast navigation asks for cmake version 3.0 (~10 years ago) even though it compiles just fine with cmake 4.x and 3.22.

This change updates the code in the following ways
1. cherry-pick the cmake utility to patch a file if its not already patched from development (this utility is not used unless you invoke it so it will not affect any other pipelines)
2. Change the recast cmake script to apply a patch to it which changes the minimum version of cmake it asks for from 3.0 to 3.22

## How was this PR tested?

CMake configure
Build and run in profile with the editor.  The version of the recast library was not changed, so there's no side effect in terms
of the actual functionality here.