### PR TITLE
Fix a CMake warning in add_custom_command

### DIFF
--- a/cmake/LYWrappers.cmake
+++ b/cmake/LYWrappers.cmake
@@ -383,8 +383,6 @@ function(ly_add_target)
             add_custom_command(TARGET ${ly_add_target_NAME} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/runtime_dependencies/$<CONFIG>/${ly_add_target_NAME}.cmake
                 COMMENT "Copying ${ly_add_target_NAME} runtime dependencies to output..."
-                DEPENDS ${CMAKE_BINARY_DIR}/runtime_dependencies/${ly_add_target_NAME}.cmake
-                COMMENT "Copying runtime dependencies..."
                 VERBATIM
             )
 


### PR DESCRIPTION
## What does this PR do?

Remove the dependency from an `TARGET`  `add_custom_command`. `add_custom_command` can either be a `TARGET` command or it can have dependencies, but not both. According to the comment above the if explains why this should be a `POST_BUILD` command so I removed the dependency.

I'm getting many warnings like the following when using CMake >= 3.31:
```
CMake Warning (dev) at cmake/LYWrappers.cmake:383 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(TARGET): DEPENDS.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
Call Stack (most recent call first):
  Gems/PythonAssetBuilder/Code/CMakeLists.txt:77 (ly_add_target)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

See https://cmake.org/cmake/help/latest/policy/CMP0175.html for more information.

## How was this PR tested?

Tested on Windows
