### PR TITLE
Enable usage of ccache with MSVC and Ninja

### DIFF
--- a/cmake/Platform/Common/MSVC/CompilerCache_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/CompilerCache_msvc.cmake
@@ -33,7 +33,7 @@
 # - This is primarily used for AR/CI processes but can also be used for local builds
 #
 
-function(o3de_compiler_cache_activation)
+function(o3de_compiler_cache_activation CACHE_EXE_PATH)
     message(STATUS "[COMPILER CACHE] Cache is enabled")
 
     # Check for custom compiler cache path, CMake variable takes precedence over environment
@@ -81,6 +81,12 @@ function(o3de_compiler_cache_activation)
 
     message(STATUS "[COMPILER CACHE] Found at ${cache_exe}, using it for this build")
 
-    # Copy cache executable as an alternative cl.exe. This will act as a wrapper for the real cl.exe
-    file(COPY_FILE ${cache_exe} ${CMAKE_BINARY_DIR}/cl.exe ONLY_IF_DIFFERENT)
+    if(CMAKE_GENERATOR MATCHES "^Ninja.*") # "Ninja" or "Ninja Multi-Config"
+        set(${CACHE_EXE_PATH} ${cache_exe} PARENT_SCOPE)
+    else()
+        # Copy cache executable as an alternative cl.exe. This will act as a wrapper for the real cl.exe
+        set(copied_cache_exe ${CMAKE_BINARY_DIR}/cl.exe)
+        file(COPY_FILE ${cache_exe} ${copied_cache_exe} ONLY_IF_DIFFERENT)
+        set(${CACHE_EXE_PATH} ${copied_cache_exe} PARENT_SCOPE)
+    endif()
 endfunction()

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -129,13 +129,13 @@ ly_append_configurations_options(
 # More details about the compiler cache can be found in CompilerCache.cmake
 
 if((O3DE_ENABLE_COMPILER_CACHE OR "$ENV{O3DE_ENABLE_COMPILER_CACHE}" STREQUAL "true") AND NOT O3DE_SCRIPT_ONLY)
-    o3de_compiler_cache_activation() # Activates the compiler cache
+    o3de_compiler_cache_activation(cache_exe_path) # Activates the compiler cache
 
     # Configure debug info format and compiler launcher for cache compatibility
     cmake_policy(SET CMP0141 NEW)
     set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
-    set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_BINARY_DIR}/cl.exe)
-    set(CMAKE_CXX_COMPILER_LAUNCHER ${CMAKE_BINARY_DIR}/cl.exe)
+    set(CMAKE_C_COMPILER_LAUNCHER ${cache_exe_path})
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${cache_exe_path})
 
     # Fallback to compiler flags if the debug format doesn't work, which can depend on CMake version
     ly_append_configurations_options(


### PR DESCRIPTION
## What does this PR do?

This PR enables the usage of ccache with the MSVC compiler and Ninja generator. Support for ccache with MSVC was already implemented in [PR18767](https://github.com/o3de/o3de/pull/18767), but this PR did not correctly account for usage of the Ninja generator. The linked PR mentions that Ninja just needs `CMAKE_CXX_COMPILER_LAUNCHER` to be set, but since the MSVC compiler arguments include `/Zi` for profile builds if `O3DE_ENABLE_COMPILER_CACHE` is not set (`/Zi` instructs MSVC to generate a separate pdb file), ccache does not cache the build artifacts. If `O3DE_ENABLE_COMPILER_CACHE` is set in addition to `CMAKE_CXX_COMPILER_LAUNCHER` (to get the `/Z7` compiler flag), the cmake script would override `CMAKE_CXX_COMPILER_LAUNCHER` with ccache copied to cl.exe, which leads to the Ninja build no longer working.

## How was this PR tested?

Compile the AzCore target on Windows with Clang, MSVC+Ninja and MSVC+"Visual Studio 17 2022" generator, then change one header file, compile the target, undo the change, compile the target again. For all three configurations the third run finished compiling the target within a few seconds.
