### PR TITLE
RaytracingAccelerationStructurePass: MultiDevice Refactor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h
@@ -413,5 +413,9 @@ namespace AZ::Render
 
         //! Retrieves the list of all procedural geometry instances in the scene
         virtual const ProceduralGeometryList& GetProceduralGeometries() const = 0;
+
+        //! Returns the device mask with the devices that build RayTracingAccelerationStructures
+        //! Only devices present in the mask can use the acceleration structures provided by this FeatureProcessor
+        virtual RHI::MultiDevice::DeviceMask GetDeviceMask() const = 0;
     };
 } // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetComputePass.h
@@ -31,13 +31,12 @@ namespace AZ
 
             Data::Instance<RPI::Shader> GetShader() const;
 
-            void SetFeatureProcessor(SkinnedMeshFeatureProcessor* m_skinnedMeshFeatureProcessor);
         private:
             void BuildInternal() override;
             void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
             void BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context) override;
 
-            SkinnedMeshFeatureProcessor* m_skinnedMeshFeatureProcessor = nullptr;
+            SkinnedMeshFeatureProcessor* GetSkinnedMeshFeatureProcessor();
         };
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -1367,6 +1367,8 @@ namespace AZ
                     auto deviceIndex = pass->GetDeviceIndex();
                     if (deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex)
                     {
+                        // We assume that the whole pipelines runs on device 0 here
+                        // Pipelines that might be scheduled on other devices have to take care to set the device index of RTAS passes
                         deviceIndex = 0;
                     }
                     if (m_blasInstanceMap.empty())
@@ -1378,7 +1380,7 @@ namespace AZ
                         // Adding new RTAS passes when a scene is already loaded is currently not supported
                         // We would need to build all current BLAS on this new device
                         // Additionally we would need to find a way to have a compacted BLAS on one device and an uncompacted on another
-                        auto newDeviceMask = AZ::RHI::SetBit(m_deviceMask, deviceIndex);
+                        [[maybe_unused]] auto newDeviceMask = AZ::RHI::SetBit(m_deviceMask, deviceIndex);
                         AZ_Assert(
                             newDeviceMask == m_deviceMask,
                             "RaytracingAccelerationStructurePasses cannot be added while the scene already contains objects");

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -166,7 +166,7 @@ namespace AZ
             blasDescriptor.Build()
                 ->AABB(aabb)
                 ;
-            rayTracingBlas->CreateBuffers(RHI::MultiDevice::AllDevices, &blasDescriptor, *m_bufferPools);
+            rayTracingBlas->CreateBuffers(m_deviceMask, &blasDescriptor, *m_bufferPools);
 
             ProceduralGeometry proceduralGeometry;
             proceduralGeometry.m_uuid = uuid;
@@ -198,7 +198,7 @@ namespace AZ
             m_blasInstanceMap.emplace(Data::AssetId(uuid), meshBlasInstance);
 
             RHI::MultiDeviceObject::IterateDevices(
-                RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
+                m_deviceMask,
                 [&](int deviceIndex)
                 {
                     m_blasToBuild[deviceIndex].insert(Data::AssetId(uuid));
@@ -818,7 +818,7 @@ namespace AZ
 
                 // create the TLAS buffers based on the descriptor
                 RHI::Ptr<RHI::RayTracingTlas>& rayTracingTlas = m_tlas;
-                rayTracingTlas->CreateBuffers(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &tlasDescriptor, *m_bufferPools);
+                rayTracingTlas->CreateBuffers(m_deviceMask, &tlasDescriptor, *m_bufferPools);
             }
 
             // update and compile the RayTracingSceneSrg and RayTracingMaterialSrg
@@ -956,8 +956,7 @@ namespace AZ
                         }
                         subMeshInstance.m_blas = rayTracingBlas;
                         // create the buffers from the BLAS descriptor
-                        subMeshInstance.m_blas->CreateBuffers(
-                            RHI::RHISystemInterface::Get()->GetRayTracingSupport(), &subMeshInstance.m_blasDescriptor, *m_bufferPools);
+                        subMeshInstance.m_blas->CreateBuffers(m_deviceMask, &subMeshInstance.m_blasDescriptor, *m_bufferPools);
                     }
 
                     if (instance.m_isSkinnedMesh)
@@ -1006,7 +1005,7 @@ namespace AZ
                                 auto& subMeshInstance = it->second.m_subMeshes[subMeshIdx];
                                 AZ_Assert(!subMeshInstance.m_compactBlas, "Trying to compact a Blas twice");
                                 AZ_Assert(
-                                    frameEvent.m_deviceMask == RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
+                                    frameEvent.m_deviceMask == m_deviceMask,
                                     "All device Blas of a SubMesh must be compacted in the same frame");
                                 AZStd::unordered_map<int, uint64_t> sizes;
                                 RHI::MultiDeviceObject::IterateDevices(
@@ -1024,7 +1023,7 @@ namespace AZ
                                 changed = true;
                             }
                             RHI::MultiDeviceObject::IterateDevices(
-                                RHI::RHISystemInterface::Get()->GetRayTracingSupport(),
+                                m_deviceMask,
                                 [&, assetId = assetId](int deviceIndex)
                                 {
                                     m_blasToCompact[deviceIndex].insert(assetId);
@@ -1357,64 +1356,41 @@ namespace AZ
                 return;
             }
 
-            // determine which devices need RayTracingAccelerationStructurePasses and distribute multiple existing ones to the devices
-            AZ::RPI::Pass* firstRayTracingAccelerationStructurePass{ nullptr };
-            auto rayTracingDeviceMask{ RHI::RHISystemInterface::Get()->GetRayTracingSupport() };
-            AZ::RHI::MultiDevice::DeviceMask devicesToAdd{ rayTracingDeviceMask };
-
-            // only enable the RayTracingAccelerationStructurePass for each device on the first pipeline in this scene, this will avoid
-            // multiple updates to the same AS
-            AZ::RPI::PassFilter passFilter =
-                AZ::RPI::PassFilter::CreateWithTemplateName(AZ::Name("RayTracingAccelerationStructurePassTemplate"), GetParentScene());
+            // Find out which devices have a RayTracingAccelerationStructurePass
+            // We then only build the BLAS and TLAS objects on these devices
+            AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithTemplateName(
+                AZ_NAME_LITERAL("RayTracingAccelerationStructurePassTemplate"), renderPipeline->GetScene());
             AZ::RPI::PassSystemInterface::Get()->ForEachPass(
                 passFilter,
-                [&devicesToAdd, &firstRayTracingAccelerationStructurePass, &rayTracingDeviceMask](
-                    AZ::RPI::Pass* pass) -> AZ::RPI::PassFilterExecutionFlow
+                [this](AZ::RPI::Pass* pass) -> AZ::RPI::PassFilterExecutionFlow
                 {
-                    if (!firstRayTracingAccelerationStructurePass)
+                    auto deviceIndex = pass->GetDeviceIndex();
+                    if (deviceIndex == AZ::RHI::MultiDevice::InvalidDeviceIndex)
                     {
-                        firstRayTracingAccelerationStructurePass = pass;
+                        deviceIndex = 0;
+                    }
+                    if (m_blasInstanceMap.empty())
+                    {
+                        m_deviceMask = AZ::RHI::SetBit(m_deviceMask, deviceIndex);
+                    }
+                    else
+                    {
+                        // Adding new RTAS passes when a scene is already loaded is currently not supported
+                        // We would need to build all current BLAS on this new device
+                        // Additionally we would need to find a way to have a compacted BLAS on one device and an uncompacted on another
+                        auto newDeviceMask = AZ::RHI::SetBit(m_deviceMask, deviceIndex);
+                        AZ_Assert(
+                            newDeviceMask == m_deviceMask,
+                            "RaytracingAccelerationStructurePasses cannot be added while the scene already contains objects");
                     }
 
-                    // we always set an invalid device index to the first available device
-                    if (pass->GetDeviceIndex() == RHI::MultiDevice::InvalidDeviceIndex)
-                    {
-                        pass->SetDeviceIndex(az_ctz_u32(AZStd::to_underlying(rayTracingDeviceMask)));
-                    }
+                    AZ_Assert(
+                        RHI::CheckBit(RHI::RHISystemInterface::Get()->GetRayTracingSupport(), deviceIndex),
+                        "Pass %s does not run on a raytracing capable device",
+                        pass->GetName().GetCStr());
 
-                    auto mask = RHI::MultiDevice::DeviceMask(AZ_BIT(pass->GetDeviceIndex()));
-
-                    // only have one RayTracingAccelerationStructurePass per device
-                    pass->SetEnabled((mask & devicesToAdd) != RHI::MultiDevice::NoDevices);
-                    devicesToAdd &= ~mask;
-
-                    return AZ::RPI::PassFilterExecutionFlow::ContinueVisitingPasses;
+                    return AZ::RPI::ContinueVisitingPasses;
                 });
-
-            // we only add the passes on the other devices if the pipeline contains one in the first place
-            if (firstRayTracingAccelerationStructurePass && changeType != RPI::SceneNotification::RenderPipelineChangeType::Removed &&
-                renderPipeline->FindFirstPass(firstRayTracingAccelerationStructurePass->GetName()))
-            {
-                // add passes for the remaining devices
-                while (devicesToAdd != RHI::MultiDevice::NoDevices)
-                {
-                    auto deviceIndex{ az_ctz_u32(AZStd::to_underlying(devicesToAdd)) };
-
-                    AZStd::shared_ptr<RPI::PassRequest> passRequest = AZStd::make_shared<RPI::PassRequest>();
-                    passRequest->m_templateName = Name("RayTracingAccelerationStructurePassTemplate");
-                    passRequest->m_passName = Name("RayTracingAccelerationStructurePass" + AZStd::to_string(deviceIndex));
-
-                    AZStd::shared_ptr<RPI::PassData> passData = AZStd::make_shared<RPI::PassData>();
-                    passData->m_deviceIndex = deviceIndex;
-                    passRequest->m_passData = passData;
-
-                    auto pass = RPI::PassSystemInterface::Get()->CreatePassFromRequest(passRequest.get());
-
-                    renderPipeline->AddPassAfter(pass, firstRayTracingAccelerationStructurePass->GetName());
-
-                    devicesToAdd &= RHI::MultiDevice::DeviceMask(~AZ_BIT(deviceIndex));
-                }
-            }
         }
 
         void RayTracingFeatureProcessor::RemoveBlasInstance(Data::AssetId id)

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -1349,7 +1349,9 @@ namespace AZ
             m_rayTracingMaterialSrg->Compile();
         }
 
-        void RayTracingFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType)
+        void RayTracingFeatureProcessor::OnRenderPipelineChanged(
+            [[maybe_unused]] RPI::RenderPipeline* renderPipeline,
+            [[maybe_unused]] RPI::SceneNotification::RenderPipelineChangeType changeType)
         {
             if (!m_rayTracingEnabled)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -118,6 +118,8 @@ namespace AZ
             bool HasProceduralGeometry() const override { return !m_proceduralGeometry.empty(); }
             bool HasGeometry() const override { return HasMeshGeometry() || HasProceduralGeometry(); }
 
+            RHI::MultiDevice::DeviceMask GetDeviceMask() const override { return m_deviceMask; }
+
         private:
             AZ_DISABLE_COPY_MOVE(RayTracingFeatureProcessor);
 
@@ -295,6 +297,8 @@ namespace AZ
             AZStd::unordered_map<Uuid, size_t> m_proceduralGeometryLookup;
 
             RHI::Ptr<RHI::RayTracingCompactionQueryPool> m_compactionQueryPool;
+
+            RHI::MultiDevice::DeviceMask m_deviceMask = {};
 
             void ConvertMaterial(MaterialInfo& materialInfo, const SubMeshMaterial& subMeshMaterial, int deviceIndex);
         };

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -563,6 +563,9 @@ namespace AZ
             RPI::Scene* scene = m_pipeline->GetScene();
             RayTracingFeatureProcessor* rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
             AZ_Assert(rayTracingFeatureProcessor, "RayTracingPass requires the RayTracingFeatureProcessor");
+            AZ_Assert(
+                RHI::CheckBit(rayTracingFeatureProcessor->GetDeviceMask(), context.GetDeviceIndex()),
+                "RayTracingPass cannot run on a device without a RayTracingAccelerationStructurePass");
 
             if (!rayTracingFeatureProcessor || !rayTracingFeatureProcessor->GetTlas()->GetTlasBuffer() ||
                 !rayTracingFeatureProcessor->HasGeometry() || !m_rayTracingShaderTable)

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshComputePass.h
@@ -33,8 +33,6 @@ namespace AZ
 
             Data::Instance<RPI::Shader> GetShader() const;
 
-            void SetFeatureProcessor(SkinnedMeshFeatureProcessor* m_skinnedMeshFeatureProcessor);
-
         private:
             void SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph) override;
             void BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context) override;
@@ -43,7 +41,7 @@ namespace AZ
             void OnShaderReinitialized(const RPI::Shader& shader) override;
             void OnShaderVariantReinitialized(const RPI::ShaderVariant& shaderVariant) override;
 
-            SkinnedMeshFeatureProcessor* m_skinnedMeshFeatureProcessor = nullptr;
+            SkinnedMeshFeatureProcessor* GetSkinnedMeshFeatureProcessor();
         };
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.h
@@ -68,11 +68,11 @@ namespace AZ
             RPI::ShaderOptionGroup CreateSkinningShaderOptionGroup(const SkinnedMeshShaderOptions shaderOptions, SkinnedMeshShaderOptionNotificationBus::Handler& shaderReinitializedHandler);
             void OnSkinningShaderReinitialized(const Data::Instance<RPI::Shader> skinningShader);
             void SubmitSkinningDispatchItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex);
-            void SetupSkinningScope(RHI::FrameGraphInterface frameGraph);
+            void SetupSkinningScope(RHI::FrameGraphInterface frameGraph, int deviceIndex);
 
             Data::Instance<RPI::Shader> GetMorphTargetShader() const;
             void SubmitMorphTargetDispatchItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex);
-            void SetupMorphTargetScope(RHI::FrameGraphInterface frameGraph);
+            void SetupMorphTargetScope(RHI::FrameGraphInterface frameGraph, int deviceIndex);
 
         private:
             AZ_DISABLE_COPY_MOVE(SkinnedMeshFeatureProcessor);
@@ -91,10 +91,10 @@ namespace AZ
             AZStd::unique_ptr<SkinnedMeshStatsCollector> m_statsCollector;
 
             AZStd::unordered_set<const RHI::DispatchItem*> m_skinningDispatches;
-            bool m_alreadyCreatedSkinningScopeThisFrame = false;
+            RHI::MultiDevice::DeviceMask m_alreadyCreatedSkinningScopeThisFrame;
 
             AZStd::unordered_set<const RHI::DispatchItem*> m_morphTargetDispatches;
-            bool m_alreadyCreatedMorphTargetScopeThisFrame = false;
+            RHI::MultiDevice::DeviceMask m_alreadyCreatedMorphTargetScopeThisFrame;
 
             AZStd::mutex m_dispatchItemMutex;
 

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceShaderResourceGroupData.cpp
@@ -145,7 +145,12 @@ namespace AZ::RHI
             bool isValidAll = true;
             for (size_t i = 0; i < imageViews.size(); ++i)
             {
-                const bool isValid = ValidateImageViewAccess<ShaderInputImageUnboundedArrayIndex, ShaderInputImageUnboundedArrayDescriptor>(inputIndex, imageViews[i], static_cast<uint32_t>(i));
+                bool isValid = true;
+                if (imageViews[i])
+                {
+                    isValid = ValidateImageViewAccess<ShaderInputImageUnboundedArrayIndex, ShaderInputImageUnboundedArrayDescriptor>(
+                        inputIndex, imageViews[i], static_cast<uint32_t>(i));
+                }
                 if (isValid)
                 {
                     m_imageViewsUnboundedArray.push_back(imageViews[i]);
@@ -201,7 +206,12 @@ namespace AZ::RHI
             bool isValidAll = true;
             for (size_t i = 0; i < bufferViews.size(); ++i)
             {
-                const bool isValid = ValidateBufferViewAccess<ShaderInputBufferUnboundedArrayIndex, ShaderInputBufferUnboundedArrayDescriptor>(inputIndex, bufferViews[i], static_cast<uint32_t>(i));
+                bool isValid = true;
+                if (bufferViews[i])
+                {
+                    isValid = ValidateBufferViewAccess<ShaderInputBufferUnboundedArrayIndex, ShaderInputBufferUnboundedArrayDescriptor>(
+                        inputIndex, bufferViews[i], static_cast<uint32_t>(i));
+                }
                 if (isValid)
                 {
                     m_bufferViewsUnboundedArray.push_back(bufferViews[i]);


### PR DESCRIPTION
## What does this PR do?

The RaytracingAccelerationStructurePass was previously duplicated for every device that supports raytracing.  This PR reverts that behavior. Multi Device render pipelines are now responsible for duplicating the pass for every device where raytracing is needed.
RTAS are now only allocated on devices where an RTAS pass exists.

Additionally this PR adds support for duplicating the MorphTarget and Skinning passes. Previously the engine assumed that only one instance of these passes with a specific name exists in the pipeline. 

## How was this PR tested?

Tested on Windows with the MainRenderPipeline and a multi device render pipeline that need RTAS on multiple devices.
