### PR TITLE
Fix StreamingImageController OnSetTargetMip

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -164,7 +164,10 @@ namespace AssetProcessorMessagesTests
             m_batchApplicationManager->InitAssetRequestHandler(m_assetRequestHandler);
             m_batchApplicationManager->ConnectAssetCatalog();
 
-            QObject::connect(m_batchApplicationManager->m_connectionManager, &ConnectionManager::ConnectionError, [](unsigned /*connId*/, QString error)
+            QObject::connect(
+                m_batchApplicationManager->m_connectionManager,
+                &ConnectionManager::ConnectionError,
+                [](unsigned /*connId*/, [[maybe_unused]] QString error)
                 {
                     AZ_Error("ConnectionManager", false, "%s", error.toUtf8().constData());
                 });

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImageController.h
@@ -103,7 +103,7 @@ namespace AZ
             size_t GetPoolMemoryUsage();
 
             // Insert image to expandable and evictable lists
-            void ReinsertImageToLists(StreamingImage* image);
+            void ReinsertImageToLists(StreamingImage* image, AZStd::optional<size_t> updatedTimestamp = {});
 
             // Called when the expanding of an image is finished or canceled
             void EndExpandImage(StreamingImage* image);

--- a/Gems/EditorPythonBindings/Code/Tests/PythonGlobalsTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonGlobalsTests.cpp
@@ -20,7 +20,7 @@
 
 namespace UnitTest
 {
-    void AcceptTwoStrings(AZStd::string stringValue1, AZStd::string stringValue2)
+    void AcceptTwoStrings([[maybe_unused]] AZStd::string stringValue1, [[maybe_unused]] AZStd::string stringValue2)
     {
         AZ_TracePrintf("python", stringValue1.empty() ? "stringValue1_is_empty" : "stringValue1_has_data");
         AZ_TracePrintf("python", stringValue2.empty() ? "stringValue2_is_empty" : "stringValue2_has_data");


### PR DESCRIPTION
## What does this PR do?

The `OnSetTargetMip` of the `StreamingImageController` sets the `m_lastAccessTimestamp` of the image and the calls `ReinsertImageToLists`.
`ReinsertImageToLists` first removes the image from the list and then reinserts it with the new priority.
Unfortunately the `m_lastAccessTimestamp` is also used in the comparison operator in the `m_evictableImages` set.
Therefor the image is not actually removed from `m_evictableImages` and it will stay there even after the image is deleted.
This leads to use after free, and to random crashes later on.

This PR fixes this problem by first removing the image from the lists, then set the timestamp, and finally insert the image into the lists again.

## How was this PR tested?

Tested with a project that sets the target mip of an image.
