### PR TITLE
Re-enable deprecated-this-capture warning

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -358,7 +358,7 @@ CConsoleSCB::CConsoleSCB(QWidget* parent)
 
     connect(ui->lineEditFind, &QLineEdit::returnPressed, this, &CConsoleSCB::findNext);
 
-    connect(ui->closeButton, &QPushButton::clicked, [=]
+    connect(ui->closeButton, &QPushButton::clicked, [this]
     {
         ui->findBar->setVisible(false);
     });
@@ -366,7 +366,7 @@ CConsoleSCB::CConsoleSCB(QWidget* parent)
     connect(ui->findPrevButton, &QPushButton::clicked, this, &CConsoleSCB::findPrevious);
     connect(ui->findNextButton, &QPushButton::clicked, this, &CConsoleSCB::findNext);
 
-    connect(ui->lineEditFind, &QLineEdit::textChanged, [=](auto text)
+    connect(ui->lineEditFind, &QLineEdit::textChanged, [this](auto text)
     {
         m_highlighter->setSearchTerm(text);
     });

--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -566,7 +566,7 @@ void EditorActionsHandler::OnActionRegistrationHook()
             EditorIdentifiers::MainWindowActionContextIdentifier,
             "o3de.action.editor.exit",
             actionProperties,
-            [=]
+            [this]
             {
                 m_mainWindow->window()->close();
             }

--- a/Code/Editor/QtViewPaneManager.cpp
+++ b/Code/Editor/QtViewPaneManager.cpp
@@ -1110,7 +1110,7 @@ void QtViewPaneManager::RestoreDefaultLayout(bool resetSettings)
     // This class does all kinds of behind the scenes magic to make docking / restore work, especially with groups
     // so instead of doing our special default layout attach / docking right now, we want to make it happen
     // after all of the other events have been processed.
-    QTimer::singleShot(0, [=]
+    QTimer::singleShot(0, [=, this]
     {
         // If we are using the new docking, set the right dock area to be absolute
         // so that the inspector will be to the right of the viewport and console

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -145,7 +145,7 @@ void CSequenceBatchRenderDialog::reject()
 void CSequenceBatchRenderDialog::OnInitDialog()
 {
     QAction* browseAction = m_ui->m_destinationEdit->addAction(style()->standardPixmap(QStyle::SP_DirOpenIcon), QLineEdit::TrailingPosition);
-    connect(browseAction, &QAction::triggered, this, [=]()
+    connect(browseAction, &QAction::triggered, this, [this]()
     {
         const QString dir = QFileDialog::getExistingDirectory(this);
         if (!dir.isEmpty())

--- a/Code/Editor/Util/ColumnSortProxyModel.cpp
+++ b/Code/Editor/Util/ColumnSortProxyModel.cpp
@@ -132,7 +132,7 @@ void ColumnSortProxyModel::setSourceModel(QAbstractItemModel* sourceModel)
     connect(sourceModel, &QAbstractItemModel::rowsInserted, this, &ColumnSortProxyModel::SortModel);
     connect(sourceModel, &QAbstractItemModel::rowsRemoved, this, &ColumnSortProxyModel::SortModel);
     connect(sourceModel, &QAbstractItemModel::modelAboutToBeReset, this, &ColumnSortProxyModel::beginResetModel);
-    connect(sourceModel, &QAbstractItemModel::modelReset, this, [=]()
+    connect(sourceModel, &QAbstractItemModel::modelReset, this, [this]()
         {
             { QSignalBlocker sb(this);
               SortModel();

--- a/Code/Editor/Util/FileChangeMonitor.cpp
+++ b/Code/Editor/Util/FileChangeMonitor.cpp
@@ -92,7 +92,7 @@ void CFileChangeMonitor::AddIgnoreFileMask(const char* pMask)
 
 void CFileChangeMonitor::RemoveIgnoreFileMask(const char* pMask, int aAfterDelayMsec)
 {
-    QTimer::singleShot(aAfterDelayMsec, [=]() {
+    QTimer::singleShot(aAfterDelayMsec, [=, this]() {
         m_ignoreMasks.removeAll(QString::fromLatin1(pMask));
     });
 }

--- a/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushBaseTests.cpp
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushBaseTests.cpp
@@ -164,7 +164,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnBrushStrokeBegin)
             .WillByDefault(
-                [=](const AZ::Color& strokeColor)
+                [this](const AZ::Color& strokeColor)
                 {
                     EXPECT_THAT(TestColor, IsClose(strokeColor));
                     return TestColor;
@@ -190,7 +190,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnGetColor)
             .WillByDefault(
-                [=](const AZ::Vector3& brushCenterPoint)
+                [this](const AZ::Vector3& brushCenterPoint)
                 {
                     // We expect the brush center to match what we passed in but with a Z value of 0
                     // because we only support painting in 2D for now.
@@ -217,7 +217,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnGetColor)
             .WillByDefault(
-                [=](const AZ::Vector3& brushCenterPoint)
+                [this](const AZ::Vector3& brushCenterPoint)
                 {
                     // We expect the brush center to match what we passed in but with a Z value of 0
                     // because we only support painting in 2D for now.

--- a/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintLocationTests.cpp
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintLocationTests.cpp
@@ -48,7 +48,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color,
+                [=, this]([[maybe_unused]] const AZ::Color& color,
                     const AZ::Aabb& dirtyArea,
                     AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     AzFramework::PaintBrushNotifications::BlendFn& blendFn)
@@ -195,9 +195,9 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
+                [=, this]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
                     // On the first PaintToLocation, we expect to get a dirtyArea that exactly fits our first paint brush stamp.
                     const AZ::Aabb expectedFirstDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius);
@@ -208,9 +208,9 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
+                [=, this]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
                     // On the second PaintToLocation, we expect the dirtyArea to only contain the next 3 paint brush stamps,
                     // but not the first one.
@@ -248,9 +248,9 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
+                [=, this]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
                     // We expect that the Y value for our dirtyArea won't be changed even though we'll call UseEyedropper
                     // with a large Y value in-between the two paint calls.
@@ -304,9 +304,9 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnPaint)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
-                    [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
+                [=, this]([[maybe_unused]] const AZ::Color& color, const AZ::Aabb& dirtyArea,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
+                          [[maybe_unused]] AzFramework::PaintBrushNotifications::BlendFn& blendFn)
                 {
                     // On the first PaintToLocation, we expect to get a dirtyArea that exactly fits our first paint brush stamp.
                     const AZ::Aabb expectedFirstDirtyArea = AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestBrushRadius);

--- a/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintSettingsTests.cpp
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushPaintSettingsTests.cpp
@@ -210,7 +210,7 @@ namespace UnitTest
         {
             m_settings.SetSize(brushRadiusSize * 2.0f);
 
-            ValidationFn validateFn = [=](const AZ::Aabb& dirtyArea,
+            ValidationFn validateFn = [=, this](const AZ::Aabb& dirtyArea,
                                   AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
             {
                 // The dirtyArea AABB should change size based on the current brush radius size that we're using.
@@ -275,7 +275,7 @@ namespace UnitTest
             m_settings.SetHardnessPercent(hardnessPercent);
 
             ValidationFn validateFn =
-                [=]([[maybe_unused]] const AZ::Aabb& dirtyArea, AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
+                [=, this]([[maybe_unused]] const AZ::Aabb& dirtyArea, AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
             {
                 // The falloff function should start at the hardness percentage from the center.
                 const float falloffStart = hardnessPercent / 100.0f;
@@ -327,7 +327,7 @@ namespace UnitTest
 
         // Verify that paint/smooth uses the hardness percent correctly.
         ValidationFn validateFn =
-            [=]([[maybe_unused]] const AZ::Aabb& dirtyArea, AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
+            [=, this]([[maybe_unused]] const AZ::Aabb& dirtyArea, AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
         {
             const AZStd::vector<AZ::Vector3> points = {
                 // Test the opacity at the brush center + 0%, 25%, 50%, 75%, 100%
@@ -384,7 +384,7 @@ namespace UnitTest
         // On the first PaintToLocation() call, we only have a single brush circle, so it should have a constant
         // opacity value that matches our flow percentage.
         ValidationFn validateFirstCallFn =
-            [=]([[maybe_unused]] const AZ::Aabb& dirtyArea, AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
+            [=, this]([[maybe_unused]] const AZ::Aabb& dirtyArea, AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
         {
             AZStd::vector<AZ::Vector3> points;
 
@@ -508,14 +508,14 @@ namespace UnitTest
             // On the first *ToLocation() call, we only have a single brush circle, so it should have a constant
             // opacity value that matches our flow percentage.
             ValidationFn validateFirstCallFn =
-                [=](const AZ::Aabb& dirtyArea, [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
+                [=, this](const AZ::Aabb& dirtyArea, [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
             {
                 // On the first call, the dirtyArea AABB should match the size of the brush.
                 EXPECT_THAT(dirtyArea, IsClose(AZ::Aabb::CreateCenterRadius(TestBrushCenter2d, TestRadiusSize)));
             };
 
             ValidationFn validateSecondCallFn =
-                [=](const AZ::Aabb& dirtyArea, [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
+                [=, this](const AZ::Aabb& dirtyArea, [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn)
             {
                 // On the second call, a number of brush circles will be applied based on the distance %. The first
                 // brush circle in this call will start distance % further than the left edge of our initial circle.

--- a/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushSmoothLocationTests.cpp
+++ b/Code/Framework/AzFramework/Tests/PaintBrush/PaintBrushSmoothLocationTests.cpp
@@ -51,7 +51,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color,
+                [=, this]([[maybe_unused]] const AZ::Color& color,
                     const AZ::Aabb& dirtyArea,
                     AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     AZStd::span<const AZ::Vector3> valuePointOffsets,
@@ -217,7 +217,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color,
+                [=, this]([[maybe_unused]] const AZ::Color& color,
                     const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
@@ -232,7 +232,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color,
+                [=, this]([[maybe_unused]] const AZ::Color& color,
                     const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
@@ -274,7 +274,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color,
+                [=, this]([[maybe_unused]] const AZ::Color& color,
                     const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,
@@ -332,7 +332,7 @@ namespace UnitTest
 
         ON_CALL(mockHandler, OnSmooth)
             .WillByDefault(
-                [=]([[maybe_unused]] const AZ::Color& color,
+                [=, this]([[maybe_unused]] const AZ::Color& color,
                     const AZ::Aabb& dirtyArea,
                     [[maybe_unused]] AzFramework::PaintBrushNotifications::ValueLookupFn& valueLookupFn,
                     [[maybe_unused]] AZStd::span<const AZ::Vector3> valuePointOffsets,

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/DockTabBar.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/DockTabBar.cpp
@@ -182,7 +182,7 @@ namespace AzQtComponents
     void DockTabBar::tabInserted(int index)
     {
         auto closeButton = new DockBarButton(DockBarButton::CloseButton);
-        connect(closeButton, &DockBarButton::clicked, this, [=] {
+        connect(closeButton, &DockBarButton::clicked, this, [=, this] {
             int widgetIndex = tabAt(closeButton->pos());
             if (widgetIndex >= 0)
             {

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
@@ -2496,7 +2496,7 @@ namespace AzQtComponents
             }
 
             // do the rest after the show has been fully processed, just to be sure
-            QTimer::singleShot(0, [=]()
+            QTimer::singleShot(0, [=, this]()
             {
                 // Ensure that the dock window is shown, because we may have hidden it when the drag started
                 dock->show();

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/ExampleAdapter.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/ExampleAdapter.cpp
@@ -32,7 +32,7 @@ namespace AZ::DocumentPropertyEditor
         builder.Label("Row Count");
         builder.BeginPropertyEditor<IntSpinBox>(m_rowCount);
         builder.OnEditorChanged(
-            [=](const Dom::Path&, const Dom::Value& value, Nodes::ValueChangeType)
+            [this](const Dom::Path&, const Dom::Value& value, Nodes::ValueChangeType)
             {
                 m_rowCount = aznumeric_caster(value.GetInt64());
                 ResizeMatrix();
@@ -41,7 +41,7 @@ namespace AZ::DocumentPropertyEditor
         builder.Label("Column Count");
         builder.BeginPropertyEditor<IntSpinBox>(m_columnCount);
         builder.OnEditorChanged(
-            [=](const Dom::Path&, const Dom::Value& value, Nodes::ValueChangeType)
+            [this](const Dom::Path&, const Dom::Value& value, Nodes::ValueChangeType)
             {
                 m_columnCount = aznumeric_caster(value.GetInt64());
                 ResizeMatrix();
@@ -67,7 +67,7 @@ namespace AZ::DocumentPropertyEditor
             {
                 builder.BeginPropertyEditor<IntSpinBox>(GetMatrixValue(i, c));
                 builder.OnEditorChanged(
-                    [=](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
+                    [=, this](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                     {
                         SetMatrixValue(i, c, aznumeric_caster(value.GetInt64()));
                         NotifyContentsChanged({ Dom::PatchOperation::ReplaceOperation(path, value) });
@@ -97,7 +97,7 @@ namespace AZ::DocumentPropertyEditor
             builder.Label(entry.m_label);
             builder.BeginPropertyEditor(Nodes::Color::Name, AZ::Dom::Utils::ValueFromType(entry.m_node->m_color));
             builder.OnEditorChanged(
-                [=](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
+                [=, this](const Dom::Path& path, const Dom::Value& value, Nodes::ValueChangeType)
                 {
                     entry.m_node->m_color = AZ::Dom::Utils::ValueToType<AZ::Color>(value).value();
                     NotifyContentsChanged({ Dom::PatchOperation::ReplaceOperation(path, value) });
@@ -111,7 +111,7 @@ namespace AZ::DocumentPropertyEditor
                 builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::RemoveElement);
                 builder.CallbackAttribute(
                     Nodes::ContainerActionButton::OnActivate,
-                    [=]()
+                    [=, this]()
                     {
                         for (auto it = entry.m_node->m_parent->m_children.begin(); it != entry.m_node->m_parent->m_children.end(); ++it)
                         {
@@ -131,7 +131,7 @@ namespace AZ::DocumentPropertyEditor
             builder.Attribute(Nodes::ContainerActionButton::Action, Nodes::ContainerAction::AddElement);
             builder.CallbackAttribute(
                 Nodes::ContainerActionButton::OnActivate,
-                [=]()
+                [=, this]()
                 {
                     ColorTreeNode child;
                     child.m_parent = entry.m_node;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetEntryChangeset.cpp
@@ -183,7 +183,7 @@ namespace AzToolsFramework
             // querying the asset database for the root folder
             m_databaseConnection->QueryScanFolderByDisplayName(
                 "root",
-                [=](ScanFolderDatabaseEntry& scanFolderDatabaseEntry)
+                [this](ScanFolderDatabaseEntry& scanFolderDatabaseEntry)
                 {
                     m_relativePath = scanFolderDatabaseEntry.m_scanFolder.c_str();
                     return true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchAssetTypeSelectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchAssetTypeSelectorWidget.cpp
@@ -123,7 +123,7 @@ namespace AzToolsFramework
                 m_actionFiltersMapping[checkbox] = FilterConstType(groupFilter);
 
                 connect(checkbox, &QCheckBox::clicked, this,
-                    [=](bool checked)
+                    [=, this](bool checked)
                     {
                         if (checked)
                         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/FilteredDPE.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/FilteredDPE.cpp
@@ -22,7 +22,7 @@ namespace AzToolsFramework
         QObject::connect(
             m_ui->m_searchBox,
             &QLineEdit::textChanged,
-            [=](const QString& filterText)
+            [this](const QString& filterText)
             {
                 m_filterAdapter->SetFilterString(filterText.toUtf8().data());
             });

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -212,7 +212,7 @@ namespace AzToolsFramework
         }
 
         connect(m_pColorDialog, &AzQtComponents::ColorPicker::currentColorChanged, this, 
-            [=](AZ::Color color)
+            [this](AZ::Color color)
         {
             color = TransformColor(color, m_config.m_colorPickerDialogColorSpaceId, m_config.m_propertyColorSpaceId);
             m_pColorDialog->setAlternateColorspaceValue(color);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -1085,34 +1085,34 @@ namespace AzToolsFramework
         {
             newWidget = aznew PropertyRowWidget(m_containerWidget);
             QObject::connect(newWidget, &PropertyRowWidget::onRequestedContainerClear, m_editor,
-                [=](InstanceDataNode* node)
+                [=, this](InstanceDataNode* node)
             {
                 m_editor->OnPropertyRowRequestClear(newWidget, node);
             }
             );
             QObject::connect(newWidget, &PropertyRowWidget::onRequestedContainerElementRemove, m_editor,
-                [=](InstanceDataNode* node)
+                [=, this](InstanceDataNode* node)
             {
                 m_editor->OnPropertyRowRequestContainerRemoveItem(newWidget, node);
             }
             );
 
             QObject::connect(newWidget, &PropertyRowWidget::onRequestedContainerAdd, m_editor,
-                [=](InstanceDataNode* node)
+                [=, this](InstanceDataNode* node)
             {
                 m_editor->OnPropertyRowRequestContainerAddItem(newWidget, node);
             }
             );
 
             QObject::connect(newWidget, &PropertyRowWidget::onUserExpandedOrContracted, m_editor,
-                [=](InstanceDataNode* node, bool expanded)
+                [=, this](InstanceDataNode* node, bool expanded)
             {
                 m_editor->OnPropertyRowExpandedOrContracted(newWidget, node, expanded, true);
             }
             );
 
             QObject::connect(newWidget, &PropertyRowWidget::onRequestedContextMenu, m_editor,
-                [=](InstanceDataNode* node, const QPoint& point)
+                [this](InstanceDataNode* node, const QPoint& point)
             {
                 if (m_ptrNotify)
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ConsoleTextEdit.cpp
@@ -49,7 +49,7 @@ namespace AzToolsFramework
             deleteAction,
             &QAction::triggered,
             this,
-            [=]()
+            [this]()
             {
                 textCursor().removeSelectedText();
             });
@@ -75,7 +75,7 @@ namespace AzToolsFramework
             this,
             &QPlainTextEdit::textChanged,
             selectAllAction,
-            [=]
+            [=, this]
             {
                 if (document() && !document()->isEmpty())
                 {

--- a/Code/Tools/AssetBundler/source/ui/RulesTabWidget.cpp
+++ b/Code/Tools/AssetBundler/source/ui/RulesTabWidget.cpp
@@ -429,12 +429,12 @@ namespace AssetBundler
 
         QAction* moveUpAction = new QAction(tr("Move Up"), this);
         moveUpAction->setEnabled(comparisonDataIndex > 0);
-        connect(moveUpAction, &QAction::triggered, this, [=]() { MoveComparisonStep(comparisonDataIndex, comparisonDataIndex - 1); });
+        connect(moveUpAction, &QAction::triggered, this, [=, this]() { MoveComparisonStep(comparisonDataIndex, comparisonDataIndex - 1); });
         menu.addAction(moveUpAction);
 
         QAction* moveDownAction = new QAction(tr("Move Down"), this);
         moveDownAction->setEnabled(comparisonDataIndex < m_selectedComparisonRules->GetNumComparisonSteps() - 1);
-        connect(moveDownAction, &QAction::triggered, this, [=]() { MoveComparisonStep(comparisonDataIndex, comparisonDataIndex + 2); });
+        connect(moveDownAction, &QAction::triggered, this, [=, this]() { MoveComparisonStep(comparisonDataIndex, comparisonDataIndex + 2); });
         menu.addAction(moveDownAction);
 
         QAction* separator = new QAction(this);
@@ -442,7 +442,7 @@ namespace AssetBundler
         menu.addAction(separator);
 
         QAction* deleteAction = new QAction(tr("Remove Comparison Step"), this);
-        connect(deleteAction, &QAction::triggered, this, [=]() { RemoveComparisonStep(comparisonDataIndex); });
+        connect(deleteAction, &QAction::triggered, this, [=, this]() { RemoveComparisonStep(comparisonDataIndex); });
         menu.addAction(deleteAction);
 
         menu.exec(position);

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
@@ -163,7 +163,7 @@ namespace AssetProcessor
             // Make sure this is the only connection to the button.
             m_ui->gotoAssetButton->m_ui->goToPushButton->disconnect();
 
-            connect(m_ui->gotoAssetButton->m_ui->goToPushButton, &QPushButton::clicked, [=] {
+            connect(m_ui->gotoAssetButton->m_ui->goToPushButton, &QPushButton::clicked, [=, this] {
                 GoToSource(SourceAssetReference(sourceEntry.m_scanFolderPK, sourceEntry.m_sourceName.c_str()).AbsolutePath().c_str());
             });
 
@@ -478,7 +478,7 @@ namespace AssetProcessor
 
         AddProductIdToScanCount(productItemData->m_databaseInfo.m_productID, scanName);
         // Run the scan on another thread so the UI remains responsive.
-        auto* job = AZ::CreateJobFunction([=]() {
+        auto* job = AZ::CreateJobFunction([=, this]() {
             MissingDependencyScannerRequestBus::Broadcast(&MissingDependencyScannerRequestBus::Events::ScanFile,
                 pathOnDisk.toUtf8().constData(),
                 MissingDependencyScanner::DefaultMaxScanIteration,
@@ -486,7 +486,7 @@ namespace AssetProcessor
                 existingDependencies,
                 m_assetDatabaseConnection,
                 /*queueDbCommandsOnMainThread*/ true,
-                [=]([[maybe_unused]] AZStd::string relativeDependencyFilePath) {
+                [=, this]([[maybe_unused]] AZStd::string relativeDependencyFilePath) {
                 RemoveProductIdFromScanCount(productItemData->m_databaseInfo.m_productID, scanName);
                 // The MissingDependencyScannerRequestBus callback always runs on the main thread, so no need to queue again.
                 AzToolsFramework::AssetDatabase::AssetDatabaseNotificationBus::Broadcast(

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
@@ -139,7 +139,7 @@ namespace AssetProcessor
             connect(
                 m_ui->gotoAssetButton->m_ui->goToPushButton,
                 &QPushButton::clicked,
-                [=]
+                [=, this]
                 {
                     GoToSource(SourceAssetReference(upstreamSource).AbsolutePath().c_str());
                 });

--- a/Code/Tools/AssetProcessor/native/utilities/MissingDependencyScanner.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/MissingDependencyScanner.cpp
@@ -225,7 +225,7 @@ namespace AssetProcessor
 
         if (queueDbCommandsOnMainThread && !m_shutdownRequested)
         {
-            AZ::SystemTickBus::QueueFunction([=]()
+            AZ::SystemTickBus::QueueFunction([=, this]()
             {
                 ReportMissingDependencies(productPK, databaseConnection, dependencyTokenName, missingDependencies, callback);
             });

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -237,7 +237,7 @@ namespace O3DE::ProjectManager
         gemSetupLayout->addWidget(m_gemTemplateLocation);
         m_gemTemplateLocation->setEnabled(false);
 
-        connect(m_formFolderRadioButton, &QRadioButton::toggled, this, [=](bool checked){
+        connect(m_formFolderRadioButton, &QRadioButton::toggled, this, [this](bool checked){
             m_gemTemplateLocation->setEnabled(checked);
         });
 

--- a/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
@@ -61,7 +61,7 @@ namespace O3DE::ProjectManager
 
 
         // When there are multiple project templates present, we re-gather the gems when changing the selected the project template.
-        connect(m_newProjectSettingsScreen, &NewProjectSettingsScreen::OnTemplateSelectionChanged, this, [=](int oldIndex, [[maybe_unused]] int newIndex)
+        connect(m_newProjectSettingsScreen, &NewProjectSettingsScreen::OnTemplateSelectionChanged, this, [this](int oldIndex, [[maybe_unused]] int newIndex)
             {
                 const GemModel* gemModel = m_projectGemCatalogScreen->GetGemModel();
                 const QVector<QModelIndex> toBeAdded = gemModel->GatherGemsToBeAdded();

--- a/Code/Tools/ProjectManager/Source/DownloadWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/DownloadWorker.cpp
@@ -20,7 +20,7 @@ namespace O3DE::ProjectManager
 
     void DownloadWorker::StartDownload()
     {
-        auto objectDownloadProgress = [=](int bytesDownloaded, int totalBytes)
+        auto objectDownloadProgress = [this](int bytesDownloaded, int totalBytes)
         {
             emit UpdateProgress(bytesDownloaded, totalBytes);
         };

--- a/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/FormLineEditTagsWidget.cpp
@@ -85,7 +85,7 @@ namespace O3DE::ProjectManager
         m_dropdownButton = new QPushButton(QIcon(":/CarrotArrowDown.svg"), "", this);
         m_dropdownButton->setObjectName("dropDownButton");
         m_frameLayout->addWidget(m_dropdownButton);
-        connect(m_dropdownButton, &QPushButton::clicked, this, [=]([[maybe_unused]]bool ignore){ m_lineEdit->completer()->complete(QRect()); });
+        connect(m_dropdownButton, &QPushButton::clicked, this, [this]([[maybe_unused]]bool ignore){ m_lineEdit->completer()->complete(QRect()); });
 
         //section of form for showing tags
         m_tagFrame = new QFrame(this);

--- a/Code/Tools/ProjectManager/Source/FormOptionsWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/FormOptionsWidget.cpp
@@ -50,7 +50,7 @@ namespace O3DE::ProjectManager
                 {
                     QCheckBox* optionCheckBox = new QCheckBox(option);
                     optionLayout->addWidget(optionCheckBox);
-                    connect(optionCheckBox, &QCheckBox::clicked, this, [=](bool checked){
+                    connect(optionCheckBox, &QCheckBox::clicked, this, [=, this](bool checked){
                         if(checked)
                         {
                             Enable(option);
@@ -66,7 +66,7 @@ namespace O3DE::ProjectManager
 
                 //Add the platform option toggle
                 m_allOptionsToggle = new QCheckBox(allOptionsText);
-                connect(m_allOptionsToggle, &QCheckBox::clicked, this, [=](bool checked){
+                connect(m_allOptionsToggle, &QCheckBox::clicked, this, [this](bool checked){
                     if(checked)
                     {
                         EnableAll();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
@@ -47,7 +47,7 @@ namespace O3DE::ProjectManager
         closeButton->setFlat(true);
         closeButton->setFocusPolicy(Qt::NoFocus);
         closeButton->setIcon(QIcon(":/WindowClose.svg"));
-        connect(closeButton, &QPushButton::clicked, this, [=]
+        connect(closeButton, &QPushButton::clicked, this, [this]
             {
                 deleteLater();
             });
@@ -59,7 +59,7 @@ namespace O3DE::ProjectManager
         CreateDownloadSection();
 
         // added
-        CreateGemSection( tr("Gem to be activated"), tr("Gems to be activated"), [=]
+        CreateGemSection( tr("Gem to be activated"), tr("Gems to be activated"), [this]
             {
                 QVector<QModelIndex> gems;
                 const QVector<QModelIndex> toBeAdded = m_gemModel->GatherGemsToBeAdded(/*includeDependencies=*/false);
@@ -76,7 +76,7 @@ namespace O3DE::ProjectManager
             });
 
         // removed
-        CreateGemSection( tr("Gem to be deactivated"), tr("Gems to be deactivated"), [=]
+        CreateGemSection( tr("Gem to be deactivated"), tr("Gems to be deactivated"), [this]
             {
                 QVector<QModelIndex> gems;
                 const QVector<QModelIndex> toBeAdded = m_gemModel->GatherGemsToBeRemoved(/*includeDependencies=*/false);
@@ -93,7 +93,7 @@ namespace O3DE::ProjectManager
             });
 
         // added dependencies 
-        CreateGemSection( tr("Dependency to be activated"), tr("Dependencies to be activated"), [=]
+        CreateGemSection( tr("Dependency to be activated"), tr("Dependencies to be activated"), [this]
             {
                 QVector<QModelIndex> dependencies;
                 const QVector<QModelIndex> toBeAdded = m_gemModel->GatherGemsToBeAdded(/*includeDependencies=*/true);
@@ -110,7 +110,7 @@ namespace O3DE::ProjectManager
             });
 
         // removed dependencies 
-        CreateGemSection( tr("Dependency to be deactivated"), tr("Dependencies to be deactivated"), [=]
+        CreateGemSection( tr("Dependency to be deactivated"), tr("Dependencies to be deactivated"), [this]
             {
                 QVector<QModelIndex> dependencies;
                 const QVector<QModelIndex> toBeRemoved = m_gemModel->GatherGemsToBeRemoved(/*includeDependencies=*/true);
@@ -144,7 +144,7 @@ namespace O3DE::ProjectManager
         TagContainerWidget* tagContainer = new TagContainerWidget();
         layout->addWidget(tagContainer);
 
-        auto update = [=]()
+        auto update = [=, this]()
         {
             const QVector<QModelIndex> tagIndices = getTagIndices();
             if (tagIndices.isEmpty())
@@ -408,7 +408,7 @@ namespace O3DE::ProjectManager
         m_layout->addWidget(m_dropDownButton);
 
         // Adjust the label text whenever the model gets updated.
-        connect(gemModel, &GemModel::dataChanged, [=]
+        connect(gemModel, &GemModel::dataChanged, [this]
             {
                 const QVector<QModelIndex> toBeAdded = m_gemModel->GatherGemsToBeAdded(/*includeDependencies=*/true);
                 const QVector<QModelIndex> toBeRemoved = m_gemModel->GatherGemsToBeRemoved(/*includeDependencies=*/true);
@@ -458,7 +458,7 @@ namespace O3DE::ProjectManager
         }
 
         m_gemCart = new GemCartWidget(m_gemModel, m_downloadController, this);
-        connect(m_gemCart, &QWidget::destroyed, this, [=]
+        connect(m_gemCart, &QWidget::destroyed, this, [this]
             {
                 // Reset the overlay pointer on destruction to prevent dangling pointers.
                 m_gemCart = nullptr;

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -98,7 +98,7 @@ namespace O3DE::ProjectManager
         connect(
             m_gemInspector,
             &GemInspector::TagClicked,
-            [=](const Tag& tag)
+            [this](const Tag& tag)
             {
                 SelectGem(tag.id);
             });

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemDependenciesDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemDependenciesDialog.cpp
@@ -62,7 +62,7 @@ namespace O3DE::ProjectManager
         QDialogButtonBox* dialogButtons = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
         connect(dialogButtons, &QDialogButtonBox::accepted, this, &QDialog::accept);
         connect(dialogButtons, &QDialogButtonBox::rejected, this,
-            [=]()
+            [=, this]()
             {
                 // de-select any Gems the user selected because they're canceling
                 for (const QModelIndex& gem : gemsToRemove)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.cpp
@@ -37,7 +37,7 @@ namespace O3DE::ProjectManager
         m_closeButton->setIconSize(QSize(12, 12));
         m_closeButton->setStyleSheet("QPushButton { background-color: transparent; border: 0px }");
         layout->addWidget(m_closeButton);
-        connect(m_closeButton, &QPushButton::clicked, this, [=]{ emit RemoveClicked(); });
+        connect(m_closeButton, &QPushButton::clicked, this, [this]{ emit RemoveClicked(); });
     }
 
     QString FilterTagWidget::text() const

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
@@ -74,7 +74,7 @@ namespace O3DE::ProjectManager
             if (showAllLessButton)
             {
                 m_seeAllLessLabel = new LinkLabel();
-                connect(m_seeAllLessLabel, &LinkLabel::clicked, this, [=]()
+                connect(m_seeAllLessLabel, &LinkLabel::clicked, this, [this]()
                     {
                         m_seeAll = !m_seeAll;
                         UpdateSeeMoreLess();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemListView.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemListView.cpp
@@ -26,16 +26,16 @@ namespace O3DE::ProjectManager
         setSelectionModel(selectionModel);
         GemItemDelegate* itemDelegate = new GemItemDelegate(model, header, readOnly, this);
         
-        connect(itemDelegate, &GemItemDelegate::MovieStartedPlaying, [=](const QMovie* playingMovie)
+        connect(itemDelegate, &GemItemDelegate::MovieStartedPlaying, [this](const QMovie* playingMovie)
             {
                 // Force redraw when movie is playing so animation is smooth
-                connect(playingMovie, &QMovie::frameChanged, this, [=]
+                connect(playingMovie, &QMovie::frameChanged, this, [this]
                     {
                         this->viewport()->repaint();
                     });
             });
         
-        connect(header, &AdjustableHeaderWidget::sectionsResized, [=] { update(); });
+        connect(header, &AdjustableHeaderWidget::sectionsResized, [this] { update(); });
 
         setItemDelegate(itemDelegate);
     }

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoListView.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoListView.cpp
@@ -28,7 +28,7 @@ namespace O3DE::ProjectManager
         GemRepoItemDelegate* itemDelegate = new GemRepoItemDelegate(model, header, this);
         connect(itemDelegate, &GemRepoItemDelegate::RemoveRepo, this, &GemRepoListView::RemoveRepo);
         connect(itemDelegate, &GemRepoItemDelegate::RefreshRepo, this, &GemRepoListView::RefreshRepo);
-        connect(header, &AdjustableHeaderWidget::sectionsResized, [=] { update(); });
+        connect(header, &AdjustableHeaderWidget::sectionsResized, [this] { update(); });
         setItemDelegate(itemDelegate);
     }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemsSubWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemsSubWidget.cpp
@@ -33,7 +33,7 @@ namespace O3DE::ProjectManager
         layout->addWidget(m_textLabel);
 
         m_tagWidget = new TagContainerWidget();
-        connect(m_tagWidget, &TagContainerWidget::TagClicked, this, [=](const Tag& tag){ emit TagClicked(tag); });
+        connect(m_tagWidget, &TagContainerWidget::TagClicked, this, [this](const Tag& tag){ emit TagClicked(tag); });
         layout->addWidget(m_tagWidget);
     }
 

--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
@@ -87,7 +87,7 @@ namespace O3DE::ProjectManager
             // QButtonGroup has overloaded buttonClicked methods so we need the QOverload
             connect(
                 m_projectTemplateButtonGroup, QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked), this,
-                [=](QAbstractButton* button)
+                [this](QAbstractButton* button)
                 {
                     if (button && button->property(k_templateIndexProperty).isValid())
                     {
@@ -386,7 +386,7 @@ namespace O3DE::ProjectManager
             templateDetailsLayout->addWidget(m_downloadTemplateButton);
 
             QPushButton* configureGemsButton = new QPushButton(tr("Configure with more Gems"), this);
-            connect(configureGemsButton, &QPushButton::clicked, this, [=]()
+            connect(configureGemsButton, &QPushButton::clicked, this, [this]()
                 {
                     emit ChangeScreenRequest(ProjectManagerScreen::ProjectGemCatalog);
                 });

--- a/Code/Tools/ProjectManager/Source/TagWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/TagWidget.cpp
@@ -45,7 +45,7 @@ namespace O3DE::ProjectManager
         foreach (const QString& tag, tags)
         {
             TagWidget* tagWidget = new TagWidget({tag, tag});
-            connect(tagWidget, &TagWidget::TagClicked, this, [=](const Tag& clickedTag){ emit TagClicked(clickedTag); });
+            connect(tagWidget, &TagWidget::TagClicked, this, [this](const Tag& clickedTag){ emit TagClicked(clickedTag); });
             layout()->addWidget(tagWidget);
         }
     }
@@ -57,7 +57,7 @@ namespace O3DE::ProjectManager
         foreach (const Tag& tag, tags)
         {
             TagWidget* tagWidget = new TagWidget(tag);
-            connect(tagWidget, &TagWidget::TagClicked, this, [=](const Tag& clickedTag){ emit TagClicked(clickedTag); });
+            connect(tagWidget, &TagWidget::TagClicked, this, [this](const Tag& clickedTag){ emit TagClicked(clickedTag); });
             layout()->addWidget(tagWidget);
         }
     }

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1874,7 +1874,7 @@ namespace AZ
                 // If the asset was modified, reload it. This will also cause a model to change back to the default missing
                 // asset if it was removed, and it will replace the default missing asset with the real asset if it was added.
                 AZ::SystemTickBus::QueueFunction(
-                    [=, meshLoader = m_parent->m_meshLoader]() mutable
+                    [=, this, meshLoader = m_parent->m_meshLoader]() mutable
                     {
                         // Only trigger the reload if the meshLoader is still being used by something other than the lambda.
                         // If the lambda is the only owner, it will get destroyed after this queued call, so there's no point

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -158,7 +158,7 @@ namespace AZ
 
             uint64_t queueValue = m_uploadFence.Increment();
 
-            m_copyQueue->QueueCommand([=](void* commandQueue)
+            m_copyQueue->QueueCommand([=, this](void* commandQueue)
             {
                 AZ_PROFILE_SCOPE(RHI, "Upload Buffer");
                 size_t pendingByteOffset = 0;
@@ -256,7 +256,7 @@ namespace AZ
 
                 RHI::DeviceStreamingImageExpandRequest cachedRequest = request;
 
-                m_copyQueue->QueueCommand([=](void* commandQueue)
+                m_copyQueue->QueueCommand([=, this](void* commandQueue)
                 {
                     AZ_PROFILE_SCOPE(RHI, "Upload Image");
                     ID3D12CommandQueue* dx12CommandQueue = static_cast<ID3D12CommandQueue*>(commandQueue);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.cpp
@@ -143,7 +143,7 @@ namespace AZ
             CommandQueueContext& context = device.GetCommandQueueContext();
             const FenceSet &compiledFences = context.GetCompiledFences();
 
-            QueueCommand([=](void* commandQueue)
+            QueueCommand([=, this](void* commandQueue)
             {
                 AZ_PROFILE_SCOPE(RHI, "ExecuteWork");
                 AZ::Debug::ScopedTimer executionTimer(m_lastExecuteDuration);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/StreamingImagePool.cpp
@@ -604,7 +604,7 @@ namespace AZ
 
             // Create new expend request and append callback from the StreamingImagePool
             RHI::DeviceStreamingImageExpandRequest newRequest = request;
-            newRequest.m_completeCallback = [=]() 
+            newRequest.m_completeCallback = [=, this]()
             {
                 Image& dxImage = static_cast<Image&>(*request.m_image);
                 dxImage.FinalizeAsyncUpload(residentMipLevelAfter);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -108,7 +108,7 @@ namespace AZ
                 fenceToSignal->SetSignalEventDependencies(1);
             }
 
-            CommandQueue::Command command = [=, &device](void* queue)
+            CommandQueue::Command command = [=, this, &device](void* queue)
             {
                 AZ_PROFILE_SCOPE(RHI, "Upload Buffer");
                 size_t pendingByteOffset = 0;
@@ -203,7 +203,7 @@ namespace AZ
             uploadFence->SetSignalEventBitToSignal(0);
             uploadFence->SetSignalEventDependencies(1);
 
-            CommandQueue::Command command = [=, &device](void* queue)
+            CommandQueue::Command command = [=, this, &device](void* queue)
             {
                 AZ_PROFILE_SCOPE(RHI, "Upload Image");
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -44,7 +44,7 @@ namespace AZ
         void CommandQueue::ExecuteWork(const RHI::ExecuteWorkRequest& rhiRequest)
         {
             const ExecuteWorkRequest& request = static_cast<const ExecuteWorkRequest&>(rhiRequest);
-            QueueCommand([=](void* queue) 
+            QueueCommand([=, this](void* queue)
             {
                 AZ_PROFILE_SCOPE(RHI, "ExecuteWork");
                 AZ::Debug::ScopedTimer executionTimer(m_lastExecuteDuration);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -501,7 +501,7 @@ namespace AZ
 
                 // thisPtr makes sure the request holds an intrusive ptr to the current StreamingImage, so it doesn't get destroyed before
                 // the callback is executed
-                request.m_completeCallback = [=, thisPtr = RHI::Ptr<StreamingImage>(this)]()
+                request.m_completeCallback = [=, this, thisPtr = RHI::Ptr<StreamingImage>(this)]()
                 {
                     AZ_UNUSED(thisPtr);
 #ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapRenderer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapRenderer.cpp
@@ -134,7 +134,7 @@ namespace AZ
             relativePath = cubeMapRelativePath;
 
             // callback from the EnvironmentCubeMapPass when the cubemap render is complete
-            RenderCubeMapCallback renderCubeMapCallback = [=](uint8_t* const* cubeMapFaceTextureData, const RHI::Format cubeMapTextureFormat)
+            RenderCubeMapCallback renderCubeMapCallback = [=, this](uint8_t* const* cubeMapFaceTextureData, const RHI::Format cubeMapTextureFormat)
             {
                 // write the cubemap data to the .dds file
                 WriteOutputFile(cubeMapFullPath.c_str(), cubeMapFaceTextureData, cubeMapTextureFormat);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/ImageBasedLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/ImageBasedLightComponentController.cpp
@@ -146,7 +146,7 @@ namespace AZ
             // 9. The "Seconday Copy Queue" thread deadlocks and never completes the work.
             // 10. Main thread is also deadlocked waiting for "Seconday Copy Queue" to complete.
             // The solution is to enqueue texture update on the next tick.
-            auto postTickLambda = [=]()
+            auto postTickLambda = [=, this]()
             {
                 if (m_configuration.m_specularImageAsset.GetId() == updatedAsset.GetId())
                 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -316,7 +316,7 @@ namespace AZ
             // the handling code to be executed on the main thread. This prevents any non
             // thread-safe code, such as Qt updates, from running on alternate threads
             AZ::SystemTickBus::QueueFunction(
-                [=]()
+                [=, this]()
                 {
                     PurgePreviews();
 

--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -564,7 +564,7 @@ namespace AZ
             SetDirty();
 
             // callback for the texture readback
-            DiffuseProbeGridBakeTexturesCallback bakeTexturesCallback = [=](
+            DiffuseProbeGridBakeTexturesCallback bakeTexturesCallback = [=, this](
                 DiffuseProbeGridTexture irradianceTexture,
                 DiffuseProbeGridTexture distanceTexture,
                 DiffuseProbeGridTexture probeDataTexture)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -1620,7 +1620,7 @@ namespace EMStudio
 
         ResetSettingsDialog* resetDialog = new ResetSettingsDialog(this);
         resetDialog->setObjectName("EMFX.MainWindow.ResetSettingsDialog");
-        EMStudio::ResetSettingsDialog::connect(resetDialog, &QDialog::finished, [=](int resultCode)
+        EMStudio::ResetSettingsDialog::connect(resetDialog, &QDialog::finished, [=, this](int resultCode)
         {
             resetDialog->deleteLater();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AttributesWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AttributesWindow.cpp
@@ -114,7 +114,7 @@ namespace EMStudio
 
                 m_addConditionButton = new AddConditionButton(m_plugin, m_conditionsWidget);
                 m_addConditionButton->setObjectName("EMFX.AttributesWindowWidget.NodeTransition.AddConditionsWidget");
-                connect(m_addConditionButton, &AddConditionButton::ObjectTypeChosen, this, [=](AZ::TypeId conditionType)
+                connect(m_addConditionButton, &AddConditionButton::ObjectTypeChosen, this, [this](AZ::TypeId conditionType)
                     {
                         AddCondition(conditionType);
                     });
@@ -139,7 +139,7 @@ namespace EMStudio
                 actionVerticalLayout->addLayout(m_actionsLayout);
 
                 AddActionButton* addActionButton = new AddActionButton(m_plugin, m_actionsWidget);
-                connect(addActionButton, &AddActionButton::ObjectTypeChosen, this, [=](AZ::TypeId actionType)
+                connect(addActionButton, &AddActionButton::ObjectTypeChosen, this, [this](AZ::TypeId actionType)
                     {
                         const AnimGraphModel::ModelItemType itemType = m_displayingModelIndex.data(AnimGraphModel::ROLE_MODEL_ITEM_TYPE).value<AnimGraphModel::ModelItemType>();
                         if (itemType == AnimGraphModel::ModelItemType::TRANSITION)
@@ -158,7 +158,7 @@ namespace EMStudio
             }
         }
 
-        connect(&plugin->GetAnimGraphModel().GetSelectionModel(), &QItemSelectionModel::selectionChanged, this, [=]([[maybe_unused]] const QItemSelection& selected, [[maybe_unused]] const QItemSelection& deselected)
+        connect(&plugin->GetAnimGraphModel().GetSelectionModel(), &QItemSelectionModel::selectionChanged, this, [this]([[maybe_unused]] const QItemSelection& selected, [[maybe_unused]] const QItemSelection& deselected)
             {
                 UpdateAndShowInInspector();
             });

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.cpp
@@ -449,7 +449,7 @@ namespace EMStudio
         m_viewportStack.addWidget(m_viewportSplitter);
         connect(m_viewportSplitter, &QSplitter::splitterMoved,
                 this,
-                [=]{m_actions[NAVIGATION_NAVPANETOGGLE]->setChecked(m_viewportSplitter->sizes().at(1) > 0 );});
+                [this]{m_actions[NAVIGATION_NAVPANETOGGLE]->setChecked(m_viewportSplitter->sizes().at(1) > 0 );});
 
         UpdateNavigation();
         UpdateAnimGraphOptions();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventPresetsWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventPresetsWidget.cpp
@@ -80,7 +80,7 @@ namespace EMStudio
 
         m_loadAction = toolBar->addAction(MysticQt::GetMysticQt()->FindIcon("Images/Icons/Open.svg"),
             tr("Load motion event preset config file"),
-            this, [=]() { LoadPresets(); /* use lambda so that we get the default value for the showDialog parameter */ });
+            this, [this]() { LoadPresets(); /* use lambda so that we get the default value for the showDialog parameter */ });
 
         m_saveMenuAction = toolBar->addAction(
             MysticQt::GetMysticQt()->FindIcon("Images/Icons/Save.svg"),
@@ -92,7 +92,7 @@ namespace EMStudio
 
             QMenu* contextMenu = new QMenu(toolBar);
 
-            m_saveAction = contextMenu->addAction("Save", this, [=]() { SavePresets(); /* use lambda so that we get the default value for the showDialog parameter */ });
+            m_saveAction = contextMenu->addAction("Save", this, [this]() { SavePresets(); /* use lambda so that we get the default value for the showDialog parameter */ });
             m_saveAsAction = contextMenu->addAction("Save as...", this, &MotionEventPresetsWidget::SaveWithDialog);
 
             m_saveMenuAction->setMenu(contextMenu);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/RecorderGroup.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/RecorderGroup.cpp
@@ -35,21 +35,21 @@ namespace EMStudio
         {
             QMenu* recordOptionsMenu = new QMenu(toolbar);
             recordOptionsMenu->addAction(tr("Recording options"))->setEnabled(false);
-            m_recordMotionsOnly = recordOptionsMenu->addAction(tr("Record motions only"), toolbar, [=] {
+            m_recordMotionsOnly = recordOptionsMenu->addAction(tr("Record motions only"), toolbar, [this] {
                 m_recordStatesOnly->setChecked(false);
                 m_recordAllNodes->setChecked(false);
                 });
             m_recordMotionsOnly->setCheckable(true);
             m_recordMotionsOnly->setChecked(true);
 
-            m_recordStatesOnly = recordOptionsMenu->addAction(tr("Record states only"), toolbar, [=] {
+            m_recordStatesOnly = recordOptionsMenu->addAction(tr("Record states only"), toolbar, [this] {
                 m_recordMotionsOnly->setChecked(false);
                 m_recordAllNodes->setChecked(false);
                 });
             m_recordStatesOnly->setCheckable(true);
             m_recordStatesOnly->setChecked(false);
 
-            m_recordAllNodes = recordOptionsMenu->addAction(tr("Record all nodes"), toolbar, [=] {
+            m_recordAllNodes = recordOptionsMenu->addAction(tr("Record all nodes"), toolbar, [this] {
                 m_recordMotionsOnly->setChecked(false);
                 m_recordStatesOnly->setChecked(false);
                 });

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
@@ -220,7 +220,7 @@ namespace EMStudio
         m_paneSplitter->setStretchFactor(1, 1);
         connect(m_paneSplitter, &QSplitter::splitterMoved,
                 this,
-                [=]{m_togglePresetsView->setChecked(m_paneSplitter->sizes().at(1) > 0 );});
+                [this]{m_togglePresetsView->setChecked(m_paneSplitter->sizes().at(1) > 0 );});
         mainLayout->addWidget(m_paneSplitter, 1, 0, 1, 2);
 
         // connect TrackDataWidget
@@ -246,7 +246,7 @@ namespace EMStudio
         // Create the motion event properties widget.
         m_motionEventWidget = new MotionEventWidget();
         m_motionEventWidget->hide();
-        connect(this, &TimeViewPlugin::SelectionChanged, this, [=]
+        connect(this, &TimeViewPlugin::SelectionChanged, this, [this]
             {
                 if (!m_motionEventWidget)
                 {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackHeaderWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackHeaderWidget.cpp
@@ -256,7 +256,7 @@ namespace EMStudio
         connect(this, &QWidget::customContextMenuRequested, this, [this](const QPoint& pos)
         {
             QMenu m;
-            auto action = m.addAction(tr("Remove track"), this, [=]
+            auto action = m.addAction(tr("Remove track"), this, [this]
             {
                 m_plugin->GetTrackDataWidget()->RemoveTrack(m_trackIndex);
             });

--- a/Gems/EMotionFX/Code/Source/Editor/ActorJointBrowseEdit.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ActorJointBrowseEdit.cpp
@@ -68,7 +68,7 @@ namespace EMStudio
         connect(m_jointSelectionWindow->GetNodeHierarchyWidget()->GetTreeWidget(), &QTreeWidget::itemSelectionChanged, this, &ActorJointBrowseEdit::OnSelectionChanged);
         connect(m_jointSelectionWindow->GetNodeHierarchyWidget(), &NodeHierarchyWidget::OnSelectionDone, this, &ActorJointBrowseEdit::OnSelectionDone);
 
-        NodeSelectionWindow::connect(m_jointSelectionWindow, &QDialog::finished, [=]([[maybe_unused]] int resultCode)
+        NodeSelectionWindow::connect(m_jointSelectionWindow, &QDialog::finished, [this]([[maybe_unused]] int resultCode)
             {
                 m_jointSelectionWindow->deleteLater();
                 m_jointSelectionWindow = nullptr;

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModelJointWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModelJointWidget.cpp
@@ -58,7 +58,7 @@ namespace EMotionFX
         separatorLayoutWidget->setLayout(separatorLayout);
         mainLayout->addWidget(separatorLayoutWidget);
 
-        connect(this, &SkeletonModelJointWidget::WidgetCountChanged, this, [=]() {
+        connect(this, &SkeletonModelJointWidget::WidgetCountChanged, this, [=, this]() {
             separatorLayoutWidget->setVisible(WidgetCount() > 0);
         });
 

--- a/Gems/EMotionFX/Code/Tests/UI/ModalPopupHandler.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/ModalPopupHandler.cpp
@@ -24,7 +24,7 @@ namespace EMotionFX
 
     void ModalPopupHandler::ShowContextMenuAndTriggerAction(QWidget* widget, const QString& actionName, int timeout, ActionCompletionCallback completionCallback)
     {
-        MenuActiveCallback menuCallback = [=](QMenu* menu)
+        MenuActiveCallback menuCallback = [=, this](QMenu* menu)
         {
             ASSERT_TRUE(menu) << "Failed to find context menu.";
 

--- a/Gems/LyShine/Code/Editor/PreviewToolbar.cpp
+++ b/Gems/LyShine/Code/Editor/PreviewToolbar.cpp
@@ -50,7 +50,7 @@ PreviewToolbar::PreviewToolbar(EditorWindow* parent)
     QObject::connect(parent,
         &EditorWindow::EditorModeChanged,
         m_editButton,
-        [=](UiEditorMode mode)
+        [this](UiEditorMode mode)
         {
             m_editButton->setEnabled(mode == UiEditorMode::Preview);
         });

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.cpp
@@ -343,7 +343,7 @@ namespace Terrain
         // 9. The "Seconday Copy Queue" thread deadlocks and never completes the work.
         // 10. Main thread is also deadlocked waiting for "Seconday Copy Queue" to complete.
         // The solution is to enqueue texture update on the next tick.
-        auto postTickLambda = [=]()
+        auto postTickLambda = [=, this]()
         {
             OnAssetReadyPostTick(asset);
         };
@@ -389,7 +389,7 @@ namespace Terrain
     void TerrainSurfaceMaterialsListComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         // REMARK: See OnAssetReady for details on why we postpone the work on the next tick.
-        auto postTickLambda = [=]()
+        auto postTickLambda = [=, this]()
         {
             OnAssetReloadedPostTick(asset);
         };

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -54,7 +54,6 @@ ly_append_configurations_options(
         -Wno-undefined-var-template
         -fno-relaxed-template-template-args
         -Wno-deprecated-no-relaxed-template-template-args
-        -Wno-deprecated-this-capture # TODO(c++20): Remove this
         -Wno-dllexport-explicit-instantiation-decl  # explicit instantiation declaration should not be 'dllexport'
 
         ###################

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -85,7 +85,7 @@ ly_append_configurations_options(
         #/we4619 # #pragma warning: there is no warning number 'number'. Unfortunately some versions of MSVC 16.X dont filter this warning coming from external headers and Qt has a bad warning in QtCore/qvector.h(340,12)
         /we4774 # 'string' : format string expected in argument number is not a string literal
         /we4777 # 'function' : format string 'string' requires an argument of type 'type1', but variadic argument number has type 'type2
-        #/we4855 # implicit capture of 'this' via '[=]' is deprecated in 'version' TODO(c++20): Enable this
+        /we4855 # implicit capture of 'this' via '[=]' is deprecated in 'version'
         /we5031 # #pragma warning(pop): likely mismatch, popping warning state pushed in different file
         /we5032 # detected #pragma warning(push) with no corresponding #pragma warning(pop)
         /we5233 # explicit lambda capture 'identifier' is not used


### PR DESCRIPTION
## What does this PR do?

This PR re-enables the warnings for deprectated-this-capture (MSVC w4855/ Clang `Wdeprecated-this-capture`), which were disabled temporarily in [PR19125](https://github.com/o3de/o3de/pull/19125), and fixes all ensuing compile warnings, as promised in this [comment](https://github.com/o3de/o3de/pull/19125#discussion_r2231094047) of PR19125.

## How was this PR tested?

Compile with MSVC and Clang on Windows, AR
