### PR TITLE
Increase the timeout of a file read test for GHA AR

### DIFF
--- a/Code/Framework/AzCore/Tests/StreamerTests.cpp
+++ b/Code/Framework/AzCore/Tests/StreamerTests.cpp
@@ -460,7 +460,7 @@ namespace AZ::IO
 
         char* buffer = new char[fileSize];
         bool readResult{ false };
-        this->PeriodicallyCheckedRead(testFile->GetFileName(), buffer, fileSize, 0, AZStd::chrono::seconds(5), readResult);
+        this->PeriodicallyCheckedRead(testFile->GetFileName(), buffer, fileSize, 0, AZStd::chrono::seconds(500), readResult);
         EXPECT_TRUE(readResult);
         if(readResult)
         {


### PR DESCRIPTION
## What does this PR do?

I notice that the Read_ReadLargeFileEntirely_FileFullyRead fails sometimes on Github AR I notice that there are two tests,
Read_ReadSmallFileEntirely_FileFullyRead - reads 50kb Read_ReadLargeFileEntirely_FileFullyRead  - reads 10mb

Both tests are time-gated to 5s or they are considered failed.

However, the Github AR machine takes a long time to write and read files.
The 50kb file often takes over 500ms to complete.   This infers a read
rate of 100kb/s.  It infers that we should give at least 100s for the
10mb file to read, with 500s being a good safety margin.

Note that both of these tests finish successfully as soon as they read their data, they do not wait for the full timeout unless they fail.

## How was this PR tested?

Just running the tests.  It doesn't change anything except the maximum amount of time it waits.  If the test manages to read the file faster, the test finishes faster.