### PR TITLE
Profiling Fix for external profiler gems

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.cpp
@@ -16,7 +16,7 @@
 
 namespace AZ::Debug
 {
-    AZStd::optional<Profiler*> ProfileScope::m_cachedProfiler;
+    Profiler* ProfileScope::m_cachedProfiler = nullptr;
 
     AZStd::string GenerateOutputFile(const char* nameHint)
     {
@@ -85,14 +85,14 @@ namespace AZ::Debug
             // Initialize the cached pointer with the current handler or nullptr if no handlers are registered.
             // We do it here because Interface::Get will do a full mutex lock if no handlers are registered
             // causing big performance hit.
-            if (!m_cachedProfiler.has_value())
+            if (!m_cachedProfiler)
             {
                 m_cachedProfiler = AZ::Interface<Profiler>::Get();
             }
 
-            if (m_cachedProfiler.value())
+            if (m_cachedProfiler)
             {
-                m_cachedProfiler.value()->BeginRegion(budget, eventName, args);
+                m_cachedProfiler->BeginRegion(budget, eventName, args);
             }
         }
 #endif // !defined(AZ_RELEASE_BUILD)
@@ -105,9 +105,9 @@ namespace AZ::Debug
         {
             budget->EndProfileRegion();
 
-            if (m_cachedProfiler.value())
+            if (m_cachedProfiler)
             {
-                m_cachedProfiler.value()->EndRegion(budget);
+                m_cachedProfiler->EndRegion(budget);
             }
 
             Platform::EndProfileRegion(budget);

--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.h
@@ -95,6 +95,6 @@ namespace AZ::Debug
         Budget* m_budget;
 
         // Optimization to avoid calling Interface<Profiler>::Get
-        static AZStd::optional<Profiler*> m_cachedProfiler;
+        static Profiler* m_cachedProfiler;
     };
 } // namespace AZ::Debug


### PR DESCRIPTION
## What does this PR do?

Related to this PR https://github.com/o3de/o3de-extras/pull/834.

The profiler interface was cached for optimization purposes, the issue is that registration was done after the first call to `AZ::Interface<Profiler>::Get()` on some threads, resulting on some events never been forwarded to the profiler implementation.

I keep the value cached but query it anytime it is nullptr. When no profiler gem is enabled it means that there is a call to `AZ::Interface<Profiler>::Get();` at every profiling event. Given that it is ifdefed behind `AZ_RELEASE_BUILD` I believe it is fine, however if nescessary we might also think of a solution which would reset the cached value when the interface is registered

## How was this PR tested?

Local windows build on latest dev.
