### PR TITLE
Fix memory leak related to vertex/pixel/compute shader functions for Metal

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -419,6 +419,14 @@ namespace AZ
         {
             if (m_graphicsPipelineState)
             {
+                if (m_renderPipelineDesc.vertexFunction)
+                {
+                    [m_renderPipelineDesc.vertexFunction release];
+                }
+                if (m_renderPipelineDesc.fragmentFunction)
+                {
+                    [m_renderPipelineDesc.fragmentFunction release];
+                }
                 [m_renderPipelineDesc release];
                 m_renderPipelineDesc = nil;
                 [m_graphicsPipelineState release];
@@ -427,6 +435,10 @@ namespace AZ
             
             if (m_computePipelineState)
             {
+                if (m_computePipelineDesc.computeFunction)
+                {
+                    [m_computePipelineDesc.computeFunction release];
+                }
                 [m_computePipelineDesc release];
                 m_computePipelineDesc = nil;
                 [m_computePipelineState release];


### PR DESCRIPTION
## What does this PR do?

Memory fix provided by carbonated. 

## How was this PR tested?

Tested AutomatedTesting default level on ios as well as mac via M1 machine 
