### PR TITLE
Fixes mesh visibilty flag not being restored on level load

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -8,9 +8,10 @@
 
 #include <Mesh/EditorMeshComponent.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
-#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorVisibilityBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConstants.h>
 
 namespace AZ
@@ -133,6 +134,11 @@ namespace AZ
 
         void EditorMeshComponent::Activate()
         {
+            using EditorVisibilityRequestBus = AzToolsFramework::EditorVisibilityRequestBus;
+            bool isVisible = true;
+            EditorVisibilityRequestBus::EventResult(isVisible, GetEntityId(), &EditorVisibilityRequestBus::Events::GetVisibilityFlag);
+            m_controller.SetVisibility(isVisible);
+
             m_controller.m_configuration.m_editorRayIntersection = true;
             BaseClass::Activate();
             AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());


### PR DESCRIPTION
## What does this PR do?

Fixes Issue: https://github.com/o3de/o3de/issues/18863

## How was this PR tested?

Manual testing, and local ci build test.

## Exception Tracking
- [x] 1. Owning SIG requests the exception, by a Sig Representative (Chair/co-chair) adding the PR to the exception requests queue board.
- [x] 2. Owning SIG comments on the PR explaining impact if this code does not go into stabilization.
- [x] 3. (Must occur at some point before SIG-Release approval) Code has been approved for merging by maintainers
- [x] 4. SIG-Release Release Manager or co-Release Manager approves the exception, adding a comment indicating approval and the SIG they represent.
- [x] 5. If all approvals are accepted, then the exception PR may be merged
- [x] 6. Merged PR is verified successful via testing. If Merged PR verification testing failed, consult reps from step 3-5 and discussion occurs on fixing the failure vs backing out change
- [x] 7. Update release documentation if needed. You might need to do this if your change affects something that was specifically called out in the release documentaiton. If your exception is early in the stabilization process then, if needed, issue a pull request against the Feature List (sig-release/releases/YY.MM.N/YYMMN.feature list.md , example (/o3de/sig-release/blob/main/releases/23.05.0/23050%20feature%20list.md ). If the release has progressed to the point where release notes are created, then please issue a pull request against the Release Notes  (o3de/o3de.org/content/docs/release-notes/YYMM-release-notes.md) where YYMM is the year and month of the release, for example (o3de/o3de.org/content/docs/release-notes/2305-release-notes.md)
- [x] 8. Exception is complete