### PR TITLE
Fix terrain artifacts by marking texture index as non-uniform.

### DIFF
--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailHelpers.azsli
@@ -96,7 +96,7 @@ void AddDetailSurface(inout DetailSurface surface, in DetailSurface surfaceToAdd
 
 float4 SampleTexture(uint index, in MaterialContext materialContext)
 {
-    return Bindless::GetTexture2D(index).SampleGrad(TerrainMaterialSrg::m_detailSampler, materialContext.m_uv, materialContext.m_ddx, materialContext.m_ddy);
+    return Bindless::GetTexture2D(NonUniformResourceIndex(index)).SampleGrad(TerrainMaterialSrg::m_detailSampler, materialContext.m_uv, materialContext.m_ddx, materialContext.m_ddy);
 }
 
 float3 GetDetailColor(in MaterialContext materialContext, in float3 macroColor)


### PR DESCRIPTION
Closes: https://github.com/o3de/o3de/issues/18924

## What does this PR do?

When using AMD GPUs, one need to explicitly mark or signal when you're accessing non-uniform texture indices. This PR does this to eliminate artifacts seen on the terrain.

## How was this PR tested?

Tested on Windows 11 dx12 with AMD GPU:

![image](https://github.com/user-attachments/assets/a460499f-f3b9-487d-8f94-339e23890967)