### PR TITLE
FTUE: When patching a 3rd party library, check for GIT

### DIFF
--- a/cmake/PatchIfNotAlreadyPatched.cmake
+++ b/cmake/PatchIfNotAlreadyPatched.cmake
@@ -27,8 +27,15 @@ set(PATCH_ALREADY_APPLIED "")
 # Check if the patch has already been applied.
 # if this command returns 0 it means that reversing the patch was successful
 # which means the patch was already applied.
+
+find_package(Git)
+
+if (NOT Git_FOUND)
+    message(FATAL_ERROR "Git executable not found.  Please make sure `git` is in your PATH")
+endif()
+
 execute_process(
-    COMMAND git apply --check --reverse "${PATCH_FILE_NAME}"
+    COMMAND ${GIT_EXECUTABLE} apply --check --reverse "${PATCH_FILE_NAME}"
     RESULT_VARIABLE PATCH_ALREADY_APPLIED
     OUTPUT_QUIET
     ERROR_QUIET
@@ -38,11 +45,11 @@ if (PATCH_ALREADY_APPLIED STREQUAL "0")
     message(STATUS "Skipping already applied patch ${PATCH_FILE_NAME} in dir ${CMAKE_BINARY_DIR}")
 else()
     message(STATUS "Cleaning directory before patch...")
-    execute_process(COMMAND git restore .)
-    execute_process(COMMAND git clean -fdx)
+    execute_process(COMMAND ${GIT_EXECUTABLE} restore .)
+    execute_process(COMMAND ${GIT_EXECUTABLE} clean -fdx)
     message(STATUS "Applying patch ${PATCH_FILE_NAME} at ${CMAKE_BINARY_DIR}...")
     execute_process(
-        COMMAND git apply --ignore-whitespace "${PATCH_FILE_NAME}"
+        COMMAND ${GIT_EXECUTABLE} apply --ignore-whitespace "${PATCH_FILE_NAME}"
         RESULT_VARIABLE PATCH_RESULT
     )
     if (NOT PATCH_RESULT EQUAL 0)


### PR DESCRIPTION
## What does this PR do?

This adds a check to our patching function (which uses git), to see if it can find `git` and if it cannot, tells the user that it cannot, instead of failing mysteriously.

(This was encountered by a user who had git installed on MSYS command line, but not in their actual windows PATH, 
trying to build from source, and failing for mysterious reasons).

Example of the error that appears now:
```
--   RecastNavigation Gem uses https://github.com/recastnavigation/recastnavigation.git commit 5a870d4 (License: Zlib)
  MSBuild version 17.14.14+a129329f1 for .NET Framework

    Performing update step for 'recastnavigation-populate'
    -- Already at requested ref: 5a870d427e47abd4a8e4ce58a95582ec049434d5
    Performing patch step for 'recastnavigation-populate'
    -- Could NOT find Git (missing: GIT_EXECUTABLE)
    CMake Error at C:/o3de-worktrees/stab/cmake/PatchIfNotAlreadyPatched.cmake:34 (message):
      Git executable not found.  Please make sure `git` is in your PATH
```

Note to reviewers `message(FATAL_ERROR` is an immediate "fail the configure"

## How was this PR tested?

Removing / Adding git from PATH and making sure the error appears.