### PR TITLE
[Track View] Fix issues 8485 and 9138: SimpleMotionComponent playing motions setup by CAssetBlendTrack keys.

### DIFF
--- a/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
+++ b/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
@@ -25,135 +25,156 @@
 
 void CAssetBlendKeyUIControls::ResetStartEndLimits(float assetBlendKeyDuration)
 {
-    const float time_zero = .0f;
-    float step = ReflectedPropertyItem::ComputeSliderStep(time_zero, assetBlendKeyDuration);
-    mv_startTime.GetVar()->SetLimits(time_zero, assetBlendKeyDuration, step, true, true);
-    mv_endTime.GetVar()->SetLimits(time_zero, assetBlendKeyDuration, step, true, true);
-    mv_blendInTime.GetVar()->SetLimits(time_zero, assetBlendKeyDuration, step, true, true);
-    mv_blendOutTime.GetVar()->SetLimits(time_zero, assetBlendKeyDuration, step, true, true);
+    float step = ReflectedPropertyItem::ComputeSliderStep(0.0f, assetBlendKeyDuration);
+    mv_blendInTime.GetVar()->SetLimits(0.0f, assetBlendKeyDuration, step, true, true);
+    mv_blendOutTime.GetVar()->SetLimits(0.0f, assetBlendKeyDuration, step, true, true);
 }
 
 bool CAssetBlendKeyUIControls::OnKeySelectionChange(const CTrackViewKeyBundle& selectedKeys)
 {
-    if (!selectedKeys.AreAllKeysOfSameType())
+    if (selectedKeys.GetKeyCount() < 1  || !selectedKeys.AreAllKeysOfSameType())
     {
         return false;
     }
 
-    bool bAssigned = false;
-    if (selectedKeys.GetKeyCount() == 1)
+    const CTrackViewKeyHandle& keyHandle = selectedKeys.GetKey(0); // Get the 1st key for editing
+    if (keyHandle.GetTrack()->GetValueType() != AnimValueType::AssetBlend)
     {
-        const CTrackViewKeyHandle& keyHandle = selectedKeys.GetKey(0);
-        if (keyHandle.GetTrack()->GetValueType() == AnimValueType::AssetBlend)
+        return false;
+    }
+
+    AZ::IAssetBlendKey assetBlendKey;
+    keyHandle.GetKey(&assetBlendKey);
+
+    // Find editor object who owns this node.
+    const CTrackViewTrack* pTrack = keyHandle.GetTrack();
+    if (pTrack && pTrack->GetAnimNode()->GetType() == AnimNodeType::Component)
+    {
+        m_componentId = pTrack->GetAnimNode()->GetComponentId();
+
+        // try to get the AZ::EntityId from the component node's parent
+        CTrackViewAnimNode* parentNode = static_cast<CTrackViewAnimNode*>(pTrack->GetAnimNode()->GetParentNode());
+        if (parentNode)
         {
-            AZ::IAssetBlendKey assetBlendKey;
-            keyHandle.GetKey(&assetBlendKey);
-
-            // Find editor object who owns this node.
-            const CTrackViewTrack* pTrack = keyHandle.GetTrack();
-            if (pTrack && pTrack->GetAnimNode()->GetType() == AnimNodeType::Component)
-            {
-                m_componentId = pTrack->GetAnimNode()->GetComponentId();
-
-                // try to get the AZ::EntityId from the component node's parent
-                CTrackViewAnimNode* parentNode = static_cast<CTrackViewAnimNode*>(pTrack->GetAnimNode()->GetParentNode());
-                if (parentNode)
-                {
-                    m_entityId = parentNode->GetAzEntityId();
-                }
-            }
-
-            mv_asset->SetUserData(assetBlendKey.m_assetId.m_subId);
-            mv_asset->SetDisplayValue(assetBlendKey.m_assetId.m_guid.ToString<AZStd::string>().c_str());
-            mv_loop = assetBlendKey.m_bLoop;
-            mv_endTime = assetBlendKey.m_endTime;
-            mv_startTime = assetBlendKey.m_startTime;
-            mv_timeScale = assetBlendKey.m_speed;
-            mv_blendInTime = assetBlendKey.m_blendInTime;
-            mv_blendOutTime = assetBlendKey.m_blendOutTime;
-
-            bAssigned = true;
+            m_entityId = parentNode->GetAzEntityId();
         }
     }
 
-    return bAssigned;
+    m_skipOnUIChange = true;
+
+    if (assetBlendKey.m_assetId.IsValid() && assetBlendKey.m_duration > 0.0f)
+    {
+        mv_asset->SetUserData(assetBlendKey.m_assetId.m_subId);
+        mv_asset->SetDisplayValue(assetBlendKey.m_assetId.m_guid.ToString<AZStd::string>().c_str());
+
+        mv_loop = assetBlendKey.m_bLoop;
+
+        {
+            float step = ReflectedPropertyItem::ComputeSliderStep(AZ::IAssetBlendKey::s_minSpeed, AZ::IAssetBlendKey::s_maxSpeed);
+            mv_timeScale = AZStd::clamp(assetBlendKey.m_speed, AZ::IAssetBlendKey::s_minSpeed, AZ::IAssetBlendKey::s_maxSpeed);
+            mv_timeScale->SetLimits(AZ::IAssetBlendKey::s_minSpeed, AZ::IAssetBlendKey::s_maxSpeed, step, true, true);
+        }
+
+        mv_blendInTime = assetBlendKey.m_blendInTime;
+        mv_blendOutTime = assetBlendKey.m_blendOutTime;
+        ResetStartEndLimits(assetBlendKey.m_duration);
+    }
+    else
+    {
+        mv_asset = "";
+        mv_loop = false;
+        mv_timeScale = 1.0f;
+        mv_blendInTime = 0.0f;
+        mv_blendOutTime = 0.0f;
+    }
+
+    m_skipOnUIChange = false;
+
+    return true;
 }
 
-// Called when UI variable changes.
 void CAssetBlendKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys)
 {
     CTrackViewSequence* pSequence = GetIEditor()->GetAnimation()->GetSequence();
 
-    if (!pSequence || !selectedKeys.AreAllKeysOfSameType())
+    if (!pSequence || !selectedKeys.AreAllKeysOfSameType() || m_skipOnUIChange || selectedKeys.GetKeyCount() < 1)
     {
         return;
     }
 
-    for (unsigned int keyIndex = 0, num = (int)selectedKeys.GetKeyCount(); keyIndex < num; keyIndex++)
+    CTrackViewKeyHandle keyHandle = selectedKeys.GetKey(0);  // Get the 1st key for editing
+    CTrackViewTrack* pTrack = keyHandle.GetTrack();
+    if (keyHandle.GetTrack()->GetValueType() != AnimValueType::AssetBlend)
     {
-        CTrackViewKeyHandle keyHandle = selectedKeys.GetKey(keyIndex);
-        CTrackViewTrack* pTrack = keyHandle.GetTrack();
+        return;
+    }
 
-        if (keyHandle.GetTrack()->GetValueType() == AnimValueType::AssetBlend)
+    AZ::IAssetBlendKey assetBlendKey;
+    keyHandle.GetKey(&assetBlendKey);
+
+    if (mv_asset.GetVar() == pVar)
+    {
+        AZStd::string stringGuid = mv_asset->GetDisplayValue().toLatin1().data();
+        if (!stringGuid.empty())
         {
-            AZ::IAssetBlendKey assetBlendKey;
-            keyHandle.GetKey(&assetBlendKey);
+            AZ::Uuid guid(stringGuid.c_str(), stringGuid.length());
+            AZ::u32 subId = mv_asset->GetUserData().value<AZ::u32>();
+            assetBlendKey.m_assetId = AZ::Data::AssetId(guid, subId);
 
-            if (mv_asset.GetVar() == pVar)
+            // Lookup Filename by assetId and get the filename part of the description
+            AZStd::string assetPath;
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetBlendKey.m_assetId);
+
+            assetBlendKey.m_description = "";
+            if (!assetPath.empty())
             {
-                AZStd::string stringGuid = mv_asset->GetDisplayValue().toLatin1().data();
-                if (!stringGuid.empty())
+                AZStd::string filename;
+                if (AzFramework::StringFunc::Path::GetFileName(assetPath.c_str(), filename))
                 {
-                    AZ::Uuid guid(stringGuid.c_str(), stringGuid.length());
-                    AZ::u32 subId = mv_asset->GetUserData().value<AZ::u32>();
-                    assetBlendKey.m_assetId = AZ::Data::AssetId(guid, subId);
-
-                    // Lookup Filename by assetId and get the filename part of the description
-                    AZStd::string assetPath;
-                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
-                        assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, assetBlendKey.m_assetId);
-
-                    assetBlendKey.m_description = "";
-                    if (!assetPath.empty())
-                    {
-                        AZStd::string filename;
-                        if (AzFramework::StringFunc::Path::GetFileName(assetPath.c_str(), filename))
-                        {
-                            assetBlendKey.m_description = filename;
-                        }
-                    }
+                    assetBlendKey.m_description = filename;
                 }
-
-                // This call is required to make sure that the newly set animation is properly triggered.
-                pTrack->GetSequence()->Reset(false);
             }
+        }
 
-            SyncValue(mv_loop, assetBlendKey.m_bLoop, false, pVar);
-            SyncValue(mv_startTime, assetBlendKey.m_startTime, false, pVar);
-            SyncValue(mv_endTime, assetBlendKey.m_endTime, false, pVar);
-            SyncValue(mv_timeScale, assetBlendKey.m_speed, false, pVar);
-            SyncValue(mv_blendInTime, assetBlendKey.m_blendInTime, false, pVar);
-            SyncValue(mv_blendOutTime, assetBlendKey.m_blendOutTime, false, pVar);
+        // This call is required to make sure that the newly set animation is properly triggered.
+        pTrack->GetSequence()->Reset(false);
+    }
 
-            if (assetBlendKey.m_assetId.IsValid())
-            {
-                // Ask entity id this asset blend is bound to, to
-                // get the duration of this asset in an async way.
-                Maestro::SequenceComponentRequests::AnimatedFloatValue currValue = 0.0f;
-                Maestro::SequenceComponentRequestBus::Event(
-                    pSequence->GetSequenceComponentEntityId(),
-                    &Maestro::SequenceComponentRequestBus::Events::GetAssetDuration,
-                    currValue,
-                    m_entityId,
-                    m_componentId,
-                    assetBlendKey.m_assetId
-                );
+    if (assetBlendKey.m_assetId.IsValid())
+    {
+        SyncValue(mv_loop, assetBlendKey.m_bLoop, false, pVar);
+        SyncValue(mv_timeScale, assetBlendKey.m_speed, false, pVar);
+        SyncValue(mv_blendInTime, assetBlendKey.m_blendInTime, false, pVar);
+        SyncValue(mv_blendOutTime, assetBlendKey.m_blendOutTime, false, pVar);
 
-                assetBlendKey.m_duration = currValue.GetFloatValue();
-                ResetStartEndLimits(assetBlendKey.m_duration);
-            }
+        // Ask entity id this asset blend is bound to, in order to
+        // get the duration of this asset in an asynchronous way.
+        Maestro::SequenceComponentRequests::AnimatedFloatValue currValue = 0.0f;
+        Maestro::SequenceComponentRequestBus::Event(pSequence->GetSequenceComponentEntityId(), &Maestro::SequenceComponentRequestBus::Events::GetAssetDuration,
+            currValue, m_entityId, m_componentId, assetBlendKey.m_assetId );
+        assetBlendKey.m_duration = currValue.GetFloatValue();
+        assetBlendKey.m_startTime = 0.0f;
+        assetBlendKey.m_endTime = assetBlendKey.m_duration;
+        ResetStartEndLimits(assetBlendKey.m_duration);
 
-            keyHandle.SetKey(&assetBlendKey);
+        const auto speed = AZStd::clamp(assetBlendKey.m_speed, 0.01f, 100.0f);
+        if (AZStd::abs(speed - assetBlendKey.m_speed) > AZ::Constants::FloatEpsilon)
+        {
+            mv_timeScale = assetBlendKey.m_speed = speed;
         }
     }
+    else
+    {
+        // Zero-initialize the key value for an invalid motion asset
+        mv_loop = assetBlendKey.m_bLoop = false;
+        mv_timeScale = assetBlendKey.m_speed = 1.0f;
+        mv_blendInTime = assetBlendKey.m_blendInTime = 0.0f;
+        mv_blendOutTime = assetBlendKey.m_blendOutTime = 0.0f;
+        assetBlendKey.m_duration = 0.0f;
+        assetBlendKey.m_startTime = 0.0f;
+        assetBlendKey.m_endTime = 0.0f;
+    }
+
+    keyHandle.SetKey(&assetBlendKey);
 }

--- a/Code/Editor/TrackView/KeyUIControls.h
+++ b/Code/Editor/TrackView/KeyUIControls.h
@@ -67,15 +67,13 @@ public:
     CSmartVariableArray mv_table;
     CSmartVariable<QString> mv_asset;
     CSmartVariable<bool> mv_loop;
-    CSmartVariable<float> mv_startTime;
-    CSmartVariable<float> mv_endTime;
     CSmartVariable<float> mv_timeScale;
     CSmartVariable<float> mv_blendInTime;
     CSmartVariable<float> mv_blendOutTime;
 
     void OnCreateVars() override
     {
-        // Init to an invalid id
+        // Initialize to an invalid id
         AZ::Data::AssetId assetId;
         assetId.SetInvalid();
         mv_asset->SetUserData(assetId.m_subId);
@@ -86,12 +84,9 @@ public:
         // "motion" for the Simple Motion Component is the only instance.
         AddVariable(mv_table, mv_asset, "Motion", IVariable::DT_MOTION);
         AddVariable(mv_table, mv_loop, "Loop");
-        AddVariable(mv_table, mv_startTime, "Start Time");
-        AddVariable(mv_table, mv_endTime, "End Time");
         AddVariable(mv_table, mv_timeScale, "Time Scale");
         AddVariable(mv_table, mv_blendInTime, "Blend In Time");
         AddVariable(mv_table, mv_blendOutTime, "Blend Out Time");
-        mv_timeScale->SetLimits(0.001f, 100.f);
     }
 
     bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
@@ -116,6 +111,7 @@ public:
 
 protected:
     void ResetStartEndLimits(float AssetBlendKeyDuration);
+    bool m_skipOnUIChange = false;
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -2963,12 +2963,26 @@ void CTrackViewDopeSheetBase::DrawKeys(CTrackViewTrack* pTrack, QPainter* painte
             {
                 // Colorize current key for Select track: green if key is valid, red if invalid
                 bool isValidKey = true;
-                if ((pTrack->GetValueType() == AnimValueType::Select))
+                switch (pTrack->GetValueType())
                 {
-                    ISelectKey cameraKey;
-                    keyHandle.GetKey(&cameraKey);
-                    isValidKey = cameraKey.IsValid();
+                case AnimValueType::Select:
+                    {
+                        ISelectKey cameraKey;
+                        keyHandle.GetKey(&cameraKey);
+                        isValidKey = cameraKey.IsValid();
+                    }
+                    break;
+                case AnimValueType::AssetBlend:
+                    {
+                        AZ::IAssetBlendKey simmpleMotionKey;
+                        keyHandle.GetKey(&simmpleMotionKey);
+                        isValidKey = simmpleMotionKey.m_assetId.IsValid();
+                    }
+                    break;
+                default:
+                    break;
                 }
+
                 if (isValidKey)
                 {
                     painter->drawPixmap(QPoint(x - 6, rect.top() + 2), QPixmap(":/Trackview/trackview_keys_00.png")); // green

--- a/Code/Legacy/CryCommon/Maestro/Types/AssetBlendKey.h
+++ b/Code/Legacy/CryCommon/Maestro/Types/AssetBlendKey.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/Asset/AssetCommon.h>
+#include <AnimKey.h>
 
 namespace AZ
 {
@@ -17,10 +18,18 @@ namespace AZ
 struct IAssetBlendKey
     : public ITimeRangeKey
 {
-    AZ::Data::AssetId m_assetId;    //!< Asset Id
-    AZStd::string m_description;    //!< Description (filename part of path)
-    float m_blendInTime;            //!< Blend in time in seconds;
-    float m_blendOutTime;            //!< Blend in time in seconds;
+    AZ::Data::AssetId m_assetId;    //!< Motion Asset Id (virtual property "Motion" of SimpleMotionComponent).
+    AZStd::string m_description;    //!< Description (filename part of path to motion asset).
+    float m_blendInTime;            //!< Blend in time in seconds (hidden virtual property "BlendInTime" of SimpleMotionComponent).
+    float m_blendOutTime;           //!< Blend out time in seconds (hidden virtual property "BlendOutTime" of SimpleMotionComponent).;
+
+    //!< ITimeRangeKey members:
+    //!< m_duration  : Duration in seconds of this animation.
+    //  There is SimpleMotionComponentRequestBus::Events::GetDuration, but TrackView uses EditorSimpleMotionComponentRequestBus::Events::GetAssetDuration.
+    //!< m_startTime : Start time of this animation, equal to key time.
+    //!< m_endTime   : End time of this animation, set to key time plus actual duration (m_duration / m_speed).
+    //!< m_bLoop     : Whether to loop motion (hidden virtual property "LoopMotion" of SimpleMotionComponent).
+    //!< m_speed     : Determines the rate at which the motion is played (hidden virtual property "PlaySpeed" of SimpleMotionComponent).
 
     IAssetBlendKey()
         : ITimeRangeKey()
@@ -28,6 +37,9 @@ struct IAssetBlendKey
         , m_blendOutTime(0.0f)
     {
     }
+
+    static constexpr const float s_minSpeed = 0.1f;
+    static constexpr const float s_maxSpeed = 10.f;
 };
 
     AZ_TYPE_INFO_SPECIALIZE(IAssetBlendKey, "{15B82C3A-6DB8-466F-AF7F-18298FCD25FD}");

--- a/Code/Legacy/CryCommon/Maestro/Types/AssetBlends.h
+++ b/Code/Legacy/CryCommon/Maestro/Types/AssetBlends.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <AzCore/Asset/AssetCommon.h>
+#include <Maestro/Types/AssetBlendKey.h>
 
 namespace Maestro
 {

--- a/Code/Legacy/CryCommon/Maestro/Types/AssetBlends.h
+++ b/Code/Legacy/CryCommon/Maestro/Types/AssetBlends.h
@@ -28,26 +28,33 @@ namespace Maestro
             m_assetId.SetInvalid();
         }
 
-        AssetBlend(const AZ::Data::AssetId& assetId, float time, float blendInTime, float blendOutTime)
+        AssetBlend(const AZ::Data::AssetId& assetId, float time, float blendInTime, float blendOutTime, float speed = 1.0f, bool loop = false)
             : m_assetId(assetId)
             , m_time(time)
             , m_blendInTime(blendInTime)
             , m_blendOutTime(blendOutTime)
+            , m_speed(speed)
+            , m_bLoop(loop)
         {
+            AZStd::clamp(m_speed, AZ::IAssetBlendKey::s_minSpeed, AZ::IAssetBlendKey::s_maxSpeed);
         }
 
-        bool IsClose(const AssetBlend& rhs, float tolerance) const
+        bool IsClose(const AssetBlend& rhs, float tolerance = AZ::Constants::Tolerance) const
         {
-            return m_assetId == rhs.m_assetId
-                && (fabsf(m_time - rhs.m_time) <= tolerance)
-                && (fabsf(m_blendInTime - rhs.m_blendInTime) <= tolerance)
-                && (fabsf(m_blendOutTime - rhs.m_blendOutTime) <= tolerance);
+            return m_assetId == rhs.m_assetId && m_bLoop == rhs.m_bLoop
+                && (AZStd::abs(m_time - rhs.m_time) <= tolerance)
+                && (AZStd::abs(m_blendInTime - rhs.m_blendInTime) <= tolerance)
+                && (AZStd::abs(m_blendOutTime - rhs.m_blendOutTime) <= tolerance)
+                && (AZStd::abs(m_speed - rhs.m_speed) <= tolerance)
+                ;
         }
 
         AZ::Data::AssetId m_assetId;
         float m_time;
         float m_blendInTime;
         float m_blendOutTime;
+        float m_speed;
+        bool  m_bLoop;
     };
 
     /**

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionLayerSystem.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionLayerSystem.cpp
@@ -206,7 +206,7 @@ namespace EMotionFX
             }
 
             // if the layer faded out, remove it when we should
-            if (source->GetWeight() <= 0.0f && (source->GetDeleteOnZeroWeight() || source->GetIsStopping()))
+            if (source->GetWeight() <= 0.0f && (source->GetDeleteOnZeroWeight() && source->GetIsStopping())) // was ||
             {
                 RemoveMotionInstance(source);
                 i--;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSystem.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSystem.h
@@ -51,6 +51,16 @@ namespace EMotionFX
         virtual MotionInstance* PlayMotion(Motion * motion, class PlayBackInfo * info = nullptr);
 
         /**
+         * Start playing the specified motion instance on this actor.
+         * @param motionInsance The motion instance to play.
+         * @param info A pointer to an object containing playback information. This pointer is NOT allowed to be nullptr here.
+         * @result A pointer to the played motion instance object or null if the argument was invalid.
+         * You can use this motion instance object to adjust and retrieve playback information at any time.
+         * @see PlayBackInfo
+         */
+        virtual MotionInstance* PlayMotion(MotionInstance* motionInsance, class PlayBackInfo* info = nullptr);
+
+        /**
          * Get the unique motion system type ID.
          * @result The motion system type identification number.
          */

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
@@ -125,6 +125,10 @@ namespace EMotionFX
 
             static EMotionFX::MotionInstance* PlayMotionInternal(const EMotionFX::ActorInstance* actorInstance, const SimpleMotionComponent::Configuration& cfg, bool deleteOnZeroWeight);
 
+            static EMotionFX::MotionInstance* StartMotionInternal(EMotionFX::MotionInstance* motionInstance, const SimpleMotionComponent::Configuration& cfg);
+
+            static EMotionFX::MotionInstance* CheckMotionInstance(EMotionFX::MotionInstance* motionInstance);
+
             Configuration                               m_configuration;        ///< Component configuration.
             EMotionFXPtr<EMotionFX::ActorInstance>      m_actorInstance;        ///< Associated actor instance (retrieved from Actor Component).
             EMotionFX::MotionInstance*                  m_motionInstance;       ///< Motion to play on the actor


### PR DESCRIPTION
## What does this PR do?
Closes GHI https://github.com/o3de/o3de/issues/8485
Closes GHI https://github.com/o3de/o3de/issues/9138

This PR just revives the functionality pre-designed by existing code: play simple motions setup by `CAssetBlendTrack` keys, while the responsibility to blend motions is left to existing `MotionSystem` of `EMotionFX` GEM.

Motions are being played in game mode in case the original `SimpleMotionComponernt` of an actor, added to sequence, has "Play on active" flag set.

As per initial design, motions are not fully controlled by the sequence time, as virtual properties provided by the `SimpleMotionComponernt` and the `MotionInstance`->`MotionSystem`->`Motion` pipeline would need wide refactoring to achieve such control.

Actually, the whole system of `MotionInstance`s in `EMotionFX` GEM IMO needs refactoring, starting with:
* changing simple (but internally referenced) `MotionInstance*` pointers to "clever" ones,
* brushing `MotionInstance`s configurations to support several `MotionInstance`s;
* providing APIs to fully control motions timelines.

### Major changes ###
* The `IAssetBlendKey` and its handling are refactored to comply with exposed `SimpleMotionComponent` virtual properties;
* * Unused properties (start / end time) are removed from editing by `CAssetBlendKeyUIControls`;
* * Transparent handling of invalid keys (with unassigned motion asset Id) is added;
* * Motion play speed limited to reasonable (0.1 .. 10) range.
* In `EMotionFX` GEM, `SimpleMotionComponent`, `EditorSimpleMotionComponent`, `MotionSystem`, `MotionLayerSystem` are updated to:
* * Keep motion instances after these are being played until explicit request to destroy these happens; this provides support for minimal blending capabilities for a couple of motions;
* * Check that `MotionInstance*` pointers are valid before using these to play motion or raise / handle events. Prior to adding such checks Editor tended to crash on attempts to index empty (destroyed / cleared) vectors of event handlers.

## How was this PR tested?
Editor run in profile and release, desired functionality observed as working (The `Jack` prefab from AutomatedTesting of O3DE repository was used to check playing motions).

Maestro and EmotionFX unit tests run successfully.

https://github.com/user-attachments/assets/539ea3b1-e463-4df2-a1f9-3f99c9f5258b

