### PR TITLE
Fix a potential AP crash when reprocessing assets

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3767,18 +3767,18 @@ namespace AssetProcessor
         int maxPerIteration = 50;
 
         // Burn through all pending files
-        const FileEntry* firstEntry = &m_activeFiles.front();
         while (m_filesToExamine.size() < maxPerIteration)
         {
-            m_alreadyActiveFiles.remove(firstEntry->m_fileName);
-            CheckSource(*firstEntry);
+            // CheckSource modifies m_activeFiles, so we need to work with a copy of the current entry
+            FileEntry firstEntry = m_activeFiles.front();
+            m_alreadyActiveFiles.remove(firstEntry.m_fileName);
+            CheckSource(firstEntry);
             m_activeFiles.pop_front();
 
             if (m_activeFiles.size() == 0)
             {
                 break;
             }
-            firstEntry = &m_activeFiles.front();
         }
 
         if (!m_alreadyScheduledUpdate)


### PR DESCRIPTION
## What does this PR do?

This fixes a crash in the AssetProcessor, that happens sometimes when a asset reprocessing is triggered from the GUI: The loop holds a reference to the front of the `m_activeFiles` - vector, but the function `CheckSource()` calls `AssessFileInternal()`, which modifies `m_activeFiles`, potentially invalidating the memory of used by that reference.

## How was this PR tested?

Windows, triggering the reprocessing of materials.