### PR TITLE
Full file path in EmotionFX RecentFiles menu.

### DIFF
--- a/Gems/EMotionFX/Code/MysticQt/Source/RecentFiles.cpp
+++ b/Gems/EMotionFX/Code/MysticQt/Source/RecentFiles.cpp
@@ -173,7 +173,7 @@ namespace MysticQt
             if (foundInScanFolders)
             {
                 const QFileInfo fileInfo(m_recentFiles[i]);
-                const QString menuItemText = QString("&%1 %2").arg(i + 1).arg(fileInfo.fileName());
+                const QString menuItemText = QString("&%1 %2").arg(i + 1).arg(fileInfo.filePath());
 
                 QAction* action = new QAction(m_recentFilesMenu);
                 action->setText(menuItemText);


### PR DESCRIPTION
## What does this PR do?

Previously, the File -> Recent Workspaces menu in EmotionFX only showed file names. This made it difficult to identify the correct workspace when multiple files had the same name. Now, this has been corrected, allowing users to easily distinguish between them. The feature is used in the UI Editor and looks great.

## How was this PR tested?

I just ran the editor and saw this. You can see it in the attached images.
![before](https://github.com/user-attachments/assets/78e09ec1-518e-490c-9682-d7e4000d83ac)
![after](https://github.com/user-attachments/assets/e576ba0e-45a5-4db4-9821-05e67cb88dee)
