### PR TITLE
Update android compatibility for Android Gradle Plugin 8.10 (latest)

### DIFF
--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -89,7 +89,7 @@ namespace
             bool continueRunning = true;
             while (continueRunning) 
             {
-                continueRunning = PumpEvents(&ALooper_pollAll);
+                continueRunning = PumpEvents(&ALooper_pollOnce);
             }
         }
 

--- a/Code/Tools/AzTestRunner/Platform/Android/platform_android.cpp
+++ b/Code/Tools/AzTestRunner/Platform/Android/platform_android.cpp
@@ -95,7 +95,7 @@ namespace
             bool continueRunning = true;
             while (continueRunning)
             {
-                continueRunning = PumpEvents(&ALooper_pollAll);
+                continueRunning = PumpEvents(&ALooper_pollOnce);
             }
         }
 

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -298,7 +298,12 @@ class AndroidGradlePluginRequirements(object):
 # Note: This map needs to be updated in conjunction with newer versions of the Android Gradle plugins.
 
 ANDROID_GRADLE_PLUGIN_COMPATIBILITY_MAP = {
-
+    '8.10': AndroidGradlePluginRequirements(agp_version='8.10',
+                                           gradle_version='8.11',
+                                           sdk_build_tools_version='35.0.0',
+                                           jdk_version='17',
+                                           release_note_url='https://developer.android.com/build/releases/gradle-plugin'),
+    
     '8.1': AndroidGradlePluginRequirements(agp_version='8.1',
                                            gradle_version='8.0',
                                            sdk_build_tools_version='33.0.1',


### PR DESCRIPTION
## What does this PR do?

Makes it so you can use Android Studio Meerkat (latest) with O3DE, assuming you're willing
to install gradle 8.11+ and ninja and set GRADLE_HOME.

* Removes deprecated use of pollAll
* AGP -> 8.10
* AGP 8.10 requires Gradle 8.11 minimum
* AGP 8.10 requires Java 17 minimum
* AGP 8.10 requires SDK Build tools 35.0.0 minimum

This allows you to compile and deploy O3DE using the latest Android studio, Meerkat Feature Drop.  You can use
https://www.docs.o3de.org/docs/user-guide/platforms/android/generating_android_project_windows/

## How was this PR tested?

Tested deploying DefaultProject template onto a real Android Pixel8 with
```
Android STUDIO latest
o3de.bat android-configure --set-value platform.sdk.api=35 --global
o3de.bat android-configure --set-value ndk.version=27* --global
o3de.bat android-configure --set-value android.gradle.plugin=8.10.0 --global
set JAVA_HOME=c:\androidstudio\jbr
```

Note:  The android studio version of JBR works fine as the JDK for O3DE.

