### PR TITLE
Remove AZ_FORCE_CPU_GPU_INSYNC macro from public Atom RHI header

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Base.h
@@ -15,15 +15,6 @@
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/smart_ptr/intrusive_ptr.h>
 
-// Enable this macro to force the cpu to run in lockstep with gpu. It will force
-// every RHI::Scope (i.e pass) into its own command list that is explicitly flushed and
-// waited on the cpu after an execute is called. This ensures that an execution for gpu
-// work related to a specific scope (i.e pass) finished successfully on the gpu
-// before the next scope is processed on the cpu. As long as you can repro this crash
-// in this mode use it to debug GPU device removals/TDR's when
-// you need to know which scope was executing right before the crash.
-//#define AZ_FORCE_CPU_GPU_INSYNC
-
 #if defined(AZ_MONOLITHIC_BUILD)
 AZ_DECLARE_BUDGET(RHI);
 #else

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Limits.h
@@ -47,11 +47,7 @@ namespace AZ::RHI
             //
             // In a more realistic scenario, a value of 3 would allow the CPU to build the current
             // frame, while the GPU could have up to two frames queued up before the CPU would wait.
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            constexpr uint32_t FrameCountMax = 1;
-#else
             constexpr uint32_t FrameCountMax = 3;
-#endif
 
             // Due to the fact that D3D12 only supports the flip model we need to allocate at least
             // a minimum of 2 swapChain images or the drivers will complain.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Debug.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Debug.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AZ::RHI
+{
+    // Set this variable to true to force the cpu to run in lockstep with the gpu. It will force
+    // every RHI::Scope (i.e pass) into its own command list that is explicitly flushed and waited
+    // on the cpu after an execute is called. This ensures that an execution for gpu work related to
+    // a specific scope (i.e pass) finished successfully on the gpu before the next scope is
+    // processed on the cpu. If you can repro a crash in this mode, use it to debug GPU device
+    // removals/TDR's when you need to know which scope was executing right before the crash.
+    // This variable replaces the old AZ_FORCE_CPU_GPU_INSYNC macro.
+    constexpr bool ForceCpuGpuInSync{ false };
+} // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -241,8 +241,7 @@ namespace AZ::RHI
 
         bool m_wasDeviceRemoved = false;
 
-        // Cache the name of the last executing scope name. Used within AZ_FORCE_CPU_GPU_INSYNC
+        // Cache the name of the last executing scope name. Used only if RHI::ForceCpuGpuInSync is enabled.
         AZStd::string m_lastExecutingScope;
-
     };
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
 #include <Atom/RHI/SwapChain.h>
@@ -268,11 +269,14 @@ namespace AZ::RHI
     {
         if (m_descriptor.m_isXrSwapChain)
         {
-#if defined (AZ_FORCE_CPU_GPU_INSYNC)
-            return m_images[0].get();
-#else
-            return m_images[m_xrSystem->GetCurrentImageIndex(m_descriptor.m_xrSwapChainIndex)].get();
-#endif
+            if constexpr (ForceCpuGpuInSync)
+            {
+                return m_images[0].get();
+            }
+            else
+            {
+                return m_images[m_xrSystem->GetCurrentImageIndex(m_descriptor.m_xrSwapChainIndex)].get();
+            }
         }
         AZ_Error("Swapchain", !m_deviceObjects.empty(), "No device swapchain image available.");
         // Note: Taking the current swapchain image index from the first device swap chain if there are multiple

--- a/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_public_files.cmake
@@ -46,6 +46,7 @@ set(FILES
     Include/Atom/RHI/DeviceCopyItem.h
     Include/Atom/RHI/CopyItem.h
     Include/Atom/RHI/ConstantsData.h
+    Include/Atom/RHI/Debug.h
     Include/Atom/RHI/DeviceDispatchItem.h
     Include/Atom/RHI/DispatchItem.h
     Include/Atom/RHI/DrawFilterTagRegistry.h

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Casting/lossy_cast.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/conversions.h>
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/ValidationLayer.h>
 #include <Atom/RHI/FactoryManagerBus.h>
 #include <comdef.h>
@@ -452,9 +453,10 @@ namespace AZ
             ID3D12Device* removedDevice = m_dx12Device.get();
             HRESULT removedReason = removedDevice->GetDeviceRemovedReason();
 
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            AZ_TracePrintf("Device", "The last executing pass before device removal was: %s\n", GetLastExecutingScope().data());
-#endif
+            if constexpr (RHI::ForceCpuGpuInSync)
+            {
+                AZ_TracePrintf("Device", "The last executing pass before device removal was: %s\n", GetLastExecutingScope().data());
+            }
             AZ_TracePrintf("Device", "Device was removed because of the following reason:\n");
             const char* removedReasonString;
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -10,6 +10,7 @@
 #include <RHI/FrameGraphExecuteGroup.h>
 #include <RHI/Device.h>
 #include <RHI/CommandQueueContext.h>
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h>
 
@@ -26,9 +27,10 @@ namespace AZ
         FrameGraphExecuter::FrameGraphExecuter()
         {
             RHI::JobPolicy graphJobPolicy = RHI::JobPolicy::Parallel;
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            graphJobPolicy = RHI::JobPolicy::Serial;
-#endif
+            if constexpr (RHI::ForceCpuGpuInSync)
+            {
+                graphJobPolicy = RHI::JobPolicy::Serial;
+            }
             SetJobPolicy(graphJobPolicy);
         }
 
@@ -54,115 +56,118 @@ namespace AZ
         {
             AZStd::vector<const Scope*> mergedScopes;
 
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            // Forces all scopes to issue a dedicated merged scope group with one command list.
-            // This will ensure that the Execute is done on only one scope and if an error happens
-            // we can be sure about the work gpu was working on before the crash.
-            for (const RHI::Scope* scopeBase : frameGraph.GetScopes())
+            if constexpr (RHI::ForceCpuGpuInSync)
             {
-                mergedScopes.push_back(static_cast<const Scope*>(scopeBase));
-                RHI::ScopeId scopeId = scopeBase->GetName();
-                FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
-                multiScopeContextGroup->Init(static_cast<Device&>(scopeBase->GetDevice()), AZStd::move(mergedScopes), scopeId);
-            }
-#else
-            bool hasUserFencesToSignal = false;
-            RHI::HardwareQueueClass mergedHardwareQueueClass = RHI::HardwareQueueClass::Graphics;
-            int mergedDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
-            uint32_t mergedGroupCost = 0;
-            uint32_t mergedSwapchainCount = 0;
-
-            const Scope* scopePrev = nullptr;
-            for (const RHI::Scope* scopeBase : frameGraph.GetScopes())
-            {
-                const Scope& scope = *static_cast<const Scope*>(scopeBase);
-
-                // Reset merged hardware queue class to match current scope if empty.
-                if (mergedGroupCost == 0)
+                // Forces all scopes to issue a dedicated merged scope group with one command list.
+                // This will ensure that the Execute is done on only one scope and if an error happens
+                // we can be sure about the work gpu was working on before the crash.
+                for (const RHI::Scope* scopeBase : frameGraph.GetScopes())
                 {
-                    mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                    mergedScopes.push_back(static_cast<const Scope*>(scopeBase));
+                    RHI::ScopeId scopeId = scopeBase->GetName();
+                    FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
+                    multiScopeContextGroup->Init(static_cast<Device&>(scopeBase->GetDevice()), AZStd::move(mergedScopes), scopeId);
                 }
+            }
+            else
+            {
+                bool hasUserFencesToSignal = false;
+                RHI::HardwareQueueClass mergedHardwareQueueClass = RHI::HardwareQueueClass::Graphics;
+                int mergedDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
+                uint32_t mergedGroupCost = 0;
+                uint32_t mergedSwapchainCount = 0;
 
-                const uint32_t estimatedItemCount = scope.GetEstimatedItemCount();
-
-                const uint32_t CommandListCostThreshold =
-                    AZStd::max(
-                        m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListCostThresholdMin,
-                        AZ::DivideAndRoundUp(estimatedItemCount, m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListsPerScopeMax));
-
-                // Computes a cost heuristic based on the number of items and number of attachments in
-                // the scope. This cost is used to partition command list generation.
-                const uint32_t totalScopeCost =
-                    estimatedItemCount * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_itemCost +
-                    static_cast<uint32_t>(scope.GetAttachments().size()) * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_attachmentCost;
-
-                const uint32_t swapchainCount = static_cast<uint32_t>(scope.GetSwapChainsToPresent().size());
-
-                // Detect if we are able to continue merging.
+                const Scope* scopePrev = nullptr;
+                for (const RHI::Scope* scopeBase : frameGraph.GetScopes())
                 {
-                    // Check if the group fits into the current running merge queue. If not, we have to flush the queue.
-                    const bool exceededCommandCost = (mergedGroupCost + totalScopeCost) > CommandListCostThreshold;
+                    const Scope& scope = *static_cast<const Scope*>(scopeBase);
 
-                    // Check if the swap chains fit into this group.
-                    const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData[scope.GetDeviceIndex()].m_swapChainsPerCommandList;
-
-                    // Check if the hardware queue classes match.
-                    const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
-
-                    bool hasUserFencesToWaitFor = !scope.GetFencesToWaitFor().empty();
-
-                    // Check if we are straddling the boundary of a fence.
-                    const bool onFenceBoundaries = (scope.HasWaitFences() || (scopePrev && scopePrev->HasSignalFence())) ||
-                        hasUserFencesToSignal || hasUserFencesToWaitFor;
-
-                    // Check if the devices match.
-                    const bool deviceMismatch = mergedDeviceIndex != scope.GetDeviceIndex();
-
-                    // If we exceeded limits, then flush the group.
-                    const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onFenceBoundaries || deviceMismatch;
-
-                    if (flushMergedScopes && mergedScopes.size())
+                    // Reset merged hardware queue class to match current scope if empty.
+                    if (mergedGroupCost == 0)
                     {
-                        hasUserFencesToSignal = false;
-                        mergedGroupCost = 0;
-                        mergedSwapchainCount = 0;
                         mergedHardwareQueueClass = scope.GetHardwareQueueClass();
-                        mergedDeviceIndex = scope.GetDeviceIndex();
-                        FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
-                        multiScopeContextGroup->Init(static_cast<Device&>(scopePrev->GetDevice()), AZStd::move(mergedScopes), m_mergedScopeId);
                     }
+
+                    const uint32_t estimatedItemCount = scope.GetEstimatedItemCount();
+
+                    const uint32_t CommandListCostThreshold =
+                        AZStd::max(
+                            m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListCostThresholdMin,
+                            AZ::DivideAndRoundUp(estimatedItemCount, m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListsPerScopeMax));
+
+                    // Computes a cost heuristic based on the number of items and number of attachments in
+                    // the scope. This cost is used to partition command list generation.
+                    const uint32_t totalScopeCost =
+                        estimatedItemCount * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_itemCost +
+                        static_cast<uint32_t>(scope.GetAttachments().size()) * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_attachmentCost;
+
+                    const uint32_t swapchainCount = static_cast<uint32_t>(scope.GetSwapChainsToPresent().size());
+
+                    // Detect if we are able to continue merging.
+                    {
+                        // Check if the group fits into the current running merge queue. If not, we have to flush the queue.
+                        const bool exceededCommandCost = (mergedGroupCost + totalScopeCost) > CommandListCostThreshold;
+
+                        // Check if the swap chains fit into this group.
+                        const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData[scope.GetDeviceIndex()].m_swapChainsPerCommandList;
+
+                        // Check if the hardware queue classes match.
+                        const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
+
+                        bool hasUserFencesToWaitFor = !scope.GetFencesToWaitFor().empty();
+
+                        // Check if we are straddling the boundary of a fence.
+                        const bool onFenceBoundaries = (scope.HasWaitFences() || (scopePrev && scopePrev->HasSignalFence())) ||
+                            hasUserFencesToSignal || hasUserFencesToWaitFor;
+
+                        // Check if the devices match.
+                        const bool deviceMismatch = mergedDeviceIndex != scope.GetDeviceIndex();
+
+                        // If we exceeded limits, then flush the group.
+                        const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onFenceBoundaries || deviceMismatch;
+
+                        if (flushMergedScopes && mergedScopes.size())
+                        {
+                            hasUserFencesToSignal = false;
+                            mergedGroupCost = 0;
+                            mergedSwapchainCount = 0;
+                            mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                            mergedDeviceIndex = scope.GetDeviceIndex();
+                            FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
+                            multiScopeContextGroup->Init(static_cast<Device&>(scopePrev->GetDevice()), AZStd::move(mergedScopes), m_mergedScopeId);
+                        }
+                    }
+
+                    // Attempt to merge the current scope.
+                    if (totalScopeCost < CommandListCostThreshold)
+                    {
+                        mergedScopes.push_back(&scope);
+                        mergedGroupCost += totalScopeCost;
+                        mergedSwapchainCount += swapchainCount;
+                        hasUserFencesToSignal = !scope.GetFencesToSignal().empty();
+                    }
+
+                    // Not mergeable, create a dedicated context group for it.
+                    else
+                    {
+                        // And then create a new group for the current scope with dedicated [1, N] command lists.
+                        const uint32_t commandListCount = AZStd::max(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u);
+
+                        FrameGraphExecuteGroup* scopeContextGroup = AddGroup<FrameGraphExecuteGroup>();
+                        scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
+                    }
+
+                    scopePrev = &scope;
                 }
 
-                // Attempt to merge the current scope.
-                if (totalScopeCost < CommandListCostThreshold)
+                if (mergedScopes.size())
                 {
-                    mergedScopes.push_back(&scope);
-                    mergedGroupCost += totalScopeCost;
-                    mergedSwapchainCount += swapchainCount;
-                    hasUserFencesToSignal = !scope.GetFencesToSignal().empty();
+                    mergedGroupCost = 0;
+                    mergedSwapchainCount = 0;
+                    FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
+                    multiScopeContextGroup->Init(static_cast<Device&>(mergedScopes.front()->GetDevice()), AZStd::move(mergedScopes), m_mergedScopeId);
                 }
-
-                // Not mergeable, create a dedicated context group for it.
-                else
-                {
-                    // And then create a new group for the current scope with dedicated [1, N] command lists.
-                    const uint32_t commandListCount = AZStd::max(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u);
-
-                    FrameGraphExecuteGroup* scopeContextGroup = AddGroup<FrameGraphExecuteGroup>();
-                    scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
-                }
-
-                scopePrev = &scope;
             }
-
-            if (mergedScopes.size())
-            {
-                mergedGroupCost = 0;
-                mergedSwapchainCount = 0;
-                FrameGraphExecuteGroupMerged* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
-                multiScopeContextGroup->Init(static_cast<Device&>(mergedScopes.front()->GetDevice()), AZStd::move(mergedScopes), m_mergedScopeId);
-            }
-#endif
         }
 
         void FrameGraphExecuter::ExecuteGroupInternal(RHI::FrameGraphExecuteGroup& groupBase)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/FrameGraphExecuteGroup.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
@@ -49,12 +51,15 @@ namespace AZ
             EndInternal();
             CommandQueue* cmdQueue = &m_device->GetCommandQueueContext().GetCommandQueue(m_hardwareQueueClass);
             cmdQueue->ExecuteWork(AZStd::move(m_workRequest));
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            //Cache the name of the scope we just queued and wait for it to finish on the cpu
-            m_device->SetLastExecutingScope(m_workRequest.m_commandList->GetName().GetStringView());
-            cmdQueue->FlushCommands();
-            cmdQueue->WaitForIdle();
-#endif
+
+            if constexpr (RHI::ForceCpuGpuInSync)
+            {
+                //Cache the name of the scope we just queued and wait for it to finish on the cpu
+                m_device->SetLastExecutingScope(m_workRequest.m_commandList->GetName().GetStringView());
+                cmdQueue->FlushCommands();
+                cmdQueue->WaitForIdle();
+            }
+
             m_isExecuted = true;
         }
 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <RHI/Device.h>
 #include <RHI/FrameGraphExecuter.h>
@@ -29,9 +30,10 @@ namespace AZ
         FrameGraphExecuter::FrameGraphExecuter()
         {
             RHI::JobPolicy graphJobPolicy = RHI::JobPolicy::Parallel;
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            graphJobPolicy = RHI::JobPolicy::Serial;
-#endif
+            if constexpr (RHI::ForceCpuGpuInSync)
+            {
+                graphJobPolicy = RHI::JobPolicy::Serial;
+            }
             SetJobPolicy(graphJobPolicy);
         }
         
@@ -59,130 +61,135 @@ namespace AZ
             const AZStd::vector<RHI::Scope*>& scopes = frameGraph.GetScopes();
             Scope* scopePrev = nullptr;
             Scope* scopeNext = nullptr;
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            // Forces all scopes to issue a dedicated merged scope group with one command list.
-            // This will ensure that the Commit is done on only one scope and if an error happens
-            // we can be sure about the work gpu was working on before the crash.
-            for (auto it = scopes.begin(); it != scopes.end(); ++it)
+
+            if constexpr (RHI::ForceCpuGpuInSync)
             {
-                Scope& scope = *static_cast<Scope*>(*it);
-                auto nextIter = it + 1;
-                scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
-                const bool subpassGroup = (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
-                                          (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
-                
-                if (subpassGroup)
+                // Forces all scopes to issue a dedicated merged scope group with one command list.
+                // This will ensure that the Commit is done on only one scope and if an error happens
+                // we can be sure about the work gpu was working on before the crash.
+                for (auto it = scopes.begin(); it != scopes.end(); ++it)
                 {
-                    FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
-                    scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, 1, GetJobPolicy());
-                }
-                else
-                {
-                    mergedScopes.push_back(static_cast<const Scope*>(scopeBase));
-                    FrameGraphExecuteGroupMerged* scopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
-                    scopeContextGroup->Init(static_cast<Device&>(scopeBase->GetDevice()), AZStd::move(mergedScopes), GetGroupCount());
+                    Scope& scope = *static_cast<Scope*>(*it);
+                    auto nextIter = it + 1;
+                    scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
+                    const bool subpassGroup = (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
+                                              (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
+
+                    if (subpassGroup)
+                    {
+                        FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
+                        scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, 1, GetJobPolicy());
+                    }
+                    else
+                    {
+                        mergedScopes.push_back(static_cast<const Scope*>(scopeBase));
+                        FrameGraphExecuteGroupMerged* scopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
+                        scopeContextGroup->Init(static_cast<Device&>(scopeBase->GetDevice()), AZStd::move(mergedScopes), GetGroupCount());
+                    }
                 }
             }
-#else
-            bool hasUserFencesToSignal = false;
-            RHI::HardwareQueueClass mergedHardwareQueueClass = RHI::HardwareQueueClass::Graphics;
-            int mergedDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
-            AZ::u32 mergedGroupCost = 0;
-            AZ::u32 mergedSwapchainCount = 0;
-
-            for (auto it = scopes.begin(); it != scopes.end(); ++it)
+            else
             {
-                Scope& scope = *static_cast<Scope*>(*it);
-                auto nextIter = it + 1;
-                scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
+                bool hasUserFencesToSignal = false;
+                RHI::HardwareQueueClass mergedHardwareQueueClass = RHI::HardwareQueueClass::Graphics;
+                int mergedDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
+                AZ::u32 mergedGroupCost = 0;
+                AZ::u32 mergedSwapchainCount = 0;
 
-                // Reset merged hardware queue class to match current scope if empty.
-                if (mergedGroupCost == 0)
+                for (auto it = scopes.begin(); it != scopes.end(); ++it)
                 {
-                    mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                    Scope& scope = *static_cast<Scope*>(*it);
+                    auto nextIter = it + 1;
+                    scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
+
+                    // Reset merged hardware queue class to match current scope if empty.
+                    if (mergedGroupCost == 0)
+                    {
+                        mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                    }
+
+                    const AZ::u32 estimatedItemCount = scope.GetEstimatedItemCount();
+
+                    const uint32_t CommandListCostThreshold =
+                        AZStd::max(
+                            m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListCostThresholdMin,
+                            RHI::DivideByMultiple(estimatedItemCount, m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListsPerScopeMax));
+
+                    /**
+                     * Computes a cost heuristic based on the number of items and number of attachments in
+                     * the scope. This cost is used to partition command list generation.
+                     */
+                    const AZ::u32 totalScopeCost =
+                        estimatedItemCount * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_itemCost +
+                        static_cast<AZ::u32>(scope.GetAttachments().size()) * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_attachmentCost;
+
+                    // Check if we are in a middle of a framegraph group.
+                    const bool subpassGroup =
+                        (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
+                        (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
+
+                    const AZ::u32 swapchainCount = static_cast<AZ::u32>(scope.GetSwapChainsToPresent().size());
+
+                    // Detect if we are able to continue merging.
+                    // Check if commandListCost applies and if the group fits into the current running merge queue. If not, we have to flush the queue.
+                    const bool exceededCommandCost = (mergedGroupCost + totalScopeCost) > CommandListCostThreshold;
+
+                    // Check if the swap chains fit into this group.
+                    const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData[scope.GetDeviceIndex()].m_swapChainsPerCommandList;
+
+                    // Check if the hardware queue classes match.
+                    const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
+
+                    // Check if we are straddling the boundary of a fence.
+                    const bool onFenceBoundaries = (scope.HasWaitFences() || (scopePrev && scopePrev->HasSignalFence())) || hasUserFencesToSignal;
+
+                           // Check if the devices match.
+                    const bool deviceMismatch = mergedDeviceIndex != scope.GetDeviceIndex();
+
+                    // If we exceeded limits, then flush the group.
+                    const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onFenceBoundaries || deviceMismatch || subpassGroup;
+
+                    if (flushMergedScopes && mergedScopes.size())
+                    {
+                        hasUserFencesToSignal = false;
+                        mergedGroupCost = 0;
+                        mergedSwapchainCount = 0;
+                        mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                        mergedDeviceIndex = scope.GetDeviceIndex();
+                        FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
+                        multiScopeContextGroup->Init(static_cast<Device&>(scopePrev->GetDevice()), AZStd::move(mergedScopes));
+                    }
+
+                    // Attempt to merge the current scope. We always merge the scopes that are writing to swapchain regardless of the cost.
+                    if (!subpassGroup && totalScopeCost < CommandListCostThreshold)
+                    {
+                        mergedScopes.push_back(&scope);
+                        mergedGroupCost += totalScopeCost;
+                        mergedSwapchainCount += swapchainCount;
+                        hasUserFencesToSignal = !scope.GetFencesToSignal().empty();
+                    }
+                    // Not mergeable, create a dedicated context group for it.
+                    else
+                    {
+                        // And then create a new group for the current scope with dedicated [1, N] command lists.
+                        const AZ::u32 commandListCount = AZStd::max(RHI::DivideByMultiple(totalScopeCost, CommandListCostThreshold), 1u);
+
+                        FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
+                        scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
+                    }
+
+                    scopePrev = &scope;
                 }
 
-                const AZ::u32 estimatedItemCount = scope.GetEstimatedItemCount();
-
-                const uint32_t CommandListCostThreshold =
-                    AZStd::max(
-                        m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListCostThresholdMin,
-                        RHI::DivideByMultiple(estimatedItemCount, m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListsPerScopeMax));
-
-                /**
-                 * Computes a cost heuristic based on the number of items and number of attachments in
-                 * the scope. This cost is used to partition command list generation.
-                 */
-                const AZ::u32 totalScopeCost =
-                    estimatedItemCount * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_itemCost +
-                    static_cast<AZ::u32>(scope.GetAttachments().size()) * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_attachmentCost;
-                
-                // Check if we are in a middle of a framegraph group.
-                const bool subpassGroup =
-                    (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
-                    (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
-
-                const AZ::u32 swapchainCount = static_cast<AZ::u32>(scope.GetSwapChainsToPresent().size());
-
-                // Detect if we are able to continue merging.
-                // Check if commandListCost applies and if the group fits into the current running merge queue. If not, we have to flush the queue.
-                const bool exceededCommandCost = (mergedGroupCost + totalScopeCost) > CommandListCostThreshold;
-
-                // Check if the swap chains fit into this group.
-                const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData[scope.GetDeviceIndex()].m_swapChainsPerCommandList;
-
-                // Check if the hardware queue classes match.
-                const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
-
-                // Check if we are straddling the boundary of a fence.
-                const bool onFenceBoundaries = (scope.HasWaitFences() || (scopePrev && scopePrev->HasSignalFence())) || hasUserFencesToSignal;
-
-                       // Check if the devices match.
-                const bool deviceMismatch = mergedDeviceIndex != scope.GetDeviceIndex();
-
-                // If we exceeded limits, then flush the group.
-                const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onFenceBoundaries || deviceMismatch || subpassGroup;
-                
-                if (flushMergedScopes && mergedScopes.size())
+                if (mergedScopes.size())
                 {
-                    hasUserFencesToSignal = false;
                     mergedGroupCost = 0;
                     mergedSwapchainCount = 0;
-                    mergedHardwareQueueClass = scope.GetHardwareQueueClass();
-                    mergedDeviceIndex = scope.GetDeviceIndex();
                     FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
-                    multiScopeContextGroup->Init(static_cast<Device&>(scopePrev->GetDevice()), AZStd::move(mergedScopes));
+                    multiScopeContextGroup->Init(static_cast<Device&>(mergedScopes.front()->GetDevice()), AZStd::move(mergedScopes));
                 }
-                
-                // Attempt to merge the current scope. We always merge the scopes that are writing to swapchain regardless of the cost.
-                if (!subpassGroup && totalScopeCost < CommandListCostThreshold)
-                {
-                    mergedScopes.push_back(&scope);
-                    mergedGroupCost += totalScopeCost;
-                    mergedSwapchainCount += swapchainCount;
-                    hasUserFencesToSignal = !scope.GetFencesToSignal().empty();
-                }
-                // Not mergeable, create a dedicated context group for it.
-                else
-                {
-                    // And then create a new group for the current scope with dedicated [1, N] command lists.
-                    const AZ::u32 commandListCount = AZStd::max(RHI::DivideByMultiple(totalScopeCost, CommandListCostThreshold), 1u);
-
-                    FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
-                    scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
-                }
-
-                scopePrev = &scope;
             }
 
-            if (mergedScopes.size())
-            {
-                mergedGroupCost = 0;
-                mergedSwapchainCount = 0;
-                FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
-                multiScopeContextGroup->Init(static_cast<Device&>(mergedScopes.front()->GetDevice()), AZStd::move(mergedScopes));
-            }
-#endif
             // Create the handlers to manage the execute groups.
             // Handlers manage one or multiple execute groups by creating a shared renderpass.
             auto groups = GetGroups();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/FrameGraphExecuteGroup.h>
 #include <RHI/FrameGraphExecuteGroup.h>
 #include <RHI/FrameGraphExecuteGroupHandler.h>
@@ -29,12 +31,15 @@ namespace AZ
             EndInternal();
             CommandQueue* cmdQueue = &m_device->GetCommandQueueContext().GetCommandQueue(m_hardwareQueueClass);
             cmdQueue->ExecuteWork(AZStd::move(m_workRequest));
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            //Cache the name of the scope we just queued and wait for it to finish on the cpu
-            m_device->SetLastExecutingScope(m_workRequest.m_commandList->GetName().GetStringView());
-            cmdQueue->FlushCommands();
-            cmdQueue->WaitForIdle();
-#endif
+
+            if constexpr (RHI::ForceCpuGpuInSync)
+            {
+                // Cache the name of the scope we just queued and wait for it to finish on the cpu
+                m_device->SetLastExecutingScope(m_workRequest.m_commandList->GetName().GetStringView());
+                cmdQueue->FlushCommands();
+                cmdQueue->WaitForIdle();
+            }
+
             m_isExecuted = true;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <AzCore/std/parallel/thread.h>
 #include <RHI/FrameGraphExecuteGroupSecondaryHandler.h>
@@ -30,9 +32,10 @@ namespace AZ
         FrameGraphExecuter::FrameGraphExecuter()
         {
             RHI::JobPolicy graphJobPolicy = RHI::JobPolicy::Parallel;
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            graphJobPolicy = RHI::JobPolicy::Serial;
-#endif
+            if constexpr (RHI::ForceCpuGpuInSync)
+            {
+                graphJobPolicy = RHI::JobPolicy::Serial;
+            }
             SetJobPolicy(graphJobPolicy);
         }
         
@@ -62,133 +65,136 @@ namespace AZ
             Scope* scopeNext = nullptr;
             const AZStd::vector<RHI::Scope*>& scopes = frameGraph.GetScopes();
 
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            // Forces all scopes to issue a dedicated merged scope group with one command list.
-            // This will ensure that the Execute is done on only one scope and if an error happens
-            // we can be sure about the work gpu was working on before the crash.
-            for (auto it = scopes.begin(); it != scopes.end(); ++it)
+            if constexpr (RHI::ForceCpuGpuInSync)
             {
-                Scope& scope = *static_cast<Scope*>(*it);
-                auto nextIter = it + 1;
-                scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
-                const bool subpassGroup = (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
-                                          (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
-                
-                if (subpassGroup)
+                // Forces all scopes to issue a dedicated merged scope group with one command list.
+                // This will ensure that the Execute is done on only one scope and if an error happens
+                // we can be sure about the work gpu was working on before the crash.
+                for (auto it = scopes.begin(); it != scopes.end(); ++it)
                 {
-                    FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
-                    scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, 1, GetJobPolicy());
-                }
-                else
-                {
-                    mergedScopes.push_back(&scope);
-                    FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
-                    multiScopeContextGroup->SetName(scope.GetName());
-                    multiScopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), AZStd::move(mergedScopes));
-                }
-                scopePrev = &scope;
-            }
-#else
-            
-            RHI::HardwareQueueClass mergedHardwareQueueClass = RHI::HardwareQueueClass::Graphics;
-            uint32_t mergedGroupCost = 0;
-            uint32_t mergedSwapchainCount = 0;
-            int mergedDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
+                    Scope& scope = *static_cast<Scope*>(*it);
+                    auto nextIter = it + 1;
+                    scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
+                    const bool subpassGroup = (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
+                                              (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
 
-            for (auto it = scopes.begin(); it != scopes.end(); ++it)
-            {
-                Scope& scope = *static_cast<Scope*>(*it);
-                auto nextIter = it + 1;
-                scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
-
-                // Reset merged hardware queue class to match current scope if empty.
-                if (mergedGroupCost == 0)
-                {
-                    mergedHardwareQueueClass = scope.GetHardwareQueueClass();
-                }
-
-                const uint32_t estimatedItemCount = scope.GetEstimatedItemCount();
-
-                const uint32_t CommandListCostThreshold =
-                    AZStd::max(
-                        m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListCostThresholdMin,
-                        AZ::DivideAndRoundUp(estimatedItemCount, m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListsPerScopeMax));
-
-                /**
-                    * Computes a cost heuristic based on the number of items and number of attachments in
-                    * the scope. This cost is used to partition command list generation.
-                    */
-                const uint32_t totalScopeCost =
-                    estimatedItemCount * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_itemCost +
-                    static_cast<uint32_t>(scope.GetAttachments().size()) * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_attachmentCost;
-
-                // Check if we are in a middle of a framegraph group.
-                const bool subpassGroup =
-                    (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
-                    (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
-
-                const uint32_t swapchainCount = static_cast<uint32_t>(scope.GetSwapChainsToPresent().size());
-
-                // Detect if we are able to continue merging.
-                {
-                    // Check if the group fits into the current running merge queue. If not, we have to flush the queue.
-                    const bool exceededCommandCost = (mergedGroupCost + totalScopeCost) > CommandListCostThreshold;
-
-                    // Check if the swap chains fit into this group.
-                    const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData[scope.GetDeviceIndex()].m_swapChainsPerCommandList;
-
-                    // Check if the hardware queue classes match.
-                    const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
-
-                    // Check if we are straddling the boundary of a fence/semaphore.
-                    const bool onSyncBoundaries = !scope.GetWaitSemaphores().empty() || !scope.GetWaitFences().empty() ||
-                        (scopePrev && (!scopePrev->GetSignalSemaphores().empty() || !scopePrev->GetSignalFences().empty()));
-
-                    // Check if the devices match.
-                    const bool deviceMismatch = mergedDeviceIndex != scope.GetDeviceIndex();
-
-                    // If we exceeded limits, then flush the group.
-                    const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onSyncBoundaries || deviceMismatch || subpassGroup;
-
-                    if (flushMergedScopes && mergedScopes.size())
+                    if (subpassGroup)
                     {
-                        // All merged scopes use a single primary command list
-                        mergedGroupCost = 0;
-                        mergedSwapchainCount = 0;
-                        mergedHardwareQueueClass = scope.GetHardwareQueueClass();
-                        mergedDeviceIndex = scope.GetDeviceIndex();
-                        FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
-                        multiScopeContextGroup->Init(static_cast<Device&>(scopePrev->GetDevice()), AZStd::move(mergedScopes));
+                        FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
+                        scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, 1, GetJobPolicy());
                     }
+                    else
+                    {
+                        mergedScopes.push_back(&scope);
+                        FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
+                        multiScopeContextGroup->SetName(scope.GetName());
+                        multiScopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), AZStd::move(mergedScopes));
+                    }
+                    scopePrev = &scope;
                 }
-
-                // Attempt to merge the current scope.
-                if (!subpassGroup && totalScopeCost < CommandListCostThreshold)
-                {
-                    mergedScopes.push_back(&scope);
-                    mergedGroupCost += totalScopeCost;
-                    mergedSwapchainCount += swapchainCount;
-                }
-                // Not mergeable, create a dedicated context group for it.
-                else
-                {
-                    // And then create a new group for the current scope with dedicated [1, N] secondary command lists
-                    const uint32_t commandListCount = AZStd::max(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u);
-                    FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
-                    scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
-                }
-                scopePrev = &scope;
             }
-
-            // Merge all pending scopes
-            if (mergedScopes.size())
+            else
             {
-                mergedGroupCost = 0;
-                mergedSwapchainCount = 0;
-                FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
-                multiScopeContextGroup->Init(static_cast<Device&>(mergedScopes.front()->GetDevice()), AZStd::move(mergedScopes));
+                RHI::HardwareQueueClass mergedHardwareQueueClass = RHI::HardwareQueueClass::Graphics;
+                uint32_t mergedGroupCost = 0;
+                uint32_t mergedSwapchainCount = 0;
+                int mergedDeviceIndex = RHI::MultiDevice::InvalidDeviceIndex;
+
+                for (auto it = scopes.begin(); it != scopes.end(); ++it)
+                {
+                    Scope& scope = *static_cast<Scope*>(*it);
+                    auto nextIter = it + 1;
+                    scopeNext = nextIter != scopes.end() ? static_cast<Scope*>(*nextIter) : nullptr;
+
+                    // Reset merged hardware queue class to match current scope if empty.
+                    if (mergedGroupCost == 0)
+                    {
+                        mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                    }
+
+                    const uint32_t estimatedItemCount = scope.GetEstimatedItemCount();
+
+                    const uint32_t CommandListCostThreshold =
+                        AZStd::max(
+                            m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListCostThresholdMin,
+                            AZ::DivideAndRoundUp(estimatedItemCount, m_frameGraphExecuterData[scope.GetDeviceIndex()].m_commandListsPerScopeMax));
+
+                    /**
+                        * Computes a cost heuristic based on the number of items and number of attachments in
+                        * the scope. This cost is used to partition command list generation.
+                        */
+                    const uint32_t totalScopeCost =
+                        estimatedItemCount * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_itemCost +
+                        static_cast<uint32_t>(scope.GetAttachments().size()) * m_frameGraphExecuterData[scope.GetDeviceIndex()].m_attachmentCost;
+
+                    // Check if we are in a middle of a framegraph group.
+                    const bool subpassGroup =
+                        (scopeNext && scopeNext->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId()) ||
+                        (scopePrev && scopePrev->GetFrameGraphGroupId() == scope.GetFrameGraphGroupId());
+
+                    const uint32_t swapchainCount = static_cast<uint32_t>(scope.GetSwapChainsToPresent().size());
+
+                    // Detect if we are able to continue merging.
+                    {
+                        // Check if the group fits into the current running merge queue. If not, we have to flush the queue.
+                        const bool exceededCommandCost = (mergedGroupCost + totalScopeCost) > CommandListCostThreshold;
+
+                        // Check if the swap chains fit into this group.
+                        const bool exceededSwapChainLimit = (mergedSwapchainCount + swapchainCount) > m_frameGraphExecuterData[scope.GetDeviceIndex()].m_swapChainsPerCommandList;
+
+                        // Check if the hardware queue classes match.
+                        const bool hardwareQueueMismatch = scope.GetHardwareQueueClass() != mergedHardwareQueueClass;
+
+                        // Check if we are straddling the boundary of a fence/semaphore.
+                        const bool onSyncBoundaries = !scope.GetWaitSemaphores().empty() || !scope.GetWaitFences().empty() ||
+                            (scopePrev && (!scopePrev->GetSignalSemaphores().empty() || !scopePrev->GetSignalFences().empty()));
+
+                        // Check if the devices match.
+                        const bool deviceMismatch = mergedDeviceIndex != scope.GetDeviceIndex();
+
+                        // If we exceeded limits, then flush the group.
+                        const bool flushMergedScopes = exceededCommandCost || exceededSwapChainLimit || hardwareQueueMismatch || onSyncBoundaries || deviceMismatch || subpassGroup;
+
+                        if (flushMergedScopes && mergedScopes.size())
+                        {
+                            // All merged scopes use a single primary command list
+                            mergedGroupCost = 0;
+                            mergedSwapchainCount = 0;
+                            mergedHardwareQueueClass = scope.GetHardwareQueueClass();
+                            mergedDeviceIndex = scope.GetDeviceIndex();
+                            FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
+                            multiScopeContextGroup->Init(static_cast<Device&>(scopePrev->GetDevice()), AZStd::move(mergedScopes));
+                        }
+                    }
+
+                    // Attempt to merge the current scope.
+                    if (!subpassGroup && totalScopeCost < CommandListCostThreshold)
+                    {
+                        mergedScopes.push_back(&scope);
+                        mergedGroupCost += totalScopeCost;
+                        mergedSwapchainCount += swapchainCount;
+                    }
+                    // Not mergeable, create a dedicated context group for it.
+                    else
+                    {
+                        // And then create a new group for the current scope with dedicated [1, N] secondary command lists
+                        const uint32_t commandListCount = AZStd::max(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u);
+                        FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
+                        scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
+                    }
+                    scopePrev = &scope;
+                }
+
+                // Merge all pending scopes
+                if (mergedScopes.size())
+                {
+                    mergedGroupCost = 0;
+                    mergedSwapchainCount = 0;
+                    FrameGraphExecuteGroupPrimary* multiScopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
+                    multiScopeContextGroup->Init(static_cast<Device&>(mergedScopes.front()->GetDevice()), AZStd::move(mergedScopes));
+                }
             }
-#endif
+
             // Create the handlers to manage the execute groups.
             // Handlers manage one or multiple execute groups by creating a shared renderpass/framebuffer
             // or advancing the subpass if needed.

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Queue.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI.Reflect/Vulkan/Conversion.h>
 #include <Atom_RHI_Vulkan_Platform.h>
 #include <AzCore/std/algorithm.h>
@@ -177,13 +179,15 @@ namespace AZ
             if (m_nativeQueue != VK_NULL_HANDLE)
             {
                 VkResult result = static_cast<Device&>(GetDevice()).GetContext().QueueWaitIdle(m_nativeQueue);
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-                if (result == VK_ERROR_DEVICE_LOST)
+
+                if constexpr (RHI::ForceCpuGpuInSync)
                 {
-                    AZ_TracePrintf("Device", "The last executing pass before device removal was: %s\n", GetDevice().GetLastExecutingScope().data());
-                    GetDevice().SetDeviceRemoved();
+                    if (result == VK_ERROR_DEVICE_LOST)
+                    {
+                        AZ_TracePrintf("Device", "The last executing pass before device removal was: %s\n", GetDevice().GetLastExecutingScope().data());
+                        GetDevice().SetDeviceRemoved();
+                    }
                 }
-#endif
                 AssertSuccess(result);
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -13,6 +13,7 @@
 
 #include <RPI.Private/RPISystemComponent.h>
 
+#include <Atom/RHI/Debug.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/RHIUtils.h>
 
@@ -190,11 +191,18 @@ namespace AZ
         
         void RPISystemComponent::OnDeviceRemoved([[maybe_unused]] RHI::Device* device)
         {
-#if defined(AZ_FORCE_CPU_GPU_INSYNC)
-            const AZStd::string errorMessage = AZStd::string::format("GPU device was removed while working on pass %s. Check the log file for more detail.", device->GetLastExecutingScope().data());
-#else
-            const AZStd::string errorMessage = "GPU device was removed. Check the log file for more detail.";
-#endif
+            AZStd::string errorMessage;
+            if constexpr (RHI::ForceCpuGpuInSync)
+            {
+                errorMessage = AZStd::string::format(
+                    "GPU device was removed while working on pass %s. Check the log file for more detail.",
+                    device->GetLastExecutingScope().data());
+            }
+            else
+            {
+                errorMessage = "GPU device was removed. Check the log file for more detail.";
+            }
+
             if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
             {
                 nativeUI->DisplayOkDialog("O3DE Fatal Error", errorMessage.c_str(), false);


### PR DESCRIPTION
## What does this PR do?

This PR removes usages of the `AZ_FORCE_CPU_GPU_INSYNC` macro from public Atom-RHI headers and replaces it with the constexpr `AZ::RHI::ForceCpuGpuInSync` boolean variable, which is no longer used in RHI header files.

This has the advantage that only 16 targets need to be rebuilt (9 compile + 7 link targets), compared to 515 targets without this change (377 compile + 138 link targets; Editor target with AutomatedTesting project, unity build), when enabling/disabling insync, which is a huge time saver when debugging GPU bugs with a cold compiler cache.
Buffers with `FrameCountMax` versions now do not change their size with insync enabled, which might be inconvenient when trying to find a specific buffer by name in a GPU debugger (eg. Nsights Object Browser the "RayTracingMeshInfo" resource is there 3 times). It would be possible to work around this problem by using a dllexported function (to keep the rebuild target count small) which returns the actual framecount, and use this to allocate and cycle buffers in `RPI::RingBuffer` and related classes, but this would then not be a very elegant solution. Also, many objects making use of FrameCoundMax are scattered throughout the engine, so it would take many code changes to catch all of these.

(The diff looks way larger than it actually is, so whitespace-insensitive diff is preferrable.)

## How was this PR tested?

Run ASV and find a sample which crashes the GPU (eg. RHI/VariableRateShading with Rate4x4 selected), verify that the error message (last pass before crash) stays the same.
Run the Editor and verify that enabling insync reduces FPS below 60.
