### PR TITLE
Change Atom_RHI.Reflect and Atom_RHI.Public to shared libraries

### DIFF
--- a/Gems/Atom/RHI/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Code/CMakeLists.txt
@@ -121,11 +121,12 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
             AZ::AzFramework
+        PUBLIC
             Gem::${gem_name}.Reflect
 )
 
 ly_add_target(
-    NAME ${gem_name}.Private.Static STATIC
+    NAME ${gem_name}.Private.Object OBJECT
     NAMESPACE Gem
     FILES_CMAKE
         atom_rhi_private_files.cmake
@@ -156,7 +157,7 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
             Gem::${gem_name}.Public
-            Gem::${gem_name}.Private.Static
+            Gem::${gem_name}.Private.Object
             Gem::${gem_name}.Profiler
     RUNTIME_DEPENDENCIES
         ${PROFILER_DEPENDENCIES}            

--- a/Gems/Atom/RHI/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Code/CMakeLists.txt
@@ -102,12 +102,15 @@ ly_add_target(
 )
 
 ly_add_target(
-    NAME ${gem_name}.Public STATIC
+    NAME ${gem_name}.Public ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         atom_rhi_public_files.cmake
         ../Assets/atom_rhi_asset_files.cmake
         ${pal_source_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+    COMPILE_DEFINITIONS
+        PRIVATE
+            ATOM_RHI_PUBLIC_EXPORTS
     INCLUDE_DIRECTORIES
         PRIVATE
             Source

--- a/Gems/Atom/RHI/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Code/CMakeLists.txt
@@ -81,10 +81,13 @@ if(PAL_TRAIT_PROF_PIX_SUPPORTED)
 endif()
 
 ly_add_target(
-    NAME ${gem_name}.Reflect STATIC
+    NAME ${gem_name}.Reflect ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         atom_rhi_reflect_files.cmake
+    COMPILE_DEFINITIONS
+        PRIVATE
+            ATOM_RHI_REFLECT_EXPORTS
     INCLUDE_DIRECTORIES
         PRIVATE
             Source

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AliasedHeapEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AliasedHeapEnums.h
@@ -37,7 +37,7 @@ namespace AZ::RHI
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::AliasedResourceTypeFlags)
 
     //! Parameters when using the Paging heap allocation strategy.
-    struct HeapPagingParameters
+    struct ATOM_RHI_REFLECT_API HeapPagingParameters
     {
         AZ_TYPE_INFO(HeapPagingParameters, "{530768C3-BE3B-4E8E-A6F6-1391FE813887}");
         static void Reflect(AZ::ReflectContext* context);
@@ -55,7 +55,7 @@ namespace AZ::RHI
     };
 
     //! Parameters when using the MemoryHint heap allocation strategy.
-    struct HeapMemoryHintParameters
+    struct ATOM_RHI_REFLECT_API HeapMemoryHintParameters
     {
         AZ_TYPE_INFO(HeapMemoryHintParameters, "{7B448FF1-62CF-4758-9753-D2FB64E73620}");
         static void Reflect(AZ::ReflectContext* context);
@@ -84,7 +84,7 @@ namespace AZ::RHI
 
     //! Parameters that controls how to allocate resources
     //! based on heap allocation strategy picked for a transient pool.
-    struct HeapAllocationParameters
+    struct ATOM_RHI_REFLECT_API HeapAllocationParameters
     {
         HeapAllocationParameters()
             : m_pagingParameters()
@@ -110,6 +110,6 @@ namespace AZ::RHI
         };
     };
 
-    const char* ToString(HeapAllocationStrategy type);
-    const char* ToString(AliasedResourceType type);
+    ATOM_RHI_REFLECT_API const char* ToString(HeapAllocationStrategy type);
+    ATOM_RHI_REFLECT_API const char* ToString(AliasedResourceType type);
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AttachmentEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AttachmentEnums.h
@@ -27,7 +27,7 @@ namespace AZ::RHI
     };
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::ScopeAttachmentAccess);
 
-    const char* ToString(ScopeAttachmentAccess attachmentAccess);
+    ATOM_RHI_REFLECT_API const char* ToString(ScopeAttachmentAccess attachmentAccess);
 
     //! Describes the underlying resource lifetime of an attachment with regards to the
     //! frame graph. Imported attachments are owned by the user and are persistent across
@@ -101,7 +101,7 @@ namespace AZ::RHI
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::ScopeAttachmentUsageMask)
 
-    const char* ToString(ScopeAttachmentUsage attachmentUsage);
+    ATOM_RHI_REFLECT_API const char* ToString(ScopeAttachmentUsage attachmentUsage);
 
     //! Describes in which pipeline stages a Scope Attachment is used
     enum class ScopeAttachmentStage : uint32_t
@@ -157,14 +157,14 @@ namespace AZ::RHI
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::ScopeAttachmentStage);
 
     //! Returns a string describing a stage
-    AZStd::string ToString(ScopeAttachmentStage attachmentStage);
+    ATOM_RHI_REFLECT_API AZStd::string ToString(ScopeAttachmentStage attachmentStage);
 
     //! Returns a string describing a usage and an access
-    const char* ToString(ScopeAttachmentUsage usage, ScopeAttachmentAccess acess);
+    ATOM_RHI_REFLECT_API const char* ToString(ScopeAttachmentUsage usage, ScopeAttachmentAccess acess);
 
     //! Modifies access to fit the constraints of the scope attachment usage. For example, a scope attachment
     //! with the usage 'Shader' and 'Write' access becomes a UAV under the hood, so it should be remapped to 'ReadWrite'.
-    ScopeAttachmentAccess AdjustAccessBasedOnUsage(ScopeAttachmentAccess access, ScopeAttachmentUsage usage);
+    ATOM_RHI_REFLECT_API ScopeAttachmentAccess AdjustAccessBasedOnUsage(ScopeAttachmentAccess access, ScopeAttachmentUsage usage);
 
     //! Describes the three major logical classes of GPU hardware queues. Each queue class is a superset
     //! of the next. Graphics can do everything, compute can do compute / copy, and copy can only do copy
@@ -186,7 +186,7 @@ namespace AZ::RHI
 
     const uint32_t HardwareQueueClassCount = static_cast<uint32_t>(HardwareQueueClass::Count);
 
-    const char* ToString(HardwareQueueClass hardwareClass);
+    ATOM_RHI_REFLECT_API const char* ToString(HardwareQueueClass hardwareClass);
 
     //! Describes hardware queues as a mask, where each bit represents the queue family.
     enum class HardwareQueueClassMask : uint32_t
@@ -200,16 +200,16 @@ namespace AZ::RHI
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::HardwareQueueClassMask)
 
     //! Returns the hardware queue class mask bit associated with the enum value.
-    HardwareQueueClassMask GetHardwareQueueClassMask(HardwareQueueClass hardwareQueueClass);
+    ATOM_RHI_REFLECT_API HardwareQueueClassMask GetHardwareQueueClassMask(HardwareQueueClass hardwareQueueClass);
 
     //! Returns the name associated with the hardware queue.
-    const char* GetHardwareQueueClassName(HardwareQueueClass hardwareQueueClass);
+    ATOM_RHI_REFLECT_API const char* GetHardwareQueueClassName(HardwareQueueClass hardwareQueueClass);
 
     //! Scans the bit mask and returns the most capable queue from the set.
-    HardwareQueueClass GetMostCapableHardwareQueue(HardwareQueueClassMask queueMask);
+    ATOM_RHI_REFLECT_API HardwareQueueClass GetMostCapableHardwareQueue(HardwareQueueClassMask queueMask);
 
     //! Returns whether the first queue is more capable than the second queue.
-    bool IsHardwareQueueMoreCapable(HardwareQueueClass queueA, HardwareQueueClass queueB);
+    ATOM_RHI_REFLECT_API bool IsHardwareQueueMoreCapable(HardwareQueueClass queueA, HardwareQueueClass queueB);
 
     //! Describes the action the hardware should use when loading an attachment prior to a scope.
     enum class AttachmentLoadAction : uint8_t
@@ -259,7 +259,7 @@ namespace AZ::RHI
         Uninitialized,
     };
 
-    const char* ToString(AZ::RHI::AttachmentType attachmentType);
+    ATOM_RHI_REFLECT_API const char* ToString(AZ::RHI::AttachmentType attachmentType);
 
     //! Describes the type of scope attachment for a QueryPool
     enum class QueryPoolScopeAttachmentType : uint8_t
@@ -287,5 +287,4 @@ namespace AZ::RHI
     AZ_TYPE_INFO_SPECIALIZE(AttachmentStoreAction, "{F580ED24-1537-47D8-90D6-2E620087BE14}");
     AZ_TYPE_INFO_SPECIALIZE(AttachmentType, "{41A254E8-C4BF-459A-80D8-5B959501943E}");
     AZ_TYPE_INFO_SPECIALIZE(ScopeAttachmentStage, "{9F875055-0DA2-49EC-A17F-4C18504A5297}");
-
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AttachmentLoadStoreAction.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/AttachmentLoadStoreAction.h
@@ -15,7 +15,7 @@
 namespace AZ::RHI
 {
     //! Describes what rules to apply when the image or buffer attachment is loaded and stored
-    struct AttachmentLoadStoreAction
+    struct ATOM_RHI_REFLECT_API AttachmentLoadStoreAction
     {
         AZ_TYPE_INFO(AttachmentLoadStoreAction, "{B41084F9-ED52-49F1-A2FA-8F648B0EC0D4}");
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
@@ -24,7 +24,11 @@
 // you need to know which scope was executing right before the crash.
 //#define AZ_FORCE_CPU_GPU_INSYNC
 
+#if defined(AZ_MONOLITHIC_BUILD)
 AZ_DECLARE_BUDGET(RHI);
+#else
+AZ_DECLARE_BUDGET_SHARED(RHI);
+#endif
 
 //#define ENABLE_RHI_PROFILE_VERBOSE
 #ifdef ENABLE_RHI_PROFILE_VERBOSE
@@ -35,6 +39,19 @@ AZ_DECLARE_BUDGET(RHI);
 // Define ENABLE_RHI_PROFILE_VERBOSE to get verbose profile markers
 #define RHI_PROFILE_SCOPE_VERBOSE(...)
 #define RHI_PROFILE_FUNCTION_VERBOSE
+#endif
+
+#if defined(AZ_MONOLITHIC_BUILD)
+    #define ATOM_RHI_REFLECT_API
+    #define ATOM_RHI_REFLECT_API_EXPORT
+#else
+    #if defined(ATOM_RHI_REFLECT_EXPORTS)
+        #define ATOM_RHI_REFLECT_API        AZ_DLL_EXPORT
+        #define ATOM_RHI_REFLECT_API_EXPORT AZ_DLL_EXPORT
+    #else
+        #define ATOM_RHI_REFLECT_API        AZ_DLL_IMPORT
+        #define ATOM_RHI_REFLECT_API_EXPORT
+    #endif
 #endif
 
 inline static constexpr AZ::Crc32 rhiMetricsId = AZ_CRC_CE("RHI");
@@ -73,7 +90,7 @@ namespace AZ::RHI
             return s_isEnabled;
         }
     private:
-        static bool s_isEnabled;
+        ATOM_RHI_REFLECT_API static bool s_isEnabled;
     };
 
     template <typename T>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferDescriptor.h
@@ -68,11 +68,11 @@ namespace AZ::RHI
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::BufferBindFlags);
 
-    BufferBindFlags GetBufferBindFlags(ScopeAttachmentUsage usage, ScopeAttachmentAccess access);
+    ATOM_RHI_REFLECT_API BufferBindFlags GetBufferBindFlags(ScopeAttachmentUsage usage, ScopeAttachmentAccess access);
 
     //! A buffer corresponds to a region of linear memory and used for rendering operations.
     //! Its lifecycle is managed by buffer pools.
-    struct BufferDescriptor
+    struct ATOM_RHI_REFLECT_API BufferDescriptor
     {
         AZ_TYPE_INFO(BufferDescriptor, "{05321516-CDE4-451D-80A2-3D179AB3DB5D}");
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferPoolDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferPoolDescriptor.h
@@ -18,7 +18,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    class BufferPoolDescriptor
+    class ATOM_RHI_REFLECT_API BufferPoolDescriptor
         : public ResourcePoolDescriptor
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h
@@ -13,7 +13,7 @@
 namespace AZ::RHI
 {
     //! Describes a buffer scope attachment, which is the specific usage of a frame graph attachment on a scope.
-    struct BufferScopeAttachmentDescriptor
+    struct ATOM_RHI_REFLECT_API BufferScopeAttachmentDescriptor
         : public ScopeAttachmentDescriptor
     {
         AZ_TYPE_INFO(BufferScopeAttachmentDescriptor, "{D40FFADC-DDD4-497A-877F-11E84FD96210}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferViewDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferViewDescriptor.h
@@ -21,7 +21,7 @@ namespace AZ
 namespace AZ::RHI
 {
     //! Buffer views describe how to interpret a region of memory in a buffer.
-    struct BufferViewDescriptor
+    struct ATOM_RHI_REFLECT_API BufferViewDescriptor
     {
         AZ_TYPE_INFO(BufferViewDescriptor, "{AC5C4601-1824-434F-B070-B4A48DBDB437}");
         AZ_CLASS_ALLOCATOR(BufferViewDescriptor, SystemAllocator);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ClearValue.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ClearValue.h
@@ -26,7 +26,7 @@ namespace AZ::RHI
         DepthStencil
     };
 
-    struct ClearDepthStencil
+    struct ATOM_RHI_REFLECT_API ClearDepthStencil
     {
         AZ_TYPE_INFO(ClearDepthStencil, "{CDD1AA45-DDBC-452E-92BF-BAD140A668E0}");
         static void Reflect(AZ::ReflectContext* context);
@@ -43,7 +43,7 @@ namespace AZ::RHI
     };
 
     //! Represents either a depth stencil, a float vector, or a uint vector clear value.
-    struct ClearValue
+    struct ATOM_RHI_REFLECT_API ClearValue
     {
         AZ_TYPE_INFO(ClearValue, "{a64f14ac-3012-4fd6-9224-4cd046eff2e2}");
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ConstantsLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ConstantsLayout.h
@@ -39,7 +39,7 @@ namespace AZ::RHI
     //! To use the class, assign shader inputs using AddShaderInput, and call Finalize to
     //! complete construction of the layout. This class is intended to be built using an offline shader
     //! compiler, and serialized to / from disk.
-    class ConstantsLayout
+    class ATOM_RHI_REFLECT_API ConstantsLayout
         : public AZStd::intrusive_base
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceDescriptor.h
@@ -20,7 +20,8 @@ namespace AZ
 namespace AZ::RHI
 {
     class PlatformLimits;
-    class DeviceDescriptor
+
+    class ATOM_RHI_REFLECT_API DeviceDescriptor
     {
     public:
         AZ_RTTI(DeviceDescriptor, "{8446A34C-A079-44B8-A20F-45D9CAB1FAFD}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceFeatures.h
@@ -18,7 +18,7 @@
 
 namespace AZ::RHI
 {
-    struct DeviceFeatures
+    struct ATOM_RHI_REFLECT_API DeviceFeatures
     {
         //! Whether the adapter supports geometry shaders.
         bool m_geometryShader;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceLimits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/DeviceLimits.h
@@ -13,7 +13,7 @@
 
 namespace AZ::RHI
 {
-    struct DeviceLimits
+    struct ATOM_RHI_REFLECT_API DeviceLimits
     {
         /// The maximum pixel size of a 1d image.
         uint32_t m_maxImageDimension1D = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Format.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Format.h
@@ -212,30 +212,30 @@ namespace AZ::RHI
     //! @brief Returns the number of bytes it takes to represent an image element using the provided format.
     //! It returns the number of bytes in a block if the given format is a block compressed format like BC1,
     //! and it do the number of bytes in a pixel otherwise.
-    uint32_t GetFormatSize(Format format);
+    ATOM_RHI_REFLECT_API uint32_t GetFormatSize(Format format);
 
     //! @brief Returns the number of elements represented by the provided format. For example, R32G32B32_FLOAT returns 3, 
     //!        and R32G32_UINT returns 2. This function is intended primarily for validation of vertex input stream formats.
-    uint32_t GetFormatComponentCount(Format format);
+    ATOM_RHI_REFLECT_API uint32_t GetFormatComponentCount(Format format);
 
-    const char* ToString(Format format);
+    ATOM_RHI_REFLECT_API const char* ToString(Format format);
 
     //! @brief Returns the required alignment for width / height of an image for the given format. Block
     //! compressed formats will return the number of blocks (e.g 4x4, 8x8, etc). Certain Packed / Planar formats may return 2.
     //!  This is especially important for low level of detail mips in the chain, which will reduce down to the alignment instead
     //! of 1x1. The returned value only applies to image width and height. Depth is unaffected.
-    RHI::Size GetFormatDimensionAlignment(Format format);
+    ATOM_RHI_REFLECT_API RHI::Size GetFormatDimensionAlignment(Format format);
 
     //! @brief Returns the SRGB equivalent to the provided linear format, if it exists. If not, the provided
     //! format is returned unchanged.
-    RHI::Format ConvertLinearToSRGB(Format format);
+    ATOM_RHI_REFLECT_API RHI::Format ConvertLinearToSRGB(Format format);
 
     //! @brief Returns the linear equivalent to the provided SRGB format. If no such equivalent exists,
     //! the provided format is returned unchanged.
-    RHI::Format ConvertSRGBToLinear(Format format);
+    ATOM_RHI_REFLECT_API RHI::Format ConvertSRGBToLinear(Format format);
 
     //! @brief Returns the image aspect flags supported by the format.
-    ImageAspectFlags GetImageAspectFlags(Format format);
+    ATOM_RHI_REFLECT_API ImageAspectFlags GetImageAspectFlags(Format format);
 
     AZ_TYPE_INFO_SPECIALIZE(Format, "{92CC7BFB-4F2B-45F9-A951-B4EBBCD485B8}");
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageDescriptor.h
@@ -17,12 +17,12 @@
 
 namespace AZ::RHI
 {    
-    ImageBindFlags GetImageBindFlags(ScopeAttachmentUsage usage, ScopeAttachmentAccess access);        
+    ATOM_RHI_REFLECT_API ImageBindFlags GetImageBindFlags(ScopeAttachmentUsage usage, ScopeAttachmentAccess access);
 
     //! Images are comprised of sub-resources corresponding to the number of mip-mip levels
     //! and array slices. Image data is stored as pixels in opaque swizzled formats. Images
     //! represent texture data to the shader.
-    struct ImageDescriptor
+    struct ATOM_RHI_REFLECT_API ImageDescriptor
     {
         AZ_TYPE_INFO(ImageDescriptor, "{D1FDAC7B-E9CF-4B2D-B1FB-646D3EE3159C}");
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImagePoolDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImagePoolDescriptor.h
@@ -17,7 +17,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    class ImagePoolDescriptor
+    class ATOM_RHI_REFLECT_API ImagePoolDescriptor
         : public ResourcePoolDescriptor
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h
@@ -13,7 +13,7 @@
 namespace AZ::RHI
 {
     //! Describes the binding of an image attachment to a scope.
-    struct ImageScopeAttachmentDescriptor
+    struct ATOM_RHI_REFLECT_API ImageScopeAttachmentDescriptor
         : public ScopeAttachmentDescriptor
     {
         AZ_TYPE_INFO(ImageScopeAttachmentDescriptor, "{66523EB6-9D3A-4633-A708-ADD57FDD5CE2}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -134,7 +134,16 @@ namespace AZ::RHI
 
         ImageSubresourceLayout() = default;
 
-        void Init(RHI::MultiDevice::DeviceMask deviceMask, const DeviceImageSubresourceLayout& deviceLayout);
+        void Init(RHI::MultiDevice::DeviceMask deviceMask, const DeviceImageSubresourceLayout& deviceLayout)
+        {
+            MultiDeviceObject::IterateDevices(
+                deviceMask,
+                [this, deviceLayout](int deviceIndex)
+                {
+                    m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
+                    return true;
+                });
+        }
 
         DeviceImageSubresourceLayout& GetDeviceImageSubresource(int deviceIndex)
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -10,6 +10,7 @@
 #include <Atom/RHI.Reflect/Size.h>
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
+#include <Atom/RHI/MultiDeviceObject.h>
 
 #include <AzCore/std/containers/unordered_map.h>
 
@@ -17,7 +18,7 @@ namespace AZ::RHI
 {
     struct ImageViewDescriptor;
 
-    struct ImageSubresource
+    struct ATOM_RHI_REFLECT_API ImageSubresource
     {
         AZ_TYPE_INFO(ImageSubresource, "{4B32F472-3B82-40AC-967A-BFE69B114C40}");
         static void Reflect(AZ::ReflectContext* context);
@@ -41,7 +42,7 @@ namespace AZ::RHI
         ImageAspect m_aspect = ImageAspect::Color;
     };
 
-    struct ImageSubresourceRange
+    struct ATOM_RHI_REFLECT_API ImageSubresourceRange
     {
         AZ_TYPE_INFO(ImageSubresourceRange, "{CD682C5C-1119-4291-84E1-253415F5D390}");
         static void Reflect(AZ::ReflectContext* context);
@@ -89,7 +90,7 @@ namespace AZ::RHI
         ImageAspectFlags m_aspectFlags = ImageAspectFlags::All;
     };
 
-    struct DeviceImageSubresourceLayout
+    struct ATOM_RHI_REFLECT_API DeviceImageSubresourceLayout
     {
         AZ_TYPE_INFO(DeviceImageSubresourceLayout, "{076A8345-B6E4-4287-A1B3-4079E1BA3CA9}");
         static void Reflect(AZ::ReflectContext* context);
@@ -156,11 +157,11 @@ namespace AZ::RHI
     //! the source of a copy from system memory to a destination RHI staging buffer. The results are
     //! platform agnostic. It works by inspecting the image size and format, and then computing the required
     //! size and memory layout requirements to represent the data as linear rows.
-    DeviceImageSubresourceLayout GetImageSubresourceLayout(Size imageSize, Format imageFormat);
-    DeviceImageSubresourceLayout GetImageSubresourceLayout(const ImageDescriptor& imageDescriptor, const ImageSubresource& subresource);
+    ATOM_RHI_REFLECT_API DeviceImageSubresourceLayout GetImageSubresourceLayout(Size imageSize, Format imageFormat);
+    ATOM_RHI_REFLECT_API DeviceImageSubresourceLayout GetImageSubresourceLayout(const ImageDescriptor& imageDescriptor, const ImageSubresource& subresource);
 
     //! Returns the image subresource index given the mip and array slices, and the total mip levels. Subresources
     //! are organized by arrays of mip chains. The formula is: subresourceIndex = mipSlice + arraySlice * mipLevels.
-    uint32_t GetImageSubresourceIndex(uint32_t mipSlice, uint32_t arraySlice, uint32_t mipLevels);
-    uint32_t GetImageSubresourceIndex(ImageSubresource subresource, uint32_t mipLevels);
+    ATOM_RHI_REFLECT_API uint32_t GetImageSubresourceIndex(uint32_t mipSlice, uint32_t arraySlice, uint32_t mipLevels);
+    ATOM_RHI_REFLECT_API uint32_t GetImageSubresourceIndex(ImageSubresource subresource, uint32_t mipLevels);
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageViewDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageViewDescriptor.h
@@ -22,7 +22,7 @@ namespace AZ
 namespace AZ::RHI
 {
     //! Image views map to a range of mips / array slices in an image.
-    struct ImageViewDescriptor
+    struct ATOM_RHI_REFLECT_API ImageViewDescriptor
     {
         AZ_TYPE_INFO(ImageViewDescriptor, "{7dc08a6e-5a1d-4730-b1fa-3a6e11bb7178}");
         AZ_CLASS_ALLOCATOR(ImageViewDescriptor, SystemAllocator);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndexFormat.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndexFormat.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <AzCore/base.h>
 
 namespace AZ::RHI
@@ -24,5 +25,5 @@ namespace AZ::RHI
     using IndexFormat = Internal::IndexFormat;
 
     //! @brief Returns the size of the given index format in bytes.
-    uint32_t GetIndexFormatSize(IndexFormat indexFormat);
+    ATOM_RHI_REFLECT_API uint32_t GetIndexFormatSize(IndexFormat indexFormat);
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndirectBufferLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndirectBufferLayout.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI.Reflect/Handle.h>
 
 #include <AzCore/Memory/SystemAllocator.h>
@@ -45,7 +46,7 @@ namespace AZ::RHI
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::IndirectCommandTiers);
 
     //! Arguments when setting an indirect Vertex Buffer View command.
-    struct IndirectBufferViewArguments
+    struct ATOM_RHI_REFLECT_API IndirectBufferViewArguments
     {
         AZ_TYPE_INFO(IndirectBufferViewArguments, "{C929045D-739C-4E9C-9C4E-1945E0C9FF2D}");
         static void Reflect(ReflectContext* context);
@@ -60,7 +61,7 @@ namespace AZ::RHI
     }
 
     //! Describes one indirect command that is part of an indirect layout.
-    struct IndirectCommandDescriptor
+    struct ATOM_RHI_REFLECT_API IndirectCommandDescriptor
     {
         AZ_TYPE_INFO(IndirectCommandDescriptor, "{A5A7351F-A86A-42FC-BE90-39DBDA8EAAA5}");
         static void Reflect(ReflectContext* context);
@@ -114,7 +115,7 @@ namespace AZ::RHI
     //!
     //! To use the class, add commands using AddIndirectCommand, and call Finalize to
     //! complete the construction of the layout.
-    struct IndirectBufferLayout
+    struct ATOM_RHI_REFLECT_API IndirectBufferLayout
     {
     public:
         AZ_TYPE_INFO(IndirectBufferLayout, "{1D9A08FE-0C13-4AB4-9556-ECE97A27F42D}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/InputStreamLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/InputStreamLayout.h
@@ -55,7 +55,7 @@ namespace AZ::RHI
     //! with it which matches the element within the shader. The data in a stream channel can be
     //! offset from the base of the parent StreamBufferView to interleave multiple channels within 
     //! the same buffer.
-    class StreamChannelDescriptor
+    class ATOM_RHI_REFLECT_API StreamChannelDescriptor
     {
     public:
         AZ_TYPE_INFO(StreamChannelDescriptor, "{BF99DCBE-C30B-443A-A92C-B07EE6F0FB1D}");
@@ -87,7 +87,7 @@ namespace AZ::RHI
     //! Describes an instance of a StreamBufferView within the stream layout. Each stream
     //! buffer provides new data to the shader at a specified step rate. The byte stride
     //! is the total width of a single element in the buffer stream.
-    class StreamBufferDescriptor
+    class ATOM_RHI_REFLECT_API StreamBufferDescriptor
     {
     public:
         AZ_TYPE_INFO(StreamBufferDescriptor, "{F1295422-9505-45EF-9E0D-47839B755F8C}");
@@ -118,7 +118,7 @@ namespace AZ::RHI
     //! This is provided to the RHI back-end at PSO compile time as part of the PipelineStateDescriptor.
     //!
     //! See InputStreamLayoutBuilder for a convenient way to construct InputStreamLayout objects.
-    class InputStreamLayout
+    class ATOM_RHI_REFLECT_API InputStreamLayout
     {
     public:
         AZ_TYPE_INFO(InputStreamLayout, "{2F628C89-76F7-458C-9DCE-2A2FFD4530E1}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/InputStreamLayoutBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/InputStreamLayoutBuilder.h
@@ -47,7 +47,7 @@ namespace AZ::RHI
     //!          ->Channel("UV1", RHI::Format::R32G32_FLOAT);
     //!      layout = layoutBuilder.End();
     //!    @endcode
-    class InputStreamLayoutBuilder
+    class ATOM_RHI_REFLECT_API InputStreamLayoutBuilder
     {
     public:
 
@@ -56,7 +56,7 @@ namespace AZ::RHI
         //! calculated automatically based on the Channels and Padding that are registered. Note that all padding
         //! in the structure must be registered including at the end of the structure, not just between channels, 
         //! in order to calculate the correct stride.
-        class BufferDescriptorBuilder
+        class ATOM_RHI_REFLECT_API BufferDescriptorBuilder
         {
             friend class InputStreamLayoutBuilder;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Interval.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Interval.h
@@ -16,7 +16,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    struct Interval
+    struct ATOM_RHI_REFLECT_API Interval
     {
         AZ_TYPE_INFO(Interval, "{B121C9FE-1C23-4721-9C3E-6BE036612743}");
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryEnums.h
@@ -12,7 +12,7 @@
 namespace AZ::RHI
 {
     //! Describes the memory requirements for allocating a resource.
-    struct ResourceMemoryRequirements
+    struct ATOM_RHI_REFLECT_API ResourceMemoryRequirements
     {
         size_t m_alignmentInBytes = 0;
         size_t m_sizeInBytes = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryStatistics.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryStatistics.h
@@ -15,7 +15,7 @@
 
 namespace AZ::RHI
 {
-    struct MemoryStatistics
+    struct ATOM_RHI_REFLECT_API MemoryStatistics
     {
         struct Buffer
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MemoryUsage.h
@@ -13,7 +13,7 @@
 
 namespace AZ::RHI
 {
-    struct HeapMemoryTransfer
+    struct ATOM_RHI_REFLECT_API HeapMemoryTransfer
     {
         HeapMemoryTransfer() = default;
         HeapMemoryTransfer(const HeapMemoryTransfer&);
@@ -29,7 +29,7 @@ namespace AZ::RHI
     //! Tracks memory usage for a specific heap in the system. The data is expected to adhere to the following constraints:
     //!  1) Reserved <= Budget (unless the budget is 0).
     //!  2) Resident <= Reserved.
-    struct HeapMemoryUsage
+    struct ATOM_RHI_REFLECT_API HeapMemoryUsage
     {
         HeapMemoryUsage() = default;
         HeapMemoryUsage(const HeapMemoryUsage&);
@@ -89,7 +89,7 @@ namespace AZ::RHI
     //! device memory heap (i.e. a single GPU) and the host memory heap. Certain pools on specific platforms
     //! may not require one or the other. In this case, the memory usage / budget will report empty values for
     //! that heap type.
-    struct PoolMemoryUsage
+    struct ATOM_RHI_REFLECT_API PoolMemoryUsage
     {
         PoolMemoryUsage() = default;
         PoolMemoryUsage(const PoolMemoryUsage&) = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MultisampleState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/MultisampleState.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
     //! Sample positions have the origin(0, 0) at the pixel top left.
     //! Each of the X and Y coordinates are unsigned values in the range 0 (top / left) to Limits::Pipeline::MultiSampleCustomLocationGridSize - 1 (bottom / right).
     //! Values outside this range are invalid. Each increment of these integer values represents 1 / Limits::Pipeline::MultiSampleCustomLocationGridSize of a pixel.
-    struct SamplePosition
+    struct ATOM_RHI_REFLECT_API SamplePosition
     {
         AZ_TYPE_INFO(SamplePosition, "{8CCB872A-2CC3-4898-AB9E-C12517AC1FB8}");
         static void Reflect(ReflectContext* context);
@@ -39,7 +39,7 @@ namespace AZ::RHI
         uint8_t m_y = 0;
     };
 
-    struct MultisampleState
+    struct ATOM_RHI_REFLECT_API MultisampleState
     {
         AZ_TYPE_INFO(MultisampleState, "{7673d8d8-c3db-462a-a155-cfe1d2331397}");
         static void Reflect(ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Origin.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Origin.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <AzCore/base.h>
 #include <AzCore/RTTI/TypeInfo.h>
 
@@ -17,7 +18,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    struct Origin
+    struct ATOM_RHI_REFLECT_API Origin
     {
         AZ_TYPE_INFO(Origin, "{323EB88E-A2BF-421F-9CD4-B668CA246AAF}");
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PhysicalDeviceDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PhysicalDeviceDescriptor.h
@@ -31,7 +31,7 @@ namespace AZ::RHI
         (Apple,         0x106B) 
     );
 
-    void ReflectVendorIdEnums(ReflectContext* context);
+    void ATOM_RHI_REFLECT_API ReflectVendorIdEnums(ReflectContext* context);
 
     enum class PhysicalDeviceType : uint32_t
     {
@@ -57,7 +57,7 @@ namespace AZ::RHI
 
     const uint32_t PhysicalDeviceTypeCount = static_cast<uint32_t>(PhysicalDeviceType::Count);
 
-    class PhysicalDeviceDescriptor
+    class ATOM_RHI_REFLECT_API PhysicalDeviceDescriptor
     {
     public:
         AZ_RTTI(PhysicalDeviceDescriptor, "{22052601-3C81-4FD2-AD46-1AE00F01E95E}");
@@ -73,7 +73,7 @@ namespace AZ::RHI
     };
 
     //! The GPU driver related information like unsupported versions, minimum version supported by the RHI.
-    class PhysicalDeviceDriverInfo
+    class ATOM_RHI_REFLECT_API PhysicalDeviceDriverInfo
     {
     public:
         AZ_RTTI(AZ::RHI::PhysicalDeviceDriverInfo, "{0063AFB9-C4F1-40F5-9F46-FEC631732F55}");
@@ -99,7 +99,7 @@ namespace AZ::RHI
 
     //! Validator for the current GPU driver.
     //! If the driver doesn't meet the requirements defined by RHI, a clear message will be output at RHI initialization time.
-    class PhysicalDeviceDriverValidator
+    class ATOM_RHI_REFLECT_API PhysicalDeviceDriverValidator
     {
     public:
         AZ_RTTI(AZ::RHI::PhysicalDeviceDriverValidator, "{EA11001D-5A5D-43D6-A90C-77E5E44273FC}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PhysicalDeviceDriverInfoSerializer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PhysicalDeviceDriverInfoSerializer.h
@@ -14,7 +14,7 @@
 namespace AZ::RHI
 {
     // Used to serialize or deserialize PhysicalDeviceDriverInfo.
-    class JsonPhysicalDeviceDriverInfoSerializer : public BaseJsonSerializer
+    class ATOM_RHI_REFLECT_API JsonPhysicalDeviceDriverInfoSerializer : public BaseJsonSerializer
     {
     public:
         AZ_RTTI(AZ::RHI::JsonPhysicalDeviceDriverInfoSerializer, "{E7C48E1F-7483-4451-897D-34472611E824}", BaseJsonSerializer);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PipelineLayoutDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PipelineLayoutDescriptor.h
@@ -34,7 +34,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    struct ResourceBindingInfo
+    struct ATOM_RHI_REFLECT_API ResourceBindingInfo
     {
         AZ_TYPE_INFO(ResourceBindingInfo, "{2B25FA97-21C2-4567-8F01-6A64F7B9DFF6}");
         static void Reflect(AZ::ReflectContext* context);
@@ -62,7 +62,7 @@ namespace AZ::RHI
 
     //! This class describes binding information about the Shader Resource Group
     //! that is part of a Pipeline. Contains the register number for each SRG resource.
-    struct ShaderResourceGroupBindingInfo
+    struct ATOM_RHI_REFLECT_API ShaderResourceGroupBindingInfo
     {
         AZ_TYPE_INFO(ShaderResourceGroupBindingInfo, "{FE67D6A9-57E7-4075-94F9-3E2F443D1BD3}");
         static void Reflect(AZ::ReflectContext* context);
@@ -85,7 +85,7 @@ namespace AZ::RHI
     //! In short, if the shader compiler needs to communicate platform-specific shader binding information
     //! when constructing a pipeline state, this is the place to do it. Platforms are expected to override
     //! this class in their PLATFORM.Reflect library, which is then exposed to the offline shader compiler.
-    class PipelineLayoutDescriptor
+    class ATOM_RHI_REFLECT_API PipelineLayoutDescriptor
         : public AZStd::intrusive_base
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PipelineLibraryData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PipelineLibraryData.h
@@ -45,7 +45,7 @@ namespace AZ::RHI
     //! Therefore, this class is designed to be immutable after creation and support reference counting.
     //! This allows the platform to safely hold a reference and guarantees that the memory is not mutated
     //! externally.
-    class PipelineLibraryData final
+    class ATOM_RHI_REFLECT_API PipelineLibraryData final
         : public AZStd::intrusive_base
     {
         friend class PipelineLibrary;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PlatformLimitsDescriptor.h
@@ -20,7 +20,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    struct TransientAttachmentPoolBudgets
+    struct ATOM_RHI_REFLECT_API TransientAttachmentPoolBudgets
     {
         AZ_TYPE_INFO(AZ::RHI::TransientAttachmentPoolBudgets, "{CE39BBEF-C9CD-4B9A-BA41-C886D9F063BC}");
         static void Reflect(AZ::ReflectContext* context);
@@ -38,7 +38,7 @@ namespace AZ::RHI
 
     //! The platform default values are initially set with those hard coded in RHI Limits.
     //! They can be overridden by PlatformLimits.azasset from each platform, if a value is provided in that file.
-    struct PlatformDefaultValues
+    struct ATOM_RHI_REFLECT_API PlatformDefaultValues
     {
         AZ_TYPE_INFO(AZ::RHI::PlatformDefaultValues, "{F928CA84-C3F8-4F0B-8F34-808A24FA7C86}");
         static void Reflect(AZ::ReflectContext* context);
@@ -51,7 +51,7 @@ namespace AZ::RHI
     };
 
     //! A descriptor used to configure limits for each backend. Can be overridden by platformlimits.azasset file
-    class PlatformLimitsDescriptor
+    class ATOM_RHI_REFLECT_API PlatformLimitsDescriptor
         : public AZStd::intrusive_base
     {
     public:
@@ -73,7 +73,7 @@ namespace AZ::RHI
         virtual void LoadPlatformLimitsDescriptor(const char* rhiName);
     };
 
-    class PlatformLimits final
+    class ATOM_RHI_REFLECT_API PlatformLimits final
     {
     public:
         AZ_RTTI(AZ::RHI::PlatformLimits, "{48158F25-5044-441C-A2B2-2D3E9255B0C3}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/QueryPoolDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/QueryPoolDescriptor.h
@@ -65,7 +65,7 @@ namespace AZ::RHI
         
     //! Descriptor for the QueryPool RHI type. Contains the type and count
     //! when initializing a query pool.
-    class QueryPoolDescriptor
+    class ATOM_RHI_REFLECT_API QueryPoolDescriptor
         : public ResourcePoolDescriptor
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ReflectSystemComponent.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ReflectSystemComponent.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <AzCore/Component/Component.h>
 
 namespace AZ
@@ -16,7 +17,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    class ReflectSystemComponent
+    class ATOM_RHI_REFLECT_API ReflectSystemComponent
         : public AZ::Component
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderAttachmentLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderAttachmentLayout.h
@@ -25,14 +25,14 @@ namespace AZ::RHI
 {
     static const uint32_t InvalidRenderAttachmentIndex = Limits::Pipeline::RenderAttachmentCountMax;
     //! Base class for extra data to be used when building a RenderAttachmentLayout
-    struct RenderAttachmentExtras
+    struct ATOM_RHI_REFLECT_API RenderAttachmentExtras
     {
         AZ_RTTI(RenderAttachmentExtras, "{0A50E3A8-78B6-4B7A-86CD-D0AB0108743E}");
         virtual ~RenderAttachmentExtras() = default;
     };
 
     //! Describes one render attachment that is part of a layout.
-    struct RenderAttachmentDescriptor
+    struct ATOM_RHI_REFLECT_API RenderAttachmentDescriptor
     {
         AZ_TYPE_INFO(RenderAttachmentDescriptor, "{2855E1D2-BDA1-45A8-ABB9-5D8FB1E78EF4}");
         static void Reflect(ReflectContext* context);
@@ -61,7 +61,7 @@ namespace AZ::RHI
     };
 
     //! Describes a subpass input attachment.
-    struct SubpassInputDescriptor
+    struct ATOM_RHI_REFLECT_API SubpassInputDescriptor
     {
         AZ_TYPE_INFO(SubpassInputDescriptor, "{5E5B933D-8209-4722-8AC5-C3FEA1D75BB3}");
         static void Reflect(ReflectContext* context);
@@ -89,7 +89,7 @@ namespace AZ::RHI
 
     //! Describes the attachments of one subpass as part of a render target layout.
     //! It include descriptions about the render targets, subpass inputs and depth/stencil attachment.
-    struct SubpassRenderAttachmentLayout
+    struct ATOM_RHI_REFLECT_API SubpassRenderAttachmentLayout
     {
         AZ_TYPE_INFO(SubpassRenderAttachmentLayout, "{7AF04EC1-D835-4F97-8433-0D445C0D6F5B}");
         static void Reflect(ReflectContext* context);
@@ -119,7 +119,7 @@ namespace AZ::RHI
     //! A RenderAttachmentLayout may be implemented by the platform using native functionality, achieving a
     //! performance gain for that specific platform. On other platforms, it may be emulated to achieve the same result
     //! but without the performance benefits. For example, Vulkan supports the concept of subpass natively.
-    class RenderAttachmentLayout
+    class ATOM_RHI_REFLECT_API RenderAttachmentLayout
     {
     public:
         AZ_TYPE_INFO(RenderAttachmentLayout, "{5ED96982-BFB0-4EFF-ABBE-1552CECE707D}");
@@ -143,7 +143,7 @@ namespace AZ::RHI
 
     //! Describes the layout of a collection of subpasses and it defines which of the subpasses this
     //! configuration will be using.
-    struct RenderAttachmentConfiguration
+    struct ATOM_RHI_REFLECT_API RenderAttachmentConfiguration
     {
         AZ_TYPE_INFO(RenderAttachmentConfiguration, "{037F27A5-B568-439B-81D4-928DFA3A74F2}");
         static void Reflect(ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h
@@ -66,10 +66,10 @@ namespace AZ::RHI
     //!     RHI::ResultCode result = layoutBuilder.End(layout);
     //!   @endcode
     //!
-    class RenderAttachmentLayoutBuilder
+    class ATOM_RHI_REFLECT_API RenderAttachmentLayoutBuilder
     {
     public:
-        class SubpassAttachmentLayoutBuilder
+        class ATOM_RHI_REFLECT_API SubpassAttachmentLayoutBuilder
         {
             friend class RenderAttachmentLayoutBuilder;
         public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderStates.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/RenderStates.h
@@ -81,9 +81,9 @@ namespace AZ::RHI
         Invalid
     );
 
-    void ReflectRenderStateEnums(ReflectContext* context);
+    ATOM_RHI_REFLECT_API void ReflectRenderStateEnums(ReflectContext* context);
 
-    struct RasterState
+    struct ATOM_RHI_REFLECT_API RasterState
     {
         AZ_TYPE_INFO(RasterState, "{57D4BE50-EBE2-4ABE-90A4-C99BF2EA43FB}");
         static void Reflect(ReflectContext* context);
@@ -101,7 +101,7 @@ namespace AZ::RHI
         uint32_t m_forcedSampleCount = 0;
     };
 
-    struct DepthState
+    struct ATOM_RHI_REFLECT_API DepthState
     {
         AZ_TYPE_INFO(DepthState, "{5F321456-052F-41F1-BD35-2D34CB26DD9D}");
         static void Reflect(ReflectContext* context);
@@ -113,7 +113,7 @@ namespace AZ::RHI
         ComparisonFunc m_func = ComparisonFunc::Less;
     };
 
-    struct StencilOpState
+    struct ATOM_RHI_REFLECT_API StencilOpState
     {
         AZ_TYPE_INFO(StencilOpState, "{6B0894AA-7FE9-4EB0-8171-FF0872CB9B7F}");
         static void Reflect(ReflectContext* context);
@@ -126,7 +126,7 @@ namespace AZ::RHI
         ComparisonFunc m_func = ComparisonFunc::Always;
     };
 
-    struct StencilState
+    struct ATOM_RHI_REFLECT_API StencilState
     {
         AZ_TYPE_INFO(StencilState, "{098EAE83-A3F3-4270-B7AC-ACD11366BBB9}");
         static void Reflect(ReflectContext* context);
@@ -140,7 +140,7 @@ namespace AZ::RHI
         StencilOpState m_backFace;
     };
 
-    struct DepthStencilState
+    struct ATOM_RHI_REFLECT_API DepthStencilState
     {
         AZ_TYPE_INFO(DepthStencilState, "{8AB45110-0727-4923-8098-B9926C1789FE}");
         static void Reflect(ReflectContext* context);
@@ -165,7 +165,7 @@ namespace AZ::RHI
         ColorWriteMaskAll = ColorWriteMaskRed | ColorWriteMaskGreen | ColorWriteMaskBlue | ColorWriteMaskAlpha
     };
     
-    struct TargetBlendState
+    struct ATOM_RHI_REFLECT_API TargetBlendState
     {
         AZ_TYPE_INFO(TargetBlendState, "{2CDF00FE-614D-44FC-929F-E6B50C348578}");
         static void Reflect(ReflectContext* context);
@@ -182,7 +182,7 @@ namespace AZ::RHI
         BlendOp m_blendAlphaOp = BlendOp::Add;
     };
 
-    struct BlendState
+    struct ATOM_RHI_REFLECT_API BlendState
     {
         AZ_TYPE_INFO(BlendState, "{EDB2333A-EF10-4A98-A157-B204E90FA179}");
         static void Reflect(ReflectContext* context);
@@ -194,7 +194,7 @@ namespace AZ::RHI
         AZStd::array<TargetBlendState, Limits::Pipeline::AttachmentColorCountMax> m_targets;
     };
 
-    struct RenderStates
+    struct ATOM_RHI_REFLECT_API RenderStates
     {
         AZ_TYPE_INFO(RenderStates, "{521D72D5-DD69-4380-B637-9CC3D8479D2B}");
         static void Reflect(ReflectContext* context);
@@ -218,28 +218,28 @@ namespace AZ::RHI
     //! Merges any render states in stateToMerge into the result state object. 
     //! The values in stateToMerge are only copied over into the result if they are
     //! not invalid (see also GetInvalidState below).
-    void MergeStateInto(const DepthState& stateToMerge, DepthState& result);
-    void MergeStateInto(const RasterState& stateToMerge, RasterState& result);
-    void MergeStateInto(const StencilOpState& stateToMerge, StencilOpState& result);
-    void MergeStateInto(const StencilState& stateToMerge, StencilState& result);
-    void MergeStateInto(const DepthStencilState& stateToMerge, DepthStencilState& result);
-    void MergeStateInto(const TargetBlendState& stateToMerge, TargetBlendState& result);
-    void MergeStateInto(const BlendState& stateToMerge, BlendState& result);
-    void MergeStateInto(const MultisampleState& stateToMerge, MultisampleState& result);
-    void MergeStateInto(const RenderStates& statesToMerge, RenderStates& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const DepthState& stateToMerge, DepthState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const RasterState& stateToMerge, RasterState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const StencilOpState& stateToMerge, StencilOpState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const StencilState& stateToMerge, StencilState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const DepthStencilState& stateToMerge, DepthStencilState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const TargetBlendState& stateToMerge, TargetBlendState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const BlendState& stateToMerge, BlendState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const MultisampleState& stateToMerge, MultisampleState& result);
+    ATOM_RHI_REFLECT_API void MergeStateInto(const RenderStates& statesToMerge, RenderStates& result);
 
     //! Mark each property in the render states to an invalid value.
     //! This set of functions can be typically used by MergeStateInto
     //! to filter out the actual properties that need to be overwritten.
-    const RasterState& GetInvalidRasterState();
-    const DepthState& GetInvalidDepthState();
-    const StencilOpState& GetInvalidStencilOpState();
-    const StencilState& GetInvalidStencilState();
-    const DepthStencilState& GetInvalidDepthStencilState();
-    const TargetBlendState& GetInvalidTargetBlendState();
-    const BlendState& GetInvalidBlendState();
-    const MultisampleState& GetInvalidMultisampleState();
-    const RenderStates& GetInvalidRenderStates();
+    ATOM_RHI_REFLECT_API const RasterState& GetInvalidRasterState();
+    ATOM_RHI_REFLECT_API const DepthState& GetInvalidDepthState();
+    ATOM_RHI_REFLECT_API const StencilOpState& GetInvalidStencilOpState();
+    ATOM_RHI_REFLECT_API const StencilState& GetInvalidStencilState();
+    ATOM_RHI_REFLECT_API const DepthStencilState& GetInvalidDepthStencilState();
+    ATOM_RHI_REFLECT_API const TargetBlendState& GetInvalidTargetBlendState();
+    ATOM_RHI_REFLECT_API const BlendState& GetInvalidBlendState();
+    ATOM_RHI_REFLECT_API const MultisampleState& GetInvalidMultisampleState();
+    ATOM_RHI_REFLECT_API const RenderStates& GetInvalidRenderStates();
 
     AZ_TYPE_INFO_SPECIALIZE(CullMode, "{AABEEE39-9185-4A9C-9BD7-229DAAAE885D}");
     AZ_TYPE_INFO_SPECIALIZE(FillMode, "{A164B54D-0A74-4F7C-89F3-032D6B6BF107}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ResolveScopeAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ResolveScopeAttachmentDescriptor.h
@@ -12,7 +12,7 @@
 namespace AZ::RHI
 {
     //! Describes the binding of a resolve image attachment to a scope.
-    struct ResolveScopeAttachmentDescriptor
+    struct ATOM_RHI_REFLECT_API ResolveScopeAttachmentDescriptor
         : public ImageScopeAttachmentDescriptor
     {
         AZ_TYPE_INFO(ResolveScopeAttachmentDescriptor, "{8ADC8E2B-2221-487B-A13F-E14218292E39}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ResourcePoolDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ResourcePoolDescriptor.h
@@ -19,7 +19,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    class ResourcePoolDescriptor
+    class ATOM_RHI_REFLECT_API ResourcePoolDescriptor
     {
     public:
         AZ_RTTI(ResourcePoolDescriptor, "{C4B9BF83-B171-4DB9-93D6-0879C7CEF5C2}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SamplerState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SamplerState.h
@@ -59,9 +59,9 @@ namespace AZ::RHI
         OpaqueWhite
     );
 
-    void ReflectSamplerStateEnums(ReflectContext* context);
+    void ATOM_RHI_REFLECT_API ReflectSamplerStateEnums(ReflectContext* context);
 
-    class SamplerState
+    class ATOM_RHI_REFLECT_API SamplerState
     {
     public:
         AZ_TYPE_INFO(SamplerState, "{03CF3A01-8C2B-4A65-8781-6C25CFF0475F}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Scissor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Scissor.h
@@ -17,7 +17,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    struct Scissor
+    struct ATOM_RHI_REFLECT_API Scissor
     {
         AZ_TYPE_INFO(Scissor, "{A0D8D250-59DB-4940-93B4-92C0FA6911CC}");
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ScopeAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ScopeAttachmentDescriptor.h
@@ -17,7 +17,7 @@
 namespace AZ::RHI
 {
     //! Describes the binding of an attachment to a scope.
-    struct ScopeAttachmentDescriptor
+    struct ATOM_RHI_REFLECT_API ScopeAttachmentDescriptor
     {
         AZ_TYPE_INFO(ScopeAttachmentDescriptor, "{04BBA36D-9A61-4E24-9CA0-7A4307C6A411}");
             

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ScopeEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ScopeEnums.h
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) Contributors to the Open 3D Engine Project.
- * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- *
- * SPDX-License-Identifier: Apache-2.0 OR MIT
- *
- */
-#pragma once

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderDataMappings.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderDataMappings.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Matrix4x4.h>
@@ -28,7 +29,7 @@ namespace AZ::RHI
     // a given type and a ShaderInputConstantId used to map that value to a shader resource group.
 
     // Color mapping for a shader constant
-    struct ShaderDataMappingColor
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingColor
     {
         AZ_TYPE_INFO(ShaderDataMappingColor, "{C71FE47C-FD3E-4032-A842-99D9BF86CE19}");
         static void Reflect(AZ::ReflectContext* context);
@@ -39,7 +40,7 @@ namespace AZ::RHI
     using ShaderMappingsColor = AZStd::vector<ShaderDataMappingColor>;
 
     // Uint mapping for a shader constant
-    struct ShaderDataMappingUint
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingUint
     {
         AZ_TYPE_INFO(ShaderDataMappingUint, "{1ECEAEF0-AA15-4836-8A48-402CC66E7651}");
         static void Reflect(AZ::ReflectContext* context);
@@ -50,7 +51,7 @@ namespace AZ::RHI
     using ShaderMappingsUint = AZStd::vector<ShaderDataMappingUint>;
 
     // Float mapping for a shader constant
-    struct ShaderDataMappingFloat
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingFloat
     {
         AZ_TYPE_INFO(ShaderDataMappingFloat, "{AE684716-7F84-4DBC-B21F-82664E88F1AD}");
         static void Reflect(AZ::ReflectContext* context);
@@ -61,7 +62,7 @@ namespace AZ::RHI
     using ShaderMappingsFloat = AZStd::vector<ShaderDataMappingFloat>;
 
     // Float2 mapping for a shader constant
-    struct ShaderDataMappingFloat2
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingFloat2
     {
         AZ_TYPE_INFO(ShaderDataMappingFloat2, "{A8D3B3CC-B00E-44FE-9038-0C9CEE0F606E}");
         static void Reflect(AZ::ReflectContext* context);
@@ -72,7 +73,7 @@ namespace AZ::RHI
     using ShaderMappingsFloat2 = AZStd::vector<ShaderDataMappingFloat2>;
 
     // Float3 mapping for a shader constant
-    struct ShaderDataMappingFloat3
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingFloat3
     {
         AZ_TYPE_INFO(ShaderDataMappingFloat3, "{E23F423D-7200-49CB-8048-9C3D7FCC3AAD}");
         static void Reflect(AZ::ReflectContext* context);
@@ -83,7 +84,7 @@ namespace AZ::RHI
     using ShaderMappingsFloat3 = AZStd::vector<ShaderDataMappingFloat3>;
 
     // Float4 mapping for a shader constant
-    struct ShaderDataMappingFloat4
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingFloat4
     {
         AZ_TYPE_INFO(ShaderDataMappingFloat4, "{16FEB44A-FE90-4406-923A-3A5E1C849E97}");
         static void Reflect(AZ::ReflectContext* context);
@@ -94,7 +95,7 @@ namespace AZ::RHI
     using ShaderMappingsFloat4 = AZStd::vector<ShaderDataMappingFloat4>;
 
     // Matrix3x3 mapping for a shader constant
-    struct ShaderDataMappingMatrix3x3
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingMatrix3x3
     {
         AZ_TYPE_INFO(ShaderDataMappingMatrix3x3, "{86EA4178-F8CA-4AF3-8D6E-F91A1875608D}");
         static void Reflect(AZ::ReflectContext* context);
@@ -105,7 +106,7 @@ namespace AZ::RHI
     using ShaderMappingsMatrix3x3 = AZStd::vector<ShaderDataMappingMatrix3x3>;
 
     // Matrix4x4 mapping for a shader constant
-    struct ShaderDataMappingMatrix4x4
+    struct ATOM_RHI_REFLECT_API ShaderDataMappingMatrix4x4
     {
         AZ_TYPE_INFO(ShaderDataMappingMatrix4x4, "{7DBD1EFA-CA1B-4950-B9CB-C36426C30535}");
         static void Reflect(AZ::ReflectContext* context);
@@ -118,7 +119,7 @@ namespace AZ::RHI
     // [GFX TODO][ATOM-2338] Revisit this class and finalize the API around it's usage.
     // Collection of values and the names of the shader constants they map to
     // Consists of lists for each of the mapping types declared above
-    struct ShaderDataMappings
+    struct ATOM_RHI_REFLECT_API ShaderDataMappings
     {
         AZ_TYPE_INFO(ShaderDataMappings, "{0C522693-ED7D-4E46-8C8F-1171994D9EEF}");
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderInputNameIndex.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderInputNameIndex.h
@@ -25,7 +25,7 @@ namespace AZ::RHI
     //! Users can initialize this class with the Name used to lookup the index and
     //! then use this class as an index. Under the hood, the code will initialize
     //! the index if it's not already initialized before using it.
-    struct ShaderInputNameIndex
+    struct ATOM_RHI_REFLECT_API ShaderInputNameIndex
     {
         AZ_TYPE_INFO(ShaderInputNameIndex, "{1A9A92A7-9289-45E1-9EFE-D08257EF2BF1}");
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayout.h
@@ -56,7 +56,7 @@ namespace AZ::RHI
     //! To use the class, assign shader inputs using AddShaderInput, and call Finalize to
     //! complete construction of the layout. This class is intended to be built using an offline shader
     //! compiler, and serialized to / from disk.
-    class ShaderResourceGroupLayout
+    class ATOM_RHI_REFLECT_API ShaderResourceGroupLayout
         : public AZStd::intrusive_base
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h
@@ -60,7 +60,7 @@ namespace AZ::RHI
 
     static const uint32_t UndefinedRegisterSlot = static_cast<uint32_t>(-1);
 
-    class ShaderInputBufferDescriptor final
+    class ATOM_RHI_REFLECT_API ShaderInputBufferDescriptor final
     {
     public:
         AZ_TYPE_INFO(ShaderInputBufferDescriptor, "{19D329BD-FCE7-43CC-A376-E2BD43EA5175}");
@@ -129,7 +129,7 @@ namespace AZ::RHI
         SubpassInput
     };
 
-    class ShaderInputImageDescriptor final
+    class ATOM_RHI_REFLECT_API ShaderInputImageDescriptor final
     {
     public:
         AZ_TYPE_INFO(ShaderInputImageDescriptor, "{913DBF3C-5556-4524-B928-174A42516D31}");
@@ -173,7 +173,7 @@ namespace AZ::RHI
         uint32_t m_spaceId = UndefinedRegisterSlot;
     };
 
-    class ShaderInputBufferUnboundedArrayDescriptor final
+    class ATOM_RHI_REFLECT_API ShaderInputBufferUnboundedArrayDescriptor final
     {
     public:
         AZ_TYPE_INFO(ShaderInputBufferUnboundedArrayDescriptor, "{7B355E06-DABA-4F49-834E-DEA26691C8DF}");
@@ -217,7 +217,7 @@ namespace AZ::RHI
         uint32_t m_spaceId = UndefinedRegisterSlot;
     };
 
-    class ShaderInputImageUnboundedArrayDescriptor final
+    class ATOM_RHI_REFLECT_API ShaderInputImageUnboundedArrayDescriptor final
     {
     public:
         AZ_TYPE_INFO(ShaderInputImageUnboundedArrayDescriptor, "{943E4C4A-E5FE-4993-93D5-EFB67565284B}");
@@ -257,7 +257,7 @@ namespace AZ::RHI
         uint32_t m_spaceId = UndefinedRegisterSlot;
     };
 
-    class ShaderInputSamplerDescriptor final
+    class ATOM_RHI_REFLECT_API ShaderInputSamplerDescriptor final
     {
     public:
         AZ_TYPE_INFO(ShaderInputSamplerDescriptor, "{F42E989D-002E-42B3-A396-062CB0DB6644}");
@@ -289,7 +289,7 @@ namespace AZ::RHI
         uint32_t m_spaceId = UndefinedRegisterSlot;
     };
 
-    class ShaderInputConstantDescriptor final
+    class ATOM_RHI_REFLECT_API ShaderInputConstantDescriptor final
     {
     public:
         AZ_TYPE_INFO(ShaderInputConstantDescriptor, "{C8DC7D2D-CCA0-45AD-9430-52C06B69325C}");
@@ -330,7 +330,7 @@ namespace AZ::RHI
         uint32_t m_spaceId = UndefinedRegisterSlot;
     };
 
-    class ShaderInputStaticSamplerDescriptor final
+    class ATOM_RHI_REFLECT_API ShaderInputStaticSamplerDescriptor final
     {
     public:
         AZ_TYPE_INFO(ShaderInputStaticSamplerDescriptor, "{A4D3C5AC-1624-4F78-9543-0E37DC93F491}");
@@ -363,12 +363,12 @@ namespace AZ::RHI
     };
 
     //! Returns the string name for the shader input type enum.
-    const char* GetShaderInputTypeName(ShaderInputBufferType bufferInputType);
-    const char* GetShaderInputTypeName(ShaderInputImageType imageInputType);
+    ATOM_RHI_REFLECT_API const char* GetShaderInputTypeName(ShaderInputBufferType bufferInputType);
+    ATOM_RHI_REFLECT_API const char* GetShaderInputTypeName(ShaderInputImageType imageInputType);
 
     //! Returns the string name for the shader input access enum.
-    const char* GetShaderInputAccessName(ShaderInputBufferAccess bufferInputAccess);
-    const char* GetShaderInputAccessName(ShaderInputImageAccess imageInputAccess);
+    ATOM_RHI_REFLECT_API const char* GetShaderInputAccessName(ShaderInputBufferAccess bufferInputAccess);
+    ATOM_RHI_REFLECT_API const char* GetShaderInputAccessName(ShaderInputImageAccess imageInputAccess);
 
     using ShaderInputBufferIndex = Handle<uint32_t, ShaderInputBufferDescriptor>;
     using ShaderInputImageIndex = Handle<uint32_t, ShaderInputImageDescriptor>;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupPoolDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupPoolDescriptor.h
@@ -22,7 +22,7 @@ namespace AZ::RHI
         Transient
     };
 
-    class ShaderResourceGroupPoolDescriptor
+    class ATOM_RHI_REFLECT_API ShaderResourceGroupPoolDescriptor
         : public ResourcePoolDescriptor
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderSemantic.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderSemantic.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <AzCore/Name/Name.h>
 #include <AzCore/Utils/TypeHash.h>
 #include <AzCore/Casting/numeric_cast.h>
@@ -14,7 +15,7 @@
 namespace AZ::RHI
 {
     //! Describes a shader semantic (name + index). This should match the semantic declared in AZSL.
-    class ShaderSemantic
+    class ATOM_RHI_REFLECT_API ShaderSemantic
     {
     public:
         AZ_TYPE_INFO(ShaderSemantic, "{C6FFF25F-FE52-4D08-8D96-D04C14048816}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStageFunction.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderStageFunction.h
@@ -28,7 +28,7 @@ namespace AZ::RHI
     //! Each platform specializes this data structure with platform-specific data necessary to compile
     //! an entry point of a shader stage on a PSO. The platform-independent runtime does not need to care
     //! about specifics, the function is merely an opaque data stream passed to the pipeline state descriptor.
-    class ShaderStageFunction
+    class ATOM_RHI_REFLECT_API ShaderStageFunction
         : public AZStd::intrusive_base
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Size.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Size.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <AzCore/base.h>
 #include <AzCore/RTTI/TypeInfo.h>
 
@@ -17,7 +18,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    struct Size
+    struct ATOM_RHI_REFLECT_API Size
     {
         AZ_TYPE_INFO(Size, "{3B8DAD61-8AFA-4BB1-BCF8-179865D8C57B}");
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/StreamingImagePoolDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/StreamingImagePoolDescriptor.h
@@ -16,7 +16,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    class StreamingImagePoolDescriptor
+    class ATOM_RHI_REFLECT_API StreamingImagePoolDescriptor
         : public ResourcePoolDescriptor
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SwapChainDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/SwapChainDescriptor.h
@@ -21,7 +21,7 @@ namespace AZ::RHI
 {
     using WindowHandle = Handle<uint64_t, class Window>;
 
-    struct SwapChainDimensions
+    struct ATOM_RHI_REFLECT_API SwapChainDimensions
     {
         AZ_TYPE_INFO(SwapChainDimensions, "{1B1D266F-15FA-4EA6-B28C-B87467844617}");
 
@@ -38,7 +38,7 @@ namespace AZ::RHI
         Format m_imageFormat = Format::Unknown;
     };
 
-    class SwapChainDescriptor
+    class ATOM_RHI_REFLECT_API SwapChainDescriptor
         : public ResourcePoolDescriptor
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/TransientBufferDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/TransientBufferDescriptor.h
@@ -13,7 +13,7 @@
 
 namespace AZ::RHI
 {
-    struct TransientBufferDescriptor
+    struct ATOM_RHI_REFLECT_API TransientBufferDescriptor
     {
         TransientBufferDescriptor() = default;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/TransientImageDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/TransientImageDescriptor.h
@@ -14,7 +14,7 @@
 
 namespace AZ::RHI
 {
-    struct TransientImageDescriptor
+    struct ATOM_RHI_REFLECT_API TransientImageDescriptor
     {
         TransientImageDescriptor() = default;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedAttachmentDescriptor.h
@@ -17,7 +17,7 @@ namespace AZ::RHI
 {
     //! A unified attachment descriptor used to store either an image or a buffer descriptor.
     //! Used primarily to simplify pass attachment logic while supporting both attachment types.
-    struct UnifiedAttachmentDescriptor
+    struct ATOM_RHI_REFLECT_API UnifiedAttachmentDescriptor
     {
         UnifiedAttachmentDescriptor();
         UnifiedAttachmentDescriptor(const BufferDescriptor& bufferDescriptor);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedScopeAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedScopeAttachmentDescriptor.h
@@ -22,7 +22,7 @@ namespace AZ::RHI
 {
     //! A unified descriptor of the binding of an attachment to a scope.
     //! Essentially a union of all possible ScopeAttachment types.
-    struct UnifiedScopeAttachmentDescriptor final
+    struct ATOM_RHI_REFLECT_API UnifiedScopeAttachmentDescriptor final
         : public ScopeAttachmentDescriptor
     {
         UnifiedScopeAttachmentDescriptor() { };

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/VariableRateShadingEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/VariableRateShadingEnums.h
@@ -82,7 +82,7 @@ namespace AZ::RHI
 
     //! Represents a texel value of a shading rate.
     //! Some implementations use a two component image format, others only one.
-    struct ShadingRateImageValue
+    struct ATOM_RHI_REFLECT_API ShadingRateImageValue
     {
         uint8_t m_x; // First component value.
         uint8_t m_y; // Second component value (may be 0 if not used).

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/VertexFormat.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/VertexFormat.h
@@ -24,11 +24,11 @@ namespace AZ::RHI
     using VertexFormat = Internal::VertexFormat;
 
     //! @brief Returns the size of the given vertex format in bytes.
-    uint32_t GetVertexFormatSize(VertexFormat vertexFormat);
+    ATOM_RHI_REFLECT_API uint32_t GetVertexFormatSize(VertexFormat vertexFormat);
 
     //! @brief Converts the given image format to a VertexFormat or asserts if no such conversion is possible
-    VertexFormat ConvertToVertexFormat(RHI::Format format);
+    ATOM_RHI_REFLECT_API VertexFormat ConvertToVertexFormat(RHI::Format format);
 
     //! @brief Converts the given VertexFormat to an image format or asserts if no such conversion is possible
-    RHI::Format ConvertToImageFormat(VertexFormat vertexFormat);
+    ATOM_RHI_REFLECT_API RHI::Format ConvertToImageFormat(VertexFormat vertexFormat);
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Viewport.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Viewport.h
@@ -16,7 +16,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    struct Viewport
+    struct ATOM_RHI_REFLECT_API Viewport
     {
         AZ_TYPE_INFO(Viewport, "{69160593-B7C3-4E94-A397-CC0A34567698}");
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasedHeap.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasedHeap.h
@@ -44,7 +44,7 @@ namespace AZ::RHI
     //! Aliased Heaps are used for allocating transient attachments (resources that are valid only during the duration of a frame).
     //! and they will reuse memory whenever possible, and will also track the necessary barriers that need to be inserted when aliasing happens.
     //! Aliased Heaps do not support aliased resources being used at the same time (even if the resources are compatible).
-    class AliasedHeap
+    class ATOM_RHI_PUBLIC_API AliasedHeap
         : public DeviceResourcePool
     {
         using Base = DeviceResourcePool;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasingBarrierTracker.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/AliasingBarrierTracker.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/TransientAttachmentStatistics.h>
+#include <Atom/RHI/Base.h>
 
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/Memory/SystemAllocator.h>
@@ -34,7 +35,7 @@ namespace AZ::RHI
     // overlaps each other, partially or totally. It doesn't add any type of synchronization between resources
     // that don't overlap. Resources must be added in order so the tracker knows which one is the source
     // and which one is the destination.
-    class AliasingBarrierTracker
+    class ATOM_RHI_PUBLIC_API AliasingBarrierTracker
     {
     public:
         AZ_CLASS_ALLOCATOR(AliasingBarrierTracker, AZ::SystemAllocator);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Allocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Allocator.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI/Base.h>
 #include <AzCore/base.h>
 
 namespace AZ::RHI
@@ -16,7 +17,7 @@ namespace AZ::RHI
     //! To account for this, VirtualAddress::Null is used instead. Check validity of the address
     //! using IsValid or IsNull instead of checking for 0. VirtualAddress is initialized
     //! to Null, so returning the default constructor is sufficient to represent an invalid address.
-    class VirtualAddress
+    class ATOM_RHI_PUBLIC_API VirtualAddress
     {
         static const VirtualAddress Null;
     public:
@@ -54,10 +55,10 @@ namespace AZ::RHI
     //! these are often deferred-released after N frames. The user may provide a garbage collection
     //! latency, which controls the number of GarbageCollect calls that must occur before an allocation
     //! is actually reclaimed. The intended use case is to garbage collect at the end of each frame.
-    class Allocator
+    class ATOM_RHI_PUBLIC_API Allocator
     {
     public:
-        struct Descriptor
+        struct ATOM_RHI_PUBLIC_API Descriptor
         {
             static const size_t DefaultAlignment = 256;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/AsyncWorkQueue.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/AsyncWorkQueue.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/Handle.h>
+#include <Atom/RHI/Base.h>
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/std/parallel/atomic.h>
@@ -24,7 +25,7 @@ namespace AZ::RHI
 
     //! Helper class to manage executing work in a background thread.
     //! Work items are processed in the order that they were received.
-    class AsyncWorkQueue
+    class ATOM_RHI_PUBLIC_API AsyncWorkQueue
     {
     public:
         AZ_CLASS_ALLOCATOR(AsyncWorkQueue, AZ::SystemAllocator);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Base.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Base.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if defined(AZ_MONOLITHIC_BUILD)
+    #define ATOM_RHI_PUBLIC_API
+    #define ATOM_RHI_PUBLIC_API_EXPORT
+#else
+    #if defined(ATOM_RHI_PUBLIC_EXPORTS)
+        #define ATOM_RHI_PUBLIC_API        AZ_DLL_EXPORT
+        #define ATOM_RHI_PUBLIC_API_EXPORT AZ_DLL_EXPORT
+    #else
+        #define ATOM_RHI_PUBLIC_API        AZ_DLL_IMPORT
+        #define ATOM_RHI_PUBLIC_API_EXPORT
+    #endif
+#endif

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
@@ -22,7 +22,7 @@ namespace AZ::RHI
     //! A Buffer holds all Buffers across multiple devices.
     //! The buffer descriptor will be shared across all the buffers.
     //! The user manages the lifecycle of a Buffer through a BufferPool
-    class Buffer : public Resource
+    class ATOM_RHI_PUBLIC_API Buffer : public Resource
     {
         using Base = Resource;
         friend class BufferPoolBase;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferFrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferFrameAttachment.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
     class BufferScopeAttachment;
 
     //! A specialization of Attachment for a buffer. Provides access to the buffer.
-    class BufferFrameAttachment
+    class ATOM_RHI_PUBLIC_API BufferFrameAttachment
         : public FrameAttachment
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
@@ -72,7 +72,7 @@ namespace AZ::RHI
     //! Buffer pool provides backing storage and context for buffer instances. The BufferPoolDescriptor
     //! contains properties defining memory characteristics of buffer pools. All buffers created on a pool
     //! share the same backing heap and buffer bind flags.
-    class BufferPool : public BufferPoolBase
+    class ATOM_RHI_PUBLIC_API BufferPool : public BufferPoolBase
     {
         friend class RayTracingBufferPools;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPoolBase.h
@@ -15,7 +15,7 @@ namespace AZ::RHI
     //! A simple base class for buffer pools. This mainly exists so that various
     //! buffer pool implementations can have some type safety separate from other
     //! resource pool types.
-    class BufferPoolBase : public ResourcePool
+    class ATOM_RHI_PUBLIC_API BufferPoolBase : public ResourcePool
     {
     public:
         AZ_RTTI(BufferPoolBase, "{08EC3384-CC9F-4F04-B87E-0BB9D23F7CB0}", ResourcePool);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferScopeAttachment.h
@@ -18,7 +18,7 @@ namespace AZ::RHI
 
     //! A specialization of a scope attachment for buffers. Provides
     //! access to the buffer view and buffer scope attachment descriptor.
-    class BufferScopeAttachment final
+    class ATOM_RHI_PUBLIC_API BufferScopeAttachment final
         : public ScopeAttachment
     {
         friend class FrameGraphCompiler;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferView.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     //! A BufferView is a light-weight representation of a view onto a multi-device buffer.
     //! It holds a ConstPtr to a multi-device buffer as well as a BufferViewDescriptor
     //! Using both, single-device BufferViews can be retrieved
-    class BufferView : public ResourceView
+    class ATOM_RHI_PUBLIC_API BufferView : public ResourceView
     {
     public:
         AZ_RTTI(BufferView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandList.h
@@ -30,7 +30,7 @@ namespace AZ::RHI
         Count
     };
 
-    class CommandList
+    class ATOM_RHI_PUBLIC_API CommandList
     {
     public:
         /// Assigns a list of viewports to the raster stage of the graphics pipe.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandListValidator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandListValidator.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
     //! This is a utility for validating that resources are in a correct state to be used for
     //! graphics / compute / copy operations on a command list. It does by crawling ShaderResourceGroups
     //! and checking that the Scope has properly declared the relevant pools and attachments.
-    class CommandListValidator
+    class ATOM_RHI_PUBLIC_API CommandListValidator
     {
     public:
         CommandListValidator() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandQueue.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CommandQueue.h
@@ -33,7 +33,7 @@ namespace AZ::RHI
 
     //! Base class that provides the backend API the ability to add
     //! commands to a queue which are executed on a separate thread
-    class CommandQueue
+    class ATOM_RHI_PUBLIC_API CommandQueue
         : public RHI::DeviceObject
     {
         using Base = RHI::DeviceObject;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ConstantsData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ConstantsData.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/PipelineLayoutDescriptor.h>
+#include <Atom/RHI/Base.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/Matrix3x3.h>
 #include <AzCore/Math/Matrix3x4.h>
@@ -24,7 +25,7 @@ namespace AZ::RHI
     //! we don't make assumptions about the data or how the user wants to operate on the data, and the convenience
     //! operations boil down to thin wrappers for single calls to SetConstantRaw and GetConstantRaw. So these
     //! convenience functions are provided in situations that are "low-hanging-fruit".
-    class ConstantsData
+    class ATOM_RHI_PUBLIC_API ConstantsData
     {
     public:
         ConstantsData() = default;
@@ -126,55 +127,55 @@ namespace AZ::RHI
     }
 
     template <>
-    bool ConstantsData::SetConstant<bool>(ShaderInputConstantIndex inputIndex, const bool& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<bool>(ShaderInputConstantIndex inputIndex, const bool& value);
 
     template <>
-    bool ConstantsData::SetConstant<Matrix3x3>(ShaderInputConstantIndex inputIndex, const Matrix3x3& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<Matrix3x3>(ShaderInputConstantIndex inputIndex, const Matrix3x3& value);
 
     template <>
-    bool ConstantsData::SetConstant<Matrix3x4>(ShaderInputConstantIndex inputIndex, const Matrix3x4& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<Matrix3x4>(ShaderInputConstantIndex inputIndex, const Matrix3x4& value);
 
     template <>
-    bool ConstantsData::SetConstant<Matrix4x4>(ShaderInputConstantIndex inputIndex, const Matrix4x4& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<Matrix4x4>(ShaderInputConstantIndex inputIndex, const Matrix4x4& value);
 
     template <>
-    bool ConstantsData::SetConstant<Vector2>(ShaderInputConstantIndex inputIndex, const Vector2& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<Vector2>(ShaderInputConstantIndex inputIndex, const Vector2& value);
 
     template <>
-    bool ConstantsData::SetConstant<Vector3>(ShaderInputConstantIndex inputIndex, const Vector3& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<Vector3>(ShaderInputConstantIndex inputIndex, const Vector3& value);
 
     template <>
-    bool ConstantsData::SetConstant<Vector4>(ShaderInputConstantIndex inputIndex, const Vector4& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<Vector4>(ShaderInputConstantIndex inputIndex, const Vector4& value);
 
     template <>
-    bool ConstantsData::SetConstant<Color>(ShaderInputConstantIndex inputIndex, const Color& value);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstant<Color>(ShaderInputConstantIndex inputIndex, const Color& value);
 
     template <>
-    bool ConstantsData::SetConstantArray<bool>(ShaderInputConstantIndex inputIndex, AZStd::span<const bool> values);
+    ATOM_RHI_PUBLIC_API bool ConstantsData::SetConstantArray<bool>(ShaderInputConstantIndex inputIndex, AZStd::span<const bool> values);
 
     template <>
-    bool ConstantsData::GetConstant<bool>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API bool ConstantsData::GetConstant<bool>(ShaderInputConstantIndex inputIndex) const;
 
     template <>
-    Matrix3x3 ConstantsData::GetConstant<Matrix3x3>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API Matrix3x3 ConstantsData::GetConstant<Matrix3x3>(ShaderInputConstantIndex inputIndex) const;
 
     template <>
-    Matrix3x4 ConstantsData::GetConstant<Matrix3x4>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API Matrix3x4 ConstantsData::GetConstant<Matrix3x4>(ShaderInputConstantIndex inputIndex) const;
 
     template <>
-    Matrix4x4 ConstantsData::GetConstant<Matrix4x4>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API Matrix4x4 ConstantsData::GetConstant<Matrix4x4>(ShaderInputConstantIndex inputIndex) const;
 
     template <>
-    Vector2 ConstantsData::GetConstant<Vector2>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API Vector2 ConstantsData::GetConstant<Vector2>(ShaderInputConstantIndex inputIndex) const;
 
     template <>
-    Vector3 ConstantsData::GetConstant<Vector3>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API Vector3 ConstantsData::GetConstant<Vector3>(ShaderInputConstantIndex inputIndex) const;
 
     template <>
-    Vector4 ConstantsData::GetConstant<Vector4>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API Vector4 ConstantsData::GetConstant<Vector4>(ShaderInputConstantIndex inputIndex) const;
 
     template <>
-    Color ConstantsData::GetConstant<Color>(ShaderInputConstantIndex inputIndex) const;
+    ATOM_RHI_PUBLIC_API Color ConstantsData::GetConstant<Color>(ShaderInputConstantIndex inputIndex) const;
 
     template <typename T, uint32_t matrixSize>
     bool ConstantsData::SetConstantMatrixRows(ShaderInputConstantIndex inputIndex, const T& value, uint32_t rowCount)

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -39,7 +39,7 @@ namespace AZ::RHI
     //! with another device.
     //!
     //! Multi-Device interop support is planned in the future and will likely require API changes.
-    class Device
+    class ATOM_RHI_PUBLIC_API Device
         : public Object
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBuffer.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
     
     //! A buffer corresponds to a region of linear memory and used for rendering operations. The user
     //! manages the lifecycle of a buffer through a DeviceBufferPool.
-    class DeviceBuffer
+    class ATOM_RHI_PUBLIC_API DeviceBuffer
         : public DeviceResource
     {
         using Base = DeviceResource;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPool.h
@@ -91,7 +91,7 @@ namespace AZ::RHI
     //! Buffer pool provides backing storage and context for buffer instances. The BufferPoolDescriptor
     //! contains properties defining memory characteristics of buffer pools. All buffers created on a pool
     //! share the same backing heap and buffer bind flags.
-    class DeviceBufferPool
+    class ATOM_RHI_PUBLIC_API DeviceBufferPool
         : public DeviceBufferPoolBase
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPoolBase.h
@@ -15,7 +15,7 @@ namespace AZ::RHI
     //! A simple base class for buffer pools. This mainly exists so that various
     //! buffer pool implementations can have some type safety separate from other
     //! resource pool types.
-    class DeviceBufferPoolBase
+    class ATOM_RHI_PUBLIC_API DeviceBufferPoolBase
         : public DeviceResourcePool
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferView.h
@@ -16,7 +16,7 @@ namespace AZ::RHI
 
     //! DeviceBufferView is contains a platform-specific descriptor mapping to a linear sub-region of a specific buffer resource.
     //! It associates 1-to-1 with a BufferViewDescriptor.
-    class DeviceBufferView
+    class ATOM_RHI_PUBLIC_API DeviceBufferView
         : public DeviceResourceView
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawPacket.h
@@ -43,7 +43,7 @@ namespace AZ::RHI
     //!   - The packet is self-contained and does not reference external memory. Use DeviceDrawPacketBuilder to construct
     //!     an instance and either store in an RHI::Ptr or call 'delete' to release.
     //! 
-    class DeviceDrawPacket final : public AZStd::intrusive_base
+    class ATOM_RHI_PUBLIC_API DeviceDrawPacket final : public AZStd::intrusive_base
     {
         friend class DeviceDrawPacketBuilder;
         friend class UnitTest::DrawPacketTest;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceDrawPacketBuilder.h
@@ -20,7 +20,7 @@ namespace AZ
 
 namespace AZ::RHI
 {
-    class DeviceDrawPacketBuilder
+    class ATOM_RHI_PUBLIC_API DeviceDrawPacketBuilder
     {
     public:
         struct DeviceDrawRequest

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceFence.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
     };
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(FenceFlags);
 
-    class DeviceFence
+    class ATOM_RHI_PUBLIC_API DeviceFence
         : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImage.h
@@ -26,7 +26,7 @@ namespace AZ::RHI
     //! number of subresources is equal to mipLevels * arraySize. All subresources share the same pixel format.
     //!
     //! @see DeviceImageView on how to interpret contents of an image.
-    class DeviceImage
+    class ATOM_RHI_PUBLIC_API DeviceImage
         : public DeviceResource
     {
         friend class DeviceImagePoolBase;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImagePool.h
@@ -65,7 +65,7 @@ namespace AZ::RHI
     //! As a result, they are intended to be produced and consumed by the GPU. Persistent Color / Depth Stencil / Image
     //! attachments should be created from this pool. This pool is not designed for intra-frame aliasing.
     //! If transient images are required, they can be created from the frame scheduler itself.
-    class DeviceImagePool
+    class ATOM_RHI_PUBLIC_API DeviceImagePool
         : public DeviceImagePoolBase
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImagePoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImagePoolBase.h
@@ -15,7 +15,7 @@ namespace AZ::RHI
     //! A simple base class for image pools. This mainly exists so that various
     //! image pool implementations can have some type safety separate from other
     //! resource pool types.
-    class DeviceImagePoolBase
+    class ATOM_RHI_PUBLIC_API DeviceImagePoolBase
         : public DeviceResourcePool
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImageView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImageView.h
@@ -17,7 +17,7 @@ namespace AZ::RHI
     //! DeviceImageView contains a platform-specific descriptor mapping to a sub-region of an image resource.
     //! It associates 1-to-1 with a ImageViewDescriptor. Image views map to a subset of image sub-resources
     //! (mip levels / array slices). They can additionally override the base format of the image
-    class DeviceImageView
+    class ATOM_RHI_PUBLIC_API DeviceImageView
         : public DeviceResourceView
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndexBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndexBufferView.h
@@ -8,13 +8,14 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/IndexFormat.h>
+#include <Atom/RHI/Base.h>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace AZ::RHI
 {
     class DeviceBuffer;
 
-    class alignas(8) DeviceIndexBufferView
+    class ATOM_RHI_PUBLIC_API alignas(8) DeviceIndexBufferView
     {
     public:
         DeviceIndexBufferView() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndirectBufferSignature.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndirectBufferSignature.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
     //!
     //! It also exposes implementation dependent offsets for the commands in
     //! a layout. This information is useful when writing commands into a buffer.
-    class DeviceIndirectBufferSignature :
+    class ATOM_RHI_PUBLIC_API DeviceIndirectBufferSignature :
         public DeviceObject
     {
         using Base = RHI::DeviceObject;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndirectBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndirectBufferView.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/Bits.h>
+#include <Atom/RHI/Base.h>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace AZ::RHI
@@ -17,7 +18,7 @@ namespace AZ::RHI
 
     //! Provides a view into a buffer, to be used as an indirect buffer. The content of the view is a contiguous
     //! list of commands sequences. It is provided to the RHI back-end at draw time.
-    class alignas(8) DeviceIndirectBufferView
+    class ATOM_RHI_PUBLIC_API alignas(8) DeviceIndirectBufferView
     {
     public:
         DeviceIndirectBufferView() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndirectBufferWriter.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceIndirectBufferWriter.h
@@ -28,7 +28,7 @@ namespace AZ::RHI
     //!
     //! It also provides basic checks, like trying to write more commands than allowed, or
     //! writing commands that are not specified in the layout.
-    class DeviceIndirectBufferWriter :
+    class ATOM_RHI_PUBLIC_API DeviceIndirectBufferWriter :
         public Object
     {
         using Base = Object;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceObject.h
@@ -13,7 +13,7 @@ namespace AZ::RHI
 {
     //! A variant of Object associated with a Device instance. It holds a strong reference to
     //! the device and provides a simple accessor API.
-    class DeviceObject
+    class ATOM_RHI_PUBLIC_API DeviceObject
         : public Object
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DevicePipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DevicePipelineLibrary.h
@@ -43,7 +43,7 @@ namespace AZ::RHI
     //! to initialize pipeline states across threads using the same DevicePipelineLibrary instance, but this will
     //! result in the two calls serializing on the mutex. Instead, see PipelineStateCache which stores
     //! a DevicePipelineLibrary instance per thread to avoid this contention.
-    class DevicePipelineLibrary : public DeviceObject
+    class ATOM_RHI_PUBLIC_API DevicePipelineLibrary : public DeviceObject
     {
     public:
         AZ_RTTI(DevicePipelineLibrary, "{843579BE-57E4-4527-AB00-C0217885AEA9}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DevicePipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DevicePipelineState.h
@@ -27,7 +27,7 @@ namespace AZ::RHI
     //!   Blend, Raster, and Depth-Stencil state.
     //! 
     //! - [Graphics Only] State to identify stream buffers to the fixed function input assembly unit.
-    class DevicePipelineState
+    class ATOM_RHI_PUBLIC_API DevicePipelineState
         : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceQuery.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceQuery.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
 
     //! DeviceQuery resource for recording gpu data like occlusion, timestamp or pipeline statistics.
     //! Queries belong to a DeviceQueryPool and their types are determined by the pool.
-    class DeviceQuery
+    class ATOM_RHI_PUBLIC_API DeviceQuery
         : public DeviceResource
     {
         friend class DeviceQueryPool;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceQueryPool.h
@@ -33,7 +33,7 @@ namespace AZ::RHI
     //! Query pool provides backing storage and context for query instances. The QueryPoolDescriptor
     //! contains properties defining memory characteristics of query pools. All queries created on a pool
     //! share the same backing and type.
-    class DeviceQueryPool
+    class ATOM_RHI_PUBLIC_API DeviceQueryPool
         : public DeviceResourcePool
     {
         using Base = DeviceResourcePool;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingAccelerationStructure.h
@@ -83,7 +83,7 @@ namespace AZ::RHI
     //! DeviceRayTracingBlas
     //!
     //! A DeviceRayTracingBlas is created from the information in the DeviceRayTracingBlasDescriptor.
-    class DeviceRayTracingBlas
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingBlas
         : public DeviceObject
     {
     public:
@@ -161,7 +161,7 @@ namespace AZ::RHI
     //! DeviceRayTracingTlas
     //!
     //! A DeviceRayTracingTlas is created from the information in the DeviceRayTracingTlasDescriptor.
-    class DeviceRayTracingTlas
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingTlas
         : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingBufferPools.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingBufferPools.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     //! This class encapsulates all of the BufferPools needed for ray tracing, freeing the application
     //! from setting up and managing the buffers pools individually.
     //!
-    class DeviceRayTracingBufferPools
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingBufferPools
         : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingCompactionQueryPool.h
@@ -28,7 +28,7 @@ namespace AZ::RHI
     //! This process takes multiple frames to complete as the compact size must be available on the CPU
     //!
     //! See https://developer.nvidia.com/blog/tips-acceleration-structure-compaction/ for a more detailed description
-    class DeviceRayTracingCompactionQuery : public DeviceObject
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingCompactionQuery : public DeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(DeviceRayTracingCompactionQuery, AZ::SystemAllocator, 0);
@@ -59,7 +59,7 @@ namespace AZ::RHI
     };
 
     //! Provides storage for DeviceRayTracingCompactionQuery objects and handles
-    class DeviceRayTracingCompactionQueryPool : public DeviceObject
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingCompactionQueryPool : public DeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(DeviceRayTracingCompactionQueryPool, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingPipelineState.h
@@ -64,7 +64,7 @@ namespace AZ::RHI
     };
 
     //! Defines the shaders, hit groups, and other parameters required for ray tracing operations.
-    class DeviceRayTracingPipelineState
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingPipelineState
         : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceRayTracingShaderTable.h
@@ -31,7 +31,7 @@ namespace AZ::RHI
     //! DeviceRayTracingShaderTableDescriptor
     //!
     //!  Describes a single-device ray tracing shader table.
-    class DeviceRayTracingShaderTableDescriptor
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingShaderTableDescriptor
     {
     public:
         void RemoveHitGroupRecords(uint32_t key);
@@ -46,7 +46,7 @@ namespace AZ::RHI
 
     //! Shader Table
     //! Specifies the ray generation, miss, and hit shaders used during the ray tracing process
-    class DeviceRayTracingShaderTable
+    class ATOM_RHI_PUBLIC_API DeviceRayTracingShaderTable
         : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResource.h
@@ -25,7 +25,7 @@ namespace AZ::RHI
     //! DeviceResource is a base class for pooled RHI resources (DeviceImage / DeviceBuffer / DeviceShaderResourceGroup, etc). It provides
     //! some common lifecycle management semantics. DeviceResource creation is separate from initialization. Resources are
     //! created separate from any pool, but its backing platform data is associated at initialization time on a specific pool.
-    class DeviceResource
+    class ATOM_RHI_PUBLIC_API DeviceResource
         : public DeviceObject
     {
         friend class Resource;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResourcePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResourcePool.h
@@ -34,7 +34,7 @@ namespace AZ::RHI
 
     //! A base class for resource pools. This class facilitates registration of resources
     //! into the pool, and allows iterating child resource instances.
-    class DeviceResourcePool
+    class ATOM_RHI_PUBLIC_API DeviceResourcePool
         : public DeviceObject
         , public MemoryStatisticsEventBus::Handler
         , public FrameEventBus::Handler

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResourceView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceResourceView.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
     //! NOTE: While initialization is separate from creation, explicit shutdown is not allowed
     //! for resource views. This is because the cost of dependency tracking with ShaderResourceGroups
     //! is too high. Instead, resource views are reference counted.
-    class DeviceResourceView
+    class ATOM_RHI_PUBLIC_API DeviceResourceView
         : public DeviceObject
         , public ResourceInvalidateBus::Handler
     {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroup.h
@@ -14,7 +14,7 @@ namespace AZ::RHI
 {
     //! This class is a platform-independent base class for a shader resource group. It has a
     //! pointer to the resource group pool, if the user initialized the group onto a pool.
-    class DeviceShaderResourceGroup
+    class ATOM_RHI_PUBLIC_API DeviceShaderResourceGroup
         : public DeviceResource
     {
         friend class DeviceShaderResourceGroupPool;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupData.h
@@ -44,7 +44,7 @@ namespace AZ::RHI
     //! prefer to share the data between them (i.e. within a single job).
     //!
     //! NOTE [SRG Constants]: The ConstantsData class is used for efficiently setting/getting the constants values of the SRG.
-    class DeviceShaderResourceGroupData
+    class ATOM_RHI_PUBLIC_API DeviceShaderResourceGroupData
     {
     public:
         //! By default creates an empty data structure. Must be initialized before use.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupPool.h
@@ -21,7 +21,7 @@ namespace AZ::RHI
     //! The platform-independent base class for ShaderResourceGroupPools. Platforms
     //! should inherit from this class to implement platform-dependent pooling of
     //! shader resource groups.
-    class DeviceShaderResourceGroupPool
+    class ATOM_RHI_PUBLIC_API DeviceShaderResourceGroupPool
         : public DeviceResourcePool
     {
         friend class DeviceShaderResourceGroup;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamBufferView.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/Format.h>
+#include <Atom/RHI/Base.h>
 #include <AzCore/std/containers/span.h>
 #include <AzCore/Utils/TypeHash.h>
 
@@ -25,7 +26,7 @@ namespace AZ::RHI
     //!   Channels maybe be stored in separate StreamBufferViews (each view having a separate StreamChannelDescriptor)
     //!   or interleaved in a single DeviceStreamBufferView (one view having multiple StreamChannelDescriptors).
     //! - The view will correspond to a single StreamBufferDescriptor.
-    class alignas(8) DeviceStreamBufferView
+    class ATOM_RHI_PUBLIC_API alignas(8) DeviceStreamBufferView
     {
     public:
         DeviceStreamBufferView() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceStreamingImagePool.h
@@ -83,7 +83,7 @@ namespace AZ::RHI
 
     using DeviceStreamingImageExpandRequest = StreamingImageExpandRequestTemplate<DeviceImage>;
 
-    class DeviceStreamingImagePool
+    class ATOM_RHI_PUBLIC_API DeviceStreamingImagePool
         : public DeviceImagePoolBase
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceSwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceSwapChain.h
@@ -12,7 +12,7 @@
 #include <Atom/RHI/XRRenderingInterface.h>
 
 #include <AzCore/Console/IConsole.h>
-AZ_CVAR_EXTERNED(bool, r_hdrOutput);
+AZ_CVAR_API_EXTERNED(ATOM_RHI_PUBLIC_API, bool, r_hdrOutput);
 
 namespace AZ::RHI
 {
@@ -23,7 +23,7 @@ namespace AZ::RHI
     //!
     //! The frame scheduler controls presentation of the swap chain. The user may attach a swap chain to a scope
     //! in order to render to the current image.
-    class DeviceSwapChain
+    class ATOM_RHI_PUBLIC_API DeviceSwapChain
         : public DeviceImagePoolBase
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceTransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceTransientAttachmentPool.h
@@ -61,7 +61,7 @@ namespace AZ::RHI
     //! be re-used within a subsequent scope. The final result of this process is a set of
     //! image / buffer attachments that are backed by guaranteed memory valid *only* for the scope in
     //! which they attached.
-    class DeviceTransientAttachmentPool
+    class ATOM_RHI_PUBLIC_API DeviceTransientAttachmentPool
         : public DeviceObject
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
@@ -27,7 +27,7 @@ namespace AZ::RHI
     template<typename T, typename NamespaceType>
     struct Handle;
 
-    struct DrawItem
+    struct ATOM_RHI_PUBLIC_API DrawItem
     {
         friend class DrawPacketBuilder;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawList.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawList.h
@@ -38,7 +38,7 @@ namespace AZ::RHI
     using DrawListsByTag = AZStd::array<DrawList, RHI::Limits::Pipeline::DrawListTagCountMax>;
 
     /// Uniformly partitions the draw list and returns the sub-list denoted by the provided index.
-    DrawListView GetDrawListPartition(DrawListView drawList, size_t partitionIndex, size_t partitionCount);
+    ATOM_RHI_PUBLIC_API DrawListView GetDrawListPartition(DrawListView drawList, size_t partitionIndex, size_t partitionCount);
 
-    void SortDrawList(DrawList& drawList, DrawListSortType sortType);
+    ATOM_RHI_PUBLIC_API void SortDrawList(DrawList& drawList, DrawListSortType sortType);
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawListContext.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawListContext.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
     //! of draw lists.
     //!
     //! Finally, in the consume phase, the context is immutable and lists are accessible via GetList.
-    class DrawListContext final
+    class ATOM_RHI_PUBLIC_API DrawListContext final
     {
     public:
         DrawListContext() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacket.h
@@ -26,7 +26,7 @@ namespace AZ::RHI
     //! A DrawPacket is only intened to be contructed via the DrawPacketBuilder.
     //! Individual device-specific DrawPackets are allocated as packed data structures, referenced via RHI::Ptrs
     //! in a map, indexed by the device-index.
-    class DrawPacket final : public AZStd::intrusive_base
+    class ATOM_RHI_PUBLIC_API DrawPacket final : public AZStd::intrusive_base
     {
         friend class DrawPacketBuilder;
         friend class UnitTest::MultiDeviceDrawPacketTest;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacketBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawPacketBuilder.h
@@ -26,7 +26,7 @@ namespace AZ::RHI
     //! Start by calling DrawPacketBuilder::Begin( )
     //! Then Set the necessary data and add a DrawRequest for each DrawItem
     //! Finalize the DrawPacket with a call to DrawPacketBuilder::End( )
-    class DrawPacketBuilder
+    class ATOM_RHI_PUBLIC_API DrawPacketBuilder
     {
     public:
         struct DrawRequest

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -13,8 +13,8 @@
 #include <AzCore/Name/Name.h>
 #include <AzCore/Console/IConsole.h>
 
-AZ_CVAR_EXTERNED(bool, r_gpuMarkersMergeGroups);
-AZ_CVAR_EXTERNED(bool, r_enablePsoCaching);
+AZ_CVAR_API_EXTERNED(ATOM_RHI_PUBLIC_API, bool, r_gpuMarkersMergeGroups);
+AZ_CVAR_API_EXTERNED(ATOM_RHI_PUBLIC_API, bool, r_enablePsoCaching);
 
 namespace AZ::RHI
 {
@@ -66,7 +66,7 @@ namespace AZ::RHI
     //! A call to Get will return the active instance. In the event that it's unclear whether
     //! a platform instance exists, you must call IsReady to determine whether it's safe to
     //! call Get. Calling Get without a registered platform will result in an assert.
-    class Factory
+    class ATOM_RHI_PUBLIC_API Factory
     {
     public:
         AZ_TYPE_INFO(Factory, "{2C0231FD-DD11-4154-A4F5-177181E26D8E}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Fence.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Fence.h
@@ -14,7 +14,7 @@ namespace AZ::RHI
 {
     //! A multi-device synchronization primitive, holding device-specific Fences, than can be used to insert
     //! dependencies between a queue and a host
-    class Fence : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API Fence : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(Fence, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameAttachment.h
@@ -12,6 +12,7 @@
 #include <Atom/RHI.Reflect/AttachmentEnums.h>
 #include <Atom/RHI.Reflect/AttachmentId.h>
 #include <Atom/RHI.Reflect/Limits.h>
+#include <Atom/RHI/Base.h>
 
 namespace AZ::RHI
 {
@@ -25,7 +26,7 @@ namespace AZ::RHI
     //! first to last scope on each device. FrameAttachments are associated with a unique AttachmentId.
     //!
     //! FrameAttachments are rebuilt every frame, and are created through the FrameGraph.
-    class FrameAttachment
+    class ATOM_RHI_PUBLIC_API FrameAttachment
     {
         friend class FrameGraphAttachmentDatabase;
         friend class FrameGraphCompiler;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraph.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraph.h
@@ -63,7 +63,7 @@ namespace AZ::RHI
     //!     1) You can traverse each "usage" of an attachment, from the first to the last scope (left / right).
     //!     2) You can traverse the list of attachments in a scope (up / down).
     //!     3) You can traverse the list of attachments matching the same type in a scope (up / down).
-    class FrameGraph final
+    class ATOM_RHI_PUBLIC_API FrameGraph final
     {
         friend class FrameGraphCompiler;
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentDatabase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphAttachmentDatabase.h
@@ -33,7 +33,7 @@ namespace AZ::RHI
     struct TransientBufferDescriptor;
     struct ResolveScopeAttachmentDescriptor;
 
-    class FrameGraphAttachmentDatabase
+    class ATOM_RHI_PUBLIC_API FrameGraphAttachmentDatabase
     {
     public:
         FrameGraphAttachmentDatabase() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompileContext.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompileContext.h
@@ -27,7 +27,7 @@ namespace AZ::RHI
     //! associated with the provided scope id, along with other query methods for
     //! accessing attachment resource data. This information can be used to
     //! compile ShaderResourceGroups.
-    class FrameGraphCompileContext
+    class ATOM_RHI_PUBLIC_API FrameGraphCompileContext
     {
     public:
         FrameGraphCompileContext() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphCompiler.h
@@ -171,7 +171,7 @@ namespace AZ::RHI
     //! 
     //!  1) Derive transition barriers by walking the scope attachment chain on each frame attachment.
     //!  2) Derive queue fence values by walking the queue-centric scope graph.
-    class FrameGraphCompiler
+    class ATOM_RHI_PUBLIC_API FrameGraphCompiler
         : public Object
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteContext.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteContext.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     //! (which is common for platforms which support multi-threaded submission), a scope will map to N execute contexts,
     //! where each context is a command list in the batch. Since commands are ordered, each context provides the index of
     //! the command list in the batch, as well as the total number of command lists in the batch.
-    class FrameGraphExecuteContext
+    class ATOM_RHI_PUBLIC_API FrameGraphExecuteContext
     {
     public:
         struct Descriptor

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuteGroup.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
     //!
     //! Alternatively, this class can be used to structure work into batches so that submission occurs once for a
     //! set of command lists.
-    class FrameGraphExecuteGroup
+    class ATOM_RHI_PUBLIC_API FrameGraphExecuteGroup
     {
         friend class FrameGraphExecuter;
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuter.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphExecuter.h
@@ -53,7 +53,7 @@ namespace AZ::RHI
     //! To implement this class, assign the job policy specific to your platform, and every Begin call, use the provided
     //! AddGroup method to partition the FrameGraph into execution groups. Each group and context will have platform
     //! specific overrides.
-    class FrameGraphExecuter
+    class ATOM_RHI_PUBLIC_API FrameGraphExecuter
         : public Object
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphLogger.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameGraphLogger.h
@@ -8,12 +8,13 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/FrameSchedulerEnums.h>
+#include <Atom/RHI/Base.h>
 
 namespace AZ::RHI
 {
     class FrameGraph;
 
-    class FrameGraphLogger
+    class ATOM_RHI_PUBLIC_API FrameGraphLogger
     {
     public:
         //! Logs the graph to the output console, with the specified verbosity.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
@@ -125,7 +125,7 @@ namespace AZ::RHI
     //! if the ResourceEventBus is replaced with a non-singleton queue data structure. Currently, it
     //! is only possible to flush this queue globally, which is incompatible with multiple frame schedulers.
     //! See [LY-83241] for more information.
-    class FrameScheduler final
+    class ATOM_RHI_PUBLIC_API FrameScheduler final
         : public FrameGraphBuilder
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FreeListAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FreeListAllocator.h
@@ -27,7 +27,7 @@ namespace AZ::RHI
         BestFit
     };
 
-    class FreeListAllocator final
+    class ATOM_RHI_PUBLIC_API FreeListAllocator final
         : public Allocator
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
@@ -190,7 +190,7 @@ namespace AZ::RHI
     };
 
     //! Validates the stream buffer views in a GeometryView
-    bool ValidateStreamBufferViews(const InputStreamLayout& inputStreamLayout, RHI::GeometryView& geometryView,
+    ATOM_RHI_PUBLIC_API bool ValidateStreamBufferViews(const InputStreamLayout& inputStreamLayout, RHI::GeometryView& geometryView,
         const RHI::StreamBufferIndices& streamIndices);
 
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
     //! number of subresources is equal to mipLevels * arraySize. All subresources share the same pixel format.
     //!
     //! @see DeviceImageView on how to interpret contents of an image.
-    class Image : public Resource
+    class ATOM_RHI_PUBLIC_API Image : public Resource
     {
         friend class ImagePoolBase;
         friend class ImagePool;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageFrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageFrameAttachment.h
@@ -18,7 +18,7 @@ namespace AZ::RHI
     class ImageScopeAttachment;
 
     //! A specialization of Attachment for an image. Provides access to the image.
-    class ImageFrameAttachment
+    class ATOM_RHI_PUBLIC_API ImageFrameAttachment
         : public FrameAttachment
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePool.h
@@ -66,7 +66,7 @@ namespace AZ::RHI
     //! As a result, they are intended to be produced and consumed by the GPU. Persistent Color / Depth Stencil / Image
     //! attachments should be created from this pool. This pool is not designed for intra-frame aliasing.
     //! If transient images are required, they can be created from the frame scheduler itself.
-    class ImagePool : public ImagePoolBase
+    class ATOM_RHI_PUBLIC_API ImagePool : public ImagePoolBase
     {
     public:
         AZ_CLASS_ALLOCATOR(ImagePool, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImagePoolBase.h
@@ -15,7 +15,7 @@ namespace AZ::RHI
     //! A simple base class for multi-device image pools. This mainly exists so that various
     //! image pool implementations can have some type safety separate from other
     //! resource pool types.
-    class ImagePoolBase : public ResourcePool
+    class ATOM_RHI_PUBLIC_API ImagePoolBase : public ResourcePool
     {
     public:
         AZ_RTTI(ImagePoolBase, "{CAC2167A-D65A-493F-A450-FDE2B1A883B1}", ResourcePool);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageScopeAttachment.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
 
     //! A specialization of a scope attachment for images. Provides
     //! access to the image view and image scope attachment descriptor.
-    class ImageScopeAttachment
+    class ATOM_RHI_PUBLIC_API ImageScopeAttachment
         : public ScopeAttachment
     {
         friend class FrameGraphCompiler;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ImageView.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
     //! A ImageView is a light-weight representation of a view onto a multi-device image.
     //! It holds a ConstPtr to a multi-device image as well as an ImageViewDescriptor
     //! Using both, single-device ImageViews can be retrieved
-    class ImageView : public ResourceView
+    class ATOM_RHI_PUBLIC_API ImageView : public ResourceView
     {
     public:
         AZ_RTTI(ImageView, "{AB366B8F-F1B7-45C6-A0D8-475D4834FAD2}", ResourceView);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndexBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndexBufferView.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     //! A multi-device class representing a view onto a Buffer holding indices, distinct from
     //! actual view classes (like DeviceBufferView), there is no representation on the API level.
     //! Its device-specific buffers are provided to the RHI back-end at draw time.
-    class alignas(8) IndexBufferView
+    class ATOM_RHI_PUBLIC_API alignas(8) IndexBufferView
     {
     public:
         IndexBufferView() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndexBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndexBufferView.h
@@ -15,8 +15,6 @@ namespace AZ::RHI
 {
     class Buffer;
 
-    uint32_t GetIndexFormatSize(IndexFormat indexFormat);
-
     //! A multi-device class representing a view onto a Buffer holding indices, distinct from
     //! actual view classes (like DeviceBufferView), there is no representation on the API level.
     //! Its device-specific buffers are provided to the RHI back-end at draw time.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferSignature.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferSignature.h
@@ -21,7 +21,7 @@ namespace AZ::RHI
 
     //! A multi-device descriptor for the IndirectBufferSignature, holding both an IndirectBufferLayout (identical across
     //! devices) as well as a PipelineState
-    struct IndirectBufferSignatureDescriptor
+    struct ATOM_RHI_PUBLIC_API IndirectBufferSignatureDescriptor
     {
         //! Returns the device-specific DeviceIndirectBufferSignatureDescriptor for the given index
         DeviceIndirectBufferSignatureDescriptor GetDeviceIndirectBufferSignatureDescriptor(int deviceIndex) const;
@@ -37,7 +37,7 @@ namespace AZ::RHI
     //!
     //! It also exposes implementation dependent offsets for the commands in
     //! a layout. This information is useful when writing commands into a buffer.
-    class IndirectBufferSignature : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API IndirectBufferSignature : public MultiDeviceObject
     {
         using Base = RHI::MultiDeviceObject;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferView.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
 
     //! Provides a view into a multi-device buffer, to be used as an indirect buffer. The content of the view is a contiguous
     //! list of commands sequences. Its device-specific buffers are provided to the RHI back-end at draw time.
-    class alignas(8) IndirectBufferView
+    class ATOM_RHI_PUBLIC_API alignas(8) IndirectBufferView
     {
     public:
         IndirectBufferView() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferWriter.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/IndirectBufferWriter.h
@@ -26,7 +26,7 @@ namespace AZ::RHI
     //!
     //! It also provides basic checks, like trying to write more commands than allowed, or
     //! writing commands that are not specified in the layout.
-    class IndirectBufferWriter : public Object
+    class ATOM_RHI_PUBLIC_API IndirectBufferWriter : public Object
     {
         using Base = Object;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/LinearAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/LinearAllocator.h
@@ -14,7 +14,7 @@ namespace AZ::RHI
 {
     //! A linear allocator where each allocation is a simple increment to the cursor. Garbage collection
     //! controls when the cursor resets back to the beginning.
-    class LinearAllocator final
+    class ATOM_RHI_PUBLIC_API LinearAllocator final
         : public Allocator
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MemoryStatisticsBuilder.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MemoryStatisticsBuilder.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/MemoryStatistics.h>
+#include <Atom/RHI/Base.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/unordered_map.h>
 
@@ -22,7 +23,7 @@ namespace AZ::RHI
         Detail
     };
 
-    class MemoryStatisticsBuilder
+    class ATOM_RHI_PUBLIC_API MemoryStatisticsBuilder
     {
     public:
         //! Begins a new statistics building pass. The MemoryStatistics struct is cleared and intermediate

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
@@ -13,7 +13,11 @@
 #include <Atom/RHI/MemoryAllocation.h>
 #include <Atom/RHI.Reflect/MemoryEnums.h>
 
+#if defined(AZ_MONOLITHIC_BUILD)
 AZ_DECLARE_BUDGET(RHI);
+#else
+AZ_DECLARE_BUDGET_SHARED(RHI);
+#endif
 
 namespace AZ::RHI
 {       

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MultiDeviceObject.h
@@ -27,7 +27,7 @@ namespace AZ::RHI
     //! In contrast to DeviceObject, which is device-specific and holds a strong reference to a specific device,
     //! MultiDeviceObject only specifies on which device an object resides/operates, specified by a
     //! DeviceMask (1 bit per device).
-    class MultiDeviceObject : public Object
+    class ATOM_RHI_PUBLIC_API MultiDeviceObject : public Object
     {
         friend struct UnitTest::MultiDeviceDrawPacketData;
         friend class ResourceView;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Object.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/Base.h>
 #include <AzCore/std/smart_ptr/intrusive_base.h>
 #include <AzCore/Name/Name.h>
 
@@ -15,7 +15,7 @@ namespace AZ::RHI
 {
     //! Base class for any persistent resource in the RHI library. Provides a name, reference
     //! counting, and a common RTTI base class for all objects in the RHI.
-    class Object
+    class ATOM_RHI_PUBLIC_API Object
     {
     public:
         AZ_RTTI(Object, "{E43378F1-2331-4173-94B8-990ED20E6003}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PageTileAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PageTileAllocator.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/Base.h>
 
 #include <AzCore/std/containers/vector.h>
 
@@ -37,7 +37,7 @@ namespace AZ::RHI
     };
 
     //! This allocator allocates tile groups from a page which is aligned by tiles.
-    class PageTileAllocator
+    class ATOM_RHI_PUBLIC_API PageTileAllocator
     {
     public:
         PageTileAllocator() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PhysicalDevice.h
@@ -14,7 +14,7 @@
 
 namespace AZ::RHI
 {
-    class PhysicalDevice
+    class ATOM_RHI_PUBLIC_API PhysicalDevice
         : public Object
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineLibrary.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineLibrary.h
@@ -72,7 +72,7 @@ namespace AZ::RHI
     //! and forwarding the call.
     //! A device-specific DevicePipelineLibrary can be accessed by calling GetDevicePipelineLibrary
     //! with the corresponding device index
-    class PipelineLibrary : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API PipelineLibrary : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(PipelineLibrary, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineState.h
@@ -23,7 +23,7 @@ namespace AZ::RHI
     //! and forwarding the call.
     //! A device-specific DevicePipelineState can be accessed by calling GetDevicePipelineState
     //! with the corresponding device index
-    class PipelineState : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API PipelineState : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(PipelineState, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateCache.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateCache.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
     using PipelineStateHash = HashValue64;
 
     //! Used for storing a PipelineState object in a hash table structure (set, map, etc)
-    struct PipelineStateEntry
+    struct ATOM_RHI_PUBLIC_API PipelineStateEntry
     {
         PipelineStateEntry(
             PipelineStateHash hash, ConstPtr<PipelineState> pipelineState, const PipelineStateDescriptor& descriptor);
@@ -135,7 +135,7 @@ namespace AZ::RHI
     //!      pipelineStateCache->ReleaseLibrary(libraryHandle);
     //! @endcode
     //!
-    class PipelineStateCache final
+    class ATOM_RHI_PUBLIC_API PipelineStateCache final
         : public AZStd::intrusive_base
     {
         friend class UnitTest::MultiDevicePipelineStateTests;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateDescriptor.h
@@ -13,6 +13,7 @@
 #include <Atom/RHI.Reflect/ShaderStageFunction.h>
 #include <AzCore/Utils/TypeHash.h>
 #include <Atom/RHI.Reflect/PipelineLayoutDescriptor.h>
+#include <Atom/RHI/Base.h>
 #include <Atom/RHI/SpecializationConstant.h>
 
 namespace AZ::RHI
@@ -28,7 +29,7 @@ namespace AZ::RHI
     const uint32_t PipelineStateTypeCount = static_cast<uint32_t>(PipelineStateType::Count);
 
     //! A base class to pipeline state descriptor.
-    class PipelineStateDescriptor
+    class ATOM_RHI_PUBLIC_API PipelineStateDescriptor
     {
     public:
         AZ_RTTI(PipelineStateDescriptor, "{B334AE47-53CB-438C-B799-DCA542FF8D5D}");
@@ -66,7 +67,7 @@ namespace AZ::RHI
     //! byte code is likely shared by many PSOs and the serialization system would simply duplicate
     //! all of that data. However, the individual pieces are serializable, so a higher-level system
     //! could easily construct a PSO library.
-    class PipelineStateDescriptorForDispatch final
+    class ATOM_RHI_PUBLIC_API PipelineStateDescriptorForDispatch final
         : public PipelineStateDescriptor
     {
     public:
@@ -88,7 +89,7 @@ namespace AZ::RHI
     //! input assembly stream layout, render target attachment layout, and various render states.
     //!
     //! NOTE: This class does not serialize by design. See PipelineStateDescriptorForDispatch for details.
-    class PipelineStateDescriptorForDraw final
+    class ATOM_RHI_PUBLIC_API PipelineStateDescriptorForDraw final
         : public PipelineStateDescriptor
     {
     public:
@@ -121,7 +122,7 @@ namespace AZ::RHI
     };
 
     //! Describes state necessary to build a ray tracing pipeline state object. 
-    class PipelineStateDescriptorForRayTracing final
+    class ATOM_RHI_PUBLIC_API PipelineStateDescriptorForRayTracing final
         : public PipelineStateDescriptor
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PoolAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PoolAllocator.h
@@ -25,7 +25,7 @@ namespace AZ::RHI
     //! to that memory and for the GPU to read it several frames later. The garbage collection latency can
     //! be set to match the maximum number of buffered frames, so the user can allocate and free at will
     //! without stomping over regions of memory being read.
-    class PoolAllocator final
+    class ATOM_RHI_PUBLIC_API PoolAllocator final
         : public Allocator
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Query.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Query.h
@@ -17,7 +17,7 @@ namespace AZ::RHI
 
     //! Query resource for recording gpu data like occlusion, timestamp or pipeline statistics.
     //! Queries belong to a QueryPool and their types are determined by the pool.
-    class Query : public Resource
+    class ATOM_RHI_PUBLIC_API Query : public Resource
     {
         friend class QueryPool;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/QueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/QueryPool.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
     //! QueryPool manages a map of device-specific QueryPools, which provide backing storage and context for query instances. The
     //! QueryPoolDescriptor contains properties defining memory characteristics of query pools. All queries created on a pool share the same
     //! backing and type.
-    class QueryPool : public ResourcePool
+    class ATOM_RHI_PUBLIC_API QueryPool : public ResourcePool
     {
         using Base = ResourcePool;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/QueryPoolSubAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/QueryPoolSubAllocator.h
@@ -6,6 +6,8 @@
  *
  */
 #pragma once
+
+#include <Atom/RHI/Base.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/set.h>
 
@@ -16,7 +18,7 @@ namespace AZ::RHI
     //! If that is not possible, it allocates in multiple smaller pieces, always trying
     //! to group as many queries in a consecutive manner as possible.
     //! This class is not thread safe.
-    class QueryPoolSubAllocator
+    class ATOM_RHI_PUBLIC_API QueryPoolSubAllocator
     {
     public:
         struct Allocation

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIMemoryStatisticsInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIMemoryStatisticsInterface.h
@@ -16,15 +16,20 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 
+#if defined(AZ_MONOLITHIC_BUILD)
 AZ_DECLARE_BUDGET(RHI);
+#else
+AZ_DECLARE_BUDGET_SHARED(RHI);
+#endif
 
-AZ_CVAR_EXTERNED(bool, r_EnableAutoGpuMemDump); 
+AZ_CVAR_API_EXTERNED(ATOM_RHI_PUBLIC_API, bool, r_EnableAutoGpuMemDump);
 
 namespace AZ::RHI
 {
     // Forward declares
     struct TransientAttachmentStatistics;
-    class RHIMemoryStatisticsInterface
+
+    class ATOM_RHI_PUBLIC_API RHIMemoryStatisticsInterface
     {
     public:
         AZ_RTTI(RHIMemoryStatisticsInterface, "{C3789EE2-7922-434D-AC19-8A2D80194C0E}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -33,7 +33,7 @@ namespace AZ::RHI
         MultiDevice
     };
 
-    class RHISystem final
+    class ATOM_RHI_PUBLIC_API RHISystem final
         : public RHISystemInterface
         , public RHIMemoryStatisticsInterface
     {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -16,7 +16,11 @@
 #include <Atom/RHI/DrawListTagRegistry.h>
 #include <Atom/RHI/XRRenderingInterface.h>
 
+#if defined(AZ_MONOLITHIC_BUILD)
 AZ_DECLARE_BUDGET(RHI);
+#else
+AZ_DECLARE_BUDGET_SHARED(RHI);
+#endif
 
 namespace AZ::RHI
 {
@@ -31,7 +35,7 @@ namespace AZ::RHI
     struct TransientAttachmentStatistics;
     struct TransientAttachmentPoolDescriptor;
 
-    class RHISystemInterface
+    class ATOM_RHI_PUBLIC_API RHISystemInterface
     {
     public:
         AZ_RTTI(RHISystemInterface, "{B70BB184-D7D5-4C15-9C82-C9459F552F13}");

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
@@ -25,46 +25,46 @@
 namespace AZ::RHI
 {
     //! Gets a pointer to the RHI device from the RHI System
-    Ptr<Device> GetRHIDevice();
+    ATOM_RHI_PUBLIC_API Ptr<Device> GetRHIDevice();
 
     //! Gets the associated format capabilities for the provided attachment usage, access and type
-    FormatCapabilities GetCapabilities(ScopeAttachmentUsage scopeUsage, AttachmentType attachmentType);
-    FormatCapabilities GetCapabilities(ScopeAttachmentUsage scopeUsage, ScopeAttachmentAccess scopeAccess, AttachmentType attachmentType);
+    ATOM_RHI_PUBLIC_API FormatCapabilities GetCapabilities(ScopeAttachmentUsage scopeUsage, AttachmentType attachmentType);
+    ATOM_RHI_PUBLIC_API FormatCapabilities GetCapabilities(ScopeAttachmentUsage scopeUsage, ScopeAttachmentAccess scopeAccess, AttachmentType attachmentType);
 
     //! Queries the RHI Device for the nearest supported format
-    Format GetNearestDeviceSupportedFormat(Format requestedFormat);
+    ATOM_RHI_PUBLIC_API Format GetNearestDeviceSupportedFormat(Format requestedFormat);
 
     //! Checks the format against the list of supported formats and returns
     //! the nearest match, with a warning if the exact format is not supported
-    Format ValidateFormat(Format format, const char* location, const AZStd::vector<Format>& formatFallbacks, FormatCapabilities requestedCapabilities = FormatCapabilities::None);
+    ATOM_RHI_PUBLIC_API Format ValidateFormat(Format format, const char* location, const AZStd::vector<Format>& formatFallbacks, FormatCapabilities requestedCapabilities = FormatCapabilities::None);
 
     //! Returns the command line value associated with the option if it exists.
     //! If multiple values exist it will return the last one
-    AZStd::string GetCommandLineValue(const AZStd::string& commandLineOption);
+    ATOM_RHI_PUBLIC_API AZStd::string GetCommandLineValue(const AZStd::string& commandLineOption);
 
     //! Returns true if the command line option is set
-    bool QueryCommandLineOption(const AZStd::string& commandLineOption);
+    ATOM_RHI_PUBLIC_API bool QueryCommandLineOption(const AZStd::string& commandLineOption);
 
     //! Returns true if the current backend is null 
-    bool IsNullRHI();
+    ATOM_RHI_PUBLIC_API bool IsNullRHI();
 
     //! Returns true if the Atom/GraphicsDevMode settings registry key is set
-    bool IsGraphicsDevModeEnabled();
+    ATOM_RHI_PUBLIC_API bool IsGraphicsDevModeEnabled();
 
     //! Returns the default supervariant name of an empty string if float16 is supported and the name of "NoFloat16" if float16 is not
     //! supported. This is useful for loading the correct supervariant when a shader needs to have a version with and without float16.
-    const AZ::Name& GetDefaultSupervariantNameWithNoFloat16Fallback();
+    ATOM_RHI_PUBLIC_API const AZ::Name& GetDefaultSupervariantNameWithNoFloat16Fallback();
 
     //! Utility function to write captured pool data to a json document
     //! Ensure the passed pool won't be modified during the call to this function
     //! Available externally to the RHI through the RHIMemoryStatisticsInterface
-    void WritePoolsToJson(
+    ATOM_RHI_PUBLIC_API void WritePoolsToJson(
         const AZStd::vector<MemoryStatistics::Pool>& pools, 
         rapidjson::Document& doc);
 
     //! Utility function to write captured pool data to a json document
     //! Available externally to the RHI through the RHIMemoryStatisticsInterface
-    AZ::Outcome<void, AZStd::string> LoadPoolsFromJson(
+    ATOM_RHI_PUBLIC_API AZ::Outcome<void, AZStd::string> LoadPoolsFromJson(
         AZStd::vector<MemoryStatistics::Pool>& pools,
         AZStd::vector<AZ::RHI::MemoryStatistics::Heap>& heaps,
         rapidjson::Document& doc,
@@ -73,15 +73,14 @@ namespace AZ::RHI
     //! Utility function to trigger an emergency dump of pool information to json.
     //! Intended to be used for gpu memory failure debugging.
     //! Available externally to the RHI through the RHIMemoryStatisticsInterface
-    void DumpPoolInfoToJson();
+    ATOM_RHI_PUBLIC_API void DumpPoolInfoToJson();
 
     //! Utility function to get the DrawListTagRegistry
-    RHI::DrawListTagRegistry* GetDrawListTagRegistry();
+    ATOM_RHI_PUBLIC_API RHI::DrawListTagRegistry* GetDrawListTagRegistry();
  
     //! Utility function to get the Name associated with a DrawListTag
-    Name GetDrawListName(DrawListTag drawListTag);
+    ATOM_RHI_PUBLIC_API Name GetDrawListName(DrawListTag drawListTag);
 
-    AZStd::string DrawListMaskToString(const RHI::DrawListMask& drawListMask);
-
+    ATOM_RHI_PUBLIC_API AZStd::string DrawListMaskToString(const RHI::DrawListMask& drawListMask);
 }
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingAccelerationStructure.h
@@ -37,7 +37,7 @@ namespace AZ::RHI
     //! RayTracingBlasDescriptor
     //!
     //! Describes a ray tracing bottom-level acceleration structure.
-    class RayTracingBlasDescriptor final
+    class ATOM_RHI_PUBLIC_API RayTracingBlasDescriptor final
     {
     public:
         //! Returns the device-specific DeviceRayTracingBlasDescriptor for the given index
@@ -51,7 +51,7 @@ namespace AZ::RHI
     //! RayTracingBlas
     //!
     //! A RayTracingBlas is created from the information in the RayTracingBlasDescriptor.
-    class RayTracingBlas : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API RayTracingBlas : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(RayTracingBlas, AZ::SystemAllocator, 0);
@@ -92,7 +92,7 @@ namespace AZ::RHI
     //! RayTracingTlas
     //!
     //! A RayTracingTlas is created from the information in the RayTracingTlasDescriptor.
-    class RayTracingTlas : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API RayTracingTlas : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(RayTracingTlas, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingBufferPools.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingBufferPools.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     //! This class encapsulates all of the BufferPools needed for ray tracing, freeing the application
     //! from setting up and managing the buffers pools individually.
     //!
-    class RayTracingBufferPools : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API RayTracingBufferPools : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(RayTracingBufferPools, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingCompactionQueryPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingCompactionQueryPool.h
@@ -30,7 +30,7 @@ namespace AZ::RHI
     };
 
     //! Provides storage for DeviceRayTracingCompactionQuery objects and handles
-    class RayTracingCompactionQueryPool : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API RayTracingCompactionQueryPool : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(RayTracingCompactionQueryPool, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingPipelineState.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
     //! RayTracingPipelineStateDescriptor
     //!
     //! Describes a ray tracing pipeline state.
-    class RayTracingPipelineStateDescriptor final
+    class ATOM_RHI_PUBLIC_API RayTracingPipelineStateDescriptor final
     {
     public:
         //! Returns the device-specific DeviceRayTracingPipelineStateDescriptor for the given index
@@ -44,7 +44,7 @@ namespace AZ::RHI
     };
 
     //! Defines the shaders, hit groups, and other parameters required for ray tracing operations across multiple devices.
-    class RayTracingPipelineState : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API RayTracingPipelineState : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(RayTracingPipelineState, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RayTracingShaderTable.h
@@ -20,7 +20,7 @@ namespace AZ::RHI
     class ShaderResourceGroup;
 
     //! Specifies the shader and any local root signature parameters that make up a record in the shader table
-    struct RayTracingShaderTableRecord
+    struct ATOM_RHI_PUBLIC_API RayTracingShaderTableRecord
     {
         explicit RayTracingShaderTableRecord(const Name& shaderExportName);
 
@@ -40,7 +40,7 @@ namespace AZ::RHI
     //! RayTracingShaderTableDescriptor
     //!
     //! Describes a ray tracing shader table.
-    class RayTracingShaderTableDescriptor
+    class ATOM_RHI_PUBLIC_API RayTracingShaderTableDescriptor
     {
     public:
         RayTracingShaderTableDescriptor() = default;
@@ -61,7 +61,7 @@ namespace AZ::RHI
 
     //! Shader Table
     //! Specifies the ray generation, miss, and hit shaders used during the ray tracing process
-    class RayTracingShaderTable : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API RayTracingShaderTable : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(RayTracingShaderTable, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResolveScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResolveScopeAttachment.h
@@ -14,7 +14,7 @@ namespace AZ::RHI
 {
     //! A specialization of a scope attachment for msaa images. Provides
     //! access to the msaa image view and msaa image scope attachment descriptor.
-    class ResolveScopeAttachment final
+    class ATOM_RHI_PUBLIC_API ResolveScopeAttachment final
         : public ImageScopeAttachment
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Resource.h
@@ -7,10 +7,10 @@
  */
 #pragma once
 
+#include <Atom/RHI/Base.h>
 #include <Atom/RHI/DeviceResource.h>
 #include <Atom/RHI/MultiDeviceObject.h>
 #include <Atom/RHI/ResourceViewCache.h>
-
 
 namespace AZ::RHI
 {
@@ -27,7 +27,7 @@ namespace AZ::RHI
     //! ShaderResourceGroup, etc). It provides some common lifecycle management semantics. Resource creation is
     //! separate from initialization. Resources are created separate from any pool, but its backing platform data is associated at
     //! initialization time on a specific pool.
-    class Resource : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API Resource : public MultiDeviceObject
     {
         friend class FrameAttachment;
         friend class ResourcePool;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceInvalidateBus.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceInvalidateBus.h
@@ -32,7 +32,7 @@ namespace AZ::RHI
     //!
     //! NOTE: This bus is currently a singleton. That effectively forces FrameScheduler
     //! to be one as well. See [LY-83241] for more information.
-    class ResourceEventInterface
+    class ATOM_RHI_PUBLIC_API ResourceEventInterface
         : public AZ::EBusTraits
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourcePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourcePool.h
@@ -24,7 +24,7 @@ namespace AZ::RHI
 
     //! A base class for multi-device resource pools. This class facilitates registration of multi-device resources
     //! into the pool, and allows iterating child resource instances.
-    class ResourcePool : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API ResourcePool : public MultiDeviceObject
     {
         friend class Resource;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourcePoolDatabase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourcePoolDatabase.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI/Base.h>
 #include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <AzCore/std/containers/vector.h>
@@ -26,7 +27,7 @@ namespace AZ::RHI
     //!
     //! DeviceResourcePool is friended to the class in order to allow it to control
     //! attachment / detachment from the database.
-    class ResourcePoolDatabase final
+    class ATOM_RHI_PUBLIC_API ResourcePoolDatabase final
     {
     public:
         ResourcePoolDatabase() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceView.h
@@ -18,7 +18,7 @@
     //! polymorphic usage of views in a generic way.
     //! As the handling of the device-specific ResourceViews is more elaborate,
     //! this does not inherit from MultiDeviceObject but manages the DeviceResourceViews on its own
-    class ResourceView : public Object
+    class ATOM_RHI_PUBLIC_API ResourceView : public Object
     {
     public:
         // The resource owns a cache of resource views, and it needs access to the refcount

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceViewCache.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceViewCache.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/Utils/TypeHash.h>
 #include <Atom/RHI.Reflect/Base.h>
+#include <Atom/RHI/Base.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/containers/unordered_map.h>
 
@@ -27,10 +28,10 @@
 
     namespace ResourceViewCacheHelper
     {
-        Ptr<DeviceImageView> CreateView(const DeviceResource* resource, const ImageViewDescriptor& imageViewDescriptor);
-        Ptr<DeviceBufferView> CreateView(const DeviceResource* resource, const BufferViewDescriptor& bufferViewDescriptor);
-        Ptr<ImageView> CreateView(const Resource* resource, const ImageViewDescriptor& imageViewDescriptor);
-        Ptr<BufferView> CreateView(const Resource* resource, const BufferViewDescriptor& bufferViewDescriptor);
+        ATOM_RHI_PUBLIC_API Ptr<DeviceImageView> CreateView(const DeviceResource* resource, const ImageViewDescriptor& imageViewDescriptor);
+        ATOM_RHI_PUBLIC_API Ptr<DeviceBufferView> CreateView(const DeviceResource* resource, const BufferViewDescriptor& bufferViewDescriptor);
+        ATOM_RHI_PUBLIC_API Ptr<ImageView> CreateView(const Resource* resource, const ImageViewDescriptor& imageViewDescriptor);
+        ATOM_RHI_PUBLIC_API Ptr<BufferView> CreateView(const Resource* resource, const BufferViewDescriptor& bufferViewDescriptor);
 
         //! Helper struct to provide correct Type and creation method for (Device)Image/Bufferview
         template<typename Type, typename DescriptorType>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Scope.h
@@ -35,7 +35,7 @@ namespace AZ::RHI
     //! and supply platform-specific scope data. All platform specific data should be built in \ref
     //! CompileInternal. At that time, the client will have access to the attachment database, which
     //! it can use to compile flat arrays of platform-specific state (fences, barriers, clears, etc).
-    class Scope
+    class ATOM_RHI_PUBLIC_API Scope
         : public Object
     {
         friend class FrameGraph;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeAttachment.h
@@ -9,7 +9,7 @@
 
 #include <Atom/RHI.Reflect/AttachmentId.h>
 #include <Atom/RHI.Reflect/AttachmentEnums.h>
-#include <Atom/RHI/Resource.h>
+#include <Atom/RHI/ResourceView.h>
 #include <AzCore/RTTI/RTTI.h>
 
 namespace AZ::RHI
@@ -25,7 +25,7 @@ namespace AZ::RHI
     //!
     //! The FrameAttachment owns the Attachment instance (i.e. the actual resource). The ScopeAttachment owns a view into that
     //! resource. A scope is able to utilize the view during compilation and execution.         
-    class ScopeAttachment
+    class ATOM_RHI_PUBLIC_API ScopeAttachment
     {
         friend class FrameGraphAttachmentDatabase;
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ScopeProducer.h
@@ -56,7 +56,7 @@ namespace AZ::RHI
     //! // invoked.
     //! frameScheduler.AddScope(scope);
 
-    class ScopeProducer
+    class ATOM_RHI_PUBLIC_API ScopeProducer
     {
         friend class FrameScheduler;
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroup.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroup.h
@@ -15,7 +15,7 @@ namespace AZ::RHI
 {
     //! This class is a platform-independent base class for a multi-device shader resource group. It has a
     //! pointer to the multi-device resource group pool, if the user initialized the group onto a pool.
-    class ShaderResourceGroup : public Resource
+    class ATOM_RHI_PUBLIC_API ShaderResourceGroup : public Resource
     {
         friend class ShaderResourceGroupPool;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
@@ -29,7 +29,7 @@ namespace AZ::RHI
     //! including ConstantsData and Samplers.
     //!
     //! This data structure holds strong references to the multi-device resource views bound onto it.
-    class ShaderResourceGroupData
+    class ATOM_RHI_PUBLIC_API ShaderResourceGroupData
     {
     public:
         //! By default creates an empty data structure. Must be initialized before use.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupDebug.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupDebug.h
@@ -16,12 +16,12 @@ namespace AZ::RHI
     /// to the reference ConstantsData. It will print the names of any constants that are different between the two.
     /// The parameter updateReferenceData can be used to set the reference data to the SRG's constant data after the comparison. This is
     /// useful for keeping track of differences in between calls to the function, such as between frames.
-    void PrintConstantDataDiff(const DeviceShaderResourceGroup& shaderResourceGroup, ConstantsData& referenceData, bool updateReferenceData = false);
+    ATOM_RHI_PUBLIC_API void PrintConstantDataDiff(const DeviceShaderResourceGroup& shaderResourceGroup, ConstantsData& referenceData, bool updateReferenceData = false);
 
     /// Given a DeviceDrawItem, an SRG binding slot on that draw item and a reference ConstantsData input, this function will fetch the ConstantsData
     /// from the draw item's SRG at the binding slot and compare it to the reference ConstantsData. It will print the names of any constants
     /// that are different between the two.
     /// The parameter updateReferenceData can be used to set the reference data to the draw item's constant data after the comparison. This is
     /// useful for keeping track of differences in between calls to the function, such as between frames.
-    void PrintConstantDataDiff(const DeviceDrawItem& drawItem, ConstantsData& referenceData, uint32_t srgBindingSlot, bool updateReferenceData = false);
+    ATOM_RHI_PUBLIC_API void PrintConstantDataDiff(const DeviceDrawItem& drawItem, ConstantsData& referenceData, uint32_t srgBindingSlot, bool updateReferenceData = false);
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupInvalidateRegistry.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupInvalidateRegistry.h
@@ -36,7 +36,7 @@ namespace AZ::RHI
     //! very expensive.
     //!
     //! The registry is not thread-safe. It needs to be externally synchronized.
-    class ShaderResourceGroupInvalidateRegistry
+    class ATOM_RHI_PUBLIC_API ShaderResourceGroupInvalidateRegistry
         : public ResourceInvalidateBus::MultiHandler
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupPool.h
@@ -22,7 +22,7 @@ namespace AZ::RHI
     //! The platform-independent base class for ShaderResourceGroupPools. Platforms
     //! should inherit from this class to implement platform-dependent pooling of
     //! multi-device shader resource groups.
-    class ShaderResourceGroupPool : public ResourcePool
+    class ATOM_RHI_PUBLIC_API ShaderResourceGroupPool : public ResourcePool
     {
         friend class ShaderResourceGroup;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SpecializationConstant.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SpecializationConstant.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/Utils/TypeHash.h>
 #include <Atom/RHI.Reflect/Handle.h>
+#include <Atom/RHI/Base.h>
 
 namespace AZ::RHI
 {
@@ -25,7 +26,7 @@ namespace AZ::RHI
 
     //! Contains all the necessary information and value of a specialization constant
     //! so it can be used when creating a PipelineState.
-    struct SpecializationConstant
+    struct ATOM_RHI_PUBLIC_API SpecializationConstant
     {
         SpecializationConstant() = default;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamBufferView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamBufferView.h
@@ -19,7 +19,7 @@ namespace AZ::RHI
 
     //! Provides a view into a multi-device buffer, to be used as vertex stream. The content of the view is a contiguous
     //! list of input vertex data. Its device-specific buffer is provided to the RHI back-end at draw time for a given device.
-    class alignas(8) StreamBufferView
+    class ATOM_RHI_PUBLIC_API alignas(8) StreamBufferView
     {
     public:
         StreamBufferView() = default;
@@ -59,6 +59,6 @@ namespace AZ::RHI
     };
 
     //! Utility function for checking that the set of StreamBufferViews aligns with the InputStreamLayout
-    bool ValidateStreamBufferViews(
+    ATOM_RHI_PUBLIC_API bool ValidateStreamBufferViews(
         const InputStreamLayout& inputStreamLayout, AZStd::span<const StreamBufferView> streamBufferViews);
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/StreamingImagePool.h
@@ -69,7 +69,7 @@ namespace AZ
 
         using StreamingImageExpandRequest = StreamingImageExpandRequestTemplate<Image>;
 
-        class StreamingImagePool : public ImagePoolBase
+        class ATOM_RHI_PUBLIC_API StreamingImagePool : public ImagePoolBase
         {
         public:
             AZ_CLASS_ALLOCATOR(StreamingImagePool, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
@@ -26,7 +26,7 @@ namespace AZ::RHI
     //! specific window. This is done by initializing it with a device index, which sets the correspondings bit in the
     //! deviceMask. The need for a multi-device class arises from the interoperability within a multi-device context,
     //! especially attachments and the FrameGraph.
-    class SwapChain : public ImagePoolBase
+    class ATOM_RHI_PUBLIC_API SwapChain : public ImagePoolBase
     {
     public:
         AZ_CLASS_ALLOCATOR(SwapChain, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChainFrameAttachment.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChainFrameAttachment.h
@@ -8,14 +8,13 @@
 #pragma once
 
 #include <Atom/RHI/ImageFrameAttachment.h>
+#include <Atom/RHI/SwapChain.h>
 #include <AzCore/Memory/PoolAllocator.h>
 
 namespace AZ::RHI
 {
-    class SwapChain;
-
     //! A swap chain registered into the frame scheduler.
-    class SwapChainFrameAttachment final
+    class ATOM_RHI_PUBLIC_API SwapChainFrameAttachment final
         : public ImageFrameAttachment
     {
     public:

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/TransientAttachmentPool.h
@@ -35,7 +35,7 @@ namespace AZ::RHI
     //! be re-used within a subsequent scope. The final result of this process is a set of
     //! image / buffer attachments that are backed by guaranteed memory valid *only* for the scope in
     //! which they attached.
-    class TransientAttachmentPool : public MultiDeviceObject
+    class ATOM_RHI_PUBLIC_API TransientAttachmentPool : public MultiDeviceObject
     {
     public:
         AZ_CLASS_ALLOCATOR(TransientAttachmentPool, AZ::SystemAllocator, 0);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ValidationLayer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ValidationLayer.h
@@ -7,6 +7,8 @@
  */
 
 #pragma once
+
+#include <Atom/RHI/Base.h>
 #include <AzCore/std/optional.h>
 
 namespace AZ::RHI
@@ -24,5 +26,5 @@ namespace AZ::RHI
 
     // Read the RHI validation mode considering configurations,
     // cvars, command line options and registry settings.
-    ValidationMode ReadValidationMode();
+    ATOM_RHI_PUBLIC_API ValidationMode ReadValidationMode();
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/AsyncWorkQueue.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/AsyncWorkQueue.cpp
@@ -9,7 +9,7 @@
 
 #include <AzCore/Debug/Profiler.h>
 
-AZ_DECLARE_BUDGET(RHI);
+AZ_DECLARE_BUDGET_SHARED(RHI);
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
@@ -87,15 +87,4 @@ namespace AZ::RHI
     {
         Resource::Shutdown();
     }
-
-    void ImageSubresourceLayout::Init(MultiDevice::DeviceMask deviceMask, const DeviceImageSubresourceLayout &deviceLayout)
-    {
-        MultiDeviceObject::IterateDevices(
-            deviceMask,
-            [this, deviceLayout](int deviceIndex)
-            {
-                m_deviceImageSubresourceLayout[deviceIndex] = deviceLayout;
-                return true;
-            });
-    }
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    Include/Atom/RHI/Base.h
     Include/Atom/RHI/Allocator.h
     Include/Atom/RHI/FreeListAllocator.h
     Include/Atom/RHI/LinearAllocator.h

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
@@ -13,7 +13,7 @@
 #include <AzCore/std/string/string.h>
 #include <dx12ma/D3D12MemAlloc.h>
 
-AZ_DECLARE_BUDGET(RHI);
+AZ_DECLARE_BUDGET_SHARED(RHI);
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

This PR changes the `Atom_RHI.Reflect` and `Atom_RHI.Public` from static to shared libraries.
This is similar to the conversion of the `Atom_RPI` targets to shared libraries from last year ([PR18427](https://github.com/o3de/o3de/pull/18427)), and more recently the `AzCore`/`AzFramework` targest in [PR19111](https://github.com/o3de/o3de/pull/19111).

There is one not so pretty change required, which was to move the `ImageSubresourceLayout::Init` (ImageSubresource.h) implementation to the header file, since it uses `MultiDeviceObject::IterateDevices`, which is defined in Atom_RHI.Public, but ImageSubresourceLayout is defined in Atom_RHI.Reflect, and the .Public target depends on the .Reflect target.

## How was this PR tested?

Compile and run the Editor on Windows, AR
