### PR TITLE
Optionally prevent model/material rebuild if material shaders change

### DIFF
--- a/Gems/Atom/Feature/Common/Registry/material_processing.setreg
+++ b/Gems/Atom/Feature/Common/Registry/material_processing.setreg
@@ -1,0 +1,12 @@
+{
+    "O3DE": {
+        "Atom": {
+            "RPI": {
+                "MaterialBuilder": {
+                    "SkipMaterialRebuildAfterMaterialTypeChange": false,
+                    "SkipModelRebuildAfterMaterialTypeChange": false
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.cpp
@@ -24,7 +24,8 @@ namespace AZ::RPI::MaterialBuilderUtils
         const AZStd::string& jobKey,
         const AZStd::string& platformId,
         const AZStd::vector<AZ::u32>& subIds,
-        const bool updateFingerprint)
+        const bool updateFingerprint,
+        const bool orderOnce)
     {
         if (updateFingerprint)
         {
@@ -34,7 +35,7 @@ namespace AZ::RPI::MaterialBuilderUtils
         AssetBuilderSDK::JobDependency jobDependency(
             jobKey,
             platformId,
-            AssetBuilderSDK::JobDependencyType::Order,
+            orderOnce ? AssetBuilderSDK::JobDependencyType::OrderOnce : AssetBuilderSDK::JobDependencyType::Order,
             AssetBuilderSDK::SourceFileDependency(
                 path, AZ::Uuid{}, AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Absolute));
         jobDependency.m_productSubIds = subIds;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilderUtils.h
@@ -34,7 +34,8 @@ namespace AZ
                 const AZStd::string& jobKey,
                 const AZStd::string& platformId = {},
                 const AZStd::vector<AZ::u32>& subIds = {},
-                const bool updateFingerprint = true);
+                const bool updateFingerprint = true,
+                const bool orderOnce = false);
 
             //! Given a material asset that has been fully built and prepared,
             //! add any image dependencies as pre-load dependencies, to the job being emitted.

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
@@ -34,7 +34,6 @@
 #include <Atom/RPI.Reflect/Material/MaterialAsset.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 
-
 namespace AZ
 {
     namespace RPI
@@ -86,12 +85,19 @@ namespace AZ
                 AssetBuilderSDK::SourceFileDependency materialTypeSource;
                 materialTypeSource.m_sourceFileDependencyPath = materialTypePath;
 
+                bool orderOnce = false;
+                if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+                {
+                    settingsRegistry->Get(orderOnce, "/O3DE/Atom/RPI/MaterialBuilder/SkipModelRebuildAfterMaterialTypeChange");
+                }
+
                 AssetBuilderSDK::JobDependency jobDependency;
                 jobDependency.m_jobKey = "Material Type Builder (Final Stage)";
                 jobDependency.m_sourceFile = materialTypeSource;
                 jobDependency.m_platformIdentifier = platformIdentifier;
                 jobDependency.m_productSubIds.push_back(0);
-                jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
+                jobDependency.m_type =
+                    orderOnce ? AssetBuilderSDK::JobDependencyType::OrderOnce : AssetBuilderSDK::JobDependencyType::Order;
 
                 jobDependencyList.push_back(jobDependency);
             }


### PR DESCRIPTION
## What does this PR do?

Both the Material builder and the Scene Builder have a dependency on MaterialTypes. The Material builder has a dependency on the reference MaterialType, while the Scene Builder has one on the MaterialType that is used as a target for the converted scene materials.
These dependencies are necessary because the builders actually depend on the output of the MaterialType job. Unfortunately this also means that all materials and scene will be reprocessed if a MaterialType changes. E.g. when a shader used in the MaterialType is changed. This makes iterating on shader code really slow in some instances. Changes a single line of shader code may take minutes to finish compilation.

This PR adds settings to skip reprocessing Materials and Scenes when changing material shaders. This behaviour can be enabled through a settings registry entry. See `material_processing.setreg` in the changes. Note however that enabling these settings may lead to problems if the parameters in the MaterialType are modified, but they should be OK if only shader code is changed.
The behaviour is implemented by changing the dependency from the Material/Scene to the MaterialType from `Order` to `OrderOnce`.

This PR also removes the dependency from the Material to the shaders of the MaterialType. The generated MaterialType already has a `Order` dependency on all the shaders, so the Material should get it implicitly anyway.

During implementation of this PR I stumbled on this issue: https://github.com/o3de/o3de/issues/19098
This is also a problem in current development and not related to the PR changes.

## How was this PR tested?

Tested on Windows by changing some material shader files and checking which files are reprocessed.
