### PR TITLE
[LUA Editor] Fix autofocus issue for the goto line dialog and support also columns

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorGoToLineDialog.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorGoToLineDialog.hxx
@@ -32,23 +32,22 @@ namespace LUAEditor
     {
         Q_OBJECT
     public:
-        LUAEditorGoToLineDialog(QWidget *parent = 0);
-        ~LUAEditorGoToLineDialog();
+        explicit LUAEditorGoToLineDialog(QWidget *parent = nullptr);
+        ~LUAEditorGoToLineDialog() override;
         
-        int getLineNumber() { return m_lineNumber; }
+        int getLineNumber() const { return m_lineNumber; }
+        int getColumnNumber() const { return m_columnNumber; }
     
-    signals:
-        void lineNumberChanged(int newNumber);        
-
     public slots:
-        void setLineNumber(int number);
+
+        void setLineNumber(int line, int column) const;
+        void handleLineNumberInput(const QString& input);
+        void validateAndAccept();
 
     private:
         Ui::goToLineDlg* m_gui;
-        int m_lineNumber;
-    private slots:
-        void spinBoxLineNumberChanged(int newNumber);
-        
+        int m_lineNumber = 0;
+        int m_columnNumber = 0;
     };
 
 }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorGoToLineDialog.ui
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorGoToLineDialog.ui
@@ -9,27 +9,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>180</width>
-    <height>86</height>
+    <width>292</width>
+    <height>97</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>180</width>
-    <height>86</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>180</width>
-    <height>86</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Go to line...</string>
@@ -44,16 +32,6 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetFixedSize</enum>
    </property>
-   <item row="2" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -62,15 +40,19 @@
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="QSpinBox" name="lineNumberSpinBox">
-     <property name="prefix">
-      <string/>
+    <widget class="QLineEdit" name="lineNumber">
+     <property name="placeholderText">
+      <string>line number[:column]</string>
      </property>
-     <property name="minimum">
-      <number>1</number>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="maximum">
-      <number>99999</number>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -1393,16 +1393,16 @@ namespace LUAEditor
 
         LUAEditorGoToLineDialog dlg(this);
 
-        int lineNumber = 0, cursorColumn = 0;
-        currentView->GetCursorPosition(lineNumber, cursorColumn);
-        dlg.setLineNumber(lineNumber + 1);
+        int lineNumber = 0, lineColumn = 0;
+        currentView->GetCursorPosition(lineNumber, lineColumn);
+        dlg.setLineNumber(lineNumber, lineColumn);
 
         if (dlg.exec() != QDialog::Rejected)
         {
-            // go to that line of the selected file.
             lineNumber = dlg.getLineNumber();
+            lineColumn = dlg.getColumnNumber();
 
-            currentView->SetCursorPosition(lineNumber, 0);
+            currentView->SetCursorPosition(lineNumber, lineColumn);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixed 18854 : https://github.com/o3de/o3de/issues/18854

One another issue is that the current implementation expects line numbers start at 1 and columns at 0. I did not change that behavior. Better would be, at some point to change the column also to start at the value 1 instead of 0.

## How was this PR tested?

Just tested on my local computer.
