### PR TITLE
Fix assert in CViewManager constructor due to improper usage of Aabb::SetMin/SetMax

### DIFF
--- a/Code/Editor/ViewManager.cpp
+++ b/Code/Editor/ViewManager.cpp
@@ -56,8 +56,7 @@ CViewManager::CViewManager()
     m_origin2D(0, 0, 0);
     m_zoom2D = 1.0f;
 
-    m_updateRegion.SetMin(AZ::Vector3(-100000, -100000, -100000));
-    m_updateRegion.SetMax(AZ::Vector3(100000, 100000, 100000));
+    m_updateRegion = AZ::Aabb::CreateFromMinMax(AZ::Vector3(-100000, -100000, -100000), AZ::Vector3(100000, 100000, 100000));
 
     m_pSelectedView = nullptr;
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes that the constructor of `CViewManager` sets the min and max values of an Aabb separately, which can lead to assertions in debug builds for certain uninitialized values of Aabb min/max (#19187).

## How was this PR tested?

Compile with Debug configuration and run the Editor, verify the assertion no longer occurs.
