### PR TITLE
Fix MaterialBuilder job dependencies

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -140,15 +140,7 @@ namespace AZ
                 if (materialTypeFormat == MaterialTypeSourceData::Format::Direct)
                 {
                     MaterialBuilderUtils::AddJobDependency(
-                        outputJobDescriptor, resolvedMaterialTypePath, MaterialTypeBuilder::FinalStageJobKey, {}, { 0 });
-
-                    for (const auto& shader : materialTypeSourceData.GetShaderReferences())
-                    {
-                        MaterialBuilderUtils::AddJobDependency(
-                            outputJobDescriptor,
-                            AssetUtils::ResolvePathReference(resolvedMaterialTypePath, shader.m_shaderFilePath),
-                            "Shader Asset");
-                    }
+                        outputJobDescriptor, resolvedMaterialTypePath, MaterialTypeBuilder::FinalStageJobKey, {}, { 0 }, false);
                 }
                 else if (materialTypeFormat == MaterialTypeSourceData::Format::Abstract)
                 {
@@ -159,7 +151,9 @@ namespace AZ
                         outputJobDescriptor,
                         resolvedMaterialTypePath,
                         MaterialTypeBuilder::PipelineStageJobKey,
-                        AssetBuilderSDK::CommonPlatformName);
+                        AssetBuilderSDK::CommonPlatformName,
+                        {},
+                        false);
 
                     // The abstract, pipeline material type will generate a direct material type as an intermediate source asset. This
                     // attempts to predict where that source asset will be located in the intermediate asset folder then maps it as a
@@ -171,14 +165,7 @@ namespace AZ
                         // Add the ordered product dependency for the intermediate material type source file so that the material cannot be
                         // processed before it's complete
                         MaterialBuilderUtils::AddJobDependency(
-                            outputJobDescriptor, intermediateMaterialTypePath, MaterialTypeBuilder::FinalStageJobKey, {}, { 0 });
-
-                        // Add a wild card job dependency for any of the shaders generated with the material type so the material will only
-                        // be processed after they are complete
-                        auto& jobDependency = MaterialBuilderUtils::AddJobDependency(
-                            outputJobDescriptor, intermediateMaterialTypePath, "Shader Asset", {}, {}, false);
-                        jobDependency.m_sourceFile.m_sourceDependencyType = AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Wildcards;
-                        AZ::StringFunc::Replace(jobDependency.m_sourceFile.m_sourceFileDependencyPath, "_generated.materialtype", "*.shader");
+                            outputJobDescriptor, intermediateMaterialTypePath, MaterialTypeBuilder::FinalStageJobKey, {}, { 0 }, false);
                     }
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Remove direct shader dependencies and fingerprint update.
The MaterialBuilder only depends on the `.materialtype` file of the MaterialType referenced in the Material. I.e. it only needs to be rebuilt if the content of that file changed.
Previously Materials were rebuilt after each change in a Material shader, now they are only rebuilt if the `.materialtype` file changes.

## How was this PR tested?

I tested this by changing Material shaders and Material parameters:

Note that there is a bug in AssetProcessor where subIds in jobs are not handled correctly when rescanning assets. Therefor the Material and Model files are still reprocessed when changing Material shaders, but not immediately. See https://discordapp.com/channels/805939474655346758/816043601754325023/1390105582161362975

The state in latest development:
1. Create a new Project with the Default Template
2. Open the Project and wait for all assets to be processed
3. Change a Material shader -> Materials, MaterialTypes and Material shaders are reprocessed
4. Go to Settings and press the `Start Scan` button -> All fbx files are reprocessed

After removing the dependencies on the MaterialType shaders and the modification of the fingerprint in the Material:
1. Delete the Cache folder from the project created above (to be sure there is no old state left)
2. Open the Project and wait for all assets to be processed
3. Change a Material shader -> Only MaterialTypes and Material shaders are reprocessed (this is expected and correct)
4. Go to Settings and press the `Start Scan` button -> All fbx files and materials are reprocessed (this is a bug in AP as @Nick_L mentioned above)

With the new changes and changing a Material parameter in MaterialType:
1. I started with the state from above, keeping the AssetProcessor running
2. Change a parameter in BaseColorPropertyGroup (I changed the defaultValue of the color) -> MaterialType, Materials and Models are reprocessed (expected and correct)
4. Go to Settings and press the `Start Scan` button -> All Materials and Models are reprocessed again (probably the same bug as above)
