### PR TITLE
Improves AP startup time and CPU Usage

### DIFF
--- a/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
+++ b/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Module/DynamicModuleHandle.h>
 #include <AzCore/Module/ModuleManagerBus.h>
 #include <AzCore/Slice/SliceSystemComponent.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -32,6 +32,9 @@
 
 namespace AssetProcessor
 {
+    // global settings for Asset Processor, they usually come from the engine config file
+    // but inidividual gems, projects, and users can override them.
+    constexpr const char* AssetProcessorSettingsKey{ "/Amazon/AssetProcessor/Settings" };
     constexpr const char* DebugChannel = "Debug"; //Use this channel name if you want to write the message to the log file only.
     constexpr const char* ConsoleChannel = "AssetProcessor";// Use this channel name if you want to write the message to both the console and the log file.
     constexpr const char* FENCE_FILE_EXTENSION = "fence"; //fence file extension
@@ -75,10 +78,11 @@ namespace AssetProcessor
     //! This enum stores all the different job escalation values
     enum JobEscalation
     {
-        ProcessAssetRequestSyncEscalation = 200,
-        ProcessAssetRequestStatusEscalation = 150,
-        AssetJobRequestEscalation = 100,
-        Default = 0
+        ProcessAssetRequestSyncEscalation = 200,     //!< Used when the Sync Compile Asset (blocking compile) is requested
+        ProcessAssetRequestStatusEscalation = 150,   //!< Used when the Get Status is called on a specific asset, but not sync compile.
+        AssetJobRequestEscalation = 100,             //!< Used when the user is asking about a specific job, but not syncing
+        CriticalDependencyEscalation = 50,           //!< Used when it is discovered that a critical job depends on this job.
+        DefaultEscalation = 0
     };
     //! This enum stores all the different asset processor status values
     enum AssetProcessorStatus

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -33,7 +33,7 @@
 namespace AssetProcessor
 {
     // global settings for Asset Processor, they usually come from the engine config file
-    // but inidividual gems, projects, and users can override them.
+    // but individual gems, projects, and users can override them.
     constexpr const char* AssetProcessorSettingsKey{ "/Amazon/AssetProcessor/Settings" };
     constexpr const char* DebugChannel = "Debug"; //Use this channel name if you want to write the message to the log file only.
     constexpr const char* ConsoleChannel = "AssetProcessor";// Use this channel name if you want to write the message to both the console and the log file.

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCCommon.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCCommon.cpp
@@ -59,6 +59,14 @@ namespace AssetProcessor
             );
     }
 
+    bool QueueElementID::operator!=(const QueueElementID& other) const
+    {
+        // if this becomes a hotspot in profile, we could use CRCs or other boost to comparison here.  These classes are constructed rarely
+        // compared to how commonly they are compared with each other.
+        return !(operator==(other));
+    }
+
+
     bool QueueElementID::operator<(const QueueElementID& other) const
     {
         int compare = m_sourceAssetReference.AbsolutePath().Compare(other.m_sourceAssetReference.AbsolutePath());

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCCommon.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCCommon.h
@@ -29,6 +29,7 @@ namespace AssetProcessor
         void SetJobDescriptor(QString jobDescriptor);
         bool operator==(const QueueElementID& other) const;
         bool operator<(const QueueElementID& other) const;
+        bool operator!=(const QueueElementID& other) const;
 
     protected:
         SourceAssetReference m_sourceAssetReference;

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCQueueSortModel.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCQueueSortModel.h
@@ -54,6 +54,9 @@ namespace AssetProcessor
         bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
         bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
+        // Debugging functions
+        void DumpJobListInSortOrder();
+
     public Q_SLOTS:
         void OnEscalateJobs(AssetProcessor::JobIdEscalationList jobIdEscalationList);
 

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.h
@@ -12,8 +12,6 @@
 #include "RCCommon.h"
 
 #include <QObject>
-#include <QProcess>
-#include <QDir>
 #include <QList>
 #include "native/utilities/AssetUtilEBusHelper.h"
 
@@ -47,6 +45,8 @@ namespace AssetProcessor
         };
         explicit RCController(QObject* parent = 0);
         virtual ~RCController();
+
+        AssetProcessor::RCJobListModel* GetQueueModel();
 
         void StartJob(AssetProcessor::RCJob* rcJob);
         int NumberOfPendingCriticalJobsPerPlatform(QString platform);

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.h
@@ -45,11 +45,8 @@ namespace AssetProcessor
             cmdExecute,
             cmdTerminate
         };
-        RCController() = default;
-        explicit RCController(int minJobs, int maxJobs, QObject* parent = 0);
+        explicit RCController(QObject* parent = 0);
         virtual ~RCController();
-
-        AssetProcessor::RCJobListModel* GetQueueModel();
 
         void StartJob(AssetProcessor::RCJob* rcJob);
         int NumberOfPendingCriticalJobsPerPlatform(QString platform);
@@ -105,13 +102,17 @@ namespace AssetProcessor
         void OnJobComplete(JobEntry completeEntry, AzToolsFramework::AssetSystem::JobStatus status);
         void OnAddedToCatalog(JobEntry jobEntry);
 
+        //! The config about # of jobs and slots may have changed, recompute it.
+        void UpdateAndComputeJobSlots();
+
     protected:
         AssetProcessor::RCQueueSortModel m_RCQueueSortModel;
 
     private:
         void FinishJob(AssetProcessor::RCJob* rcJob);
 
-        unsigned int m_maxJobs;
+        unsigned int m_maxJobs = 0; //<! 0 means autocompute, read from registry key
+        bool m_alwaysUseMaxJobs = false; //<! normally, it only uses maxJobs cpu cores when critical or escalated work is present to save CPU usage
 
         bool m_dispatchingJobs = false;
         bool m_shuttingDown = false;

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.cpp
@@ -97,6 +97,13 @@ namespace AssetProcessor
 
     void RCJob::Init(JobDetails& details)
     {
+        // jobs for the "Common" platform exist to emit additional source files, which themselves could be critical
+        // so they are automatically critical as well.
+        if (GetPlatformInfo().m_identifier == AssetBuilderSDK::CommonPlatformName)
+        {
+            details.m_critical = true;
+        }
+
         m_jobDetails = AZStd::move(details);
         m_queueElementID = QueueElementID(GetJobEntry().m_sourceAssetReference, GetPlatformInfo().m_identifier.c_str(), GetJobKey());
     }

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjob.h
@@ -263,7 +263,7 @@ namespace AssetProcessor
 
         QueueElementID m_queueElementID; // cached to prevent lots of construction of this all over the place
 
-        int m_JobEscalation = AssetProcessor::JobEscalation::Default; // Escalation indicates how important the job is and how soon it needs processing, the greater the number the greater the escalation
+        int m_JobEscalation = AssetProcessor::JobEscalation::DefaultEscalation; // Escalation indicates how important the job is and how soon it needs processing, the greater the number the greater the escalation
 
         QDateTime m_timeCreated;
         QDateTime m_timeLaunched;

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjoblistmodel.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjoblistmodel.h
@@ -79,7 +79,8 @@ namespace AssetProcessor
         // Returns how many finished jobs that haven't been updated in the catalog.
         unsigned int jobsPendingCatalog() const;
 
-        void UpdateJobEscalation(AssetProcessor::RCJob* rcJob, int jobPrioririty);
+        void UpdateJobEscalation(const QueueElementID& toEscalate, int valueToEscalateTo);
+        void UpdateJobEscalation(AssetProcessor::RCJob* rcJob, int valueToEscalateTo);
         void UpdateRow(int jobIndex);
 
         bool isEmpty();

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
@@ -155,7 +155,7 @@ namespace UnitTests
 
         AZ::Utils::WriteFile("unit test file", m_testFilePath);
 
-        m_rc = AZStd::make_unique<TestingRCController>(1, 1);
+        m_rc = AZStd::make_unique<TestingRCController>();
         m_rc->SetDispatchPaused(false);
 
         QObject::connect(

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.h
@@ -78,9 +78,8 @@ namespace UnitTests
         : public AssetProcessor::RCController
     {
     public:
-        TestingRCController() = default;
-        explicit TestingRCController(int minJobs, int maxJobs, QObject* parent = 0)
-            : AssetProcessor::RCController(minJobs, maxJobs, parent)
+        explicit TestingRCController(QObject* parent = 0)
+            : AssetProcessor::RCController(parent)
         {
 
         }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -5544,7 +5544,7 @@ void ChainJobDependencyTest::SetUp()
 
     m_data = AZStd::make_unique<StaticData>();
 
-    m_data->m_rcController.reset(new RCController(/*minJobs*/1, /*maxJobs*/1));
+    m_data->m_rcController.reset(new RCController());
     m_data->m_rcController->SetDispatchPaused(false);
 
     // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own

--- a/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCControllerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCControllerTest.cpp
@@ -163,7 +163,7 @@ public:
     {
         RCcontrollerTest::SetUp();
         using namespace AssetProcessor;
-        m_rcController.reset(new RCController(/*minJobs*/1, /*maxJobs*/1));
+        m_rcController.reset(new RCController());
         m_rcController->SetDispatchPaused(false);
         m_rcJobListModel = m_rcController->GetQueueModel();
 

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -604,10 +604,10 @@ void MainWindow::Activate()
     const auto apm = m_guiApplicationManager->GetAssetProcessorManager();
 
     // Zero Analysis mode ("Fast scan mode") is enabled by default in the gui (running this mainwindow file), false in batch mode.
-    bool zeroAnalysisMode = AssetUtilities::GetUserSetting("zeroAnalysisMode", true);
-    bool enableBuilderDebugFlag = AssetUtilities::GetUserSetting("enableBuilderDebugFlag", apm->GetBuilderDebugFlag());
-    bool initialScanSkippingEnabled = AssetUtilities::GetUserSetting("initialScanSkippingEnabled", apm->GetInitialScanSkippingFeatureEnabled());
-    bool verboseLogDump = AssetUtilities::GetUserSetting("verboseLogging", false);
+    bool zeroAnalysisMode = AssetUtilities::GetUserSetting(AssetUtilities::ZeroAnalysisModeOptionName, true);
+    bool enableBuilderDebugFlag = AssetUtilities::GetUserSetting(AssetUtilities::EnableBuilderDebugFlagOptionName, apm->GetBuilderDebugFlag());
+    bool initialScanSkippingEnabled = AssetUtilities::GetUserSetting(AssetUtilities::SkipInitialScanOptionName, apm->GetInitialScanSkippingFeatureEnabled());
+    bool verboseLogDump = AssetUtilities::GetUserSetting(AssetUtilities::VerboseLoggingOptionName, false);
     // zero analysis flag
 
     apm->SetEnableModtimeSkippingFeature(zeroAnalysisMode);
@@ -626,7 +626,7 @@ void MainWindow::Activate()
         {
             bool newOption = newCheckState == Qt::Checked ? true : false;
             m_guiApplicationManager->GetAssetProcessorManager()->SetEnableModtimeSkippingFeature(newOption);
-            AssetUtilities::SetUserSetting("zeroAnalysisMode", newOption);
+            AssetUtilities::SetUserSetting(AssetUtilities::ZeroAnalysisModeOptionName, newOption);
         });
 
     QObject::connect(ui->debugOutputCheckBox, &QCheckBox::stateChanged, this,
@@ -634,7 +634,7 @@ void MainWindow::Activate()
         {
             bool newOption = newCheckState == Qt::Checked ? true : false;
             m_guiApplicationManager->GetAssetProcessorManager()->SetBuilderDebugFlag(newOption);
-            AssetUtilities::SetUserSetting("enableBuilderDebugFlag", newOption);
+            AssetUtilities::SetUserSetting(AssetUtilities::EnableBuilderDebugFlagOptionName, newOption);
         });
 
 
@@ -643,15 +643,14 @@ void MainWindow::Activate()
         {
             // this is not something that we change while running, so just set it for next time.
             bool newOption = newCheckState == Qt::Checked ? true : false;
-            AssetUtilities::SetUserSetting("initialScanSkippingEnabled", newOption);
+            AssetUtilities::SetUserSetting(AssetUtilities::SkipInitialScanOptionName, newOption);
         });
 
      QObject::connect(ui->verboseLoggingCheckbox, &QCheckBox::stateChanged, this,
         [](int newCheckState)
         {
             bool newOption = newCheckState == Qt::Checked ? true : false;
-            AssetUtilities::SetUserSetting("verboseLogging", newOption);
-            // Todo: Notify the log system immediately
+            AssetUtilities::SetUserSetting(AssetUtilities::VerboseLoggingOptionName, newOption);
         });
 
     // Shared Cache tab:

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -599,65 +599,60 @@ void MainWindow::Activate()
     AzQtComponents::CheckBox::applyToggleSwitchStyle(ui->modtimeSkippingCheckBox);
     AzQtComponents::CheckBox::applyToggleSwitchStyle(ui->disableStartupScanCheckBox);
     AzQtComponents::CheckBox::applyToggleSwitchStyle(ui->debugOutputCheckBox);
+    AzQtComponents::CheckBox::applyToggleSwitchStyle(ui->verboseLoggingCheckbox);
 
     const auto apm = m_guiApplicationManager->GetAssetProcessorManager();
 
-    // Note: the settings can't be used in ::MainWindow(), because the application name
-    // hasn't been set up and therefore the settings will load from somewhere different than later
-    // on.
-    // Read the current settings to give command line options a chance to override the default
-    QSettings settings;
-    settings.beginGroup("Options");
-    bool zeroAnalysisModeFromSettings = settings.value("EnableZeroAnalysis", QVariant(true)).toBool() || apm->GetModtimeSkippingFeatureEnabled();
-    bool enableBuilderDebugFlag = settings.value("EnableBuilderDebugFlag", QVariant(false)).toBool() || apm->GetBuilderDebugFlag();
-    bool initialScanSkippingEnabled = settings.value("SkipInitialScan", QVariant(false)).toBool() || apm->GetInitialScanSkippingFeatureEnabled();
-    settings.endGroup();
-
+    // Zero Analysis mode ("Fast scan mode") is enabled by default in the gui (running this mainwindow file), false in batch mode.
+    bool zeroAnalysisMode = AssetUtilities::GetUserSetting("zeroAnalysisMode", true);
+    bool enableBuilderDebugFlag = AssetUtilities::GetUserSetting("enableBuilderDebugFlag", apm->GetBuilderDebugFlag());
+    bool initialScanSkippingEnabled = AssetUtilities::GetUserSetting("initialScanSkippingEnabled", apm->GetInitialScanSkippingFeatureEnabled());
+    bool verboseLogDump = AssetUtilities::GetUserSetting("verboseLogging", false);
     // zero analysis flag
-    apm->SetEnableModtimeSkippingFeature(zeroAnalysisModeFromSettings);
-    ui->modtimeSkippingCheckBox->setCheckState(zeroAnalysisModeFromSettings ? Qt::Checked : Qt::Unchecked);
 
-    // Connect after updating settings to avoid saving a command line override
+    apm->SetEnableModtimeSkippingFeature(zeroAnalysisMode);
+    apm->SetBuilderDebugFlag(enableBuilderDebugFlag);
+    apm->SetInitialScanSkippingFeature(initialScanSkippingEnabled);
+
+    // first, update the visual checkboxes, and then connect to the "changed" notify
+    // so that we don't save settings applied by the apm command line
+    ui->modtimeSkippingCheckBox->setCheckState(zeroAnalysisMode ? Qt::Checked : Qt::Unchecked);
+    ui->debugOutputCheckBox->setCheckState(enableBuilderDebugFlag ? Qt::Checked : Qt::Unchecked);
+    ui->disableStartupScanCheckBox->setCheckState(initialScanSkippingEnabled ? Qt::Checked : Qt::Unchecked);
+    ui->verboseLoggingCheckbox->setCheckState(verboseLogDump ? Qt::Checked : Qt::Unchecked);
+
     QObject::connect(ui->modtimeSkippingCheckBox, &QCheckBox::stateChanged, this,
         [this](int newCheckState)
-    {
-        bool newOption = newCheckState == Qt::Checked ? true : false;
-        m_guiApplicationManager->GetAssetProcessorManager()->SetEnableModtimeSkippingFeature(newOption);
-        QSettings settingsInCallback;
-        settingsInCallback.beginGroup("Options");
-        settingsInCallback.setValue("EnableZeroAnalysis", QVariant(newOption));
-        settingsInCallback.endGroup();
-    });
-
-    // output debug flag
-    apm->SetBuilderDebugFlag(enableBuilderDebugFlag);
-    ui->debugOutputCheckBox->setCheckState(enableBuilderDebugFlag ? Qt::Checked : Qt::Unchecked);
+        {
+            bool newOption = newCheckState == Qt::Checked ? true : false;
+            m_guiApplicationManager->GetAssetProcessorManager()->SetEnableModtimeSkippingFeature(newOption);
+            AssetUtilities::SetUserSetting("zeroAnalysisMode", newOption);
+        });
 
     QObject::connect(ui->debugOutputCheckBox, &QCheckBox::stateChanged, this,
         [this](int newCheckState)
         {
             bool newOption = newCheckState == Qt::Checked ? true : false;
             m_guiApplicationManager->GetAssetProcessorManager()->SetBuilderDebugFlag(newOption);
-            QSettings settingsInCallback;
-            settingsInCallback.beginGroup("Options");
-            settingsInCallback.setValue("EnableBuilderDebugFlag", QVariant(newOption));
-            settingsInCallback.endGroup();
+            AssetUtilities::SetUserSetting("enableBuilderDebugFlag", newOption);
         });
 
-    apm->SetInitialScanSkippingFeature(initialScanSkippingEnabled);
-    ui->disableStartupScanCheckBox->setCheckState(initialScanSkippingEnabled ? Qt::Checked : Qt::Unchecked);
 
     QObject::connect(ui->disableStartupScanCheckBox, &QCheckBox::stateChanged, this,
         [](int newCheckState)
-    {
-        bool newOption = newCheckState == Qt::Checked ? true : false;
-        // don't change initial scan skipping feature value, as it's only relevant on the first scan
-        // save the value for the next run
-        QSettings settingsInCallback;
-        settingsInCallback.beginGroup("Options");
-        settingsInCallback.setValue("SkipInitialScan", QVariant(newOption));
-        settingsInCallback.endGroup();
-    });
+        {
+            // this is not something that we change while running, so just set it for next time.
+            bool newOption = newCheckState == Qt::Checked ? true : false;
+            AssetUtilities::SetUserSetting("initialScanSkippingEnabled", newOption);
+        });
+
+     QObject::connect(ui->verboseLoggingCheckbox, &QCheckBox::stateChanged, this,
+        [](int newCheckState)
+        {
+            bool newOption = newCheckState == Qt::Checked ? true : false;
+            AssetUtilities::SetUserSetting("verboseLogging", newOption);
+            // Todo: Notify the log system immediately
+        });
 
     // Shared Cache tab:
     SetupAssetServerTab();
@@ -1850,7 +1845,6 @@ void MainWindow::ResetLoggingPanel()
 {
     if (m_loggingPanel)
     {
-        m_loggingPanel->AddLogTab(AzToolsFramework::LogPanel::TabSettings("Debug", "", ""));
         m_loggingPanel->AddLogTab(AzToolsFramework::LogPanel::TabSettings("Messages", "", "", true, true, true, false));
         m_loggingPanel->AddLogTab(AzToolsFramework::LogPanel::TabSettings("Warnings/Errors Only", "", "", false, true, true, false));
     }

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -1546,7 +1546,7 @@
                <widget class="QLabel" name="fullScanHeader">
                 <property name="minimumSize">
                  <size>
-                  <width>170</width>
+                  <width>190</width>
                   <height>0</height>
                  </size>
                 </property>
@@ -1685,7 +1685,7 @@
                <widget class="QLabel" name="fastScanHeader">
                 <property name="minimumSize">
                  <size>
-                  <width>170</width>
+                  <width>190</width>
                   <height>0</height>
                  </size>
                 </property>
@@ -1830,7 +1830,7 @@
                <widget class="QLabel" name="disableStartupScanHeader">
                 <property name="minimumSize">
                  <size>
-                  <width>170</width>
+                  <width>190</width>
                   <height>0</height>
                  </size>
                 </property>
@@ -1963,7 +1963,7 @@
                <widget class="QLabel" name="debugOutputHeader">
                 <property name="minimumSize">
                  <size>
-                  <width>170</width>
+                  <width>190</width>
                   <height>0</height>
                  </size>
                 </property>
@@ -2114,7 +2114,7 @@
                <widget class="QLabel" name="logfileLevelHeader">
                 <property name="minimumSize">
                  <size>
-                  <width>170</width>
+                  <width>190</width>
                   <height>0</height>
                  </size>
                 </property>

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.ui
@@ -314,7 +314,7 @@
        <number>8</number>
       </property>
       <item>
-       <widget class="AzQtComponents::SegmentBar" name="buttonList">
+       <widget class="AzQtComponents::SegmentBar" name="buttonList" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -1537,7 +1537,7 @@
          </layout>
         </widget>
         <widget class="QWidget" name="SettingsPage">
-         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <layout class="QVBoxLayout" name="verticalLayout">
           <item>
            <layout class="QVBoxLayout" name="fullScanLayout">
             <item>
@@ -2095,10 +2095,161 @@
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>16</width>
-              <height>40</height>
+              <height>16</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="logFileLevelLayout">
+            <item>
+             <layout class="QHBoxLayout" name="logFileLevelLayoutLine">
+              <item>
+               <widget class="QLabel" name="logfileLevelHeader">
+                <property name="minimumSize">
+                 <size>
+                  <width>170</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="baseSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Verbose Logging Output&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_9">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="verboseLoggingCheckbox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>100</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_10">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="Line" name="line_5">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="baseSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: #616161;</string>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="logFileLevelLayoutDescription">
+              <item>
+               <widget class="QLabel" name="logFileLevelDescription">
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enables, outputs debugging data to the Asset Processor log files.  Slows down processing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="scaledContents">
+                 <bool>false</bool>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="indentSpacer4_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="gapSpacer5">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>16</width>
+              <height>77</height>
              </size>
             </property>
            </spacer>

--- a/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
@@ -31,8 +31,6 @@ namespace
     constexpr int MaxProcessingWaitTimeMs = 60 * 1000; // Wait up to 1 minute.  Give a generous amount of time to allow for slow CPUs
     const ScanFolderInfo TestScanFolderInfo("c:/samplepath", "sampledisplayname", "samplekey", false, false);
     const AZ::Uuid BuilderUuid = AZ::Uuid::CreateRandom();
-    constexpr int MinRCJobs = 1;
-    constexpr int MaxRCJobs = 4;
 }
 
 class MockRCJob
@@ -233,7 +231,7 @@ void RCcontrollerUnitTests::SetUp()
 {
     UnitTest::AssetProcessorUnitTestBase::SetUp();
 
-    m_rcController = AZStd::make_unique<AssetProcessor::RCController>(MinRCJobs, MaxRCJobs);
+    m_rcController = AZStd::make_unique<AssetProcessor::RCController>();
 
     QDir assetRootPath(m_assetDatabaseRequestsHandler->GetAssetRootDir().c_str());
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -60,6 +60,7 @@ namespace AssetProcessor
     //! we filter the main app logs to only include non-job-thread messages:
     class FilteredLogComponent
         : public AzFramework::LogComponent
+        , public AssetUtilities::AssetProcessorUserSettingsNotificationBus::Handler
     {
     public:
         AZ_CLASS_ALLOCATOR(FilteredLogComponent, AZ::SystemAllocator)
@@ -90,11 +91,40 @@ namespace AssetProcessor
                 return;
             }
 
-            AzFramework::LogComponent::OutputMessage(severity, window, message);
+            if ((m_verboseMode) || (severity >= AzFramework::LogFile::SEV_NORMAL))
+            {
+                AzFramework::LogComponent::OutputMessage(severity, window, message);
+            }
+        }
+
+        void Activate() override
+        {
+            if (auto* registry = AZ::SettingsRegistry::Get())
+            {
+                m_verboseMode = AssetUtilities::GetUserSetting("logVerbosity", false);
+            }
+
+            AssetUtilities::AssetProcessorUserSettingsNotificationBus::Handler::BusConnect();
+            AzFramework::LogComponent::Activate();
+        }
+
+        void Deactivate() override
+        {
+            AzFramework::LogComponent::Deactivate();
+            AssetUtilities::AssetProcessorUserSettingsNotificationBus::Handler::BusDisconnect();
+        }
+
+        void OnSettingChanged(const AZStd::string_view& settingName) override
+        {
+            if (settingName == "logVerbosity")
+            {
+                m_verboseMode = AssetUtilities::GetUserSetting("logVerbosity", false);
+            }
         }
 
     protected:
         bool m_inException = false;
+        bool m_verboseMode = false;
     };
 }
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -101,7 +101,7 @@ namespace AssetProcessor
         {
             if (auto* registry = AZ::SettingsRegistry::Get())
             {
-                m_verboseMode = AssetUtilities::GetUserSetting("logVerbosity", false);
+                m_verboseMode = AssetUtilities::GetUserSetting(AssetUtilities::VerboseLoggingOptionName, false);
             }
 
             AssetUtilities::AssetProcessorUserSettingsNotificationBus::Handler::BusConnect();
@@ -116,9 +116,9 @@ namespace AssetProcessor
 
         void OnSettingChanged(const AZStd::string_view& settingName) override
         {
-            if (settingName == "logVerbosity")
+            if (settingName == AssetUtilities::VerboseLoggingOptionName)
             {
-                m_verboseMode = AssetUtilities::GetUserSetting("logVerbosity", false);
+                m_verboseMode = AssetUtilities::GetUserSetting(AssetUtilities::VerboseLoggingOptionName, false);
             }
         }
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -383,7 +383,7 @@ void ApplicationManagerBase::ConnectAssetCatalog()
 
 void ApplicationManagerBase::InitRCController()
 {
-    m_rcController = new AssetProcessor::RCController(m_platformConfiguration->GetMinJobs(), m_platformConfiguration->GetMaxJobs());
+    m_rcController = new AssetProcessor::RCController();
 
     QObject::connect(m_assetProcessorManager, &AssetProcessor::AssetProcessorManager::AssetToProcess, m_rcController, &AssetProcessor::RCController::JobSubmitted);
     QObject::connect(m_rcController, &AssetProcessor::RCController::FileCompiled, m_assetProcessorManager, &AssetProcessor::AssetProcessorManager::AssetProcessed, Qt::UniqueConnection);

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -24,7 +24,7 @@
 #include <native/FileWatcher/FileWatcher.h>
 #include <native/utilities/ApplicationServer.h>
 #include <native/utilities/AssetServerHandler.h>
-#include <native/utilities/AssetUtils.h>
+#include <native/utilities/assetUtils.h>
 #include <native/InternalBuilders/SettingsRegistryBuilder.h>
 #include <AzToolsFramework/Application/Ticker.h>
 #include <AzToolsFramework/ToolsFileUtils/ToolsFileUtils.h>

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -24,6 +24,7 @@
 #include <native/FileWatcher/FileWatcher.h>
 #include <native/utilities/ApplicationServer.h>
 #include <native/utilities/AssetServerHandler.h>
+#include <native/utilities/AssetUtils.h>
 #include <native/InternalBuilders/SettingsRegistryBuilder.h>
 #include <AzToolsFramework/Application/Ticker.h>
 #include <AzToolsFramework/ToolsFileUtils/ToolsFileUtils.h>
@@ -166,7 +167,7 @@ void ApplicationManagerBase::InitAssetProcessorManager(AZStd::vector<Application
     AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetCommandLine);
 
     const APCommandLineSwitch Command_waitOnLaunch(commandLineInfo, "waitOnLaunch", "Briefly pauses Asset Processor during initializiation. Useful if you want to attach a debugger.");
-    const APCommandLineSwitch Command_zeroAnalysisMode(commandLineInfo, "zeroAnalysisMode", "Enables using file modification time when examining source assets for processing.");
+    const APCommandLineSwitch Command_zeroAnalysisMode(commandLineInfo, AssetUtilities::ZeroAnalysisModeOptionName, "Enables using file modification time when examining source assets for processing.");
     const APCommandLineSwitch Command_enableQueryLogging(commandLineInfo, "enableQueryLogging", "Enables logging database queries.");
     const APCommandLineSwitch Command_dependencyScanPattern(commandLineInfo, "dependencyScanPattern", "Scans assets that match the given pattern for missing product dependencies.");
     const APCommandLineSwitch Command_dsp(commandLineInfo, "dsp", Command_dependencyScanPattern.m_helpText);

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -18,6 +18,7 @@
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QMessageBox>
+#include <QProcess>
 #include <QSettings>
 
 #include <AzQtComponents/Components/StyleManager.h>

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -627,8 +627,6 @@ namespace AssetProcessor
 
     PlatformConfiguration::PlatformConfiguration(QObject* pParent)
         : QObject(pParent)
-        , m_minJobs(1)
-        , m_maxJobs(8)
     {
     }
 
@@ -1132,19 +1130,7 @@ namespace AssetProcessor
         AZ::IO::FixedMaxPath engineRoot(AZ::IO::PosixPathSeparator);
         settingsRegistry->Get(engineRoot.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
         engineRoot = engineRoot.LexicallyNormal(); // Normalize the path to use posix slashes
-
-        AZ::s64 jobCount = m_minJobs;
-        if (settingsRegistry->Get(jobCount, AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorSettingsKey) + "/Jobs/minJobs"))
-        {
-            m_minJobs = aznumeric_cast<int>(jobCount);
-        }
-
-        jobCount = m_maxJobs;
-        if (settingsRegistry->Get(jobCount, AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorSettingsKey) + "/Jobs/maxJobs"))
-        {
-            m_maxJobs = aznumeric_cast<int>(jobCount);
-        }
-
+       
         if (!skipScanFolders)
         {
             AZStd::unordered_map<AZStd::string, AZ::IO::Path> gemNameToPathMap;
@@ -1840,16 +1826,6 @@ namespace AssetProcessor
             {
                 return scanFolder.ScanPath() == scanFolderPath;
             });
-    }
-
-    int PlatformConfiguration::GetMinJobs() const
-    {
-        return m_minJobs;
-    }
-
-    int PlatformConfiguration::GetMaxJobs() const
-    {
-        return m_maxJobs;
     }
 
     void PlatformConfiguration::EnableCommonPlatform()

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
@@ -36,7 +36,6 @@ namespace AZ
 
 namespace AssetProcessor
 {
-    inline constexpr const char* AssetProcessorSettingsKey{ "/Amazon/AssetProcessor/Settings" };
     inline constexpr const char* AssetProcessorServerKey{ "/O3DE/AssetProcessor/Settings/Server" };
     class PlatformConfiguration;
     class ScanFolderInfo;
@@ -177,10 +176,6 @@ namespace AssetProcessor
         bool IsMetaDataTypeRealFile(QString relativeName) const;
 
         void EnablePlatform(const AssetBuilderSDK::PlatformInfo& platform, bool enable = true);
-
-        //! Gets the minumum jobs specified in the configuration file
-        int GetMinJobs() const;
-        int GetMaxJobs() const;
 
         void EnableCommonPlatform();
         void AddIntermediateScanFolder();
@@ -331,9 +326,6 @@ namespace AssetProcessor
         QSet<QString> m_metaDataRealFiles;
         AZStd::vector<AzFramework::GemInfo> m_gemInfoList;
         mutable AZ::s64 m_intermediateAssetScanFolderId = -1; // Cached ID for intermediate scanfolder, for quick lookups
-
-        int m_minJobs = 1;
-        int m_maxJobs = 3;
 
         // used only during file read, keeps the total running list of all the enabled platforms from all config files and command lines
         AZStd::vector<AZStd::string> m_tempEnabledPlatforms;

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -9,6 +9,7 @@
 
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Math/Sha1.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 #include <native/assetprocessor.h>
 #include <native/utilities/PlatformConfiguration.h>
@@ -171,10 +172,9 @@ namespace AssetUtilsInternal
         constexpr AZStd::string_view BootstrapSettingsKey = AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey;
         constexpr AZStd::string_view UserSettingsKey = AssetProcessorUserSettingsRootKey;
 
-        auto allowedListKey = AZ::SettingsRegistryInterface::FixedValueString(BootstrapSettingsKey) + "/allowed_list";
-        auto branchTokenKey = AZ::SettingsRegistryInterface::FixedValueString(BootstrapSettingsKey) + "/assetProcessor_branch_token";
-        auto generalUserSettingsKey = AZ::SettingsRegistryInterface::FixedValueString(UserSettingsKey);
-
+        const auto allowedListKey = AZ::SettingsRegistryInterface::FixedValueString(BootstrapSettingsKey) + "/allowed_list";
+        const auto branchTokenKey = AZ::SettingsRegistryInterface::FixedValueString(BootstrapSettingsKey) + "/assetProcessor_branch_token";
+        const auto generalUserSettingsKey = AZ::SettingsRegistryInterface::FixedValueString(UserSettingsKey);
 
         AZStd::string apSettingsJson;
         AZ::IO::ByteContainerStream apSettingsStream(&apSettingsJson);

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -66,6 +66,9 @@ namespace AssetUtilsInternal
     // This is because Qt has to init random number gen on each thread.
     AZ_THREAD_LOCAL bool g_hasInitializedRandomNumberGenerator = false;
 
+    constexpr AZStd::string_view AssetProcessorUserSetregRelPath = "user/Registry/asset_processor.setreg";
+
+
     // so that even if we do init two seeds at exactly the same msec time, theres still this extra
     // changing number
     static AZStd::atomic_int g_randomNumberSequentialSeed;
@@ -158,11 +161,21 @@ namespace AssetUtilsInternal
         return true;
     }
 
-    static bool DumpAssetProcessorUserSettingsToFile(AZ::SettingsRegistryInterface& settingsRegistry,
-        const AZ::IO::FixedMaxPath& setregPath)
+    static bool DumpAssetProcessorUserSettingsToFile(AZ::SettingsRegistryInterface& settingsRegistry)
     {
-        // The AssetProcessor settings are currently under the Bootstrap object(This may change in the future
-        constexpr AZStd::string_view AssetProcessorUserSettingsRootKey = AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey;
+        using namespace AssetUtilities;
+        AZ::IO::FixedMaxPath setregPath = AZ::Utils::GetProjectPath();
+        setregPath /= AssetProcessorUserSetregRelPath;
+
+        // AssetProcessor saves Bootstrap settings and user settings
+        constexpr AZStd::string_view BootstrapSettingsKey = AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey;
+        constexpr AZStd::string_view UserSettingsKey = AssetProcessorUserSettingsRootKey;
+
+        auto allowedListKey = AZ::SettingsRegistryInterface::FixedValueString(BootstrapSettingsKey) + "/allowed_list";
+        auto branchTokenKey = AZ::SettingsRegistryInterface::FixedValueString(BootstrapSettingsKey) + "/assetProcessor_branch_token";
+        auto generalUserSettingsKey = AZ::SettingsRegistryInterface::FixedValueString(UserSettingsKey);
+
+
         AZStd::string apSettingsJson;
         AZ::IO::ByteContainerStream apSettingsStream(&apSettingsJson);
 
@@ -170,23 +183,16 @@ namespace AssetUtilsInternal
         apDumperSettings.m_prettifyOutput = true;
         AZ_PUSH_DISABLE_WARNING(5233, "-Wunknown-warning-option") // Older versions of MSVC toolchain require to pass constexpr in the
                                                                   // capture. Newer versions issue unused warning
-        apDumperSettings.m_includeFilter = [&AssetProcessorUserSettingsRootKey](AZStd::string_view path)
+        apDumperSettings.m_includeFilter = [&allowedListKey, &branchTokenKey, &generalUserSettingsKey](AZStd::string_view path)
         AZ_POP_DISABLE_WARNING
         {
-            // The AssetUtils only updates the following keys in the registry
-            // Dump them all out to the setreg file
-            auto allowedListKey = AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorUserSettingsRootKey)
-                + "/allowed_list";
-            auto branchTokenKey = AZ::SettingsRegistryInterface::FixedValueString(AssetProcessorUserSettingsRootKey)
-                + "/assetProcessor_branch_token";
             // The objects leading up to the keys to dump must be included in order the keys to be dumped
-            return allowedListKey.starts_with(path.substr(0, allowedListKey.size()))
-                || branchTokenKey.starts_with(path.substr(0, branchTokenKey.size()));
+            return allowedListKey.starts_with(path.substr(0, allowedListKey.size())) ||
+                   branchTokenKey.starts_with(path.substr(0, branchTokenKey.size())) ||
+                   generalUserSettingsKey.starts_with(path.substr(0, generalUserSettingsKey.size()));
         };
-        apDumperSettings.m_jsonPointerPrefix = AssetProcessorUserSettingsRootKey;
 
-        if (AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(settingsRegistry, AssetProcessorUserSettingsRootKey,
-            apSettingsStream, apDumperSettings))
+        if (AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(settingsRegistry, "", apSettingsStream, apDumperSettings))
         {
             constexpr const char* AssetProcessorTmpSetreg = "asset_processor.setreg.tmp";
             // Write to a temporary file first before renaming it to the final file location
@@ -219,8 +225,7 @@ namespace AssetUtilsInternal
         }
         else
         {
-            AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Dump of AssetProcessor User Settings failed at JSON pointer %.*s \n",
-                aznumeric_cast<int>(AssetProcessorUserSettingsRootKey.size()), AssetProcessorUserSettingsRootKey.data());
+            AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Dump of AssetProcessor User Settings failed. \n");
         }
 
         return false;
@@ -229,8 +234,6 @@ namespace AssetUtilsInternal
 
 namespace AssetUtilities
 {
-    constexpr AZStd::string_view AssetProcessorUserSetregRelPath = "user/Registry/asset_processor.setreg";
-
     // do not place Qt objects in global scope, they allocate and refcount threaded data.
     AZ::SettingsRegistryInterface::FixedValueString s_projectPath;
     AZ::SettingsRegistryInterface::FixedValueString s_projectName;
@@ -614,9 +617,6 @@ namespace AssetUtilities
 
     bool WriteAllowedlistToSettingsRegistry(const QStringList& newAllowedList)
     {
-        AZ::IO::FixedMaxPath assetProcessorUserSetregPath = AZ::Utils::GetProjectPath();
-        assetProcessorUserSetregPath /= AssetProcessorUserSetregRelPath;
-
         auto settingsRegistry = AZ::SettingsRegistry::Get();
         if (!settingsRegistry)
         {
@@ -649,7 +649,7 @@ namespace AssetUtilities
         AZStd::string azNewAllowedList{ newAllowedList.join(',').toUtf8().constData() };
         settingsRegistry->Set(allowedListKey, azNewAllowedList);
 
-        return AssetUtilsInternal::DumpAssetProcessorUserSettingsToFile(*settingsRegistry, assetProcessorUserSetregPath);
+        return AssetUtilsInternal::DumpAssetProcessorUserSettingsToFile(*settingsRegistry);
     }
 
     quint16 ReadListeningPortFromSettingsRegistry(QString initialFolder /*= QString()*/)
@@ -944,9 +944,6 @@ namespace AssetUtilities
 
     bool UpdateBranchToken()
     {
-        AZ::IO::FixedMaxPath assetProcessorUserSetregPath = AZ::Utils::GetProjectPath();
-        assetProcessorUserSetregPath /= AssetProcessorUserSetregRelPath;
-
         AZStd::string appBranchToken;
         AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::CalculateBranchTokenForEngineRoot, appBranchToken);
 
@@ -964,21 +961,21 @@ namespace AssetUtilities
             if (appBranchToken == registryBranchToken)
             {
                 // no need to update, branch token match
-                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Branch token (%s) is already correct in (%s)\n", appBranchToken.c_str(), assetProcessorUserSetregPath.c_str());
+                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Branch token (%s) is already correct, not updating\n", appBranchToken.c_str());
                 return true;
             }
 
-            AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Updating branch token (%s) in (%s)\n", appBranchToken.c_str(), assetProcessorUserSetregPath.c_str());
+            AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Updating branch token (%s)\n", appBranchToken.c_str());
         }
         else
         {
-            AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Adding branch token (%s) in (%s)\n", appBranchToken.c_str(), assetProcessorUserSetregPath.c_str());
+            AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Adding branch token (%s)\n", appBranchToken.c_str());
         }
 
         // Update Settings Registry with new token
         settingsRegistry->Set(branchTokenKey, appBranchToken);
 
-        return AssetUtilsInternal::DumpAssetProcessorUserSettingsToFile(*settingsRegistry, assetProcessorUserSetregPath);
+        return AssetUtilsInternal::DumpAssetProcessorUserSettingsToFile(*settingsRegistry);
     }
 
     QString ComputeJobDescription(const AssetProcessor::AssetRecognizer* recognizer)
@@ -1051,6 +1048,61 @@ namespace AssetUtilities
         response.m_isSuccess = true;
         return ReadJobLogResult::Success;
     }
+
+    template<typename T>
+    bool SetUserSetting(const char* settingName, T value)
+    {
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        {
+            constexpr AZStd::string_view UserSettingsKey = AssetProcessorUserSettingsRootKey;
+            auto settingKey = AZ::SettingsRegistryInterface::FixedValueString(UserSettingsKey) + "/" + settingName;
+            bool wasSet = settingsRegistry->Set(settingKey, value);
+            if (wasSet)
+            {
+                AssetProcessorUserSettingsNotificationBus::Broadcast(&AssetProcessorUserSettingsNotificationBus::Events::OnSettingChanged, settingName);
+                return AssetUtilsInternal::DumpAssetProcessorUserSettingsToFile(*settingsRegistry);
+            }
+        }
+
+        return false;
+    }
+    template<typename T>
+    T GetUserSetting(const char* settingName, T defaultValue)
+    {
+        T resultValue = defaultValue;
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        {
+            constexpr AZStd::string_view UserSettingsKey = AssetProcessorUserSettingsRootKey;
+            auto settingKey = AZ::SettingsRegistryInterface::FixedValueString(UserSettingsKey) + "/" + settingName;
+            settingsRegistry->Get(resultValue, settingKey);
+        }
+        return resultValue;
+    }
+
+    bool SaveSettingsFile()
+    {
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        {
+            return AssetUtilsInternal::DumpAssetProcessorUserSettingsToFile(*settingsRegistry);
+        }
+        return false;
+    }
+
+    // we implement these for the types the settings registry allows
+    template bool SetUserSetting<bool>(const char* settingName, bool value);
+    template bool GetUserSetting<bool>(const char* settingName, bool defaultValue);
+
+    template bool SetUserSetting<AZ::s64>(const char* settingName, AZ::s64 value);
+    template AZ::s64 GetUserSetting<AZ::s64>(const char* settingName, AZ::s64 defaultValue);
+
+    template bool SetUserSetting<AZ::u64>(const char* settingName, AZ::u64 value);
+    template AZ::u64 GetUserSetting<AZ::u64>(const char* settingName, AZ::u64 defaultValue);
+
+    template bool SetUserSetting<double>(const char* settingName, double value);
+    template double GetUserSetting<double>(const char* settingName, double defaultValue);
+
+    template bool SetUserSetting<AZStd::string>(const char* settingName, AZStd::string value);
+    template AZStd::string GetUserSetting<AZStd::string>(const char* settingName, AZStd::string defaultValue);
 
     unsigned int GenerateFingerprint(const AssetProcessor::JobDetails& jobDetail)
     {

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -52,7 +52,12 @@ namespace AssetProcessor
 
 namespace AssetUtilities
 {
+    // option and parameter names
     inline constexpr char ProjectPathOverrideParameter[] = "project-path";
+    inline constexpr char ZeroAnalysisModeOptionName[] = "zeroAnalysisMode";
+    inline constexpr char EnableBuilderDebugFlagOptionName[] = "enableBuilderDebugFlag";
+    inline constexpr char SkipInitialScanOptionName[] = "initialScanSkippingEnabled";
+    inline constexpr char VerboseLoggingOptionName[] = "verboseLogging";
 
     //! You can read and write any sub-keys to this key and it will be persisted to the project user registry folder:
     inline constexpr AZStd::string_view AssetProcessorUserSettingsRootKey = "/O3DE/AssetProcessor/UserSettings";

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
@@ -34,11 +34,16 @@ namespace AZ
             ATOM_RPI_REFLECT_API Data::AssetId GetAssetIdForProductPath(const char* productPath, TraceLevel reporting = TraceLevel::Warning, Data::AssetType assetType = Data::s_invalidAssetType);
 
             //! Tries to compile the asset at the given product path.
-            //! This will actively try to compile the asset every time it is called, it won't skip compilation just because the
-            //! asset exists. This should only be used for assets that need to be at their most up-to-date version of themselves
+            //! This will check with the Asset processor whenever it is called, even if the asset is already compiled before.
+            //! It will return instantly if the asset does not exist and cannot be found by the asset processor, or if the
+            //! asset processor is not running or connected.  It only takes time if the asset processor is VERY busy (cpu throttled)
+            //! or if the asset needs to be compiled.
+            //! 
+            //! This should only be used for assets that need to be at their most up-to-date version of themselves
             //! before getting loaded into the engine, as it can take seconds to minutes for this call to return. It is synchronously
             //! asking the Asset Processor to compile the asset, and then blocks until it gets a result. If the AP is busy, it can
             //! take a while to get a result even if the asset is already up-to-date.
+            //! 
             //! In release builds where the AP isn't connected this will immediately return with "Unknown".
             //! @param assetProductFilePath - the relative file path to the product asset (ex: default/models/sphere.azmodel)
             //! @param reporting - the reporting level to use for problems.
@@ -48,6 +53,10 @@ namespace AZ
             //! (Compiled, Failed, Missing, etc), but if this is called *before* the AP is connected, it's possible to get Unknown
             //! even when you think the AP is (or will be) connected.
             ATOM_RPI_REFLECT_API bool TryToCompileAsset(const AZStd::string& assetProductFilePath, TraceLevel reporting);
+
+            //! Given an asssetID, ensures that it is compiled and ready to load, if it exists.
+            //! Same caveats as above
+            ATOM_RPI_REFLECT_API bool TryToCompileAsset(const AZ::Data::AssetId& assetId, TraceLevel reporting);
 
             //! Gets an Asset<AssetDataT> reference for a given product file path. This function does not cause the asset to load.
             //! @return a null asset if the asset could not be found.

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -183,18 +183,6 @@ namespace AZ
                 }
             }
 
-            // Assign dependencies from image properties
-            for (const auto& [propertyId, propertyValue] : materialSourceData.GetPropertyValues())
-            {
-                AZ_UNUSED(propertyId);
-
-                if (MaterialUtils::LooksLikeImageFileReference(propertyValue))
-                {
-                    MaterialBuilderUtils::AddPossibleImageDependencies(
-                        materialSourcePath, propertyValue.GetValue<AZStd::string>(), outputJobDescriptor);
-                }
-            }
-
             // Create the output jobs for each platform
             for (const AssetBuilderSDK::PlatformInfo& platformInfo : request.m_enabledPlatforms)
             {
@@ -285,6 +273,8 @@ namespace AZ
                 return;
             }
 
+            MaterialBuilderUtils::AddImageAssetDependenciesToProduct(materialAsset.Get(), jobProduct);
+           
             response.m_outputProducts.emplace_back(AZStd::move(jobProduct));
 
             response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
@@ -14,6 +14,9 @@ namespace AZ
 {
     namespace RPI
     {
+        class MaterialAsset;
+        class MaterialTypeAsset;
+
         namespace MaterialBuilderUtils
         {
             //! @brief configure and register a job dependency with the job descriptor
@@ -33,14 +36,14 @@ namespace AZ
                 const AZStd::vector<AZ::u32>& subIds = {},
                 const bool updateFingerprint = true);
 
-            //! Resolve potential paths and add source and job dependencies for image assets
-            //! @param originatingSourceFilePath The path of the .material or .materialtype file being processed
-            //! @param referencedSourceFilePath The path to the referenced file as it appears in the current file
-            //! @param jobDescriptor Used to update job dependencies
-            void AddPossibleImageDependencies(
-                const AZStd::string& originatingSourceFilePath,
-                const AZStd::string& referencedSourceFilePath,
-                AssetBuilderSDK::JobDescriptor& jobDescriptor);
+            //! Given a material asset that has been fully built and prepared,
+            //! add any image dependencies as pre-load dependencies, to the job being emitted.
+            //! This will cause them to auto preload as part of loading the material, as well as make sure
+            //! they are included in any pak files shipped with the product.
+            void AddImageAssetDependenciesToProduct(const AZ::RPI::MaterialAsset* materialAsset, AssetBuilderSDK::JobProduct& product);
+
+            //! Same as the above overload, but for material TYPE assets.
+            void AddImageAssetDependenciesToProduct(const AZ::RPI::MaterialTypeAsset* materialTypeAsset, AssetBuilderSDK::JobProduct& product);
 
             //! Append a fingerprint value to the job descriptor using the file modification time of the specified file path
             void AddFingerprintForDependency(const AZStd::string& path, AssetBuilderSDK::JobDescriptor& jobDescriptor);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -256,18 +256,6 @@ namespace AZ
                     return true;
                 });
 
-            materialTypeSourceData.EnumerateProperties(
-                [&outputJobDescriptor, &materialTypeSourcePath](const MaterialPropertySourceData* property, const MaterialNameContext&)
-                {
-                    if (property->m_dataType == MaterialPropertyDataType::Image &&
-                        MaterialUtils::LooksLikeImageFileReference(property->m_value))
-                    {
-                        MaterialBuilderUtils::AddPossibleImageDependencies(
-                            materialTypeSourcePath, property->m_value.GetValue<AZStd::string>(), outputJobDescriptor);
-                    }
-                    return true;
-                });
-
             for (const auto& pipelinePair : materialTypeSourceData.m_pipelineData)
             {
                 addFunctorDependencies(pipelinePair.second.m_materialFunctorSourceData);
@@ -897,6 +885,8 @@ namespace AZ
                     AZ_Error(MaterialTypeBuilderName, false, "Failed to output product dependencies.");
                     return;
                 }
+
+                MaterialBuilderUtils::AddImageAssetDependenciesToProduct(materialTypeAsset.Get(), jobProduct);
 
                 response.m_outputProducts.emplace_back(AZStd::move(jobProduct));
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
@@ -459,18 +459,9 @@ namespace AZ
                 "Model id " AZ_STRING_FORMAT " not found in asset catalog, using fallback model.\n",
                 AZ_STRING_ARG(asset.GetId().ToFixedString()));
 
-            // Find out if the asset is missing completely or just still processing
-            // and escalate the asset to the top of the list if it's queued.
-            AzFramework::AssetSystem::AssetStatus missingAssetStatus = AzFramework::AssetSystem::AssetStatus::AssetStatus_Unknown;
-            AzFramework::AssetSystemRequestBus::BroadcastResult(
-                missingAssetStatus, &AzFramework::AssetSystem::AssetSystemRequests::GetAssetStatusById, asset.GetId().m_guid);
-
-            if (missingAssetStatus == AzFramework::AssetSystem::AssetStatus::AssetStatus_Queued)
-            {
-                bool sendSucceeded = false;
-                AzFramework::AssetSystemRequestBus::BroadcastResult(
-                    sendSucceeded, &AzFramework::AssetSystem::AssetSystemRequests::EscalateAssetByUuid, asset.GetId().m_guid);
-            }
+            // escalate the asset to the top of the processing list, if it can be (this is a fire and forget message that puts it in the queue
+            // and returns instantly, without waiting). 
+            AzFramework::AssetSystemRequestBus::Broadcast(&AzFramework::AssetSystem::AssetSystemRequests::EscalateAssetByUuid, asset.GetId().m_guid);
 
             // Make sure the default model asset has an entry in the asset catalog so that the asset system will try to load it.
             // Note that we specifically give it a 0-byte size and a non-empty path so that the load will just trivially succeed

--- a/Registry/settings.assetprocessorbatch.setreg
+++ b/Registry/settings.assetprocessorbatch.setreg
@@ -1,0 +1,19 @@
+{
+    // This file is only loaded by the AssetProcessorBatch executable.
+    "Amazon": {
+        "AssetProcessor": {
+            "Settings": {
+                "Jobs": {
+                    // maxJobs 0 means use an automatic amount of CPU cores, detected from hardware.
+                    "maxJobs" : 0,  
+
+                    // AlwaysUseMaxJobs: true means always use maxJobs CPUs at all time.
+                    // The default behavior for AP is to reserve half CPUs for background work
+                    // and half CPUs for escalated (user requested) and critical work.
+                    // Batch is usually used in CLI or automated builds,  so no need.
+                    "AlwaysUseMaxJobs": true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Its a basic rework of how the user options in AssetProcessor work (move away from QSettings, which is a global settings options that goes in your windows registry, to SetReg instead).

### User Settings changes:
* Asset Processor `AssetUtilities::` now has a Set User Setting, Get User Setting, and a change notify for user settings, utility functions.
* Existing settings on the `settings` page moved over to this new system to avoid bleeding settings across projects
* new "Log verbosity" option to stop logs from becoming hundreds of megabytes long unless you want it.  Takes effect instantly.
* Minjobs (useless setting) removed.
* MaxJobs setting retained but its now read by the thing that uses it instead (the actual job queue controller that starts jobs).
![image](https://github.com/user-attachments/assets/6be20aa3-1d4d-41e2-8f54-420fc04d37a0)

### Job Queue changes
* MaterialBuilder no longer specifies that all textures are job dependencies of materials (this was unnecessary and made it so that textures were escalated above other asset types).
* AssetProcessor escalates jobs that are blocking critical jobs from starting instead of just waiting for them to happen naturally.
* AssetProcessor reserves half jof the CPU cores for critical jobs.  When no critical jobs are running, it uses fewer cores to give more CPU usage to the editor to maintain framerates.  Batch version keeps using all cpus.
* Setting added to make AP use all cores instead, and that setting is set to true in the AssetProcessorBatch, false (default) in all other situations.
* Escalating a job (so when the editor asks for you to compile an asset immediately) causes a dispatch of the job queue, so that it can immediately use up those reserved slots.
* Common platform jobs are now critical jobs by default, because they are jobs which generate other jobs, which themselves could be critical.

### Misc changes
* Utility function to dump the job queue for debugging
* Cleaning up incorrect comments or outputs
* Removing using Qt to discover cores in favor of std.
* Renamed an enum value in AssetProcessor namespace from `AssetProcessor::Default` to `AssetProcessor::DefaultEscalation` - `Default` is not a good name for something in that entire namespace.  (not an enum class!)
* Sped up escalation by adding a escalate-by-queueid function
* Sped up escalation by not escalating jobs already escalated.

Timing WITH new changes (starting editor with no cache)
  *   42s (  42s total) analyzing
  * 2m45s (3m28s total) "Asset Processor working..."
  * 1m15s (4m44s total) 60fps interactive editor with defaultlevel (meshes still compiling)

Timing WITHOUT the new changes (starting editor with no cache)
  *   42s (  42s total) analyzing (I did not change analyze so this makes sense)
  * 3m34s (4m18s total) "Asset processor working..."
  * 1m22s (5m40s total) 10-20 fps interactive editor with defaultlevel (meshes still compiling)

So about a 45s saving on "Asset Processor Working" and about 56s total saving with a 60fps editor while it works in background.

Both timings were captured with all other variables hte same, and were performed on a "hot" file cache, as in, run it once, then clear cache
and immediately run it again to get official timings.    The timing
on a cold cache for the new changes is even more of a difference than
a cold cache without the changes.

## How was this PR tested?

Starting AP from scratch repeatedly and opening up the default level as soon as its possible to do so, making sure no crash, and that the level eventually fully loads.
