### PR TITLE
Make AZ::RHI::GeometryView constructor with one parameter explicit

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
@@ -27,7 +27,7 @@ namespace AzToolsFramework
             const AZ::EntityId entityId = entityComponentIdPair.GetEntityId();
             AZ_Assert(entityId.IsValid(), "Attempting to create a Component Mode with an invalid EntityId");
 
-            if (const AZ::Entity* entity = AzToolsFramework::GetEntity(entityId))
+            if ([[maybe_unused]] const AZ::Entity* entity = AzToolsFramework::GetEntity(entityId))
             {
                 AZ_Assert(entity->GetState() == AZ::Entity::State::Active,
                     "Attempting to create a Component Mode for an Entity which is not currently active. "

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
@@ -276,7 +276,7 @@ namespace LegacyFramework
         if (m_applicationEntity)
         {
             // if the component already exists on the system entity, this is an error.
-            if (auto comp = m_ptrSystemEntity->FindComponent(componentCRC))
+            if ([[maybe_unused]] auto comp = m_ptrSystemEntity->FindComponent(componentCRC))
             {
                 AZ_Warning("EditorFramework", 0, "Attempt to add a component that already exists on the system entity: %s\n", comp->RTTI_GetTypeName());
                 return true;

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -99,7 +99,7 @@ namespace AssetProcessor
 
         void Activate() override
         {
-            if (auto* registry = AZ::SettingsRegistry::Get())
+            if (AZ::SettingsRegistry::Get())
             {
                 m_verboseMode = AssetUtilities::GetUserSetting(AssetUtilities::VerboseLoggingOptionName, false);
             }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
@@ -37,7 +37,7 @@ namespace AZ::RHI
     public:
         friend class StreamIterator<GeometryView, StreamBufferView>;
 
-        GeometryView(MultiDevice::DeviceMask deviceMask)
+        explicit GeometryView(MultiDevice::DeviceMask deviceMask)
         {
             MultiDeviceObject::IterateDevices(
                 deviceMask,

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -56,7 +56,7 @@ namespace AZ
 
             for (const ModelLodAsset::Mesh& mesh : lodAsset->GetMeshes())
             {
-                Mesh meshInstance{ RHI::MultiDevice::AllDevices };
+                Mesh meshInstance{ RHI::GeometryView{ RHI::MultiDevice::AllDevices } };
 
                 const BufferAssetView& indexBufferAssetView = mesh.GetIndexBufferAssetView();
                 const Data::Asset<BufferAsset>& indexBufferAsset = indexBufferAssetView.GetBufferAsset();


### PR DESCRIPTION
## What does this PR do?

This PR marks the `AZ::RHI::GeometryView` constructor with one parameter, which was introduced in [PR19009](https://github.com/o3de/o3de/pull/19009) as `explicit`. This ensures that the class is not instantiated implicitly, eg. by assigning a value of the parameter type in a class member declaration, which is more ambiguous than calling the class constructor explicitly.
(There are 3 small unrelated changes, which are necessary for compiling the engine with Clang on Windows due to unused variable errors, which are not triggered for MSVC.)

## How was this PR tested?

Compile the engine and ASV in profile and release mode.
