### PR TITLE
Prevent Emfx widget from creating a default MotionSet upon initializing.

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -930,20 +930,7 @@ namespace EMStudio
             return;
         }
 
-        // enable the menus if at least one motion set
-        bool emptyDefaultMotionSet = false;
-        if (EMotionFX::GetMotionManager().GetNumMotionSets() == 1)
-        {
-            EMotionFX::MotionSet* motionSet = EMotionFX::GetMotionManager().GetMotionSet(0);
-            if (motionSet->GetNumChildSets() == 0 &&
-                motionSet->GetNumMotionEntries() == 0 &&
-                motionSet->GetNameString() == CommandSystem::s_defaultMotionSetName)
-            {
-                emptyDefaultMotionSet = true;
-            }
-        }
-
-        if (EMotionFX::GetMotionManager().GetNumMotionSets() > 0 && !emptyDefaultMotionSet)
+        if (EMotionFX::GetMotionManager().GetNumMotionSets() > 0)
         {
             m_resetAction->setEnabled(true);
             m_saveAllAction->setEnabled(true);
@@ -1543,7 +1530,7 @@ namespace EMStudio
     }
 
 
-    void MainWindow::Reset(bool clearActors, bool clearMotionSets, bool clearMotions, bool clearAnimGraphs, MCore::CommandGroup* commandGroup, bool addDefaultMotionSet)
+    void MainWindow::Reset(bool clearActors, bool clearMotionSets, bool clearMotions, bool clearAnimGraphs, MCore::CommandGroup* commandGroup)
     {
         // create and relink to a temporary new command group in case the input command group has not been specified
         MCore::CommandGroup newCommandGroup("Reset Scene");
@@ -1562,10 +1549,6 @@ namespace EMStudio
             if (clearMotionSets)
             {
                 CommandSystem::ClearMotionSetsCommand(&newCommandGroup);
-                if (addDefaultMotionSet)
-                {
-                    CommandSystem::CreateDefaultMotionSet(/*forceCreate=*/true, &newCommandGroup);
-                }
             }
             if (clearMotions)
             {
@@ -1585,10 +1568,6 @@ namespace EMStudio
             if (clearMotionSets)
             {
                 CommandSystem::ClearMotionSetsCommand(commandGroup);
-                if (addDefaultMotionSet)
-                {
-                    CommandSystem::CreateDefaultMotionSet(/*forceCreate=*/true, commandGroup);
-                }
             }
             if (clearMotions)
             {
@@ -2227,7 +2206,7 @@ namespace EMStudio
                 MCore::CommandGroup workspaceCommandGroup("Load workspace", 64);
 
                 // clear everything before laoding a new workspace file
-                Reset(/*clearActors=*/true, /*clearMotionSets=*/true, /*clearMotions=*/true, /*clearAnimGraphs=*/true, &workspaceCommandGroup, /*addDefaultMotionSet=*/false);
+                Reset(/*clearActors=*/true, /*clearMotionSets=*/true, /*clearMotions=*/true, /*clearAnimGraphs=*/true, &workspaceCommandGroup);
                 workspaceCommandGroup.SetReturnFalseAfterError(true);
 
                 // load the first workspace of the list as more doesn't make sense anyway

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
@@ -128,7 +128,7 @@ namespace EMStudio
 
         GUIOptions& GetOptions()                                                { return m_options; }
 
-        void Reset(bool clearActors = true, bool clearMotionSets = true, bool clearMotions = true, bool clearAnimGraphs = true, MCore::CommandGroup* commandGroup = nullptr, bool addDefaultMotionSet = true);
+        void Reset(bool clearActors = true, bool clearMotionSets = true, bool clearMotions = true, bool clearAnimGraphs = true, MCore::CommandGroup* commandGroup = nullptr);
 
         // settings
         void SavePreferences();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetsWindowPlugin.cpp
@@ -95,8 +95,6 @@ namespace EMStudio
         m_dialogStack->Add(m_motionSetWindow, tr("Motions"), /*closed=*/false, /*maximizeSize=*/true);
 
         ReInit();
-        CommandSystem::CreateDefaultMotionSet();
-
         return true;
     }
 

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Menus/FileMenu/CanReset.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Menus/FileMenu/CanReset.cpp
@@ -54,7 +54,7 @@ namespace EMotionFX
         ASSERT_EQ(GetActorManager().GetNumActorInstances(), 0) << "Expected to see no actor instances";
         ASSERT_EQ(GetAnimGraphManager().GetNumAnimGraphs(), 0) << "Anim graph manager should contain 0 anim graphs.";
         const size_t oldNumMotionSets = GetMotionManager().GetNumMotionSets();
-        ASSERT_EQ(oldNumMotionSets, 1) << "Expected only the default motion set";
+        ASSERT_EQ(oldNumMotionSets, 0) << "Expected no motion set";
         ASSERT_EQ(GetMotionManager().GetNumMotions(), 0) << "Expected exactly zero motions";
 
         // Create Actor, AnimGraph, MotionSet and Motion
@@ -73,7 +73,7 @@ namespace EMotionFX
         ASSERT_EQ(GetActorManager().GetNumActors(), 1) << "Expected to see one actor";
         ASSERT_EQ(GetActorManager().GetNumActorInstances(), 1) << "Expected to see one actor instance";
         ASSERT_EQ(GetAnimGraphManager().GetNumAnimGraphs(), 1) << "Anim graph manager should contain 1 anim graph.";
-        ASSERT_EQ(EMotionFX::GetMotionManager().GetNumMotionSets(), oldNumMotionSets + 1) << "Expected the default and the newly created motion set";
+        ASSERT_EQ(EMotionFX::GetMotionManager().GetNumMotionSets(), oldNumMotionSets + 1) << "Expected the newly created motion set";
         ASSERT_EQ(GetMotionManager().GetNumMotions(), 1) << "Expected exactly one motion";
 
         // Trigger reset from menu

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Menus/FileMenu/CanReset.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Menus/FileMenu/CanReset.cpp
@@ -96,7 +96,7 @@ namespace EMotionFX
         EXPECT_EQ(GetActorManager().GetNumActors(), 0) << "Expected to see no actors";
         EXPECT_EQ(GetActorManager().GetNumActorInstances(), 0) << "Expected to see no actor instances";
         EXPECT_EQ(EMotionFX::GetAnimGraphManager().GetNumAnimGraphs(), 0) << "Anim graph manager should contain 0 anim graphs.";
-        ASSERT_EQ(GetMotionManager().GetNumMotionSets(), 1) << "Expected only the default motion set";
+        ASSERT_EQ(GetMotionManager().GetNumMotionSets(), 0) << "Expected exactly zero motion sets";
         EXPECT_EQ(GetMotionManager().GetNumMotions(), 0) << "Expected exactly zero motions";
 
         QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/MotionSet/CanRemoveMotionSet.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/MotionSet/CanRemoveMotionSet.cpp
@@ -26,6 +26,7 @@ namespace EMotionFX
     {
         RecordProperty("test_case_id", "C24255735");
 
+        CommandSystem::CreateDefaultMotionSet();
         const size_t oldNumMotionSets = GetMotionManager().GetNumMotionSets();
 
         // Select the motion set.
@@ -62,7 +63,7 @@ namespace EMotionFX
             removeSelectedAction->trigger();
         }
 
-        motionSetWindow->ReInit();       
+        motionSetWindow->ReInit();
 
         // Data verification.
         EXPECT_EQ(GetMotionManager().GetNumMotionSets(), oldNumMotionSets - 1);

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanAddMotions.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanAddMotions.cpp
@@ -47,6 +47,7 @@ namespace EMotionFX
         EMStudio::MotionSetTableWidget* tableWidget = motionSetWindow->GetTableWidget();
         ASSERT_TRUE(tableWidget) << "Could not find the motion set table widget.";
 
+        CommandSystem::CreateDefaultMotionSet();
         // Make sure no motions exists yet
         EXPECT_EQ(GetMotionManager().GetNumMotions(), 0) << "Expected to have no motions for the Manager";
         EXPECT_EQ(tableWidget->rowCount(), 0) << "Expected the table to have no rows yet";

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanRemoveMotions.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanRemoveMotions.cpp
@@ -45,6 +45,7 @@ namespace EMotionFX
         EMStudio::MotionSetTableWidget* tableWidget = motionSetWindow->GetTableWidget();
         ASSERT_TRUE(tableWidget) << "Could not find the motion set table widget.";
 
+        CommandSystem::CreateDefaultMotionSet();
         // Make sure no motions exists yet
         EXPECT_EQ(GetMotionManager().GetNumMotions(), 0) << "Expected to have no motions for the Manager";
         EXPECT_EQ(tableWidget->rowCount(), 0) << "Expected the table to have no rows yet";

--- a/Gems/EMotionFX/Code/Tests/UI/CanAddMotionToAnimGraphNode.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAddMotionToAnimGraphNode.cpp
@@ -44,6 +44,7 @@ namespace EMotionFX
         const EMStudio::MotionSetWindow* motionSetWindow = motionSetPlugin->GetMotionSetWindow();
         ASSERT_TRUE(motionSetWindow) << "No motion set window found";
 
+        CommandSystem::CreateDefaultMotionSet();
         // Check there aren't any motion sets yet.
         const size_t oldNumMotionSets = EMotionFX::GetMotionManager().GetNumMotionSets();
 

--- a/Gems/EMotionFX/Code/Tests/UI/CanAddMotionToMotionSet.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAddMotionToMotionSet.cpp
@@ -37,7 +37,7 @@ namespace EMotionFX
         EMStudio::MotionSetWindow* motionSetWindow = motionSetPlugin->GetMotionSetWindow();
         ASSERT_TRUE(motionSetWindow) << "No motion set window found";
 
-
+        CommandSystem::CreateDefaultMotionSet();
         // Check there is now a motion set.
         size_t numMotionSetsAfterCreate = EMotionFX::GetMotionManager().GetNumMotionSets();
         ASSERT_EQ(numMotionSetsAfterCreate, 1);

--- a/Gems/EMotionFX/Code/Tests/UI/CanRemoveMotionFromMotionSet.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanRemoveMotionFromMotionSet.cpp
@@ -42,7 +42,7 @@ namespace EMotionFX
 
         // Check if only the default motion set is there.
         const size_t numOldMotionSets = EMotionFX::GetMotionManager().GetNumMotionSets();
-        EXPECT_EQ(numOldMotionSets, 1);
+        EXPECT_EQ(numOldMotionSets, 0);
 
         // Find the action to create a new motion set and press it.
         QWidget* addMotionSetButton = GetWidgetWithNameFromNamedToolbar(managementWindow, "MotionSetManagementWindow.ToolBar", "MotionSetManagementWindow.ToolBar.AddNewMotionSet");

--- a/Gems/Vegetation/Code/Tests/PrefabInstanceSpawnerTests.cpp
+++ b/Gems/Vegetation/Code/Tests/PrefabInstanceSpawnerTests.cpp
@@ -129,7 +129,7 @@ namespace UnitTest
         }
         AZ::Data::AssetHandler::LoadResult LoadAssetData(
             [[maybe_unused]] const AZ::Data::Asset<AZ::Data::AssetData>& asset,
-            AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
+            [[maybe_unused]] AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
             [[maybe_unused]] const AZ::Data::AssetFilterCB& assetLoadFilterCB) override
         {
             MockAssetData* temp = reinterpret_cast<MockAssetData*>(asset.GetData());


### PR DESCRIPTION
## What does this PR do?

Currently Emfx editor always create an empty MotionSet called "Default", even when the editor is loading an existing motionset. This PR disables this behavior.

## How was this PR tested?

Manual
