### PR TITLE
Fix some issues with drag interactivity in the Asset AssetBrowser

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -1321,7 +1321,7 @@ namespace AzQtComponents
         bool isLeftButton = (m_queuedMouseEvent->button() == Qt::LeftButton);
         if (!isLeftButton)
         {
-            // we don't support right-drgging
+            // we don't support right-dragging
             return;
         }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -29,6 +29,8 @@ AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: 'in
 #include <QStyledItemDelegate>
 #include <QTextDocument>
 #include <QTimer>
+#include <QApplication>
+
 AZ_POP_DISABLE_WARNING
 
 namespace
@@ -1309,9 +1311,30 @@ namespace AzQtComponents
 
     void AssetFolderThumbnailView::HandleDrag()
     {
+        // m_queuedMouseEvent is the state of the mouse when the drag operation started
+        // since then, it has moved to m_mousePosition.
+        if (!m_queuedMouseEvent)
+        {
+            return;
+        }
+
+        bool isLeftButton = (m_queuedMouseEvent->button() == Qt::LeftButton);
+        if (!isLeftButton)
+        {
+            // we don't support right-drgging
+            return;
+        }
+
+        // Only start a drag if the mouse has moved far enough since the button was held down:
+        const int moveDistance = (m_queuedMouseEvent->pos() - m_mousePosition).manhattanLength();
+
+        if (moveDistance < QApplication::startDragDistance())
+        {
+            return;
+        }
+
         // Retrieve the index at the click position.
         QModelIndex indexAtClick = indexAt(m_queuedMouseEvent->pos()).siblingAtColumn(0);
-
         // If the index is selected, we should move the whole selection.
         if (selectionModel()->isSelected(indexAtClick))
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -261,6 +261,8 @@ namespace AzToolsFramework
             if (action == Qt::IgnoreAction)
                 return true;
 
+            auto sourceparent = parent.data(AssetBrowserModel::Roles::EntryRole).value<const AssetBrowserEntry*>();
+
             const AssetBrowserEntry* item = static_cast<const AssetBrowserEntry*>(parent.internalPointer());
 
             // We should only have an item as a folder but will check
@@ -291,7 +293,7 @@ namespace AzToolsFramework
                         return false;
                     }
 
-                    Qt::DropAction selectedAction = AssetBrowserViewUtils::SelectDropActionForEntries(entries);
+                    Qt::DropAction selectedAction = AssetBrowserViewUtils::SelectDropActionForEntries(sourceparent, entries);
                     if (selectedAction == Qt::IgnoreAction)
                     {
                         return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserTableViewProxyModel.cpp
@@ -204,7 +204,7 @@ namespace AzToolsFramework
 
                 if (Utils::FromMimeData(data, entries))
                 {
-                    Qt::DropAction selectedAction = AssetBrowserViewUtils::SelectDropActionForEntries(entries);
+                    Qt::DropAction selectedAction = AssetBrowserViewUtils::SelectDropActionForEntries(sourceparent, entries);
                     if (selectedAction == Qt::IgnoreAction)
                     {
                         return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserThumbnailViewProxyModel.cpp
@@ -142,7 +142,7 @@ namespace AzToolsFramework
 
                 if (Utils::FromMimeData(data, entries))
                 {
-                    Qt::DropAction selectedAction = AssetBrowserViewUtils::SelectDropActionForEntries(entries);
+                    Qt::DropAction selectedAction = AssetBrowserViewUtils::SelectDropActionForEntries(sourceparent, entries);
                     if (selectedAction == Qt::IgnoreAction)
                     {
                         return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
@@ -846,7 +846,7 @@ namespace AzToolsFramework
             // we only drop if all the entries are being dropped into a different folder.
             for (auto entry : entries)
             {
-                const AssetBrowserEntry* entryParent = entryParent = entry->GetParent();
+                const AssetBrowserEntry* entryParent = entry->GetParent();
                 if (entryParent)
                 {
                     if (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h
@@ -31,7 +31,7 @@ namespace AzToolsFramework
             static bool IsFolderEmpty(AZStd::string_view path);
             static bool IsEngineOrProjectFolder(AZStd::string_view path);
 
-            static Qt::DropAction SelectDropActionForEntries(const AZStd::vector<const AssetBrowserEntry*>& entries);
+            static Qt::DropAction SelectDropActionForEntries(const AssetBrowserEntry* parent, const AZStd::vector<const AssetBrowserEntry*>& entries);
 
             // Returns the custom image or default icon for a given asset browser entry
             // @param returnIcon - when set to true, always returns the default icon for a given entry


### PR DESCRIPTION
## What does this PR do?

* Fixes https://github.com/o3de/o3de/issues/17610
  - Dragging an asset into the same folder it already exists in no longer causes any action to happen.
  - This works between the same view, but also different Views such as the Asset Thumbnail view and tree view.

* Fixes https://github.com/o3de/o3de/issues/18010
  - The dead zone for beginning a drag is now the same as the dead zone for any other drag operation in the application.

## How was this PR tested?

Just manual tests
* Dragging an asset from somewhere to the to the same place
* Dragging an asset from somewhere onto a different place
     * a different folder in the same view
     * a different folder in the tree view on the left
     * the same folder in the tree view on the left.
     
The above were tested on several different assets, dragging from the list view and icon and tree view.
Dragging something into the place it already was no longer asks you to copy the asset or move it.
Note that you can still duplicate the asset using the right click context menu or pressing CTRL+D


