### PR TITLE
Adds ChangeNotify callback to containers.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -161,6 +161,7 @@ namespace AZ::DocumentPropertyEditor
                 // notify the new value in the container so that listeners can update dom / store overrides / undo redo
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
                 impl->m_adapter->NotifyResetDocument();
@@ -175,8 +176,8 @@ namespace AZ::DocumentPropertyEditor
                 // Notify that the document has changed with the new value in the container:
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
-
                 // rebuild the view based on the new contents, which could be many rows.
                 // This deletes the 'this' pointer!
                 impl->m_adapter->NotifyResetDocument(); 
@@ -471,6 +472,7 @@ namespace AZ::DocumentPropertyEditor
                 // notify about the new values in the container:
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
                 impl->m_adapter->NotifyResetDocument();
@@ -484,6 +486,7 @@ namespace AZ::DocumentPropertyEditor
                 //  notify about the new values in the container:
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
+                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
                 impl->m_adapter->NotifyResetDocument();


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/19015 where changing a container with the container buttons (add, clear, remove, change order) would not issue the change notify callback.

Containers take a different path through the Reflection / Propery editor system than other types, so the ChangeNotify being sent from the other code simply wasn't being invoked.

## How was this PR tested?

Tested using the Tag Component.  It has a vector of vector of elementss and a change notify attached.

I did clear-box testing - that is, set a breakpoint in the Tag Component's Change Notify function and then trigger the various container editing functions.

I tested it using both prefabs (so overrides) and regular edits without prefabs, in debug builds.
I tested it with **Address Sanitizer enabled**, scanning for use-after-free, etc, no issues.
