### PR TITLE
Fixed the File Pattern field tooltip description

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/FileTagAsset.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/FileTagAsset.cpp
@@ -37,7 +37,7 @@ namespace AzFramework
                     editContext->Class<FileTagData>("Definition", "Files/Patterns and their associated tags.")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->DataElement(AZ::Edit::UIHandlers::ComboBox, &FileTagData::m_filePatternType,
-                            "File Pattern", "File Pattern can either be a regex or a wildcard.")
+                            "File Pattern", "File Pattern can either be an exact value, a regex or a wildcard.")
                         ->Attribute(AZ::Edit::Attributes::EnumValues,
                             AZStd::vector<AZ::Edit::EnumConstant<FilePatternType>>
                     {


### PR DESCRIPTION
## What does this PR do?
This PR updates the tooltip description for the File Pattern field to include the missing "exact value" option.

**Old behavior:** `File Pattern can either be a regex or a wildcard.`

**New behavior:** `File Pattern can either be an exact value, a regex or a wildcard.`

**Issue:** https://github.com/o3de/o3de/issues/4148

## How was this PR tested?

Content Verification at Editor > Tools > Asset Editor > File > New > File Tag > + > Type your New Key > OK > Expand your Key > Hover the mouse on the File Pattern field.
