### PR TITLE
Decouple AssImp from Scene API

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpNodeWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpNodeWrapper.h
@@ -11,6 +11,8 @@
 
 struct aiScene;
 
+struct aiNode;
+
 namespace AZ
 {
     namespace AssImpSDKWrapper

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -11,6 +11,7 @@
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
 #include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 #include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
 #include <assimp/postprocess.h>
 
 #if AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
@@ -40,7 +41,7 @@ namespace AZ
         }
 
 #if AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
-        void signal_handler([[maybe_unused]] int signal) 
+        void signal_handler([[maybe_unused]] int signal)
         {
             AZ_TracePrintf(
                 SceneAPI::Utilities::ErrorWindow,
@@ -188,6 +189,76 @@ namespace AZ
             result.first = static_cast<AssImpSceneWrapper::AxisVector>(frontVectorRead);
             return result;
         }
-    }//namespace AssImpSDKWrapper
+        AZStd::optional<SceneAPI::DataTypes::MatrixType> AssImpSceneWrapper::UseForcedRootTransform() const
+        {
+            static constexpr const char* s_ReadRootTransformKey = "/O3DE/Preferences/SceneAPI/AssImpReadRootTransform";
+            bool readRootTransform = false;
+            if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get())
+            {
+                settingsRegistry->Get(readRootTransform, s_ReadRootTransformKey);
+            }
+
+            // for FBX, root transform is not converted where there are no meshes in the scene.
+            if ((m_assImpScene->mFlags | AI_SCENE_FLAGS_INCOMPLETE) && m_assImpScene->mMetaData->HasKey("UpAxis"))
+            {
+                readRootTransform = false;
+            }
+            if (!readRootTransform)
+            {
+                return AZStd::nullopt;
+            }
+
+            SceneAPI::DataTypes::MatrixType rootTransform = AssImpTypeConverter::ToTransform(m_assImpScene->mRootNode->mTransformation);
+            /* Check if metadata has information about "UnitScaleFactor" or "OriginalUnitScaleFactor".
+             * This particular metadata is FBX format only. */
+            if (!m_assImpScene->mMetaData->HasKey("UnitScaleFactor") &&
+                !m_assImpScene->mMetaData->HasKey("OriginalUnitScaleFactor"))
+            {
+                // Some file formats (like DAE) embed the scale in the root transformation, so extract that scale from here.
+                auto unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
+                rootTransform /= unitSizeInMeters;
+            }
+
+
+            // AssImp SDK internally uses a Y-up coordinate system, so we need to adjust the coordinate system to match the O3DE coordinate system (Z-up).
+            AZ::Matrix3x4 adjustmatrix = AZ::Matrix3x4::CreateFromRows(
+                AZ::Vector4(1, 0, 0, 0),
+                AZ::Vector4(0, 0, -1, 0),
+                AZ::Vector4(0, 1, 0, 0)
+            );
+            return SceneAPI::DataTypes::MatrixType(adjustmatrix * rootTransform);
+        }
+
+        float AssImpSceneWrapper::GetUnitSizeInMeters() const
+        {
+            float unitSizeInMeters;
+            float originalUnitSizeInMeters;
+            /* Check if metadata has information about "UnitScaleFactor" or "OriginalUnitScaleFactor".
+             * This particular metadata is FBX format only. */
+            if (m_assImpScene->mMetaData->HasKey("UnitScaleFactor") || m_assImpScene->mMetaData->HasKey("OriginalUnitScaleFactor"))
+            {
+                // If either metadata piece is not available, the default of 1 will be used.
+                m_assImpScene->mMetaData->Get("UnitScaleFactor", unitSizeInMeters);
+                m_assImpScene->mMetaData->Get("OriginalUnitScaleFactor", originalUnitSizeInMeters);
+
+                /* Conversion factor for converting from centimeters to meters.
+                 * This applies to an FBX format in which the default unit is a centimeter. */
+                unitSizeInMeters = unitSizeInMeters * .01f;
+            }
+            else
+            {
+                // Some file formats (like DAE) embed the scale in the root transformation, so extract that scale from here.
+                auto rootTransform = AssImpSDKWrapper::AssImpTypeConverter::ToTransform(m_assImpScene->mRootNode->mTransformation);
+                unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
+            }
+            return unitSizeInMeters;
+        }
+
+        AZ::Aabb AssImpSceneWrapper::GetAABB() const
+        {
+            return AZ::Aabb::CreateFromMinMaxValues(
+                m_aabb.mMin.x, m_aabb.mMin.y, m_aabb.mMin.z, m_aabb.mMax.x, m_aabb.mMax.y, m_aabb.mMax.z);
+        }
+    } // namespace AssImpSDKWrapper
 
 } // namespace AZ

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
@@ -34,23 +34,16 @@ namespace AZ
             void Clear() override;
             void CalculateAABBandVertices(const aiScene* scene, aiAABB& aabb, uint32_t& vertices);
 
-            enum class AxisVector
-            {
-                X = 0,
-                Y = 1,
-                Z = 2,
-                Unknown
-            };
-
-            AZStd::pair<AxisVector, int32_t> GetUpVectorAndSign() const;
-            AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const;
+            AZStd::pair<AxisVector, int32_t> GetUpVectorAndSign() const override;
+            AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const override;
+            AZStd::optional<SceneAPI::DataTypes::MatrixType> UseForcedRootTransform() const override;
+            float GetUnitSizeInMeters() const override;
 
             AZStd::string GetSceneFileName() const { return m_sceneFileName; }
-            aiAABB GetAABB() const { return m_aabb; }
-            uint32_t GetVertices() const { return m_vertices; }
+            AZ::Aabb GetAABB() const override;
+            uint32_t GetVerticesCount() const override { return m_vertices; }
 
             bool GetExtractEmbeddedTextures() const { return m_extractEmbeddedTextures; }
-
         protected:
             const aiScene* m_assImpScene = nullptr;
             AZStd::unique_ptr<Assimp::Importer> m_importer;

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.cpp
@@ -34,20 +34,6 @@ namespace AZ
             return transform;
         }
 
-        SceneAPI::DataTypes::MatrixType AssImpTypeConverter::ToTransform(const AZ::Matrix4x4& matrix)
-        {
-            SceneAPI::DataTypes::MatrixType transform;
-            for (int row = 0; row < 3; ++row)
-            {
-                for (int column = 0; column < 4; ++column)
-                {
-                    transform.SetElement(row, column, matrix.GetElement(row, column));
-                }
-            }
-
-            return transform;
-        }
-
         SceneAPI::DataTypes::Color AssImpTypeConverter::ToColor(const aiColor4D& color)
         {
             return AZ::SceneAPI::DataTypes::Color(color.r, color.g, color.b, color.a);

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.h
@@ -27,7 +27,6 @@ namespace AZ
         {
         public:
             static SceneAPI::DataTypes::MatrixType ToTransform(const aiMatrix4x4& matrix);
-            static SceneAPI::DataTypes::MatrixType ToTransform(const AZ::Matrix4x4& matrix);
             static SceneAPI::DataTypes::Color ToColor(const aiColor4D& color);
             static AZ::Vector3 ToVector3(const aiVector3D& vector3);
         };

--- a/Code/Tools/SceneAPI/SDKWrapper/MaterialWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/MaterialWrapper.h
@@ -11,8 +11,6 @@
 #include <AzCore/std/string/string.h>
 #include <AzCore/Math/Vector3.h>
 
-struct aiMaterial;
-
 namespace AZ
 {
     namespace SDKMaterial

--- a/Code/Tools/SceneAPI/SDKWrapper/NodeWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/NodeWrapper.h
@@ -9,8 +9,6 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 
-struct aiNode;
-
 namespace AZ
 {
     namespace SDKNode

--- a/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <AzCore/Math/Aabb.h>
 #include <SceneAPI/SDKWrapper/SceneWrapper.h>
 
 namespace AZ
@@ -36,5 +37,51 @@ namespace AZ
         void SceneWrapperBase::Clear()
         {
         }
+
+        AZStd::pair<SceneWrapperBase::AxisVector, int32_t> SceneWrapperBase::GetUpVectorAndSign() const
+        {
+            return {AxisVector::Z, 1};
+        }
+
+        AZStd::pair<SceneWrapperBase::AxisVector, int32_t> SceneWrapperBase::GetFrontVectorAndSign() const
+        {
+            return { AxisVector::X, 1 };
+        }
+        AZStd::optional<SceneAPI::DataTypes::MatrixType> SceneWrapperBase::UseForcedRootTransform() const
+        {
+            return AZStd::nullopt;
+        }
+
+        float SceneWrapperBase::GetUnitSizeInMeters() const
+        {
+            return 1.0f;
+        }
+
+        AZ::Aabb SceneWrapperBase::GetAABB() const
+        {
+            return AZ::Aabb::CreateNull();
+        }
+
+        uint32_t SceneWrapperBase::GetVerticesCount() const
+        {
+            return 0u;
+        }
+
+
+        SceneAPI::DataTypes::MatrixType SceneTypeConverter::ToTransform(const AZ::Matrix4x4& matrix)
+        {
+            SceneAPI::DataTypes::MatrixType transform;
+            for (int row = 0; row < 3; ++row)
+            {
+                for (int column = 0; column < 4; ++column)
+                {
+                    transform.SetElement(row, column, matrix.GetElement(row, column));
+                }
+            }
+
+            return transform;
+        }
+
+
     } //namespace SDKScene
 }// namespace AZ

--- a/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.h
@@ -8,10 +8,10 @@
 #pragma once
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
+#include <AzCore/Math/Aabb.h>
 #include <SceneAPI/SDKWrapper/NodeWrapper.h>
+#include <SceneAPI/SceneCore/DataTypes/MatrixType.h>
 #include <SceneAPI/SceneCore/Import/SceneImportSettings.h>
-
-struct aiScene;
 
 namespace AZ
 {
@@ -31,8 +31,31 @@ namespace AZ
 
             virtual void Clear();
 
+            enum class AxisVector
+            {
+                X = 0,
+                Y = 1,
+                Z = 2,
+                Unknown
+            };
+
+            virtual AZStd::pair<AxisVector, int32_t> GetUpVectorAndSign() const;
+            virtual AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const;
+            // some SceneAPI might force the usage of custom root transformation
+            // O3DE shall not try to reorient scene in such cases
+            virtual AZStd::optional<SceneAPI::DataTypes::MatrixType> UseForcedRootTransform() const;
+            virtual float GetUnitSizeInMeters() const;
+            virtual AZ::Aabb GetAABB() const;
+            virtual uint32_t GetVerticesCount() const;
+
             static const char* s_defaultSceneName;
         };
 
-    } //namespace Scene
-} //namespace AZ
+        class SceneTypeConverter
+        {
+        public:
+            static SceneAPI::DataTypes::MatrixType ToTransform(const AZ::Matrix4x4& matrix);
+        };
+
+    } // namespace SDKScene
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/DllMain.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/DllMain.cpp
@@ -28,6 +28,9 @@
 #include <SceneAPI/SceneBuilder/Importers/AssImpBoneImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpAnimationImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h>
+#include <SceneAPI/SceneBuilder/SceneBuilderSystemComponent.h>
+
 
 namespace AZ
 {
@@ -49,6 +52,9 @@ namespace AZ
                     // Global importer and behavior
                     g_componentDescriptors.push_back(SceneBuilder::SceneImporter::CreateDescriptor());
                     g_componentDescriptors.push_back(SceneImportRequestHandler::CreateDescriptor());
+
+                    // ImportContextProviderRegistry
+                    g_componentDescriptors.push_back(SceneBuilderSystemComponent::CreateDescriptor());
 
                     // Node and attribute importers
                     g_componentDescriptors.push_back(AssImpBitangentStreamImporter::CreateDescriptor());
@@ -103,6 +109,8 @@ namespace AZ
 
 extern "C" AZ_DLL_EXPORT void InitializeDynamicModule()
 {
+    // Scott-Meyers singleton as no clear way how to add SystemComponent to module
+    AZ::SceneAPI::SceneBuilder::ImportContextRegistryManager::GetInstance();
 }
 extern "C" AZ_DLL_EXPORT void Reflect(AZ::SerializeContext* context)
 {

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistry.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistry.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            struct ImportContextProvider;
+
+            // ImportContextRegistry realizes Abstract Factory Pattern.
+            // It provides a family of objects related to a particular Import Context.
+            // Those include ImportContext specializations for different stages of the Import pipeline
+            // as well as Scene and Node wrappers.
+            // To add a new library for importing scene assets:
+            // - specialize and implement the ImportContextProvider
+            // - register specialization with this interface
+            class ImportContextRegistry
+            {
+            public:
+                AZ_RTTI(ImportContextRegistry, "{5faaaa8a-2497-41d7-8b5c-5af4390af776}");
+                AZ_CLASS_ALLOCATOR(ImportContextRegistry, AZ::SystemAllocator, 0);
+
+                virtual ~ImportContextRegistry() = default;
+
+                virtual void RegisterContextProvider(ImportContextProvider* provider) = 0;
+                virtual void UnregisterContextProvider(ImportContextProvider* provider) = 0;
+                virtual ImportContextProvider* SelectImportProvider(AZStd::string_view fileExtension) const = 0;
+            };
+
+            using ImportContextRegistryInterface = AZ::Interface<ImportContextRegistry>;
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ImportContextRegistryManager.h"
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            ImportContextRegistryManager::ImportContextRegistryManager()
+            {
+                // register AssImp default provider
+                auto assimpContextProvider = aznew AssImpImportContextProvider();
+                m_importContextProviders.push_back(AZStd::unique_ptr<ImportContextProvider>(assimpContextProvider));
+            };
+
+            void ImportContextRegistryManager::RegisterContextProvider(ImportContextProvider* provider)
+            {
+                if (provider)
+                {
+                    m_importContextProviders.push_back(AZStd::unique_ptr<ImportContextProvider>(provider));
+                }
+            }
+
+            void ImportContextRegistryManager::UnregisterContextProvider(ImportContextProvider* provider)
+            {
+                AZ_TracePrintf("SceneAPI", "Unregistered ImportContextProvider %s", provider->GetImporterName().data());
+                for (auto it = m_importContextProviders.begin(); it != m_importContextProviders.end(); ++it)
+                {
+                    if (it->get() == provider)
+                    {
+                        m_importContextProviders.erase(it);
+                        break; // Assuming only one instance can be registered at a time
+                    }
+                }
+            }
+
+            ImportContextProvider* ImportContextRegistryManager::SelectImportProvider(AZStd::string_view fileExtension) const
+            {
+                AZ_TracePrintf(
+                    "SceneAPI",
+                    "Finding ImportContextProvider (registered %d) suitable for extension: %.*s",
+                    m_importContextProviders.size(),
+                    static_cast<int>(fileExtension.length()),
+                    fileExtension.data());
+                // search in reverse order since the default AssImp Provider can handle all extenstions
+                for (auto it = m_importContextProviders.rbegin(); it != m_importContextProviders.rend(); ++it)
+                {
+                    if (it->get()->CanHandleExtension(fileExtension))
+                    {
+                        return it->get();
+                    }
+                    else
+                    {
+                        AZ_TracePrintf(
+                            "SceneAPI",
+                            "Importer %s cannot handle %.*s",
+                            it->get()->GetImporterName().data(),
+                            static_cast<int>(fileExtension.length()),
+                            fileExtension.data());
+                    }
+                }
+                return nullptr; // No provider found
+            }
+            ImportContextRegistryManager& ImportContextRegistryManager::GetInstance()
+            {
+                static ImportContextRegistryManager instance;
+                return instance;
+            }
+
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.h
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+#include <SceneAPI/SceneBuilder/ImportContextRegistry.h>
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/std/containers/vector.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            // Implementation of the ImportContextRegistryInterface.
+            class ImportContextRegistryManager : public ImportContextRegistryInterface::Registrar
+            {
+            public:
+                AZ_RTTI(ImportContextRegistryManager, "{d3107473-4f99-4421-b4a8-ece66a922191}", ImportContextRegistry);
+                AZ_CLASS_ALLOCATOR(ImportContextRegistryManager, AZ::SystemAllocator, 0);
+
+                ImportContextRegistryManager();
+                ImportContextRegistryManager(const ImportContextRegistryManager&) = delete;
+                ImportContextRegistryManager& operator=(const ImportContextRegistryManager&) = delete;
+
+                ~ImportContextRegistryManager() override = default;
+
+                void RegisterContextProvider(ImportContextProvider* provider) override;
+                void UnregisterContextProvider(ImportContextProvider* provider) override;
+                ImportContextProvider* SelectImportProvider(AZStd::string_view fileExtension) const override;
+
+                static ImportContextRegistryManager& GetInstance();
+            private:
+                AZStd::vector<AZStd::unique_ptr<ImportContextProvider>> m_importContextProviders;
+            };
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "AssImpImportContextProvider.h"
+#include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            AZStd::shared_ptr<NodeEncounteredContext> AssImpImportContextProvider::CreateNodeEncounteredContext(
+                Containers::Scene& scene,
+                Containers::SceneGraph::NodeIndex currentGraphPosition,
+                const SceneSystem& sourceSceneSystem,
+                RenamedNodesMap& nodeNameMap,
+                SDKScene::SceneWrapperBase& sourceScene,
+                SDKNode::NodeWrapper& sourceNode)
+            {
+                // need to cast NodeWrapper
+                auto assImpNode = azrtti_cast<AZ::AssImpSDKWrapper::AssImpNodeWrapper*>(&sourceNode);
+                auto assImpScene = azrtti_cast<AZ::AssImpSDKWrapper::AssImpSceneWrapper*>(&sourceScene);
+
+                if (!assImpNode)
+                {
+                    // Handle error: parent is not of the expected type
+                    AZ_Error("SceneBuilder", false, "Incorrect node type. Cannot create NodeEncounteredContext");
+                    return nullptr;
+                }
+                if (!assImpScene)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect scene type. Cannot create NodeEncounteredContext");
+                    return nullptr;
+                }
+                auto context = AZStd::make_shared<AssImpNodeEncounteredContext>(
+                    scene, currentGraphPosition, *assImpScene, sourceSceneSystem, nodeNameMap, *assImpNode);
+                context->m_contextProvider = this;
+                return context;
+            }
+
+            AZStd::shared_ptr<SceneDataPopulatedContextBase> AssImpImportContextProvider::CreateSceneDataPopulatedContext(
+                NodeEncounteredContext& parent, AZStd::shared_ptr<DataTypes::IGraphObject> graphData, const AZStd::string& dataName)
+            {
+                // Downcast the parent to the AssImp-specific type to access AssImpImportContext members
+                AssImpNodeEncounteredContext* assImpParent = azrtti_cast<AssImpNodeEncounteredContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneDataPopulatedContext");
+                    return nullptr;
+                }
+
+                auto context = AZStd::make_shared<AssImpSceneDataPopulatedContext>(*assImpParent, AZStd::move(graphData), dataName);
+
+                context->m_contextProvider = this;
+                return context;
+            }
+
+            AZStd::shared_ptr<SceneNodeAppendedContextBase> AssImpImportContextProvider::CreateSceneNodeAppendedContext(
+                SceneDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneDataPopulatedContext* assImpParent = azrtti_cast<AssImpSceneDataPopulatedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeAppendedContext");
+                    return nullptr;
+                }
+
+                auto context = AZStd::make_shared<AssImpSceneNodeAppendedContext>(*assImpParent, newIndex);
+                context->m_contextProvider = this;
+                return context;
+            }
+
+            AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> AssImpImportContextProvider::CreateSceneAttributeDataPopulatedContext(
+                SceneNodeAppendedContextBase& parent,
+                AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
+                const Containers::SceneGraph::NodeIndex attributeNodeIndex,
+                const AZStd::string& dataName)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneNodeAppendedContext* assImpParent = azrtti_cast<AssImpSceneNodeAppendedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneAttributeDataPopulatedContext");
+                    return nullptr;
+                }
+                auto context = AZStd::make_shared<AssImpSceneAttributeDataPopulatedContext>(
+                    *assImpParent, AZStd::move(nodeData), attributeNodeIndex, dataName);
+                context->m_contextProvider = this;
+                return context;
+            }
+
+            AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> AssImpImportContextProvider::CreateSceneAttributeNodeAppendedContext(
+                SceneAttributeDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneAttributeDataPopulatedContext* assImpParent = azrtti_cast<AssImpSceneAttributeDataPopulatedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneAttributeNodeAppendedContext");
+                    return nullptr;
+                }
+                auto context = AZStd::make_shared<AssImpSceneAttributeNodeAppendedContext>(*assImpParent, newIndex);
+                context->m_contextProvider = this;
+                return context;
+            }
+
+            AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> AssImpImportContextProvider::CreateSceneNodeAddedAttributesContext(
+                SceneNodeAppendedContextBase& parent)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneNodeAppendedContext* assImpParent = azrtti_cast<AssImpSceneNodeAppendedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeAddedAttributesContext");
+                    return nullptr;
+                }
+                auto context = AZStd::make_shared<AssImpSceneNodeAddedAttributesContext>(*assImpParent);
+                context->m_contextProvider = this;
+                return context;
+            }
+
+            AZStd::shared_ptr<SceneNodeFinalizeContextBase> AssImpImportContextProvider::CreateSceneNodeFinalizeContext(
+                SceneNodeAddedAttributesContextBase& parent)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneNodeAddedAttributesContext* assImpParent = azrtti_cast<AssImpSceneNodeAddedAttributesContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeFinalizeContext");
+                    return nullptr;
+                }
+                auto context = AZStd::make_shared<AssImpSceneNodeFinalizeContext>(*assImpParent);
+                context->m_contextProvider = this;
+                return context;
+            }
+
+            AZStd::shared_ptr<FinalizeSceneContextBase> AssImpImportContextProvider::CreateFinalizeSceneContext(
+                Containers::Scene& scene,
+                const SceneSystem& sourceSceneSystem,
+                SDKScene::SceneWrapperBase& sourceScene,
+                RenamedNodesMap& nodeNameMap)
+            {
+                AssImpSDKWrapper::AssImpSceneWrapper* assImpScene = azrtti_cast<AssImpSDKWrapper::AssImpSceneWrapper*>(&sourceScene);
+                if (!assImpScene)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect scene type. Cannot create FinalizeSceneContext");
+                    return nullptr;
+                }
+                auto context = AZStd::make_shared<AssImpFinalizeSceneContext>(scene, *assImpScene, sourceSceneSystem, nodeNameMap);
+                context->m_contextProvider = this;
+                return context;
+            }
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "ImportContextProvider.h"
+
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            // Concrete provider for creating AssImp-specific import classes.
+            struct AssImpImportContextProvider : public ImportContextProvider
+            {
+                AZ_RTTI(AssImpImportContextProvider, "{6c263adb-e73c-4017-955a-9c212ded3637}");
+
+                AssImpImportContextProvider() = default;
+
+                AZStd::shared_ptr<NodeEncounteredContext> CreateNodeEncounteredContext(
+                    Containers::Scene& scene,
+                    Containers::SceneGraph::NodeIndex currentGraphPosition,
+                    const SceneSystem& sourceSceneSystem,
+                    RenamedNodesMap& nodeNameMap,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    SDKNode::NodeWrapper& sourceNode) override;
+
+                AZStd::shared_ptr<SceneDataPopulatedContextBase> CreateSceneDataPopulatedContext(
+                    NodeEncounteredContext& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> graphData,
+                    const AZStd::string& dataName) override;
+
+                AZStd::shared_ptr<SceneNodeAppendedContextBase> CreateSceneNodeAppendedContext(
+                    SceneDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) override;
+
+                AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> CreateSceneAttributeDataPopulatedContext(
+                    SceneNodeAppendedContextBase& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
+                    const Containers::SceneGraph::NodeIndex attributeNodeIndex,
+                    const AZStd::string& dataName) override;
+
+                AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> CreateSceneAttributeNodeAppendedContext(
+                    SceneAttributeDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) override;
+
+                AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> CreateSceneNodeAddedAttributesContext(
+                    SceneNodeAppendedContextBase& parent) override;
+
+                AZStd::shared_ptr<SceneNodeFinalizeContextBase> CreateSceneNodeFinalizeContext(
+                    SceneNodeAddedAttributesContextBase& parent) override;
+
+                AZStd::shared_ptr<FinalizeSceneContextBase> CreateFinalizeSceneContext(
+                    Containers::Scene& scene,
+                    const SceneSystem& sourceSceneSystem,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    RenamedNodesMap& nodeNameMap) override;
+
+                bool CanHandleExtension(AZStd::string_view fileExtension) const override
+                {
+                    // The AssImp is our default provider and returns true for all registered extensions.
+                    return true;
+                }
+
+                AZStd::unique_ptr<AZ::SDKScene::SceneWrapperBase> CreateSceneWrapper() const override
+                {
+                    return AZStd::make_unique<AZ::AssImpSDKWrapper::AssImpSceneWrapper>();
+                }
+
+                AZStd::string_view GetImporterName() const override
+                {
+                    return "AssImp";
+                }
+            };
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h
@@ -180,4 +180,3 @@ namespace AZ
         } // namespace SceneBuilder
     } // namespace SceneAPI
 } // namespace AZ
-

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "ImportContexts.h"
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/string/string.h>
+#include <SceneAPI/SDKWrapper/NodeWrapper.h>
+#include <SceneAPI/SceneBuilder/SceneSystem.h>
+#include <SceneAPI/SceneCore/Containers/SceneGraph.h>
+
+namespace AZ::SDKScene
+{
+    class SceneWrapperBase;
+}
+namespace AZ::SDKNode
+{
+    class NodeWrapper;
+}
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace Containers
+        {
+            class Scene;
+        }
+
+        namespace SceneBuilder
+        {
+            class RenamedNodesMap;
+            struct NodeEncounteredContext;
+            struct SceneDataPopulatedContextBase;
+            struct SceneNodeAppendedContextBase;
+            struct SceneAttributeDataPopulatedContextBase;
+            struct SceneAttributeNodeAppendedContextBase;
+            struct SceneNodeAddedAttributesContextBase;
+            struct SceneNodeFinalizeContextBase;
+            struct FinalizeSceneContextBase;
+            // ImportContextProvider realizes factory pattern and provides classes specialized for particular Scene Import library.
+            struct ImportContextProvider
+            {
+                AZ_RTTI(ImportContextProvider, "{5df22f6c-8a43-417d-b735-9d9d7d069efc}");
+
+                virtual ~ImportContextProvider() = default;
+
+                virtual AZStd::shared_ptr<NodeEncounteredContext> CreateNodeEncounteredContext(
+                    Containers::Scene& scene,
+                    Containers::SceneGraph::NodeIndex currentGraphPosition,
+                    const SceneSystem& sourceSceneSystem,
+                    RenamedNodesMap& nodeNameMap,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    AZ::SDKNode::NodeWrapper& sourceNode) = 0;
+
+                virtual AZStd::shared_ptr<SceneDataPopulatedContextBase> CreateSceneDataPopulatedContext(
+                    NodeEncounteredContext& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> graphData,
+                    const AZStd::string& dataName) = 0;
+
+                 virtual AZStd::shared_ptr<SceneNodeAppendedContextBase> CreateSceneNodeAppendedContext(
+                    SceneDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) = 0;
+
+                virtual AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> CreateSceneAttributeDataPopulatedContext(
+                    SceneNodeAppendedContextBase& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
+                    const Containers::SceneGraph::NodeIndex attributeNodeIndex,
+                    const AZStd::string& dataName) = 0;
+
+                virtual AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> CreateSceneAttributeNodeAppendedContext(
+                    SceneAttributeDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) = 0;
+
+                virtual AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> CreateSceneNodeAddedAttributesContext(
+                    SceneNodeAppendedContextBase& parent) = 0;
+
+                virtual AZStd::shared_ptr<SceneNodeFinalizeContextBase> CreateSceneNodeFinalizeContext(
+                    SceneNodeAddedAttributesContextBase& parent) = 0;
+
+                virtual AZStd::shared_ptr<FinalizeSceneContextBase> CreateFinalizeSceneContext(
+                    Containers::Scene& scene,
+                    const SceneSystem& sourceSceneSystem,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    RenamedNodesMap& nodeNameMap) = 0;
+
+                // Creates an instance of the scene wrapper
+                virtual AZStd::unique_ptr<SDKScene::SceneWrapperBase> CreateSceneWrapper() const = 0;
+
+                // Checks if this provider can handle the given file extension
+                virtual bool CanHandleExtension(AZStd::string_view fileExtension) const = 0;
+
+                // Get a descriptive name for Context Provider
+                virtual AZStd::string_view GetImporterName() const { return "Unknown Importer"; }
+            };
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
@@ -21,12 +21,14 @@ namespace AZ
                 : m_scene(scene)
                 , m_currentGraphPosition(currentGraphPosition)
                 , m_nodeNameMap(nodeNameMap)
+                , m_contextProvider(nullptr)
             {
             }
 
             ImportContext::ImportContext(Containers::Scene& scene, RenamedNodesMap& nodeNameMap)
                 : m_scene(scene)
                 , m_nodeNameMap(nodeNameMap)
+                , m_contextProvider(nullptr)
             {
                 m_currentGraphPosition = Containers::SceneGraph::NodeIndex();
             }

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
+#include "ImportContextProvider.h"
+
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string.h>
-#include <SceneAPI/SceneCore/Events/CallProcessorBus.h>
-#include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
-
+#include <SceneAPI/SceneCore/Containers/SceneGraph.h>
+#include <SceneAPI/SceneCore/Events/CallProcessorBus.h>
 
 namespace AZ
 {    
@@ -36,6 +37,7 @@ namespace AZ
 
         namespace SceneBuilder
         {
+            struct ImportContextProvider;
             class RenamedNodesMap;
 
             //  ImportContext
@@ -52,6 +54,7 @@ namespace AZ
                 Containers::Scene& m_scene;
                 Containers::SceneGraph::NodeIndex m_currentGraphPosition;
                 RenamedNodesMap& m_nodeNameMap; // Map of the nodes that have received a new name.
+                ImportContextProvider* m_contextProvider; // The provider that created this context.
             };
 
             //  NodeEncounteredContext
@@ -177,4 +180,3 @@ namespace AZ
         } // namespace SceneBuilder
     } // namespace SceneAPI
 } // namespace AZ
-

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.cpp
@@ -116,12 +116,12 @@ namespace AZ
                     context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, m_defaultNodeName);
 
                 Events::ProcessingResult bitangentResults;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, bitangentStream, newIndex, m_defaultNodeName);
-                bitangentResults = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, bitangentStream, newIndex, m_defaultNodeName);
+                bitangentResults = Events::Process(*dataPopulated);
 
                 if (bitangentResults != Events::ProcessingResult::Failure)
                 {
-                    bitangentResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                    bitangentResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
                 return bitangentResults;
             }

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
@@ -285,12 +285,12 @@ namespace AZ
                         context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, nodeName.c_str());
 
                     Events::ProcessingResult blendShapeResult;
-                    AssImpSceneAttributeDataPopulatedContext dataPopulated(context, blendShapeData, newIndex, nodeName);
-                    blendShapeResult = Events::Process(dataPopulated);
+                    auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, blendShapeData, newIndex, nodeName);
+                    blendShapeResult = Events::Process(*dataPopulated);
 
                     if (blendShapeResult != Events::ProcessingResult::Failure)
                     {
-                        blendShapeResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                        blendShapeResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                     }
                     combinedBlendShapeResult += blendShapeResult;
                 }

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.cpp
@@ -113,12 +113,12 @@ namespace AZ
                         context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, nodeName.c_str());
 
                     Events::ProcessingResult colorMapResults;
-                    AssImpSceneAttributeDataPopulatedContext dataPopulated(context, vertexColors, newIndex, nodeName.c_str());
-                    colorMapResults = Events::Process(dataPopulated);
+                    auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, vertexColors, newIndex, nodeName.c_str());
+                    colorMapResults = Events::Process(*dataPopulated);
 
                     if (colorMapResults != Events::ProcessingResult::Failure)
                     {
-                        colorMapResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                        colorMapResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                     }
 
                     combinedVertexColorResults += colorMapResults;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpCustomPropertyImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpCustomPropertyImporter.cpp
@@ -114,12 +114,12 @@ namespace AZ::SceneAPI::SceneBuilder
                 }
 
                 Events::ProcessingResult attributeResult;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, customPropertyMapData, newIndex, nodeName);
-                attributeResult = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, customPropertyMapData, newIndex, nodeName);
+                attributeResult = Events::Process(*dataPopulated);
 
                 if (attributeResult != Events::ProcessingResult::Failure)
                 {
-                    attributeResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                    attributeResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
 
                 return attributeResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
@@ -158,12 +158,12 @@ namespace AZ
                             continue;
                         }
 
-                        AssImpSceneAttributeDataPopulatedContext dataPopulated(context, material, newIndex, materialName);
-                        materialResult = Events::Process(dataPopulated);
+                        auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, material, newIndex, materialName);
+                        materialResult = Events::Process(*dataPopulated);
 
                         if (materialResult != Events::ProcessingResult::Failure)
                         {
-                            materialResult = SceneAPI::SceneBuilder::AddAttributeDataNodeWithContexts(dataPopulated);
+                            materialResult = SceneAPI::SceneBuilder::AddAttributeDataNodeWithContexts(*dataPopulated);
                         }
 
                         combinedMaterialImportResults += materialResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
@@ -111,12 +111,13 @@ namespace AZ
                 }
 
                 Events::ProcessingResult skinWeightsResult;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, skinWeightData, weightsIndexForMesh, skinWeightName);
-                skinWeightsResult = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(
+                    context, skinWeightData, weightsIndexForMesh, skinWeightName);
+                skinWeightsResult = Events::Process(*dataPopulated);
 
                 if (skinWeightsResult != Events::ProcessingResult::Failure)
                 {
-                    skinWeightsResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                    skinWeightsResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
 
                 combinedSkinWeightsResult += skinWeightsResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
@@ -54,7 +54,6 @@ namespace AZ
                 }
                 const aiNode* currentNode = context.m_sourceNode.GetAssImpNode();
                 const aiScene* scene = context.m_sourceScene.GetAssImpScene();
-                
                 const auto meshHasTangentsAndBitangents = [&scene](const unsigned int meshIndex)
                 {
                     return scene->mMeshes[meshIndex]->HasTangentsAndBitangents();
@@ -118,12 +117,13 @@ namespace AZ
                     context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, m_defaultNodeName);
 
                 Events::ProcessingResult tangentResults;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, tangentStream, newIndex, m_defaultNodeName);
-                tangentResults = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(
+                    context, tangentStream, newIndex, m_defaultNodeName);
+                tangentResults = Events::Process(*dataPopulated);
 
                 if (tangentResults != Events::ProcessingResult::Failure)
                 {
-                    tangentResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                    tangentResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
                 return tangentResults;
             }

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
@@ -86,12 +86,13 @@ namespace AZ
                         }
 
                         Events::ProcessingResult transformAttributeResult;
-                        AssImpSceneAttributeDataPopulatedContext dataPopulated(context, transformData, newIndex, nodeName);
-                        transformAttributeResult = Events::Process(dataPopulated);
+                        auto dataPopulated =
+                            context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, transformData, newIndex, nodeName);
+                        transformAttributeResult = Events::Process(*dataPopulated);
 
                         if (transformAttributeResult != Events::ProcessingResult::Failure)
                         {
-                            transformAttributeResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                            transformAttributeResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                         }
 
                         return transformAttributeResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpUvMapImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpUvMapImporter.cpp
@@ -161,12 +161,12 @@ namespace AZ
                         context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, name.c_str());
 
                     Events::ProcessingResult uvMapResults;
-                    AssImpSceneAttributeDataPopulatedContext dataPopulated(context, uvMap, newIndex, name);
-                    uvMapResults = Events::Process(dataPopulated);
+                    auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, uvMap, newIndex, name);
+                    uvMapResults = Events::Process(*dataPopulated);
 
                     if (uvMapResults != Events::ProcessingResult::Failure)
                     {
-                        uvMapResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                        uvMapResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                     }
 
                     combinedUvMapResults += uvMapResults;

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SceneBuilderSystemComponent.h"
+#include "ImportContexts/AssImpImportContextProvider.h"
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            void SceneBuilderSystemComponent::Activate()
+            {
+                // Get the import context registy
+                if (auto* registry = ImportContextRegistryInterface::Get())
+                {
+                    // Create and register the ImportContextProvider for AssImp
+                    // It should be always present and be used as a fallback if no specialized provider is available
+                    auto assImpContextProvider = aznew AssImpImportContextProvider();
+                    registry->RegisterContextProvider(assImpContextProvider);
+                    AZ_Info("SceneAPI", "AssImp Import Context was registered.\n");
+                }
+                else
+                {
+                    AZ_Error("SceneAPI", false, "ImportContextRegistryInterface not found. AssImp Import Context was not registered.");
+                }
+            }
+
+            void SceneBuilderSystemComponent::Deactivate()
+            {
+            }
+
+            void SceneBuilderSystemComponent::Reflect(ReflectContext* context)
+            {
+                SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
+                if (serializeContext)
+                {
+                    serializeContext->Class<SceneBuilderSystemComponent, AZ::Component>()->Version(1);
+                }
+            }
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <SceneAPI/SceneBuilder/ImportContextRegistryManager.h>
+#include <SceneAPI/SceneCore/SceneCoreConfiguration.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            // Scene system components are components that can be used to create system components
+            //      in situations where the full initialization and/or construction of regular
+            //      system components don't apply such as in the ResourceCompilerScene.
+            class SceneBuilderSystemComponent
+                : public AZ::Component
+            {
+            public:
+                AZ_COMPONENT(SceneBuilderSystemComponent, "{9453ddf4-882c-4675-86eb-834f1d1dc5ef}");
+
+                ~SceneBuilderSystemComponent() override = default;
+
+                void Activate() override;
+                void Deactivate() override;
+
+                static void Reflect(ReflectContext* context);
+            private:
+                ImportContextRegistryManager m_sceneSystemRegistry;
+            };
+        } // namespace SceneCore
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.h
@@ -8,14 +8,16 @@
 
 #pragma once
 
-#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <SceneAPI/SDKWrapper/SceneWrapper.h>
+#include <SceneAPI/SceneBuilder/ImportContextRegistryManager.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
+#include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Components/LoadingComponent.h>
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/Events/ImportEventContext.h>
 #include <SceneAPI/SceneCore/Import/SceneImportSettings.h>
-#include <SceneAPI/SceneBuilder/SceneSystem.h>
-#include <SceneAPI/SDKWrapper/SceneWrapper.h>
 
 namespace AZ
 {
@@ -48,6 +50,8 @@ namespace AZ
 
                 AZStd::unique_ptr<SDKScene::SceneWrapperBase> m_sceneWrapper;
                 AZStd::shared_ptr<SceneSystem> m_sceneSystem;
+                AZStd::unique_ptr<ImportContextProvider> m_contextProvider {};
+                ImportContextRegistryManager m_contextRegistry;
             };
         } // namespace SceneBuilder
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -6,13 +6,12 @@
  *
  */
 
+#include "SceneWrapper.h"
+
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
-#include <assimp/scene.h>
 
 
 namespace AZ
@@ -29,60 +28,15 @@ namespace AZ
 
         void SceneSystem::Set(const SDKScene::SceneWrapperBase* scene)
         {
-            static constexpr const char* s_ReadRootTransformKey = "/O3DE/Preferences/SceneAPI/AssImpReadRootTransform";
-            bool readRootTransform = false;
-            if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get())
+            m_unitSizeInMeters = scene->GetUnitSizeInMeters();
+            if (auto forcedRootTransform = scene->UseForcedRootTransform())
             {
-                settingsRegistry->Get(readRootTransform, s_ReadRootTransformKey);
-            }
-            // Get unit conversion factor to meter.
-            if (!azrtti_istypeof<AssImpSDKWrapper::AssImpSceneWrapper>(scene))
-            {
-                return;
-            }
-
-            const AssImpSDKWrapper::AssImpSceneWrapper* assImpScene = azrtti_cast<const AssImpSDKWrapper::AssImpSceneWrapper*>(scene);
-            DataTypes::MatrixType rootTransform = AssImpSDKWrapper::AssImpTypeConverter::ToTransform(assImpScene->GetAssImpScene()->mRootNode->mTransformation);
-            /* Check if metadata has information about "UnitScaleFactor" or "OriginalUnitScaleFactor". 
-             * This particular metadata is FBX format only. */
-            if (assImpScene->GetAssImpScene()->mMetaData->HasKey("UnitScaleFactor") ||
-                assImpScene->GetAssImpScene()->mMetaData->HasKey("OriginalUnitScaleFactor"))
-            {
-                // If either metadata piece is not available, the default of 1 will be used.
-                assImpScene->GetAssImpScene()->mMetaData->Get("UnitScaleFactor", m_unitSizeInMeters);
-                assImpScene->GetAssImpScene()->mMetaData->Get("OriginalUnitScaleFactor", m_originalUnitSizeInMeters);
-
-                /* Conversion factor for converting from centimeters to meters.
-                 * This applies to an FBX format in which the default unit is a centimeter. */
-                m_unitSizeInMeters = m_unitSizeInMeters * .01f;
-            }
-            else
-            {
-                // Some file formats (like DAE) embed the scale in the root transformation, so extract that scale from here.
-                m_unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
-                rootTransform /= m_unitSizeInMeters;
-            }
-            // for FBX, root transform is not converted where there are no meshes in the scene.
-            if ((assImpScene->GetAssImpScene()->mFlags | AI_SCENE_FLAGS_INCOMPLETE)
-                && assImpScene->GetAssImpScene()->mMetaData->HasKey("UpAxis"))
-            {
-                readRootTransform = false;
-            }
-
-            if (readRootTransform)
-            {
-                // AssImp SDK internally uses a Y-up coordinate system, so we need to adjust the coordinate system to match the O3DE coordinate system (Z-up).
-                AZ::Matrix3x4 adjustmatrix = AZ::Matrix3x4::CreateFromRows(
-                    AZ::Vector4(1, 0, 0, 0),
-                    AZ::Vector4(0, 0, -1, 0),
-                    AZ::Vector4(0, 1, 0, 0)
-                );
-                m_adjustTransform.reset(new DataTypes::MatrixType(adjustmatrix * rootTransform));
+                m_adjustTransform.reset(new DataTypes::MatrixType(*forcedRootTransform));
                 m_adjustTransformInverse.reset(new DataTypes::MatrixType(m_adjustTransform->GetInverseFull()));
                 return;
             }
 
-            AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> upAxisAndSign = assImpScene->GetUpVectorAndSign();
+            AZStd::pair<SDKScene::SceneWrapperBase::AxisVector, int32_t> upAxisAndSign = scene->GetUpVectorAndSign();
 
             if (upAxisAndSign.second <= 0)
             {
@@ -90,10 +44,10 @@ namespace AZ
                 return;
             }
 
-            AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> frontAxisAndSign = assImpScene->GetFrontVectorAndSign();
+            AZStd::pair<SDKScene::SceneWrapperBase::AxisVector, int32_t> frontAxisAndSign = scene->GetFrontVectorAndSign();
 
-            if (upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Z &&
-                upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Unknown)
+            if (upAxisAndSign.first != SDKScene::SceneWrapperBase::AxisVector::Z &&
+                upAxisAndSign.first != SDKScene::SceneWrapperBase::AxisVector::Unknown)
             {
                 AZ::Matrix4x4 currentCoordMatrix = AZ::Matrix4x4::CreateIdentity();
                 //(UpVector = +Z, FrontVector = +Y, CoordSystem = -X(RightHanded))
@@ -105,7 +59,7 @@ namespace AZ
 
                 switch (upAxisAndSign.first)
                 {
-                case AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::X: {
+                case SDKScene::SceneWrapperBase::AxisVector::X: {
                     if (frontAxisAndSign.second == 1)
                     {
                         currentCoordMatrix = AZ::Matrix4x4::CreateFromColumns(
@@ -124,7 +78,7 @@ namespace AZ
                     }
                 }
                 break;
-                case AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Y: {
+                case SDKScene::SceneWrapperBase::AxisVector::Y: {
                     if (frontAxisAndSign.second == 1)
                     {
                         currentCoordMatrix = AZ::Matrix4x4::CreateFromColumns(
@@ -145,7 +99,7 @@ namespace AZ
                 break;
                 }
                 AZ::Matrix4x4 adjustmatrix = targetCoordMatrix * currentCoordMatrix.GetInverseTransform();
-                m_adjustTransform.reset(new DataTypes::MatrixType(AssImpSDKWrapper::AssImpTypeConverter::ToTransform(adjustmatrix)));
+                m_adjustTransform.reset(new DataTypes::MatrixType(SDKScene::SceneTypeConverter::ToTransform(adjustmatrix)));
                 m_adjustTransformInverse.reset(new DataTypes::MatrixType(m_adjustTransform->GetInverseFull()));
             }
         }

--- a/Code/Tools/SceneAPI/SceneBuilder/scenebuilder_files.cmake
+++ b/Code/Tools/SceneAPI/SceneBuilder/scenebuilder_files.cmake
@@ -14,10 +14,18 @@ set(FILES
     SceneImporter.cpp
     SceneSystem.h
     SceneSystem.cpp
+    SceneBuilderSystemComponent.h
+    SceneBuilderSystemComponent.cpp
+    ImportContextRegistry.h
+    ImportContextRegistryManager.h
+    ImportContextRegistryManager.cpp
     ImportContexts/ImportContexts.h
     ImportContexts/ImportContexts.cpp
+    ImportContexts/ImportContextProvider.h
     ImportContexts/AssImpImportContexts.h
     ImportContexts/AssImpImportContexts.cpp
+    ImportContexts/AssImpImportContextProvider.h
+    ImportContexts/AssImpImportContextProvider.cpp
     Importers/Utilities/AssImpMeshImporterUtilities.h
     Importers/Utilities/AssImpMeshImporterUtilities.cpp
     Importers/Utilities/RenamedNodesMap.h


### PR DESCRIPTION
## What does this PR do?

We would like to use a different library for scene asset import yet still benefit from all offerings of the Scene API pipeline.
This PR reviews the interface between Scene API and AssImp and fixes the abstraction where it was leaking or non-existent.
It is an enabler for addition of different scene import libraries as Gems. By itself no functional changes were intended: all existing assets should be imported as before.

It removes references to AssImp specific code from the generic part of the SceneSystem/SceneImporter.
It enhances SceneWrapperBase with additional methods that provide clear boundaries.
It refactors AssImp SDKWrapper and AssimpImportContext to be provided by AssimpImportContextProvider factory.
It uses Abstract Factory Pattern to decouple AssImp specific ImportContext from SceneImporter
It implements an ImportContextRegistry Interface for registration of additional ImportContextProviders


## How was this PR tested?

I mostly tested inside internal project - but was using stabilization as a base. Therefore recent additions into pipeline should be reviewed carefully.