### PR TITLE
Merge stabilization 25.05.0 into development

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.cpp
@@ -157,7 +157,11 @@ namespace AzNetworking
         if (::bind(aznumeric_cast<int32_t>(m_socketFd), (const sockaddr*)&hints, sizeof(hints)) != 0)
         {
             const int32_t error = GetLastNetworkError();
-            AZLOG_WARN("Failed to bind TCP socket to port %u (%d:%s)", uint32_t(port), error, GetNetworkErrorDesc(error));
+            if (m_warnedBindForPortFailure != port)
+            {
+                m_warnedBindForPortFailure = port;
+                AZLOG_WARN("Failed to bind TCP listen socket to port %u (%d:%s)", uint32_t(port), error, GetNetworkErrorDesc(error));
+            }
             return false;
         }
 
@@ -183,8 +187,12 @@ namespace AzNetworking
 
             if (::bind(aznumeric_cast<int32_t>(m_socketFd), (const sockaddr*)&hints, sizeof(hints)) != 0)
             {
-                const int32_t error = GetLastNetworkError();
-                AZLOG_WARN("Failed to bind TCP socket to port %u (%d:%s)", uint32_t(localPort), error, GetNetworkErrorDesc(error));
+                if (m_warnedBindForPortFailure != localPort)
+                {
+                    m_warnedBindForPortFailure = localPort;
+                    const int32_t error = GetLastNetworkError();
+                    AZLOG_WARN("Failed to bind TCP connect socket to port %u (%d:%s)", uint32_t(localPort), error, GetNetworkErrorDesc(error));
+                }
                 return false;
             }
         }

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocket.h
@@ -86,6 +86,12 @@ namespace AzNetworking
         bool SocketCreateInternal();
 
         SocketFd m_socketFd;
+
+        // prevent warning spam for bind failure, if something is sitting on the port.
+        // These threads usually try 100x a second or faster, so warning for every bind failure is bad
+        // We'll remember the last warned port so that if the app layer responds to a listen failure
+        // by trying another port, that will show up.
+        uint16_t m_warnedBindForPortFailure = 0; //! Which port have we most recently warned for?
     };
 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -1291,24 +1291,19 @@ namespace AzToolsFramework
         }
 
         // if we are in an undo already, and its already the expected one, just return it.
-        if ((m_currentBatchUndo) && (m_currentBatchUndo == expected))
+        UndoSystem::URSequencePoint* searchNode = m_currentBatchUndo;
+        while (searchNode)
         {
-            if (m_undoStack->GetTop() == m_currentBatchUndo)
+            if (searchNode == expected)
             {
-                m_undoStack->PopTop();
+                return searchNode;
             }
-
-            return m_currentBatchUndo;
+            searchNode = searchNode->GetParent(); // walk up the tree.
         }
 
-        const auto ptr = m_undoStack->GetTop();
-        if (ptr && ptr == expected)
-        {
-            m_currentBatchUndo = ptr;
-            m_undoStack->PopTop();
-
-            return m_currentBatchUndo;
-        }
+        // note that when resuming an undo batch, we do not pop any values, this allows the node to
+        // continue adding data to nodes without creating new undos.
+        // we only create a new undo node if the one we are trying to resume is not anywhere in the current undo tree.
 
         return BeginUndoBatch(label);
     }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DllMain.cpp
@@ -8,8 +8,6 @@
 
 #if !defined(AZ_MONOLITHIC_BUILD)
 
-#include <Atom/RPI.Public/SceneBus.h>
-#include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 #include <AzCore/PlatformDef.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
@@ -19,6 +17,9 @@ extern "C" AZ_DLL_EXPORT void CleanUpRpiPublicGenericClassInfo()
 }
 
 #endif
+
+#include <Atom/RPI.Public/SceneBus.h>
+#include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 
 DECLARE_EBUS_INSTANTIATION_DLL_MULTI_ADDRESS(RPI::SceneNotification);
 DECLARE_EBUS_INSTANTIATION_DLL_MULTI_ADDRESS(RPI::ShaderReloadNotifications);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindow.cpp
@@ -25,7 +25,6 @@ namespace ScriptCanvasEditor
         , m_ui(new Ui::LoggingWindow)
     {
         m_ui->setupUi(this);
-        m_ui->emptyCapture->setParent(this);
 
         // Hack to hide the close button on the first tab. Since we always want it open.
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/ScriptCanvasConstants.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/ScriptCanvasConstants.h
@@ -14,5 +14,5 @@ namespace ScriptCanvas
 {
     static const AZ::Name RemoteToolsName = AZ::Name::FromStringLiteral("ScriptCanvasRemoteTools", nullptr);
     static constexpr AZ::Crc32 RemoteToolsKey("ScriptCanvasRemoteTools");
-    static constexpr uint16_t RemoteToolsPort = 6787;
+    static constexpr uint16_t RemoteToolsPort = 45641;
 }


### PR DESCRIPTION
## What does this PR do?

Merge additional fixes from stabilization into development

The following fixes are included
* Fixes issues with undo and redo and continuous edits ([#18872](https://github.com/o3de/o3de/pull/18872))
* Fixes spam when a TCP socket fails to bind in Remote tools. ([#18838](https://github.com/o3de/o3de/pull/18838))
* Fix SceneNotification/ShaderReloadNotificationBus instantiation compile error when building a monolithic-nounity-configuration ([#18825](https://github.com/o3de/o3de/pull/18825))

The following commits originally came from development and, while included
for the purposes of history tracking, did not affect any lines in development
when merged:

* Update slot names if the referenced variable is renamed ([#18852](https://github.com/o3de/o3de/pull/18852))
* ScriptCanvas: Fix default file path when saving a new graph  ([#18853](https://github.com/o3de/o3de/pull/18853))
* DPE: Don't request a size update for every Dom change ([#18821](https://github.com/o3de/o3de/pull/18821))
* Added PhysX locking to ArticulationLink component. ([#18828](https://github.com/o3de/o3de/pull/18828))

