### PR TITLE
Improved the Mesh FP GetDrawSrg API.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -322,8 +322,8 @@ namespace AZ
             //! Returns the DrawSrg from the first DrawItem that matches @drawListTag
             //! and its material pipeline matches @materialPipelineMask.
             //! The search is done only within the DrawItems of the subMesh identifiable by the tuple (@meshHandle, @lodIndex, @subMeshIndex). 
-            virtual Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(const MeshHandle& meshHandle, uint32_t lodIndex, uint32_t subMeshIndex,
-                RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) = 0;
+            virtual const Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(const MeshHandle& meshHandle, uint32_t lodIndex, uint32_t subMeshIndex,
+                RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) const = 0;
 
         };
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1683,9 +1683,9 @@ namespace AZ
             }
         }
 
-        Data::Instance<RPI::ShaderResourceGroup>& MeshFeatureProcessor::GetDrawSrg(const MeshHandle& meshHandle,
+        const Data::Instance<RPI::ShaderResourceGroup>& MeshFeatureProcessor::GetDrawSrg(const MeshHandle& meshHandle,
             uint32_t lodIndex, uint32_t subMeshIndex,
-            RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask)
+            RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) const
         {
             if (!meshHandle.IsValid())
             {

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
@@ -290,8 +290,8 @@ namespace AZ
             MeshInstanceManager& GetMeshInstanceManager();
             bool IsMeshInstancingEnabled() const;
 
-            Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(const MeshHandle& meshHandle, uint32_t lodIndex, uint32_t subMeshIndex,
-                RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) override;
+            const Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(const MeshHandle& meshHandle, uint32_t lodIndex, uint32_t subMeshIndex,
+                RHI::DrawListTag drawListTag, RHI::DrawFilterMask materialPipelineMask) const override;
 
         private:
             MeshFeatureProcessor(const MeshFeatureProcessor&) = delete;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -88,7 +88,7 @@ namespace AZ
             void DebugOutputShaderVariants();
 
             //! Returns the DrawSrg from the DrawItem that corresponds to @drawItemIndex.
-            Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(uint32_t drawItemIndex);
+            const Data::Instance<RPI::ShaderResourceGroup>& GetDrawSrg(uint32_t drawItemIndex) const;
 
         private:
             bool DoUpdate(const Scene& parentScene);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -247,7 +247,7 @@ namespace AZ
 #endif
         }
 
-        Data::Instance<RPI::ShaderResourceGroup>& MeshDrawPacket::GetDrawSrg(uint32_t drawItemIndex)
+        const Data::Instance<RPI::ShaderResourceGroup>& MeshDrawPacket::GetDrawSrg(uint32_t drawItemIndex) const
         {
             if (drawItemIndex >= aznumeric_cast<uint32_t>(m_perDrawSrgs.size()))
             {


### PR DESCRIPTION
## What does this PR do?

GetDrawSrg() now returns a const reference and the function itself is const.

This update prevents the possibility of modifying
the content of the MeshDrawPacket::m_perDrawSrgs array.

The inspiration for this update occurred because
inadvertently I was getting crashes when using the non-const references in a way that was modifying the array of DrawSrgs.

## How was this PR tested?

Tested on Win11 and Android (Quest3).