### PR TITLE
Remove usages of the AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING macro

### DIFF
--- a/Code/Editor/AnimationContext.h
+++ b/Code/Editor/AnimationContext.h
@@ -267,7 +267,6 @@ private:
 
     bool m_bAutoRecording;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     //! Time range of active animation sequence.
     Range m_timeRange;
 
@@ -331,7 +330,6 @@ private:
 
     //! Listeners
     std::vector<IAnimationContextListener*> m_contextListeners;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 #endif // CRYINCLUDE_EDITOR_ANIMATIONCONTEXT_H

--- a/Code/Editor/AssetEditor/AssetEditorWindow.cpp
+++ b/Code/Editor/AssetEditor/AssetEditorWindow.cpp
@@ -25,9 +25,7 @@
 // Editor
 #include "LyViewPaneNames.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <AssetEditor/ui_AssetEditorWindow.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace AssetEditorUtils
 {

--- a/Code/Editor/AssetImporter/UI/FilesAlreadyExistDialog.cpp
+++ b/Code/Editor/AssetImporter/UI/FilesAlreadyExistDialog.cpp
@@ -14,9 +14,7 @@
 #include <QPushButton>
 #include <QStyle>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <AssetImporter/UI/ui_FilesAlreadyExistDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 FilesAlreadyExistDialog::FilesAlreadyExistDialog(QString message ,int numberOfFiles, QWidget* parent)
     : QDialog(parent)

--- a/Code/Editor/AssetImporter/UI/ProcessingAssetsDialog.cpp
+++ b/Code/Editor/AssetImporter/UI/ProcessingAssetsDialog.cpp
@@ -14,9 +14,7 @@
 #include <QPushButton>
 #include <QStyle>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <AssetImporter/UI/ui_ProcessingAssetsDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 ProcessingAssetsDialog::ProcessingAssetsDialog(int numberOfProcessedFiles, QWidget* parent)
     : QDialog(parent)

--- a/Code/Editor/AssetImporter/UI/SelectDestinationDialog.cpp
+++ b/Code/Editor/AssetImporter/UI/SelectDestinationDialog.cpp
@@ -16,10 +16,7 @@
 #include <QStyle>
 #include <QPushButton>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <AssetImporter/UI/ui_SelectDestinationDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
 
 static const char* g_assetProcessorLink = "<a href=\"https://www.o3de.org/docs/user-guide/assets/asset-processor/\">Asset Processor</a>";
 static const char* g_copyFilesMessage = "The original file will remain outside of the project and the %1 will not monitor the file.";

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.h
@@ -40,7 +40,6 @@ namespace AzToolsFramework
 
 // this also triggers a MEMBER warning on the actual EBus Handler we derive from
 // because it has members like m_node.
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 class AzAssetBrowserWindow;
 
@@ -97,6 +96,3 @@ protected:
     AzAssetBrowserWindow* FindAzAssetBrowserWindow(QWidget* widgetToStartSearchFrom);
     AzAssetBrowserWindow* FindAzAssetBrowserWindowThatContainsWidget(QWidget* widget);
 };
-
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -32,12 +32,9 @@
 #include <AzQtComponents/Components/Widgets/AssetFolderTableView.h>
 
 // Editor
+#include <AzAssetBrowser/ui_AzAssetBrowserWindow.h>
 #include "AzAssetBrowser/AzAssetBrowserRequestHandler.h"
 #include "LyViewPaneNames.h"
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-#include <AzAssetBrowser/ui_AzAssetBrowserWindow.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 AZ_CVAR_API_EXTERNED(AZTF_API, bool, ed_useNewAssetBrowserListView);
 

--- a/Code/Editor/CheckOutDialog.cpp
+++ b/Code/Editor/CheckOutDialog.cpp
@@ -10,19 +10,13 @@
 #include "EditorDefs.h"
 
 #include "CheckOutDialog.h"
+#include "ui_CheckOutDialog.h"
 
 // Qt
 #include <QStyle>
 
 // AzToolsFramework
 #include <AzToolsFramework/SourceControl/SourceControlAPI.h> // for AzToolsFramework::SourceControlConnectionRequestBus
-
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-#include "ui_CheckOutDialog.h"
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
-
 
 // CCheckOutDialog dialog
 int CCheckOutDialog::m_lastResult = CCheckOutDialog::CANCEL;

--- a/Code/Editor/Clipboard.h
+++ b/Code/Editor/Clipboard.h
@@ -52,11 +52,9 @@ private:
     // Resolves the last request Put operation
     void SendPendingPut();
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     static XmlNodeRef m_node;
     static QString m_title;
     static QVariant s_pendingPut;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     QWidget* m_parent;
     QTimer m_putDebounce;

--- a/Code/Editor/Commands/CommandManager.h
+++ b/Code/Editor/Commands/CommandManager.h
@@ -73,14 +73,12 @@ protected:
 
     //! A full command name to an actual command mapping
     typedef std::map<AZStd::string, SCommandTableEntry> CommandTable;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     CommandTable m_commands;
 
     //! A command ID to an actual UI command mapping
     //! This table will contain a subset of commands among all registered to the above table.
     typedef std::map<int, CCommand0*> UICommandTable;
     UICommandTable m_uiCommands;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     bool m_bWarnDuplicate;
 
     static int GenNewCommandId();

--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -33,13 +33,11 @@
 #include "Util/Variable.h"
 #include "CvarDPE.h"
 
+#include <Controls/ui_ConsoleSCB.h>
+
 #include <AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
 
 static void OnVariableUpdated(ICVar* pCVar);
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-#include <Controls/ui_ConsoleSCB.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace ConsoleConstants
 {

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.h
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.h
@@ -238,22 +238,18 @@ private:
     QWidget* m_filterWidget;
     QLabel* m_titleLabel;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     _smart_ptr<CVarBlock> m_pVarBlock;
     _smart_ptr<ReflectedPropertyItem> m_root;
     AZStd::unique_ptr<CPropertyContainer> m_rootContainer;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     AZ::SerializeContext* m_serializeContext;
 
     bool m_bEnableCallback;
     QString m_filterString;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     UpdateVarCallback m_updateVarFunc;
     UpdateObjectCallback m_updateObjectFunc;
     SelChangeCallback m_selChangeFunc;
     UndoCallback m_undoFunc;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     bool m_bStoreUndoByItems;
     bool m_bForceModified;
@@ -266,10 +262,9 @@ private:
     bool m_isTwoColumnSection;
 
     //custom popup menu
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     std::vector<SCustomPopupItem> m_customPopupMenuItems;
     std::vector<SCustomPopupMenu> m_customPopupMenuPopups;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
+
     template<typename T>
     void RemoveCustomPopup(const QString& text, T& customPopup);
 };
@@ -326,11 +321,9 @@ protected:
 private:
     void ToggleTwoColumnLayout();
 
- AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QVector<PropertyCard*> m_controlList;
     QVector<_smart_ptr<CVarBlock>> m_varBlockList;
     _smart_ptr<CVarBlock> m_pVarBlock;
- AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     QWidget *m_leftContainer;
     QWidget *m_rightContainer;

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyItem.h
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyItem.h
@@ -136,19 +136,15 @@ public:
 protected:
     PropertyType m_type;
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     //The variable being edited.
     _smart_ptr<IVariable> m_pVariable;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     //holds the CReflectedVar and syncs its value with IVariable when either changes
     ReflectedVarAdapter* m_reflectedVarAdapter;
     ReflectedVarContainerAdapter* m_reflectedVarContainerAdapter;
 
     ReflectedPropertyItem* m_parent;
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     std::vector<_smart_ptr<ReflectedPropertyItem> > m_childs;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     ReflectedPropertyControl* m_propertyCtrl;
 
@@ -159,10 +155,8 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QString m_strNoScriptDefault;
     QString m_strScriptDefault;
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     IVariable::OnSetCallback m_onSetCallback;
     IVariable::OnSetEnumCallback m_onSetEnumCallback;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 typedef _smart_ptr<ReflectedPropertyItem> ReflectedPropertyItemPtr;

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVarWrapper.h
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVarWrapper.h
@@ -64,9 +64,7 @@ public:
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarInt > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     float m_valueMultiplier = 1.0f;
 };
 
@@ -80,9 +78,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarFloat > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     float m_valueMultiplier = 1.0f;
 };
 
@@ -95,9 +91,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarString > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarBoolAdapter
@@ -109,9 +103,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarBool > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarEnumAdapter
@@ -133,14 +125,10 @@ protected:
     virtual void updateIVariableEnumList([[maybe_unused]] IVariable* pVariable) {};
 
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarEnum<AZStd::string>  > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     IVariable* m_pVariable;
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     IVarEnumListPtr m_enumList;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     bool m_updatingEnums;
 };
 
@@ -153,9 +141,7 @@ public:
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 
 private:
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarVector3> m_reflectedVar;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarColor4Adapter : public ReflectedVarAdapter
@@ -167,9 +153,7 @@ public:
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 
 private:
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarVector4> m_reflectedVar;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 
@@ -182,9 +166,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarVector2 > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarVector3Adapter
@@ -196,9 +178,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarVector3 > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarVector4Adapter
@@ -210,9 +190,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarVector4 > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarResourceAdapter
@@ -224,9 +202,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarResource> m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarUserAdapter
@@ -240,9 +216,7 @@ public:
         return m_reflectedVar.data();
     }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarUser> m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class EDITOR_CORE_API ReflectedVarSplineAdapter
@@ -257,9 +231,7 @@ public:
         return m_reflectedVar.data();
     }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarSpline > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     bool m_bDontSendToControl;
     PropertyType m_propertyType;
     ReflectedPropertyItem *m_parentItem;
@@ -276,9 +248,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarGenericProperty > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     PropertyType m_propertyType;
 };
 
@@ -291,9 +261,7 @@ public:
     void SyncIVarToReflectedVar(IVariable* pVariable) override;
     CReflectedVar* GetReflectedVar() override { return m_reflectedVar.data(); }
 private:
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QScopedPointer<CReflectedVarMotion > m_reflectedVar;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -48,9 +48,8 @@ public:
     void WriteList();
 
     static const int Max = 12;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
+
     QStringList m_arrNames;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QSettings m_settings;
 };
 
@@ -82,14 +81,12 @@ enum class COpenSameLevelOptions
     NotReopenIfSame
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SANDBOX_API CCryEditApp
     : public QObject
     , protected AzFramework::AssetSystemInfoBus::Handler
     , protected EditorIdleProcessingBus::Handler
     , protected AzFramework::AssetSystemStatusBus::Handler
 {
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     friend MainWindow;
     Q_OBJECT
 public:
@@ -305,9 +302,7 @@ private:
     CCryDocManager* m_pDocManager = nullptr;
 
 // Disable warning for dll export since this member won't be used outside this class
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZ::IO::FileDescriptorRedirector m_stdoutRedirection = AZ::IO::FileDescriptorRedirector(1); // < 1 for STDOUT
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 private:
     // Optional Uri to start an external lua debugger. If not specified,
@@ -325,9 +320,7 @@ private:
     static constexpr AZStd::string_view LuaDebuggerUriRegistryKey = "/O3DE/Lua/Debugger/Uri";
 
     struct PythonOutputHandler;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZStd::shared_ptr<PythonOutputHandler> m_pythonOutputHandler;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     friend struct PythonTestOutputHandler;
 
     void OpenProjectManager(const AZStd::string& screen);

--- a/Code/Editor/CustomAspectRatioDlg.cpp
+++ b/Code/Editor/CustomAspectRatioDlg.cpp
@@ -15,9 +15,7 @@
 
 #include "CustomAspectRatioDlg.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_CustomAspectRatioDlg.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 #define MIN_ASPECT 1
 #define MAX_ASPECT 16384

--- a/Code/Editor/CustomResolutionDlg.cpp
+++ b/Code/Editor/CustomResolutionDlg.cpp
@@ -18,9 +18,7 @@
 // Qt
 #include <QTextStream>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_CustomResolutionDlg.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 #define MIN_RES 64
 #define MAX_RES 8192

--- a/Code/Editor/CustomizeKeyboardDialog.cpp
+++ b/Code/Editor/CustomizeKeyboardDialog.cpp
@@ -18,9 +18,7 @@
 // AzQtComponents
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include "ui_CustomizeKeyboardDialog.h"
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 using namespace AzQtComponents;
 

--- a/Code/Editor/Dialogs/PythonScriptsDialog.cpp
+++ b/Code/Editor/Dialogs/PythonScriptsDialog.cpp
@@ -30,11 +30,7 @@
 #include "Settings.h"
 #include "LyViewPaneNames.h"
 
-
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <Dialogs/ui_PythonScriptsDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 //////////////////////////////////////////////////////////////////////////
 namespace

--- a/Code/Editor/EditorPreferencesDialog.cpp
+++ b/Code/Editor/EditorPreferencesDialog.cpp
@@ -42,10 +42,7 @@
 #include "EditorPreferencesPageViewportDebug.h"
 #include "EditorPreferencesPageAWS.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_EditorPreferencesDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 using namespace AzQtComponents;
 

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -82,7 +82,6 @@ struct EditorViewportSettings : public AzToolsFramework::ViewportInteraction::Vi
 };
 
 //! EditorViewportWidget window
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SANDBOX_API EditorViewportWidget final
     : public QtViewport
     , public AzFramework::ViewportBorderRequestBus::Handler
@@ -97,7 +96,6 @@ class SANDBOX_API EditorViewportWidget final
     , private AZ::RPI::SceneNotificationBus::Handler
     , private AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
 {
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Q_OBJECT
 
 public:
@@ -302,8 +300,6 @@ private:
     // Members ...
     friend class AZ::ViewportHelpers::EditorEntityNotifications;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
     // Singleton for the primary viewport
     static EditorViewportWidget* m_pPrimaryViewport;
 
@@ -386,6 +382,4 @@ private:
 
     // DO NOT USE THIS! It exists only to satisfy the signature of the base class method GetViewTm
     mutable Matrix34 m_viewTmStorage;
-
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };

--- a/Code/Editor/ErrorDialog.cpp
+++ b/Code/Editor/ErrorDialog.cpp
@@ -10,10 +10,7 @@
 
 #include "ErrorDialog.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_ErrorDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace SandboxEditor
 {

--- a/Code/Editor/ErrorDialog.h
+++ b/Code/Editor/ErrorDialog.h
@@ -63,9 +63,7 @@ namespace SandboxEditor
         //! @return the QString representation of that message type.
         QString GetMessageTypeString(MessageType messageType) const;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QScopedPointer<Ui::ErrorLogDialog> m_ui; ///< Tracks the Qt UI associated with this class.
         QSet<QString> m_uniqueStrings;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 }

--- a/Code/Editor/ErrorReportDialog.cpp
+++ b/Code/Editor/ErrorReportDialog.cpp
@@ -31,12 +31,7 @@
 #include "GameEngine.h"
 #include "LyViewPaneNames.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_ErrorReportDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
-
 
 //////////////////////////////////////////////////////////////////////////
 CErrorReportDialog* CErrorReportDialog::m_instance = nullptr;

--- a/Code/Editor/FBXExporterDialog.cpp
+++ b/Code/Editor/FBXExporterDialog.cpp
@@ -13,9 +13,7 @@
 
 #include <QMessageBox>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_FBXExporterDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 CFBXExporterDialog::CFBXExporterDialog(bool bDisplayOnlyFPSSetting, QWidget* pParent)
     : QDialog(pParent)

--- a/Code/Editor/GameEngine.h
+++ b/Code/Editor/GameEngine.h
@@ -135,7 +135,6 @@ private:
     bool m_bJustCreated;
     bool m_bIgnoreUpdates;
     ISystem* m_pISystem;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Matrix34 m_playerViewTM;
     struct SSystemUserCallback* m_pSystemUserCallback;
     AZStd::unique_ptr<AZ::DynamicModuleHandle> m_hSystemHandle;
@@ -147,6 +146,5 @@ private:
     };
     EPendingGameMode m_ePendingGameMode;
     AZStd::unique_ptr<class ModalWindowDismisser> m_modalWindowDismisser;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 

--- a/Code/Editor/GenericSelectItemDialog.cpp
+++ b/Code/Editor/GenericSelectItemDialog.cpp
@@ -11,9 +11,7 @@
 
 #include "GenericSelectItemDialog.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_GenericSelectItemDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 // CGenericSelectItemDialog dialog
 

--- a/Code/Editor/GotoPositionDlg.cpp
+++ b/Code/Editor/GotoPositionDlg.cpp
@@ -20,9 +20,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_GotoPositionDlg.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 void GoToPositionPitchConstraints::DeterminePitchRange(const AngleRangeConfigureFn& configurePitchRangeFn) const
 {

--- a/Code/Editor/KeyboardCustomizationSettings.h
+++ b/Code/Editor/KeyboardCustomizationSettings.h
@@ -53,23 +53,18 @@ public:
     static void ImportFromFile(QWidget* parentWindow);
 
 private:
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     const QWidget* m_parent;
     const QString m_group;
     const Snapshot m_defaults;
     bool m_shortcutsEnabled;
     Snapshot m_lastEnabledShortcuts; // just to avoid load/save IO from/to disk
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     void LoadFromSnapshot(const Snapshot& snapshot);
-
     QJsonObject ExportGroup();
     void ImportGroup(const QJsonObject& group);
     void ClearShortcutsAndAccelerators();
-private:
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
+
     static QVector<KeyboardCustomizationSettings*> m_instances;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 #endif //CRYINCLUDE_EDITOR_KEYBOARD_CUSTOMIZATION_SETTINGS_H

--- a/Code/Editor/LayoutConfigDialog.cpp
+++ b/Code/Editor/LayoutConfigDialog.cpp
@@ -14,9 +14,7 @@
 // AzQtComponents
 #include <AzQtComponents/Components/StyleManager.h>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_LayoutConfigDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 class LayoutConfigModel
     : public QAbstractListModel

--- a/Code/Editor/LevelFileDialog.cpp
+++ b/Code/Editor/LevelFileDialog.cpp
@@ -23,9 +23,7 @@
 #include "API/ToolsApplicationAPI.h"
 
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_LevelFileDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 static const char lastLoadPathFilename[] = "lastLoadPath.preset";
 

--- a/Code/Editor/MainWindow.h
+++ b/Code/Editor/MainWindow.h
@@ -87,13 +87,11 @@ public Q_SLOTS:
     void Update(int count);
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SANDBOX_API MainWindow
     : public QMainWindow
     , public IEditorNotifyListener
     , private AzToolsFramework::SourceControlNotificationBus::Handler
 {
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Q_OBJECT
 
 public:
@@ -224,14 +222,12 @@ private:
 
     CLayoutWnd* m_pLayoutWnd;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZStd::shared_ptr<EngineConnectionListener> m_connectionListener;
     QTimer* m_connectionLostTimer;
 
     QScopedPointer<AzToolsFramework::QtSourceControlNotificationHandler> m_sourceControlNotifHandler;
 
     EditorActionsHandler m_editorActionsHandler;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     static MainWindow* m_instance;
 

--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -20,10 +20,7 @@
 #include <QToolButton>
 #include <QListWidgetItem>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_NewLevelDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
 
 // Folder in which levels are stored
 static const char kNewLevelDialog_LevelsFolder[] = "Levels";

--- a/Code/Editor/PluginManager.h
+++ b/Code/Editor/PluginManager.h
@@ -64,12 +64,9 @@ public:
     }
 
 protected:
-
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     TPluginList m_plugins;
     TPluginEventMap m_pluginEventMap;
     TUIIDPluginMap m_uuidPluginMap;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     int m_currentUUID;
 };
 #endif // CRYINCLUDE_EDITOR_PLUGINMANAGER_H

--- a/Code/Editor/Plugins/EditorCommon/ActionOutput.h
+++ b/Code/Editor/Plugins/EditorCommon/ActionOutput.h
@@ -46,10 +46,8 @@ namespace AZ
     private:
         AZStd::string BuildMessage(const IssueToDetails& issues) const;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         IssueToDetails m_errorToDetails;
         IssueToDetails m_warningToDetails;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         int m_errorCount;
         int m_warningCount;
     };

--- a/Code/Editor/Plugins/EditorCommon/DockTitleBarWidget.h
+++ b/Code/Editor/Plugins/EditorCommon/DockTitleBarWidget.h
@@ -53,8 +53,6 @@ private:
         int id;
         QAbstractButton* button;
     };
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     std::vector<SCustomButton> m_customButtons;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 

--- a/Code/Editor/Plugins/EditorCommon/SaveUtilities/AsyncSaveRunner.h
+++ b/Code/Editor/Plugins/EditorCommon/SaveUtilities/AsyncSaveRunner.h
@@ -126,11 +126,9 @@ namespace AZ
 
     private:
         AsyncSaveRunner& m_owner;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZStd::vector<AZStd::shared_ptr<SaveOperationCache>> m_allSaveOperations;
         SaveCompleteCallback m_onSaveComplete;
         AZStd::atomic<size_t> m_completedCount;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         bool m_currentSaveResult = true;
     };
 
@@ -155,14 +153,12 @@ namespace AZ
         friend class SaveOperationController;
         void HandleRunnerFinished(SaveOperationController* runner, bool success);
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZStd::vector<AZStd::shared_ptr<SaveOperationController>> m_allSaveControllers;
         SaveCompleteCallback m_onSaveAllComplete;
         AZStd::shared_ptr<ActionOutput> m_actionOutput;
         // If controller order is random this keeps track of the number of completed tasks, if the order is sequential it
         //      keeps track of the currently executing controller.
         AZStd::atomic<size_t> m_counter;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         ControllerOrder m_order;
         bool m_allWereSuccessfull = true;
     };

--- a/Code/Editor/QtViewPaneManager.h
+++ b/Code/Editor/QtViewPaneManager.h
@@ -236,7 +236,6 @@ private:
 
     bool ClosePane(QtViewPane* pane, QtViewPane::CloseModes closeModes = QtViewPane::CloseMode::None);
     int NextAvailableId();
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QtViewPanes m_registeredPanes;
     QByteArray m_defaultMainWindowState;
     QByteArray m_loadedMainWindowState;
@@ -255,7 +254,6 @@ private:
     using EditorWindowRequestBusImpl = AzToolsFramework::EditorWindowRequestBusImpl;
     EditorWindowRequestBusImpl m_windowRequest;                         //!< Helper for EditorWindowRequestBus so
                                                                         //!< QtViewPaneManager does not need to inherit directly from it. */
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 template<class TWidget>

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -302,7 +302,6 @@ struct SANDBOX_API SEditorSettings
     //////////////////////////////////////////////////////////////////////////
     SViewportsSettings viewports;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     SToolViewSettings toolViewSettings;
 
     //////////////////////////////////////////////////////////////////////////
@@ -383,7 +382,6 @@ struct SANDBOX_API SEditorSettings
 
     // Object Highlight Settings
     SObjectColors objectColorSettings;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     SSmartOpenDialogSettings smartOpenSettings;
 

--- a/Code/Editor/SettingsManagerDialog.cpp
+++ b/Code/Editor/SettingsManagerDialog.cpp
@@ -24,9 +24,7 @@
 #include "Util/AutoDirectoryRestoreFileDialog.h"    // for CAutoDirectoryRestoreFileDialog
 #include "LyViewPaneNames.h"                        // for LyViewPane::
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include "ui_SettingsManagerDialog.h"
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 //////////////////////////////////////////////////////////////////////////
 CSettingsManagerDialog::CSettingsManagerDialog(QWidget* pParent)

--- a/Code/Editor/StartupLogoDialog.cpp
+++ b/Code/Editor/StartupLogoDialog.cpp
@@ -15,9 +15,7 @@
 #include <QPainter>
 #include <QThread>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_StartupLogoDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 CStartupLogoDialog* CStartupLogoDialog::s_pLogoWindow = nullptr;
 

--- a/Code/Editor/ToolsConfigPage.cpp
+++ b/Code/Editor/ToolsConfigPage.cpp
@@ -26,11 +26,8 @@
 #include "MainWindow.h"
 #include "ToolBox.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_ToolsConfigPage.h>
 #include <ui_IconListDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace
 {

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -37,9 +37,7 @@
 #include "ViewPane.h"
 #include "Viewport.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <TrackView/ui_SequenceBatchRenderDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace
 {

--- a/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
+++ b/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
@@ -29,10 +29,7 @@
 #include "TrackViewDialog.h"
 #include "QtUI/ColorButton.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <TrackView/ui_TVCustomizeTrackColorsDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 #define TRACKCOLOR_ENTRY_PREFIX ("TrackColor")
 #define TRACKCOLOR_FOR_OTHERS_ENTRY ("TrackColorForOthers")

--- a/Code/Editor/TrackView/TVEventsDialog.cpp
+++ b/Code/Editor/TrackView/TVEventsDialog.cpp
@@ -22,10 +22,7 @@
 // Editor
 #include "AnimationContext.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <TrackView/ui_TVEventsDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 // CTVEventsDialog dialog
 

--- a/Code/Editor/TrackView/TVSequenceProps.cpp
+++ b/Code/Editor/TrackView/TVSequenceProps.cpp
@@ -22,11 +22,7 @@
 #include "TrackViewSequenceManager.h"
 #include "AnimationContext.h"
 
-
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <TrackView/ui_TVSequenceProps.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 CTVSequenceProps::CTVSequenceProps(CTrackViewSequence* pSequence, float fps, QWidget* pParent)
     : QDialog(pParent)

--- a/Code/Editor/TrackView/TrackViewCurveEditor.cpp
+++ b/Code/Editor/TrackView/TrackViewCurveEditor.cpp
@@ -13,9 +13,7 @@
 
 #include <AzCore/std/containers/set.h>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include "TrackView/ui_TrackViewCurveEditor.h"
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 
 TrackViewCurveEditorDialog::TrackViewCurveEditorDialog(QWidget* parent)

--- a/Code/Editor/TrackView/TrackViewFindDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewFindDlg.cpp
@@ -15,9 +15,7 @@
 #include "TrackViewSequenceManager.h"
 #include "AnimationContext.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <TrackView/ui_TrackViewFindDlg.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include "Maestro/Types/AnimNodeType.h"
 
 // CTrackViewFindDlg dialog

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
@@ -24,10 +24,7 @@
 // Editor
 #include "Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <TrackView/ui_TrackViewTrackPropsDlg.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
 
 void CTrackViewKeyUIControls::OnInternalVariableChange(IVariable* var)
 {

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -344,10 +344,7 @@ enum EMenuItem
 
 // The 'MI' represents a Menu Item.
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <TrackView/ui_TrackViewNodes.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
 
 CTrackViewNodesCtrl::CTrackViewNodesCtrl(QWidget* hParentWnd, CTrackViewDialog* parent /* = 0 */)
     : QWidget(hParentWnd)

--- a/Code/Editor/TrackView/TrackViewPythonFuncs.h
+++ b/Code/Editor/TrackView/TrackViewPythonFuncs.h
@@ -29,12 +29,10 @@ namespace AzToolsFramework
     };
 
     //! Component to access the TrackView
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     class SANDBOX_API TrackViewComponent final
         : public AZ::Component
         , public EditorLayerTrackViewRequestBus::Handler
     {
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     public:
         AZ_COMPONENT(TrackViewComponent, "{3CF943CC-6F10-4B19-88FC-CFB697558FFD}")
 

--- a/Code/Editor/TrackViewExportKeyTimeDlg.cpp
+++ b/Code/Editor/TrackViewExportKeyTimeDlg.cpp
@@ -11,9 +11,7 @@
 
 #include "TrackViewExportKeyTimeDlg.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_TrackViewExportKeyTimeDlg.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 //////////////////////////////////////////////////////////////////////////
 CTrackViewExportKeyTimeDlg::CTrackViewExportKeyTimeDlg(QWidget* parent)

--- a/Code/Editor/TrackViewFBXImportPreviewDialog.cpp
+++ b/Code/Editor/TrackViewFBXImportPreviewDialog.cpp
@@ -14,11 +14,7 @@
 // Qt
 #include <QAbstractListModel>
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_TrackViewFBXImportPreviewDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
 
 class FBXImportModel
     : public QAbstractListModel

--- a/Code/Editor/TrackViewNewSequenceDialog.cpp
+++ b/Code/Editor/TrackViewNewSequenceDialog.cpp
@@ -21,10 +21,7 @@
 // Editor
 #include "TrackView/TrackViewSequenceManager.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_TrackViewNewSequenceDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace
 {

--- a/Code/Editor/Undo/Undo.h
+++ b/Code/Editor/Undo/Undo.h
@@ -253,13 +253,10 @@ private: // ---------------------------------------------------------------
 
     AssetManagerUndoInterruptor* m_assetManagerUndoInterruptor;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
     std::list<CUndoStep*>      m_undoStack;
     std::list<CUndoStep*>      m_redoStack;
 
     std::vector<IUndoManagerListener*> m_listeners;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 class CScopedSuspendUndo

--- a/Code/Editor/UsedResources.h
+++ b/Code/Editor/UsedResources.h
@@ -22,8 +22,6 @@ public:
     CUsedResources();
     void Add(const char* pResourceFileName);
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     TResourceFiles files;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 #endif // CRYINCLUDE_EDITOR_USEDRESOURCES_H

--- a/Code/Editor/Util/PakFile.h
+++ b/Code/Editor/Util/PakFile.h
@@ -51,11 +51,10 @@ public:
 
     //! Return archive of this pak file wrapper.
     AZ::IO::INestedArchive* GetArchive() { return m_pArchive.get(); };
+
 private:
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZStd::intrusive_ptr<AZ::IO::INestedArchive> m_pArchive;
     AZ::IO::IArchive* m_pCryPak;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 #endif // CRYINCLUDE_EDITOR_UTIL_PAKFILE_H

--- a/Code/Editor/Util/Variable.h
+++ b/Code/Editor/Util/Variable.h
@@ -647,12 +647,10 @@ protected:
     //! Optional user data pointer
     QVariant m_userData;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     //! Extended data (Extended data is never copied, it's always private to this variable).
     WiredList m_wiredVars;
     OnSetCallbackList m_onSetFuncs;
     OnSetEnumCallbackList m_onSetEnumFuncs;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     uint16 m_flags;
     //! Limited to 8 flags.
@@ -880,9 +878,7 @@ public:
 
 protected:
     typedef std::vector<IVariablePtr> Variables;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Variables m_vars;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     //! Any string value displayed in properties.
     QString m_strValue;
 };
@@ -2032,9 +2028,7 @@ struct CSmartVariableArray
     VarType* GetVar() const { return pVar; };
 
 private:
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     _smart_ptr<VarType> pVar;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 //////////////////////////////////////////////////////////////////////////
 
@@ -2139,9 +2133,7 @@ protected:
     void GatherUsedResourcesInVar(IVariable* pVar, CUsedResources& resources);
 
     typedef std::vector<IVariablePtr> Variables;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Variables m_vars;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 typedef _smart_ptr<CVarBlock> CVarBlockPtr;
@@ -2174,9 +2166,7 @@ protected:
     void CopyVariableValues(CVarObject* sourceObject);
 
 private:
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     CVarBlockPtr m_vars;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 Q_DECLARE_METATYPE(IVariable *);

--- a/Code/Editor/Util/VariablePropertyType.h
+++ b/Code/Editor/Util/VariablePropertyType.h
@@ -64,9 +64,7 @@ namespace Prop
 
         PropertyType m_type;
         int m_numImages;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         IVarEnumListPtr m_enumList;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         float m_rangeMin;
         float m_rangeMax;
         float m_step;

--- a/Code/Editor/ViewManager.h
+++ b/Code/Editor/ViewManager.h
@@ -120,7 +120,6 @@ private:
     //FIELDS.
     float   m_zoomFactor;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZ::Aabb m_updateRegion;
 
     //! Origin of 2d viewports.
@@ -137,7 +136,6 @@ private:
     CViewport* m_pSelectedView;
 
     AZStd::shared_ptr<AzToolsFramework::ManipulatorManager> m_manipulatorManager;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 };
 
 #endif // CRYINCLUDE_EDITOR_VIEWMANAGER_H

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -252,13 +252,11 @@ public:
 protected:
     CLayoutViewPane* m_viewPane = nullptr;
     CViewManager* m_viewManager;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     // Screen Matrix
     Matrix34 m_screenTM;
     int m_nCurViewportID;
     // Final game view matrix before dropping back to editor
     Matrix34 m_gameTM;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     // Custom drop callback (Leroy@Conffx)
     DropCallback m_dropCallback;
@@ -444,7 +442,6 @@ public:
     void setRay(QPoint& vp, Vec3& raySrc, Vec3& rayDir) override;
 
     QPoint m_vp;
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Vec3 m_raySrc;
     Vec3 m_rayDir;
 
@@ -453,7 +450,6 @@ public:
     // during the SScopedCurrentContext count check of m_cameraSetForWidgetRenderingCount.
     int m_processingMouseCallbacksCounter = 0;
 
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 protected:
     friend class CViewManager;
     bool IsVectorInValidRange(const Vec3& v) const { return fabs(v.x) < 1e+8 && fabs(v.y) < 1e+8 && fabs(v.z) < 1e+8; }
@@ -498,9 +494,7 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent* event) override;
     void dropEvent(QDropEvent* event) override;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AzToolsFramework::ViewportUi::ViewportUiManager m_viewportUi;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     float m_selectionTolerance;
     QMenu m_cViewMenu;
@@ -537,11 +531,8 @@ protected:
 
     QRect m_rcClient;
 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
     typedef std::vector<_smart_ptr<IPostRenderer> > PostRenderers;
     PostRenderers   m_postRenderers;
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 protected:
     bool m_mouseCaptured = false;

--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -48,9 +48,7 @@
 
 #include <LmbrCentral/Audio/AudioSystemComponentBus.h>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include "ui_ViewportTitleDlg.h"
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #endif //! defined(Q_MOC_RUN)
 
 // CViewportTitleDlg dialog

--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
@@ -40,9 +40,7 @@
 #include "CryEdit.h"
 #include "LevelFileDialog.h"
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <WelcomeScreen/ui_WelcomeScreenDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 using namespace AzQtComponents;
 

--- a/Code/Framework/AzCore/AzCore/PlatformDef.h
+++ b/Code/Framework/AzCore/AzCore/PlatformDef.h
@@ -113,13 +113,6 @@
 #define AZ_POP_DISABLE_WARNING                          \
     __pragma(warning(pop))
 
-
-/// Disables a warning for dll exported classes which has non dll-exported members as this can cause ABI issues if the layout of those classes differs between dlls.
-/// QT classes such as QList, QString, QMap, etc... and Cry Math classes such Vec3, Quat, Color don't dllexport their interfaces
-/// Therefore this macro can be used to disable the warning when caused by 3rdParty libraries
-#define AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
-#define AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING AZ_POP_DISABLE_WARNING
-
 #   define AZ_FORCE_INLINE  __forceinline
 
 /// Pointer will be aliased.
@@ -183,9 +176,6 @@
     _Pragma("GCC diagnostic pop")
 
 #endif // defined(AZ_COMPILER_CLANG)
-
-#define AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-#define AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 #   define AZ_FORCE_INLINE  inline
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/ButtonStripe.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/ButtonStripe.h
@@ -38,9 +38,7 @@ namespace AzQtComponents
     private:
         QGridLayout* const m_gridLayout;
         QButtonGroup* const m_buttonGroup;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QList<QPushButton*> m_buttons;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 } // namespace AzQtComponents
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/DockTabWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/DockTabWidget.h
@@ -63,9 +63,6 @@ namespace AzQtComponents
     private:
         DockTabBar* m_tabBar;
         QWidget* m_mainEditorWindow;
-
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QMap<QDockWidget*, QMetaObject::Connection> m_titleBarChangedConnections;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.h
@@ -181,7 +181,6 @@ namespace AzQtComponents
         bool WidgetContainsPoint(QWidget* widget, const QPoint& pos) const;
 
         QMainWindow* m_mainWindow;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QList<QScreen*> m_desktopScreens;
 
 #ifdef AZ_PLATFORM_WINDOWS
@@ -193,7 +192,6 @@ namespace AzQtComponents
         QWidget* m_emptyWidget;
 
         FancyDockingDropZoneState m_dropZoneState;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
         // When a user hovers over a drop zone, we will fade it in using this timer
         QTimer* m_dropZoneHoverFadeInTimer;
@@ -236,11 +234,8 @@ namespace AzQtComponents
         private:
             QPointer<QScreen> m_placeholderScreen;
             QRect m_placeholder;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         } m_state;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         // map QDockWidget name with its last floating dock.
         QMap<QString, QString> m_placeholders;
         // map floating dock name with it's serialization and the geometry
@@ -258,7 +253,6 @@ namespace AzQtComponents
         QList<FancyDockingDropZoneWidget*> m_activeDropZoneWidgets;
 
         QList<QString> m_orderedFloatingDockWidgetNames;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
         QString m_floatingWindowIdentifierPrefix;
         QString m_tabContainerIdentifierPrefix;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotification.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotification.h
@@ -70,9 +70,7 @@ namespace AzQtComponents
         QTimer m_lifeSpan;
         uint32_t m_borderRadius = 0;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZStd::chrono::milliseconds m_fadeDuration;
         QScopedPointer<Ui::ToastNotification> m_ui;        
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotificationConfiguration.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/ToastNotificationConfiguration.h
@@ -39,9 +39,7 @@ namespace AzQtComponents
         QString m_customIconImage;
         uint32_t m_borderRadius = 0;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZStd::chrono::milliseconds m_duration = AZStd::chrono::milliseconds(5000);
         AZStd::chrono::milliseconds m_fadeDuration = AZStd::chrono::milliseconds(250);
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorLabel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorLabel.h
@@ -52,9 +52,6 @@ namespace AzQtComponents
     private:
         Swatch* m_swatch;
         ColorHexEdit* m_hexEdit;
-
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZ::Color m_color;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/ColorPreview.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/ColorPreview.h
@@ -49,10 +49,8 @@ namespace AzQtComponents
     private:
         AZ::Color colorUnderPoint(const QPoint& p);
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZ::Color m_currentColor;
         AZ::Color m_selectedColor;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QPoint m_dragStartPosition;
         Swatch* m_draggedSwatch;
     };

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/ColorWarning.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/ColorWarning.h
@@ -53,11 +53,8 @@ namespace AzQtComponents
 
     private:
         Mode m_mode = Mode::Warning;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZ::Color m_color;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QString m_message;
-
         QLabel* m_iconLabel;
         QLabel* m_messageLabel;
     };

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCard.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCard.h
@@ -52,10 +52,7 @@ namespace AzQtComponents
         explicit PaletteCardBase(QSharedPointer<Palette> palette, Internal::ColorController* controller, QUndoStack* undoStack, QWidget* parent = nullptr);
 
         bool m_modified;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QSharedPointer<Palette> m_palette;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
-
         CardHeader* m_header;
         PaletteView* m_paletteView;
         QLayout* m_contentsLayout;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.h
@@ -73,7 +73,6 @@ namespace AzQtComponents
         QUndoStack* m_undoStack;
 
         QVBoxLayout* m_layout;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QVector<QSharedPointer<PaletteCard>> m_paletteCards;
         QSize m_swatchSize;
         bool m_gammaEnabled = false;
@@ -81,6 +80,5 @@ namespace AzQtComponents
         int m_paletteWidth = 276;
 
         QSet<QObject*> m_registeredPaletteCards;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/Swatch.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/Swatch.h
@@ -44,9 +44,7 @@ namespace AzQtComponents
         void paintEvent(QPaintEvent* event) override;
 
     private:
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         AZ::Color m_color;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/GradientSlider.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/GradientSlider.h
@@ -77,10 +77,8 @@ namespace AzQtComponents
         void initGradientColors();
         QBrush gradientBrush() const;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         ColorFunction m_colorFunction;
         ToolTipFunction m_toolTipFunction;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QLinearGradient m_gradient;
         QPoint m_toolTipOffset;
         int m_decimals = 7;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/OverlayWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/OverlayWidget.h
@@ -129,14 +129,12 @@ namespace AzQtComponents
         static int PushLayer(OverlayWidget* targetOverlay, Internal::OverlayWidgetLayer* layer, bool hasBreakoutWindow);
 
         int m_layerIdCounter;
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QVector<LayerInfo> m_layers;
         QStackedLayout* m_stack;
         int m_rootIndex;
 
         Qt::DockWidgetAreas m_originalDockWidgetAreas;
         QPointer<QDockWidget> m_parentDockWidget;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     };
 } // namespace AzQtComponents
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidgetActionToolBar.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidgetActionToolBar.h
@@ -37,9 +37,7 @@ namespace AzQtComponents
         friend class TabWidget;
         friend class TabWidgetActionToolBarContainer;
 
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QHash<QAction*, QToolButton*> m_actionButtons;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
         void removeWidgetFromLayout(QWidget* widget);
     };

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.h
@@ -22,8 +22,7 @@ namespace AzQtComponents
 
     // 'AzQtComponents::VectorElement::m_deferredExternalValue': class 'AZStd::optional<AzQtComponents::VectorElement::DeferredSetValue>' needs to
     // have dll-interface to be used by clients of class 'AzQtComponents::VectorElement' 
-    AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
-    
+
     /*!
      * \class VectorElement
      * \brief All flexible vector GUI's are constructed using a number vector elements. Each Vector
@@ -127,8 +126,6 @@ namespace AzQtComponents
         //! avoid overwriting their work, until they finish editing
         AZStd::optional<DeferredSetValue> m_deferredExternalValue;
     };
-
-    AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
     //////////////////////////////////////////////////////////////////////////
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/SelectionProxyModel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/SelectionProxyModel.h
@@ -54,9 +54,7 @@ namespace AzQtComponents
 
         // Contains the chain of proxy models that leads us to the real model. The outer-most proxy model
         // comes first and is followed by inner proxy models.
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QVector<QAbstractProxyModel*> m_proxyModels;
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         QItemSelectionModel* m_sourceSelectionModel;
     };
 } // namespace AzQtComponents

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptHelpDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptHelpDialog.cpp
@@ -24,9 +24,7 @@
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>    // for EditorPythonConsoleInterface
 #include <AzToolsFramework/API/EditorWindowRequestBus.h>
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <AzToolsFramework/PythonTerminal/ui_ScriptHelpDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.cpp
@@ -30,10 +30,7 @@
 // Editor
 #include "ScriptHelpDialog.h"
 
-
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <AzToolsFramework/PythonTerminal/ui_ScriptTermDialog.h>
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 namespace AzToolsFramework
 {

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.h
@@ -47,10 +47,8 @@ namespace AZ
             float m_unitSizeInMeters = 1;
             float m_originalUnitSizeInMeters = 1;
 
-            AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
             AZStd::unique_ptr<DataTypes::MatrixType> m_adjustTransform;
             AZStd::unique_ptr<DataTypes::MatrixType> m_adjustTransformInverse;
-            AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
         };
     }
 };

--- a/Code/Tools/SceneAPI/SceneUI/CommonWidgets/JobWatcher.h
+++ b/Code/Tools/SceneAPI/SceneUI/CommonWidgets/JobWatcher.h
@@ -50,12 +50,10 @@ namespace AZ
             private:
                 static const int s_jobQueryInterval;
 
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 AZStd::vector<u64> m_reportedJobs;
                 AZStd::string m_sourceAssetFullPath;
                 QTimer* m_jobQueryTimer;
                 Uuid m_traceTag;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
             };
         } // namespace SceneUI
     } //  namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.h
+++ b/Code/Tools/SceneAPI/SceneUI/CommonWidgets/SceneSettingsCard.h
@@ -70,10 +70,8 @@ private:
     friend class SceneSettingsCard;
 };
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 class SCENE_UI_API SceneSettingsCard : public AzQtComponents::Card, public AZ::Debug::TraceMessageBus::Handler
 {
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Q_OBJECT
 public:
     enum class Layout
@@ -126,7 +124,6 @@ private:
     void ShowLogContextMenu(const QPoint& pos);
     void AddLogTableEntry(AzQtComponents::StyledDetailsTableModel::TableEntry& entry);
 
-AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     QMap<int, QVector<QPair<QString, QString>>> m_additionalLogDetails;
     
     AzToolsFramework::Debug::TraceContextMultiStackHandler m_traceStackHandler;
@@ -134,7 +131,6 @@ AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AzQtComponents::StyledDetailsTableModel* m_reportModel = nullptr;
     AzQtComponents::TableView* m_reportView = nullptr;
     AZStd::shared_ptr<AZ::SceneAPI::SceneUI::ProcessingHandler> m_targetHandler;
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
     SceneSettingsCardHeader* m_settingsHeader = nullptr;
     CompletionState m_completionState = CompletionState::Success;
     State m_sceneCardState = State::Loading;

--- a/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/AsyncOperationProcessingHandler.h
+++ b/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/AsyncOperationProcessingHandler.h
@@ -39,11 +39,9 @@ namespace AZ
                 void OnBackgroundOperationComplete();
 
             private:
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 AZStd::function<void()> m_operationToRun;
                 AZStd::function<void()> m_onComplete;
                 QThread* m_thread = nullptr;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
             };
         }
     }

--- a/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/ExportJobProcessingHandler.h
+++ b/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/ExportJobProcessingHandler.h
@@ -38,10 +38,8 @@ namespace AZ
                 void OnAllJobsComplete();
 
             private:
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 AZStd::string m_sourceAssetPath;
                 AZStd::unique_ptr<JobWatcher> m_jobWatcher;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
             };
         } // namespace SceneUI
     } //  namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/ProcessingHandler.h
+++ b/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/ProcessingHandler.h
@@ -46,9 +46,7 @@ namespace AZ
                 void ProcessingComplete();
 
             protected:
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 Uuid m_traceTag;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
             };
         }
     }

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionWidget.h
@@ -68,14 +68,12 @@ namespace AZ
                 size_t CalculateSelectedCount();
                 size_t CalculateTotalCount();
 
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 AZStd::set<Uuid> m_filterTypes;
                 AZStd::set<Crc32> m_filterVirtualTypes;
                 AZStd::string m_filterName;
                 QScopedPointer<Ui::NodeTreeSelectionWidget> ui;
                 AZStd::unique_ptr<SceneGraphWidget> m_treeWidget;
                 AZStd::unique_ptr<DataTypes::ISceneNodeSelectionList> m_list;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 bool m_narrowSelection;
             };
         } // UI

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.h
@@ -58,11 +58,9 @@ namespace AZ
                 void SetScale(const float scale);
 
             private:
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 AZ::Vector3 m_translation;
                 AZ::Vector3 m_rotation;
                 float m_scale;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
             };
 
             class TransformRowWidget : public QWidget

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/ManifestWidget.h
@@ -79,11 +79,9 @@ namespace AZ
                 void BuildPages();
                 void AddPage(const QString& category, ManifestWidgetPage* page);
 
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 PageList m_pages;
                 QScopedPointer<Ui::ManifestWidget> ui;
                 AZStd::shared_ptr<Containers::Scene> m_scene;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 SerializeContext* m_serializeContext;
             };
         } // namespace UI

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphInspectWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphInspectWidget.h
@@ -59,11 +59,9 @@ namespace AZ
             protected:
                 void OnSelectionChanged(AZStd::shared_ptr<const DataTypes::IGraphObject> item);
 
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 QScopedPointer<Ui::SceneGraphInspectWidget> ui;
                 QScopedPointer<SceneGraphWidget> m_graphView;
                 QScopedPointer<AzToolsFramework::ReflectedPropertyEditor> m_propertyEditor;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
                 SerializeContext* m_context;
             };

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphWidget.h
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphWidget.h
@@ -119,14 +119,12 @@ namespace AZ
                 QCheckBox* GetQCheckBox();
                 QTreeView* GetQTreeView();
 
-                AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 AZStd::vector<QStandardItem*> m_treeItems;
                 AZStd::set<Uuid> m_filterTypes;
                 AZStd::set<Crc32> m_filterVirtualTypes;
                 QScopedPointer<Ui::SceneGraphWidget> ui;
                 QScopedPointer<QStandardItemModel> m_treeModel;
                 AZStd::unique_ptr<DataTypes::ISceneNodeSelectionList> m_targetList;
-                AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
                 const Containers::Scene& m_scene;
 
                 size_t m_selectedCount;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
@@ -118,8 +118,6 @@ namespace AtomToolsFramework
         const AZ::Crc32 m_toolId = {};
 
         // Disable warning for dll export since this member won't be used outside this class
-        AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING;
         AZ::IO::FileDescriptorRedirector m_stdoutRedirection = AZ::IO::FileDescriptorRedirector(1); // < 1 for STDOUT
-        AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING;
     };
 } // namespace AtomToolsFramework


### PR DESCRIPTION
## What does this PR do?

This PR removes all instances and the declaration of the `AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING`/`AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING` macros. These macros are no longer required since [PR18427](https://github.com/o3de/o3de/pull/18427) disabled MSVC warning [4251](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251) globally, and add unnecessary clutter to many classes.

The very similar [PR19155](https://github.com/o3de/o3de/pull/19155), which removes all usages of the `AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING`, has already been merged.

## How was this PR tested?

Compile with MSVC on Windows, AR