### PR TITLE
Non-global DepthLinear attachment connection for SSAO

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
@@ -532,6 +532,13 @@
                                 "Pass": "SubsurfaceScatteringPass",
                                 "Attachment": "Output"
                             }
+                        },
+                        {
+                            "LocalSlot": "DepthLinear",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "DepthLinear"
+                            }
                         }
                     ]
                 },

--- a/Gems/Atom/Feature/Common/Assets/Passes/SsaoParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SsaoParent.pass
@@ -13,6 +13,11 @@
                     "ScopeAttachmentUsage": "Shader"
                 },
                 {
+                    "Name": "DepthLinear",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
                     "Name": "Output",
                     "SlotType": "Output",
                     "ScopeAttachmentUsage": "Shader"
@@ -36,7 +41,7 @@
                         {
                             "LocalSlot": "FullResDepth",
                             "AttachmentRef": {
-                                "Pass": "PipelineGlobal",
+                                "Pass": "Parent",
                                 "Attachment": "DepthLinear"
                             }
                         }
@@ -84,7 +89,7 @@
                         {
                             "LocalSlot": "FullResDepth",
                             "AttachmentRef": {
-                                "Pass": "PipelineGlobal",
+                                "Pass": "Parent",
                                 "Attachment": "DepthLinear"
                             }
                         },


### PR DESCRIPTION
## What does this PR do?

This PR changes the connection to the "DepthLinear" attachment through a slot to the "Parent" pass instead of connecting to "PipelineGlobal". This should not affect the functionality at all. But the big benefit is that it makes the `SsaoParent.pass` more versatile insofar as that it can be used in scenarios where different "DepthLinear" attachments are used. By connecting via "PipelineGlobal", only one specific connection is possible---by using "Parent", further options are enabled.

## How was this PR tested?

Run a project. Should not change anything.
