### PR TITLE
Introduce Alternate Frame Rendering capability to the engine

### DIFF
--- a/Gems/AFR/CMakeLists.txt
+++ b/Gems/AFR/CMakeLists.txt
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+o3de_gem_setup("AFR")
+
+ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
+
+add_subdirectory(Code)

--- a/Gems/AFR/Code/CMakeLists.txt
+++ b/Gems/AFR/Code/CMakeLists.txt
@@ -1,0 +1,197 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# The ${gem_name}.Private.Object target is an internal target
+# It should not be used outside of this Gems CMakeLists.txt
+ly_add_target(
+    NAME ${gem_name}.Private.Object STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        afr_private_files.cmake
+    TARGET_PROPERTIES
+        O3DE_PRIVATE_TARGET TRUE
+    INCLUDE_DIRECTORIES
+        PRIVATE
+            Include
+            Source
+    BUILD_DEPENDENCIES
+        PRIVATE
+            Gem::Atom_Feature_Common.Public
+            Gem::DiffuseProbeGrid.Static
+        PUBLIC
+            AZ::AzCore
+            AZ::AzFramework
+            Gem::Atom_RPI.Public
+)
+
+# Here add ${gem_name} target, it depends on the Private Object library and Public API interface
+ly_add_target(
+    NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAMESPACE Gem
+    FILES_CMAKE
+        afr_shared_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            Include
+        PRIVATE
+            Source
+    BUILD_DEPENDENCIES
+        PRIVATE
+            Gem::${gem_name}.Private.Object
+)
+
+# Include the gem name into the Client Module source file
+# for use with the AZ_DECLARE_MODULE_CLASS macro
+# This is to allow renaming of the gem to also cause
+# the CreateModuleClass_Gem_<gem-name> function which
+# is used to bootstrap the gem in monolithic builds to link to the new gem name
+ly_add_source_properties(
+SOURCES
+    Source/Clients/AFRModule.cpp
+PROPERTY COMPILE_DEFINITIONS
+    VALUES
+        O3DE_GEM_NAME=${gem_name}
+        O3DE_GEM_VERSION=${gem_version})
+
+# By default, we will specify that the above target ${gem_name} would be used by
+# Client and Server type targets when this gem is enabled.  If you don't want it
+# active in Clients or Servers by default, delete one of both of the following lines:
+ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Unified NAMESPACE Gem TARGETS Gem::${gem_name})
+
+# Add in CMake dependencies for each gem dependency listed in this gem's gem.json file
+# for the Clients, Servers, Unified gem variants
+o3de_add_variant_dependencies_for_gem_dependencies(GEM_NAME ${gem_name} VARIANTS Clients Servers Unified)
+
+# If we are on a host platform, we want to add the host tools targets like the ${gem_name}.Editor MODULE target
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    # The ${gem_name}.Editor.Private.Object target is an internal target
+    # which is only to be used by this gems CMakeLists.txt and any subdirectories
+    # Other gems should not use this target
+    ly_add_target(
+        NAME ${gem_name}.Editor.Private.Object STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            afr_editor_private_files.cmake
+        TARGET_PROPERTIES
+            O3DE_PRIVATE_TARGET TRUE
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Include
+                Source
+        BUILD_DEPENDENCIES
+            PUBLIC
+                AZ::AzToolsFramework
+                ${gem_name}.Private.Object
+    )
+
+    ly_add_target(
+        NAME ${gem_name}.Editor GEM_MODULE
+        NAMESPACE Gem
+        AUTOMOC
+        FILES_CMAKE
+            afr_editor_shared_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Source
+            PUBLIC
+                Include
+        BUILD_DEPENDENCIES
+            PRIVATE
+                Gem::${gem_name}.Editor.Private.Object
+    )
+
+    # Include the gem name into the Editor Module source file
+    # for use with the AZ_DECLARE_MODULE_CLASS macro
+    # This is to allow renaming of the gem to also cause
+    # the CreateModuleClass_Gem_<gem-name> function which
+    # is used to bootstrap the gem in monolithic builds to link to the new gem name
+    ly_add_source_properties(
+    SOURCES
+        Source/Tools/AFREditorModule.cpp
+    PROPERTY COMPILE_DEFINITIONS
+        VALUES
+            O3DE_GEM_NAME=${gem_name}
+            O3DE_GEM_VERSION=${gem_version})
+
+    # By default, we will specify that the above target ${gem_name} would be used by
+    # Tool and Builder type targets when this gem is enabled.  If you don't want it
+    # active in Tools or Builders by default, delete one of both of the following lines:
+    ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+
+    # For the Tools and Builders variants of ${gem_name} Gem, an alias to the ${gem_name}.Editor API target will be made
+    ly_create_alias(NAME ${gem_name}.Tools.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
+    ly_create_alias(NAME ${gem_name}.Builders.API NAMESPACE Gem TARGETS Gem::${gem_name}.Editor.API)
+
+    # Add in CMake dependencies for each gem dependency listed in this gem's gem.json file
+    # for the Tools and Builders gem variants
+    o3de_add_variant_dependencies_for_gem_dependencies(GEM_NAME ${gem_name} VARIANTS Tools Builders)
+endif()
+
+################################################################################
+# Tests
+################################################################################
+# See if globally, tests are supported
+if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+    # We globally support tests, see if we support tests on this platform for ${gem_name}.Tests
+    if(PAL_TRAIT_AFR_TEST_SUPPORTED)
+        # We support ${gem_name}.Tests on this platform, add dependency on the Private Object target
+        ly_add_target(
+            NAME ${gem_name}.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+            NAMESPACE Gem
+            FILES_CMAKE
+                afr_tests_files.cmake
+            INCLUDE_DIRECTORIES
+                PRIVATE
+                    Tests
+                    Source
+                    Include
+            BUILD_DEPENDENCIES
+                PRIVATE
+                    AZ::AzTest
+                    AZ::AzFramework
+                    Gem::${gem_name}.Private.Object
+        )
+
+        # Add ${gem_name}.Tests to googletest
+        ly_add_googletest(
+            NAME Gem::${gem_name}.Tests
+        )
+    endif()
+
+    # If we are a host platform we want to add tools test like editor tests here
+    if(PAL_TRAIT_BUILD_HOST_TOOLS)
+        # We are a host platform, see if Editor tests are supported on this platform
+        if(PAL_TRAIT_AFR_EDITOR_TEST_SUPPORTED)
+            # We support ${gem_name}.Editor.Tests on this platform, add ${gem_name}.Editor.Tests target which depends on
+            # private ${gem_name}.Editor.Private.Object target
+            ly_add_target(
+                NAME ${gem_name}.Editor.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+                NAMESPACE Gem
+                FILES_CMAKE
+                    afr_editor_tests_files.cmake
+                INCLUDE_DIRECTORIES
+                    PRIVATE
+                        Tests
+                        Source
+                        Include
+                BUILD_DEPENDENCIES
+                    PRIVATE
+                        AZ::AzTest
+                        Gem::${gem_name}.Editor.Private.Object
+            )
+
+            # Add ${gem_name}.Editor.Tests to googletest
+            ly_add_googletest(
+                NAME Gem::${gem_name}.Editor.Tests
+            )
+        endif()
+    endif()
+endif()

--- a/Gems/AFR/Code/Include/AFR/AFRBus.h
+++ b/Gems/AFR/Code/Include/AFR/AFRBus.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AFR/AFRTypeIds.h>
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+
+namespace AFR
+{
+    class AFRRequests
+    {
+    public:
+        AZ_RTTI(AFRRequests, AFRRequestsTypeId);
+        virtual ~AFRRequests() = default;
+        // Put your public methods here
+    };
+
+    class AFRBusTraits
+        : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using AFRRequestBus = AZ::EBus<AFRRequests, AFRBusTraits>;
+    using AFRInterface = AZ::Interface<AFRRequests>;
+
+} // namespace AFR

--- a/Gems/AFR/Code/Include/AFR/AFRFeatureProcessor.h
+++ b/Gems/AFR/Code/Include/AFR/AFRFeatureProcessor.h
@@ -23,6 +23,7 @@ namespace AZ
 
 namespace AFR
 {
+    //! This feature processor alternates the rendered frames over the available GPUs to achieve alternate frame rendering
     class AFRFeatureProcessor
         : public AZ::RPI::FeatureProcessor
         , public AZ::RHI::FrameEventBus::Handler

--- a/Gems/AFR/Code/Include/AFR/AFRFeatureProcessor.h
+++ b/Gems/AFR/Code/Include/AFR/AFRFeatureProcessor.h
@@ -15,11 +15,6 @@
 
 namespace AZ
 {
-    namespace RHI
-    {
-        class ScopeProducer;
-    }
-
     namespace RPI
     {
         class Pass;
@@ -65,8 +60,7 @@ namespace AFR
         };
 
         //! AFR Methods
-        void addAFRCopyPass(AZ::RPI::RenderPipeline* renderPipeline, int deviceIndex);
-        void scheduleRTASP(AZ::RPI::RenderPipeline* renderPipeline);
+        void AddAFRCopyPass(AZ::RPI::RenderPipeline* renderPipeline, int deviceIndex);
         void CollectPassesToSchedule(AZ::RPI::RenderPipeline* renderPipeline);
 
         //! AFR members

--- a/Gems/AFR/Code/Include/AFR/AFRFeatureProcessor.h
+++ b/Gems/AFR/Code/Include/AFR/AFRFeatureProcessor.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/FrameEventBus.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
+
+#include <AzCore/std/containers/unordered_map.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        class ScopeProducer;
+    }
+
+    namespace RPI
+    {
+        class Pass;
+    }
+} // namespace AZ
+
+namespace AFR
+{
+    class AFRFeatureProcessor
+        : public AZ::RPI::FeatureProcessor
+        , public AZ::RHI::FrameEventBus::Handler
+        , public AZ::RHI::RHISystemNotificationBus::Handler
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(AFRFeatureProcessor, AZ::SystemAllocator)
+        AZ_RTTI(AFR::AFRFeatureProcessor, "{78F458F3-E68D-4390-86B6-9154C4AAFE4E}", AZ::RPI::FeatureProcessor);
+        AZ_DISABLE_COPY_MOVE(AFRFeatureProcessor);
+        AZ_FEATURE_PROCESSOR(AFRFeatureProcessor);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AFRFeatureProcessor() = default;
+        ~AFRFeatureProcessor() = default;
+
+        //! AZ::RPI::FeatureProcessor overrides...
+        void Activate() override;
+        void Deactivate() override;
+
+        //! FrameEventBus::Handler
+        //! Called just after the frame scheduler begins a frame.
+        void OnFrameBegin() override;
+
+        //! called from RenderPipeline::OnPassModified, when a Pipeline is added/removed or Passes are added/removed
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* renderPipeline, RenderPipelineChangeType pipelineChangeType) override;
+
+    private:
+        enum class AFRSetupState
+        {
+            NOT_INITIALIZED,
+            INITIALIZING,
+            SETUP_DONE,
+            SCHEDULING
+        };
+
+        //! AFR Methods
+        void addAFRCopyPass(AZ::RPI::RenderPipeline* renderPipeline, int deviceIndex);
+        void scheduleRTASP(AZ::RPI::RenderPipeline* renderPipeline);
+        void CollectPassesToSchedule(AZ::RPI::RenderPipeline* renderPipeline);
+
+        //! AFR members
+        int m_deviceCount{};
+        AZStd::vector<AZ::RHI::Ptr<AZ::RPI::Pass>> m_scheduledPasses;
+        AZStd::unordered_map<int, AZ::RHI::Ptr<AZ::RPI::Pass>> m_afrCopyPasses;
+        AFRSetupState m_afrSetupState{AFRFeatureProcessor::AFRSetupState::NOT_INITIALIZED};
+        AZStd::pair<AZ::RPI::RenderPipelineId, AZ::RPI::RenderPipeline*> m_afrRenderPipeline;
+        AZStd::string m_afrPipelineName;
+    };
+} // namespace AFR

--- a/Gems/AFR/Code/Include/AFR/AFRTypeIds.h
+++ b/Gems/AFR/Code/Include/AFR/AFRTypeIds.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace AFR
+{
+    // System Component TypeIds
+    inline constexpr const char* AFRSystemComponentTypeId = "{9417D00E-172B-44D9-9945-FFD2FFB6D866}";
+    inline constexpr const char* AFREditorSystemComponentTypeId = "{720D600B-ADA3-4E3E-B1FC-316547FDF772}";
+
+    // Module derived classes TypeIds
+    inline constexpr const char* AFRModuleInterfaceTypeId = "{E50CB15F-6EDC-4150-98D5-EEAFD88DC348}";
+    inline constexpr const char* AFRModuleTypeId = "{C2CEF52D-20F4-4E86-9A9C-56A77032879D}";
+    // The Editor Module by default is mutually exclusive with the Client Module
+    // so they use the Same TypeId
+    inline constexpr const char* AFREditorModuleTypeId = AFRModuleTypeId;
+
+    // Interface TypeIds
+    inline constexpr const char* AFRRequestsTypeId = "{38D283F8-6456-40AC-AB51-C5CD04D747D0}";
+} // namespace AFR

--- a/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
+++ b/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/RHIUtils.h>
+#include <Atom/RPI.Public/Pass/CopyPass.h>
+#include <Atom/RPI.Public/Pass/ParentPass.h>
+#include <Atom/RPI.Public/Pass/PassFilter.h>
+#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
+#include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
+#include <Atom/RPI.Public/PipelinePassChanges.h>
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
+#include <Atom/RPI.Reflect/Pass/CopyPassData.h>
+
+#include <AFR/AFRFeatureProcessor.h>
+
+namespace AFR
+{
+    void AFRFeatureProcessor::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<AFRFeatureProcessor, AZ::RPI::FeatureProcessor>()->Version(0);
+        }
+    }
+
+    void AFRFeatureProcessor::Activate()
+    {
+        // Check if AFR should be active
+        m_afrPipelineName = AZ::RHI::GetCommandLineValue("afr");
+        if (m_afrPipelineName.empty())
+        {
+            return;
+        }
+
+        m_deviceCount = AZ::RHI::RHISystemInterface::Get()->GetDeviceCount();
+
+        // Enable scene notifications to get notified on RenderPipeline changes and add CopyPasses as needed
+        EnableSceneNotification();
+
+        // Connect to the FrameEventBus to access the OnFrameBegin() event to affect the scheduling of passes
+        AZ::RHI::FrameEventBus::Handler::BusConnect(
+            AZ::RHI::RHISystemInterface::Get()->GetDevice(AZ::RHI::MultiDevice::DefaultDeviceIndex));
+    }
+
+    void AFRFeatureProcessor::Deactivate()
+    {
+        DisableSceneNotification();
+
+        AZ::RHI::FrameEventBus::Handler::BusDisconnect();
+    }
+
+    void AFRFeatureProcessor::OnRenderPipelineChanged(AZ::RPI::RenderPipeline* renderPipeline, RenderPipelineChangeType pipelineChangeType)
+    {
+        switch (pipelineChangeType)
+        {
+        case RenderPipelineChangeType::Added:
+            {
+                if (renderPipeline->GetId().GetStringView().contains(m_afrPipelineName))
+                {
+                    if(m_afrRenderPipeline.second)
+                    {
+                        AZ_Assert(false, "AFR Pipeline had already been set, reset to this pipeline");
+                        m_afrRenderPipeline = { "", nullptr };
+                        m_afrCopyPasses.clear();
+                    }
+
+                    // Remember this pipeline as the one AFR is running on
+                    m_afrRenderPipeline = { renderPipeline->GetId(), renderPipeline };
+                    CollectPassesToSchedule(renderPipeline);
+                }
+
+                return;
+            }
+        case RenderPipelineChangeType::PassChanged:
+            {
+                if(m_afrSetupState == AFRSetupState::INITIALIZING)
+                {
+                    // We triggered this update, no need to collect passes -> return
+                    m_afrSetupState = AFRSetupState::SETUP_DONE;
+                    return;
+                }
+                else if (renderPipeline->GetId() == m_afrRenderPipeline.first)
+                {
+                    CollectPassesToSchedule(renderPipeline);
+                }
+
+                return;
+            }
+        case RenderPipelineChangeType::Removed:
+            {
+                if (renderPipeline->GetId().GetStringView().contains(m_afrPipelineName))
+                {
+                    // Clear CopyPasses
+                    m_afrRenderPipeline = { "", nullptr };
+                    m_afrCopyPasses.clear();
+                    m_scheduledPasses.clear();
+                    m_afrSetupState = AFRSetupState::NOT_INITIALIZED;
+                }
+
+                return;
+            }
+        }
+    }
+
+    void AFRFeatureProcessor::CollectPassesToSchedule(AZ::RPI::RenderPipeline* renderPipeline)
+    {
+        if(m_afrSetupState == AFRSetupState::SCHEDULING)
+        {
+            // To detect valid passes, reset our previous scheduling for now
+            for(const auto& pass : m_scheduledPasses)
+            {
+                pass->SetDeviceIndex(AZ::RHI::MultiDevice::InvalidDeviceIndex);
+            }
+        }
+        m_scheduledPasses.clear();
+
+        AZStd::stack<AZ::RPI::Pass*> stack;
+        stack.push(renderPipeline->GetRootPass().get());
+        while (!stack.empty())
+        {
+            auto pass{ stack.top() };
+            stack.pop();
+            auto parentPass{ pass->AsParent() };
+
+            // If pass is a ParentPass, go over all children
+            if (parentPass != nullptr)
+            {
+                for (auto it{ parentPass->GetChildren().rbegin() }; it != parentPass->GetChildren().rend(); it++)
+                {
+                    stack.push(it->get());
+                }
+            }
+            else
+            {
+                // We do not want to schedule the "CopyToSwapChain" pass or any pass that is
+                // already scheduled to a fixed device index
+                if (!pass->GetName().GetStringView().contains("CopyToSwapChain") &&
+                    pass->GetDeviceIndex() == AZ::RHI::MultiDevice::InvalidDeviceIndex)
+                {
+                    m_scheduledPasses.emplace_back(pass);
+                }
+            }
+        }
+    }
+
+    bool IsEnabled(AZ::RPI::Pass* pass)
+    {
+        if(!pass->IsEnabled())
+        {
+            return false;
+        }
+        // Check if parent (or its parent etc.) is enabled
+        if (auto parentPass{pass->GetParent()}; parentPass != nullptr)
+        {
+            if(!parentPass->IsEnabled())
+            {
+                return false;
+            }
+            IsEnabled(parentPass);
+        }
+        return true;
+    }
+
+    void AFRFeatureProcessor::OnFrameBegin()
+    {
+        static int frameNumber{ 0 };
+
+        if (auto& [_, renderPipeline]{ m_afrRenderPipeline }; renderPipeline && renderPipeline->NeedsRender())
+        {
+            if(m_afrSetupState == AFRSetupState::NOT_INITIALIZED)
+            {
+                // Add CopyPasses for all devices (except for the first, which is the display GPU)
+                for(auto deviceIndex{1u}; deviceIndex < m_deviceCount; ++deviceIndex)
+                {
+                    addAFRCopyPass(renderPipeline, deviceIndex);
+                }
+                m_afrSetupState = AFRSetupState::INITIALIZING;
+                // This will trigger a "OnRenderPipelineChanged::PassChanged" event
+                renderPipeline->UpdatePasses();
+            }
+
+            auto deviceIndex{ frameNumber % m_deviceCount };
+            for (auto pass : m_scheduledPasses)
+            {
+                if(IsEnabled(pass.get()))
+                {
+                    pass->SetDeviceIndex(deviceIndex);
+                }
+            }
+
+            // Enable appropriate CopyPass for deviceIndex and disable rest
+            for (auto& [index, copyPass] : m_afrCopyPasses)
+            {
+                copyPass->SetEnabled(deviceIndex == index);
+            }
+
+            m_afrSetupState = AFRSetupState::SCHEDULING;
+        }
+
+        ++frameNumber;
+    }
+    void AFRFeatureProcessor::addAFRCopyPass(AZ::RPI::RenderPipeline* renderPipeline, int deviceIndex)
+    {
+        if (m_afrCopyPasses.contains(deviceIndex))
+        {
+            // Already setup
+            AZ::RPI::PassFilter passFilter =
+                AZ::RPI::PassFilter::CreateWithPassName(AZ::Name("SwapchainMultiDeviceCopyPass"+ AZStd::to_string(deviceIndex)) , renderPipeline);
+
+            AZ::RPI::Pass* pass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
+
+            if (m_afrRenderPipeline.second != renderPipeline || pass)
+            {
+                return;
+            }
+        }
+
+        AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithPassName(AZ::Name("CopyToSwapChain"), renderPipeline);
+
+        AZ::RPI::Pass* copyToSwapchainPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
+
+        if (!copyToSwapchainPass)
+        {
+            // Sanity check, can only setup AFR in a pipeline that copies to the SwapChain in the end
+            return;
+        }
+
+        // Add a multi-device CopyPass to copy from deviceIndex to MultiDevice::DefaultDeviceIndex
+
+        AZStd::shared_ptr<AZ::RPI::PassRequest> passRequest = AZStd::make_shared<AZ::RPI::PassRequest>();
+
+        passRequest->m_templateName = AZ::Name("MultiDeviceCopyPassTemplate");
+
+        passRequest->m_passName = AZ::Name("SwapchainMultiDeviceCopyPass" + AZStd::to_string(deviceIndex));
+
+        AZStd::shared_ptr<AZ::RPI::CopyPassData> passData = AZStd::make_shared<AZ::RPI::CopyPassData>();
+        passData->m_sourceDeviceIndex = deviceIndex;
+        passData->m_destinationDeviceIndex = AZ::RHI::MultiDevice::DefaultDeviceIndex;
+        passData->m_cloneInput = false;
+        passRequest->m_passData = passData;
+
+        AZ::RPI::PassConnection passConnection;
+
+        passConnection.m_localSlot = AZ::Name{ "InputOutput" };
+
+        // This works as long as this connection is built with a pass request and not a template (which is fine as it isn't done this
+        // way for the CopyToSwapChain pass):
+        bool found{ false };
+
+        for (auto& connection : copyToSwapchainPass->GetPassDescriptor().m_passRequest->m_connections)
+        {
+            if (connection.m_localSlot.GetStringView() == AZ::Name{ "Input" }.GetStringView())
+            {
+                passConnection.m_attachmentRef = connection.m_attachmentRef;
+                found = true;
+                break;
+            }
+        }
+
+        AZ_Assert(found, "Connection not found!");
+
+        passRequest->m_connections.emplace_back(passConnection);
+
+        auto afrCopyPass{ AZ::RPI::PassSystemInterface::Get()->CreatePassFromRequest(passRequest.get()) };
+        m_afrCopyPasses[deviceIndex] = afrCopyPass;
+
+        auto* parent{ copyToSwapchainPass->GetParent() };
+        parent->InsertChild(afrCopyPass, parent->FindChildPassIndex(copyToSwapchainPass->GetName()).GetIndex());
+    }
+} // namespace AFR

--- a/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
+++ b/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
@@ -195,7 +195,7 @@ namespace AFR
                 // Add CopyPasses for all devices (except for the first, which is the display GPU)
                 for(auto deviceIndex{1}; deviceIndex < m_deviceCount; ++deviceIndex)
                 {
-                    addAFRCopyPass(renderPipeline, deviceIndex);
+                    AddAFRCopyPass(renderPipeline, deviceIndex);
                 }
                 m_afrSetupState = AFRSetupState::INITIALIZING;
                 // This will trigger a "OnRenderPipelineChanged::PassChanged" event
@@ -222,7 +222,7 @@ namespace AFR
 
         ++frameNumber;
     }
-    void AFRFeatureProcessor::addAFRCopyPass(AZ::RPI::RenderPipeline* renderPipeline, int deviceIndex)
+    void AFRFeatureProcessor::AddAFRCopyPass(AZ::RPI::RenderPipeline* renderPipeline, int deviceIndex)
     {
         if (m_afrCopyPasses.contains(deviceIndex))
         {

--- a/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
+++ b/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
@@ -193,7 +193,7 @@ namespace AFR
             if(m_afrSetupState == AFRSetupState::NOT_INITIALIZED)
             {
                 // Add CopyPasses for all devices (except for the first, which is the display GPU)
-                for(auto deviceIndex{1u}; deviceIndex < m_deviceCount; ++deviceIndex)
+                for(auto deviceIndex{1}; deviceIndex < m_deviceCount; ++deviceIndex)
                 {
                     addAFRCopyPass(renderPipeline, deviceIndex);
                 }

--- a/Gems/AFR/Code/Source/AFRModuleInterface.cpp
+++ b/Gems/AFR/Code/Source/AFRModuleInterface.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "AFRModuleInterface.h"
+#include <AzCore/Memory/Memory.h>
+
+#include <AFR/AFRTypeIds.h>
+
+#include <Clients/AFRSystemComponent.h>
+
+namespace AFR
+{
+    AZ_TYPE_INFO_WITH_NAME_IMPL(AFRModuleInterface,
+        "AFRModuleInterface", AFRModuleInterfaceTypeId);
+    AZ_RTTI_NO_TYPE_INFO_IMPL(AFRModuleInterface, AZ::Module);
+    AZ_CLASS_ALLOCATOR_IMPL(AFRModuleInterface, AZ::SystemAllocator);
+
+    AFRModuleInterface::AFRModuleInterface()
+    {
+        // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
+        // Add ALL components descriptors associated with this gem to m_descriptors.
+        // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
+        // This happens through the [MyComponent]::Reflect() function.
+        m_descriptors.insert(m_descriptors.end(), {
+            AFRSystemComponent::CreateDescriptor(),
+            });
+    }
+
+    AZ::ComponentTypeList AFRModuleInterface::GetRequiredSystemComponents() const
+    {
+        return AZ::ComponentTypeList{
+            azrtti_typeid<AFRSystemComponent>(),
+        };
+    }
+} // namespace AFR

--- a/Gems/AFR/Code/Source/AFRModuleInterface.h
+++ b/Gems/AFR/Code/Source/AFRModuleInterface.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/Memory/Memory_fwd.h>
+#include <AzCore/Module/Module.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
+
+namespace AFR
+{
+    class AFRModuleInterface
+        : public AZ::Module
+    {
+    public:
+        AZ_TYPE_INFO_WITH_NAME_DECL(AFRModuleInterface)
+        AZ_RTTI_NO_TYPE_INFO_DECL()
+        AZ_CLASS_ALLOCATOR_DECL
+
+        AFRModuleInterface();
+
+        /**
+         * Add required SystemComponents to the SystemEntity.
+         */
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override;
+    };
+}// namespace AFR

--- a/Gems/AFR/Code/Source/Clients/AFRModule.cpp
+++ b/Gems/AFR/Code/Source/Clients/AFRModule.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AFR/AFRTypeIds.h>
+#include <AFRModuleInterface.h>
+#include "AFRSystemComponent.h"
+
+namespace AFR
+{
+    class AFRModule
+        : public AFRModuleInterface
+    {
+    public:
+        AZ_RTTI(AFRModule, AFRModuleTypeId, AFRModuleInterface);
+        AZ_CLASS_ALLOCATOR(AFRModule, AZ::SystemAllocator);
+    };
+}// namespace AFR
+
+#if defined(O3DE_GEM_NAME)
+AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME), AFR::AFRModule)
+#else
+AZ_DECLARE_MODULE_CLASS(Gem_AFR, AFR::AFRModule)
+#endif

--- a/Gems/AFR/Code/Source/Clients/AFRSystemComponent.cpp
+++ b/Gems/AFR/Code/Source/Clients/AFRSystemComponent.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "AFRSystemComponent.h"
+
+#include <AFR/AFRTypeIds.h>
+
+#include <Atom/RPI.Public/FeatureProcessorFactory.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <AFR/AFRFeatureProcessor.h>
+
+namespace AFR
+{
+    AZ_COMPONENT_IMPL(AFRSystemComponent, "AFRSystemComponent",
+        AFRSystemComponentTypeId);
+
+    void AFRSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        AFRFeatureProcessor::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<AFRSystemComponent, AZ::Component>()
+                ->Version(0)
+                ;
+        }
+    }
+
+    void AFRSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("AFRService"));
+    }
+
+    void AFRSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("AFRService"));
+    }
+
+    void AFRSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("AssetDatabaseService", 0x3abf5601));
+        required.push_back(AZ_CRC("RPISystem", 0xf2add773));
+        required.push_back(AZ_CRC("BootstrapSystemComponent", 0xb8f32711));
+    }
+
+    void AFRSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+
+    AFRSystemComponent::AFRSystemComponent()
+    {
+        if (AFRInterface::Get() == nullptr)
+        {
+            AFRInterface::Register(this);
+        }
+    }
+
+    AFRSystemComponent::~AFRSystemComponent()
+    {
+        if (AFRInterface::Get() == this)
+        {
+            AFRInterface::Unregister(this);
+        }
+    }
+
+    void AFRSystemComponent::Init()
+    {
+    }
+
+    void AFRSystemComponent::Activate()
+    {
+        AFRRequestBus::Handler::BusConnect();
+        AZ::TickBus::Handler::BusConnect();
+
+        AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<AFRFeatureProcessor>();
+    }
+
+    void AFRSystemComponent::Deactivate()
+    {
+        AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<AFRFeatureProcessor>();
+
+        AZ::TickBus::Handler::BusDisconnect();
+        AFRRequestBus::Handler::BusDisconnect();
+    }
+
+    void AFRSystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+    }
+
+} // namespace AFR

--- a/Gems/AFR/Code/Source/Clients/AFRSystemComponent.h
+++ b/Gems/AFR/Code/Source/Clients/AFRSystemComponent.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AFR/AFRBus.h>
+
+namespace AFR
+{
+    class AFRSystemComponent
+        : public AZ::Component
+        , protected AFRRequestBus::Handler
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT_DECL(AFRSystemComponent);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        AFRSystemComponent();
+        ~AFRSystemComponent();
+
+    protected:
+        ////////////////////////////////////////////////////////////////////////
+        // AFRRequestBus interface implementation
+
+        ////////////////////////////////////////////////////////////////////////
+
+        ////////////////////////////////////////////////////////////////////////
+        // AZ::Component interface implementation
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+        ////////////////////////////////////////////////////////////////////////
+
+        ////////////////////////////////////////////////////////////////////////
+        // AZTickBus interface implementation
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        ////////////////////////////////////////////////////////////////////////
+    };
+
+} // namespace AFR

--- a/Gems/AFR/Code/Source/Tools/AFREditorModule.cpp
+++ b/Gems/AFR/Code/Source/Tools/AFREditorModule.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AFR/AFRTypeIds.h>
+#include <AFRModuleInterface.h>
+#include "AFREditorSystemComponent.h"
+
+namespace AFR
+{
+    class AFREditorModule
+        : public AFRModuleInterface
+    {
+    public:
+        AZ_RTTI(AFREditorModule, AFREditorModuleTypeId, AFRModuleInterface);
+        AZ_CLASS_ALLOCATOR(AFREditorModule, AZ::SystemAllocator);
+
+        AFREditorModule()
+        {
+            // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
+            // Add ALL components descriptors associated with this gem to m_descriptors.
+            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
+            // This happens through the [MyComponent]::Reflect() function.
+            m_descriptors.insert(m_descriptors.end(), {
+                AFREditorSystemComponent::CreateDescriptor(),
+            });
+        }
+
+        /**
+         * Add required SystemComponents to the SystemEntity.
+         * Non-SystemComponents should not be added here
+         */
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override
+        {
+            return AZ::ComponentTypeList {
+                azrtti_typeid<AFREditorSystemComponent>(),
+            };
+        }
+    };
+}// namespace AFR
+
+#if defined(O3DE_GEM_NAME)
+AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME, _Editor), AFR::AFREditorModule)
+#else
+AZ_DECLARE_MODULE_CLASS(Gem_AFR_Editor, AFR::AFREditorModule)
+#endif

--- a/Gems/AFR/Code/Source/Tools/AFREditorSystemComponent.cpp
+++ b/Gems/AFR/Code/Source/Tools/AFREditorSystemComponent.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/Serialization/SerializeContext.h>
+#include "AFREditorSystemComponent.h"
+
+#include <AFR/AFRTypeIds.h>
+
+namespace AFR
+{
+    AZ_COMPONENT_IMPL(AFREditorSystemComponent, "AFREditorSystemComponent",
+        AFREditorSystemComponentTypeId, BaseSystemComponent);
+
+    void AFREditorSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<AFREditorSystemComponent, AFRSystemComponent>()
+                ->Version(0);
+        }
+    }
+
+    AFREditorSystemComponent::AFREditorSystemComponent() = default;
+
+    AFREditorSystemComponent::~AFREditorSystemComponent() = default;
+
+    void AFREditorSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        BaseSystemComponent::GetProvidedServices(provided);
+        provided.push_back(AZ_CRC_CE("AFREditorService"));
+    }
+
+    void AFREditorSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        BaseSystemComponent::GetIncompatibleServices(incompatible);
+        incompatible.push_back(AZ_CRC_CE("AFREditorService"));
+    }
+
+    void AFREditorSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        BaseSystemComponent::GetRequiredServices(required);
+    }
+
+    void AFREditorSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        BaseSystemComponent::GetDependentServices(dependent);
+    }
+
+    void AFREditorSystemComponent::Activate()
+    {
+        AFRSystemComponent::Activate();
+        AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+    }
+
+    void AFREditorSystemComponent::Deactivate()
+    {
+        AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
+        AFRSystemComponent::Deactivate();
+    }
+
+} // namespace AFR

--- a/Gems/AFR/Code/Source/Tools/AFREditorSystemComponent.h
+++ b/Gems/AFR/Code/Source/Tools/AFREditorSystemComponent.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+
+#include <Clients/AFRSystemComponent.h>
+
+namespace AFR
+{
+    /// System component for AFR editor
+    class AFREditorSystemComponent
+        : public AFRSystemComponent
+        , protected AzToolsFramework::EditorEvents::Bus::Handler
+    {
+        using BaseSystemComponent = AFRSystemComponent;
+    public:
+        AZ_COMPONENT_DECL(AFREditorSystemComponent);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AFREditorSystemComponent();
+        ~AFREditorSystemComponent();
+
+    private:
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+    };
+} // namespace AFR

--- a/Gems/AFR/Code/afr_api_files.cmake
+++ b/Gems/AFR/Code/afr_api_files.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+set(FILES
+    Include/AFR/AFRBus.h
+    Include/AFR/AFRTypeIds.h
+)

--- a/Gems/AFR/Code/afr_editor_private_files.cmake
+++ b/Gems/AFR/Code/afr_editor_private_files.cmake
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+set(FILES
+    Source/Tools/AFREditorSystemComponent.cpp
+    Source/Tools/AFREditorSystemComponent.h
+)

--- a/Gems/AFR/Code/afr_editor_shared_files.cmake
+++ b/Gems/AFR/Code/afr_editor_shared_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+set(FILES
+    Source/Tools/AFREditorModule.cpp
+)

--- a/Gems/AFR/Code/afr_private_files.cmake
+++ b/Gems/AFR/Code/afr_private_files.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+set(FILES
+    Source/AFRModuleInterface.cpp
+    Source/AFRModuleInterface.h
+    Source/Clients/AFRSystemComponent.cpp
+    Source/Clients/AFRSystemComponent.h
+    Include/AFR/AFRFeatureProcessor.h
+    Source/AFRFeatureProcessor.cpp
+)

--- a/Gems/AFR/Code/afr_shared_files.cmake
+++ b/Gems/AFR/Code/afr_shared_files.cmake
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+set(FILES
+    Source/Clients/AFRModule.cpp
+)

--- a/Gems/AFR/gem.json
+++ b/Gems/AFR/gem.json
@@ -1,0 +1,28 @@
+{
+    "gem_name": "AFR",
+    "version": "1.0.0",
+    "display_name": "AFR",
+    "license": "License used i.e. Apache-2.0 or MIT",
+    "license_url": "Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0",
+    "origin": "The name of the originator or creator",
+    "origin_url": "The website for this Gem",
+    "type": "Code",
+    "summary": "This gem enables alternate frame rendering (AFR) by alterating rendering tasks over the GPUs",
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [
+        "AFR"
+    ],
+    "platforms": [
+        ""
+    ],
+    "icon_path": "preview.png",
+    "requirements": "Notice of any requirements for this Gem i.e. This requires X other gem",
+    "documentation_url": "Link to any documentation of your Gem",
+    "dependencies": [],
+    "repo_uri": "",
+    "compatible_engines": [],
+    "engine_api_dependencies": [],
+    "restricted": "AFR"
+}

--- a/Gems/AFR/gem.json
+++ b/Gems/AFR/gem.json
@@ -7,7 +7,7 @@
     "origin": "The name of the originator or creator",
     "origin_url": "The website for this Gem",
     "type": "Code",
-    "summary": "This gem enables alternate frame rendering (AFR) by alterating rendering tasks over the GPUs",
+    "summary": "This gem enables alternate frame rendering (AFR) by alterating rendering tasks over the GPUs. The Gem is enabled by passing --afr <pipelinename> (as well as --device-count <#gpus> with the number of GPUs to use) to the executable on the command line. <pipelinename> should be a (at least partial) match for a RenderPipeline name, for which AFR should execute. This RenderPipeline needs to have a CopyToSwapChain pass at the end. If no <pipelinename> is passed, AFR is applied to the first pipeline that posses such a CopyToSwapChain pass.",
     "canonical_tags": [
         "Gem"
     ],

--- a/Gems/AFR/preview.png
+++ b/Gems/AFR/preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:248e3ffe1fc9ffc02afb2ba8914e222a5a5d13ac45a48b98c95ee062e959a94c
+size 4475

--- a/engine.json
+++ b/engine.json
@@ -16,6 +16,7 @@
     "build": 0,
     "external_subdirectories": [
         "Gems/Achievements",
+        "Gems/AFR",
         "Gems/Archive",
         "Gems/AssetValidation",
         "Gems/Atom",


### PR DESCRIPTION
## What does this PR do?

This PR introduces alternate frame rendering (AFR) functionality to the engine by latching on to a `RenderPipeline`, capturing all passes that are not already scheduled to a fixed device (as well as the `CopyToSwapchain` pass which always runs on the default display device), alternating them between the devices over successive frames and inserting a `CopyPass` from the auxiliary GPUs to the display GPUs at the end, right before `CopyToSwapchain`.

AFR is currently enabled by adding a command lind parameter `--afr <PartialPipelineName>` (e.g. `--afr MainPipeline` to run for the MainPipeline (not an exact match as additional runtime parameters might be added to a pipeline name, like `ViewportId`), if no name is pipeline name is passed, it latches onto the first pipeline which has a `CopyToSwapChain` pass in it), and then applies AFR to this `RenderPipeline` every frame.
The `RenderPipeline` passed to AFR must have a `CopyToSwapChain` pass, otherwise an `AZ_Error` is raised and execution continues without AFR.

Although functional, the application of AFR is somewhat limited at the moment as custom interconnects have unfortunately been abandoned on most consumer cards currently on the market. 
That means that currently copies have to go through PCIe, which is significantly slower than custom interconnects (like SLI/Crossfire in the past or NVLink on some NVIDIA GPUs).
Furthermore, AFR only improves performance once CPU frame time is significantly less than the GPU frame time, as otherwise the CPU is not fast enough in submitting new frames so that the GPUs can even run in parallel.
That is why enabling AFR on a very simple level (like the Shaderball test scene) that is CPU bound will slow down the application, as we gain nothing from parallel submission (as the CPU is slower than the GPU), but also introduce additional overhead through the copy.
On the other hand, if a Pipeline + level has a higher shader load and is dominated by GPU frame time, AFR can improve performance (for the included scene, AFR improves the performance on two 4090s from around $10 ms$ to around $6.2ms$ (`dx12` on Windows or `vulkan` on Linux).

### Performance
Performance measurements for the included Shaderball level with many shaderballs to increase GPU load without impacting CPU load.
#### dx12 (without AFR)
![noAFR](https://github.com/user-attachments/assets/53a33751-2b41-4b1e-af14-ed6da11a49a8)
#### dx12 (AFR)
![AFR](https://github.com/user-attachments/assets/e61c4a45-54d5-4606-a6b9-cfc3cf034c51)
#### vulkan (AFR) on Windows
`vulkan` performance on Windows is somewhat worse than `dx12`, as certain parts (like cross-device `Fence`s) are only supported on Linux, but still faster than without AFR.
![AFR_vulkan](https://github.com/user-attachments/assets/d525bccf-1582-4cf8-b4d9-2001e7aa169e)

## How was this PR tested?

Tested `Editor` and `GameLauncher` on both Windows (`dx12` and `vulkan`) and Linux (`vulkan`) with the standard Shaderball test level as well as with a custom [ShaderballLevelLarge.zip](https://github.com/user-attachments/files/20899540/ShaderballLevelLarge.zip) (that places a large number of shaderballs instead of a single one) to show off the performance benefit on GPU-bound applications.
