### PR TITLE
Fix #19047 - Fix External scripts editor settings

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -1182,23 +1182,46 @@ void AzAssetBrowserRequestHandler::OpenAssetInAssociatedEditor(const AZ::Data::A
         const SourceFileOpenerDetails* firstValidOpener = nullptr;
         int numValidOpeners = 0;
         QMenu menu(mainWindow);
-        for (const SourceFileOpenerDetails& openerDetails : openers)
+        const auto addOpener =
+            [&numValidOpeners, &firstValidOpener, &menu, switchToOpener, mainWindow](const SourceFileOpenerDetails& opener)
         {
-            // bind that function to the current loop element.
-            if (openerDetails.m_opener) // only VALID openers with an actual callback.
+            if (opener.m_opener) // only VALID openers with an actual callback.
             {
                 ++numValidOpeners;
                 if (!firstValidOpener)
                 {
-                    firstValidOpener = &openerDetails;
+                    firstValidOpener = &opener;
                 }
                 // bind a callback such that when the menu item is clicked, it sets that as the opener to use.
-                menu.addAction(openerDetails.m_iconToUse, QObject::tr(openerDetails.m_displayText.c_str()), mainWindow, [switchToOpener, details = &openerDetails] { return switchToOpener(details); });
-                // Stop looking for openers after finding a prioritized one, as this should be the only one displayed
-                if (openerDetails.m_isPrioritized)
-                {
-                    break;
-                }
+                menu.addAction(
+                    opener.m_iconToUse,
+                    QObject::tr(opener.m_displayText.c_str()),
+                    mainWindow,
+                    [switchToOpener, details = &opener]()
+                    {
+                        return switchToOpener(details);
+                    });
+            }
+        };
+
+        // Check if any prioritized opener exists
+        const auto it = std::find_if(
+            openers.begin(),
+            openers.end(),
+            [](const SourceFileOpenerDetails& opener)
+            {
+                return opener.m_opener && opener.m_isPrioritized;
+            });
+
+        if (it != openers.end())
+        {
+            addOpener(*it);
+        }
+        else
+        {
+            for (const SourceFileOpenerDetails& openerDetails : openers)
+            {
+                addOpener(openerDetails);
             }
         }
 

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -1194,6 +1194,11 @@ void AzAssetBrowserRequestHandler::OpenAssetInAssociatedEditor(const AZ::Data::A
                 }
                 // bind a callback such that when the menu item is clicked, it sets that as the opener to use.
                 menu.addAction(openerDetails.m_iconToUse, QObject::tr(openerDetails.m_displayText.c_str()), mainWindow, [switchToOpener, details = &openerDetails] { return switchToOpener(details); });
+                // Stop looking for openers after finding a prioritized one, as this should be the only one displayed
+                if (openerDetails.m_isPrioritized)
+                {
+                    break;
+                }
             }
         }
 

--- a/Code/Editor/EditorPreferencesPageFiles.cpp
+++ b/Code/Editor/EditorPreferencesPageFiles.cpp
@@ -69,7 +69,8 @@ void CEditorPreferencesPage_Files::Reflect(AZ::SerializeContext& serialize)
             ->DataElement(AZ::Edit::UIHandlers::LineEdit, &Files::m_saveLocation, "UI Slice Save location", "Specify the default location to save new UI slices");
 
         editContext->Class<ExternalEditors>("External Editors", "External Editors")
-            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_scripts, "Scripts Editor", "Scripts Text Editor")
+            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_scripts, "Scripts Editor", "Scripts Text Editor (Default to O3DE internal tool when empty)")
+            ->Attribute(AZ::Edit::Attributes::PlaceholderText, "Default to O3DE internal tool when empty")
             ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_shaders, "Shaders Editor", "Shaders Text Editor")
             ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_BSpaces, "BSpace Editor", "Bspace Text Editor")
             ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_textures, "Texture Editor", "Texture Editor")

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -169,12 +169,12 @@ SEditorSettings::SEditorSettings()
     enableSourceControl = false;
 
 #if AZ_TRAIT_OS_PLATFORM_APPLE
-    textEditorForScript = "TextEdit";
+    textEditorForScript = "";
     textEditorForShaders = "TextEdit";
     textEditorForBspaces = "TextEdit";
     textureEditor = "Photoshop";
 #elif defined(AZ_PLATFORM_WINDOWS)
-    textEditorForScript = "notepad++.exe";
+    textEditorForScript = "";
     textEditorForShaders = "notepad++.exe";
     textEditorForBspaces = "notepad++.exe";
     textureEditor = "Photoshop.exe";
@@ -478,11 +478,11 @@ void SEditorSettings::Save(bool isEditorClosing)
     SaveValue("Settings", "ShowScaleWarnings", viewports.bShowScaleWarnings);
     SaveValue("Settings", "ShowRotationWarnings", viewports.bShowRotationWarnings);
 
-    SaveValue("Settings", "TextEditorScript", textEditorForScript);
-    SaveValue("Settings", "TextEditorShaders", textEditorForShaders);
-    SaveValue("Settings", "TextEditorBSpaces", textEditorForBspaces);
-    SaveValue("Settings", "TextureEditor", textureEditor);
-    SaveValue("Settings", "AnimationEditor", animEditor);
+    SaveValue("Settings\\Editor", "TextEditorScript", textEditorForScript);
+    SaveValue("Settings\\Editor", "TextEditorShaders", textEditorForShaders);
+    SaveValue("Settings\\Editor", "TextEditorBSpaces", textEditorForBspaces);
+    SaveValue("Settings\\Editor", "TextureEditor", textureEditor);
+    SaveValue("Settings\\Editor", "AnimationEditor", animEditor);
 
     SaveEnableSourceControlFlag(true);
 
@@ -654,11 +654,11 @@ void SEditorSettings::Load()
     LoadValue("Settings", "ShowScaleWarnings", viewports.bShowScaleWarnings);
     LoadValue("Settings", "ShowRotationWarnings", viewports.bShowRotationWarnings);
 
-    LoadValue("Settings", "TextEditorScript", textEditorForScript);
-    LoadValue("Settings", "TextEditorShaders", textEditorForShaders);
-    LoadValue("Settings", "TextEditorBSpaces", textEditorForBspaces);
-    LoadValue("Settings", "TextureEditor", textureEditor);
-    LoadValue("Settings", "AnimationEditor", animEditor);
+    LoadValue("Settings\\Editor", "TextEditorScript", textEditorForScript);
+    LoadValue("Settings\\Editor", "TextEditorShaders", textEditorForShaders);
+    LoadValue("Settings\\Editor", "TextEditorBSpaces", textEditorForBspaces);
+    LoadValue("Settings\\Editor", "TextureEditor", textureEditor);
+    LoadValue("Settings\\Editor", "AnimationEditor", animEditor);
 
     LoadEnableSourceControlFlag();
 

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -478,11 +478,11 @@ void SEditorSettings::Save(bool isEditorClosing)
     SaveValue("Settings", "ShowScaleWarnings", viewports.bShowScaleWarnings);
     SaveValue("Settings", "ShowRotationWarnings", viewports.bShowRotationWarnings);
 
-    SaveValue("Settings\\Editor", "TextEditorScript", textEditorForScript);
-    SaveValue("Settings\\Editor", "TextEditorShaders", textEditorForShaders);
-    SaveValue("Settings\\Editor", "TextEditorBSpaces", textEditorForBspaces);
-    SaveValue("Settings\\Editor", "TextureEditor", textureEditor);
-    SaveValue("Settings\\Editor", "AnimationEditor", animEditor);
+    SaveValue("Settings/Editor", "TextEditorScript", textEditorForScript);
+    SaveValue("Settings/Editor", "TextEditorShaders", textEditorForShaders);
+    SaveValue("Settings/Editor", "TextEditorBSpaces", textEditorForBspaces);
+    SaveValue("Settings/Editor", "TextureEditor", textureEditor);
+    SaveValue("Settings/Editor", "AnimationEditor", animEditor);
 
     SaveEnableSourceControlFlag(true);
 
@@ -654,11 +654,11 @@ void SEditorSettings::Load()
     LoadValue("Settings", "ShowScaleWarnings", viewports.bShowScaleWarnings);
     LoadValue("Settings", "ShowRotationWarnings", viewports.bShowRotationWarnings);
 
-    LoadValue("Settings\\Editor", "TextEditorScript", textEditorForScript);
-    LoadValue("Settings\\Editor", "TextEditorShaders", textEditorForShaders);
-    LoadValue("Settings\\Editor", "TextEditorBSpaces", textEditorForBspaces);
-    LoadValue("Settings\\Editor", "TextureEditor", textureEditor);
-    LoadValue("Settings\\Editor", "AnimationEditor", animEditor);
+    LoadValue("Settings/Editor", "TextEditorScript", textEditorForScript);
+    LoadValue("Settings/Editor", "TextEditorShaders", textEditorForShaders);
+    LoadValue("Settings/Editor", "TextEditorBSpaces", textEditorForBspaces);
+    LoadValue("Settings/Editor", "TextureEditor", textureEditor);
+    LoadValue("Settings/Editor", "AnimationEditor", animEditor);
 
     LoadEnableSourceControlFlag();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
@@ -121,14 +121,19 @@ namespace AzToolsFramework
             //! This is the function to call.  If you fill a nullptr in here, then the default operating system behavior will be suppressed
             //! but no opener will be opened.  This will also cause the 'open' option in context menus to disappear if the only openers
             //! are nullptr ones.
-            SourceFileOpenerFunctionType m_opener; 
+            SourceFileOpenerFunctionType m_opener;
+
+            //! Indicates whether this opener should be prioritized when multiple openers are available
+            //! If set to true, this opener will take precedence over others
+            bool m_isPrioritized = false;
 
             SourceFileOpenerDetails() = default;
-            SourceFileOpenerDetails(const char* identifier, const char* displayText, QIcon icon, SourceFileOpenerFunctionType functionToCall)
+            SourceFileOpenerDetails(const char* identifier, const char* displayText, QIcon icon, SourceFileOpenerFunctionType functionToCall, bool isPrioritized = false)
                 : m_identifier(identifier)
                 , m_displayText(displayText)
                 , m_iconToUse(icon)
-                , m_opener(functionToCall) {}
+                , m_opener(functionToCall)
+                , m_isPrioritized(isPrioritized) {}
         };
 
         typedef AZStd::vector<SourceFileOpenerDetails> SourceFileOpenerList;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
@@ -139,7 +139,7 @@ namespace AzToolsFramework
                 AzToolsFramework::EditorSettingsAPIBus::BroadcastResult(
                     textEditorScriptSettings,
                     &AzToolsFramework::EditorSettingsAPIBus::Handler::GetValue,
-                    "Settings\\Editor|TextEditorScript");
+                    "Settings/Editor|TextEditorScript");
                 AZStd::any textEditorScriptSettingsValue = textEditorScriptSettings.GetValue<AZStd::any>();
                 AZStd::string textEditorScriptSettingsString = AZStd::any_cast<AZStd::string>(textEditorScriptSettingsValue);
 


### PR DESCRIPTION
## What does this PR do?

Fix #19047 so that users can open scripts (i.e Lua scripts) with the choosen editor instead of using the built-in by double-clicking on the file.

Also added a new action to the contextual menu "Open with external editor"

![image](https://github.com/user-attachments/assets/33b99501-1b4b-43e4-ab7e-9c9079ee403e)

By default on windows, the "Scripts editor" setting is now empty (it was already the case for Linux).

![image](https://github.com/user-attachments/assets/afab1a85-1b28-411e-a595-d676e03af48b)

## Further improvments for developer

⚠️  This is mostly a quick fix

- Editor Settings are not up to date. We need to change the logic to settings registry (https://docs.o3de.org/docs/user-guide/settings/). 

- If I understood well, the editor set in the "Scripts editor" setting was never used by the Asset Browser. Whenever you click on "Open with associated application..." it is going through `OpenWithOS` which uses the default application set for the OS to open this kind of file. We might want to improve this system. 
Also, imo, the wording used in the contextual menu is a bit confusing.

## How was this PR tested?

Local build. **Tested on Windows.** 

#### By default, without having a prefered editor set : 

- In the editor, go to Edit > Editor Settings > Global Preferences > Files > External Editors.
- Set the 'Scripts Editor' option to external editor of your choice.
- Click 'OK'.
- Open any Lua script from the editor.
- The Lua script is opened with the built-in Lua Editor 

#### If a editor is set

- In the editor, go to Edit > Editor Settings > Global Preferences > Files > External Editors.
- Set the 'Scripts Editor' option to external editor of your choice (I've tried with notepad).
- Click 'OK'.
- Open any Lua script from the editor.
- The specified external editor (for my test, notepad) in the External Editors is used
