### PR TITLE
Disable RTAS compaction for models with too many submeshes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -379,6 +379,25 @@ namespace AZ
                 // Note: the build flags are set to be the same for each BLAS created for the mesh
                 RHI::RayTracingAccelerationStructureBuildFlags buildFlags =
                     CreateRayTracingAccelerationStructureBuildFlags(mesh.m_isSkinnedMesh);
+
+                auto rpiDesc = RPI::RPISystemInterface::Get()->GetDescriptor();
+                if (mesh.m_subMeshIndices.size() > rpiDesc.m_rayTracingSystemDescriptor.m_rayTracingCompactionQueryPoolSize)
+                {
+                    AZ_Warning(
+                        "RaytracingFeatureProcessor",
+                        false,
+                        "CompactionQueryPool is not large enough for model %s.\n"
+                        "Pool size: %d\n"
+                        "Num meshes in model: %d\n"
+                        "Raytracing Acceleration Structure Compaction will be disabled for this model\n"
+                        "Consider increasing the size of the pool through the registry setting "
+                        "O3DE/Atom/RPI/Initialization/RayTracingSystemDescriptor/RayTracingCompactionQueryPoolSize",
+                        mesh.m_assetId.ToFixedString().c_str(),
+                        rpiDesc.m_rayTracingSystemDescriptor.m_rayTracingCompactionQueryPoolSize,
+                        mesh.m_subMeshIndices.size());
+                    buildFlags = buildFlags & ~RHI::RayTracingAccelerationStructureBuildFlags::ENABLE_COMPACTION;
+                }
+
                 for (uint32_t subMeshIndex = 0; subMeshIndex < mesh.m_subMeshIndices.size(); ++subMeshIndex)
                 {
                     const SubMesh& subMesh = m_subMeshes[mesh.m_subMeshIndices[subMeshIndex]];


### PR DESCRIPTION
## What does this PR do?

Disables RTAS compaction for models with too many submeshes.
Previously models with too many submeshes broke the raytracing scene as creating BLAS was halted (see [this line](https://github.com/o3de/o3de/blob/e0a467f21d779e982bb9833a4cafdef24b8fa86a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp#L960) in `RayTracingFeatureProcessor.cpp`), leading to missing models.
This PR removes the `ENABLE_COMPACTION` compaction flag from all submeshes of these models and prints a warning.

## How was this PR tested?

Tested on Windows with DX12 and Vulkan and a model with more than 344 submeshes
