### PR TITLE
Fix compilation errors when disabling USE_BINDLESS_SRG macro in RayTracingFeatureProcessor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -25,6 +25,7 @@
 #include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/Transform.h>
+#include <RayTracing/RayTracingResourceList.h>
 
 // this define specifies that the mesh buffers and material textures are stored in the Bindless Srg
 // Note1: The previous implementation using separate unbounded arrays is preserved since it demonstrates a TDR caused by

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/RingBuffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/RingBuffer.h
@@ -69,8 +69,8 @@ namespace AZ::RPI
 
         //! Increments the current buffer index, potentially resized the current buffer and updates the data of the current data. This is a
         //! convenience function which calls AdvanceCurrentBuffer(), CreateOrResizeCurrentBuffer(...) and UpdateCurrentBufferData(...)
-        template<typename T>
-        void AdvanceCurrentBufferAndUpdateData(AZStd::unordered_map<int, AZStd::span<const T>> data)
+        template<typename T, typename = AZStd::enable_if_t<AZStd::is_convertible_v<T, AZStd::span<const typename T::value_type>>>>
+        void AdvanceCurrentBufferAndUpdateData(const AZStd::unordered_map<int, T>& data)
         {
             AZStd::unordered_map<int, const void*> rawData;
 
@@ -80,13 +80,6 @@ namespace AZ::RPI
             }
 
             AdvanceCurrentBufferAndUpdateData(rawData, data.begin()->second.size() * sizeof(T));
-        }
-
-        //! Convenience function which allows automatic conversion from vector/array to span
-        template<typename T>
-        void AdvanceCurrentBufferAndUpdateData(const AZStd::unordered_map<int, T>& data)
-        {
-            AdvanceCurrentBufferAndUpdateData<typename T::value_type>(data);
         }
 
         //! Creates or resizes the current buffer to fit the given number of bytes.
@@ -121,7 +114,7 @@ namespace AZ::RPI
 
         //! Updates the data of the current buffer.
         template<typename T>
-        void UpdateCurrentBufferData(AZStd::unordered_map<int, AZStd::span<const T>> data, u64 bufferElementOffset = 0)
+        void UpdateCurrentBufferData(const AZStd::unordered_map<int, AZStd::span<const T>>& data, u64 bufferElementOffset = 0)
         {
             AZStd::unordered_map<int, const void*> rawData;
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes compilation errors when changing the `USE_BINDLESS_SRG` define in RayTracingFeatureProcessor.h to `0`. This seems to be an oversight from the introduction of the Multi-GPU classes, but was likely not noticed since the compilation of these code pieces is deactivated by the bindless-srg-macro.
The change in the RingBuffer class is necessary since an `unordered_map<int, ...>` with contiguous memory collection as value type (eg. `unordered_map<int, vector>`, `..., array>`, `..., string>`) is not automatically converted to an `unordered_map<int, span>`.

## How was this PR tested?

Create a small test scene with some objects with different materials and textures, add a ground plane with mirror-like material, add a "Specular Reflections" level component and set the reflection method to Ray Tracing. With this change, all meshes show up in the ray-traced reflection correctly, same as when setting `USE_BINDLESS_SRG` to `1`.
