### PR TITLE
CharacterController_FixUpDirection

### DIFF
--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -500,10 +500,11 @@ namespace PhysX
         return PxMathConvert(m_pxController->getUpDirection());
     }
 
-    void CharacterController::SetUpDirection([[maybe_unused]] const AZ::Vector3& upDirection)
+    void CharacterController::SetUpDirection(const AZ::Vector3& upDirection)
     {   
         if (!m_pxController)
         {
+            AZ_Error("PhysX Character Controller", false, "Invalid character controller.");
             return;
         }
 

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -501,9 +501,14 @@ namespace PhysX
     }
 
     void CharacterController::SetUpDirection([[maybe_unused]] const AZ::Vector3& upDirection)
-    {
-        AZ_Warning("PhysX Character Controller", false, "Setting up direction is not currently supported.");
-        return;
+    {   
+        if (!m_pxController)
+        {
+            return;
+        }
+
+        PHYSX_SCENE_READ_LOCK(m_pxController->getScene());
+        m_pxController->setUpDirection(PxMathConvert(upDirection));
     }
 
     float CharacterController::GetSlopeLimitDegrees() const

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -176,7 +176,7 @@ namespace PhysX
         return AZ::Vector3::CreateZero();
     }
 
-    void CharacterControllerComponent::SetUpDirection([[maybe_unused]] const AZ::Vector3& upDirection)
+    void CharacterControllerComponent::SetUpDirection(const AZ::Vector3& upDirection)
     {
         if (auto* controller = GetController())
         {

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -178,7 +178,10 @@ namespace PhysX
 
     void CharacterControllerComponent::SetUpDirection([[maybe_unused]] const AZ::Vector3& upDirection)
     {
-        AZ_Warning("PhysX Character Controller Component", false, "Setting up direction is not currently supported.");
+        if (auto* controller = GetController())
+        {
+            controller->SetUpDirection(upDirection);
+        }
     }
 
     float CharacterControllerComponent::GetSlopeLimitDegrees() const


### PR DESCRIPTION
## What does this PR do?

In CharacterController.cpp and in CharacterControllerComponent.cpp was not implemented SetUpDirection. 

https://github.com/o3de/o3de/issues/14081

## How was this PR tested?

We use this in our Game Reverb many times and all looks good,
