### PR TITLE
Use AZ::Data::AssetHandler::SaveAssetData to serialize in memory asset in AssetEditorTab::GenerateSaveDataSnapshot().

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -705,13 +705,9 @@ namespace AzToolsFramework
             AZ::IO::ByteContainerStream<AZStd::vector<AZ::u8>> dstByteStream(&newSaveData);
 
             AssetEditorValidationRequestBus::Event(m_sourceAssetId, &AssetEditorValidationRequests::PreAssetSave, m_inMemoryAsset);
+            auto assetHandler = const_cast<AZ::Data::AssetHandler*>(AZ::Data::AssetManager::Instance().GetHandler(m_inMemoryAsset.GetType()));
 
-            if (AZ::Utils::SaveObjectToStream(
-                    dstByteStream,
-                    AZ::DataStream::ST_XML,
-                    m_inMemoryAsset.Get(),
-                    m_inMemoryAsset.Get()->RTTI_GetType(),
-                    m_serializeContext))
+            if (m_inMemoryAsset && assetHandler && assetHandler->SaveAssetData(m_inMemoryAsset, &dstByteStream))
             {
                 AZStd::swap(newSaveData, m_saveData);
             }


### PR DESCRIPTION
## What does this PR do?

This is a follow-up of https://github.com/o3de/o3de/pull/18823 , which allows GenericAssetHandler to save objects in a custom ObjectStream format. This PR allows Asset Editor to use AZ::Data::AssetHandler::SaveAssetData to save the asset in-place so that it will be saved in the custom ObjectStream format.

## How was this PR tested?

Load a asset from the Asset Editor, modify it and use Ctrl-S to save the asset in-place.
