### PR TITLE
Make sure shared samplers are always initialized

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
@@ -60,7 +60,7 @@ namespace AZ::RPI
     private:
         bool LoadMaterialSrgShaderAsset();
         void CreateSceneMaterialSrg();
-        void UpdateSceneMaterialSrg();
+        bool UpdateSceneMaterialSrg();
         bool UpdateSharedSamplerStates();
         void PrepareMaterialParameterBuffers();
         void UpdateChangedMaterialParameters();


### PR DESCRIPTION
## What does this PR do?

Makes sure the shared texture samplers are initialized on the GPU at least once, even if only the default shared sampler is used. This is noticeable with DX12, since there the 'uninitialized' sampler state is different enough from the default sampler state. 

Before:
![prev](https://github.com/user-attachments/assets/cb6cd301-2af7-4ee8-9e05-1a3d99a642af)

After:
![after](https://github.com/user-attachments/assets/2675e964-bc9f-4c3d-8c32-75cfaa632860)


## How was this PR tested?
Windows with DX12 and vulkan.

