### PR TITLE
Fix a mistake introduced in #18829 that results in assimp importing FBX meshes through old transform behavior.

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -63,7 +63,7 @@ namespace AZ
                 rootTransform /= m_unitSizeInMeters;
             }
             // for FBX, root transform is not converted where there are no meshes in the scene.
-            if ((assImpScene->GetAssImpScene()->mFlags | AI_SCENE_FLAGS_INCOMPLETE)
+            if ((assImpScene->GetAssImpScene()->mFlags & AI_SCENE_FLAGS_INCOMPLETE)
                 && assImpScene->GetAssImpScene()->mMetaData->HasKey("UpAxis"))
             {
                 readRootTransform = false;


### PR DESCRIPTION
## What does this PR do?

This PR fixed a mistake in #18829, that causes assimp importer to revert to old transform paradigm when importing FBX mesh files, which results in the orientation of FBX mesh different from Blender (which uses the same coordinate system as O3DE).

## How was this PR tested?

Export FBX mesh from Blender to O3DE, the orientation should remain the same in all combinations of front and up axis in the export option.