### PR TITLE
Fix compile error for windows monolithic builds

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/AsyncWorkQueue.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/AsyncWorkQueue.cpp
@@ -9,7 +9,11 @@
 
 #include <AzCore/Debug/Profiler.h>
 
+#if defined(AZ_MONOLITHIC_BUILD)
+AZ_DECLARE_BUDGET(RHI);
+#else
 AZ_DECLARE_BUDGET_SHARED(RHI);
+#endif
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
@@ -13,7 +13,11 @@
 #include <AzCore/std/string/string.h>
 #include <dx12ma/D3D12MemAlloc.h>
 
+#if defined(AZ_MONOLITHIC_BUILD)
+AZ_DECLARE_BUDGET(RHI);
+#else
 AZ_DECLARE_BUDGET_SHARED(RHI);
+#endif
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

This fixes a compile error for windows monolithic builds caused by a missing AZ_MONOLITHIC checks for using static vs shared AZ_BUDGET macros for Atom RHI.

Fixes https://github.com/o3de/o3de/issues/19168 

## How was this PR tested?

Built locally using
```
 python\python.cmd scripts\build\ci_build.py -p Windows -t install_mono_release
```
