### PR TITLE
Possible fix for mouse cursor and ui background missing

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -844,7 +844,19 @@ namespace AZ
 
         void CommandList::SetStreamBuffers(const RHI::DeviceGeometryView& geometryView, const RHI::StreamBufferIndices& streamIndices)
         {
-            auto streamIter = geometryView.CreateStreamIterator(streamIndices);
+            // its possible that streamIndices is empty if we're in a situation where we're
+            // doing non-indexed (linear) geometry.  So if that's the case, use the full stream buffer indices instead of
+            // the passed-in streamIndices.
+            RHI::StreamBufferIndices indicesToUse;
+            AZ::u8 indexSize = streamIndices.Size();
+            bool hasAnyIndices = indexSize != 0;
+            if (!hasAnyIndices)
+            {
+                indicesToUse = geometryView.GetFullStreamBufferIndices();
+                indexSize = indicesToUse.Size();
+            }
+            auto streamIter = geometryView.CreateStreamIterator(hasAnyIndices ? streamIndices : indicesToUse);
+
             RHI::Interval interval = InvalidInterval;
 
             for (u8 index = 0; !streamIter.HasEnded(); ++streamIter, ++index)


### PR DESCRIPTION
## What does this PR do?

My analysis showed that for non-indexed rendering, in both vulkan and dx12, the code that was supposed to set the vertex buffer was not being called.  The CommandList class that is responsible for setting them doesn't do anything if there are no index buffers.  Thus the draw call was being executed with either no buffer set for the IA, or would be whatever was previously bound, so garbage.

This is a tenative fix which uses the other buffers (ie, the vertex buffer) if its told to set the vertex buffer with no index buffers present.

I was able to repro the problem in both vulkan and dx12. This fixes the problem in both vulkan and dx12.

Fixes https://github.com/o3de/o3de/issues/18769
Fixes https://github.com/o3de/o3de/issues/18890

## How was this PR tested?

DX12 and Vulkan testing - after this change, mouse cursor and checkerboard background in ui editor is back
UI renders ok.  Mouse renders ok.
Other levels such as anubis / atom feature test levels / etc render fine.   Looks the same as before.