### PR TITLE
Make Restricted Optional, Fix the gem setup.

### DIFF
--- a/cmake/PAL.cmake
+++ b/cmake/PAL.cmake
@@ -253,6 +253,11 @@ endforeach()
 
 # set the O3DE_ENGINE_RESTRICTED_PATH
 o3de_restricted_path(${LY_ROOT_FOLDER}/engine.json O3DE_ENGINE_RESTRICTED_PATH)
+if(NOT O3DE_ENGINE_RESTRICTED_PATH)
+    # If the engine.json does not have a 'restricted' field use the engine dir and append /restricted
+    set(O3DE_ENGINE_RESTRICTED_PATH "${LY_ROOT_FOLDER}/restricted")
+    message(STATUS "No restricted path found in engine.json, using default: ${O3DE_ENGINE_RESTRICTED_PATH}")
+endif()
 
 # detect platforms in the restricted path
 file(GLOB detection_files ${O3DE_ENGINE_RESTRICTED_PATH}/*/cmake/PALDetection_*.cmake)

--- a/cmake/install/engine.json.in
+++ b/cmake/install/engine.json.in
@@ -1,6 +1,5 @@
 {
     "engine_name": "@O3DE_INSTALL_ENGINE_NAME@",
-    "restricted_name": "@O3DE_INSTALL_ENGINE_NAME@",
     "display_version": "@O3DE_INSTALL_DISPLAY_VERSION_STRING@",
     "version": "@O3DE_INSTALL_VERSION_STRING@",
     "api_versions": @O3DE_INSTALL_API_VERSIONS@,

--- a/engine.json
+++ b/engine.json
@@ -1,6 +1,5 @@
 {
     "engine_name": "o3de",
-    "restricted": "o3de",
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -136,28 +136,24 @@ def get_default_o3de_manifest_json_data() -> dict:
     default_restricted_engine_folder.mkdir(parents=True, exist_ok=True)
     default_restricted_templates_folder = default_restricted_folder / 'Templates'
     default_restricted_templates_folder.mkdir(parents=True, exist_ok=True)
-    default_restricted_engine_folder_json = default_restricted_engine_folder / 'restricted.json'
-    if not default_restricted_engine_folder_json.is_file():
-        with default_restricted_engine_folder_json.open('w') as s:
-            restricted_json_data = {}
-            restricted_json_data.update({'restricted_name': 'o3de'})
-            s.write(json.dumps(restricted_json_data, indent=4) + '\n')
 
-    json_data = {}
-    json_data.update({'o3de_manifest_name': f'{username}'})
-    json_data.update({'origin': o3de_folder.as_posix()})
-    json_data.update({'default_engines_folder': default_engines_folder.as_posix()})
-    json_data.update({'default_projects_folder': default_projects_folder.as_posix()})
-    json_data.update({'default_gems_folder': default_gems_folder.as_posix()})
-    json_data.update({'default_templates_folder': default_templates_folder.as_posix()})
-    json_data.update({'default_restricted_folder': default_restricted_folder.as_posix()})
-    json_data.update({'default_third_party_folder': default_third_party_folder.as_posix()})
-    json_data.update({'projects': []})
-    json_data.update({'external_subdirectories': []})
-    json_data.update({'templates': []})
-    json_data.update({'restricted': [default_restricted_engine_folder.as_posix()]})
-    json_data.update({'repos': []})
-    json_data.update({'engines': []})
+    json_data = {
+        'o3de_manifest_name': f'{username}',
+        'origin': o3de_folder.as_posix(),
+        'default_engines_folder': default_engines_folder.as_posix(),
+        'default_projects_folder': default_projects_folder.as_posix(),
+        'default_gems_folder': default_gems_folder.as_posix(),
+        'default_templates_folder': default_templates_folder.as_posix(),
+        'default_restricted_folder': default_restricted_folder.as_posix(),
+        'default_third_party_folder': default_third_party_folder.as_posix(),
+        'engines': [],
+        'projects': [],
+        'external_subdirectories': [],
+        'templates': [],
+        'restricted': [],
+        'repos': []
+    }
+
     return json_data
 
 def get_o3de_manifest() -> pathlib.Path:


### PR DESCRIPTION
This change makes restricted objects completely optional for ALL objects, including the engine which previously required a restricted object. Now if the object doesn't have a restricted or if restricted object if not present will just default to the <object_path>/restricted. This is fine as long as it is a valid path.

