### PR TITLE
Cherry pick changes from 24.09.0 (#18396) (#18428) (#18425) (#18982)

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -338,7 +338,7 @@ real DirectionalShadowCalculator::GetVisibilityFromLightPcf()
         [branch]
         if (blendBetweenCascadesAmount < 1.0f && nextCascadeIndex < m_cascadeCount)
         {
-            const real nextLit = SamplePcfBicubic(real3(m_shadowCoords[nextCascadeIndex]), nextCascadeIndex);
+            const real nextLit = SamplePcfBicubic(m_shadowCoords[nextCascadeIndex], nextCascadeIndex);
             lit = lerp(nextLit, lit, blendBetweenCascadesAmount);
         }
     } 
@@ -394,7 +394,7 @@ float DirectionalShadowCalculator::GetVisibilityFromLightEsmPcf()
                 static const real pcfFallbackThreshold = 1.04;
                 if (ratio > pcfFallbackThreshold)
                 {
-                    ratio = SamplePcfBicubic(real3(shadowCoord), indexOfCascade);
+                    ratio = SamplePcfBicubic(shadowCoord, indexOfCascade);
                 }
                 return saturate(ratio);
             }

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexableList.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexableList.h
@@ -120,6 +120,7 @@ namespace AZ
 
                 m_data[positionToRemove].m_next = m_freeListHead;
                 m_freeListHead = positionToRemove;
+                m_data[positionToRemove].m_value = {};
             }
 
             void clear()

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -123,7 +123,6 @@ namespace AZ
 
         void DecalTextureArray::RemoveMaterial(const int index)
         {
-            m_materials[index] = {};
             m_materials.erase(index);
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -675,9 +675,10 @@ namespace AZ
 
                     addVisibleObjectsToBucketsTG.AddTask(
                         addVisibleObjectsToBucketsTaskDescriptor,
-                        [this, view, viewIndex, batchStart, currentBatchCount]()
+                        // Don't capture the shared_ptr because that causes incorrect ref counting when copying/moving the lambda
+                        [this, viewPtr = view.get(), viewIndex, batchStart, currentBatchCount]()
                         {
-                            RPI::VisibleObjectListView visibilityList = view->GetVisibleObjectList();
+                            RPI::VisibleObjectListView visibilityList = viewPtr->GetVisibleObjectList();
                             AZStd::vector<InstanceGroupBucket>& currentViewInstanceGroupBuckets = m_perViewInstanceGroupBuckets[viewIndex];
                             for (size_t i = batchStart; i < batchStart + currentBatchCount; ++i)
                             {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -15,6 +15,7 @@
 #include <Atom/RHI.Reflect/Metal/ShaderStageFunction.h>
 #include <Atom/RHI.Reflect/Limits.h>
 #include <Atom/RHI/RHIUtils.h>
+#include <AzCore/std/string/regex.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
 namespace AZ
@@ -613,6 +614,12 @@ namespace AZ
                 finalMetalSLStr.insert(startOfShaderPos + startOfShaderTag.length() + 1, constantBufferTempStructs);
                 finalMetalSLStr.insert(startOfShaderPos + startOfShaderTag.length() + 1, structuredBufferTempStructs);
             }
+
+            //spirv-cross introduced the keyword [[clang::optnone]] across shader functions which cancels all optimizations
+            //for the tagged method. This is suppose to be tied to the keyword 'precise' but is contaminating areas outside its usage.
+            //Removing this manually until a better solution is established.
+            //GHI for ref - https://github.com/KhronosGroup/SPIRV-Cross/issues/1999
+            finalMetalSLStr = AZStd::regex_replace(finalMetalSLStr, AZStd::regex("\\[\\[clang::optnone\\]\\]"), "");
 
             compiledShader = AZStd::vector<char>(finalMetalSLStr.begin(), finalMetalSLStr.end());
             return true;

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Platform/iOS/AzslcPlatformHeader.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/Platform/iOS/AzslcPlatformHeader.azsli
@@ -23,11 +23,24 @@
 // disable using the bindless SRG for material textures in the SingleMaterialSrg
 #define AZ_TRAIT_SINGLE_MATERIAL_USE_TEXTURE_ARRAY
 
-// use half float for ios
-#define real half
-#define real2 half2
-#define real3 half3
-#define real4 half4
-#define real3x3 half3x3
-#define real3x4 half3x4
-#define real4x4 half4x4
+// use half float for iOS
+#define USE_HALF_FLOATS_FOR_IOS 1
+
+
+#if USE_HALF_FLOATS_FOR_IOS
+    #define real half
+    #define real2 half2
+    #define real3 half3
+    #define real4 half4
+    #define real3x3 half3x3
+    #define real3x4 half3x4
+    #define real4x4 half4x4
+#else
+    #define real float
+    #define real2 float2
+    #define real3 float3
+    #define real4 float4
+    #define real3x3 float3x3
+    #define real3x4 float3x4
+    #define real4x4 float4x4
+#endif

--- a/cmake/Platform/Windows/Packaging/BootstrapperTheme.wxl.in
+++ b/cmake/Platform/Windows/Packaging/BootstrapperTheme.wxl.in
@@ -61,7 +61,7 @@ Setup will install [WixBundleName] on your computer. Click install to continue, 
     <String Id="FailureUninstallHeader">Uninstall Failed</String>
     <String Id="FailureRepairHeader">Repair Failed</String>
     <String Id="FailureHyperlinkLogText">
-One or more issues caused the setup to fail.  Please fix the issues and then retry setup.  For more information, see the log file.
+One or more issues caused the setup to fail.  Please fix the issues and then retry setup.  For more information, see the log file or retry with '/log (path to log)' to create debug logs
 
 &lt;a href="#"&gt;View Log File&lt;/a&gt;
     </String>

--- a/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
+++ b/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
@@ -45,7 +45,7 @@
         </DirectoryRef>
 
         <CustomAction Id="ExtractCMake"
-            ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C tar -x -f &quot;[root.tools.redist.cmake]$(var.CPACK_CMAKE_PACKAGE_NAME).zip&quot; -C &quot;[root.tools.redist]CMake&quot;"
+            ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C %SystemRoot%\System32\tar.exe -x -f &quot;[root.tools.redist.cmake]$(var.CPACK_CMAKE_PACKAGE_NAME).zip&quot; -C &quot;[root.tools.redist]CMake&quot;"
             Directory="INSTALL_ROOT"
             Execute="deferred"
             Impersonate="no"/>


### PR DESCRIPTION
## What does this PR do?

Cherry-picks three changes that went directly into the 24.x release at the last minute, and were missed
to merge into dev.   See https://github.com/o3de/o3de/pull/18982

Nick_L note:
> These changes were committed to 24.09.1 release and never
> made it into development, so were missed for 2505.0 
> Note that the shader files in development were relocated post 2505.0 cut,
> so I manually merged the changes into the ios shader file in its new location.
> The android shader file already had the changes.

Original cherry-picker was Mike Chang.

## How was this PR tested?
Local CI Build testing, as well as basic smoke test (opening editor, poking around, etc)

