### PR TITLE
Update MultiDeviceObject.h (AZ_Error->AZ_Warning)

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -53,7 +53,7 @@ namespace AZ::RHI
         template<typename T>
         static AZ_FORCE_INLINE void IterateDevices(MultiDevice::DeviceMask deviceMask, T callback)
         {
-            AZ_Error(
+            AZ_Warning(
                 "RPI::MultiDeviceObject::IterateDevices",
                 AZStd::to_underlying(deviceMask) != 0u,
                 "Device mask is not initialized with a valid value.");


### PR DESCRIPTION
When launching GameLauncher, an AZ_Error may be triggered, resulting in an interrupting pop-up message  for the user. Changing this to AZ_Warning will still notify the user (logged for reference) but will no longer disrupt the normal flow when starting the GameLauncher.