### PR TITLE
Fix artifacts in Lyshine UI image by marking texture index as non-uniform.

### DIFF
--- a/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
+++ b/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
@@ -87,11 +87,11 @@ float4 SampleTriangleTexture(uint texIndex, float2 uv)
 {
     if ((InstanceSrg::m_isClamp & (1U << texIndex)) != 0)
     {
-        return InstanceSrg::m_texture[texIndex].Sample(InstanceSrg::m_clampSampler, uv);
+        return InstanceSrg::m_texture[NonUniformResourceIndex(texIndex)].Sample(InstanceSrg::m_clampSampler, uv);
     }
     else
     {
-        return InstanceSrg::m_texture[texIndex].Sample(InstanceSrg::m_wrapSampler, uv);
+        return InstanceSrg::m_texture[NonUniformResourceIndex(texIndex)].Sample(InstanceSrg::m_wrapSampler, uv);
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR closes https://github.com/o3de/o3de/issues/18904 by marking texture index as non-uniform.

## How was this PR tested?

Tested on Windows 11 dx12 backend with AMD GPU. Artifacts have disappeared with this PR:

![image](https://github.com/user-attachments/assets/54d3a432-6ba3-430f-9743-16a27d28740f)
