### PR TITLE
Cherrypick from stab - Fix crash on startup issue for 25050

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
@@ -354,7 +354,7 @@ namespace AssetProcessor
     }
     void RCController::DispatchJobs()
     {
-        if (!m_dispatchJobsQueued)
+        if ((!m_dispatchJobsQueued) && (!m_dispatchingPaused))
         {
             m_dispatchJobsQueued = true;
             QMetaObject::invokeMethod(this, "DispatchJobsImpl", Qt::QueuedConnection);

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -612,6 +612,7 @@ namespace AZ
                 {
                     m_meshes.clear();
                     m_subMeshes.clear();
+                    m_blasInstanceMap.clear();
 
                     for (auto& [deviceIndex, meshInfos] : m_meshInfos)
                     {


### PR DESCRIPTION
## What does this PR do?
Cherry-picks the PR https://github.com/o3de/o3de/pull/18995 from stabilization to development.

See the above PR for more details

## How was this PR tested?

After cherry picking, did the local AR run (pass)
Did some smoke testing (loading up the editor before AP finishes, loading a level, watching the meshes pop in without crashing).
