### PR TITLE
Fix viewport drop handler catching all events

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Utilities/ViewportDragDropHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Utilities/ViewportDragDropHandler.cpp
@@ -80,6 +80,11 @@ void ScriptCanvasAssetDragDropHandler::DragEnter(QDragEnterEvent* event, AzQtCom
         QFileInfo info(absPath);
         QString extension = info.completeSuffix();
 
+        if (extension.compare("scriptcanvas", Qt::CaseInsensitive) != 0)
+        {
+            break;
+        }
+
         // if it's not an empty folder directory or if it's a file,
         // then allow the drag and drop process.
         // Otherwise, prevent users from dragging and dropping empty folders


### PR DESCRIPTION
## What does this PR do?

The drag/drop viewport handler for Script Canvas was accepting drag events regardless of the file type in the mime data. This fix brings back the correct behavior when dragging other asset types into the viewport.

Currently will not support dragging multiple assets of different types.

## How was this PR tested?

Drag/dropping Script Canvas and FBX files into the viewport ensuring the correct entity with the correct components is created