### PR TITLE
Fix RayTracingAccelerationStructurePass not reading scope query resut when only animated meshes are updated

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -74,9 +74,9 @@ namespace AZ
                 rayTracingFeatureProcessor->BeginFrame();
                 auto revision = rayTracingFeatureProcessor->GetRevision();
                 m_rayTracingRevisionOutDated = revision != m_rayTracingRevision;
-                if (m_rayTracingRevisionOutDated)
+                m_rayTracingRevision = revision;
+                if (m_rayTracingRevisionOutDated || rayTracingFeatureProcessor->GetSkinnedMeshCount() != 0)
                 {
-                    m_rayTracingRevision = revision;
                     ReadbackScopeQueryResults();
                 }
             }


### PR DESCRIPTION
## What does this PR do?

This PR fixes that `RayTracingAccelerationStructurePass` is not inserting a TimestampQuery or PipelineStatisticsQuery if animated meshes are present in a scene (and no static meshes are currently moving). This omission lead to the RayTracingAccelerationStructurePass always showing up as 0ms in the "TimestampView", even though BLAS update/BLAS build and TLAS build commands are issued each frame for the animated meshes.

## How was this PR tested?

Create a small test scene with a "Actor" and "Simple Motion" component, and load an animated test model, then open the GpuProfiler/TimestampView debug window and look at the pass times. Without this PR, the time of the RayTracingAccelerationStructurePass is only >0 for a very short time if the whole model is being moved by the transform component, and with this PR the time is around 0.4ms all the time.
