### PR TITLE
Fix crash on startup issue for 25050

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
@@ -354,7 +354,7 @@ namespace AssetProcessor
     }
     void RCController::DispatchJobs()
     {
-        if (!m_dispatchJobsQueued)
+        if ((!m_dispatchJobsQueued) && (!m_dispatchingPaused))
         {
             m_dispatchJobsQueued = true;
             QMetaObject::invokeMethod(this, "DispatchJobsImpl", Qt::QueuedConnection);

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -593,6 +593,7 @@ namespace AZ
                 {
                     m_meshes.clear();
                     m_subMeshes.clear();
+                    m_blasInstanceMap.clear();
 
                     for (auto& [deviceIndex, meshInfos] : m_meshInfos)
                     {


### PR DESCRIPTION
## What does this PR do?

Fixes the showstopper crash on startup problem we encountered with the 2505 prerelease.

## How was this PR tested?

2 phases of testing, windows only currently but the code isn't platform specific.

First phase of testing, I used a synthetic Asset Processor (I modified asset processor) to only compile until it had finished compiling critical assets and then slow down immensely so that the editor would load without any non-critical assets, which made the problems 100% reproducable, since they are timining related.

Then I fixed the issues, was easy to test since they were now 100% repro.

Then for the second phase of testing I reverted everything except for the actual fixes, so it was using a vanilla asset processor, and tested it using vanilla everything just the fixes. (No issue anymore).

Then for the second phase I emulated having a very slow computer by restricting the AP job count in its config file, to only 4 jobs at a time, so that its similar to the previous situation of not haveing everything compiled before the AP starts.   No issues.

## Other info

One crash is caused by the font not having its data or shader ready (very early crash)
The crash is aggrivated by a logic error that would allow the Asset Processor to start processing assets before it had tallied all the critical assets, allowing it to start early before all crits were actually done.

One crash is caused by the raytrace feature processor.  This is a special case.

When the scene contains ONLY meshes without materials, the atom mesh feature processor would pass the raytrace feature processor empty meshes without submeshes, ending in a situation where the Raytrace feature processor (RTFP) would have its m_meshes and m_blasInstanceMap full of meshes, but 0 submeshes for them (so no geometry basically).

The ray trace feature processor counts how many submeshes there are, and when you remove a mesh, if that number hits 0, it clears all its caches.  But it forgot to clear that one instance map when it did so, leading to a situation where the instance map is not empty, but the rest of its maps are, which it cannot realy handle when the next addmesh is called.

Note that this is a really special corner case and requires a scene with ONLY meshes that have invalid materials in them.  Any other case would not crash (0 meshes, 1 mesh with materials, etc).

It could happen, theoretically, in other circumstances, it technically has nothing to do with AP and critical assets, more with FBX rebuilding, but when AP hasn't compiled any meshes yet and you start the editor and load a level its very likely you get into this situation, as all meshes in the view will have no material yet.