### PR TITLE
Ensure call to ::tolower in cache path resolve function does not invalidate utf8 characters

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
@@ -878,7 +878,7 @@ namespace AZ
                 {
                     for (AZ::u64 i = aliasLen; i < bufferLen && inOutBuffer[i] != '\0'; ++i)
                     {
-                        inOutBuffer[i] = static_cast<char>(std::tolower(static_cast<int>(inOutBuffer[i])));
+                        inOutBuffer[i] = AZStd::tolower(inOutBuffer[i]);
                     }
 
                     return true;


### PR DESCRIPTION
## What does this PR do?

This RP fixes asset names with non-ascii characters being incorrectly converted to lower-case when searching for them in the cache folder during editor startup. The function `std::tolower` uses the current locale to do this conversion, and on my machine (Windows 10 without the UTF-8 region setting enabled) it appears to be using a non utf8-locale to convert the two utf8-bytes of the `Ä` character to some other bytes, which are no longer valid utf8.
By using `AZStd::tolower` instead, the locale for the conversion is set to a default `std::locale{}`, which does not show this behavior, but also does not convert non-ascii characters to lower case. In the cache folder, however, the asset name is in lower case (eg. `ä.fbx.abdata.json`), so this might lead to problems on Linux which uses a case-sensitive filesystem by default. A better solution would probably be to use a proper utf8-aware to-lower function (In this case the problem originates in `AzToolsFramework::AssetBrowser::RootAssetBrowserEntry`, so it should also be possible to use the to-lower conversion from Qt in this class instead of all the way down in `LocalFileIO`).

This bug does not prevent the usage of assets with unicode names in general, which was enabled by [PR18741](https://github.com/o3de/o3de/pull/18741), it only shows a console warning for the `...abdata.json` product asset, which does not seem to be terribly important anyway.

## How was this PR tested?

Create an asset with the name `Ä.fbx` ("Latin Capital Letter A with Diaeresis", ie. german umlaut A; but also many characters other non-ASCII-alphabets show the same problem), then open the editor and look for errors in the console.
