### PR TITLE
Cherry-pick from point release 2505.1 - Fixes all `unused variable` compile warnings.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Instance/InstancePool.h
+++ b/Code/Framework/AzCore/AzCore/Instance/InstancePool.h
@@ -150,7 +150,7 @@ namespace AZ
             typename InstancePool<T>::ResetInstance resetFunc = [](T&){},
             [[maybe_unused]] typename InstancePool<T>::CreateInstance createFunc = []() { return new T{}; })
         {
-            return CreatePool<T>(GetDefaultName<T>(), resetFunc);
+            return CreatePool<T>(GetDefaultName<T>(), resetFunc, createFunc);
         }
 
         // returns the pool with the specified name

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableMonitor.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableMonitor.cpp
@@ -98,7 +98,7 @@ namespace AzFramework
         OnSpawnableLoaded();
     }
 
-    void SpawnableMonitor::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    void SpawnableMonitor::OnAssetReloaded([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         AZ_Assert(m_isLoaded, "Trying to reload a spawnable %s (%s) that wasn't loaded.",
             asset.GetHint().c_str(), asset.GetId().ToString<AZStd::string>().c_str());
@@ -113,7 +113,7 @@ namespace AzFramework
         OnSpawnableUnloaded();
     }
 
-    void SpawnableMonitor::OnAssetError(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    void SpawnableMonitor::OnAssetError([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         if (m_isLoaded)
         {
@@ -126,7 +126,7 @@ namespace AzFramework
         OnSpawnableIssue(IssueType::Error, message);
     }
 
-    void SpawnableMonitor::OnAssetCanceled(AZ::Data::AssetId assetId)
+    void SpawnableMonitor::OnAssetCanceled([[maybe_unused]] AZ::Data::AssetId assetId)
     {
         if (m_isLoaded)
         {
@@ -139,7 +139,7 @@ namespace AzFramework
         OnSpawnableIssue(IssueType::Cancel, message);
     }
 
-    void SpawnableMonitor::OnAssetReloadError(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    void SpawnableMonitor::OnAssetReloadError([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         if (m_isLoaded)
         {

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.cpp
@@ -38,7 +38,7 @@ namespace AzQtComponents
     QSharedPointer<PaletteCard> PaletteCardCollection::makeCard(QSharedPointer<Palette> palette, const QString& title)
     {
         auto card = QSharedPointer<PaletteCard>::create(palette, m_colorController, m_undoStack, this);
-        card->setTitle(uniquePaletteName(card, title));
+        card->setTitle(uniquePaletteName(title));
         card->setSwatchSize(m_swatchSize);
         card->setGammaEnabled(m_gammaEnabled);
         card->setGamma(m_gamma);
@@ -206,7 +206,7 @@ namespace AzQtComponents
         }
     }
 
-    QString PaletteCardCollection::uniquePaletteName([[maybe_unused]] QSharedPointer<PaletteCard> card, const QString& name) const
+    QString PaletteCardCollection::uniquePaletteName(const QString& name) const
     {
         const auto paletteNameExists = [this](const QString& name)
         {

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.h
@@ -66,7 +66,7 @@ namespace AzQtComponents
         void paletteCountChanged();
 
     private:
-        QString uniquePaletteName(QSharedPointer<PaletteCard> card, const QString& name) const;
+        QString uniquePaletteName(const QString& name) const;
         void paletteCardDestroyed(QObject* obj);
 
         Internal::ColorController* m_colorController;

--- a/Code/Tools/CrashHandler/Support/platform/Windows/crash_handler_support_windows_files.cmake
+++ b/Code/Tools/CrashHandler/Support/platform/Windows/crash_handler_support_windows_files.cmake
@@ -7,5 +7,5 @@
 #
 
 set(FILES
-    ../../Platform/win/CrashSupport_win.cpp
+    ../../platform/win/CrashSupport_win.cpp
 )

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventsAssetRef.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventsAssetRef.h
@@ -84,7 +84,7 @@ namespace ScriptEvents
 
         void OnAssetSaved([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset, [[maybe_unused]] bool isSuccessful) override
         {
-            SetAsset(m_asset);
+            SetAsset(asset);
         }
         //=====================================================================
 


### PR DESCRIPTION
## What does this PR do?

Cherry picks the same PR from 25.05.1.

Note that most of these were already fixed in dev, so I discarded any changes that were already in dev, preferred to keep existing to minimize the amount of changes.

## How was this PR tested?

Just compilation - compile profile, release, in both latest msvc as well as clang19.
