### PR TITLE
GHA AR 3P Dev Bucket

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,10 +32,6 @@ on:
       last_artifact:
         required: false
         type: boolean
-      package_server_urls:
-        required: false
-        type: string
-        description: "Package server URLs for downloading dependencies"
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
@@ -205,7 +201,7 @@ jobs:
         timeout-minutes: 330
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
-          $env:LY_PACKAGE_SERVER_URLS = "${{ inputs.package_server_urls || vars.LY_PACKAGE_SERVER_URLS }}"
+          $env:LY_PACKAGE_SERVER_URLS = "https://d1gg6ket0m44ly.cloudfront.net;https://d3t6xeg4fgfoum.cloudfront.net"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"
           scripts\o3de.bat register --this-engine # Resolves registration issue with gradle build

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -200,7 +200,7 @@ jobs:
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         timeout-minutes: 330
         run: |
-          $env:LY_PACKAGE_SERVER_URLS = ${{ vars.LY_PACKAGE_SERVER_URLS }}
+          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -200,8 +200,8 @@ jobs:
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         timeout-minutes: 330
         run: |
-          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
+          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"
           scripts\o3de.bat register --this-engine # Resolves registration issue with gradle build

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -200,6 +200,7 @@ jobs:
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         timeout-minutes: 330
         run: |
+          $env:LY_PACKAGE_SERVER_URLS = ${{ vars.LY_PACKAGE_SERVER_URLS }}
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -14,24 +14,28 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      compiler: 
+      compiler:
         required: true
         type: string
-      config: 
+      config:
         required: true
         type: string
-      image: 
+      image:
         required: true
         type: string
-      platform: 
+      platform:
         required: true
         type: string
-      type: 
+      type:
         required: true
         type: string
-      last_artifact: 
+      last_artifact:
         required: false
         type: boolean
+      package_server_urls:
+        required: false
+        type: string
+        description: "Package server URLs for downloading dependencies"
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
@@ -201,7 +205,7 @@ jobs:
         timeout-minutes: 330
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
-          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
+          $env:LY_PACKAGE_SERVER_URLS = "${{ inputs.package_server_urls || vars.LY_PACKAGE_SERVER_URLS }}"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"
           scripts\o3de.bat register --this-engine # Resolves registration issue with gradle build

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -62,7 +62,6 @@ jobs:
             platform: Windows
             type: profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }} # If CLEAN_ARTIFACTS is false, then this returns true
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
     
     Windows-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -74,7 +73,6 @@ jobs:
             image: windows-2022
             platform: Windows
             type: asset_profile
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Windows-Test:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -86,7 +84,6 @@ jobs:
             image: windows-2022
             platform: Windows
             type: test_cpu_profile
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Windows-Release:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -98,7 +95,6 @@ jobs:
             platform: Windows
             type: release
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
 #### Linux Build ####
     Linux-Profile:
@@ -111,7 +107,6 @@ jobs:
             platform: Linux
             type: profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Linux-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
@@ -123,7 +118,6 @@ jobs:
             image: ubuntu-22.04
             platform: Linux
             type: asset_profile
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Linux-Test:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
@@ -136,7 +130,6 @@ jobs:
             platform: Linux
             type: test_profile
             desktop: true
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
 #### Android Build ####
     Android-Profile:
@@ -149,7 +142,6 @@ jobs:
             platform: Android
             type: profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Android-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
@@ -161,7 +153,6 @@ jobs:
             platform: Android
             type: asset_profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
             
     Android-Gradle:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
@@ -173,4 +164,3 @@ jobs:
             platform: Android
             type: gradle
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -62,6 +62,7 @@ jobs:
             platform: Windows
             type: profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }} # If CLEAN_ARTIFACTS is false, then this returns true
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
     
     Windows-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -73,6 +74,7 @@ jobs:
             image: windows-2022
             platform: Windows
             type: asset_profile
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Windows-Test:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -84,6 +86,7 @@ jobs:
             image: windows-2022
             platform: Windows
             type: test_cpu_profile
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Windows-Release:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -95,6 +98,7 @@ jobs:
             platform: Windows
             type: release
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
 #### Linux Build ####
     Linux-Profile:
@@ -107,6 +111,7 @@ jobs:
             platform: Linux
             type: profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Linux-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
@@ -118,6 +123,7 @@ jobs:
             image: ubuntu-22.04
             platform: Linux
             type: asset_profile
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Linux-Test:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
@@ -130,6 +136,7 @@ jobs:
             platform: Linux
             type: test_profile
             desktop: true
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
 #### Android Build ####
     Android-Profile:
@@ -142,6 +149,7 @@ jobs:
             platform: Android
             type: profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
 
     Android-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
@@ -153,6 +161,7 @@ jobs:
             platform: Android
             type: asset_profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}
             
     Android-Gradle:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
@@ -164,3 +173,4 @@ jobs:
             platform: Android
             type: gradle
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
+            package_server_urls: ${{ vars.LY_PACKAGE_SERVER_URLS }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -14,27 +14,31 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      compiler: 
+      compiler:
         required: true
         type: string
-      config: 
+      config:
         required: true
         type: string
-      image: 
+      image:
         required: true
         type: string
-      platform: 
+      platform:
         required: true
         type: string
-      type: 
+      type:
         required: true
         type: string
-      last_artifact: 
+      last_artifact:
         required: false
         type: boolean
       desktop:
         required: false
         type: boolean
+      package_server_urls:
+        required: false
+        type: string
+        description: "Package server URLs for downloading dependencies"
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
@@ -180,7 +184,7 @@ jobs:
         timeout-minutes: 330
         run: |
           export LY_3RDPARTY_PATH=${{ github.workspace }}/3rdParty
-          export LY_PACKAGE_SERVER_URLS="${{ vars.LY_PACKAGE_SERVER_URLS }}"
+          export LY_PACKAGE_SERVER_URLS="${{ inputs.package_server_urls || vars.LY_PACKAGE_SERVER_URLS }}"
           export CC=${{ inputs.compiler == 'gcc' && 'gcc' || 'clang'   }}
           export CXX=${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}
           export CMAKE_C_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -179,7 +179,7 @@ jobs:
         # Builds with presets in ../scripts/build/Platform/Linux/build_config.json
         timeout-minutes: 330
         run: |
-          export LY_PACKAGE_SERVER_URLS=${{ vars.LY_PACKAGE_SERVER_URLS }}
+          export LY_PACKAGE_SERVER_URLS="${{ vars.LY_PACKAGE_SERVER_URLS }}"
           export LY_3RDPARTY_PATH=${{ github.workspace }}/3rdParty
           export CC=${{ inputs.compiler == 'gcc' && 'gcc' || 'clang'   }}
           export CXX=${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -35,10 +35,6 @@ on:
       desktop:
         required: false
         type: boolean
-      package_server_urls:
-        required: false
-        type: string
-        description: "Package server URLs for downloading dependencies"
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
@@ -184,7 +180,7 @@ jobs:
         timeout-minutes: 330
         run: |
           export LY_3RDPARTY_PATH=${{ github.workspace }}/3rdParty
-          export LY_PACKAGE_SERVER_URLS="${{ inputs.package_server_urls || vars.LY_PACKAGE_SERVER_URLS }}"
+          export LY_PACKAGE_SERVER_URLS="https://d1gg6ket0m44ly.cloudfront.net;https://d3t6xeg4fgfoum.cloudfront.net"
           export CC=${{ inputs.compiler == 'gcc' && 'gcc' || 'clang'   }}
           export CXX=${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}
           export CMAKE_C_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -179,6 +179,7 @@ jobs:
         # Builds with presets in ../scripts/build/Platform/Linux/build_config.json
         timeout-minutes: 330
         run: |
+          export LY_PACKAGE_SERVER_URLS=${{ vars.LY_PACKAGE_SERVER_URLS }}
           export LY_3RDPARTY_PATH=${{ github.workspace }}/3rdParty
           export CC=${{ inputs.compiler == 'gcc' && 'gcc' || 'clang'   }}
           export CXX=${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -179,8 +179,8 @@ jobs:
         # Builds with presets in ../scripts/build/Platform/Linux/build_config.json
         timeout-minutes: 330
         run: |
-          export LY_PACKAGE_SERVER_URLS="${{ vars.LY_PACKAGE_SERVER_URLS }}"
           export LY_3RDPARTY_PATH=${{ github.workspace }}/3rdParty
+          export LY_PACKAGE_SERVER_URLS="${{ vars.LY_PACKAGE_SERVER_URLS }}"
           export CC=${{ inputs.compiler == 'gcc' && 'gcc' || 'clang'   }}
           export CXX=${{ inputs.compiler == 'gcc' && 'g++' || 'clang++' }}
           export CMAKE_C_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -192,8 +192,8 @@ jobs:
         working-directory: "${{ env.DEV_DRIVE_WORKSPACE }}"
         timeout-minutes: 330
         run: |
-          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
+          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp"
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"
           python\python.cmd -u scripts\build\ci_build.py --platform ${{ inputs.platform }} --type ${{ inputs.type }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -192,7 +192,7 @@ jobs:
         working-directory: "${{ env.DEV_DRIVE_WORKSPACE }}"
         timeout-minutes: 330
         run: |
-          $env:LY_PACKAGE_SERVER_URLS = ${{ vars.LY_PACKAGE_SERVER_URLS }}
+          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp"
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -32,10 +32,6 @@ on:
       last_artifact:
         required: false
         type: boolean
-      package_server_urls:
-        required: false
-        type: string
-        description: "Package server URLs for downloading dependencies"
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
@@ -197,7 +193,7 @@ jobs:
         timeout-minutes: 330
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
-          $env:LY_PACKAGE_SERVER_URLS = "${{ inputs.package_server_urls || vars.LY_PACKAGE_SERVER_URLS }}"
+          $env:LY_PACKAGE_SERVER_URLS = "https://d1gg6ket0m44ly.cloudfront.net;https://d3t6xeg4fgfoum.cloudfront.net"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp"
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"
           python\python.cmd -u scripts\build\ci_build.py --platform ${{ inputs.platform }} --type ${{ inputs.type }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -192,6 +192,7 @@ jobs:
         working-directory: "${{ env.DEV_DRIVE_WORKSPACE }}"
         timeout-minutes: 330
         run: |
+          $env:LY_PACKAGE_SERVER_URLS = ${{ vars.LY_PACKAGE_SERVER_URLS }}
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp"
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -14,24 +14,28 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
-      compiler: 
+      compiler:
         required: true
         type: string
-      config: 
+      config:
         required: true
         type: string
-      image: 
+      image:
         required: true
         type: string
-      platform: 
+      platform:
         required: true
         type: string
-      type: 
+      type:
         required: true
         type: string
-      last_artifact: 
+      last_artifact:
         required: false
         type: boolean
+      package_server_urls:
+        required: false
+        type: string
+        description: "Package server URLs for downloading dependencies"
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
@@ -193,7 +197,7 @@ jobs:
         timeout-minutes: 330
         run: |
           $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
-          $env:LY_PACKAGE_SERVER_URLS = "${{ vars.LY_PACKAGE_SERVER_URLS }}"
+          $env:LY_PACKAGE_SERVER_URLS = "${{ inputs.package_server_urls || vars.LY_PACKAGE_SERVER_URLS }}"
           $env:TEMP = "${{ env.DEV_DRIVE }}\temp"
           $env:TMP = "${{ env.DEV_DRIVE }}\temp"
           python\python.cmd -u scripts\build\ci_build.py --platform ${{ inputs.platform }} --type ${{ inputs.type }}


### PR DESCRIPTION
## What does this PR do?

- Updates the build workflows to include a new environment variable, `LY_PACKAGE_SERVER_URLS`, which uses the current cloudfront CDNs for Dev and Prod 3P buckets
- This allows 3P packages that were published to the 3P Dev bucket to be pulled into Github Actions AR

## How was this PR tested?

Tested in my fork with a 3P PR that only has packages in the 3P Dev bucket: https://github.com/amzn-changml/o3de/actions/runs/16710596613
