### PR TITLE
Fix LightingChannelFlags in LightingChannelConfiguration

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/LightingChannel/LightingChannelConfiguration.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/LightingChannel/LightingChannelConfiguration.h
@@ -30,7 +30,7 @@ namespace AZ
 
             uint32_t GetLightingChannelMask() const;
 
-            AZStd::array<bool, LightingChannelsCount> m_lightingChannelFlags{ true, false, false, false, false };
+            AZStd::array<bool, LightingChannelsCount> m_lightingChannelFlags{ true, true, true, true, true };
 
         private:
             AZStd::string GetLabelForIndex(int index) const;

--- a/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/Feature/LightingChannel/LightingChannelConfiguration.h>
+#include <Atom/RHI.Reflect/Bits.h>
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -45,8 +46,8 @@ namespace AZ
         void LightingChannelConfiguration::SetLightingChannelMask(const uint32_t mask)
         {
             for (uint32_t index = 0; index < m_lightingChannelFlags.size(); ++index)
-            {
-                m_lightingChannelFlags[index] = (mask & (0x01 << index)) > 0;
+            {                
+                m_lightingChannelFlags[index] = RHI::CheckBit(mask, index);
             }
         }
 
@@ -57,7 +58,7 @@ namespace AZ
             {
                 if (m_lightingChannelFlags[index])
                 {
-                    mask |= static_cast<uint32_t>(0x01 << index);
+                    mask = RHI::SetBit(mask, index);                    
                 }
             }
             return mask;

--- a/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
@@ -46,16 +46,19 @@ namespace AZ
         {
             for (uint32_t index = 0; index < m_lightingChannelFlags.size(); ++index)
             {
-                m_lightingChannelFlags[index] = (static_cast<bool>(mask >> index) & 0x01);
+                m_lightingChannelFlags[index] = (mask & (0x01 << index)) > 0;
             }
         }
 
         uint32_t LightingChannelConfiguration::GetLightingChannelMask() const
         {
-            uint32_t mask = 0;
+            uint32_t mask(0);
             for (uint32_t index = 0; index < m_lightingChannelFlags.size(); ++index)
             {
-                mask |= (static_cast<uint32_t>(m_lightingChannelFlags[index]) << (index));
+                if (m_lightingChannelFlags[index])
+                {
+                    mask |= static_cast<uint32_t>(0x01 << index);
+                }
             }
             return mask;
         }


### PR DESCRIPTION
## What does this PR do?

1. Before SetLightingChannelMask and GetLightingChannelMask worked incorrect. Problem was in bit operations.
2. Changed default light flags set. In preview version was set only one (first) light layer. I think default set must have all accessible light layer. Because if you create game, you have many assets, and in practice most of them use all layers and only a small amount using custom light layer sets.

https://github.com/o3de/o3de/issues/18949

## How was this PR tested?

Check in game and all looks good. 
