### PR TITLE
Fixed crash when doing Cubemap Captures.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CubeMapCapture/CubeMapRenderer.cpp
@@ -59,8 +59,8 @@ namespace AZ
 
             // store the current exposure values
             Data::Instance<RPI::ShaderResourceGroup> sceneSrg = m_scene->GetShaderResourceGroup();
-            m_previousGlobalIblExposure = sceneSrg->GetConstant<float>(m_globalIblExposureConstantIndex.GetConstantIndex());
-            m_previousSkyBoxExposure = sceneSrg->GetConstant<float>(m_skyBoxExposureConstantIndex.GetConstantIndex());
+            m_previousGlobalIblExposure = sceneSrg->GetConstant<float>(m_globalIblExposureConstantIndex);
+            m_previousSkyBoxExposure = sceneSrg->GetConstant<float>(m_skyBoxExposureConstantIndex);
 
             // add the pipeline to the scene
             m_scene->AddRenderPipeline(environmentCubeMapPipeline);


### PR DESCRIPTION
## What does this PR do?

The crash was introduced by this #17974 almost a year ago.

Fixed it by reverting it to its previous version:
```
m_previousGlobalIblExposure = sceneSrg->GetConstant<float>(m_globalIblExposureConstantIndex);
m_previousSkyBoxExposure = sceneSrg->GetConstant<float>(m_skyBoxExposureConstantIndex);
```

## How was this PR tested?

Was able to capture both Specular and Diffuse Cubemaps on Win11 with Vulkan
