### PR TITLE
Filter out abstract classes when enumerating derived classes in ReflectionAdapter.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -202,7 +202,10 @@ namespace AZ::DocumentPropertyEditor
                     serialContext->EnumerateDerived(
                         [&derivedClasses](const AZ::SerializeContext::ClassData* classData, const AZ::Uuid& /*knownType*/) -> bool
                         {
-                            derivedClasses->push_back(classData);
+                            if (!(classData->m_azRtti && classData->m_azRtti->IsAbstract()))
+                            {
+                                derivedClasses->push_back(classData);
+                            }
                             return true;
                         },
                         containerClassElement->m_typeId,


### PR DESCRIPTION
## What does this PR do?

Currently when creating derived classes for reflected pointers in asset editor, abstract derived classes also show in the drop down dialog. This PR filters them out.

## How was this PR tested?

Manual