### PR TITLE
UI Editor: Fix #18048 and #18909 - Alpha property slider

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
@@ -23,6 +23,7 @@ namespace AzToolsFramework
         QHBoxLayout* pLayout = new QHBoxLayout(this);
         pLayout->setContentsMargins(0,0,0,0);
         m_sliderCombo = new AzQtComponents::SliderDoubleCombo(this);
+        m_sliderCombo->spinbox()->setStepType(QAbstractSpinBox::AdaptiveDecimalStepType);
         pLayout->addWidget(m_sliderCombo);
         setFocusProxy(m_sliderCombo);
 

--- a/Gems/LyShine/Code/Source/UiInteractableState.cpp
+++ b/Gems/LyShine/Code/Source/UiInteractableState.cpp
@@ -248,7 +248,9 @@ void UiInteractableStateAlpha::Reflect(AZ::ReflectContext* context)
 
             editInfo->DataElement("ComboBox", &UiInteractableStateAlpha::m_targetEntity, "Target", "The target element.")
                 ->Attribute("EnumValues", &UiInteractableStateAlpha::PopulateTargetEntityList);
-            editInfo->DataElement("Slider", &UiInteractableStateAlpha::m_alpha, "Alpha", "The opacity.");
+            editInfo->DataElement("Slider", &UiInteractableStateAlpha::m_alpha, "Alpha", "The opacity.")
+                ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                ->Attribute(AZ::Edit::Attributes::Max, 1.0f);
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fix #18048 : the step of the alpha slider now goes from 0.0f to 1.0f using decimal values.

![slider_step](https://github.com/user-attachments/assets/0e7af739-01b2-4de7-8068-225399e89fad)

Fix #18909  : set min max values to the slider, ensuring the slider value are within the given bounds [0.0f, 1.0f].

![lyshine_fixbutton](https://github.com/user-attachments/assets/0ec7ae9d-7cf1-4f7c-9e2c-712befe5c500)

## How was this PR tested?

Local build. Tested with the description of the concerned issues :

- Open UI Editor
- New Empty element
- Add any component with the Alpha property
- Change the value using the buttons < > of the Alpha property
=> Slider values are updating correctly
- Add Button Component.
- Add Hover Event Value, Alpha
=> Slider values are updating correctly