### PR TITLE
Fix OnActiveViewChanged event in scripts

### DIFF
--- a/Gems/Camera/Code/Source/CameraComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraComponent.cpp
@@ -69,7 +69,7 @@ namespace Camera
 
         void OnActiveViewChanged(const AZ::EntityId& cameraId) override
         {
-            Call(FN_OnCameraRemoved, cameraId);
+            Call(FN_OnActiveViewChanged, cameraId);
         };
     };
 


### PR DESCRIPTION
## What does this PR do?

I noticed that the CameraNotificationBus wasn't dispatching the "OnActiveViewChanged" event correctly to ScriptCanvas, and I tracked it down to a simple typo.

## How was this PR tested?

Tested on the 2409.2 tag on Bazzite Linux (Fedora 41)