### PR TITLE
Defuse an assert when not using the SceneMaterialSrg (e.g. on android)

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
@@ -81,7 +81,7 @@ namespace AZ::RPI
                 auto desc = m_sceneMaterialSrg->GetLayout()->GetShaderInput(samplerIndex);
                 [[maybe_unused]] uint32_t maxTextureSamplerStates = desc.m_count;
                 AZ_Assert(
-                    maxTextureSamplerStates == m_sceneTextureSamplers.GetMaxNumSamplerStates(),
+                    maxTextureSamplerStates >= m_sceneTextureSamplers.GetMaxNumSamplerStates(),
                     "SceneMaterialSrg::m_samplers[] has size %d, expected size is AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS (%d)",
                     maxTextureSamplerStates,
                     AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS);


### PR DESCRIPTION
## What does this PR do?

For Android the `AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS` isn't set, so the fallback values is 0.
But the Srg-Layout of the `SceneMaterialSrg` still contains the `m_samplers` array with a hardcoded size of 8, even though the layout is not used by any shader on that platform.

The modified assert previously was triggered anytime the array size didn't match, now it triggers only if the maximum number of samplers can't fit in the SRG - array.

## How was this PR tested?

Trying to start the OpenXR office level on an Pixel 7a. 