### PR TITLE
Added a shortcut for Simulate mode.

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -962,6 +962,8 @@ void EditorActionsHandler::OnActionRegistrationHook()
 
         // This action is only accessible outside of Component Modes
         m_actionManagerInterface->AssignModeToAction(AzToolsFramework::DefaultActionContextModeIdentifier, actionIdentifier);
+
+        m_hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "Ctrl+Alt+G");
     }
 
     // Move Player and Camera Separately


### PR DESCRIPTION
## What does this PR do?

UX improvement with a shortcut for Simulate mode.

Issue: https://github.com/o3de/o3de/issues/18957

## How was this PR tested?

Using the shortcut to enter the Simulate mode and tested keyboard keys and combination of keys to be sure that Simulate only stops with the correct command.
