### PR TITLE
Remove Clang -fno-relaxed-template-template-args compile option

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/TemplateInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TemplateInfo.h
@@ -97,12 +97,11 @@ namespace AZ::AzGenericTypeInfo::Internal
     template<template<class, auto> class T, class = void>
     inline constexpr bool ExactClassAutoMatch = true;
 
-#if defined(AZ_COMPILER_MSVC)
     template<template<class, auto, class> class T>
-    using ClassAutoHasDefaultParam = void;
+    inline constexpr void ClassAutoHasDefaultParam() {}
+
     template<template<class, auto> class T>
     inline constexpr bool ExactClassAutoMatch<T, decltype(ClassAutoHasDefaultParam<T>())> = false;
-#endif
 
     template<template<class, auto> class T>
     auto GetTemplateIdentity() ->

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -52,8 +52,6 @@ ly_append_configurations_options(
         -Wno-reorder
         -Wno-switch
         -Wno-undefined-var-template
-        -fno-relaxed-template-template-args
-        -Wno-deprecated-no-relaxed-template-template-args
         -Wno-dllexport-explicit-instantiation-decl  # explicit instantiation declaration should not be 'dllexport'
 
         ###################


### PR DESCRIPTION
## What does this PR do?

This PR removes the `-fno-relaxed-template-template-args` and the corresponding `-Wno-deprecated-no-relaxed-template-template-args` compiler flags, since they are going to be phased out in [Clang-21](https://github.com/llvm/llvm-project/commit/8a334af417ff2ef49e0bc74f9421b4f3aa479805). The change in TemplateInfo.h was suggested by @nick-l-o3de in [this comment](https://github.com/o3de/o3de/issues/18470#issuecomment-2963926641). This change alone seems to be enough to get rid of the compiler flag.

## How was this PR tested?

Compile with Clang-20 on Windows, AR
