### PR TITLE
Motion coordinate spinboxes in BlendSpace*DNode editable if users manually set motion coordinates

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace1DNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace1DNode.cpp
@@ -582,6 +582,10 @@ namespace EMotionFX
             motion.SetXCoordinate(computedMotionCoords.GetX());
             motion.MarkXCoordinateSetByUser(false);
         }
+        else
+        {
+            motion.MarkXCoordinateSetByUser(true);
+        }
     }
 
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace2DNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace2DNode.cpp
@@ -672,11 +672,19 @@ namespace EMotionFX
             motion.SetXCoordinate(computedMotionCoords.GetX());
             motion.MarkXCoordinateSetByUser(false);
         }
+        else
+        {
+            motion.MarkXCoordinateSetByUser(true);
+        }
 
         if (m_calculationMethodY == ECalculationMethod::AUTO)
         {
             motion.SetYCoordinate(computedMotionCoords.GetY());
             motion.MarkYCoordinateSetByUser(false);
+        }
+        else
+        {
+            motion.MarkYCoordinateSetByUser(true);
         }
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
@@ -95,8 +95,6 @@ namespace EMStudio
         m_dialogStack->Add(m_motionSetWindow, tr("Motions"), /*closed=*/false, /*maximizeSize=*/true);
 
         ReInit();
-        CommandSystem::CreateDefaultMotionSet();
-
         return true;
     }
 


### PR DESCRIPTION

## What does this PR do?

On dev branch the coordinate spinboxes for motions remain disabled even if "Calculation method" combobox is set to "Manual". This PR addresses this issue.

I've also found on dev branch is that automatic coordinate evaluation doesn't work, but that's a separate issue.

## How was this PR tested?
Manual

