### PR TITLE
Add workaround for key repeat issue on X11

### DIFF
--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
@@ -49,6 +49,8 @@ namespace Editor
     {
         auto* interface = AzFramework::XcbConnectionManagerInterface::Get();
         interface->SetEnableXInput(GetXcbConnectionFromQt(), false);
+
+        AzFramework::XcbEventHandlerBus::Broadcast(&AzFramework::XcbEventHandler::ResetStoredInputStates);
     }
 
     bool EditorQtApplicationXcb::nativeEventFilter([[maybe_unused]] const QByteArray& eventType, void* message, long*)

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbEventHandler.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbEventHandler.h
@@ -25,6 +25,9 @@ namespace AzFramework
         virtual ~XcbEventHandler() = default;
 
         virtual void HandleXcbEvent(xcb_generic_event_t* event) = 0;
+
+        // Resets previous keyboard, mouse, joystick, etc. events.
+        virtual void ResetStoredInputStates() {};
     };
 
     class XcbEventHandlerBusTraits : public AZ::EBusTraits

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceKeyboard.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceKeyboard.h
@@ -13,6 +13,7 @@
 
 #include <xcb/xcb.h>
 #include <xkbcommon/xkbcommon.h>
+#include <xcb/xcb_keysyms.h>
 
 struct xcb_xkb_state_notify_event_t;
 
@@ -27,6 +28,7 @@ namespace AzFramework
 
         using InputDeviceKeyboard::Implementation::Implementation;
         XcbInputDeviceKeyboard(InputDeviceKeyboard& inputDevice);
+        ~XcbInputDeviceKeyboard() override;
 
         bool IsConnected() const override;
 
@@ -36,6 +38,7 @@ namespace AzFramework
         void TickInputDevice() override;
 
         void HandleXcbEvent(xcb_generic_event_t* event) override;
+        void ResetStoredInputStates() override;
 
     private:
         [[nodiscard]] const InputChannelId* InputChannelFromKeyEvent(xcb_keycode_t code) const;
@@ -51,5 +54,7 @@ namespace AzFramework
         uint8_t m_xkbEventCode{0};
         bool m_initialized{false};
         bool m_hasTextEntryStarted{false};
+        xcb_connection_t* m_connection = nullptr;
+        AZStd::array<uint8_t, 32> m_lastKeysStates;
     };
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Linux/platform_nativeui_linux.cmake
+++ b/Code/Framework/AzFramework/Platform/Linux/platform_nativeui_linux.cmake
@@ -27,6 +27,7 @@ if (${PAL_TRAIT_LINUX_WINDOW_MANAGER} STREQUAL "xcb")
             3rdParty::X11::xkbcommon
             3rdParty::X11::xkbcommon_X11
             xcb-xinput
+            xcb-keysyms
     )
 
 elseif(PAL_TRAIT_LINUX_WINDOW_MANAGER STREQUAL "wayland")

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
@@ -109,6 +109,16 @@ uint32_t xcb_generate_id(xcb_connection_t *c)
     return MockXcbInterface::Instance()->xcb_generate_id(c);
 }
 
+xcb_query_keymap_cookie_t xcb_query_keymap(xcb_connection_t* c)
+{
+    return MockXcbInterface::Instance()->xcb_query_keymap(c);
+}
+
+xcb_query_keymap_reply_t* xcb_query_keymap_reply(xcb_connection_t* c, xcb_query_keymap_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_query_keymap_reply(c, cookie, e);
+}
+
 // ----------------------------------------------------------------------------
 // xcb-xkb
 xcb_xkb_use_extension_cookie_t xcb_xkb_use_extension(xcb_connection_t* c, uint16_t wantedMajor, uint16_t wantedMinor)

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
@@ -95,6 +95,8 @@ public:
     MOCK_CONST_METHOD3(xcb_get_property_reply, xcb_get_property_reply_t*(xcb_connection_t* c, xcb_get_property_cookie_t cookie, xcb_generic_error_t** e));
     MOCK_CONST_METHOD1(xcb_get_property_value, void*(const xcb_get_property_reply_t* R));
     MOCK_CONST_METHOD1(xcb_generate_id, uint32_t(xcb_connection_t *c));
+    MOCK_CONST_METHOD1(xcb_query_keymap, xcb_query_keymap_cookie_t(xcb_connection_t* c));
+    MOCK_CONST_METHOD3(xcb_query_keymap_reply, xcb_query_keymap_reply_t*(xcb_connection_t* c, xcb_query_keymap_cookie_t cookie, xcb_generic_error_t** e));
 
     // xcb-xkb
     MOCK_CONST_METHOD3(xcb_xkb_use_extension, xcb_xkb_use_extension_cookie_t(xcb_connection_t* c, uint16_t wantedMajor, uint16_t wantedMinor));
@@ -143,6 +145,9 @@ public:
     MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_length, int(const xcb_input_raw_button_press_event_t* R));
     MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_raw, xcb_input_fp3232_t*(const xcb_input_raw_button_press_event_t* R));
     MOCK_CONST_METHOD1(xcb_input_raw_button_press_valuator_mask, uint32_t*(const xcb_input_raw_button_press_event_t* R));
+
+
+
 
 private:
     static inline MockXcbInterface* self = nullptr;

--- a/cmake/Platform/Linux/Packaging_linux.cmake
+++ b/cmake/Platform/Linux/Packaging_linux.cmake
@@ -49,6 +49,7 @@ elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
         libxcb-xfixes0-dev                      # For mouse input
         libxcb-xinput-dev                       # For mouse input
         libxcb-randr0-dev                       # For xcb display
+        libxcb-keysyms1-dev
         libpcre2-16-0
         zlib1g-dev
         mesa-common-dev

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-bionic.txt
@@ -22,6 +22,7 @@ libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
 libxcb-image0-dev                       # For xcb image support
 libxcb-randr0-dev                       # For xcb display info
+libxcb-keysyms1-dev                     # For xcb query keymap
 xxd
 zlib1g-dev
 mesa-common-dev

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-focal.txt
@@ -21,6 +21,7 @@ libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
 libxcb-image0-dev                       # For xcb image support
 libxcb-randr0-dev                       # For xcb display info
+libxcb-keysyms1-dev                     # For xcb query keymap
 xxd
 zlib1g-dev
 mesa-common-dev

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
@@ -21,6 +21,7 @@ libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
 libxcb-image0-dev                       # For xcb image support
 libxcb-randr0-dev                       # For xcb display info
+libxcb-keysyms1-dev                     # For xcb query keymap
 xxd
 zlib1g-dev
 mesa-common-dev

--- a/scripts/build/build_node/Platform/Linux/package-list.ubuntu-noble.txt
+++ b/scripts/build/build_node/Platform/Linux/package-list.ubuntu-noble.txt
@@ -20,6 +20,7 @@ libxkbcommon-dev                        # For xcb keyboard input
 libxcb-xfixes0-dev                      # For mouse input
 libxcb-xinput-dev                       # For mouse input
 libxcb-randr0-dev                       # For xcb display info
+libxcb-keysyms1-dev                     # For xcb query keymap
 zlib1g-dev
 mesa-common-dev
 ros-jazzy-ackermann-msgs               # ROS2 development tools


### PR DESCRIPTION
## What does this PR do?

Tries to fix the following issue: https://github.com/o3de/o3de/issues/16920.

**Seen behavior:**

On Linux (X11) auto-repeat is on. This will lead to repeatedly fired OnPress/OnRelease events when a key is held.

**Expected behavior**

On fire once when key is pressed 'OnPress' and repeatedly 'OnHeld' when key is held and once 'OnRelease' when key is released.

## How was this PR tested?

Test on my KDE Plasma environment (KDE Neon on X11 and XWayland)

## Approach
xcb_query_keymap_reply reads the current real-time state of all keys on the keyboard and stores it in a 32-byte array. Each bit in this array represents a single key, allowing up to 256 keys to be handled. Virtual key presses and releases are not tracked in this data.

Whenever Qt or X11 (i.e., the application itself) fires a key event, we read the full keymap and check whether the specific key reported by the system is actually physically pressed or released. An event is queued with QueueRawKeyEvent only when a real change is detected.

I know this isn't the most ideal solution, but I’ve tried other approaches mentioned in the related issue without success. If anyone has suggestions or better ideas, I’d be happy to hear them.

Also, it would be great if a few Linux users could help test this.

Best regards,

Yaakuro
