### PR TITLE
Improves output of cmake configure by showing basic info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,30 @@ if(NOT PROJECT_NAME)
     )
 endif()
 
+# Output some useful-for-debugging information in case something goes wrong and the user sends a log.
+# this cannot be done until project() is called.
+get_property(O3DE_SCRIPT_ONLY GLOBAL PROPERTY "O3DE_SCRIPT_ONLY")
+if (O3DE_SCRIPT_ONLY)
+    message(STATUS  "Basic Configuration Information (Script-only mode):\n" 
+                    "   CMAKE_VERSION: ${CMAKE_VERSION}\n"
+                    "   CMAKE_GENERATOR: ${CMAKE_GENERATOR}"
+            )
+else()
+    message(STATUS  "Basic Configuration Information:\n" 
+                    "   CMAKE_VERSION: ${CMAKE_VERSION}\n"
+                    "   CMAKE_GENERATOR: ${CMAKE_GENERATOR}\n"
+                    "   CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}\n"
+                    "   CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}\n"
+                    "   O3DE_INSTALL_VERSION_STRING: ${O3DE_INSTALL_VERSION_STRING}\n"
+                    "   INSTALLED_ENGINE: ${INSTALLED_ENGINE}"
+            )
+endif()
+
 ################################################################################
 # Initialize
 ################################################################################
+message(STATUS "Initializing O3DE CMake system...")
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
 include(CTest)
 include(cmake/PAL.cmake)
 include(cmake/PALTools.cmake)
@@ -55,7 +76,6 @@ include(cmake/O3DEJson.cmake)
 include(cmake/Subdirectories.cmake)
 include(cmake/TestImpactFramework/LYTestImpactFramework.cmake) # Put at end as nothing else depends on it
 
-get_property(O3DE_SCRIPT_ONLY GLOBAL PROPERTY "O3DE_SCRIPT_ONLY")
 if (O3DE_SCRIPT_ONLY AND NOT INSTALLED_ENGINE)
     get_property(engine_root GLOBAL PROPERTY O3DE_ENGINE_ROOT_FOLDER)
     message(FATAL_ERROR "Script-only projects require pre-built versions of O3DE.\n\
@@ -69,12 +89,17 @@ endif()
 # into the O3DE_EXTERNAL_SUBDIRS_O3DE_MANIFEST_PROPERTY
 add_o3de_manifest_json_external_subdirectories()
 
+list(POP_BACK CMAKE_MESSAGE_INDENT)
+message(STATUS "Executing CMake scripts...")
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+
 # Add the projects first so the Launcher can find them
 include(cmake/Projects.cmake)
 
 # Add external subdirectories listed in the engine.json.
 # O3DE_EXTERNAL_SUBDIRS is a cache variable so the user can add extra
 # external subdirectories.
+
 add_engine_json_external_subdirectories()
 
 if(NOT INSTALLED_ENGINE)
@@ -101,6 +126,13 @@ endif()
 # Post-processing
 ################################################################################
 # The following steps have to be done after all targets are registered:
+list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+message(STATUS "Finishing up configuration...")
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+
+# Most of these post processing steps are nearly instantaneous, so no point in displaying a message
+# but if any of them take a time, we can add a message.
 
 # 1. Add any dependencies registered via ly_enable_gems
 ly_enable_gems_delayed()
@@ -120,12 +152,15 @@ ly_delayed_generate_settings_registry()
 ly_delayed_target_link_libraries()
 
 # 5. generate a registry file for unit testing for platforms that support unit testing
+
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     ly_delayed_generate_unit_test_module_registry()
 endif()
 
 # 5. inject runtime dependencies to the targets. We need to do this after (1) since we are going to walk through
 #    the dependencies
+#    This step takes a bit of time, so we display a message
+message(STATUS "Computing Runtime Dependencies (files to copy to the target's output directory)...")
 ly_delayed_generate_runtime_dependencies()
 
 # 6. Perform test impact framework post steps once all of the targets have been enumerated
@@ -134,6 +169,8 @@ if(O3DE_TEST_IMPACT_NATIVE_TEST_TARGETS_ENABLED OR O3DE_TEST_IMPACT_PYTHON_TEST_
         ly_test_impact_post_step()
     endif()
 endif()
+
+list(POP_BACK CMAKE_MESSAGE_INDENT)
 
 # 7. Generate the O3DE find file and setup install locations for scripts, tools, assets etc., required by the engine
 if(LY_INSTALL_ENABLED)

--- a/cmake/3rdPartyPackages.cmake
+++ b/cmake/3rdPartyPackages.cmake
@@ -737,7 +737,8 @@ if (NOT CMAKE_SCRIPT_MODE_FILE)
     include(${LY_ROOT_FOLDER}/cmake/3rdParty/BuiltInPackages.cmake)
 endif()
 
-if(PAL_TRAIT_BUILD_HOST_TOOLS)
+get_property(O3DE_SCRIPT_ONLY GLOBAL PROPERTY "O3DE_SCRIPT_ONLY")
+if(PAL_TRAIT_BUILD_HOST_TOOLS AND NOT O3DE_SCRIPT_ONLY)
     include(${LY_ROOT_FOLDER}/cmake/LYWrappers.cmake)
     # Importing this globally to handle AUTOMOC, AUTOUIC, AUTORCC
     ly_parse_third_party_dependencies(3rdParty::Qt)

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -126,7 +126,7 @@ ly_append_configurations_options(
 # Look for O3DE_ENABLE_COMPILER_CACHE as a CMake flag or environment variable, then sets the appropriate compatible flags for caching
 # More details about the compiler cache can be found in CompilerCache.cmake
 
-if((O3DE_ENABLE_COMPILER_CACHE OR "$ENV{O3DE_ENABLE_COMPILER_CACHE}" STREQUAL "true"))
+if((O3DE_ENABLE_COMPILER_CACHE OR "$ENV{O3DE_ENABLE_COMPILER_CACHE}" STREQUAL "true") AND NOT O3DE_SCRIPT_ONLY)
     o3de_compiler_cache_activation() # Activates the compiler cache
 
     # Configure debug info format and compiler launcher for cache compatibility


### PR DESCRIPTION
## What does this PR do?

When running cmake configure, it will output a block of information (not containing user identifying information), which will be useful for debugging and helping people if they paste their logs into discord or some other location.  The new section looks like this:

```
-- Basic Configuration Information:
   CMAKE_VERSION: 4.0.2
   CMAKE_GENERATOR: Visual Studio 17 2022
   CMAKE_CXX_COMPILER_ID: MSVC
   CMAKE_CXX_COMPILER_VERSION: 19.43.34809.0
   O3DE_INSTALL_VERSION_STRING: 4.2.0
   INSTALLED_ENGINE: FALSE
```

* Also slightly speeds up Script Only Mode - it does not need Qt's SDK to be downlaoded and installed to work and was downloading and installing it for no reason.

* Also adds a few messages during CMake Configuration to indicate progress, eg, the general flow looks like this:
```
-- ... The above block of info is output ...
-- Initializing O3DE CMake system...
--    ... initial execution and macros go here.
-- Executing CMake scripts...
--    ... all the running of the cmake scripts here
-- Finishing up configuration...
--    ... miscelanous output here if any
--    Computing Runtime Dependencies (files to copy to the target's output directory)...
--    .. any final output here
```

The above basically covers any steps that take significant time to execute.

Previously, the "executing cmake scripts..." section would run and show 3rd parties being downloaded or activated, but there was no indication after that section that progress is being made.

Output in Script Only Mode:
```
-- This is a script-only project, no C++ compiler will be used
-- Selecting engine 'C:/o3de-repos/o3de/install'
-- Basic Configuration Information (Script-only mode):
   CMAKE_VERSION: 4.0.2
   CMAKE_GENERATOR: Ninja Multi-Config
-- Initializing O3DE CMake system...
--   Using package C:/Users/xxxxx/.o3de/Python/packages/python-3.10.13-rev1-windows
--   Using Python venv at C:/Users/xxxxx/.o3de/Python/venv/627bb6c4
-- Executing CMake scripts...
--   RecastNavigation Gem uses https://github.com/recastnavigation/recastnavigation.git commit 5a870d4 (License: Zlib)
-- Finishing up configuration...
--   Computing Runtime Dependencies (files to copy to the target's output directory)...
-- Configuring done (4.9s)
-- Generating done (1.4s)
-- Build files have been written to: C:/o3de-projects/scriptonly2505/build/windows
```

output in normal mode (default project)
```
-- Selecting engine 'C:/o3de-repos/o3de'
-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.26100.
-- Basic Configuration Information:
   CMAKE_VERSION: 4.0.2
   CMAKE_GENERATOR: Visual Studio 17 2022
   CMAKE_CXX_COMPILER_ID: MSVC
   CMAKE_CXX_COMPILER_VERSION: 19.43.34809.0
   O3DE_INSTALL_VERSION_STRING: 4.2.0
   INSTALLED_ENGINE: FALSE
-- Initializing O3DE CMake system...
--   [COMPILER CACHE] Cache is enabled
--   [COMPILER CACHE] Detected Chocolatey shim path, searching in lib directory
--   [COMPILER CACHE] Found at c:/programdata/chocolatey/lib/ccache/tools/ccache-4.11.3-windows-x86_64/ccache.exe, using it for this build
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/zlib-1.2.11-rev5-windows
--   Using the O3DE version of the ZLIB library from C:/Users/xxxxx/.o3de/3rdParty/packages/zlib-1.2.11-rev5-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/qt-5.15.2-rev7-windows
--   Using package C:/Users/xxxxx/.o3de/Python/packages/python-3.10.13-rev1-windows
--   Using Python venv at C:/Users/xxxxx/.o3de/Python/venv/196a2159
-- Executing CMake scripts...
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/RapidJSON-1.1.0-rev1-multiplatform
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/Lua-5.4.4-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/RapidXML-1.13-rev1-multiplatform
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/zstd-1.35-multiplatform
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/cityhash-1.1-multiplatform
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/googlebenchmark-1.7.0-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/lz4-1.9.4-rev1-windows
--   AzTest uses googletest v1.15.2 (BSD-3-Clause) from https://github.com/google/googletest.git
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/SQLite-3.37.2-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/OpenSSL-1.1.1o-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/expat-2.4.2-rev2-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/tiff-4.2.0.15-rev3-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/assimp-5.4.3-rev3-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/xxhash-0.7.4-rev1-multiplatform
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/pybind11-2.10.0-rev1-multiplatform
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/d3dx12-headers-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/vulkan-validationlayers-1.3.261-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/mcpp-2.7.2_az.2-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/DirectXShaderCompilerDxc-1.7.2308-o3de-rev2-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/SPIRVCross-1.3.275.0-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/azslc-1.8.22-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/astc-encoder-3.2-rev2-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/squish-ccr-deb557d-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/ISPCTexComp-36b80aa-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/OpenEXR-3.1.3-rev5-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/openimageio-opencolorio-2.3.17-rev4-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/png-1.6.37-rev2-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/freetype-2.11.1-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/mikkelsen-1.0.0.4-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/pyside2-5.15.2.1-py3.10-rev6-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/libsamplerate-0.2.1-rev2-windows
--   Using miniaudio C:/o3de-projects/DefaultProject/build/windows/_deps/miniaudio-src/miniaudio.h - see C:/o3de-repos/o3de/Gems/MiniAudio/3rdParty/miniaudio/LICENSE.TXT
--   Using stb_vorbis C:/o3de-projects/DefaultProject/build/windows/_deps/stb_vorbis-src/stb_vorbis.c - see C:/o3de-repos/o3de/Gems/MiniAudio/3rdParty/stb_vorbis/LICENSE.TXT
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/NvCloth-v1.1.6-4-gd243404-pr58-rev1-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/PhysX-4.1.2.29882248-rev8-windows
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/poly2tri-7f0487a-rev1-windows
--   PhysX gem uses v-hacd v4.1.0 (BSD-3-Clause) https://github.com/kmammou/v-hacd.git
--   Using package C:/Users/xxxxx/.o3de/3rdParty/packages/PhysX-5.1.1-rev4-windows
--   RecastNavigation Gem uses https://github.com/recastnavigation/recastnavigation.git commit 5a870d4 (License: Zlib)
--   WhiteBox Gem uses OpenMesh-11.0 (BSD-3-Clause) https://gitlab.vci.rwth-aachen.de:9000/OpenMesh/OpenMesh.git
--         With patch: C:/o3de-repos/o3de/Gems/WhiteBox/3rdParty/openmesh-o3de-11.0.patch
-- Finishing up configuration...
--   Computing Runtime Dependencies (files to copy to the target's output directory)...
-- Configuring done (17.3s)
```

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

_Please describe any testing performed._
