### PR TITLE
Fixes `main` tests running a periodic test which fails

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(metadata_relocation_tests)
         NAME AssetPipelineTests.Periodic
         PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Periodic.py
         TEST_SUITE periodic
+        PYTEST_MARKS "SUITE_periodic"
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessor
             AutomatedTesting.Assets
@@ -33,6 +34,7 @@ add_subdirectory(metadata_relocation_tests)
         PATH ${CMAKE_CURRENT_LIST_DIR}/wwise_bank_dependency_tests/bank_info_parser_tests.py
         EXCLUDE_TEST_RUN_TARGET_FROM_IDE
         TEST_SUITE periodic
+        PYTEST_MARKS "SUITE_periodic"
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessorBatch
     )

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/metadata_relocation_tests/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/metadata_relocation_tests/CMakeLists.txt
@@ -7,21 +7,11 @@
 #
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_add_pytest(
-        NAME AutomatedTesting::MetadataRelocation.Main
-        TEST_SUITE main
-        TEST_SERIAL
-        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite.py
-        RUNTIME_DEPENDENCIES
-            Legacy::Editor
-            AZ::AssetProcessor
-            AutomatedTesting.Assets
-        COMPONENT
-            MetadataRelocation
-    )
+    # Metadata Relocation Tests only currently contain one periodic test (see TestSuite.py).
     ly_add_pytest(
         NAME AutomatedTesting::MetadataRelocation.Periodic
         TEST_SUITE periodic
+        PYTEST_MARKS "SUITE_periodic"
         TEST_SERIAL
         PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite.py
         RUNTIME_DEPENDENCIES
@@ -31,16 +21,5 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         COMPONENT
             MetadataRelocation
     )
-    ly_add_pytest(
-        NAME AutomatedTesting::MetadataRelocation.Sandbox
-        TEST_SUITE sandbox
-        TEST_SERIAL
-        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite.py
-        RUNTIME_DEPENDENCIES
-            Legacy::Editor
-            AZ::AssetProcessor
-            AutomatedTesting.Assets
-        COMPONENT
-            MetadataRelocation
-    )
+  
 endif()

--- a/AutomatedTesting/Levels/MetadataTest/MetadataTest.prefab
+++ b/AutomatedTesting/Levels/MetadataTest/MetadataTest.prefab
@@ -375,10 +375,10 @@
                         "Configuration": {
                             "ModelAsset": {
                                 "assetId": {
-                                    "guid": "{1270F006-F9E6-4CBD-9E78-604A9EB00298}",
+                                    "guid": "{0C6BBB76-4EC2-583A-B8C6-1A4C4FD1FE9D}",
                                     "subId": 283109893
                                 },
-                                "assetHint": "objects/bunny.azmodel"
+                                "assetHint": "objects/bunny.fbx.azmodel"
                             }
                         }
                     }


### PR DESCRIPTION
## What does this PR do?

Two fixes here.  One is that the `periodic` test
was running when it should not, because it was not marked with SUITE_periodic in its pytest marks.

The other is that the test itself had an invalid
asset reference to the bunny model.  Its no clear
to me why the reference changed, but it did.  This is a very ancient asset, so its possible that it changed some time in the deep past.

## How was this PR tested?

1. Running `main` and seeing this test run (when it should not)
2. Fixing the code
3. running `main` and seeing this test no longer run.
4. running `periodic` and seeing this test run still.
5. Fixing the actual failing test also, so that it passes in `periodic`
