### PR TITLE
Fix resources leak when exit GameLauncher.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
@@ -692,8 +692,17 @@ namespace AZ::RPI
         if (m_sceneMaterialSrgShaderAsset)
         {
             AZ::Data::AssetBus::Handler::BusDisconnect(m_sceneMaterialSrgShaderAsset.GetId());
-            m_sceneMaterialSrgShaderAsset->Release();
+            m_sceneMaterialSrgShaderAsset.Reset();
         }
+        if (m_sceneMaterialSrg)
+        {
+            m_sceneMaterialSrg.reset();
+        }
+        if (m_materialTypeBufferIndicesBuffer)
+        {
+            m_materialTypeBufferIndicesBuffer.reset();
+        }
+        m_materialTypeData.clear();
         MaterialInstanceHandlerInterface::Unregister(this);
         Data::InstanceDatabase<Material>::Destroy();
     }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -131,10 +131,10 @@ namespace AZ
             m_featureProcessorFactory.Shutdown();
             m_passSystem.Shutdown();
             m_dynamicDraw.Shutdown();
-            m_bufferSystem.Shutdown();
             m_materialSystem.Shutdown();
             m_modelSystem.Shutdown();
             m_shaderSystem.Shutdown();
+            m_bufferSystem.Shutdown();
             m_imageSystem.Shutdown();
             m_querySystem.Shutdown();
             m_rhiSystem.Shutdown();


### PR DESCRIPTION
## What does this PR do?

This PR fix https://github.com/o3de/o3de/issues/19157.

After material system shut down, it still hold references to some resources. They will be reported as leaks and trigger unexpected behaviors, like trying to recreate the destroyed AsyncUploadQueue.

Moreover, the buffer system shut down too early. Material system uses buffers.


## How was this PR tested?

Manually tested.
