### PR TITLE
DPE : Fix search linting on widgets

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -65,6 +65,11 @@ namespace AZ::DocumentPropertyEditor
         handler.Connect(m_messageEvent);
     }
 
+    void DocumentAdapter::ConnectFilterHandler(FilterEvent::Handler& handler)
+    {
+        handler.Connect(m_filterEvent);
+    }
+
     void DocumentAdapter::SetRouter(RoutingAdapter* /*router*/, const Dom::Path& /*route*/)
     {
         // By default, setting a router is a no-op, this only matters for nested routing adapters
@@ -184,6 +189,11 @@ namespace AZ::DocumentPropertyEditor
             }
         }
         m_changedEvent.Signal(*appliedPatch);
+    }
+
+    void DocumentAdapter::NotifyFilterChanged(const AZStd::string& filter)
+    {
+        m_filterEvent.Signal(filter);
     }
 
     Dom::Value DocumentAdapter::SendAdapterMessage(const AdapterMessage& message)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
@@ -114,6 +114,7 @@ namespace AZ::DocumentPropertyEditor
         using ResetEvent = Event<>;
         using ChangedEvent = Event<const Dom::Patch&>;
         using MessageEvent = Event<const AdapterMessage&, Dom::Value&>;
+        using FilterEvent = Event<const AZStd::string&>;
 
         virtual ~DocumentAdapter() = default;
 
@@ -133,6 +134,9 @@ namespace AZ::DocumentPropertyEditor
         //! Connects a listener for the message event, fired when SendAdapterMessage is called.
         //! is invoked. This can be used to prompt the view for a response, e.g. when asking for a confirmation dialog.
         void ConnectMessageHandler(MessageEvent::Handler& handler);
+        //! Connects a listener for the filter event, fired when the contents of this adapter have been filtered.
+        //! This can be used by widgets to update their linting
+        void ConnectFilterHandler(FilterEvent::Handler& handler);
 
         //! Sets a router responsible for chaining nested adapters, if supported.
         //! \see RoutingAdapter
@@ -192,11 +196,14 @@ namespace AZ::DocumentPropertyEditor
         //! This patch should apply cleanly on the last result GetContents would have returned after any preceding changed
         //! or reset events.
         void NotifyContentsChanged(const Dom::Patch& patch);
+        //! Subclasses may call this to notify the view that this adapter's content has been filtered
+        void NotifyFilterChanged(const AZStd::string& filter);
 
     private:
         ResetEvent m_resetEvent;
         ChangedEvent m_changedEvent;
         MessageEvent m_messageEvent;
+        FilterEvent m_filterEvent;
 
         mutable Dom::Value m_cachedContents;
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
@@ -77,6 +77,11 @@ namespace AzToolsFramework::Prefab
         return true;
     }
 
+    void PrefabOverrideLabelHandler::SetFilter(const QString& filter)
+    {
+        m_textLabel->SetFilter(filter);
+    }
+
     void PrefabOverrideLabelHandler::ShowContextMenu(const QPoint& position)
     {
         if (!m_overridden)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.h
@@ -36,6 +36,8 @@ namespace AzToolsFramework::Prefab
 
         bool ResetToDefaults() override;
 
+        void SetFilter(const QString& filter) override;
+
         static constexpr const AZStd::string_view GetHandlerName()
         {
             return PrefabPropertyEditorNodes::PrefabOverrideLabel::Name;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -16,13 +16,14 @@
 #include <QVBoxLayout>
 
 #include <AzCore/Console/IConsole.h>
+#include <AzCore/Debug/Profiler.h>
 #include <AzCore/DOM/DomUtils.h>
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorSystem.h>
 #include <AzQtComponents/Components/Widgets/CheckBox.h>
+#include <AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h>
 #include <AzToolsFramework/UI/DPEDebugViewer/DPEDebugModel.h>
 #include <AzToolsFramework/UI/DPEDebugViewer/DPEDebugWindow.h>
-#include <AzToolsFramework/UI/DocumentPropertyEditor/KeyQueryDPE.h>
 
 AZ_CVAR(
     bool,
@@ -1345,6 +1346,13 @@ namespace AzToolsFramework
             });
         m_adapter->ConnectMessageHandler(m_domMessageHandler);
 
+        m_filterHandler = AZ::DocumentPropertyEditor::DocumentAdapter::FilterEvent::Handler(
+            [this](const AZStd::string& filter)
+            {
+                this->SetFilterString(filter);
+            });
+        m_adapter->ConnectFilterHandler(m_filterHandler);
+
         // Free the settings ptr which saves any in-memory settings to disk and replace it
         // with a default in-memory only settings object until a saved state key is specified
         m_dpeSettings.reset();
@@ -1435,6 +1443,44 @@ namespace AzToolsFramework
     {
         m_dpeSettings.reset();
         Clear();
+    }
+
+    void DocumentPropertyEditor::SetFilterString(AZStd::string str)
+    {
+        AZ_PROFILE_FUNCTION(Editor);
+
+        const QString filter = str.c_str();
+
+        auto applyFilterRecursively = [&filter](DPERowWidget* currRow, auto&& applyFilterRecursively) -> void
+        {
+            const size_t numChildren = currRow->m_domOrderedChildren.size();
+            for (size_t childIndex = 0; childIndex < numChildren; ++childIndex)
+            {
+                QWidget* widget = currRow->m_domOrderedChildren[childIndex];
+                if (!widget)
+                    continue;
+
+                auto handlerInfo = DocumentPropertyEditor::GetInfoFromWidget(widget);
+                if (!handlerInfo.IsNull())
+                {
+                    handlerInfo.handlerInterface->SetFilter(filter);
+                }
+                else if (auto* label = qobject_cast<AzQtComponents::ElidingLabel*>(widget))
+                {
+                    label->SetFilter(filter);
+                }
+                else if (auto* row = qobject_cast<DPERowWidget*>(widget))
+                {
+                    applyFilterRecursively(row, applyFilterRecursively);
+                }
+            }
+        };
+
+        if (m_rootNode)
+        {
+            applyFilterRecursively(m_rootNode, applyFilterRecursively);
+            update(); // Need to redraw for the linting to be applied
+        }
     }
 
     void DocumentPropertyEditor::SetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded)
@@ -1635,6 +1681,8 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::HandleDomChange(const AZ::Dom::Patch& patch)
     {
+        AZ_PROFILE_FUNCTION(Editor);
+
         if (m_isBeingCleared)
         {
             AZ_Assert(false, "DocumentPropertyEditor::HandleDomChange called while being cleared.  check the callstack.  Suppress your signals during cleanup and destruction of widgets!");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1447,7 +1447,7 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::SetFilterString(AZStd::string str)
     {
-        AZ_PROFILE_FUNCTION(Editor);
+        AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         const QString filter = str.c_str();
 
@@ -1681,7 +1681,7 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::HandleDomChange(const AZ::Dom::Patch& patch)
     {
-        AZ_PROFILE_FUNCTION(Editor);
+        AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         if (m_isBeingCleared)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -203,8 +203,6 @@ namespace AzToolsFramework
          *  to make the DPE arbitrarily narrow. */
         void SetEnforceMinWidth(bool enforceMinWidth);
 
-        virtual QSize sizeHint() const override;
-
         auto GetAdapter()
         {
             return m_adapter;
@@ -225,9 +223,15 @@ namespace AzToolsFramework
         void ExpandAll();
         void CollapseAll();
 
+        // QScrollArea overrides
+        virtual QSize sizeHint() const override;
+        // ~QScrollArea overrides
+
         // IPropertyEditor overrides
         void SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName = {}) override;
         void ClearInstances() override;
+        void SetFilterString(AZStd::string str) override; // Only used for linting, filtering is handled by the DocumentAdapter
+        // ~IPropertyEditor overrides
 
         AZ::Dom::Value GetDomValueForRow(DPERowWidget* row) const;
 
@@ -295,6 +299,7 @@ namespace AzToolsFramework
         AZ::DocumentPropertyEditor::DocumentAdapter::ResetEvent::Handler m_resetHandler;
         AZ::DocumentPropertyEditor::DocumentAdapter::ChangedEvent::Handler m_changedHandler;
         AZ::DocumentPropertyEditor::DocumentAdapter::MessageEvent::Handler m_domMessageHandler;
+        AZ::DocumentPropertyEditor::DocumentAdapter::FilterEvent::Handler m_filterHandler;
 
         QVBoxLayout* m_layout = nullptr;
         bool m_allowVerticalScroll = true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
@@ -39,6 +39,12 @@ namespace AzToolsFramework
         {
             return false;
         }
+
+        //! Allow the widget to lint its matching text to outline the current search
+        virtual void SetFilter([[maybe_unused]] const QString& filter)
+        {
+        }
+
         //! Returns the first widget in the tab order for this property editor, i.e. the widget that should be selected
         //! when the user hits tab on the widget immediately prior to this.
         //! By default, this returns GetWidget, a single widget tab order.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ValueStringFilter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ValueStringFilter.cpp
@@ -8,6 +8,8 @@
 #include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/ValueStringFilter.h>
 
+#include <QTimer>
+
 namespace AZ::DocumentPropertyEditor
 {
     ValueStringFilter::ValueStringFilter()
@@ -38,7 +40,12 @@ namespace AZ::DocumentPropertyEditor
                 SetFilterActive(true);
             }
 
-            NotifyFilterChanged(m_filterString);
+             QTimer::singleShot(
+                0,
+                [this]()
+                {
+                    NotifyFilterChanged(m_filterString);
+                });
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ValueStringFilter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ValueStringFilter.cpp
@@ -37,6 +37,8 @@ namespace AZ::DocumentPropertyEditor
             {
                 SetFilterActive(true);
             }
+
+            NotifyFilterChanged(m_filterString);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Fix https://github.com/o3de/o3de/issues/19013

When doing a search in DPE-powered property trees, the matching text on labels should have a background color to outline that it matches the search.

![change](https://github.com/user-attachments/assets/1470e0dd-633e-4e97-81e7-b9527d3e96f7)

## How was this PR tested?

Local build against development branch
