### PR TITLE
add .command_settings file to ScriptOnlyProject template, fix #18887

### DIFF
--- a/Templates/ScriptOnlyProject/Template/.command_settings
+++ b/Templates/ScriptOnlyProject/Template/.command_settings
@@ -1,0 +1,4 @@
+[export_project]
+option.build.assets = True
+seedlist.paths = AssetBundling/SeedLists/*.seed
+archive.output.format = zip

--- a/Templates/ScriptOnlyProject/template.json
+++ b/Templates/ScriptOnlyProject/template.json
@@ -23,6 +23,10 @@
             "isTemplated": false
         },
         {
+            "file": ".command_settings",
+            "isTemplated": false
+        },
+        {
             "file": "CMakeLists.txt",
             "isTemplated": true
         },


### PR DESCRIPTION
## What does this PR do?

This Pull Request adds a `.command_settings` file to `ScriptOnlyProject` template, this fix #18887.

> [!NOTE]
> This commit adds `.commands_settings` file, which by default is ignored:
https://github.com/o3de/o3de/blob/7e655e3c908c183fccbc5bdc22a0f2a12c15789c/.gitignore#L25

## How was this PR tested?

I created a new Script-Only project, built it and opened it. After asset processing completion, I closed the editor, opened the export settings, but made no changes, then used the export option to linux on project manager.

The project got exported as expected.

Tested on same environment of the issue (Fedora Linux 40, PC).
