### PR TITLE
Removed declaration of unused variable triggering compile error

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -99,7 +99,7 @@ namespace AssetProcessor
 
         void Activate() override
         {
-            if (auto* registry = AZ::SettingsRegistry::Get())
+            if (AZ::SettingsRegistry::Get())
             {
                 m_verboseMode = AssetUtilities::GetUserSetting(AssetUtilities::VerboseLoggingOptionName, false);
             }


### PR DESCRIPTION
## What does this PR do?

This PR removes the declaration of an unused variable triggering the configured `-Werror-unused-but-set-variable` flag on Clang.

## How was this PR tested?

The file now compiles successfully.