### PR TITLE
Fix ScriptCanvasNode Template 

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
@@ -1023,7 +1023,7 @@ namespace AzToolsFramework
         }
 
         void PrefabSaveHandler::SourceFileRemoved(
-            AZStd::string relativePath, AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid sourceUUID)
+            AZStd::string relativePath, [[maybe_unused]] AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid sourceUUID)
         {
             // This gets triggered for every source file. We only need source files that are prefabs and are loaded in the current level.
             TemplateId loadedTemplateId = s_prefabSystemComponentInterface->GetTemplateIdFromFilePath(relativePath.c_str());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -606,7 +606,7 @@ namespace ScriptCanvas
             return AZStd::const_pointer_cast<Scope>(m_graphScope)->AddVariableName(name);
         }
 
-        void AbstractCodeModel::AddUserOutToLeaf(ExecutionTreePtr parent, ExecutionTreeConstPtr root, AZStd::string_view name)
+        void AbstractCodeModel::AddUserOutToLeaf(ExecutionTreePtr parent, [[maybe_unused]] ExecutionTreeConstPtr root, AZStd::string_view name)
         {
             ExecutionTreePtr out;
 

--- a/Templates/ScriptCanvasNode/Template/${Name}_files.cmake
+++ b/Templates/ScriptCanvasNode/Template/${Name}_files.cmake
@@ -11,12 +11,8 @@ get_property(scriptcanvas_gem_root GLOBAL PROPERTY "@GEMROOT:ScriptCanvas@")
 set(FILES
     ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Header.jinja
     ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Source.jinja
-    ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Header.jinja
-    ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammarRegistry_Source.jinja
     ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
     ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
-    ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Header.jinja
-    ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeableRegistry_Source.jinja
 
     Include/${Name}.h
     Source/${Name}.ScriptCanvasNodeable.xml

--- a/Templates/ScriptCanvasNode/Template/CMakeLists.txt
+++ b/Templates/ScriptCanvasNode/Template/CMakeLists.txt
@@ -25,13 +25,11 @@ ly_add_target(
         PUBLIC
             AZ::AzCore
             AZ::AzFramework
-            Gem::ScriptCanvas.Shared
+            Gem::ScriptCanvas.API
             Gem::ScriptCanvas.Extensions
     AUTOGEN_RULES
         *.ScriptCanvasNodeable.xml,ScriptCanvasNodeable_Header.jinja,$path/$fileprefix.generated.h
         *.ScriptCanvasNodeable.xml,ScriptCanvasNodeable_Source.jinja,$path/$fileprefix.generated.cpp
-        *.ScriptCanvasNodeable.xml,ScriptCanvasNodeableRegistry_Header.jinja,$path/$fileprefix_Nodeables.generated.h
-        *.ScriptCanvasNodeable.xml,ScriptCanvasNodeableRegistry_Source.jinja,$path/$fileprefix_Nodeables.generated.cpp
 )
 
 set (dependent_targets ${gem_name}.Private.Object;${gem_name};${gem_name}.Editor)

--- a/Templates/ScriptCanvasNode/Template/Source/${Name}.cpp
+++ b/Templates/ScriptCanvasNode/Template/Source/${Name}.cpp
@@ -15,8 +15,7 @@
 // You can keep it here, or move it into this module's 
 // system component
 #include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
-#include <Source/${Name}_Nodeables.generated.h>
-REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE(${Name}Object);
+
 /////////////////////////////////////////////////////////////
 
 namespace ScriptCanvas::Nodes


### PR DESCRIPTION
## What does this PR do?

* Update the **ScriptCanvasNode Template** by updating it to confirm to impactful change for [Script Canvas](https://github.com/o3de/o3de/pull/16678).
* Fix unused variable warning

Fixes #18923 

## How was this PR tested?

* Create a new C++ Gem
* Followed the [instructions](https://github.com/o3de/o3de/blob/development/Templates/ScriptCanvasNode/Template/README.md)  to create ScriptCanvasNode in the new gem 
* Create a new minimal project and included the new gem
* Built the project
