### PR TITLE
Remove usages of the AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING macro

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.h
@@ -38,12 +38,6 @@ namespace AzToolsFramework
     }
 }
 
-// on windows, this is a DLL Exported class that derives from non-dll-exported
-// baseclasses, which issues a warning (which is then treated as an error).
-// However, all of the derived classes are ebus handlers that are all available in static
-// libraries or by direct header inclusions, so they ARE available:
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
 // this also triggers a MEMBER warning on the actual EBus Handler we derive from
 // because it has members like m_node.
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
@@ -105,5 +99,4 @@ protected:
 };
 
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 

--- a/Code/Editor/Commands/CommandManager.h
+++ b/Code/Editor/Commands/CommandManager.h
@@ -21,11 +21,9 @@
 #include "Include/SandboxAPI.h"
 #include "Include/ICommandManager.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class SANDBOX_API CEditorCommandManager
     : public ICommandManager
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     enum
     {

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.h
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.h
@@ -31,13 +31,11 @@ namespace AzToolsFramework {
     class ComponentEditorHeader;
 }
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 //ReflectedPropertyEditor-based implementation of the MFC CPropertyCtrl API
 class EDITOR_CORE_API ReflectedPropertyControl
     : public QWidget
     , public AzToolsFramework::IPropertyEditorNotify
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         Q_OBJECT
 public:
     //! For alternative undo.
@@ -276,11 +274,9 @@ private:
     void RemoveCustomPopup(const QString& text, T& customPopup);
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class EDITOR_CORE_API TwoColumnPropertyControl
     : public QWidget
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     Q_OBJECT
 public:
     TwoColumnPropertyControl(QWidget* parent = nullptr);

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -82,7 +82,6 @@ enum class COpenSameLevelOptions
     NotReopenIfSame
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SANDBOX_API CCryEditApp
     : public QObject
@@ -91,7 +90,6 @@ class SANDBOX_API CCryEditApp
     , protected AzFramework::AssetSystemStatusBus::Handler
 {
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     friend MainWindow;
     Q_OBJECT
 public:

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -82,7 +82,6 @@ struct EditorViewportSettings : public AzToolsFramework::ViewportInteraction::Vi
 };
 
 //! EditorViewportWidget window
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SANDBOX_API EditorViewportWidget final
     : public QtViewport
@@ -99,7 +98,6 @@ class SANDBOX_API EditorViewportWidget final
     , private AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
 {
     AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-    AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     Q_OBJECT
 
 public:

--- a/Code/Editor/GameEngine.h
+++ b/Code/Editor/GameEngine.h
@@ -38,12 +38,10 @@ private:
     ISystemUserCallback* m_userCallback;
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 //! This class serves as a high-level wrapper for CryEngine game.
 class SANDBOX_API CGameEngine
     : public IEditorNotifyListener
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     CGameEngine();
     ~CGameEngine(void);

--- a/Code/Editor/LogFile.h
+++ b/Code/Editor/LogFile.h
@@ -40,14 +40,12 @@ SANDBOX_API void LogV(const char* format, va_list argList);
 SANDBOX_API void Warning(const char* format, ...);
 SANDBOX_API void WarningV(const char* format, va_list argList);
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 /*!
  *  CLogFile implements ILog interface.
  */
 class SANDBOX_API CLogFile
     : public ILogCallback
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     static const char* GetLogFileName();
     static void AttachListBox(QListWidget* hWndListBox);

--- a/Code/Editor/MainWindow.h
+++ b/Code/Editor/MainWindow.h
@@ -87,7 +87,6 @@ public Q_SLOTS:
     void Update(int count);
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SANDBOX_API MainWindow
     : public QMainWindow
@@ -95,7 +94,6 @@ class SANDBOX_API MainWindow
     , private AzToolsFramework::SourceControlNotificationBus::Handler
 {
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     Q_OBJECT
 
 public:

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -240,11 +240,10 @@ struct SSmartOpenDialogSettings
 /** Various editor settings.
 */
 AZ_CVAR_EXTERNED(int64_t, ed_backgroundSystemTickCap);
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
+
 struct SANDBOX_API SEditorSettings
     : AzToolsFramework::EditorSettingsAPIBus::Handler
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     SEditorSettings();
     ~SEditorSettings() = default;
     void    Save(bool isEditorClosing = false);

--- a/Code/Editor/TrackView/TrackViewPythonFuncs.h
+++ b/Code/Editor/TrackView/TrackViewPythonFuncs.h
@@ -29,14 +29,12 @@ namespace AzToolsFramework
     };
 
     //! Component to access the TrackView
-    AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     class SANDBOX_API TrackViewComponent final
         : public AZ::Component
         , public EditorLayerTrackViewRequestBus::Handler
     {
     AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-    AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     public:
         AZ_COMPONENT(TrackViewComponent, "{3CF943CC-6F10-4B19-88FC-CFB697558FFD}")
 

--- a/Code/Editor/Undo/Undo.h
+++ b/Code/Editor/Undo/Undo.h
@@ -135,14 +135,12 @@ private: // ------------------------------------------------------
     std::vector<IUndoObject*> m_undoObjects;
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 /*!
  *  CUndoManager is keeping and operating on CUndo class instances.
  *  TODO: this class is superseded by AzToolsFramework::UndoSystem
  */
 class EDITOR_CORE_API CUndoManager
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     CUndoManager();
     ~CUndoManager();

--- a/Code/Editor/Util/3DConnexionDriver.h
+++ b/Code/Editor/Util/3DConnexionDriver.h
@@ -38,11 +38,9 @@ struct S3DConnexionMessage
 };
 
 #if defined(AZ_PLATFORM_WINDOWS)
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class SANDBOX_API C3DConnexionDriver
     : public IPlugin
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     C3DConnexionDriver();
     ~C3DConnexionDriver();

--- a/Code/Editor/Util/FileUtil_impl.h
+++ b/Code/Editor/Util/FileUtil_impl.h
@@ -26,11 +26,9 @@
 #undef CopyFile
 #endif
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class SANDBOX_API CFileUtil_impl
     : public IFileUtil
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     bool ScanDirectory(const QString& path, const QString& fileSpec, FileArray& files, bool recursive = true, bool addDirAlso = false, ScanDirectoryUpdateCallBack updateCB = nullptr, bool bSkipPaks = false) override;
 

--- a/Code/Editor/Util/Variable.h
+++ b/Code/Editor/Util/Variable.h
@@ -384,7 +384,6 @@ struct IVariable
 // Smart pointer to this parameter.
 typedef _smart_ptr<IVariable> IVariablePtr;
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 /**
  **************************************************************************************
  * CVariableBase implements IVariable interface and provide default implementation
@@ -396,7 +395,6 @@ AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class EDITOR_CORE_API CVariableBase
     : public IVariable
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     virtual ~CVariableBase() {}
 
@@ -1741,13 +1739,11 @@ typedef _smart_ptr<IVarEnumList> IVarEnumListPtr;
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING;
 //! Selection list shown in combo box, for enumerated variable.
 template <class T>
 class CVarEnumListBase
     : public IVarEnumList
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     CVarEnumListBase(){}
 
@@ -2044,11 +2040,9 @@ private:
 
 
 //////////////////////////////////////////////////////////////////////////
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class EDITOR_CORE_API CVarBlock
     : public IVariableContainer
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     // Dtor.
     virtual ~CVarBlock() {}

--- a/Code/Editor/ViewManager.h
+++ b/Code/Editor/ViewManager.h
@@ -27,13 +27,11 @@ namespace AzToolsFramework
     class ManipulatorManager;
 }
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 /** Manages set of viewports.
 */
 class SANDBOX_API CViewManager
     : public IEditorNotifyListener
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     static bool IsMultiViewportEnabled();
 

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -81,11 +81,9 @@ enum EStdCursor
     STD_CURSOR_LAST,
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class SANDBOX_API CViewport
     : public IDisplayViewport
 {
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 public:
     typedef void(* DropCallback)(CViewport* viewport, int ptx, int pty, void* custom);
 

--- a/Code/Framework/AzCore/AzCore/EBus/EBus.h
+++ b/Code/Framework/AzCore/AzCore/EBus/EBus.h
@@ -1979,10 +1979,8 @@ namespace AZ \
 namespace AZ \
 { \
    extern template class _API EBus<a, a>; \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    extern template class _API Internal::NonIdHandler<a, a, EBus<a, a>::BusesContainer>; \
    extern template struct _API Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, a>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 //! Explicitly instantiates an EBus which was declared with the function directly above
@@ -1990,10 +1988,8 @@ namespace AZ \
 namespace AZ \
 { \
    template class AZ_DLL_EXPORT EBus<a, a>; \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    template class AZ_DLL_EXPORT Internal::NonIdHandler<a, a, EBus<a, a>::BusesContainer>; \
    template struct AZ_DLL_EXPORT Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, a>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 //! Declares an EBus class template, which uses an address policy different from EBusAddressPolicy::Single and is instantiated in a shared
@@ -2002,11 +1998,9 @@ namespace AZ \
 namespace AZ \
 { \
    extern template class _API EBus<a, a>;  \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    extern template class _API Internal::IdHandler<a, a, EBus<a, a>::BusesContainer>; \
    extern template class _API Internal::MultiHandler<a, a, EBus<a, a>::BusesContainer>; \
    extern template struct _API Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, a>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 //! Explicitly instantiates an EBus which was declared with the function directly above
@@ -2014,11 +2008,9 @@ namespace AZ \
 namespace AZ \
 { \
    template class AZ_DLL_EXPORT EBus<a, a>; \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    template class AZ_DLL_EXPORT Internal::IdHandler<a, a, EBus<a, a>::BusesContainer>; \
    template class AZ_DLL_EXPORT Internal::MultiHandler<a, a, EBus<a, a>::BusesContainer>; \
    template struct AZ_DLL_EXPORT Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, a>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 //! Declares an EBus class template, which uses EBusAddressPolicy::Single and is instantiated in a shared library, as extern with both the
@@ -2027,10 +2019,8 @@ namespace AZ \
 namespace AZ \
 { \
    extern template class _API EBus<a, b>;     \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    extern template class _API Internal::NonIdHandler<a, b, EBus<a, b>::BusesContainer>; \
    extern template struct _API Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, b>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 //! Explicitly instantiates an EBus which was declared with the function directly above
@@ -2038,10 +2028,8 @@ namespace AZ \
 namespace AZ \
 { \
    template class AZ_DLL_EXPORT EBus<a, b>; \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    template class AZ_DLL_EXPORT Internal::NonIdHandler<a, b, EBus<a, b>::BusesContainer>; \
    template struct AZ_DLL_EXPORT Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, b>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 //! Declares an EBus class template, which uses an address policy different from EBusAddressPolicy::Single and is instantiated in a shared
@@ -2050,11 +2038,9 @@ namespace AZ \
 namespace AZ \
 { \
    extern template class _API EBus<a, b>;  \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    extern template class _API Internal::IdHandler<a, b, EBus<a, b>::BusesContainer>; \
    extern template class _API Internal::MultiHandler<a, b, EBus<a, b>::BusesContainer>; \
    extern template struct _API Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, b>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 //! Explicitly instantiates an EBus which was declared with the function directly above
@@ -2062,11 +2048,9 @@ namespace AZ \
 namespace AZ \
 { \
    template class AZ_DLL_EXPORT EBus<a, b>; \
-   AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
    template class AZ_DLL_EXPORT Internal::IdHandler<a, b, EBus<a, b>::BusesContainer>; \
    template class AZ_DLL_EXPORT Internal::MultiHandler<a, b, EBus<a, b>::BusesContainer>; \
    template struct AZ_DLL_EXPORT Internal::EBusCallstackStorage<Internal::CallstackEntryBase<a, b>, true>; \
-   AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING \
 }
 
 #endif //defined(AZ_MONOLITHIC_BUILD)

--- a/Code/Framework/AzCore/AzCore/PlatformDef.h
+++ b/Code/Framework/AzCore/AzCore/PlatformDef.h
@@ -114,10 +114,6 @@
     __pragma(warning(pop))
 
 
-/// Classes in Editor Sandbox and Tools which dll export there interfaces, but inherits from a base class that doesn't dll export
-/// will trigger a warning
-#define AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING AZ_PUSH_DISABLE_WARNING(4275, "-Wunknown-warning-option")
-#define AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING AZ_POP_DISABLE_WARNING
 /// Disables a warning for dll exported classes which has non dll-exported members as this can cause ABI issues if the layout of those classes differs between dlls.
 /// QT classes such as QList, QString, QMap, etc... and Cry Math classes such Vec3, Quat, Color don't dllexport their interfaces
 /// Therefore this macro can be used to disable the warning when caused by 3rdParty libraries
@@ -188,8 +184,6 @@
 
 #endif // defined(AZ_COMPILER_CLANG)
 
-#define AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-#define AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 #define AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #define AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 

--- a/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.h
+++ b/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.h
@@ -70,12 +70,10 @@ private:
     friend class SceneSettingsCard;
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SCENE_UI_API SceneSettingsCard : public AzQtComponents::Card, public AZ::Debug::TraceMessageBus::Handler
 {
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     Q_OBJECT
 public:
     enum class Layout

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionHandler.h
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionHandler.h
@@ -45,12 +45,10 @@ namespace AZ
     {
         namespace UI
         {
-            AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             class SCENE_UI_API NodeTreeSelectionHandler
                 : public QObject
                 , public AzToolsFramework::PropertyHandler<DataTypes::ISceneNodeSelectionList, NodeTreeSelectionWidget>
             {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
                 Q_OBJECT
             public:
                 AZ_CLASS_ALLOCATOR_DECL

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialFunctorSourceDataSerializer.h
@@ -18,12 +18,9 @@ namespace AZ
 
     namespace RPI
     {
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_EDIT_API JsonMaterialFunctorSourceDataSerializer
             : public BaseJsonSerializer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(AZ::RPI::JsonMaterialFunctorSourceDataSerializer, "{56F2F0D8-165C-45BB-9FE7-54FA90148FE9}", BaseJsonSerializer);
             AZ_CLASS_ALLOCATOR_DECL;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyConnectionSerializer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyConnectionSerializer.h
@@ -21,12 +21,9 @@ namespace AZ
         //! The property connection itself is rather simple, but we need this custom serializer to provide backward compatibility
         //! for when the "id" key was changed to "name". If the JSON serialization system is ever updated to provide built-in
         //! support for versioning, then we can probably remove this class.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_EDIT_API JsonMaterialPropertyConnectionSerializer
             : public BaseJsonSerializer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(JsonMaterialPropertyConnectionSerializer, "{2B7F00CF-51F7-4409-9C0E-914E59696FB9}", BaseJsonSerializer);
             AZ_CLASS_ALLOCATOR_DECL;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyGroupSerializer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyGroupSerializer.h
@@ -21,12 +21,9 @@ namespace AZ
         //! The property group itself is rather simple, but we need this custom serializer to provide backward compatibility
         //! for when the "id" key was changed to "name". If the JSON serialization system is ever updated to provide built-in
         //! support for versioning, then we can probably remove this class.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_EDIT_API JsonMaterialPropertyGroupSerializer
             : public BaseJsonSerializer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(JsonMaterialPropertyGroupSerializer, "{74C56BBC-2084-46AF-9393-04C2FBDF6B20}", BaseJsonSerializer);
             AZ_CLASS_ALLOCATOR_DECL;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySerializer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertySerializer.h
@@ -20,12 +20,9 @@ namespace AZ
         struct MaterialPropertySourceData;
         class MaterialPropertyValue;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_EDIT_API JsonMaterialPropertySerializer
             : public BaseJsonSerializer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(JsonMaterialPropertySerializer, "{1AFEC5BD-AB2E-4BDB-911B-80727EDA0C26}", BaseJsonSerializer);
             AZ_CLASS_ALLOCATOR_DECL;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyValueSerializer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyValueSerializer.h
@@ -18,12 +18,9 @@ namespace AZ
 
     namespace RPI
     {
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_EDIT_API JsonMaterialPropertyValueSerializer
             : public BaseJsonSerializer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(AZ::RPI::JsonMaterialPropertyValueSerializer, "{A52B1ED8-C849-4269-9AA7-9D0814D2EC59}", BaseJsonSerializer);
             AZ_CLASS_ALLOCATOR_DECL;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyValueSourceDataSerializer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPropertyValueSourceDataSerializer.h
@@ -19,12 +19,9 @@ namespace AZ
 
     namespace RPI
     {
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_EDIT_API JsonMaterialPropertyValueSourceDataSerializer
             : public BaseJsonSerializer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(AZ::RPI::JsonMaterialPropertyValueSourceDataSerializer, "{940D9CA4-8BA5-4747-A566-3ED92CD217F7}", BaseJsonSerializer);
             AZ_CLASS_ALLOCATOR_DECL;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/Buffer.h
@@ -33,11 +33,9 @@ namespace AZ
     {
         class BufferPool;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API Buffer final
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class BufferSystem;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Buffer/BufferPool.h
@@ -25,11 +25,9 @@ namespace AZ
     {
         class ResourcePoolAsset;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API BufferPool final
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class BufferSystem;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
@@ -43,11 +43,9 @@ namespace AZ
         //! 
         //!         It is recommended that each feature processor maintain a data buffer that is buffered N times for the data that is
         //!         expected to be delivered via an Ebus.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API FeatureProcessor
             : public SceneNotificationBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class Scene;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImagePool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/AttachmentImagePool.h
@@ -24,11 +24,9 @@ namespace AZ
     {
         class ResourcePoolAsset;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API AttachmentImagePool final
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ImageSystem;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageTagSystemComponent.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/ImageTagSystemComponent.h
@@ -21,13 +21,10 @@ namespace AZ
 {
     namespace RPI
     {
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ImageTagSystemComponent final
             : public AZ::Component
             , ImageTagBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_COMPONENT(ImageTagSystemComponent, "{1AC446A3-6F20-4D5C-9C09-BB034C9188D5}");
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImage.h
@@ -44,12 +44,10 @@ namespace AZ
         //! 
         //! A trim operation will immediately trim the GPU image down and cancel any in-flight mip chain fetches.
         //!
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API StreamingImage final
             : public Image
             , public Data::AssetBus::MultiHandler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             static_assert(RHI::Limits::Image::MipCountMax < 16, "StreamingImageAsset is optimized to support a maximum of 16 mip levels.");
 
             friend class ImageSystem;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Image/StreamingImagePool.h
@@ -37,11 +37,9 @@ namespace AZ
         //! Users won't need to interact directly with pools. If a streaming image is instantiated which references
         //! the pool (by asset id), the pool is automatically brought up to accommodate the request. Likewise, if a pool
         //! is no longer referenced by a streaming image, it is shut down.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API StreamingImagePool final
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class StreamingImage;
             friend class ImageSystem;
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -47,12 +47,10 @@ namespace AZ
         //! an error is emitted and the call returns false without performing the requested operation. Likewise, if
         //! a getter method fails, an error is emitted and an empty value is returned. If validation is disabled, the
         //! operation is always performed.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API Material
             : public Data::InstanceData
             , public ShaderReloadNotificationBus::MultiHandler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class MaterialSystem;
         public:
             AZ_INSTANCE_DATA(Material, "{C99F75B2-8BD5-4CD8-8672-1E01EF0A04CF}");

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
@@ -26,12 +26,10 @@ namespace AZ::RPI
     class Material;
 
     //! Manages system-wide initialization and support for material classes
-    AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     class ATOM_RPI_PUBLIC_API MaterialSystem
         : public MaterialInstanceHandlerInterface::Registrar
         , public Data::AssetBus::Handler
     {
-        AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     public:
         static void Reflect(AZ::ReflectContext* context);
         static void GetAssetHandlers(AssetHandlerPtrList& assetHandlers);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/Model.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/Model.h
@@ -27,11 +27,9 @@ namespace AZ
     {
         class ModelAsset;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API Model final
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ModelSystem;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelLod.h
@@ -34,11 +34,9 @@ namespace AZ
         //! A map matches the UV shader inputs of this material to the custom UV names from the model.
         using MaterialModelUvOverrideMap = AZStd::unordered_map<RHI::ShaderSemantic, AZ::Name>;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ModelLod final
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ModelSystem;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelTagSystemComponent.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Model/ModelTagSystemComponent.h
@@ -21,13 +21,10 @@ namespace AZ
 {
     namespace RPI
     {
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ModelTagSystemComponent final
             : public AZ::Component
             , ModelTagBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_COMPONENT(ModelTagSystemComponent, "{93D69578-C521-43BC-ADAE-230DB09B361C}");
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassLibrary.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassLibrary.h
@@ -37,11 +37,9 @@ namespace AZ
         //!
         //! Because PassLibrary enables PassTemplates to be referenced with just a Name,
         //! this enables code to reference Passes defined in data and vice-versa
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API PassLibrary final
             : public Data::AssetBus::MultiHandler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             AZ_DISABLE_COPY_MOVE(PassLibrary);
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -35,12 +35,10 @@ namespace AZ
 
         //! A RenderPass is a leaf Pass (i.e. a Pass that has no children) that 
         //! implements rendering functionality (raster, compute, copy)
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API RenderPass :
             public Pass,
             public RHI::ScopeProducer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             AZ_RPI_PASS(RenderPass);
 
             using ScopeQuery = AZStd::array<RHI::Ptr<Query>, static_cast<size_t>(ScopeQueryType::Count)>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
@@ -26,11 +26,9 @@ namespace AZ
         class RenderPass;
 
         //! A scope producer to copy the input attachment and output a copy of this attachment
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ImageAttachmentCopy final
             : public RHI::ScopeProducer
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ImageAttachmentPreviewPass;
         public:
             AZ_RTTI(ImageAttachmentCopy, "{27E35230-48D1-4950-8489-F301A45D4A0B}", RHI::ScopeProducer);
@@ -65,13 +63,11 @@ namespace AZ
         };
 
         //! Render preview of specified image attachment to the selected output attachment.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ImageAttachmentPreviewPass final
             : public Pass
             , public RHI::ScopeProducer
             , public Data::AssetBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             AZ_RPI_PASS(ImageAttachmentPreviewPass);
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/PipelineState.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/PipelineState.h
@@ -25,13 +25,10 @@ namespace AZ
 
         //! The PipelineStateForDraw caches descriptor for RHI::PipelineState's creation so the RHI::PipelineState can be created
         //! or updated later when Scene's render pipelines changed or any other data in the descriptor has changed.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API PipelineStateForDraw
             : public AZStd::intrusive_base
             , public ShaderReloadNotificationBus::MultiHandler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_CLASS_ALLOCATOR(PipelineStateForDraw, SystemAllocator);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
@@ -47,13 +47,11 @@ namespace AZ
     {
         class FeatureProcessor;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API RPISystem final
             : public RPISystemInterface
             , public AZ::SystemTickBus::Handler
             , public AZ::Debug::TraceMessageBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class UnitTest::RPITestFixture;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
@@ -52,13 +52,11 @@ namespace AZ
         //! 
         //! Remember that the returned RHI::PipelineState instance lifetime is tied to the Shader lifetime.
         //! If you need guarantee lifetime, it is safe to take a reference on the returned pipeline state.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API Shader final
             : public Data::InstanceData
             , public Data::AssetBus::MultiHandler
             , public ShaderVariantFinderNotificationBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ShaderSystem;
         public:
             AZ_INSTANCE_DATA(Shader, "{232D8BD6-3BD4-4842-ABD2-F380BD5B0863}");

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -47,11 +47,9 @@ namespace AZ
          * Likewise, if a getter method fails, an error is emitted and an empty value or empty array
          * is returned. If validation is disabled, the operation is always performed.
          */
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ShaderResourceGroup final
             : public AZ::Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ShaderSystem;
             friend class ShaderResourceGroupPool;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroupPool.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroupPool.h
@@ -35,11 +35,9 @@ namespace AZ
          *
          * User code should not need to access this pool directly; RPI::ShaderResourceGroup uses it internally.
          */
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ShaderResourceGroupPool final
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ShaderSystem;
         public:
             AZ_INSTANCE_DATA(ShaderResourceGroupPool, "{D75561AF-C10A-41BC-BABF-63DBFA160388}");

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderVariantAsyncLoader.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderVariantAsyncLoader.h
@@ -30,13 +30,10 @@ namespace AZ
          * and ShaderVariantAssets.
          * The notifications of assets being loaded & ready are dispatched via ShaderVariantFinderNotificationBus.
          */
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ShaderVariantAsyncLoader final
             : public AZ::Interface<IShaderVariantFinder>::Registrar
             , public AZ::Data::AssetBus::MultiHandler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             static constexpr char LogName[] = "ShaderVariantAsyncLoader";
             ~ShaderVariantAsyncLoader() { Shutdown(); }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
@@ -27,14 +27,11 @@ namespace AZ
         //! in which a scene is rendered on-screen.
         //! ViewportContexts are registered on creation to allow consumers to listen to notifications
         //! and manage the view stack for a given viewport.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API ViewportContext
             : public SceneNotificationBus::Handler
             , public AzFramework::WindowNotificationBus::Handler
             , public AzFramework::ViewportRequestBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_CLASS_ALLOCATOR(ViewportContext, AZ::SystemAllocator);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/WindowContext.h
@@ -29,13 +29,10 @@ namespace AZ
         //! and passes it down throughout the RPI. This is a convenient way to
         //! package the SwapChain, Window size, Attachment info and other
         //! window information needed to present to a surface.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_PUBLIC_API WindowContext final
             : public AzFramework::WindowNotificationBus::Handler
             , public AzFramework::ExclusiveFullScreenRequestBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_CLASS_ALLOCATOR(WindowContext, AZ::SystemAllocator);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/AssetUtils.h
@@ -218,14 +218,11 @@ namespace AZ
              //                              | StreaminImage::Destructor()                     
              //                              | AssetBus::Disconnect()                          
              //                              | AssetBus::lock(mutex) <- Deadlocked             
-             //                                                                                                           
-            AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
+             //
             class ATOM_RPI_REFLECT_API AsyncAssetLoader :
                 private Data::AssetBus::Handler,
                 private SystemTickBus::Handler
             {
-                AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
             public:
                 AZ_RTTI(AZ::RPI::AssetUtils::AsyncAssetLoader, "{E0FB5B08-B97D-40DF-8478-226249C0B654}");
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/BuiltInAssetHandler.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Asset/BuiltInAssetHandler.h
@@ -93,12 +93,9 @@ namespace AZ
         //!         Data::Asset<Bar> m_bar1;
         //!         Data::Asset<Bar> m_bar2;
         //!     };
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API BuiltInAssetHandler
             : public Data::AssetHandler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_CLASS_ALLOCATOR(BuiltInAssetHandler, AZ::SystemAllocator);
             AZ_RTTI(BuiltInAssetHandler, "{C6615D6C-72AF-4444-8C27-8B88D89074E8}", Data::AssetHandler);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Buffer/BufferAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Buffer/BufferAsset.h
@@ -30,11 +30,9 @@ namespace AZ
     {
         //! An asset representation of a buffer meant to be uploaded to the GPU.
         //! For example: vertex buffer, index buffer, etc
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API BufferAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class BufferAssetCreator;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/Image.h
@@ -26,11 +26,9 @@ namespace AZ
         class ImageAsset;
 
         //! A base class for images providing access to common image information.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API Image
             : public Data::InstanceData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ImageSystem;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageAsset.h
@@ -25,12 +25,9 @@ namespace AZ
         //! Image assets are domain specific (e.g. streaming vs. attachments) so
         //! the details of how to source content for an image is defined by the specialized variant. The base
         //! class provides access to the RHI image and default image view.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ImageAsset
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             static constexpr const char* DisplayName{ "ImageAsset" };
             static constexpr const char* Group{ "Image" };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageMipChainAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/ImageMipChainAsset.h
@@ -35,11 +35,9 @@ namespace AZ
         //! a parent image mip slice to the local container slice index.
         //! This is an immutable, serialized asset. It can be either serialized-in or created dynamically using ImageMipChainAssetCreator.
         //! See RPI::ImageMipChain for runtime features based on this asset.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ImageMipChainAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ImageMipChainAssetCreator;
             friend class ImageMipChainAssetHandler;
             friend class ImageMipChainAssetTester;
@@ -123,11 +121,9 @@ namespace AZ
             AZStd::vector<uint8_t, Allocator> m_imageData;
         };
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ImageMipChainAssetHandler final
             : public AssetHandler<ImageMipChainAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<ImageMipChainAsset>;
         public:
             ImageMipChainAssetHandler() = default;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAssetHandler.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAssetHandler.h
@@ -17,12 +17,10 @@ namespace AZ
     namespace RPI
     {
         //! The StreamingImageAsset's handler with customized loading steps in LoadAssetData override.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API StreamingImageAssetHandler final
             : public AssetHandler<StreamingImageAsset>
             , private Data::AssetBus::MultiHandler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<StreamingImageAsset>;
         public:
             AZ_CLASS_ALLOCATOR(StreamingImageAssetHandler, AZ::SystemAllocator)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageControllerAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageControllerAsset.h
@@ -25,12 +25,9 @@ namespace AZ
         //! concrete streaming image controller instance. Users should derive from this class, store
         //! configuration data on it for your specific back-end, and implement the factory method to create
         //! an instance at runtime.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API StreamingImageControllerAsset
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(StreamingImageControllerAsset, "{0797F48F-B097-4209-8D6F-DA40DC0FAB42}", Data::AssetData);
             AZ_CLASS_ALLOCATOR(StreamingImageControllerAsset, SystemAllocator);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImagePoolAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImagePoolAsset.h
@@ -34,11 +34,9 @@ namespace AZ
         //! Both of these overrides should be assigned at asset build time for the specific platform.
         //! This is an immutable, serialized asset. It can be either serialized-in or created dynamically using StreamingImagePoolAssetCreator.
         //! See RPI::StreamingImagePool for runtime features based on this asset.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API StreamingImagePoolAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class StreamingImagePoolAssetCreator;
             friend class StreamingImagePoolAssetTester;
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialAsset.h
@@ -35,12 +35,10 @@ namespace AZ
 
         //! MaterialAsset defines a single material, which can be used to create a Material instance for rendering at runtime.
         //! Use a MaterialAssetCreator to create a MaterialAsset.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API MaterialAsset
             : public AZ::Data::AssetData
             , public AssetInitBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class MaterialVersionUpdates;
             friend class MaterialAssetCreator;
             friend class MaterialAssetHandler;
@@ -167,12 +165,9 @@ namespace AZ
 
             bool m_isNonSerializedDataInitialized = false;
         };
-       
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API MaterialAssetHandler : public AssetHandler<MaterialAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<MaterialAsset>;
         public:
             AZ_RTTI(MaterialAssetHandler, "{949DFEF5-6E19-4C81-8CF0-C764F474CCDD}", Base);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
@@ -53,13 +53,11 @@ namespace AZ
         //! which can be used to render meshes at runtime.
         //! 
         //! Use a MaterialTypeAssetCreator to create a MaterialTypeAsset.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API MaterialTypeAsset
             : public AZ::Data::AssetData
             , public Data::AssetBus::MultiHandler
             , public AssetInitBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class MaterialTypeAssetCreator;
             friend class MaterialTypeAssetHandler;
 
@@ -224,10 +222,8 @@ namespace AZ
             bool m_isNonSerializedDataInitialized = false;
         };
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API MaterialTypeAssetHandler : public AssetHandler<MaterialTypeAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<MaterialTypeAsset>;
         public:
             AZ_RTTI(MaterialTypeAssetHandler, "{08568C59-CB7A-4F8F-AFCD-0B69F645B43F}", Base);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
@@ -28,11 +28,9 @@ namespace AZ
         //! Contains a set of RPI::ModelLodAsset objects.
         //! Serialized to a .azmodel file.
         //! Actual model data is stored in the BufferAssets referenced by ModelLodAssets.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ModelAsset
             : public AZ::Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ModelAssetCreator;
             friend class ModelAssetHelpers;
 
@@ -172,12 +170,9 @@ namespace AZ
             AZStd::vector<AZ::Name> m_tags;
         };
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ModelAssetHandler
             : public AssetHandler<ModelAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(ModelAssetHandler, "{993B8CE3-1BBF-4712-84A0-285DB9AE808F}", AssetHandler<ModelAsset>);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
@@ -30,11 +30,9 @@ namespace AZ
         //! Contains a set of ModelLodAsset::Mesh objects and BufferAsset objects, representing the data a single level-of-detail for a Model.
         //! Serialized to a .azlod file.
         //! Actual vertex and index buffer data is stored in the BufferAssets.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ModelLodAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ModelLodAssetCreator;
             friend class ModelAsset;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
@@ -18,12 +18,9 @@ namespace AZ::RPI
 {
     //! The morph target meta asset is an optional asset that belongs to a model.
     //! In case the model does not contain any morph targets, the meta asset won't be generated.
-    AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     class ATOM_RPI_REFLECT_API MorphTargetMetaAsset final
         : public Data::AssetData
     {
-        AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
     public:
         static constexpr inline const char* DisplayName = "MorphTargetMeta";
         static constexpr inline const char* Extension = "morphTargetMeta";

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/SkinMetaAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/SkinMetaAsset.h
@@ -19,12 +19,9 @@ namespace AZ
     {
         //! The skin meta asset is an optional asset that belongs to a model.
         //! In case the model does not contain any mesh with skinning information, the skin meta asset won't be generated.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API SkinMetaAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             static constexpr inline const char* DisplayName = "SkinMeta";
             static constexpr inline const char* Extension = "skinMeta";

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAsset.h
@@ -28,11 +28,9 @@ namespace AZ
     {
         //! An asset that describes the root of a pass by having a PassTemplate.
         //! By adding PassRequests to the template you can describe an entire tree of passes.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API PassAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class PassSystem;
             friend class UnitTest::PassBuilderTests;
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/ResourcePoolAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/ResourcePoolAsset.h
@@ -30,11 +30,9 @@ namespace AZ
         //! ResourcePoolAsset is the AssetData class for a resource pool asset.
         //! This is an immutable, serialized asset. It can be either serialized-in or created dynamically using ResourcePoolAssetCreator.
         //! Multiple runtime pool classes are based on this asset, for example RPI::ImagePool, RPI::StreamingImagePool, RPI::ShaderResourceGroupPool.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ResourcePoolAsset
             : public AZ::Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ResourcePoolAssetCreator;
 
         public:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/PrecompiledShaderAssetSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/PrecompiledShaderAssetSourceData.h
@@ -21,12 +21,9 @@ namespace AZ
     {
         //! This asset is loaded from a Json file and contains information about
         //! precompiled shader variants and their associated API name.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         struct ATOM_RPI_REFLECT_API PrecompiledRootShaderVariantAssetSourceData final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(PrecompiledRootShaderVariantAssetSourceData, "{661EF8A7-7BAC-41B6-AD5C-C7249B2390AD}");
             AZ_CLASS_ALLOCATOR(PrecompiledRootShaderVariantAssetSourceData, SystemAllocator);
@@ -39,12 +36,9 @@ namespace AZ
 
         //! This asset is loaded from a Json file and contains information about
         //! precompiled shader supervariants
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         struct ATOM_RPI_REFLECT_API PrecompiledSupervariantSourceData final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(PrecompiledSupervariantSourceData, "{630BDF15-CE7C-4E2C-882E-4F7AF09C8BB6}");
             AZ_CLASS_ALLOCATOR(PrecompiledSupervariantSourceData, SystemAllocator);
@@ -57,12 +51,9 @@ namespace AZ
 
         //! This asset is loaded from a Json file and contains information about
         //! precompiled shader assets.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         struct ATOM_RPI_REFLECT_API PrecompiledShaderAssetSourceData final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
-
         public:
             AZ_RTTI(PrecompiledShaderAssetSourceData, "{C6B606EF-B788-4979-BA0F-6A28B33A1372}");
             AZ_CLASS_ALLOCATOR(PrecompiledShaderAssetSourceData, SystemAllocator);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAsset.h
@@ -52,13 +52,11 @@ namespace AZ
                             //!< with dxc, or spirv-cross, etc.
         };
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ShaderAsset final
             : public Data::AssetData
             , public ShaderVariantFinderNotificationBus::Handler
             , public AssetInitBus::Handler
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ShaderAssetCreator;
             friend class ShaderAssetHandler;
             friend class ShaderAssetTester;
@@ -343,11 +341,9 @@ namespace AZ
             bool m_isFullySpecialized = false;
         };
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ShaderAssetHandler final
             : public AssetHandler<ShaderAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<ShaderAsset>;
         public:
             ShaderAssetHandler() = default;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantAsset.h
@@ -20,11 +20,9 @@ namespace AZ
     {
         //! A ShaderVariantAsset contains the shader byte code for each shader stage (Vertex, Fragment, Tessellation, etc) for a given RHI::APIType (dx12, vulkan, metal, etc).
         //! One independent file per RHI::APIType.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ShaderVariantAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ShaderVariantAssetHandler;
             friend class ShaderVariantAssetCreator;
 
@@ -83,11 +81,9 @@ namespace AZ
 
         };
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ShaderVariantAssetHandler final
             : public AssetHandler<ShaderVariantAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<ShaderVariantAsset>;
         public:
             ShaderVariantAssetHandler() = default;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantTreeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantTreeAsset.h
@@ -34,11 +34,9 @@ namespace AZ
         //! The variant searched using the tree has a key that matches the requested key, but some values can be undefined.
         //! For example, requesting a key equal to "00101" could return a variant with ID "0?10?", in which ? stands for undefined values.
         //! The undefined values must be provided to the fallback constant buffer. (See Shader::FindFallbackShaderResourceGroupAsset).
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ShaderVariantTreeAsset final
             : public Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class ShaderVariantTreeAssetHandler;
             friend class ShaderVariantTreeAssetCreator;
             friend struct ShaderVariantTreeNode;
@@ -101,11 +99,9 @@ namespace AZ
             AZStd::vector<ShaderVariantTreeNode> m_nodes;
         };
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API ShaderVariantTreeAssetHandler final
             : public AssetHandler<ShaderVariantTreeAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<ShaderVariantTreeAsset>;
         public:
             ShaderVariantTreeAssetHandler() = default;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/System/AnyAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/System/AnyAsset.h
@@ -21,11 +21,9 @@ namespace AZ
     {
         //! Any asset can be used for storage any az serialization class data. So user don't need to create their own 
         //! builder and handler.
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API AnyAsset
             : public AZ::Data::AssetData
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             friend class AnyAssetHandler;
             friend class AnyAssetBuilder;
             friend class AnyAssetCreator;
@@ -77,11 +75,9 @@ namespace AZ
             return dataT;
         }
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
         class ATOM_RPI_REFLECT_API AnyAssetHandler
             : public AssetHandler<AnyAsset>
         {
-            AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
             using Base = AssetHandler<AnyAsset>;
         public:
             Data::AssetHandler::LoadResult LoadAssetData(


### PR DESCRIPTION
## What does this PR do?

This PR removes all instances and the declaration of the `AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING`/`AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING` macros. These macros are no longer required since [PR19111](https://github.com/o3de/o3de/pull/19111) disabled MSVC warning [4275](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275) globally, and add unnecessary clutter to many class declarations.

A similar PR, which removes all usages of the `AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING`, will follow.

## How was this PR tested?

Compile with MSVC on Windows, AR
