### PR TITLE
Cherry-pick from stabilization: Fix memory leak related to vertex/pixel/compute shader functions

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -419,6 +419,14 @@ namespace AZ
         {
             if (m_graphicsPipelineState)
             {
+                if (m_renderPipelineDesc.vertexFunction)
+                {
+                    [m_renderPipelineDesc.vertexFunction release];
+                }
+                if (m_renderPipelineDesc.fragmentFunction)
+                {
+                    [m_renderPipelineDesc.fragmentFunction release];
+                }
                 [m_renderPipelineDesc release];
                 m_renderPipelineDesc = nil;
                 [m_graphicsPipelineState release];
@@ -427,6 +435,10 @@ namespace AZ
             
             if (m_computePipelineState)
             {
+                if (m_computePipelineDesc.computeFunction)
+                {
+                    [m_computePipelineDesc.computeFunction release];
+                }
                 [m_computePipelineDesc release];
                 m_computePipelineDesc = nil;
                 [m_computePipelineState release];


### PR DESCRIPTION
## What does this PR do?

Cherry-picks the changes from https://github.com/o3de/o3de/pull/18998 to development.
See the original description in pull 18998, but they are a memory leak fix for METAL (IOS, Apple) devices.

## How was this PR tested?

Tested in stabilization by @moudgils  and the usual stabilization CI and regular testing.
These changes only affect compilation in ios and mac.
