### PR TITLE
Improved AssetEditor recent files and last used folders

### DIFF
--- a/Code/Editor/AssetEditor/AssetEditorWindow.cpp
+++ b/Code/Editor/AssetEditor/AssetEditorWindow.cpp
@@ -101,9 +101,22 @@ void AssetEditorWindow::SaveAssetAs(const AZStd::string_view assetPath)
         return;
     }
 
-    auto absoluteAssetPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / assetPath;
+    AZ::IO::FixedMaxPath projectSourcePath = AZ::Utils::GetProjectPath();
+    projectSourcePath /= "Assets";
+    projectSourcePath /= assetPath;
 
-    if (!m_ui->m_assetEditorWidget->SaveAssetToPath(absoluteAssetPath.Native()))
+    QDir dir(projectSourcePath.c_str());
+    if (!dir.exists())
+    {
+        auto result = AZ::IO::SystemFile::CreateDir(projectSourcePath.c_str());
+        if (!result)
+        {
+            AZ_Error("Script Canvas", false, "Failed to make new folder: %s", projectSourcePath.c_str());
+            return;
+        }
+    }
+
+    if (!m_ui->m_assetEditorWidget->SaveAssetToPath(projectSourcePath.Native()))
     {
         AZ_Warning("Asset Editor", false, "File was not saved correctly via SaveAssetAs.");
     }
@@ -127,7 +140,6 @@ void AssetEditorWindow::OnAssetOpened(const AZ::Data::Asset<AZ::Data::AssetData>
         AZStd::string extension;
         AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetPath, &AZ::Data::AssetCatalogRequests::GetAssetPathById, asset.GetId());
         AzFramework::StringFunc::Path::Split(assetPath.c_str(), nullptr, nullptr, &assetName, &extension);
-//        AZStd::string windowTitle = AZStd::string::format("Edit Asset: %s", (assetName + extension).c_str());
 
         AZStd::string windowTitle = asset.GetHint();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -33,29 +33,31 @@
 
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Asset/GenericAssetHandler.h>
+#include <AzFramework/DocumentPropertyEditor/ReflectionAdapter.h>
 #include <AzFramework/StringFunc/StringFunc.h>
+
+#include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
 #include <SourceControl/SourceControlAPI.h>
 
+#include <UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
+#include <UI/DocumentPropertyEditor/FilteredDPE.h>
 #include <UI/PropertyEditor/PropertyRowWidget.hxx>
 #include <UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 
-#include <AzFramework/DocumentPropertyEditor/ReflectionAdapter.h>
-#include <UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
-#include <UI/DocumentPropertyEditor/FilteredDPE.h>
-
 #include <AzQtComponents/Components/Widgets/FileDialog.h>
-#include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
+#include <QAction>
+#include <QDir>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QVBoxLayout>
+
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 'QFileInfo::d_ptr': class 'QSharedDataPointer<QFileInfoPrivate>' needs to have
                                                           // dll-interface to be used by clients of class 'QFileInfo'
 #include <QFileDialog>
 AZ_POP_DISABLE_WARNING
-#include <QAction>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -362,7 +362,7 @@ namespace AzToolsFramework
                         {
                             Q_EMIT OnAssetSavedSignal();
                                             
-                            m_parentEditorWidget->AddRecentPath(assetFullPath);
+                            m_parentEditorWidget->AddRecentPath(m_inMemoryAsset->GetType(), assetFullPath);
                             if (!m_useDPE)
                             {
                                 m_propertyEditor->QueueInvalidation(Refresh_AttributesAndValues);
@@ -466,19 +466,10 @@ namespace AzToolsFramework
                     {
                         AzFramework::StringFunc::Path::StripPath(fileName);
                         m_currentAsset = fileName.c_str();
-
-                        m_parentEditorWidget->SetLastSavePath(targetFilePath);
-                        AZStd::size_t findIndex = targetFilePath.find(fileName.c_str());
-
-                        if (findIndex != AZStd::string::npos)
-                        {
-                            AZStd::string savePath = m_parentEditorWidget->GetLastSavePath().toUtf8().data();
-                            m_parentEditorWidget->SetLastSavePath(savePath.substr(0, findIndex));
-                        }
                     }
 
                     m_dirty = false;
-                    m_parentEditorWidget->AddRecentPath(targetFilePath);
+                    m_parentEditorWidget->AddRecentPath(asset.GetType(), targetFilePath);
                     m_parentEditorWidget->UpdateTabTitle(this);
                     SetStatusText(Status::assetCreated);
 
@@ -533,7 +524,7 @@ namespace AzToolsFramework
             auto serializeContext = AZ::EntityUtils::GetApplicationSerializeContext();
             serializeContext->CloneObjectInplace((*m_inMemoryAsset.GetData()), asset.GetData());
 
-            // Make sure the saved state key is reset since this could be a file opened with the same property editor intance
+            // Make sure the saved state key is reset since this could be a file opened with the same property editor instance
             m_savedStateKey = AZ::Crc32(&asset.GetId(), sizeof(AZ::Data::AssetId));
 
             UpdatePropertyEditor(m_inMemoryAsset);
@@ -548,6 +539,8 @@ namespace AzToolsFramework
             SetupHeader();
             m_parentEditorWidget->SetCurrentTab(this);
             m_parentEditorWidget->UpdateSaveMenuActionsStatus();
+
+            m_parentEditorWidget->AddRecentPath(asset.GetType(), asset.GetHint());
         }
 
         void AssetEditorTab::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
@@ -645,8 +638,27 @@ namespace AzToolsFramework
                 filter.append(")");
             }
 
-            const QString saveAs = AzQtComponents::FileDialog::GetSaveFileName(
-                AzToolsFramework::GetActiveWindow(), tr("Save As..."), m_parentEditorWidget->GetLastSavePath(), filter);
+            AZ::IO::FixedMaxPath projectSourcePath = AZ::Utils::GetProjectPath();
+            projectSourcePath /= "Assets";
+
+            auto& recentPathForAssetType = m_parentEditorWidget->GetRecentPathForAssetType(m_inMemoryAsset.GetType());
+            if (!recentPathForAssetType.isEmpty())
+            {
+                projectSourcePath = recentPathForAssetType.toStdString().c_str();
+            }
+
+            QDir dir(projectSourcePath.c_str());
+            if (!dir.exists())
+            {
+                auto result = AZ::IO::SystemFile::CreateDir(projectSourcePath.c_str());
+                if (!result)
+                {
+                    AZ_Error("Script Canvas", false, "Failed to make new folder: %s", projectSourcePath.c_str());
+                    return false;
+                }
+            }
+
+            const QString saveAs = AzQtComponents::FileDialog::GetSaveFileName(AzToolsFramework::GetActiveWindow(), tr("Save As..."), projectSourcePath.c_str(), filter);
 
             return SaveImpl(m_inMemoryAsset, saveAs);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -33,7 +33,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
-#include <AzCore/UserSettings/UserSettings.h>
+
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/sort.h>
 
@@ -77,7 +77,7 @@ namespace AzToolsFramework
         {
             if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
             {
-                serialize->Class<AssetEditorWidgetUserSettings, AZ::UserSettings>()
+                serialize->Class<AssetEditorWidgetUserSettings>()
                     ->Version(1)
                     ->Field("m_recentFiles", &AssetEditorWidgetUserSettings::m_recentFiles)
                     ->Field("m_recentPathPerAssetType", &AssetEditorWidgetUserSettings::m_recentPathPerAssetType)
@@ -688,6 +688,7 @@ namespace AzToolsFramework
         {
             m_userSettings.AddRecentPath(assetType, recentPath);
             UpdateRecentFileListState();
+            SaveSettings();
         }
 
         void AssetEditorWidget::PopulateRecentMenu()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -69,7 +69,6 @@ namespace AzToolsFramework
         // AssetEditorWidgetUserSettings
         //////////////////////////////////
 
-        const AZ::Crc32 k_assetEditorWidgetSettings = AZ_CRC_CE("AssetEditorSettings");
         static constexpr const char* k_assetEditorSettingsPath = "/O3DE/Preferences/AssetEditor/Settings";
 
         void AssetEditorWidgetUserSettings::Reflect(AZ::ReflectContext* context)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -137,6 +137,21 @@ namespace AzToolsFramework
 
         }
 
+        void AssetEditorWidgetUserSettings::Clear()
+        {
+            m_recentFiles.clear();
+            m_recentPathPerAssetType.clear();
+        }
+
+        const AZStd::string AssetEditorWidgetUserSettings::GetRecentPathForAssetType(AZ::Data::AssetType assetType) const
+        {
+            if (m_recentPathPerAssetType.contains(assetType))
+            {
+                return m_recentPathPerAssetType.find(assetType)->second;
+            }
+            return {};
+        }
+
         //////////////////////////////////////////////////////////////////////////
         // AssetEditorWidget
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -39,10 +39,12 @@ AZ_POP_DISABLE_WARNING
 
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Asset/GenericAssetHandler.h>
+#include <AzFramework/DocumentPropertyEditor/ReflectionAdapter.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
 #include <AzQtComponents/Components/Widgets/FileDialog.h>
 
+#include <AzToolsFramework/Editor/EditorSettingsAPIBus.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
 #include <SourceControl/SourceControlAPI.h>
@@ -50,7 +52,6 @@ AZ_POP_DISABLE_WARNING
 #include <UI/PropertyEditor/PropertyRowWidget.hxx>
 #include <UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 
-#include <AzFramework/DocumentPropertyEditor/ReflectionAdapter.h>
 #include <UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
 #include <UI/DocumentPropertyEditor/FilteredDPE.h>
 
@@ -59,8 +60,6 @@ AZ_POP_DISABLE_WARNING
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QVBoxLayout>
-
-#include <AzToolsFramework/Editor/EditorSettingsAPIBus.h>
 
 namespace AzToolsFramework
 {
@@ -710,7 +709,7 @@ namespace AzToolsFramework
         {
             m_recentFileMenu->clear();
 
-            if (m_userSettings.m_recentFiles.empty())
+            if (m_userSettings.GetRecentFiles().empty())
             {
                 m_recentFileMenu->setEnabled(false);
             }
@@ -718,7 +717,7 @@ namespace AzToolsFramework
             {
                 m_recentFileMenu->setEnabled(true);
 
-                for (const AZStd::string& recentFile : m_userSettings.m_recentFiles)
+                for (const AZStd::string& recentFile : m_userSettings.GetRecentFiles())
                 {
                     bool hasResult = false;
                     AZStd::string relativePath;
@@ -795,7 +794,7 @@ namespace AzToolsFramework
         {
             if (m_recentFileMenu)
             {
-                if (m_userSettings.m_recentFiles.empty())
+                if (m_userSettings.GetRecentFiles().empty())
                 {
                     m_recentFileMenu->setEnabled(false);
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -65,6 +65,8 @@ namespace AzToolsFramework
             void Clear();
             const AZStd::string GetRecentPathForAssetType(AZ::Data::AssetType assetType) const;
 
+            const AZStd::vector<AZStd::string>& GetRecentFiles() const { return m_recentFiles; }
+
         private:
 
             AZStd::unordered_map<AZ::Data::AssetType, AZStd::string> m_recentPathPerAssetType;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -18,7 +18,6 @@
 
 namespace AZ
 {
-    class SerializeContext;
     namespace DocumentPropertyEditor
     {
         class ReflectionAdapter;
@@ -60,10 +59,31 @@ namespace AzToolsFramework
             AssetEditorWidgetUserSettings();
             ~AssetEditorWidgetUserSettings() override = default;
 
-            void AddRecentPath(const AZStd::string& recentPath);
+            void AddRecentPath(AZ::Data::AssetType, const AZStd::string& recentPath);
+
+            void Clear()
+            {
+                m_lastSavePath.clear();
+                m_recentFiles.clear();
+                m_recentPathPerAssetType.clear();
+            }
+
+            void Save();
+             
+            const AZStd::string GetRecentPathForAssetType(AZ::Data::AssetType assetType) const
+            {
+                if (m_recentPathPerAssetType.contains(assetType))
+                {
+                    return m_recentPathPerAssetType.find(assetType)->second;
+                }
+                return {};
+            }
+
+            AZStd::unordered_map<AZ::Data::AssetType, AZStd::string> m_recentPathPerAssetType;
 
             AZStd::string m_lastSavePath;
-            AZStd::vector<AZStd::string> m_recentPaths;
+            AZStd::vector<AZStd::string> m_recentFiles;
+
         };
 
         /**
@@ -92,9 +112,10 @@ namespace AzToolsFramework
             void SetCurrentTab(AssetEditorTab* tab);
 
             void UpdateTabTitle(AssetEditorTab* tab);
-            void SetLastSavePath(const AZStd::string& savePath);
-            const QString GetLastSavePath() const;
-            void AddRecentPath(const AZStd::string& recentPath);
+
+            const QString GetRecentPathForAssetType(AZ::Data::AssetType) const;
+
+            void AddRecentPath(AZ::Data::AssetType, const AZStd::string& recentPath);
 
             void CloseTab(AssetEditorTab* tab);
             void CloseTabAndContainerIfEmpty(AssetEditorTab* tab);
@@ -164,13 +185,15 @@ namespace AzToolsFramework
 
             unsigned int m_nextNewAssetIndex = 1;
 
-            AZStd::intrusive_ptr<AssetEditorWidgetUserSettings> m_userSettings;
+            AssetEditorWidgetUserSettings m_userSettings;
+
             AZStd::unique_ptr<Ui::AssetEditorStatusBar> m_statusBar;
 
             AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeEvent::Handler m_propertyChangeHandler;
             AZ::Crc32 m_savedStateKey;
 
             void PopulateGenericAssetTypes();
+            void SaveSettings();
         };
     } // namespace AssetEditor
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -48,9 +48,11 @@ namespace AzToolsFramework
     {
         class AssetEditorTab;
 
+        //! Stores the recent used folder and file settings used by the Asset Editor
         class AssetEditorWidgetUserSettings final
         {
         public:
+
             AZ_RTTI(AssetEditorWidgetUserSettings, "{382FE424-4541-4D93-9BA4-DE17A6DF8676}");
             AZ_CLASS_ALLOCATOR(AssetEditorWidgetUserSettings, AZ::SystemAllocator);
 
@@ -60,30 +62,17 @@ namespace AzToolsFramework
             ~AssetEditorWidgetUserSettings() = default;
 
             void AddRecentPath(AZ::Data::AssetType, const AZStd::string& recentPath);
+            void Clear();
+            const AZStd::string GetRecentPathForAssetType(AZ::Data::AssetType assetType) const;
 
-            void Clear()
-            {
-                m_recentFiles.clear();
-                m_recentPathPerAssetType.clear();
-            }
-
-            const AZStd::string GetRecentPathForAssetType(AZ::Data::AssetType assetType) const
-            {
-                if (m_recentPathPerAssetType.contains(assetType))
-                {
-                    return m_recentPathPerAssetType.find(assetType)->second;
-                }
-                return {};
-            }
+        private:
 
             AZStd::unordered_map<AZ::Data::AssetType, AZStd::string> m_recentPathPerAssetType;
             AZStd::vector<AZStd::string> m_recentFiles;
 
         };
 
-        /**
-         * Provides ability to create, edit, and save reflected assets.
-         */
+         //! Provides ability to create, edit, and save reflected assets.
         class AssetEditorWidget
             : public QWidget
         {
@@ -119,6 +108,7 @@ namespace AzToolsFramework
             void CreateAsset(AZ::Data::AssetType assetType);
 
         public Q_SLOTS:
+
             void OpenAssetWithDialog();
             void OpenAssetFromPath(const AZStd::string& fullPath);
             void OnAssetSaveFailed(const AZStd::string& error);
@@ -133,10 +123,12 @@ namespace AzToolsFramework
             void onTabCloseButtonPressed(int tabIndexToClose);
 
         Q_SIGNALS:
+
             void OnAssetSaveFailedSignal(const AZStd::string& error);
             void OnAssetOpenedSignal(const AZ::Data::Asset<AZ::Data::AssetData>& asset);
 
-        protected: // IPropertyEditorNotify
+        protected:
+
             void UpdateRecentFileListState();
 
         private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -48,16 +48,16 @@ namespace AzToolsFramework
     {
         class AssetEditorTab;
 
-        class AssetEditorWidgetUserSettings : public AZ::UserSettings
+        class AssetEditorWidgetUserSettings final
         {
         public:
-            AZ_RTTI(AssetEditorWidgetUserSettings, "{382FE424-4541-4D93-9BA4-DE17A6DF8676}", AZ::UserSettings);
+            AZ_RTTI(AssetEditorWidgetUserSettings, "{382FE424-4541-4D93-9BA4-DE17A6DF8676}");
             AZ_CLASS_ALLOCATOR(AssetEditorWidgetUserSettings, AZ::SystemAllocator);
 
             static void Reflect(AZ::ReflectContext* context);
 
             AssetEditorWidgetUserSettings();
-            ~AssetEditorWidgetUserSettings() override = default;
+            ~AssetEditorWidgetUserSettings() = default;
 
             void AddRecentPath(AZ::Data::AssetType, const AZStd::string& recentPath);
 
@@ -68,8 +68,6 @@ namespace AzToolsFramework
                 m_recentPathPerAssetType.clear();
             }
 
-            void Save();
-             
             const AZStd::string GetRecentPathForAssetType(AZ::Data::AssetType assetType) const
             {
                 if (m_recentPathPerAssetType.contains(assetType))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.h
@@ -63,7 +63,6 @@ namespace AzToolsFramework
 
             void Clear()
             {
-                m_lastSavePath.clear();
                 m_recentFiles.clear();
                 m_recentPathPerAssetType.clear();
             }
@@ -78,8 +77,6 @@ namespace AzToolsFramework
             }
 
             AZStd::unordered_map<AZ::Data::AssetType, AZStd::string> m_recentPathPerAssetType;
-
-            AZStd::string m_lastSavePath;
             AZStd::vector<AZStd::string> m_recentFiles;
 
         };


### PR DESCRIPTION
## What does this PR do?

* Moved the Asset Editor settings to use the Settings Registry rather than AZ::UserSettings
* Ensure that the AssetEditor defaults to a folder in the project path
* Fixed the logic to store the last used path per asset type