### PR TITLE
Adjust the asset processor batch lock file path

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -71,7 +71,7 @@ foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME launcher_gener
                 COMMENT "Processing ${project_name} assets..."
                 USES_TERMINAL # Do not buffer output of run command
                 COMMAND "${CMAKE_COMMAND}"
-                    -DLY_LOCK_FILE=$<GENEX_EVAL:$<TARGET_FILE_DIR:AZ::AssetProcessorBatch>>/project_assets.lock
+                    -DLY_LOCK_FILE=${project_real_path}/user/AssetProcessorTemp/project_assets.lock
                     -P ${LY_ROOT_FOLDER}/cmake/CommandExecution.cmake
                         EXEC_COMMAND $<GENEX_EVAL:$<TARGET_FILE:AZ::AssetProcessorBatch>>
                             --zeroAnalysisMode


### PR DESCRIPTION
## What does this PR do?

The O3DE SDK from the Debian package installs into the `/opt/` directory, which requires superuser permissions. The `<project>.Assets` target attempts to create a lock file in this directory, causing an error. This pull request resolves the issue by relocating the lock file to `<project>/user/AssetProcessorTemp`, where the necessary user permissions are available.

## How was this PR tested?

1. Installed SDK in /opt.
2. Created project.
3. Used `<project>.Assets` target without problem.
