### PR TITLE
Add option to invert mouse wheel zoom direction

### DIFF
--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -227,6 +227,11 @@ namespace SandboxEditor
             return SandboxEditor::CameraScrollSpeedScaled();
         };
 
+        m_firstPersonScrollCamera->m_invertZoomFn = []
+        {
+            return SandboxEditor::CameraZoomInverted();
+        };
+
         const auto focusPivotFn = []() -> AZStd::optional<AZ::Vector3>
         {
             // use the manipulator transform as the pivot point
@@ -366,6 +371,11 @@ namespace SandboxEditor
         m_orbitScrollDollyCamera->m_scrollSpeedFn = []
         {
             return SandboxEditor::CameraScrollSpeedScaled();
+        };
+
+        m_orbitScrollDollyCamera->m_invertZoomFn = []
+        {
+            return SandboxEditor::CameraZoomInverted();
         };
 
         m_orbitMotionDollyCamera = AZStd::make_shared<AzFramework::OrbitMotionDollyCameraInput>(SandboxEditor::CameraOrbitDollyChannelId());

--- a/Code/Editor/EditorPreferencesPageViewportCamera.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportCamera.cpp
@@ -76,6 +76,7 @@ void CEditorPreferencesPage_ViewportCamera::CameraMovementSettings::Reflect(AZ::
         ->Field("OrbitYawRotationInverted", &CameraMovementSettings::m_orbitYawRotationInverted)
         ->Field("PanInvertedX", &CameraMovementSettings::m_panInvertedX)
         ->Field("PanInvertedY", &CameraMovementSettings::m_panInvertedY)
+        ->Field("ZoomInverted", &CameraMovementSettings::m_zoomInverted)
         ->Field("DefaultPosition", &CameraMovementSettings::m_defaultPosition)
         ->Field("DefaultOrientation", &CameraMovementSettings::m_defaultPitchYaw)
         ->Field("DefaultOrbitDistance", &CameraMovementSettings::m_defaultOrbitDistance)
@@ -165,6 +166,11 @@ void CEditorPreferencesPage_ViewportCamera::CameraMovementSettings::Reflect(AZ::
                 &CameraMovementSettings::m_panInvertedY,
                 "Invert Pan Y",
                 "Invert direction of pan in local Y axis")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox,
+                &CameraMovementSettings::m_zoomInverted,
+                "Invert Zoom Direction",
+                "Invert Mouse Wheel Zoom direction")
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_captureCursorLook,
@@ -392,6 +398,7 @@ void CEditorPreferencesPage_ViewportCamera::OnApply()
     SandboxEditor::SetCameraOrbitYawRotationInverted(m_cameraMovementSettings.m_orbitYawRotationInverted);
     SandboxEditor::SetCameraPanInvertedX(m_cameraMovementSettings.m_panInvertedX);
     SandboxEditor::SetCameraPanInvertedY(m_cameraMovementSettings.m_panInvertedY);
+    SandboxEditor::SetCameraZoomInverted(m_cameraMovementSettings.m_zoomInverted);
     SandboxEditor::SetCameraDefaultEditorPosition(m_cameraMovementSettings.m_defaultPosition);
     SandboxEditor::SetCameraDefaultOrbitDistance(m_cameraMovementSettings.m_defaultOrbitDistance);
     SandboxEditor::SetCameraDefaultEditorOrientation(m_cameraMovementSettings.m_defaultPitchYaw);
@@ -440,6 +447,7 @@ void CEditorPreferencesPage_ViewportCamera::CameraMovementSettings::Reset()
     SandboxEditor::ResetCameraOrbitYawRotationInverted();
     SandboxEditor::ResetCameraPanInvertedX();
     SandboxEditor::ResetCameraPanInvertedY();
+    SandboxEditor::ResetCameraZoomInverted();
     SandboxEditor::ResetCameraDefaultEditorPosition();
     SandboxEditor::ResetCameraDefaultOrbitDistance();
     SandboxEditor::ResetCameraDefaultEditorOrientation();
@@ -466,6 +474,7 @@ void CEditorPreferencesPage_ViewportCamera::CameraMovementSettings::Initialize()
     m_orbitYawRotationInverted = SandboxEditor::CameraOrbitYawRotationInverted();
     m_panInvertedX = SandboxEditor::CameraPanInvertedX();
     m_panInvertedY = SandboxEditor::CameraPanInvertedY();
+    m_zoomInverted = SandboxEditor::CameraZoomInverted();
     m_defaultPosition = SandboxEditor::CameraDefaultEditorPosition();
     m_defaultOrbitDistance = SandboxEditor::CameraDefaultOrbitDistance();
     m_defaultPitchYaw = SandboxEditor::CameraDefaultEditorOrientation();

--- a/Code/Editor/EditorPreferencesPageViewportCamera.h
+++ b/Code/Editor/EditorPreferencesPageViewportCamera.h
@@ -65,6 +65,7 @@ private:
         bool m_orbitYawRotationInverted;
         bool m_panInvertedX;
         bool m_panInvertedY;
+        bool m_zoomInverted;
         bool m_rotateSmoothing;
         bool m_translateSmoothing;
         bool m_goToPositionInstantly;

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -39,6 +39,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view CameraPanInvertedXSetting = "/Amazon/Preferences/Editor/Camera/PanInvertedX";
     constexpr AZStd::string_view CameraPanInvertedYSetting = "/Amazon/Preferences/Editor/Camera/PanInvertedY";
     constexpr AZStd::string_view CameraPanSpeedSetting = "/Amazon/Preferences/Editor/Camera/PanSpeed";
+    constexpr AZStd::string_view CameraZoomInvertedSetting = "/Amazon/Preferences/Editor/Camera/ZoomInverted";
     constexpr AZStd::string_view CameraRotateSmoothnessSetting = "/Amazon/Preferences/Editor/Camera/RotateSmoothness";
     constexpr AZStd::string_view CameraTranslateSmoothnessSetting = "/Amazon/Preferences/Editor/Camera/TranslateSmoothness";
     constexpr AZStd::string_view CameraTranslateSmoothingSetting = "/Amazon/Preferences/Editor/Camera/TranslateSmoothing";
@@ -434,6 +435,16 @@ namespace SandboxEditor
         AzToolsFramework::SetRegistry(CameraPanSpeedSetting, speed);
     }
 
+    bool CameraZoomInverted()
+    {
+        return AzToolsFramework::GetRegistry(CameraZoomInvertedSetting, false);
+    }
+
+    void SetCameraZoomInverted(const bool inverted)
+    {
+        AzToolsFramework::SetRegistry(CameraZoomInvertedSetting, inverted);
+    }
+
     float CameraRotateSmoothness()
     {
         return aznumeric_cast<float>(AzToolsFramework::GetRegistry(CameraRotateSmoothnessSetting, 5.0));
@@ -781,6 +792,11 @@ namespace SandboxEditor
     void ResetCameraPanInvertedY()
     {
         AzToolsFramework::ClearRegistry(CameraPanInvertedYSetting);
+    }
+
+    void ResetCameraZoomInverted()
+    {
+        AzToolsFramework::ClearRegistry(CameraZoomInvertedSetting);
     }
 
     void ResetCameraDefaultEditorPosition()

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -106,6 +106,9 @@ namespace SandboxEditor
     SANDBOX_API float CameraPanSpeedScaled();
     SANDBOX_API void SetCameraPanSpeed(float speed);
 
+    SANDBOX_API bool CameraZoomInverted();
+    SANDBOX_API void SetCameraZoomInverted(bool inverted);
+
     SANDBOX_API float CameraRotateSmoothness();
     SANDBOX_API void SetCameraRotateSmoothness(float smoothness);
 
@@ -207,6 +210,7 @@ namespace SandboxEditor
     SANDBOX_API void ResetCameraOrbitYawRotationInverted();
     SANDBOX_API void ResetCameraPanInvertedX();
     SANDBOX_API void ResetCameraPanInvertedY();
+    SANDBOX_API void ResetCameraZoomInverted();
     SANDBOX_API void ResetCameraDefaultEditorPosition();
     SANDBOX_API void ResetCameraDefaultOrbitDistance();
     SANDBOX_API void ResetCameraDefaultEditorOrientation();

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -724,6 +724,11 @@ namespace AzFramework
         {
             return 0.03f;
         };
+
+        m_invertZoomFn = []() constexpr
+        {
+            return false;
+        };
     }
 
     bool OrbitScrollDollyCameraInput::HandleEvents(
@@ -770,7 +775,7 @@ namespace AzFramework
         const float scrollDelta,
         [[maybe_unused]] const float deltaTime)
     {
-        const auto nextCamera = OrbitDolly(targetCamera, aznumeric_cast<float>(scrollDelta) * m_scrollSpeedFn());
+        const auto nextCamera = OrbitDolly(targetCamera, aznumeric_cast<float>(scrollDelta * Invert(m_invertZoomFn())) * m_scrollSpeedFn());
         EndActivation();
         return nextCamera;
     }
@@ -811,6 +816,11 @@ namespace AzFramework
         {
             return 0.02f;
         };
+
+        m_invertZoomFn = []() constexpr
+        {
+            return false;
+        };
     }
 
     bool LookScrollTranslationCameraInput::HandleEvents(
@@ -835,7 +845,7 @@ namespace AzFramework
         const auto translation_basis = LookTranslation(nextCamera);
         const auto axisY = translation_basis.GetBasisY();
 
-        nextCamera.m_pivot += axisY * scrollDelta * m_scrollSpeedFn();
+        nextCamera.m_pivot += axisY * aznumeric_cast<float>(scrollDelta * Invert(m_invertZoomFn())) * m_scrollSpeedFn();
 
         EndActivation();
 

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -625,6 +625,7 @@ namespace AzFramework
         Camera StepCamera(const Camera& targetCamera, const ScreenVector& cursorDelta, float scrollDelta, float deltaTime) override;
 
         AZStd::function<float()> m_scrollSpeedFn;
+        AZStd::function<bool()> m_invertZoomFn;
     };
 
     //! A camera input to handle motion deltas that can modify the camera offset.
@@ -658,6 +659,7 @@ namespace AzFramework
         Camera StepCamera(const Camera& targetCamera, const ScreenVector& cursorDelta, float scrollDelta, float deltaTime) override;
 
         AZStd::function<float()> m_scrollSpeedFn;
+        AZStd::function<bool()> m_invertZoomFn;
     };
 
     //! A camera input that doubles as its own set of camera inputs.


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new toggle to invert the mouse wheel zoom direction, enhancing the user experience.
It provides an optional setting to reverse the default zoom behavior.
The feature is especially beneficial for professionals familiar with CAD tools.

## How was this PR tested?

Minimal project with default shaderball level loaded in Editor,  and the functionality works as expected.
