### PR TITLE
Add missing type to the File Pattern field tooltip

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -962,6 +962,8 @@ void EditorActionsHandler::OnActionRegistrationHook()
 
         // This action is only accessible outside of Component Modes
         m_actionManagerInterface->AssignModeToAction(AzToolsFramework::DefaultActionContextModeIdentifier, actionIdentifier);
+
+        m_hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "Ctrl+Alt+G");
     }
 
     // Move Player and Camera Separately

--- a/Code/Framework/AzFramework/AzFramework/Asset/FileTagAsset.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/FileTagAsset.cpp
@@ -37,7 +37,7 @@ namespace AzFramework
                     editContext->Class<FileTagData>("Definition", "Files/Patterns and their associated tags.")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->DataElement(AZ::Edit::UIHandlers::ComboBox, &FileTagData::m_filePatternType,
-                            "File Pattern", "File Pattern can either be a regex or a wildcard.")
+                            "File Pattern", "File Pattern can either be an exact, a regex or a wildcard.")
                         ->Attribute(AZ::Edit::Attributes::EnumValues,
                             AZStd::vector<AZ::Edit::EnumConstant<FilePatternType>>
                     {


### PR DESCRIPTION
## What does this PR do?

This PR updates the tooltip for the File Pattern field to include the missing "exact" word value. Old behavior:

    "File Pattern can either be a regex or a wildcard"

New behavior:

    "File Pattern can either be an exact, a regex, or a wildcard."

Related issue: https://github.com/o3de/o3de/issues/4148

## How was this PR tested?

Performed content verification on the following path:

    Asset Browser > New > File Tag > hover over File Pattern field
