### PR TITLE
DPE : Prevent currentColumnLayout nullptr to be deref

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -291,6 +291,11 @@ namespace AzToolsFramework
         // Loop through all items one by one.
         auto* myRow = GetRow();
         const int itemCount = count();
+        if (itemCount == 0)
+        {
+            return;
+        }
+
         for (int itemIndex = 0; itemIndex < itemCount; ++itemIndex)
         {
             auto* currentItem = itemAt(itemIndex);


### PR DESCRIPTION
## What does this PR do?

I was working on the "StarterGame" project and upon switching the LOD type in the mesh component from SpecificLOD to default it crashed in the DPE code. This adds a basic early return to prevent dereferencing `currentColumnLayout`. Callstack can be seen below

[error.log](https://github.com/user-attachments/files/20813512/error.log)

## How was this PR tested?

Local windows build
