### PR TITLE
Fix #2376: check templateId collision when saving prefab

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
@@ -779,6 +779,21 @@ namespace AzToolsFramework
                     WarningDialog("Prefab Path Error", message);
                     return false;
                 }
+
+                // We also check if the prefab template already exists in the Prefabs Database.
+                // This happens if the prefab file having the same name was removed from the disk, 
+                // but the prefab instance still exists in the Editor.
+                TemplateId templateId = s_prefabSystemComponentInterface->GetTemplateIdFromFilePath(prefabRelativeName.c_str());
+                if (templateId != Prefab::InvalidTemplateId)
+                {
+                    const AZStd::string message = AZStd::string::format(                        
+                        "A prefab with the path '%s' already exists in the Asset Database. \r\n\r\n"
+                        "Overriding it will damage instances or cascades of this prefab.",
+                        prefabRelativeName.c_str());
+
+                    WarningDialog("Prefab Path Error", message);
+                    return false;
+                }
             }
 
             AZStd::string saveDir(prefabSaveFileInfo.absoluteDir().absolutePath().toUtf8().constData());


### PR DESCRIPTION
## What does this PR do?

Closes #2376
I found a very old issue with a recent comment and decided to investigate it. Steps to reproduce:
- create a level with a prefab
- delete this prefab from the drive (using the operating system tools)
- try to save a new prefab under the same name

When a prefab is deleted from the disk, AssetProcessor discovers it and sends a notification. However, O3DE keeps the prefab in memory because it is still loaded in the level (user is notified that the file was removed and has a chance to save it back from O3DE). Because the prefab is kept in memory, a new prefab under the same name cannot be created in memory. This triggers a crash later, when saving the prefab from memory to the output file (it is missing in memory due to the name collision).

A proper fix for the issue would be to avoid the name collision in memory. However, this requires a large refactor. Since the crash is caused by an unusual usage, the fix that does not let you create a prefab under the same name is enough.

## How was this PR tested?

The reproduction was performed with and without a fix.
