### PR TITLE
Fixes latest MSVC compile warnings/errors

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -164,7 +164,7 @@ namespace AssetProcessorMessagesTests
             m_batchApplicationManager->InitAssetRequestHandler(m_assetRequestHandler);
             m_batchApplicationManager->ConnectAssetCatalog();
 
-            QObject::connect(m_batchApplicationManager->m_connectionManager, &ConnectionManager::ConnectionError, [](unsigned /*connId*/, QString error)
+            QObject::connect(m_batchApplicationManager->m_connectionManager, &ConnectionManager::ConnectionError, [](unsigned /*connId*/, [[maybe_unused]]  QString error)
                 {
                     AZ_Error("ConnectionManager", false, "%s", error.toUtf8().constData());
                 });

--- a/Gems/EditorPythonBindings/Code/Tests/PythonGlobalsTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonGlobalsTests.cpp
@@ -20,7 +20,7 @@
 
 namespace UnitTest
 {
-    void AcceptTwoStrings(AZStd::string stringValue1, AZStd::string stringValue2)
+    void AcceptTwoStrings([[maybe_unused]] AZStd::string stringValue1, [[maybe_unused]] AZStd::string stringValue2)
     {
         AZ_TracePrintf("python", stringValue1.empty() ? "stringValue1_is_empty" : "stringValue1_has_data");
         AZ_TracePrintf("python", stringValue2.empty() ? "stringValue2_is_empty" : "stringValue2_has_data");


### PR DESCRIPTION
## What does this PR do?
* fix issue https://github.com/o3de/o3de/issues/19095 
* fix issue https://github.com/o3de/o3de/issues/19096

For release consideration: Microsoft updated vs2022 latest automatically and added these warnings in.

If we don't accept it, users will not be able to build with vs2022 latest.  Also affects clang, most likely.

## How was this PR tested?

Compiling.  It doesn't affect functionality, its triggering a compile warning (which we treat as a hard stop error) becuase variables are unused.  The code makes them look like they are used, but macros like AZ_ERROR, AZ_TRACE, AZ_WARNING and so on are optimized out in release builds, which makes unused variable warnings happne.
