### PR TITLE
Add maybe_unused to fix vegetation test gem build on MSVC latest

### DIFF
--- a/Gems/Vegetation/Code/Tests/PrefabInstanceSpawnerTests.cpp
+++ b/Gems/Vegetation/Code/Tests/PrefabInstanceSpawnerTests.cpp
@@ -129,7 +129,7 @@ namespace UnitTest
         }
         AZ::Data::AssetHandler::LoadResult LoadAssetData(
             [[maybe_unused]] const AZ::Data::Asset<AZ::Data::AssetData>& asset,
-            AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
+            [[maybe_unused]] AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
             [[maybe_unused]] const AZ::Data::AssetFilterCB& assetLoadFilterCB) override
         {
             MockAssetData* temp = reinterpret_cast<MockAssetData*>(asset.GetData());


### PR DESCRIPTION
## What does this PR do?

As reported in https://discord.com/channels/805939474655346758/869974333009854464/1387552271369506866
When building all gems on MSVC latest, we currently run into an unused variable warning which fails the build. With this fixed, it is possible to run the install target on windows.

Related to 
- https://github.com/o3de/o3de/pull/18994
- https://github.com/o3de/o3de/pull/19049

## How was this PR tested?

Local windows build on dev branch latest
