### PR TITLE
Fixes potential deadlocks in Atom related to the queue system

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/AsyncWorkQueue.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/AsyncWorkQueue.cpp
@@ -83,9 +83,10 @@ namespace AZ::RHI
 
     void AsyncWorkQueue::ProcessQueue()
     {
-        WorkItem workItem;
         for (;;)
         {
+            // use a fresh workitem each time, so that we don't end up clearing its variables during move below.
+            WorkItem workItem;
             {
                 AZStd::unique_lock<AZStd::mutex> lock(m_workQueueMutex);
 
@@ -108,6 +109,7 @@ namespace AZ::RHI
                 AZStd::unique_lock<AZStd::mutex> lock(m_waitWorkItemMutex);
                 m_lastCompletedWorkItem = workItem.m_handle;
             }
+
             m_waitWorkItemCondition.notify_all();
         }
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CommandQueue.cpp
@@ -110,9 +110,9 @@ namespace AZ::RHI
     void CommandQueue::ProcessQueue()
     {
         //runs forever in a background thread
-        Command command;
         for (;;)
         {
+            Command command;
             {
                 AZStd::unique_lock<AZStd::mutex> lock(m_workQueueMutex);
                     


### PR DESCRIPTION
## What does this PR do?

This could affect any number of deadlocks, or other problems in atom, becuase of the unpredictability of what it affects.  Its *definitely* a fix, though, what happened before was *definitely* broken, its just that this could be the root cause for an unpredictable number of other problems.

Basically, what's happening here is that the async / render queues (used for all sorts of device access) often have lambda captured RHI objects, such as streaming images, in the queue.  For example when a mip chain asset loads, it puts a command in the queue to expand the mip chain, and that command is hooked to a lambda which captures a copy of the streaming image being modified.  (So increases its refcount when the lambda is created, and would decrement the refcount when the lamba goes out of scope or is destructed).

But the queue had this pseudocode pattern

```cpp
Command command;
while (!quit)
{
    // remove a command while the queue is locked
    m_queueMutex.lock();
    command = std::move(m_queue.front());
    m_queue.pop_front();
    m_queueMutex.unlock();

    // execute the command outside of the lock
    if (command)
    {
        command.Execute();
    }
};
```

while this seems reasonable, there is a fatal problem. The problem is the reuse of the `command` variable.  Command.execute does not clear the command variable, it still has its functor in there, which means the lambda and its captures are still alive for the next time around the while loop.  Until operator= is invoked **inside the locked mutex**, at which point, the lambda captured objects are freed, which causes reference counted objects to be dropped and the renderer and other systems to activate and do stuff... still inside the locked section.

 This means that any destructorsrelated to the command, such as variables captured by lambdas, are destructed while the queue is locked, instead of outside the locked section.

It also means that "work is being done" and interactions are happening with atom and other systems, while the queue is locked.

It also causes messed up reference counting.

The fix is not to reuse the command variable - either make a fresh one each loop (it doesn't change the stack allocation), or call clear().

Without this change:
Random deadlocks can occur.
Streaming images release their last refcount during the operator=() call from the std::move() and unload inside the critical section, even during upload of fresh mips.

With this change:
Streaming images only release their last refcount when objects using them are no longer present.

## How was this PR tested?

clear-box testing (breakpoints).  Running various levels and switching between them.

