### PR TITLE
Fix compile error in AFR gem due to unused variable in release build

### DIFF
--- a/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
+++ b/Gems/AFR/Code/Source/AFRFeatureProcessor.cpp
@@ -268,7 +268,7 @@ namespace AFR
 
         // This works as long as this connection is built with a pass request and not a template (which is fine as it isn't done this
         // way for the CopyToSwapChain pass):
-        bool found{ false };
+        [[maybe_unused]] bool found{ false };
 
         for (auto& connection : copyToSwapchainPass->GetPassDescriptor().m_passRequest->m_connections)
         {


### PR DESCRIPTION
## What does this PR do?

The variable `bool found` in AFRFeatureProcessor.cpp is defined, set and then later only read inside a `AZ_Assert` call, which leads to a compile error in release build.

## How was this PR tested?

Compile the engine with Clang on Windows in Release configuration
