### PR TITLE
Allow for disabling part of ar.yml in workflow_dispatch

### DIFF
--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -17,6 +17,21 @@ on:
             description: Use no artifacts for next build (will be saved as clean artifacts)
             required: false
             default: false
+        windows_build:
+            description: 'Build Windows'
+            required: false
+            default: true
+            type: boolean
+        linux_build:
+            description: 'Build Linux'
+            required: false
+            default: true
+            type: boolean
+        android_build:
+            description: 'Build Android'
+            required: false
+            default: true
+            type: boolean
   push:
     branches:
       - main
@@ -38,6 +53,7 @@ jobs:
 
 #### Windows Build ####
     Windows-Profile:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
         uses: ./.github/workflows/windows-build.yml
         with:
             compiler: msvc
@@ -48,6 +64,7 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }} # If CLEAN_ARTIFACTS is false, then this returns true
     
     Windows-Asset:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
         needs: Windows-Profile
         uses: ./.github/workflows/windows-build.yml
         with:
@@ -58,6 +75,7 @@ jobs:
             type: asset_profile
 
     Windows-Test:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
         needs: Windows-Asset
         uses: ./.github/workflows/windows-build.yml
         with:
@@ -68,6 +86,7 @@ jobs:
             type: test_cpu_profile
 
     Windows-Release:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
         uses: ./.github/workflows/windows-build.yml
         with:
             compiler: msvc
@@ -79,6 +98,7 @@ jobs:
 
 #### Linux Build ####
     Linux-Profile:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
         uses: ./.github/workflows/linux-build.yml
         with:
             compiler: clang
@@ -89,6 +109,7 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
 
     Linux-Asset:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
         needs: Linux-Profile
         uses: ./.github/workflows/linux-build.yml
         with:
@@ -99,6 +120,7 @@ jobs:
             type: asset_profile
 
     Linux-Test:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
         needs: Linux-Asset
         uses: ./.github/workflows/linux-build.yml
         with:
@@ -111,6 +133,7 @@ jobs:
 
 #### Android Build ####
     Android-Profile:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
         uses: ./.github/workflows/android-build.yml
         with:
             compiler: clang
@@ -121,6 +144,7 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
 
     Android-Asset:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
         uses: ./.github/workflows/android-build.yml
         with:
             compiler: msvc
@@ -131,6 +155,7 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
             
     Android-Gradle:
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
         uses: ./.github/workflows/android-build.yml
         with:
             compiler: clang


### PR DESCRIPTION
## What does this PR do?

Testing code that we want to merge into __O3DE__ is very important.
Ideally before opening a PR, feature / fix should be complete and correct.  
This PR allows contributors to forks of this repository to trigger __AR__ tests which they didn't perform manually.

This change does not impact o3de directly, it allows contributors to run __AR__ on subset of platforms which is beneficial when testing before PR / during development.

## How was this PR tested?

I triggered 3 jobs on fork RobotecAI/o3de to test that workflow dispatch flags work as expected
| name | command | job |
| -- | -- | -- |
| linux only | gh workflow run ar.yml --repo robotecai/o3de --ref mw/custom_ga -f windows_build=false -f android_build=false | [link](https://github.com/RobotecAI/o3de/actions/runs/15295871960) | 
| android only | gh workflow run ar.yml --repo robotecai/o3de --ref mw/custom_ga -f windows_build=false -f linux_build=false | [link](https://github.com/RobotecAI/o3de/actions/runs/15295880220) |
| windows only | gh workflow run ar.yml --repo robotecai/o3de --ref mw/custom_ga -f android_build=false -f linux_build=false | [link](https://github.com/RobotecAI/o3de/actions/runs/15295887921) | 
