### PR TITLE
BUGFIX - Fixes cloth simulation rendering

### DIFF
--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -565,7 +565,7 @@ namespace NvCloth
             const auto& destTangentsData = destTangents.GetBuffer();
             const auto& destBitangentsData = destBitangents.GetBuffer();
 
-            if (!destVerticesData.empty())
+            if (destVerticesData.empty())
             {
                 AZ_Error("ClothComponentMesh", AZ::RHI::IsNullRHI(),
                     "Invalid vertex position buffer obtained from the render mesh to be modified.");


### PR DESCRIPTION

## What does this PR do?

Cloth was entirely broken and caused crazy artifacting.  Turns out it wasn't updating its render
buffer each frame like it should.

I investigated, found that the history of this code changed when atom changed, 

The code went from `if (!somepointer)` to `if (!somemap.empty())` due to a previous change, which flips the logic.  Checking for a null pointer and bailing early would be `if (somemap.empty())` without the `!` negation.

This fixes it.

### Before:

https://github.com/user-attachments/assets/2370965f-a4aa-4a54-84a0-c88aac8d2f0a

### After:

https://github.com/user-attachments/assets/76842972-f6ac-479e-8ac5-55946e2f8b9f

## How was this PR tested?

As above, kind of obvious breaking looking at the code. 