### PR TITLE
Update O3DE Splash Screen background for 25.05

### DIFF
--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d543f9bfef1a186b2f68c6144320c369ca155a40c6ed81023b14ee1d3e0bfe0
-size 1800167
+oid sha256:7f8f56e7917f368b72c4286b13d9c671e0008cdf4b26e13661033f6ad458b8bc
+size 3264421


### PR DESCRIPTION
## What does this PR do?

This updates the O3DE editor splash screen for the 25.05 release with this image:

![splashscreen_background](https://github.com/user-attachments/assets/08cec2cc-6568-4ee1-9959-24cefb0bae66)