### PR TITLE
Limit viewport resize events to prevent freezing the editor

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <QWidget>
+#include <QTimer>
 #include <QElapsedTimer>
 #include <Atom/RPI.Public/Base.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
@@ -161,5 +162,7 @@ namespace AtomToolsFramework
         AzToolsFramework::QtEventToAzInputMapper* m_inputChannelMapper = nullptr;
         // Implementation of ViewportInteractionRequests (handles viewport picking operations).
         AZStd::unique_ptr<ViewportInteractionImpl> m_viewportInteractionImpl;
+        // Allow to delay the resize event to prevent freezing the editor on continuous mouse drag
+        QTimer m_resizeEventCooldown;
     };
 } //namespace AtomToolsFramework


### PR DESCRIPTION
## What does this PR do?

Related to https://github.com/o3de/o3de/issues/16532 and [talks on discord](https://discord.com/channels/805939474655346758/855167846240485396/1384793102497087518+)

Adds a simple one-shot timer to prevent the viewport from being resized too many times per frame when user is doing a continuous resize drag on the viewport. This also impact other tools such as the Material Editor.

## How was this PR tested?

Windows build on development branch, using a GTX 1060 (without the change, resize lags)

https://github.com/user-attachments/assets/156750ff-3445-4638-b1f0-dd23a0421608


