### PR TITLE
Fix the coordinate system transform for fbx animations.

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -188,6 +188,16 @@ namespace AZ
             result.first = static_cast<AssImpSceneWrapper::AxisVector>(frontVectorRead);
             return result;
         }
+
+        AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> AssImpSceneWrapper::GetRightVectorAndSign() const
+        {
+            AZStd::pair<AssImpSceneWrapper::AxisVector, int32_t> result(AxisVector::X, 1);
+            int32_t rightVectorRead(static_cast<int32_t>(result.first));
+            m_assImpScene->mMetaData->Get("CoordAxis", rightVectorRead);
+            m_assImpScene->mMetaData->Get("CoordAxisSign", result.second);
+            result.first = static_cast<AssImpSceneWrapper::AxisVector>(rightVectorRead);
+            return result;
+        }
     }//namespace AssImpSDKWrapper
 
 } // namespace AZ

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
@@ -44,6 +44,7 @@ namespace AZ
 
             AZStd::pair<AxisVector, int32_t> GetUpVectorAndSign() const;
             AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const;
+            AZStd::pair<AxisVector, int32_t> GetRightVectorAndSign() const;
 
             AZStd::string GetSceneFileName() const { return m_sceneFileName; }
             aiAABB GetAABB() const { return m_aabb; }

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -62,21 +62,31 @@ namespace AZ
                 m_unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
                 rootTransform /= m_unitSizeInMeters;
             }
-            // for FBX, root transform is not converted where there are no meshes in the scene.
-            if ((assImpScene->GetAssImpScene()->mFlags & AI_SCENE_FLAGS_INCOMPLETE)
-                && assImpScene->GetAssImpScene()->mMetaData->HasKey("UpAxis"))
-            {
-                readRootTransform = false;
-            }
-
             if (readRootTransform)
             {
-                // AssImp SDK internally uses a Y-up coordinate system, so we need to adjust the coordinate system to match the O3DE coordinate system (Z-up).
-                AZ::Matrix3x4 adjustmatrix = AZ::Matrix3x4::CreateFromRows(
-                    AZ::Vector4(1, 0, 0, 0),
-                    AZ::Vector4(0, 0, -1, 0),
-                    AZ::Vector4(0, 1, 0, 0)
-                );
+                AZ::Matrix3x4 adjustmatrix = AZ::Matrix3x4::CreateZero();
+                // for FBX, root transform is not converted where there are no meshes in the scene.
+                if ((assImpScene->GetAssImpScene()->mFlags & AI_SCENE_FLAGS_INCOMPLETE)
+                    && assImpScene->GetAssImpScene()->mMetaData->HasKey("UpAxis"))
+                {
+                    auto upAxisAndSign = assImpScene->GetUpVectorAndSign();
+                    auto frontAxisAndSign = assImpScene->GetFrontVectorAndSign();
+                    auto rightAxisAndSign = assImpScene->GetRightVectorAndSign();
+
+                    // Set transform matrix with basis vector (-right, front, up)
+                    adjustmatrix.SetElement(0, (int)rightAxisAndSign.first, -(float)rightAxisAndSign.second);
+                    adjustmatrix.SetElement(1, (int)frontAxisAndSign.first, (float)frontAxisAndSign.second);
+                    adjustmatrix.SetElement(2, (int)upAxisAndSign.first, (float)upAxisAndSign.second);
+                }
+                else
+                {
+                    // AssImp SDK internally uses a Y-up coordinate system, so we need to adjust the coordinate system to match the O3DE coordinate system (Z-up).
+                    adjustmatrix = AZ::Matrix3x4::CreateFromRows(
+                        AZ::Vector4(-1, 0, 0, 0),
+                        AZ::Vector4(0, 0, 1, 0),
+                        AZ::Vector4(0, 1, 0, 0)
+                    );
+                }
                 m_adjustTransform.reset(new DataTypes::MatrixType(adjustmatrix * rootTransform));
                 m_adjustTransformInverse.reset(new DataTypes::MatrixType(m_adjustTransform->GetInverseFull()));
                 return;


### PR DESCRIPTION
Rotate the imported models 180 degrees on Z axis to face the positive Y axis.

## What does this PR do?

Previous fixes on animation coordinate only tested on unreal-exported animations. When tested with mixamo animations the orientation of animations are incorrect. This PR took the transform algorithm from assimp to ensure the right orientation for fbx animations.

This PR also rotates models by 180 degrees on Z axis. Previously the importer uses blender's orientation which places front axis on -Y. This PR places the front axis on Y instead.

## How was this PR tested?

Tested characters and animations imported from mixamo and unreal engine 
