### PR TITLE
AR 3P archive target change and retry reuse

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -198,7 +198,7 @@ jobs:
         # Builds with presets in ../scripts/build/Platform/Android/build_config.json
         # Set temp folders to the workspace drive as the boot drive is slow
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
-        timeout-minutes: 320
+        timeout-minutes: 330
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -107,11 +107,24 @@ jobs:
             temporary_dir=${{ env.DEV_DRIVE }}\temp
             cache_dir=${{ env.DEV_DRIVE_WORKSPACE }}\.ccache
       
+      - name: Check for rerun
+        id: check-rerun
+        run: |
+          # GitHub sets GITHUB_RUN_ATTEMPT to track reruns
+          if ($env:GITHUB_RUN_ATTEMPT -gt 1) {
+            echo "is_rerun=true" >> $env:GITHUB_OUTPUT
+            echo "This is rerun attempt #$env:GITHUB_RUN_ATTEMPT"
+          } else {
+            echo "is_rerun=false" >> $env:GITHUB_OUTPUT
+            echo "This is the first run attempt"
+          }
+
       - name: Get last run
         # Get the last runid of the target branch of a PR or the current branch
+        # Skip if this is a rerun to either freshly build or get artifacts from existing run
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
         id: last-run-id
-        if: ${{ inputs.last_artifact }}
+        if: ${{ inputs.last_artifact && steps.check-rerun.outputs.is_rerun != 'true' }}
         continue-on-error: true
         with:
           workflow_search: true

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -118,6 +118,7 @@ jobs:
           workflow_conclusion: ""
           branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
           search_artifacts: true
+          check_artifacts: true
           name: O3DE-${{ inputs.platform }}-${{ inputs.config }}-build
           dry_run: true
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -184,7 +184,7 @@ jobs:
         # Builds with presets in ../scripts/build/Platform/Android/build_config.json
         # Set temp folders to the workspace drive as the boot drive is slow
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
-        timeout-minutes: 310
+        timeout-minutes: 320
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 
@@ -203,8 +203,8 @@ jobs:
           try {
             tar --format=posix -cvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar `
               .ccache `
-              .o3de\python `
-              3rdParty\packages `
+              .o3de\python\downloaded_packages `
+              3rdParty\downloaded_packages `
               AutomatedTesting\Cache
           } catch {
             echo "Warning: Error during tar compression"

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -177,7 +177,7 @@ jobs:
           
       - name: Build ${{ inputs.type }}
         # Builds with presets in ../scripts/build/Platform/Linux/build_config.json
-        timeout-minutes: 320
+        timeout-minutes: 330
         run: |
           export LY_3RDPARTY_PATH=${{ github.workspace }}/3rdParty
           export CC=${{ inputs.compiler == 'gcc' && 'gcc' || 'clang'   }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -163,6 +163,7 @@ jobs:
           
       - name: Build ${{ inputs.type }}
         # Builds with presets in ../scripts/build/Platform/Linux/build_config.json
+        timeout-minutes: 320
         run: |
           export LY_3RDPARTY_PATH=${{ github.workspace }}/3rdParty
           export CC=${{ inputs.compiler == 'gcc' && 'gcc' || 'clang'   }}
@@ -185,10 +186,10 @@ jobs:
         run: |
           tar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
             .ccache \
-            .o3de/python \
-            3rdParty/packages \
+            .o3de/python/downloaded_packages \
+            3rdParty/downloaded_packages \
             AutomatedTesting/Cache
-  
+
       - name: Save artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -92,13 +92,13 @@ jobs:
         id: check-rerun
         run: |
           # GitHub sets GITHUB_RUN_ATTEMPT to track reruns
-          if ($env:GITHUB_RUN_ATTEMPT -gt 1) {
-            echo "is_rerun=true" >> $env:GITHUB_OUTPUT
-            echo "This is rerun attempt #$env:GITHUB_RUN_ATTEMPT"
-          } else {
-            echo "is_rerun=false" >> $env:GITHUB_OUTPUT
+          if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "is_rerun=true" >> $GITHUB_OUTPUT
+            echo "This is rerun attempt #$GITHUB_RUN_ATTEMPT"
+          else
+            echo "is_rerun=false" >> $GITHUB_OUTPUT
             echo "This is the first run attempt"
-          }
+          fi
 
       - name: Get last run
         # Get the last runid of the target branch of a PR or the current branch

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -99,6 +99,7 @@ jobs:
           workflow_conclusion: ""
           branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
           search_artifacts: true
+          check_artifacts: true
           name: O3DE-${{ inputs.platform }}-${{ inputs.config }}-build
           dry_run: true
                   

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -88,11 +88,24 @@ jobs:
             hash_dir=false
             cache_dir=${{ github.workspace }}/.ccache
 
+      - name: Check for rerun
+        id: check-rerun
+        run: |
+          # GitHub sets GITHUB_RUN_ATTEMPT to track reruns
+          if ($env:GITHUB_RUN_ATTEMPT -gt 1) {
+            echo "is_rerun=true" >> $env:GITHUB_OUTPUT
+            echo "This is rerun attempt #$env:GITHUB_RUN_ATTEMPT"
+          } else {
+            echo "is_rerun=false" >> $env:GITHUB_OUTPUT
+            echo "This is the first run attempt"
+          }
+
       - name: Get last run
         # Get the last runid of the target branch of a PR or the current branch
+        # Skip if this is a rerun to either freshly build or get artifacts from existing run
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
         id: last-run-id
-        if: ${{ inputs.last_artifact }}
+        if: ${{ inputs.last_artifact && steps.check-rerun.outputs.is_rerun != 'true' }}
         continue-on-error: true
         with:
           workflow_search: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -106,11 +106,24 @@ jobs:
             temporary_dir=${{ env.DEV_DRIVE }}\temp
             cache_dir=${{ env.DEV_DRIVE_WORKSPACE }}\.ccache
 
+      - name: Check for rerun
+        id: check-rerun
+        run: |
+          # GitHub sets GITHUB_RUN_ATTEMPT to track reruns
+          if ($env:GITHUB_RUN_ATTEMPT -gt 1) {
+            echo "is_rerun=true" >> $env:GITHUB_OUTPUT
+            echo "This is rerun attempt #$env:GITHUB_RUN_ATTEMPT"
+          } else {
+            echo "is_rerun=false" >> $env:GITHUB_OUTPUT
+            echo "This is the first run attempt"
+          }
+
       - name: Get last run
         # Get the last runid of the target branch of a PR or the current branch
+        # Skip if this is a rerun to either freshly build or get artifacts from existing run
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
         id: last-run-id
-        if: ${{ inputs.last_artifact }}
+        if: ${{ inputs.last_artifact && steps.check-rerun.outputs.is_rerun != 'true' }}
         continue-on-error: true
         with:
           workflow_search: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -105,7 +105,7 @@ jobs:
             hash_dir=false
             temporary_dir=${{ env.DEV_DRIVE }}\temp
             cache_dir=${{ env.DEV_DRIVE_WORKSPACE }}\.ccache
-      
+
       - name: Get last run
         # Get the last runid of the target branch of a PR or the current branch
         uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
@@ -117,6 +117,7 @@ jobs:
           workflow_conclusion: ""
           branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
           search_artifacts: true
+          check_artifacts: true
           name: O3DE-${{ inputs.platform }}-${{ inputs.config }}-build
           dry_run: true
     

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -195,7 +195,7 @@ jobs:
             tar --format=posix -cvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar `
               .ccache `
               .o3de\python `
-              3rdParty\packages `
+              3rdParty\downloaded_packages `
               AutomatedTesting\Cache
           } catch {
             echo "Warning: Error during tar compression"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -190,7 +190,7 @@ jobs:
         # Builds with presets in ../scripts/build/Platform/Windows/build_config.json
         # Set temp folders to the workspace drive as the boot drive is slow
         working-directory: "${{ env.DEV_DRIVE_WORKSPACE }}"
-        timeout-minutes: 320
+        timeout-minutes: 330
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -176,7 +176,7 @@ jobs:
         # Builds with presets in ../scripts/build/Platform/Windows/build_config.json
         # Set temp folders to the workspace drive as the boot drive is slow
         working-directory: "${{ env.DEV_DRIVE_WORKSPACE }}"
-        timeout-minutes: 310
+        timeout-minutes: 320
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp"
@@ -194,7 +194,7 @@ jobs:
           try {
             tar --format=posix -cvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar `
               .ccache `
-              .o3de\python `
+              .o3de\python\downloaded_packages `
               3rdParty\downloaded_packages `
               AutomatedTesting\Cache
           } catch {


### PR DESCRIPTION
## What does this PR do?

- (Windows, Linux, Android): Changes the archive target of the 3P packages within the build from the uncompressed packages to the compressed packages stored in `downloaded_packages`. This is to reduces instances where the uncompressed packages are not being written to disk or are somehow corrupted.

- (Windows, Linux, Android): Adds check for existing artifacts in rerun situations and uses them instead of the last run

- (Windows, Linux, Android): Increases the build job timeout to 330mins, to grab more artifacts before timing out

## How was this PR tested?

Tested in my fork. Example run here: https://github.com/amzn-changml/o3de/actions/runs/16029644667
