### PR TITLE
Vulkan: Fix HDR crash

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceSwapChain.h
@@ -11,6 +11,9 @@
 #include <Atom/RHI/DeviceImagePoolBase.h>
 #include <Atom/RHI/XRRenderingInterface.h>
 
+#include <AzCore/Console/IConsole.h>
+AZ_CVAR_EXTERNED(bool, r_hdrOutput);
+
 namespace AZ::RHI
 {
     //! The platform-independent swap chain base class. Swap chains contain a "chain" of images which

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceSwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceSwapChain.cpp
@@ -9,6 +9,9 @@
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>
+
+AZ_CVAR(bool, r_hdrOutput, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Enable HDR output. Restart required");
+
 namespace AZ::RHI
 {
     DeviceSwapChain::DeviceSwapChain() {}

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -926,16 +926,17 @@ namespace AZ
                 physicalDevice.GetNativePhysicalDevice(), vkSurface, &surfaceFormatCount, surfaceFormats.data()));
 
             bool colorSpaceExt = false;
-#ifndef AZ_PLATFORM_LINUX
-            for (const char* loaded_extension : Instance::GetInstance().GetLoadedExtensions())
+            if (r_hdrOutput)
             {
-                if (strcmp(loaded_extension, VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0)
+                for (const char* loaded_extension : Instance::GetInstance().GetLoadedExtensions())
                 {
-                    colorSpaceExt = true;
-                    break;
+                    if (strcmp(loaded_extension, VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0)
+                    {
+                        colorSpaceExt = true;
+                        break;
+                    }
                 }
             }
-#endif
 
             AZStd::set<RHI::Format> formats;
             for (const VkSurfaceFormatKHR& surfaceFormat : surfaceFormats)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -81,6 +81,7 @@ namespace AZ
             m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 #endif
             m_descriptor.m_optionalExtensions.push_back(VK_EXT_HDR_METADATA_EXTENSION_NAME);
+            m_descriptor.m_optionalExtensions.push_back(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME);
 
             uint32_t appApiVersion = VK_API_VERSION_1_0;
             m_instanceVersion = VK_API_VERSION_1_0;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -575,8 +575,7 @@ namespace AZ
 
             bool hdrEnabled = false;
 
-            if (device.GetContext().SetHdrMetadataEXT != nullptr &&
-                m_surfaceFormat.format == VK_FORMAT_A2R10G10B10_UNORM_PACK32 &&
+            if (m_surfaceFormat.format == VK_FORMAT_A2R10G10B10_UNORM_PACK32 &&
                 m_surfaceFormat.colorSpace == VK_COLOR_SPACE_HDR10_ST2084_EXT)
             {
                 hdrEnabled = true;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -453,7 +453,7 @@ namespace AZ
                         return surfaceFormats[index];
                     }
 
-                    if (matchedFormat.format != VK_FORMAT_UNDEFINED)
+                    if (matchedFormat.format == VK_FORMAT_UNDEFINED)
                     {
                         matchedFormat = surfaceFormats[index];
                     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -678,16 +678,17 @@ namespace AZ
             auto& device = static_cast<Device&>(GetDevice());
 
             VkColorSpaceKHR preferredColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-#ifndef AZ_PLATFORM_LINUX
-            for (const char* loaded_extension : Instance::GetInstance().GetLoadedExtensions())
+            if (r_hdrOutput)
             {
-                if (strcmp(loaded_extension, VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0)
+                for (const char* loaded_extension : Instance::GetInstance().GetLoadedExtensions())
                 {
-                    preferredColorSpace = VK_COLOR_SPACE_HDR10_ST2084_EXT;
-                    break;
+                    if (strcmp(loaded_extension, VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0)
+                    {
+                        preferredColorSpace = VK_COLOR_SPACE_HDR10_ST2084_EXT;
+                        break;
+                    }
                 }
             }
-#endif
 
             m_surfaceCapabilities = GetSurfaceCapabilities();
             m_surfaceFormat = GetSupportedSurfaceFormat(m_dimensions.m_imageFormat, preferredColorSpace);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -442,7 +442,8 @@ namespace AZ
                 physicalDevice.GetNativePhysicalDevice(), m_surface->GetNativeSurface(), &surfaceFormatCount, surfaceFormats.data()));
 
             const VkFormat format = ConvertFormat(rhiFormat);
-            VkSurfaceFormatKHR matchedFormat = { .format = VK_FORMAT_UNDEFINED };
+            VkSurfaceFormatKHR matchedFormat = {};
+            matchedFormat.format = VK_FORMAT_UNDEFINED;
             for (uint32_t index = 0; index < surfaceFormatCount; ++index)
             {
                 if (surfaceFormats[index].format == format)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -679,16 +679,9 @@ namespace AZ
             auto& device = static_cast<Device&>(GetDevice());
 
             VkColorSpaceKHR preferredColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-            if (r_hdrOutput)
+            if (r_hdrOutput && m_dimensions.m_imageFormat == RHI::Format::R10G10B10A2_UNORM)
             {
-                for (const char* loaded_extension : Instance::GetInstance().GetLoadedExtensions())
-                {
-                    if (strcmp(loaded_extension, VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME) == 0)
-                    {
-                        preferredColorSpace = VK_COLOR_SPACE_HDR10_ST2084_EXT;
-                        break;
-                    }
-                }
+                preferredColorSpace = VK_COLOR_SPACE_HDR10_ST2084_EXT;
             }
 
             m_surfaceCapabilities = GetSurfaceCapabilities();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -78,7 +78,7 @@ namespace AZ
             bool ValidateSurfaceDimensions(const RHI::SwapChainDimensions& dimensions);
             //! Returns the corresponding Vulkan format that is supported by the surface.
             //! If such format is not found, return the first supported format from the surface.
-            VkSurfaceFormatKHR GetSupportedSurfaceFormat(const RHI::Format format) const;
+            VkSurfaceFormatKHR GetSupportedSurfaceFormat(const RHI::Format format, const VkColorSpaceKHR preferredColorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) const;
             //! Returns the correct presentation mode.
             //! If verticalSyncInterval is non-zero, returns VK_PRESENT_MODE_FIFO_KHR.
             //! Otherwise, choose preferred mode if they are supported.


### PR DESCRIPTION
## What does this PR do?

This adds the needed Vulkan extension for `VK_COLOR_SPACE_HDR10_ST2084_EXT` and hardens the checks to use `SetHDRMetaData`. 
Previously, it was possible to not be in an HDR colorspace but have the `A2R10G10B10` VK format which would cause problems when calling into `SetHDRMetaData`.

## How was this PR tested?

Linux Fedora 42, tested with `PAL_TRAIT_LINUX_WINDOW_MANAGER` set to xcb and wayland. 