### PR TITLE
Fix error compiling with VS 2019 related to AZStd::range

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
@@ -77,8 +77,6 @@ namespace AZ::IO
     template class AZCORE_API_EXPORT BasicPath<AZStd::string>;
     template class AZCORE_API_EXPORT BasicPath<FixedMaxPathString>;
     template class AZCORE_API_EXPORT PathIterator<const PathView>;
-    template class AZCORE_API_EXPORT PathIterator<Path>;
-    template class AZCORE_API_EXPORT PathIterator<FixedMaxPath>;
 
     // Swap function instantiations
     template void AZCORE_API_EXPORT swap<AZStd::string>(Path& lhs, Path& rhs) noexcept;

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.cpp
@@ -77,8 +77,8 @@ namespace AZ::IO
     template class AZCORE_API_EXPORT BasicPath<AZStd::string>;
     template class AZCORE_API_EXPORT BasicPath<FixedMaxPathString>;
     template class AZCORE_API_EXPORT PathIterator<const PathView>;
-    template class AZCORE_API_EXPORT PathIterator<const Path>;
-    template class AZCORE_API_EXPORT PathIterator<const FixedMaxPath>;
+    template class AZCORE_API_EXPORT PathIterator<Path>;
+    template class AZCORE_API_EXPORT PathIterator<FixedMaxPath>;
 
     // Swap function instantiations
     template void AZCORE_API_EXPORT swap<AZStd::string>(Path& lhs, Path& rhs) noexcept;

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -733,7 +733,6 @@ namespace AZ::IO
 
     private:
         friend class PathView;
-        friend class PathIterator<BasicPath>;
 
         string_type m_path;
         value_type m_preferred_separator = AZ_TRAIT_OS_PATH_SEPARATOR;

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -733,6 +733,7 @@ namespace AZ::IO
 
     private:
         friend class PathView;
+        friend class PathIterator<BasicPath>;
 
         string_type m_path;
         value_type m_preferred_separator = AZ_TRAIT_OS_PATH_SEPARATOR;


### PR DESCRIPTION
## What does this PR do?

Fixes compilation error from https://github.com/o3de/o3de/pull/19111#issuecomment-3116858112 related to building with VS2019.

## How was this PR tested?
Built with VS 2019
