### PR TITLE
Fixes various CMake related warnings CMP0177 that happen if you use SDK builds.

### DIFF
--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -117,8 +117,11 @@ configure_file(${LY_ROOT_FOLDER}/cmake/Packaging/LicenseScan.cmake.in
 ly_install(SCRIPT ${CPACK_BINARY_DIR}/LicenseScan.cmake
     COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
 )
+
+cmake_path(SET _destination_normalized NORMALIZE .)
+
 ly_install(FILES ${CPACK_3P_LICENSE_FILE} ${CPACK_3P_MANIFEST_FILE}
-    DESTINATION .
+    DESTINATION ${_destination_normalized}
     COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
 )
 

--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -339,11 +339,12 @@ set_property(TARGET ${NAME_PLACEHOLDER}
 
     set(target_install_source_dir ${CMAKE_CURRENT_BINARY_DIR}/install/${relative_target_source_dir})
     file(GENERATE OUTPUT "${target_install_source_dir}/Platform/${PAL_PLATFORM_NAME}/${LY_BUILD_PERMUTATION}/${NAME_PLACEHOLDER}_$<CONFIG>.cmake" CONTENT "${target_file_contents}")
+    cmake_path(SET destination_path NORMALIZE "${relative_target_source_dir}/Platform/${PAL_PLATFORM_NAME}/${LY_BUILD_PERMUTATION}")
 
     foreach(conf IN LISTS CMAKE_CONFIGURATION_TYPES)
         string(TOUPPER ${conf} UCONF)
         ly_install(FILES "${target_install_source_dir}/Platform/${PAL_PLATFORM_NAME}/${LY_BUILD_PERMUTATION}/${NAME_PLACEHOLDER}_${conf}.cmake"
-            DESTINATION ${relative_target_source_dir}/Platform/${PAL_PLATFORM_NAME}/${LY_BUILD_PERMUTATION}
+            DESTINATION "${destination_path}"
             COMPONENT ${LY_INSTALL_PERMUTATION_COMPONENT}_${UCONF}
             CONFIGURATIONS ${conf}
         )
@@ -449,7 +450,7 @@ endfunction()
 function(ly_setup_3p_dependencies)
 
     # 3p dependency generation is only relevant to installer builds, which is expected to happen only if no project is being built
-    # prevent this code from running in non-instlaler-builds, otherwise it will try to hang these commands off a non-existant generic
+    # prevent this code from running in non-installer-builds, otherwise it will try to hang these commands off a non-existant generic
     # game launcher target (which itself is also only relevant to installer builds for script-only mode.)
     if (LY_PROJECTS)
         return()
@@ -532,8 +533,9 @@ endif()
     set_property(DIRECTORY "${absolute_target_source_dir}" APPEND_STRING PROPERTY O3DE_SUBDIRECTORY_CMAKELIST_CONTENT "${subdirectory_cmakelist_content}")
     file(WRITE "${target_install_source_dir}/CMakeLists.txt" "${subdirectory_cmakelist_content}")
 
+    cmake_path(SET relative_target_source_dir NORMALIZE "${relative_target_source_dir}")
     ly_install(FILES "${target_install_source_dir}/CMakeLists.txt"
-        DESTINATION ${relative_target_source_dir}
+        DESTINATION "${relative_target_source_dir}"
         COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
     )
 
@@ -547,8 +549,9 @@ else()
     include(Platform/${PAL_PLATFORM_NAME}/Default/permutation.cmake)
 endif()
 ]])
+    cmake_path(SET destination_path NORMALIZE "${relative_target_source_dir}/Platform/${PAL_PLATFORM_NAME}")
     ly_install(FILES "${target_install_source_dir}/Platform/${PAL_PLATFORM_NAME}/platform_${PAL_PLATFORM_NAME_LOWERCASE}.cmake"
-        DESTINATION ${relative_target_source_dir}/Platform/${PAL_PLATFORM_NAME}
+        DESTINATION "${destination_path}"
         COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
     )
 
@@ -572,8 +575,9 @@ endif()
         "${ENABLE_GEMS_PLACEHOLDER}"
     )
 
+    cmake_path(SET destination_path NORMALIZE "${relative_target_source_dir}/Platform/${PAL_PLATFORM_NAME}/${LY_BUILD_PERMUTATION}")
     ly_install(FILES "${target_install_source_dir}/Platform/${PAL_PLATFORM_NAME}/${LY_BUILD_PERMUTATION}/permutation.cmake"
-        DESTINATION ${relative_target_source_dir}/Platform/${PAL_PLATFORM_NAME}/${LY_BUILD_PERMUTATION}
+        DESTINATION "${destination_path}"
         COMPONENT ${LY_INSTALL_PERMUTATION_COMPONENT}
     )
 
@@ -581,9 +585,9 @@ endfunction()
 
 #! ly_setup_cmake_install: install the "cmake" folder
 function(ly_setup_cmake_install)
-
+    cmake_path(SET current_folder_normalized NORMALIZE ".")
     ly_install(DIRECTORY "${LY_ROOT_FOLDER}/cmake"
-        DESTINATION .
+        DESTINATION "${current_folder_normalized}"
         COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
         PATTERN "__pycache__" EXCLUDE
         PATTERN "Findo3de.cmake" EXCLUDE
@@ -678,10 +682,11 @@ function(ly_setup_cmake_install)
 
     configure_file(${LY_ROOT_FOLDER}/cmake/install/engine.json.in ${CMAKE_CURRENT_BINARY_DIR}/cmake/engine.json @ONLY)
 
+    cmake_path(SET current_folder_normalized NORMALIZE ".")
     ly_install(FILES
             "${LY_ROOT_FOLDER}/CMakeLists.txt"
             "${CMAKE_CURRENT_BINARY_DIR}/cmake/engine.json"
-        DESTINATION .
+        DESTINATION "${current_folder_normalized}"
         COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
     )
 
@@ -1160,19 +1165,21 @@ function(ly_setup_o3de_install)
     ly_setup_3p_dependencies()
 
     # Misc
+    cmake_path(SET current_folder_normalized NORMALIZE ".")
+
     ly_install(FILES
         ${LY_ROOT_FOLDER}/pytest.ini
         ${LY_ROOT_FOLDER}/LICENSE.txt
         ${LY_ROOT_FOLDER}/README.md
         ${LY_ROOT_FOLDER}/CMakePresets.json
-        DESTINATION .
+        DESTINATION "${current_folder_normalized}"
         COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
     )
 
     if("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
         ly_install(FILES
             ${LY_ROOT_FOLDER}/Code/Tools/ProjectManager/Resources/o3de_desktop.svg
-            DESTINATION .
+            DESTINATION "${current_folder_normalized}"
             COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
         )
     endif()


### PR DESCRIPTION
## What does this PR do?

CMake 4.x normalizes all paths sent as `DESTINATION` paths, in calls to `install`.

Example
```cmake

install( 
    SOURCE blabhblahb
    DESTINATION ./somefolder/../whatever
```

The above DESTINATION would normalize to `whatever` since `./` just means the current folder, which is assumed, and it has a `/../` in it which goes back up a folder (eliminating `somefolder`).  Because the normalized form (`whatever`) does not match the original form (`./somefolder/../whatever`) it issues a warning for a dev to come look and make sure its ok.

Earlier versions did not normalize these paths.

As such, any time it finds a non-normalized path, it warns you about it, and then normalizes it.  The warning is there for developers to know that this may change the result.

**This would only affect script-only or installer (SDK) builds, so only users using a prebuilt SDK would see this warning spam**

There were many warnings when using a installer / sdk, they did not stop o3de from compiling or anything from working, but they did add noise to the build logs when something else was wrong.  An example

```

CMake Warning (dev) at C:/o3de-worktrees/stab/cmake/Install.cmake:29 (install):
  Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
  "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
Call Stack (most recent call first):
  C:/o3de-worktrees/stab/cmake/Platform/Common/Install_common.cmake:535 (ly_install)
  C:/o3de-worktrees/stab/cmake/Platform/Common/Install_common.cmake:363 (ly_setup_subdirectory)
  C:/o3de-worktrees/stab/cmake/Platform/Common/Install_common.cmake:1156 (ly_setup_subdirectories)
  C:/o3de-worktrees/stab/CMakeLists.txt:141 (ly_setup_o3de_install)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## How was this PR tested?
Building using the modified code
Making an installer using the modified code
Making a script only, and also a regular project based on the modified code.  No issues.
