### PR TITLE
Fixes a crash that occurs when meshes update in RaytraceFeatureProcessor (due to hot reload or AP finish)

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -1117,7 +1117,7 @@ namespace AZ
                         break;
                     }
                 }
-                for (auto toRemove : toRemoveFromCreateList)
+                for (auto& toRemove : toRemoveFromCreateList)
                 {
                     m_blasToCreate.erase(toRemove);
                 }
@@ -1175,7 +1175,7 @@ namespace AZ
                         toDelete.insert(assetId);
                     }
                 }
-                for (auto assetId : toDelete)
+                for (auto& assetId : toDelete)
                 {
                     blasEnqueuedForCompact.erase(assetId);
                 }
@@ -1210,7 +1210,7 @@ namespace AZ
                         toDelete.insert(assetId);
                     }
                 }
-                for (auto assetId : toDelete)
+                for (auto& assetId : toDelete)
                 {
                     uncompactedBlasEnqueuedForDeletion.erase(assetId);
                 }
@@ -1523,11 +1523,11 @@ namespace AZ
             {
                 entries.erase(id);
             }
-            for (auto [deviceIndex, blasEnqueuedForCompact] : m_blasEnqueuedForCompact)
+            for (auto& [deviceIndex, blasEnqueuedForCompact] : m_blasEnqueuedForCompact)
             {
                 blasEnqueuedForCompact.erase(id);
             }
-            for (auto [deviceIndex, uncompactedBlasEnqueuedForDeletion] : m_uncompactedBlasEnqueuedForDeletion)
+            for (auto& [deviceIndex, uncompactedBlasEnqueuedForDeletion] : m_uncompactedBlasEnqueuedForDeletion)
             {
                 uncompactedBlasEnqueuedForDeletion.erase(id);
             }


### PR DESCRIPTION
## What does this PR do?

The raytrace feature processor was incorrectly using `auto` instead of `auto &` when iterating over its structures.  Most of the time, this would only be a slight performance hit, but fatally, when a mesh was cleared out of the raytracing feature processor, it used

```cpp
for (auto [deviceIndex, uncompactedBlasEnqueuedForDeletion] : m_uncompactedBlasEnqueuedForDeletion)
{
    uncompactedBlasEnqueuedForDeletion.erase(id);
}
```

The lack of the ampersand meand that the erase was being carried out on a copy of the map, which would not actually remove the item from the original map, leaving bogus entries in there.

## How was this PR tested?

100% crash before this fix, 0% crash after this fix.  Fairly straightforward.
