### PR TITLE
Remove default constructor from AZ::RHI::GeometryView

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/GeometryView.h
@@ -35,8 +35,6 @@ namespace AZ::RHI
         u8 m_dummyStreamBufferIndex = InvalidStreamBufferIndex;
 
     public:
-        GeometryView() = default;
-
         friend class StreamIterator<GeometryView, StreamBufferView>;
 
         explicit GeometryView(MultiDevice::DeviceMask deviceMask)


### PR DESCRIPTION
## What does this PR do?

This PR removes the default constructor of the `AZ::RHI::GeometryView` class. The one-argument constructor was made explicit in [PR19067](https://github.com/o3de/o3de/pull/19067) to disallow assigning a `MultiDevice::DeviceMask` to the GeometryView, which is semantically ambiguous. The default constructor was then added in the shared framework PR, but it can lead to runtime errors (instead of compile errors) if the GeometryView is not initialized, which happens eg. when pre-[PR19009](https://github.com/o3de/o3de/pull/19009)-code is used with the current version.

## How was this PR tested?

AR
