### PR TITLE
Fix #18874 - Project manager: Message box when closing if an action is going on

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectBuilderController.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderController.cpp
@@ -34,10 +34,13 @@ namespace O3DE::ProjectManager
         connect(&m_workerThread, &QThread::started, m_worker, &ProjectBuilderWorker::BuildProject);
         connect(m_worker, &ProjectBuilderWorker::Done, this, &ProjectBuilderController::HandleResults);
         connect(m_worker, &ProjectBuilderWorker::UpdateProgress, this, &ProjectBuilderController::UpdateUIProgress);
+
+        ProjectManagerUtilityRequestsBus::Handler::BusConnect();
     }
 
     ProjectBuilderController::~ProjectBuilderController()
     {
+        ProjectManagerUtilityRequestsBus::Handler::BusDisconnect();
         m_workerThread.requestInterruption();
         m_workerThread.quit();
         m_workerThread.wait();
@@ -135,4 +138,11 @@ namespace O3DE::ProjectManager
         m_workerThread.quit();
         emit Done(false);
     }
+
+    void ProjectBuilderController::CanCloseProjectManager(bool& result) const
+    {
+        // Always return false because ProjectBuilderController only exists when building a project
+        result = false;
+    }
+
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectBuilderController.h
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderController.h
@@ -13,6 +13,8 @@
 #include <QThread>
 #endif
 
+#include "ProjectManagerBuses.h"
+
 QT_FORWARD_DECLARE_CLASS(QProcess)
 
 namespace O3DE::ProjectManager
@@ -20,7 +22,9 @@ namespace O3DE::ProjectManager
     QT_FORWARD_DECLARE_CLASS(ProjectButton)
     QT_FORWARD_DECLARE_CLASS(ProjectBuilderWorker)
 
-    class ProjectBuilderController : public QObject
+    class ProjectBuilderController
+        : public QObject
+        , public ProjectManagerUtilityRequestsBus::Handler
     {
         Q_OBJECT
 
@@ -42,6 +46,10 @@ namespace O3DE::ProjectManager
     signals:
         void Done(bool success = true);
         void NotifyBuildProject(const ProjectInfo& projectInfo);
+
+    private:
+        // ProjectManagerUtilityRequests overrides...
+        void CanCloseProjectManager(bool& result) const override;
 
     private:
         ProjectInfo m_projectInfo;

--- a/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
@@ -31,10 +31,13 @@ namespace O3DE::ProjectManager
         connect(&m_workerThread, &QThread::started, m_worker, &ProjectExportWorker::ExportProject);
         connect(m_worker, &ProjectExportWorker::Done, this, &ProjectExportController::HandleResults);
         connect(m_worker, &ProjectExportWorker::UpdateProgress, this, &ProjectExportController::UpdateUIProgress);
+
+        ProjectManagerUtilityRequestsBus::Handler::BusConnect();
     }
 
     ProjectExportController::~ProjectExportController()
     {
+        ProjectManagerUtilityRequestsBus::Handler::BusDisconnect();
         m_workerThread.requestInterruption();
         m_workerThread.quit();
         m_workerThread.wait();
@@ -170,5 +173,11 @@ namespace O3DE::ProjectManager
     {
         m_workerThread.quit();
         emit Done(false);
+    }
+
+    void ProjectExportController::CanCloseProjectManager(bool& result) const
+    {
+        // Always return false because ProjectExportController only exists when exporting a project
+        result = false;
     }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectExportController.h
+++ b/Code/Tools/ProjectManager/Source/ProjectExportController.h
@@ -13,6 +13,8 @@
 #include <QThread>
 #endif
 
+#include "ProjectManagerBuses.h"
+
 QT_FORWARD_DECLARE_CLASS(QProcess)
 
 namespace O3DE::ProjectManager
@@ -20,7 +22,9 @@ namespace O3DE::ProjectManager
     QT_FORWARD_DECLARE_CLASS(ProjectButton)
     QT_FORWARD_DECLARE_CLASS(ProjectExportWorker)
 
-    class ProjectExportController : public QObject
+    class ProjectExportController
+        : public QObject
+        , public ProjectManagerUtilityRequestsBus::Handler
     {
         Q_OBJECT
 
@@ -32,7 +36,7 @@ namespace O3DE::ProjectManager
         const ProjectInfo& GetProjectInfo() const;
 
         constexpr static int s_maxDisplayedBuiltOutputChars = 25;
-        inline static const char * LauncherExportFailedMessage = "Launcher failed to export.";
+        inline static const char* LauncherExportFailedMessage = "Launcher failed to export.";
 
     public slots:
         void Start();
@@ -43,6 +47,10 @@ namespace O3DE::ProjectManager
     signals:
         void Done(bool success = true);
         void NotifyExportProject(const ProjectInfo& projectInfo);
+
+    private:
+        // ProjectManagerUtilityRequests overrides...
+        void CanCloseProjectManager(bool& result) const override;
 
     private:
         ProjectInfo m_projectInfo;

--- a/Code/Tools/ProjectManager/Source/ProjectManagerBuses.h
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerBuses.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+
+namespace O3DE::ProjectManager
+{
+    class ProjectManagerUtilityRequests : public AZ::EBusTraits
+    {
+    public:
+        using Bus = AZ::EBus<ProjectManagerUtilityRequests>;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+
+        virtual void CanCloseProjectManager(bool& result) const = 0;
+    };
+
+    using ProjectManagerUtilityRequestsBus = AZ::EBus<ProjectManagerUtilityRequests>;
+} // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerWindow.cpp
@@ -6,10 +6,14 @@
  *
  */
 
-#include <ProjectManagerWindow.h>
-#include <PythonBindingsInterface.h>
-#include <ScreensCtrl.h>
-#include <DownloadController.h>
+#include "ProjectManagerWindow.h"
+#include "DownloadController.h"
+#include "ProjectManagerBuses.h"
+#include "PythonBindingsInterface.h"
+#include "ScreensCtrl.h"
+
+#include <QCloseEvent>
+#include <QMessageBox>
 
 namespace O3DE::ProjectManager
 {
@@ -61,5 +65,28 @@ namespace O3DE::ProjectManager
             const QString path = QString::fromUtf8(projectPath.Native().data(), aznumeric_cast<int>(projectPath.Native().size()));
             emit screensCtrl->NotifyCurrentProject(path);
         }
+    }
+
+    void ProjectManagerWindow::closeEvent(QCloseEvent* event)
+    {
+        bool canClose = true;
+        ProjectManagerUtilityRequestsBus::Broadcast(&ProjectManagerUtilityRequestsBus::Events::CanCloseProjectManager, canClose);
+
+        if (!canClose)
+        {
+            QMessageBox::StandardButton reply = QMessageBox::question(
+                this,
+                tr("Project action ongoing"),
+                tr("A project action is currently going on. Are you sure you want to exit?"),
+                QMessageBox::Yes | QMessageBox::No);
+
+            if (reply == QMessageBox::No)
+            {
+                event->ignore();
+                return;
+            }
+        }
+
+        QMainWindow::closeEvent(event);
     }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectManagerWindow.h
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerWindow.h
@@ -28,6 +28,9 @@ namespace O3DE::ProjectManager
             ProjectManagerScreen startScreen = ProjectManagerScreen::Projects);
 
     private:
+        void closeEvent(QCloseEvent* event) override;
+
+    private:
         QPointer<DownloadController> m_downloadController;
     };
 

--- a/Code/Tools/ProjectManager/project_manager_files.cmake
+++ b/Code/Tools/ProjectManager/project_manager_files.cmake
@@ -63,6 +63,7 @@ set(FILES
     Source/ProjectExportWorker.cpp
     Source/ProjectExportController.h
     Source/ProjectExportController.cpp
+    Source/ProjectManagerBuses.h
     Source/UpdateProjectSettingsScreen.h
     Source/UpdateProjectSettingsScreen.cpp
     Source/NewProjectSettingsScreen.h


### PR DESCRIPTION
## What does this PR do?

Fix #18874 so that users are aware (by a message box) that they are closing the Project Manager while an action (export or build) is in progress.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/d2e6d894-41ec-47f9-9855-5ccbb35f55a3" />

## How was this PR tested?

Local Windows build.

- Start project build
- Exit project manager
- A message box appears to indicate that an action on a project is going on
- Clicking "Yes" closes the project manager
- Clicking "No" leaves the project manager open
- No message box is showing on close when no action is going on

Same goes on when exporting a project