### PR TITLE
Prevents creation of invalid project/gem/template names

### DIFF
--- a/scripts/o3de/o3de/engine_template.py
+++ b/scripts/o3de/o3de/engine_template.py
@@ -95,6 +95,14 @@ O3DE_LICENSE_TEXT = \
 # {END_LICENSE}
 """
 
+# This is a list of reserved words that should not be used for project names, gem names, etc.
+TEMPLATE_RESERVED_WORDS = [ "project", "project_name", "and", "or", "not", "in", "is", "if", "else", "elif", "while",
+                            "for", "return", "break", "continue", "def", "class", "import", "from", "name", "version",
+                            "as", "with", "try", "except", "finally", "raise", "assert" , "projectid", "o3de", "sdk",
+                            "nameupper", "namelower", "sanitizedcppname", "projectpath", "enginepath", "moduleclassid",
+# and then all the reserved words that you don't want to see in cmake files that mean something to cmake:
+                            "editorsyscompclassid", "module", "shared", "static", "namespace", "target"]
+
 this_script_parent = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
 
 
@@ -576,6 +584,11 @@ def create_template(source_path: pathlib.Path,
     # template name cannot be the same as a restricted platform name
     if template_name in restricted_platforms:
         logger.error(f'Template path cannot be a restricted name. {template_name}')
+        return 1
+    
+    # there are some reserved words that it is bad idea to use as a template name
+    if template_name.lower() in TEMPLATE_RESERVED_WORDS:
+        logger.error(f'Template name cannot be "{template_name}" as this might cause issues with compilation.  Please try another name.')
         return 1
 
     # if the source restricted name was given and no source restricted path, look up the restricted name to fill
@@ -1724,16 +1737,15 @@ def create_project(project_path: pathlib.Path,
         logger.error(
             f'Project name must be fewer than 64 characters, contain only alphanumeric, "_" or "-" characters, and start with a letter.  {project_name}')
         return 1
+    
+    # there are some reserved words that it is bad idea to use as a project name
+    if project_name.lower() in TEMPLATE_RESERVED_WORDS:
+        logger.error(f'Project name cannot be "{project_name}" as this might cause issues with compilation.  Please try another name.')
+        return 1
 
     # project name cannot be the same as a restricted platform name
     if project_name in restricted_platforms:
         logger.error(f'Project name cannot be a restricted name. {project_name}')
-        return 1
-
-    # the generic launcher (and the engine, often) are referred to as o3de, so prevent the user from 
-    # accidentally creating a confusing error situation.
-    if project_name.lower() == 'o3de':
-        logger.error(f"Project name cannot be 'o3de' as this is reserved for the generic launcher.")
         return 1
 
     # project restricted name
@@ -2143,6 +2155,11 @@ def create_gem(gem_path: pathlib.Path,
     # gem name cannot be the same as a restricted platform name
     if gem_name in restricted_platforms:
         logger.error(f'Gem path cannot be a restricted name. {gem_name}')
+        return 1
+    
+    # there are some reserved words that it is bad idea to use as a gem name
+    if gem_name.lower() in TEMPLATE_RESERVED_WORDS:
+        logger.error(f'Project name cannot be "{gem_name}" as this might cause issues with compilation.  Please try another name.')
         return 1
 
     # gem restricted name


### PR DESCRIPTION
This also restricts templates and gems.  It works with the script as well as the O3DE.EXE gui.

Fixes issue #18836 

![image](https://github.com/user-attachments/assets/030fed04-a054-4a69-9d76-c1e29a73fcd8)

Testing:

Attempting to create invalid template, project, gems.


## Exception Tracking
- [x] 1. Owning SIG requests the exception, by a Sig Representative (Chair/co-chair) adding the PR to the exception requests queue board.
- [x] 2. Owning SIG comments on the PR explaining impact if this code does not go into stabilization.
- [x] 3. (Must occur at some point before SIG-Release approval) Code has been approved for merging by maintainers
- [x] 4. SIG-Release Release Manager or co-Release Manager approves the exception, adding a comment indicating approval and the SIG they represent.
- [ ] 5. If all approvals are accepted, then the exception PR may be merged
- [ ] 6. Merged PR is verified successful via testing. If Merged PR verification testing failed, consult reps from step 3-5 and discussion occurs on fixing the failure vs backing out change
- [ ] 7. Update release documentation if needed. You might need to do this if your change affects something that was specifically called out in the release documentaiton. If your exception is early in the stabilization process then, if needed, issue a pull request against the Feature List (sig-release/releases/YY.MM.N/YYMMN.feature list.md , example (/o3de/sig-release/blob/main/releases/23.05.0/23050%20feature%20list.md ). If the release has progressed to the point where release notes are created, then please issue a pull request against the Release Notes  (o3de/o3de.org/content/docs/release-notes/YYMM-release-notes.md) where YYMM is the year and month of the release, for example (o3de/o3de.org/content/docs/release-notes/2305-release-notes.md)
- [ ] 8. Exception is complete