### PR TITLE
Fix the build: Move a using directive from a namespace to a function

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -161,8 +161,6 @@
 
 namespace ScriptCanvasEditor
 {
-    using namespace AzToolsFramework;
-
     namespace
     {
         template <typename T>
@@ -4072,6 +4070,8 @@ namespace ScriptCanvasEditor
 
     void MainWindow::AssignGraphToEntityImpl(const AZ::EntityId& entityId)
     {
+        using namespace AzToolsFramework;
+
         EditorScriptCanvasComponentRequests* firstRequestBus = nullptr;
         EditorScriptCanvasComponentRequests* firstEmptyRequestBus = nullptr;
 
@@ -4515,4 +4515,4 @@ namespace ScriptCanvasEditor
 
 
 #include <Editor/View/Windows/moc_MainWindow.cpp>
-}
+} // namespace ScriptCanvasEditor


### PR DESCRIPTION
## What does this PR do?

Fixes a ambiguous reference error, that broke the CI.
The error can be seen here: https://github.com/o3de/o3de/actions/runs/15435944409/job/43442336356?pr=18989#step:13:1159
Removed a using directive from a namespace and moved it into the only function in the cpp that actually needs it.

I'm not a fan of putting using directive globally in a cpp. This often breaks the unity build, especially if the aggregation of the files somehow changes.

## How was this PR tested?

Tested on Windows with clang
