### PR TITLE
Enable generation of bindless indices for structured buffer views in Vulkan

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.cpp
@@ -55,7 +55,7 @@ namespace AZ
             // Vulkan BufferViews are used to enable shaders to access buffer contents interpreted as formatted data.
             bool shaderRead = RHI::CheckBitsAny(bindFlags, RHI::BufferBindFlags::ShaderRead);
             bool shaderReadWrite = RHI::CheckBitsAny(bindFlags, RHI::BufferBindFlags::ShaderWrite);
-            if (viewDescriptor.m_elementFormat != RHI::Format::Unknown && (shaderRead || shaderReadWrite))
+            if (shaderRead || shaderReadWrite)
             {
 #if defined(AZ_RHI_ENABLE_VALIDATION)
                 AZ_Assert(
@@ -65,7 +65,12 @@ namespace AZ
                     "Typed Buffer View has to be aligned to a multiple of %d bytes.",
                     device.GetLimits().m_minTexelBufferOffsetAlignment);
 #endif
-                auto result = BuildNativeBufferView(device, buffer, viewDescriptor);
+
+                RHI::ResultCode result = RHI::ResultCode::Success;
+                if (viewDescriptor.m_elementFormat != RHI::Format::Unknown)
+                {
+                    result = BuildNativeBufferView(device, buffer, viewDescriptor);
+                }
 
                 if (device.GetBindlessDescriptorPool().IsInitialized())
                 {


### PR DESCRIPTION
## What does this PR do?

Currently the Vulkan backend does not allow accessing structured buffers from the bindless srg. Since a `ByteAddressBuffer` can also be used to read a struct with the syntax `buffer.Load<MyStruct>(index * sizeof(MyStruct))`, it makes sense to allow structured buffers to be accessed like this as well (A simple workaround for this issue is to just use a R32-typed buffer view instead, but if the source data is already a vector of structs, it makes sense to also use a structured buffer for this).

## How was this PR tested?

Change some typed buffer views created with `RHI::BufferViewDescriptor::CreateRaw`, which are accessed with the bindless srg, to structured buffer views created by `RHI::BufferViewDescriptor::CreateStructured`, and verify that the rendering result is still correct:
* MeshFeatureProcessor.cpp: eg. `normalBufferDescriptor` or `uvBufferDescriptor` of the ray tracing mesh description
* MaterialSystem.cpp: `bufferViewDescriptor` in `PrepareMaterialParameterBuffers()`, which is used to read the material parameters in the new material system
