### PR TITLE
Fix Clang20 compile errors

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.cpp
@@ -124,9 +124,8 @@ namespace AZ::Dom
     }
 
     Value::Value(Value&& value) noexcept
+        : m_value(AZStd::move(value.m_value))
     {
-        memcpy(this, &value, sizeof(Value));
-        memset(&value, 0, sizeof(Value));
     }
 
     Value::Value(AZStd::string_view stringView, bool copy)
@@ -273,9 +272,7 @@ namespace AZ::Dom
 
     Value& Value::operator=(Value&& other) noexcept
     {
-        SetNull();
-        memcpy(this, &other, sizeof(Value));
-        memset(&other, 0, sizeof(Value));
+        m_value = AZStd::move(other.m_value);
         return *this;
     }
 
@@ -298,10 +295,7 @@ namespace AZ::Dom
 
     void Value::Swap(Value& other) noexcept
     {
-        AZStd::aligned_storage_for_t<Value> temp;
-        memcpy(&temp, this, sizeof(Value));
-        memcpy(this, &other, sizeof(Value));
-        memcpy(&other, &temp, sizeof(Value));
+        AZStd::swap(m_value, other.m_value);
     }
 
     Type Dom::Value::GetType() const

--- a/Code/Framework/AzCore/AzCore/DOM/DomValueWriter.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValueWriter.cpp
@@ -85,10 +85,7 @@ namespace AZ::Dom
     template <class T, class A>
     void MoveVectorMemory(AZStd::vector<T, A>& dest, AZStd::vector<T, A>& source)
     {
-        dest.resize_no_construct(source.size());
-        const size_t size = sizeof(T) * source.size();
-        memcpy(dest.data(), source.data(), size);
-        memset(source.data(), 0, size);
+        dest = AZStd::move(source);
         source.resize(0);
     }
 

--- a/Code/Framework/AzCore/AzCore/Task/Internal/Task.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/Internal/Task.cpp
@@ -15,7 +15,7 @@ namespace AZ::Internal
         if (!other.m_relocator)
         {
             // The type-erased lambda is trivially relocatable OR, the lambda is heap allocated
-            memcpy(this, &other, sizeof(Task));
+            memcpy(reinterpret_cast<void*>(this), &other, sizeof(Task));
 
             // Prevent deletion in the event the lambda had spilled to the heap
             other.m_destroyer = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -269,7 +269,7 @@ namespace AzToolsFramework
             return m_entryType;
         }
 
-        inline constexpr auto operator"" _hash(const char* str, size_t len)
+        inline constexpr auto operator ""_hash(const char* str, size_t len)
         {
             return AZStd::hash<AZStd::string_view>{}(AZStd::string_view{ str, len });
         }

--- a/Code/Legacy/CryCommon/ISplines.h
+++ b/Code/Legacy/CryCommon/ISplines.h
@@ -362,24 +362,18 @@ namespace spline
     }
 
     /****************************************************************************
-    **                            Key classes                                                                    **
+    **                            Key classes                                  **
     ****************************************************************************/
-    template    <class T>
-    struct  SplineKey
+    template <class T>
+    struct SplineKey
     {
-        typedef T   value_type;
+        typedef T value_type;
 
-        float               time;       //!< Key time.
-        int                 flags;  //!< Key flags.
-        value_type  value;  //!< Key value.
-        value_type  ds;         //!< Incoming tangent.
-        value_type  dd;         //!< Outgoing tangent.
-        SplineKey()
-        {
-            memset(this, 0, sizeof(SplineKey));
-        }
-
-        SplineKey& operator=(const SplineKey& src) { memcpy(this, &src, sizeof(*this)); return *this; }
+        float time = 0;                 //!< Key time.
+        int flags = 0;                  //!< Key flags.
+        value_type value = type_zero(); //!< Key value.
+        value_type ds = type_zero();    //!< Incoming tangent.
+        value_type dd = type_zero();    //!< Outgoing tangent.
 
         static void Reflect(AZ::ReflectContext* context) {}
     };

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.h
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.h
@@ -23,9 +23,9 @@ namespace Archive
 {
     inline namespace literals
     {
-        constexpr AZ::u64 operator"" _kib(AZ::u64 value);
-        constexpr AZ::u64 operator"" _mib(AZ::u64 value);
-        constexpr AZ::u64 operator"" _gib(AZ::u64 value);
+        constexpr AZ::u64 operator ""_kib(AZ::u64 value);
+        constexpr AZ::u64 operator ""_mib(AZ::u64 value);
+        constexpr AZ::u64 operator ""_gib(AZ::u64 value);
     }
 
     // tag index that indicates the archived content being examined is uncompressed

--- a/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
+++ b/Gems/Archive/Code/Include/Archive/Clients/ArchiveInterfaceStructs.inl
@@ -13,17 +13,17 @@ namespace Archive
     // Implement byte storage multipliers
     inline namespace literals
     {
-        constexpr AZ::u64 operator"" _kib(AZ::u64 value)
+        constexpr AZ::u64 operator ""_kib(AZ::u64 value)
         {
             return value * (1 << 10);
         }
 
-        constexpr AZ::u64 operator"" _mib(AZ::u64 value)
+        constexpr AZ::u64 operator ""_mib(AZ::u64 value)
         {
             return value * (1 << 20);
         }
 
-        constexpr AZ::u64 operator"" _gib(AZ::u64 value)
+        constexpr AZ::u64 operator ""_gib(AZ::u64 value)
         {
             return value * (1 << 30);
         }

--- a/Gems/AtomTressFX/External/Code/src/Math/Vector3D.cpp
+++ b/Gems/AtomTressFX/External/Code/src/Math/Vector3D.cpp
@@ -30,14 +30,6 @@
 
 namespace AMD
 {
-    Vector3::Vector3(const Vector3& other)
-    {
-        x = other.x;
-        y = other.y;
-        z = other.z;
-        w = other.w;
-    }
-
     Vector3::Vector3(const Vector3& begin, const Vector3& end)
     {
         x = end.x - begin.x;
@@ -89,16 +81,6 @@ namespace AMD
         {
             return Vector3(0.0f, 0.0f, 0.0f);
         }
-    }
-
-    Vector3& Vector3::operator=(const Vector3& other)
-    {
-        x = other.x;
-        y = other.y;
-        z = other.z;
-        w = other.w;
-
-        return *this;
     }
 
     Vector3& Vector3::operator=(float val)

--- a/Gems/AtomTressFX/External/Code/src/Math/Vector3D.h
+++ b/Gems/AtomTressFX/External/Code/src/Math/Vector3D.h
@@ -63,9 +63,8 @@ namespace AMD
             m[2] = z;
         };
         Vector3(float* xyz);
-        Vector3(const Vector3& other);
+
         Vector3(const Vector3& begin, const Vector3& end);
-        ~Vector3() {};
 
     public:
         Vector3& Normalize();
@@ -87,7 +86,6 @@ namespace AMD
         const float& operator[](unsigned int i) const { return m[i]; }
         float& operator[](unsigned int i) { return m[i]; }
 
-        Vector3& operator=(const Vector3& other);
         Vector3& operator=(float val);
         Vector3& operator=(float* xyz);
         bool operator!=(float val) const;

--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientImageCreatorUtils.cpp
@@ -22,7 +22,12 @@
 #endif
 
 AZ_PUSH_DISABLE_WARNING(4777, "-Wunknown-warning-option")
+// Clang20 on Windows complains about the expression "(begin - &*context_.begin())" in OpenImageIo/detail/fmt/core.h:2716 not being a
+// constant expression, but other compilers dont. To fix this without needing to update the library, define an empty FMT_CONSTEVAL macro,
+// which disables constexpr format strings for the library entirely
+#define FMT_CONSTEVAL
 #include <OpenImageIO/imageio.h>
+#undef FMT_CONSTEVAL
 AZ_POP_DISABLE_WARNING
 
 namespace GradientSignal::ImageCreatorUtils

--- a/Gems/GradientSignal/Code/Tests/EditorGradientSignalBakerTests.cpp
+++ b/Gems/GradientSignal/Code/Tests/EditorGradientSignalBakerTests.cpp
@@ -23,7 +23,12 @@
 #include <Tests/GradientSignalTestFixtures.h>
 
 AZ_PUSH_DISABLE_WARNING(4777, "-Wunknown-warning-option")
+// Clang20 on Windows complains about the expression "(begin - &*context_.begin())" in OpenImageIo/detail/fmt/core.h:2716 not being a
+// constant expression, but other compilers dont. To fix this without needing to update the library, define an empty FMT_CONSTEVAL macro,
+// which disables constexpr format strings for the library entirely
+#define FMT_CONSTEVAL
 #include <OpenImageIO/imageio.h>
+#undef FMT_CONSTEVAL
 AZ_POP_DISABLE_WARNING
 
 

--- a/Gems/ImGui/External/ImGui/v1.82/imgui/imgui.cpp
+++ b/Gems/ImGui/External/ImGui/v1.82/imgui/imgui.cpp
@@ -834,6 +834,7 @@ CODE
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"  // warning: zero as null pointer constant                    // some standard header variations use #define NULL 0
 #pragma clang diagnostic ignored "-Wdouble-promotion"               // warning: implicit conversion from 'float' to 'double' when passing argument to function  // using printf() is a misery with this as C++ va_arg ellipsis changes float to double.
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"             // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'xxx'
 #elif defined(__GNUC__)
 // We disable -Wpragmas because GCC doesn't provide an has_warning equivalent and some forks/patches may not following the warning/version association.
 #pragma GCC diagnostic ignored "-Wpragmas"                  // warning: unknown option after '#pragma GCC diagnostic' kind

--- a/Gems/ImGui/External/ImGui/v1.82/imgui/imgui.h
+++ b/Gems/ImGui/External/ImGui/v1.82/imgui/imgui.h
@@ -104,6 +104,7 @@ Index of this file:
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"
 #if __has_warning("-Wzero-as-null-pointer-constant")
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif

--- a/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_draw.cpp
+++ b/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_draw.cpp
@@ -77,6 +77,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wreserved-id-macro"              // warning: macro name is a reserved identifier
 #pragma clang diagnostic ignored "-Wdouble-promotion"               // warning: implicit conversion from 'float' to 'double' when passing argument to function  // using printf() is a misery with this as C++ va_arg ellipsis changes float to double.
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"             // warning: first argument in call to 'memset'/'memcpy' is a pointer to non-trivially copyable type 'xxx'
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wpragmas"                  // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wunused-function"          // warning: 'xxxx' defined but not used

--- a/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_internal.h
+++ b/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_internal.h
@@ -70,6 +70,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #pragma clang diagnostic ignored "-Wdouble-promotion"
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"              // warning: unknown option after '#pragma GCC diagnostic' kind

--- a/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_tables.cpp
+++ b/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_tables.cpp
@@ -226,6 +226,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wenum-enum-conversion"           // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_')
 #pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"// warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"             // warning: first argument in call to 'memset'/'memcpy' is a pointer to non-trivially copyable type 'xxx'
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wpragmas"                          // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"                // warning: format not a string literal, format string not checked

--- a/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_widgets.cpp
+++ b/Gems/ImGui/External/ImGui/v1.82/imgui/imgui_widgets.cpp
@@ -77,6 +77,7 @@ Index of this file:
 #pragma clang diagnostic ignored "-Wenum-enum-conversion"           // warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_')
 #pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"// warning: bitwise operation between different enumeration types ('XXXFlags_' and 'XXXFlagsPrivate_') is deprecated
 #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#pragma clang diagnostic ignored "-Wnontrivial-memcall"             // warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'xxx'
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wpragmas"                          // warning: unknown option after '#pragma GCC diagnostic' kind
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"                // warning: format not a string literal, format string not checked

--- a/Gems/LyShine/Code/Source/Animation/2DSpline.h
+++ b/Gems/LyShine/Code/Source/Animation/2DSpline.h
@@ -300,22 +300,16 @@ namespace UiSpline
         }
     };
 
-    template    <class T>
-    struct  SplineKey
+    template <class T>
+    struct SplineKey
     {
-        typedef T   value_type;
+        typedef T value_type;
 
-        float               time;       //!< Key time.
-        int                 flags;  //!< Key flags.
-        value_type  value;  //!< Key value.
-        value_type  ds;         //!< Incoming tangent.
-        value_type  dd;         //!< Outgoing tangent.
-        SplineKey()
-        {
-            memset(this, 0, sizeof(SplineKey));
-        }
-
-        SplineKey& operator=(const SplineKey& src) { memcpy(this, &src, sizeof(*this)); return *this; }
+        float time = 0;                 //!< Key time.
+        int flags = 0;                  //!< Key flags.
+        value_type value = type_zero(); //!< Key value.
+        value_type ds = type_zero();    //!< Incoming tangent.
+        value_type dd = type_zero();    //!< Outgoing tangent.
 
         static void Reflect(AZ::ReflectContext*) {}
     };

--- a/Gems/WhiteBox/Code/Source/Core/WhiteBoxToolApi.cpp
+++ b/Gems/WhiteBox/Code/Source/Core/WhiteBoxToolApi.cpp
@@ -73,6 +73,7 @@ namespace OpenMesh
 AZ_PUSH_DISABLE_WARNING(4702, "-Wunknown-warning-option") // OpenMesh\Core\Utils\Property.hh has unreachable code
 AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations") // OpenMesh\Core\Utils\PropertyManager.hh uses deprecated functions
 AZ_PUSH_DISABLE_WARNING(4127, "-Wunknown-warning-option") // Conditional expression is constant.
+AZ_PUSH_DISABLE_WARNING(, "-Wdeprecated-literal-operator") // OpenMesh\Core\Geometry\Vector11T.hh uses deprecated literal operator
 #include <OpenMesh/Core/IO/MeshIO.hh>
 #include <OpenMesh/Core/IO/SR_binary.hh>
 #include <OpenMesh/Core/IO/importer/ImporterT.hh>
@@ -80,6 +81,7 @@ AZ_PUSH_DISABLE_WARNING(4127, "-Wunknown-warning-option") // Conditional express
 #include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
 #include <OpenMesh/Core/Utils/GenProg.hh>
 #include <OpenMesh/Core/Utils/vector_traits.hh>
+AZ_POP_DISABLE_WARNING
 AZ_POP_DISABLE_WARNING
 AZ_POP_DISABLE_WARNING
 AZ_POP_DISABLE_WARNING


### PR DESCRIPTION
## What does this PR do?

This PR fixes compile errors for Clang20, which are mostly caused by more strict heuristics:
* Use `memcpy`/`memset` for non-trivially-copyable classes (either remove the memcpy call or make the class/struct trivially copyable)
  * In one instance (Task.cpp move constructor) this was not easily possible, so I just cast it to `void*` (which is also what the compiler suggests). Just copying or moving the members of the class did not work (test case failure), keeping the memcpy operation works for all testcases
* User-defined literals must not have a space between `operator ""` and the suffix

The change in the GradientSignal gem are weird: The OpenImageIO library uses some constexpr format strings which do not work with Clang20, but work normally in MSVC. I did not really find a solution other than disabling constexpr formt strings for the whole library.

## How was this PR tested?

Compile with Clang20 on Windows, AR
