### PR TITLE
Cherrypick from dev: Fixing DrawLinear issue in DynamicDrawContext caused by GeometryView

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawContext.cpp
@@ -634,6 +634,7 @@ namespace AZ
             vertexBuffer->Write(vertexData, vertexDataSize);
             newGeometryView.AddStreamBufferView(vertexBuffer->GetStreamBufferView(m_perVertexDataSize));
 
+            drawItem.SetStreamIndices(newGeometryView.GetFullStreamBufferIndices());
             drawItemInfo.m_cachedIndex = static_cast<u32>(m_cachedGeometryViews.size());
             m_cachedGeometryViews.emplace_back(AZStd::move(newGeometryView));
 


### PR DESCRIPTION
## What does this PR do?
Cherrypicks the following commit from dev:

Author: antonmic <56370189+antonmic@users.noreply.github.com>
Date:   Thu May 8 04:29:00 2025 -0700

    Fixing DrawLinear issue in DynamicDrawContext caused by GeometryView changes (#18899)

    Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>

from https://github.com/o3de/o3de/pull/18899

Fixes various UICanvas / LyShine rendering issues, like the mouse cursor and others.

Fixes https://github.com/o3de/o3de/issues/18769
Fixes https://github.com/o3de/o3de/issues/18890
Fixes https://github.com/o3de/o3de/issues/18898

