### PR TITLE
Fixed a shading precision issue that causes NaNs on Quest 3 hardware

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Microfacet/Brdf.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Microfacet/Brdf.azsli
@@ -101,7 +101,10 @@ real3 SpecularGGX( real3 dirToCamera, real3 dirToLight, real3 normal, real3 spec
     G = max(0.0, G);
 
     // Multiply with multiscattering compensation in order to take account for several specular light bounces.
-    return multiScatterCompensation * (D * G * F * NdotL);
+    // Note: the specific order and placement of real() here is deliberate and prevents half precision issues on mobile/Quest
+    real3 specularLighting = (real((D * G) * NdotL) * F) * multiScatterCompensation;
+
+    return specularLighting;
 }
 
 real3 AnisotropicGGX( real3 dirToCamera, real3 dirToLight, real3 normal, real3 tangent, real3 bitangent, real2 anisotropyFactors,


### PR DESCRIPTION
## What does this PR do?

Fixed a shading precision issue that causes NaNs on Quest 3 hardware

## How was this PR tested?

Tested on Quest 3, NaNs no longer occur