### PR TITLE
Change Atom_Feature_Common.Public target to shared library

### DIFF
--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -87,6 +87,7 @@
 
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Matrix3x3.h>
@@ -180,10 +181,10 @@ namespace AZ
             PerceptualQuantizer = 2
         };
 
-        SegmentedSplineParamsC9 GetAcesODTParameters(OutputDeviceTransformType odtType);
-        ShaperParams GetLog2ShaperParameters(float minStops, float maxStops);
-        ShaperParams GetAcesShaperParameters(OutputDeviceTransformType odtType);
-        Matrix3x3 GetColorConvertionMatrix(ColorConvertionMatrixType type);
+        ATOM_FEATURE_COMMON_API SegmentedSplineParamsC9 GetAcesODTParameters(OutputDeviceTransformType odtType);
+        ATOM_FEATURE_COMMON_API ShaperParams GetLog2ShaperParameters(float minStops, float maxStops);
+        ATOM_FEATURE_COMMON_API ShaperParams GetAcesShaperParameters(OutputDeviceTransformType odtType);
+        ATOM_FEATURE_COMMON_API Matrix3x3 GetColorConvertionMatrix(ColorConvertionMatrixType type);
 
     }   // namespace Render
 

--- a/Gems/Atom/Feature/Common/Code/CMakeLists.txt
+++ b/Gems/Atom/Feature/Common/Code/CMakeLists.txt
@@ -40,7 +40,7 @@ ly_add_target(
 )
 
 ly_add_target(
-    NAME ${gem_name}.Public STATIC
+    NAME ${gem_name}.Public ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         atom_feature_common_public_files.cmake
@@ -53,6 +53,7 @@ ly_add_target(
             3rdParty/ACES
     COMPILE_DEFINITIONS
         PRIVATE
+            ATOM_FEATURE_COMMON_EXPORTS
             IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     BUILD_DEPENDENCIES
         PRIVATE

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h
@@ -10,6 +10,7 @@
 
 #include <Atom/RPI.Public/FeatureProcessor.h>
 
+#include <Atom/Feature/Base.h>
 #include <Atom/Feature/DisplayMapper/DisplayMapperFeatureProcessorInterface.h>
 #include <ACES/Aces.h>
 #include <Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h>
@@ -52,7 +53,7 @@ namespace AZ
          *  This class create display mapper shader input parameters by using
          *  the ACES reference implementation.
          */
-        class AcesDisplayMapperFeatureProcessor final
+        class ATOM_FEATURE_COMMON_API AcesDisplayMapperFeatureProcessor final
             : public DisplayMapperFeatureProcessorInterface
         {
         public:

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Base.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Base.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if defined(AZ_MONOLITHIC_BUILD)
+    #define ATOM_FEATURE_COMMON_API
+    #define ATOM_FEATURE_COMMON_API_EXPORT
+#else
+    #if defined(ATOM_FEATURE_COMMON_EXPORTS)
+        #define ATOM_FEATURE_COMMON_API        AZ_DLL_EXPORT
+        #define ATOM_FEATURE_COMMON_API_EXPORT AZ_DLL_EXPORT
+    #else
+        #define ATOM_FEATURE_COMMON_API        AZ_DLL_IMPORT
+        #define ATOM_FEATURE_COMMON_API_EXPORT
+    #endif
+#endif

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PhotometricValue.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PhotometricValue.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Math/Color.h>
@@ -42,7 +43,7 @@ namespace AZ
         };
 
         //! Stores and converts between photometric data stored in various units like Lux, Lumens, and EV100
-        class PhotometricValue final
+        class ATOM_FEATURE_COMMON_API PhotometricValue final
         {
         public:
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h
@@ -12,6 +12,7 @@
 
 #include <ACES/Aces.h>
 
+#include <Atom/Feature/Base.h>
 #include <Atom/RPI.Reflect/Pass/PassAsset.h>
 #include <Atom/RPI.Reflect/Pass/PassData.h>
 #include <Atom/RPI.Reflect/System/AnyAsset.h>
@@ -26,7 +27,7 @@ namespace AZ
          * The ACES display mapper parameter overrides.
          * These parameters override default ACES parameters when m_overrideDefaults is true.
          */
-        struct AcesParameterOverrides final
+        struct ATOM_FEATURE_COMMON_API AcesParameterOverrides final
         {
             AZ_TYPE_INFO(AcesParameterOverrides, "{3EE8C0D4-3792-46C0-B91C-B89A81C36B91}");
             static void Reflect(ReflectContext* context);
@@ -66,7 +67,7 @@ namespace AZ
         };
 
         //! A descriptor used to configure the DisplayMapper
-        struct DisplayMapperConfigurationDescriptor final
+        struct ATOM_FEATURE_COMMON_API DisplayMapperConfigurationDescriptor final
         {
             AZ_TYPE_INFO(DisplayMapperConfigurationDescriptor, "{655B0C35-C96D-4EDA-810E-B50D58BC1D20}");
             static void Reflect(AZ::ReflectContext* context);
@@ -83,7 +84,7 @@ namespace AZ
         };
 
         //! Custom pass data for DisplayMapperPass.
-        struct DisplayMapperPassData
+        struct ATOM_FEATURE_COMMON_API DisplayMapperPassData
             : public RPI::PassData
         {
             using Base = RPI::PassData;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ImGui/ImGuiPass.h
@@ -22,6 +22,8 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Reflect/Pass/RasterPassData.h>
 
+#include <Atom/Feature/Base.h>
+
 #include <imgui/imgui.h>
 
 namespace AZ
@@ -53,7 +55,7 @@ namespace AZ
         };
 
         //! This pass owns and manages activation of an Imgui context.
-        class ImGuiPass
+        class ATOM_FEATURE_COMMON_API ImGuiPass
             : public RPI::RenderPass
             , private AzFramework::InputChannelEventListener
             , private AzFramework::InputTextEventListener

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/LightingChannel/LightingChannelConfiguration.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/LightingChannel/LightingChannelConfiguration.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <AzCore/base.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/RTTI/ReflectContext.h>
@@ -18,7 +19,7 @@ namespace AZ
     {
         const uint32_t LightingChannelsCount = 5;
 
-        struct LightingChannelConfiguration
+        struct ATOM_FEATURE_COMMON_API LightingChannelConfiguration
         {
             AZ_TYPE_INFO(LightingChannelConfiguration, "{7FFD6D01-BABE-FE35-612F-63A30925E5F7}");
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/ConvertEmissiveUnitFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/ConvertEmissiveUnitFunctor.h
@@ -10,6 +10,7 @@
 
 #include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
 #include <Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h>
+#include <Atom/Feature/Base.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 
 namespace AZ
@@ -18,7 +19,7 @@ namespace AZ
     {
         //! The functor can be used to convert between different emissive light unit
         //! Only support Ev100 and Lux
-        class ConvertEmissiveUnitFunctor final
+        class ATOM_FEATURE_COMMON_API ConvertEmissiveUnitFunctor final
             : public AZ::RPI::MaterialFunctor
         {
             friend class ConvertEmissiveUnitFunctorSourceData;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshVertexStreams.h>
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshInstance.h>
 #include <Atom/RPI.Reflect/Model/ModelLodAsset.h>
@@ -38,7 +39,7 @@ namespace AZ
         //! and the index of the target vertex that is going to be modified
         //! The morph target pass will read these values, apply a weight, and write the accumulated deltas
         //! to an intermediate buffer that will be consumed by the skinning pass
-        class MorphTargetInputBuffers
+        class ATOM_FEATURE_COMMON_API MorphTargetInputBuffers
             : public AZStd::intrusive_base
         {
         public:

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RayTracing/RayTracingPass.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <Atom/RHI/DispatchRaysIndirectBuffer.h>
 #include <Atom/RHI/DispatchRaysItem.h>
 #include <Atom/RHI/RayTracingPipelineState.h>
@@ -23,7 +24,7 @@ namespace AZ
         struct RayTracingPassData;
 
         //! This pass executes a raytracing shader as specified in the PassData.
-        class RayTracingPass
+        class ATOM_FEATURE_COMMON_API RayTracingPass
             : public RPI::RenderPass
             , private RPI::ShaderReloadNotificationBus::MultiHandler
         {

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
@@ -66,7 +66,7 @@ namespace AZ
         };
 
         //! Container for all the buffers and views needed for a single lod of a skinned mesh
-        class SkinnedMeshInputLod
+        class ATOM_FEATURE_COMMON_API SkinnedMeshInputLod
         {
             friend class SkinnedMeshInputBuffers;
         public:
@@ -148,7 +148,7 @@ namespace AZ
         };
 
         //! Container for all the buffers and views needed for per-source model input to both the skinning shader and subsequent mesh shaders
-        class SkinnedMeshInputBuffers
+        class ATOM_FEATURE_COMMON_API SkinnedMeshInputBuffers
             : public AZStd::intrusive_base
         {
         public:

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInstance.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInstance.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshOutputStreamManagerInterface.h>
 #include <Atom/Feature/MorphTargets/MorphTargetInputBuffers.h>
 #include <Atom/RPI.Public/Model/Model.h>
@@ -24,7 +25,7 @@ namespace AZ
 
         //! SkinnedMeshInstance contains the data that is needed to represent the output from skinning a single instance of a skinned mesh.
         //! It does not contain the actual skinned vertex data, but rather views into the buffers that do contain the data, which are owned by the SkinnedMeshOutputStreamManager
-        class SkinnedMeshInstance
+        class ATOM_FEATURE_COMMON_API SkinnedMeshInstance
             : public AZStd::intrusive_base
         {
         public:

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkyBox/SkyBoxFogSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkyBox/SkyBoxFogSettings.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/RTTI/RTTI.h>
 
@@ -15,7 +16,7 @@ namespace AZ
 {
     namespace Render
     {
-        struct SkyBoxFogSettings final
+        struct ATOM_FEATURE_COMMON_API SkyBoxFogSettings final
         {
             AZ_RTTI(AZ::Render::SkyBoxFogSettings, "{DB13027C-BA92-4E46-B428-BB77C2A80C51}");
             

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SplashScreen/SplashScreenSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SplashScreen/SplashScreenSettings.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
@@ -14,7 +15,7 @@ namespace AZ::Render
 {
     //! Splash screen settings that describe how to render.
     //! The settings will be retrieved from setting registry: splash_screen.setreg.
-    class SplashScreenSettings
+    class ATOM_FEATURE_COMMON_API SplashScreenSettings
     {
     public:
         AZ_RTTI(AZ::Render::SplashScreenSettings, "{4B441F73-8F72-4DCA-9451-416C40693487}");

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
@@ -12,6 +12,7 @@
 #include <AzCore/Preprocessor/Enum.h>
 #include <AzFramework/Windowing/WindowBus.h>
 
+#include <Atom/Feature/Base.h>
 #include <Atom/RPI.Public/Pass/AttachmentReadback.h>
 #include <Atom/Utils/ImageComparison.h>
 
@@ -21,7 +22,7 @@ namespace AZ
     {
         //! The errors met in initializing the frame capture.
         //! It is used for script Ebus calls to provide a richer debug environment.
-        struct FrameCaptureError
+        struct ATOM_FEATURE_COMMON_API FrameCaptureError
         {
             AZ_TYPE_INFO(FrameCaptureError, "{9459AC1D-B0EE-4D89-9EEC-6A65790C76BF}");
             static void Reflect(ReflectContext* context);
@@ -128,11 +129,11 @@ namespace AZ
         };
 
         //! Writes out content of ReadbackResult in the Dds image format.
-        FrameCaptureOutputResult DdsFrameCaptureOutput(
+        ATOM_FEATURE_COMMON_API FrameCaptureOutputResult DdsFrameCaptureOutput(
             const AZStd::string& outputFilePath, const AZ::RPI::AttachmentReadback::ReadbackResult& readbackResult);
 
         //! Writes out content of ReadbackResult in the Ppm image format.
-        FrameCaptureOutputResult PpmFrameCaptureOutput(
+        ATOM_FEATURE_COMMON_API FrameCaptureOutputResult PpmFrameCaptureOutput(
             const AZStd::string& outputFilePath, const AZ::RPI::AttachmentReadback::ReadbackResult& readbackResult);
 
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureTestBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureTestBus.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/Feature/Base.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/std/string/string.h>
@@ -16,7 +17,7 @@ namespace AZ
     namespace Render
     {
         //! The errors met when calling frame capture test request bus.
-        struct FrameCaptureTestError
+        struct ATOM_FEATURE_COMMON_API FrameCaptureTestError
         {
             AZ_TYPE_INFO(FrameCaptureTestError, "{C96D1649-6B7C-42AE-87C3-3253EA5214E2}");
             static void Reflect(ReflectContext* context);

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/GpuBufferHandler.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/GpuBufferHandler.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/std/string/string.h>
+#include <Atom/Feature/Base.h>
 #include <Atom/RHI/DeviceBufferView.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
@@ -19,7 +20,7 @@ namespace AZ
     {
 
         // This helper class manages a re-sizable structured or typed buffer which is (only) used for a shader's SRV
-        class GpuBufferHandler
+        class ATOM_FEATURE_COMMON_API GpuBufferHandler
         {
         public:
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/LightingPreset.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/LightingPreset.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/string/string.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Color.h>
+#include <Atom/Feature/Base.h>
 #include <Atom/Feature/CoreLights/ShadowConstants.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 #include <Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h>
@@ -30,7 +31,7 @@ namespace AZ
         class ExposureControlSettingsInterface;
 
         //! ExposureControlConfig describes exposure settings that can be added to a LightingPreset
-        struct ExposureControlConfig final
+        struct ATOM_FEATURE_COMMON_API ExposureControlConfig final
         {
             AZ_TYPE_INFO(AZ::Render::ExposureControlConfig, "{C6FD75F7-58BA-46CE-8FBA-2D64CB4ECFF9}");
             static void Reflect(AZ::ReflectContext* context);
@@ -52,7 +53,7 @@ namespace AZ
         };
 
         //! LightConfig describes a directional light that can be added to a LightingPreset
-        struct LightConfig final
+        struct ATOM_FEATURE_COMMON_API LightConfig final
         {
             AZ_TYPE_INFO(AZ::Render::LightConfig, "{02644F52-9483-47A8-9028-37671695C34E}");
             static void Reflect(AZ::ReflectContext* context);
@@ -69,7 +70,7 @@ namespace AZ
         };
 
         //! LightingPreset describes a lighting environment that can be applied to the viewport
-        struct LightingPreset final
+        struct ATOM_FEATURE_COMMON_API LightingPreset final
         {
             AZ_TYPE_INFO(AZ::Render::LightingPreset, "{6EEACBC0-2D97-414C-8E87-088E7BA231A9}");
             AZ_CLASS_ALLOCATOR(LightingPreset, AZ::SystemAllocator);

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ModelPreset.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ModelPreset.h
@@ -14,6 +14,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
+#include <Atom/Feature/Base.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 
@@ -22,7 +23,7 @@ namespace AZ
     namespace Render
     {
         //! ModelPreset describes a model that can be displayed in the viewport
-        struct ModelPreset final
+        struct ATOM_FEATURE_COMMON_API ModelPreset final
         {
             AZ_TYPE_INFO(AZ::Render::ModelPreset, "{A7304AE2-EC26-44A4-8C00-89D9731CCB13}");
             AZ_CLASS_ALLOCATOR(ModelPreset, AZ::SystemAllocator);

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -47,43 +47,6 @@ namespace AZ
     {
         AZ_ENUM_DEFINE_REFLECT_UTILITIES(FrameCaptureResult);
 
-        void FrameCaptureError::Reflect(ReflectContext* context)
-        {
-            if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
-            {
-                serializeContext->Class<FrameCaptureError>()
-                    ->Version(1)
-                    ->Field("ErrorMessage", &FrameCaptureError::m_errorMessage);
-            }
-
-            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-            {
-                behaviorContext->Class<FrameCaptureError>("FrameCaptureError")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                    ->Attribute(AZ::Script::Attributes::Module, "utils")
-                    ->Property("ErrorMessage", BehaviorValueProperty(&FrameCaptureError::m_errorMessage))
-                        ->Attribute(AZ::Script::Attributes::Alias, "error_message");
-            }
-        }
-        void FrameCaptureTestError::Reflect(ReflectContext* context)
-        {
-            if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
-            {
-                serializeContext->Class<FrameCaptureTestError>()
-                    ->Version(1)
-                    ->Field("ErrorMessage", &FrameCaptureTestError::m_errorMessage);
-            }
-
-            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-            {
-                behaviorContext->Class<FrameCaptureTestError>("FrameCaptureTestError")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                    ->Attribute(AZ::Script::Attributes::Module, "utils")
-                    ->Property("ErrorMessage", BehaviorValueProperty(&FrameCaptureTestError::m_errorMessage))
-                        ->Attribute(AZ::Script::Attributes::Alias, "error_message");
-            }
-        }
-
         AZ_CVAR(unsigned int,
             r_pngCompressionLevel,
             3, // A compression level of 3 seems like the best default in terms of file size and saving speeds

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/FrameCaptureBus.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/FrameCaptureBus.cpp
@@ -7,11 +7,50 @@
  */
 
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
+#include <Atom/Feature/Utils/FrameCaptureTestBus.h>
 #include <Atom/Utils/DdsFile.h>
 #include <Atom/Utils/PpmFile.h>
 
 namespace AZ::Render
 {
+    void FrameCaptureError::Reflect(ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+        {
+            serializeContext->Class<FrameCaptureError>()
+                ->Version(1)
+                ->Field("ErrorMessage", &FrameCaptureError::m_errorMessage);
+        }
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<FrameCaptureError>("FrameCaptureError")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Module, "utils")
+                ->Property("ErrorMessage", BehaviorValueProperty(&FrameCaptureError::m_errorMessage))
+                    ->Attribute(AZ::Script::Attributes::Alias, "error_message");
+        }
+    }
+
+    void FrameCaptureTestError::Reflect(ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+        {
+            serializeContext->Class<FrameCaptureTestError>()
+                ->Version(1)
+                ->Field("ErrorMessage", &FrameCaptureTestError::m_errorMessage);
+        }
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<FrameCaptureTestError>("FrameCaptureTestError")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Module, "utils")
+                ->Property("ErrorMessage", BehaviorValueProperty(&FrameCaptureTestError::m_errorMessage))
+                    ->Attribute(AZ::Script::Attributes::Alias, "error_message");
+        }
+    }
+
     FrameCaptureOutputResult DdsFrameCaptureOutput(
         const AZStd::string& outputFilePath, const AZ::RPI::AttachmentReadback::ReadbackResult& readbackResult)
     {

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -11,6 +11,7 @@ set(FILES
     3rdParty/ACES/ACES/Aces.h
     Include/Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h
     Include/Atom/Feature/Automation/AtomAutomationBus.h
+    Include/Atom/Feature/Base.h
     Include/Atom/Feature/ColorGrading/LutResolution.h
     Include/Atom/Feature/CoreLights/CapsuleLightFeatureProcessorInterface.h
     Include/Atom/Feature/CoreLights/CoreLightsConstants.h


### PR DESCRIPTION
## What does this PR do?

This PR changes the `Atom_Feature_Common.Public` target from a static to a shared library.
This is similar to the conversion of the Atom_RHI targets to shared libraries in [PR19154](https://github.com/o3de/o3de/pull/19154), but in this case it is a much smaller changeset since most classes in this target are header-only.

## How was this PR tested?

Compile and run the Editor on Windows, AR
