### PR TITLE
Added missing CS_SAMPLERS - defines

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/TransmissionInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/TransmissionInput.azsli
@@ -20,7 +20,11 @@ real4 GeTransmissionInput(Texture2D map, sampler mapSampler, float2 uv, real4 tr
         }
         else
         {
+            #ifdef CS_SAMPLERS
+            transmissionTintThickness.w *= real(map.SampleLevel(mapSampler, uv, 0).r);
+            #else
             transmissionTintThickness.w *= real(map.Sample(mapSampler, uv).r);
+            #endif
         }
     }
     return transmissionTintThickness;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/TransmissionInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/TransmissionInput.azsli
@@ -20,11 +20,11 @@ real4 GeTransmissionInput(Texture2D map, sampler mapSampler, float2 uv, real4 tr
         }
         else
         {
-            #ifdef CS_SAMPLERS
+#ifdef CS_SAMPLERS
             transmissionTintThickness.w *= real(map.SampleLevel(mapSampler, uv, 0).r);
-            #else
+#else
             transmissionTintThickness.w *= real(map.Sample(mapSampler, uv).r);
-            #endif
+#endif /* CS_SAMPLERS */
         }
     }
     return transmissionTintThickness;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_Common.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_Common.azsli
@@ -107,11 +107,11 @@ real3 GetApplicableBlendMaskValues(const MaterialParameters params, LayerBlendSo
                 }
                 else
                 {
-                #ifdef CS_SAMPLERS
+#ifdef CS_SAMPLERS
                     blendSourceValues = real3(GetMaterialTexture(params.m_blendMaskTexture).SampleLevel(GetMaterialTextureSampler(), blendMaskUv, 0).rgb);
-                #else
+#else
                     blendSourceValues = real3(GetMaterialTexture(params.m_blendMaskTexture).Sample(GetMaterialTextureSampler(), blendMaskUv).rgb);
-                #endif
+#endif /* CS_SAMPLERS */
                 }
                 break;
             case LayerBlendSource::BlendMaskVertexColors:
@@ -258,7 +258,7 @@ real3 GetBlendWeights(const MaterialParameters params, LayerBlendSource blendSou
         layerDepthValues = real3(GetLayerDepthValues(params, uv, float2(0, 0), float2(0, 0)));
 #else
         layerDepthValues = real3(GetLayerDepthValues(params, uv, ddx_fine(uv), ddy_fine(uv)));
-#endif
+#endif /* CS_SAMPLERS */
 
         if(useBlendMask)
         {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_Common.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_Common.azsli
@@ -253,8 +253,12 @@ real3 GetBlendWeights(const MaterialParameters params, LayerBlendSource blendSou
         bool useBlendMask = 
            LayerBlendSource::Displacement_With_BlendMaskTexture == blendSource || 
            LayerBlendSource::Displacement_With_BlendMaskVertexColors == blendSource;
-           
+
+#ifdef CS_SAMPLERS
+        layerDepthValues = real3(GetLayerDepthValues(params, uv, float2(0, 0), float2(0, 0)));
+#else
         layerDepthValues = real3(GetLayerDepthValues(params, uv, ddx_fine(uv), ddy_fine(uv)));
+#endif
 
         if(useBlendMask)
         {

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Textures/sample_texture_2d.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/Textures/sample_texture_2d.materialgraphnode
@@ -13,7 +13,11 @@
                 "Atom/Features/ColorManagement/TransformColor.azsli"
             ],
             "instructions": [
-                "SLOTTYPE(outColor) outColor = TransformColor4(GetMaterialTexture(params.inValue).Sample(GetMaterialTextureSampler(params.inSampler), (float2)inUV), inColorSpaceFrom, inColorSpaceTo);"
+                "#ifdef CS_SAMPLERS",
+                "SLOTTYPE(outColor) outColor = TransformColor4(GetMaterialTexture(params.inValue).SampleLevel(GetMaterialTextureSampler(params.inSampler), (float2)inUV, 0), inColorSpaceFrom, inColorSpaceTo);",
+                "#else",
+                "SLOTTYPE(outColor) outColor = TransformColor4(GetMaterialTexture(params.inValue).Sample(GetMaterialTextureSampler(params.inSampler), (float2)inUV), inColorSpaceFrom, inColorSpaceTo);",
+                "#endif /* CS_SAMPLERS */"
             ]
         },
         "propertySlots": [


### PR DESCRIPTION
## What does this PR do?

Added the CS_SAMPLERS - define to a few places where it was still missing, so all materials can be used in a compute or raytracing shader.

## How was this PR tested?

Ran into shader compile errors when developing material hit shaders for raytracing passes. 