### PR TITLE
Cherry-pick remaining stabilization 2505.0 fixes to dev.

### DIFF
--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d543f9bfef1a186b2f68c6144320c369ca155a40c6ed81023b14ee1d3e0bfe0
-size 1800167
+oid sha256:7f8f56e7917f368b72c4286b13d9c671e0008cdf4b26e13661033f6ad458b8bc
+size 3264421

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_mac.mm
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_mac.mm
@@ -13,6 +13,7 @@
 #include <QPixmap>
 #include <QtMac>
 
+#include <AzCore/Debug/Trace.h>
 #include <AzQtComponents/Components/Widgets/Eyedropper.h>
 #include <AzQtComponents/Utilities/ScreenGrabber.h>
 
@@ -57,20 +58,20 @@ namespace AzQtComponents
         QRect region({}, m_size);
         region.moveCenter(point);
         CGRect bounds = CGRectMake(region.x(), region.y(), region.width(), region.height());
-
+#if defined(__MAC_14_0)
         //TODO - Add proper support for macOS 14.0+.
         //Try looking into SCScreenshotManager (https://developer.apple.com/documentation/screencapturekit/scscreenshotmanager?language=objc)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        AZ_Error("ScreenGrabber", false, "ScreenGrabber::grab not implmented for Mac OS 14.0+");
+        Q_UNUSED(bounds);
+        return QImage();
+#else
         CGImageRef cgImage = CGWindowListCreateImageFromArray(bounds, windows, kCGWindowImageNominalResolution);
-#pragma clang diagnostic pop
-
         CFRelease(windows);
-
+        
         QImage result = QtMac::fromCGImageRef(cgImage).toImage();
         CGImageRelease(cgImage);
-
         return result;
+#endif
     }
 
 } // namespace AzQtComponents

--- a/Code/Legacy/CryCommon/Maestro/Bus/SequenceComponentBus.h
+++ b/Code/Legacy/CryCommon/Maestro/Bus/SequenceComponentBus.h
@@ -188,7 +188,7 @@ namespace Maestro
             AZStd::string GetStringValue() const override
             {
                 char buffer[33] = { 0 };
-                azsprintf(buffer, "%f", m_value);
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%f", m_value);
                 return AZStd::string(buffer);
             }
 
@@ -317,7 +317,7 @@ namespace Maestro
             AZStd::string GetStringValue() const override
             {
                 char buffer[97] = { 0 };
-                azsprintf(buffer, "%f,%f,%f", m_value.GetX(), m_value.GetY(), m_value.GetZ());
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%f,%f,%f", m_value.GetX(), m_value.GetY(), m_value.GetZ());
                 return AZStd::string(buffer);
             }
 
@@ -450,7 +450,7 @@ namespace Maestro
             AZStd::string GetStringValue() const override
             {
                 char buffer[129] = { 0 };
-                azsprintf(buffer, "%f,%f,%f,%f", m_value.GetX(), m_value.GetY(), m_value.GetZ(), m_value.GetW());
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%f,%f,%f,%f", m_value.GetX(), m_value.GetY(), m_value.GetZ(), m_value.GetW());
                 return AZStd::string(buffer);
             }
 
@@ -583,7 +583,7 @@ namespace Maestro
             AZStd::string GetStringValue() const override
             {
                 char buffer[2] = { 0 };
-                azsprintf(buffer, "%d", m_value ? 1 : 0); // 1 or 0 representation
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%d", m_value ? 1 : 0); // 1 or 0 representation
                 return AZStd::string(buffer);
             }
 
@@ -881,42 +881,42 @@ namespace Maestro
             bool SetValue(const AZ::Vector3& vector3Value) override
             {
                 char buffer[97] = { 0 };
-                azsprintf(buffer, "%f,%f,%f", vector3Value.GetX(), vector3Value.GetY(), vector3Value.GetZ());
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%f,%f,%f", vector3Value.GetX(), vector3Value.GetY(), vector3Value.GetZ());
                 m_value = buffer;
                 return false;
             }
             bool SetValue(const AZ::Quaternion& quaternionValue) override
             {
                 char buffer[129] = { 0 };
-                azsprintf(buffer, "%f,%f,%f,%f", quaternionValue.GetX(), quaternionValue.GetY(), quaternionValue.GetZ(), quaternionValue.GetW());
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%f,%f,%f,%f", quaternionValue.GetX(), quaternionValue.GetY(), quaternionValue.GetZ(), quaternionValue.GetW());
                 m_value = buffer;
                 return false;
             }
             bool SetValue(float floatValue) override
             {
                 char buffer[33] = { 0 };
-                azsprintf(buffer, "%f", floatValue);
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%f", floatValue);
                 m_value = buffer;
                 return false;
             }
             bool SetValue(bool boolValue) override
             {
                 char buffer[2] = { 0 };
-                azsprintf(buffer, "%d", boolValue ? 1 : 0);
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%d", boolValue ? 1 : 0);
                 m_value = buffer;
                 return false;
             }
             bool SetValue(AZ::s32 s32Value) override
             {
                 char buffer[33] = { 0 };
-                azsprintf(buffer, "%d", s32Value);
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%d", s32Value);
                 m_value = buffer;
                 return false;
             }
             bool SetValue(AZ::u32 u32Value) override
             {
                 char buffer[33] = { 0 };
-                azsprintf(buffer, "%u", u32Value);
+                azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "%u", u32Value);
                 m_value = buffer;
                 return false;
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -100,7 +100,14 @@ namespace AZ
                 {
                     //In case byte code was not generated try to create the lib with source code
                     MTLCompileOptions* compileOptions = [MTLCompileOptions alloc];
+#if defined(__IPHONE_18_0) || defined(__MAC_15_0)
+                    if(@available(iOS 18.0, macOS 15.0, *))
+                    {
+                        compileOptions.mathMode = MTLMathModeFast;
+                    }
+#else
                     compileOptions.fastMathEnabled = YES;
+#endif
                     compileOptions.languageVersion = MTLLanguageVersion2_2;
                     lib = [mtlDevice newLibraryWithSource:source
                                                   options:compileOptions

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
@@ -13,6 +13,7 @@
 #include <Atom/RHI/PhysicalDevice.h>
 #include <Atom/RHI/DeviceQueryPool.h>
 #include <Atom/RHI/DeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/DeviceRayTracingCompactionQueryPool.h>
 #include <Atom/RHI/DeviceRayTracingPipelineState.h>
 #include <Atom/RHI/DeviceRayTracingShaderTable.h>
 #include <Atom/RHI/DeviceDispatchRaysIndirectBuffer.h>
@@ -250,13 +251,13 @@ namespace AZ
             return nullptr;
         }
 
-        RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> CreateRayTracingCompactionQueryPool()
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQueryPool> SystemComponent::CreateRayTracingCompactionQueryPool()
         {
             AZ_Assert(false, "Not implemented");
             return nullptr;
         }
 
-        RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> CreateRayTracingCompactionQuery()
+        RHI::Ptr<RHI::DeviceRayTracingCompactionQuery> SystemComponent::CreateRayTracingCompactionQuery()
         {
             AZ_Assert(false, "Not implemented");
             return nullptr;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -8,9 +8,10 @@
 
 #include <Mesh/EditorMeshComponent.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
-#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorVisibilityBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConstants.h>
 
 namespace AZ
@@ -133,6 +134,11 @@ namespace AZ
 
         void EditorMeshComponent::Activate()
         {
+            using EditorVisibilityRequestBus = AzToolsFramework::EditorVisibilityRequestBus;
+            bool isVisible = true;
+            EditorVisibilityRequestBus::EventResult(isVisible, GetEntityId(), &EditorVisibilityRequestBus::Events::GetVisibilityFlag);
+            m_controller.SetVisibility(isVisible);
+
             m_controller.m_configuration.m_editorRayIntersection = true;
             BaseClass::Activate();
             AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());

--- a/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack_Vec2Specialization.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimSplineTrack_Vec2Specialization.cpp
@@ -569,7 +569,7 @@ namespace Maestro
         }
 
         Spline::key_type& k = m_spline->key(keyIndex);
-        azsprintf(str, "%.2f", k.value.y);
+        azsnprintf(str, AZ_ARRAY_SIZE(str), "%.2f", k.value.y);
     }
 
 } // namespace Maestro

--- a/Gems/Maestro/Code/Source/Cinematics/CaptureTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CaptureTrack.cpp
@@ -64,11 +64,11 @@ namespace Maestro
         description = buffer;
         if (!m_keys[keyIndex].folder.empty())
         {
-            azsprintf(buffer, "[%s], %.3f, %s", prefix, m_keys[keyIndex].timeStep, m_keys[keyIndex].folder.c_str());
+            azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "[%s], %.3f, %s", prefix, m_keys[keyIndex].timeStep, m_keys[keyIndex].folder.c_str());
         }
         else
         {
-            azsprintf(buffer, "[%s], %.3f", prefix, m_keys[keyIndex].timeStep);
+            azsnprintf(buffer, AZ_ARRAY_SIZE(buffer), "[%s], %.3f", prefix, m_keys[keyIndex].timeStep);
         }
     }
 

--- a/Gems/Maestro/Code/Source/Cinematics/GotoTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/GotoTrack.cpp
@@ -125,7 +125,7 @@ namespace Maestro
         static char str[64];
         description = str;
         const float& k = m_keys[keyIndex].m_fValue;
-        azsprintf(str, "%.2f", k);
+        azsnprintf(str, AZ_ARRAY_SIZE(str), "%.2f", k);
     }
 
     void CGotoTrack::SetKeyAtTime(float time, IKey* key)

--- a/cmake/Platform/iOS/RuntimeDependencies_ios.cmake
+++ b/cmake/Platform/iOS/RuntimeDependencies_ios.cmake
@@ -103,9 +103,10 @@ function(ly_delayed_generate_runtime_dependencies)
         endif()
     endforeach()
 
-
-    add_dependencies("AzTestRunner" ${test_runner_dependencies})
-    
+    if(test_runner_dependencies)
+        add_dependencies("AzTestRunner" ${test_runner_dependencies})
+    endif()
+ 
     # We still need to add indirect dependencies(eg. 3rdParty)
     unset(dependencies)
     o3de_get_filtered_dependencies_for_target(dependencies AzTestRunner)


### PR DESCRIPTION
## What does this PR do?

Grabs the last 3 changes that are NOT the version number change, to cherry pick from stabilization to dev.
These changes were never applied to dev, and were originated in stabilization.

* https://github.com/o3de/o3de/pull/18926
* https://github.com/o3de/o3de/pull/18939
* https://github.com/o3de/o3de/pull/18938

## How was this PR tested?

Local smoke test by editor gui work, as well as the local ci_build test.
