### PR TITLE
Cherrypick texture uniform fixes from dev to stabilization for 2505.0

### DIFF
--- a/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
+++ b/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
@@ -87,11 +87,11 @@ float4 SampleTriangleTexture(uint texIndex, float2 uv)
 {
     if ((InstanceSrg::m_isClamp & (1U << texIndex)) != 0)
     {
-        return InstanceSrg::m_texture[texIndex].Sample(InstanceSrg::m_clampSampler, uv);
+        return InstanceSrg::m_texture[NonUniformResourceIndex(texIndex)].Sample(InstanceSrg::m_clampSampler, uv);
     }
     else
     {
-        return InstanceSrg::m_texture[texIndex].Sample(InstanceSrg::m_wrapSampler, uv);
+        return InstanceSrg::m_texture[NonUniformResourceIndex(texIndex)].Sample(InstanceSrg::m_wrapSampler, uv);
     }
 }
 

--- a/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailHelpers.azsli
+++ b/Gems/Terrain/Assets/Shaders/Terrain/TerrainDetailHelpers.azsli
@@ -96,7 +96,7 @@ void AddDetailSurface(inout DetailSurface surface, in DetailSurface surfaceToAdd
 
 float4 SampleTexture(uint index, in MaterialContext materialContext)
 {
-    return Bindless::GetTexture2D(index).SampleGrad(TerrainMaterialSrg::m_detailSampler, materialContext.m_uv, materialContext.m_ddx, materialContext.m_ddy);
+    return Bindless::GetTexture2D(NonUniformResourceIndex(index)).SampleGrad(TerrainMaterialSrg::m_detailSampler, materialContext.m_uv, materialContext.m_ddx, materialContext.m_ddy);
 }
 
 float3 GetDetailColor(in MaterialContext materialContext, in float3 macroColor)


### PR DESCRIPTION
## What does this PR do?

Cherry picks the below two changes fixing texture corruption issues in lyshine and terrain, from dev, to stabiliztaion 2505.0.

See the two below commits by @rossbridger  
* https://github.com/o3de/o3de/pull/18930 - lyshine texture fix corruption
* https://github.com/o3de/o3de/pull/18932 - terrain texture fix corruption

## How was this PR tested?

Local testing, seeing no issues. 
