### PR TITLE
Fix compilation on latest version of MSVC

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
@@ -1023,7 +1023,7 @@ namespace AzToolsFramework
         }
 
         void PrefabSaveHandler::SourceFileRemoved(
-            AZStd::string relativePath, AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid sourceUUID)
+            AZStd::string relativePath, [[maybe_unused]] AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid sourceUUID)
         {
             // This gets triggered for every source file. We only need source files that are prefabs and are loaded in the current level.
             TemplateId loadedTemplateId = s_prefabSystemComponentInterface->GetTemplateIdFromFilePath(relativePath.c_str());

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
@@ -362,10 +362,9 @@ namespace ScriptCanvasEditor
 
         void Modifier::ReportModificationSuccess()
         {
-            using namespace AzFramework;
             // \note DO NOT put asset into the m_assetsCompletedByAP here. That can only be done when the message is received by the AP
             m_results.m_successes.push_back(m_result.asset.Describe());
-            AssetSystemRequestBus::Broadcast(&AssetSystem::AssetSystemRequests::EscalateAssetByUuid, m_result.asset.Id());
+            AzFramework::AssetSystemRequestBus::Broadcast(&AzFramework::AssetSystem::AssetSystemRequests::EscalateAssetByUuid, m_result.asset.Id());
             NextModification();
         }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -606,7 +606,7 @@ namespace ScriptCanvas
             return AZStd::const_pointer_cast<Scope>(m_graphScope)->AddVariableName(name);
         }
 
-        void AbstractCodeModel::AddUserOutToLeaf(ExecutionTreePtr parent, ExecutionTreeConstPtr root, AZStd::string_view name)
+        void AbstractCodeModel::AddUserOutToLeaf(ExecutionTreePtr parent, [[maybe_unused]] ExecutionTreeConstPtr root, AZStd::string_view name)
         {
             ExecutionTreePtr out;
 

--- a/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
+++ b/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
@@ -166,7 +166,7 @@ namespace ScriptEventsEditor
         scriptEventAsset->m_definition.IncreaseVersion();
     }
 
-    void ScriptEventAssetHandler::BeforePropertyEdit(AzToolsFramework::InstanceDataNode* node, AZ::Data::Asset<AZ::Data::AssetData> asset)
+    void ScriptEventAssetHandler::BeforePropertyEdit(AzToolsFramework::InstanceDataNode* node, [[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         ScriptEventData::VersionedProperty* property = nullptr;
         AzToolsFramework::InstanceDataNode* parent = node;


### PR DESCRIPTION
## What does this PR do?

Fix compilation on windows with latest version of msvc, and c++ 17 standards (default during cmake configuration)

Same as https://github.com/o3de/o3de/pull/18961 but also fix ambiguous symbols in ` Modifier::ReportModificationSuccess()`. 

## How was this PR tested?

Local windows build on development branch
