### PR TITLE
Remove any structs from disabled extensions in pNext chain in Vulkan

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -91,9 +91,6 @@ namespace AZ
             ToRawStringList(requiredLayerStrings, requiredLayers);
             ToRawStringList(requiredExtensionStrings, requiredExtensions);
 
-            RawStringList optionalExtensions = physicalDevice.FilterSupportedOptionalExtensions();
-            requiredExtensions.insert(requiredExtensions.end(), optionalExtensions.begin(), optionalExtensions.end());
-
             // We now need to find the queues that the physical device has available and make sure
             // it has what we need. We're just expecting a Graphics queue for now.
             BuildDeviceQueueInfo(physicalDevice);
@@ -234,75 +231,98 @@ namespace AZ
 
             // unbounded array functionality
             VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptorIndexingFeatures = {};
-            VkBaseOutStructure& chainInit = reinterpret_cast<VkBaseOutStructure&>(descriptorIndexingFeatures);
-            descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
-            const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& physicalDeviceDescriptorIndexingFeatures =
-                physicalDevice.GetPhysicalDeviceDescriptorIndexingFeatures();
-            descriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing = physicalDeviceDescriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing;
-            descriptorIndexingFeatures.shaderUniformTexelBufferArrayDynamicIndexing = physicalDeviceDescriptorIndexingFeatures.shaderUniformTexelBufferArrayDynamicIndexing;
-            descriptorIndexingFeatures.shaderStorageTexelBufferArrayDynamicIndexing = physicalDeviceDescriptorIndexingFeatures.shaderStorageTexelBufferArrayDynamicIndexing;
-            descriptorIndexingFeatures.shaderUniformBufferArrayNonUniformIndexing = physicalDeviceDescriptorIndexingFeatures.shaderUniformBufferArrayNonUniformIndexing;
-            descriptorIndexingFeatures.shaderSampledImageArrayNonUniformIndexing = physicalDeviceDescriptorIndexingFeatures.shaderSampledImageArrayNonUniformIndexing;
-            descriptorIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing = physicalDeviceDescriptorIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing;
-            descriptorIndexingFeatures.shaderStorageImageArrayNonUniformIndexing = physicalDeviceDescriptorIndexingFeatures.shaderStorageImageArrayNonUniformIndexing;
-            descriptorIndexingFeatures.shaderInputAttachmentArrayNonUniformIndexing = physicalDeviceDescriptorIndexingFeatures.shaderInputAttachmentArrayNonUniformIndexing;
-            descriptorIndexingFeatures.shaderUniformTexelBufferArrayNonUniformIndexing = physicalDeviceDescriptorIndexingFeatures.shaderUniformTexelBufferArrayNonUniformIndexing;
-            descriptorIndexingFeatures.shaderStorageTexelBufferArrayNonUniformIndexing = physicalDeviceDescriptorIndexingFeatures.shaderStorageTexelBufferArrayNonUniformIndexing;
-            descriptorIndexingFeatures.descriptorBindingPartiallyBound = physicalDeviceDescriptorIndexingFeatures.descriptorBindingPartiallyBound;
-            descriptorIndexingFeatures.descriptorBindingVariableDescriptorCount = physicalDeviceDescriptorIndexingFeatures.descriptorBindingVariableDescriptorCount;
-            descriptorIndexingFeatures.runtimeDescriptorArray = physicalDeviceDescriptorIndexingFeatures.runtimeDescriptorArray;
-            descriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind = physicalDeviceDescriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind;
-            descriptorIndexingFeatures.descriptorBindingStorageImageUpdateAfterBind = physicalDeviceDescriptorIndexingFeatures.descriptorBindingStorageImageUpdateAfterBind;
-            descriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind = physicalDeviceDescriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind;
 
-            auto bufferDeviceAddressFeatures = physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures();
-            auto depthClipEnabled = physicalDevice.GetPhysicalDeviceDepthClipEnableFeatures();
-            auto rayQueryFeatures = physicalDevice.GetRayQueryFeatures();
-            auto shaderImageAtomicInt64 = physicalDevice.GetShaderImageAtomicInt64Features();
+            VkDeviceCreateInfo deviceInfo = {};
+            deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+
+            VkPhysicalDeviceBufferDeviceAddressFeaturesEXT bufferDeviceAddressFeatures;
+            VkPhysicalDeviceDepthClipEnableFeaturesEXT depthClipEnabled;
+            VkPhysicalDeviceRayQueryFeaturesKHR rayQueryFeatures;
+            VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT shaderImageAtomicInt64;
 
             VkPhysicalDeviceRobustness2FeaturesEXT robustness2 = {};
-            robustness2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
-            robustness2.nullDescriptor = physicalDevice.GetPhysicalDeviceRobustness2Features().nullDescriptor;
 
-            bufferDeviceAddressFeatures.pNext = nullptr;
-            depthClipEnabled.pNext = nullptr;
-            rayQueryFeatures.pNext = nullptr;
-            shaderImageAtomicInt64.pNext = nullptr;
-            robustness2.pNext = nullptr;
+            if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DepthClipEnable))
+            {
+                depthClipEnabled = physicalDevice.GetPhysicalDeviceDepthClipEnableFeatures();
+                depthClipEnabled.pNext = nullptr;
 
-            AppendVkStruct(
-                chainInit, { &bufferDeviceAddressFeatures, &depthClipEnabled, &rayQueryFeatures, &shaderImageAtomicInt64, &robustness2 });
+                AppendVkStruct(deviceInfo, &depthClipEnabled);
+            }
 
-            auto subpassMergeFeedback = physicalDevice.GetPhysicalSubpassMergeFeedbackFeatures();
+            if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderImageAtomicInt64))
+            {
+                shaderImageAtomicInt64 = physicalDevice.GetShaderImageAtomicInt64Features();
+                shaderImageAtomicInt64.pNext = nullptr;
+
+                AppendVkStruct(deviceInfo, &shaderImageAtomicInt64);
+            }
+
+            if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::Robustness2))
+            {
+                robustness2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
+                robustness2.nullDescriptor = physicalDevice.GetPhysicalDeviceRobustness2Features().nullDescriptor;
+                robustness2.pNext = nullptr;
+
+                AppendVkStruct(deviceInfo, &robustness2);
+            }
+
+            VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT subpassMergeFeedback;
+
+            if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SubpassMergeFeedback))
+            {
+                subpassMergeFeedback = physicalDevice.GetPhysicalSubpassMergeFeedbackFeatures();
 
 #if !defined(AZ_RELEASE_BUILD)
-            subpassMergeFeedback.subpassMergeFeedback = false;
+                subpassMergeFeedback.subpassMergeFeedback = false;
 #endif
-            if (!subpassMergeFeedback.subpassMergeFeedback &&
-                physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SubpassMergeFeedback))
-            {
-                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::SubpassMergeFeedback);
-                subpassMergeFeedback.pNext = nullptr;
-                AppendVkStruct(chainInit, &subpassMergeFeedback);
+                if (!subpassMergeFeedback.subpassMergeFeedback)
+                {
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::SubpassMergeFeedback);
+                }
+                else
+                {
+                    subpassMergeFeedback.pNext = nullptr;
+                    AppendVkStruct(deviceInfo, &subpassMergeFeedback);
+                }
             }
 
-            auto fragmentDensityMapFeatures = physicalDevice.GetPhysicalDeviceFragmentDensityMapFeatures();
-            auto fragmentShadingRateFeatures = physicalDevice.GetPhysicalDeviceFragmentShadingRateFeatures();
+            VkPhysicalDeviceFragmentDensityMapFeaturesEXT fragmentDensityMapFeatures;
+            VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragmentShadingRateFeatures;
 
-            if (fragmentShadingRateFeatures.attachmentFragmentShadingRate)
+            if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentShadingRate))
             {
-                // Must disable the "FragmentDensityMap" usage if "attachmentFragmentShadingRate" is enabled.
-                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentDensityMap);
-                fragmentShadingRateFeatures.pNext = nullptr;
-                AppendVkStruct(chainInit, &fragmentShadingRateFeatures);
+                fragmentShadingRateFeatures = physicalDevice.GetPhysicalDeviceFragmentShadingRateFeatures();
+
+                if (fragmentShadingRateFeatures.attachmentFragmentShadingRate)
+                {
+                    // Must disable the "FragmentDensityMap" usage if "attachmentFragmentShadingRate" is enabled.
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentDensityMap);
+                    fragmentShadingRateFeatures.pNext = nullptr;
+                    AppendVkStruct(deviceInfo, &fragmentShadingRateFeatures);
+                }
+                else
+                {
+                    // We only support NonSubsampledImages when using fragment density map
+                    // Must disable the "FragmentShadingRate" usage so "fragmentDensityMap" can be enabled.
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentShadingRate);
+                }
             }
-            else if (fragmentDensityMapFeatures.fragmentDensityMap && fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages)
+
+            // if the extension is not supported or we got disabled within the if above we won't go into this if
+            if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentDensityMap))
             {
-                // We only support NonSubsampledImages when using fragment density map
-                // Must disable the "FragmentShadingRate" usage if "fragmentDensityMap" is enabled.
-                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentShadingRate);
-                fragmentDensityMapFeatures.pNext = nullptr;
-                AppendVkStruct(chainInit, &fragmentDensityMapFeatures);
+                fragmentDensityMapFeatures = physicalDevice.GetPhysicalDeviceFragmentDensityMapFeatures();
+
+                if (fragmentDensityMapFeatures.fragmentDensityMap && fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages)
+                {
+                    fragmentDensityMapFeatures.pNext = nullptr;
+                    AppendVkStruct(deviceInfo, &fragmentDensityMapFeatures);
+                }
+                else
+                {
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentDensityMap);
+                }
             }
 
             VkPhysicalDeviceVulkan12Features vulkan12Features = {};
@@ -312,37 +332,74 @@ namespace AZ
             VkPhysicalDeviceAccelerationStructureFeaturesKHR accelerationStructureFeatures = {};
             VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures = {};
 
-            VkDeviceCreateInfo deviceInfo = {};
-            deviceInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-
-            auto timelineSemaphore = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures();
+            VkPhysicalDeviceTimelineSemaphoreFeatures timelineSemaphore;
             // If we are running Vulkan >= 1.2, then we must use VkPhysicalDeviceVulkan12Features instead
             // of VkPhysicalDeviceShaderFloat16Int8FeaturesKHR or VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR.
             if (majorVersion >= 1 && minorVersion >= 2)
             {
+                const auto& physicalDeviceVulkan12Features = physicalDevice.GetPhysicalDeviceVulkan12Features();
+
                 vulkan12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
-                vulkan12Features.drawIndirectCount = physicalDevice.GetPhysicalDeviceVulkan12Features().drawIndirectCount;
-                vulkan12Features.shaderFloat16 = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderFloat16;
-                vulkan12Features.shaderInt8 = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderInt8;
-                vulkan12Features.separateDepthStencilLayouts = physicalDevice.GetPhysicalDeviceVulkan12Features().separateDepthStencilLayouts;
-                vulkan12Features.descriptorBindingPartiallyBound = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingPartiallyBound;
-                vulkan12Features.descriptorIndexing = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorIndexing;
-                vulkan12Features.descriptorBindingVariableDescriptorCount = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingVariableDescriptorCount;
-                // We use the "VkPhysicalDeviceBufferDeviceAddressFeatures" instead of the "VkPhysicalDeviceVulkan12Features" for buffer device address
-                // because some drivers (e.g. Intel) don't report any features of buffer device address through the "PhysicalDeviceVulkan12Features" but they do
-                // through the "VK_EXT_buffer_device_address" extension.
+                vulkan12Features.drawIndirectCount = physicalDeviceVulkan12Features.drawIndirectCount;
+                vulkan12Features.shaderFloat16 = physicalDeviceVulkan12Features.shaderFloat16;
+                vulkan12Features.shaderInt8 = physicalDeviceVulkan12Features.shaderInt8;
+                vulkan12Features.separateDepthStencilLayouts = physicalDeviceVulkan12Features.separateDepthStencilLayouts;
+                vulkan12Features.descriptorBindingPartiallyBound = physicalDeviceVulkan12Features.descriptorBindingPartiallyBound;
+                vulkan12Features.descriptorIndexing = physicalDeviceVulkan12Features.descriptorIndexing;
+                vulkan12Features.descriptorBindingVariableDescriptorCount =
+                    physicalDeviceVulkan12Features.descriptorBindingVariableDescriptorCount;
+                vulkan12Features.shaderInputAttachmentArrayDynamicIndexing =
+                    physicalDeviceVulkan12Features.shaderInputAttachmentArrayDynamicIndexing;
+                vulkan12Features.shaderUniformTexelBufferArrayDynamicIndexing =
+                    physicalDeviceVulkan12Features.shaderUniformTexelBufferArrayDynamicIndexing;
+                vulkan12Features.shaderStorageTexelBufferArrayDynamicIndexing =
+                    physicalDeviceVulkan12Features.shaderStorageTexelBufferArrayDynamicIndexing;
+                vulkan12Features.shaderUniformBufferArrayNonUniformIndexing =
+                    physicalDeviceVulkan12Features.shaderUniformBufferArrayNonUniformIndexing;
+                vulkan12Features.shaderSampledImageArrayNonUniformIndexing =
+                    physicalDeviceVulkan12Features.shaderSampledImageArrayNonUniformIndexing;
+                vulkan12Features.shaderStorageBufferArrayNonUniformIndexing =
+                    physicalDeviceVulkan12Features.shaderStorageBufferArrayNonUniformIndexing;
+                vulkan12Features.shaderStorageImageArrayNonUniformIndexing =
+                    physicalDeviceVulkan12Features.shaderStorageImageArrayNonUniformIndexing;
+                vulkan12Features.shaderInputAttachmentArrayNonUniformIndexing =
+                    physicalDeviceVulkan12Features.shaderInputAttachmentArrayNonUniformIndexing;
+                vulkan12Features.shaderUniformTexelBufferArrayNonUniformIndexing =
+                    physicalDeviceVulkan12Features.shaderUniformTexelBufferArrayNonUniformIndexing;
+                vulkan12Features.shaderStorageTexelBufferArrayNonUniformIndexing =
+                    physicalDeviceVulkan12Features.shaderStorageTexelBufferArrayNonUniformIndexing;
+                vulkan12Features.descriptorBindingPartiallyBound = physicalDeviceVulkan12Features.descriptorBindingPartiallyBound;
+                vulkan12Features.descriptorBindingVariableDescriptorCount =
+                    physicalDeviceVulkan12Features.descriptorBindingVariableDescriptorCount;
+                vulkan12Features.runtimeDescriptorArray = physicalDeviceVulkan12Features.runtimeDescriptorArray;
+                vulkan12Features.descriptorBindingSampledImageUpdateAfterBind =
+                    physicalDeviceVulkan12Features.descriptorBindingSampledImageUpdateAfterBind;
+                vulkan12Features.descriptorBindingStorageImageUpdateAfterBind =
+                    physicalDeviceVulkan12Features.descriptorBindingStorageImageUpdateAfterBind;
+                vulkan12Features.descriptorBindingStorageBufferUpdateAfterBind =
+                    physicalDeviceVulkan12Features.descriptorBindingStorageBufferUpdateAfterBind;
+
+                // We use the "VkPhysicalDeviceBufferDeviceAddressFeatures" instead of the "VkPhysicalDeviceVulkan12Features" for buffer
+                // device address because some drivers (e.g. Intel) don't report any features of buffer device address through the
+                // "PhysicalDeviceVulkan12Features" but they do through the "VK_EXT_buffer_device_address" extension.
                 vulkan12Features.bufferDeviceAddress = physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures().bufferDeviceAddress;
-                vulkan12Features.bufferDeviceAddressMultiDevice = physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures().bufferDeviceAddressMultiDevice;
-                vulkan12Features.runtimeDescriptorArray = physicalDevice.GetPhysicalDeviceVulkan12Features().runtimeDescriptorArray;
-                vulkan12Features.shaderSharedInt64Atomics = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderSharedInt64Atomics;
-                vulkan12Features.shaderBufferInt64Atomics = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderBufferInt64Atomics;
-                vulkan12Features.descriptorBindingSampledImageUpdateAfterBind = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingSampledImageUpdateAfterBind;
-                vulkan12Features.descriptorBindingStorageImageUpdateAfterBind = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingStorageImageUpdateAfterBind;
-                vulkan12Features.descriptorBindingStorageBufferUpdateAfterBind = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingStorageBufferUpdateAfterBind;
-                vulkan12Features.descriptorBindingUpdateUnusedWhilePending = physicalDevice.GetPhysicalDeviceVulkan12Features().descriptorBindingUpdateUnusedWhilePending;
-                vulkan12Features.shaderOutputViewportIndex = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputViewportIndex;
-                vulkan12Features.shaderOutputLayer = physicalDevice.GetPhysicalDeviceVulkan12Features().shaderOutputLayer;
-                vulkan12Features.timelineSemaphore = timelineSemaphore.timelineSemaphore;
+                vulkan12Features.bufferDeviceAddressMultiDevice =
+                    physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures().bufferDeviceAddressMultiDevice;
+
+                vulkan12Features.runtimeDescriptorArray = physicalDeviceVulkan12Features.runtimeDescriptorArray;
+                vulkan12Features.shaderSharedInt64Atomics = physicalDeviceVulkan12Features.shaderSharedInt64Atomics;
+                vulkan12Features.shaderBufferInt64Atomics = physicalDeviceVulkan12Features.shaderBufferInt64Atomics;
+                vulkan12Features.descriptorBindingSampledImageUpdateAfterBind =
+                    physicalDeviceVulkan12Features.descriptorBindingSampledImageUpdateAfterBind;
+                vulkan12Features.descriptorBindingStorageImageUpdateAfterBind =
+                    physicalDeviceVulkan12Features.descriptorBindingStorageImageUpdateAfterBind;
+                vulkan12Features.descriptorBindingStorageBufferUpdateAfterBind =
+                    physicalDeviceVulkan12Features.descriptorBindingStorageBufferUpdateAfterBind;
+                vulkan12Features.descriptorBindingUpdateUnusedWhilePending =
+                    physicalDeviceVulkan12Features.descriptorBindingUpdateUnusedWhilePending;
+                vulkan12Features.shaderOutputViewportIndex = physicalDeviceVulkan12Features.shaderOutputViewportIndex;
+                vulkan12Features.shaderOutputLayer = physicalDeviceVulkan12Features.shaderOutputLayer;
+                vulkan12Features.timelineSemaphore = physicalDeviceVulkan12Features.timelineSemaphore;
 
                 accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
                 accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;
@@ -351,9 +408,28 @@ namespace AZ
                 rayTracingPipelineFeatures.rayTracingPipeline = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipeline;
                 rayTracingPipelineFeatures.rayTracingPipelineTraceRaysIndirect = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipelineTraceRaysIndirect;
 
-                AppendVkStruct(chainInit, { &vulkan12Features, &accelerationStructureFeatures, &rayTracingPipelineFeatures });
-                // Do not start from the chainInit, but from the depthClipEnabled struct
-                deviceInfo.pNext = &depthClipEnabled;
+                AppendVkStruct(deviceInfo, &vulkan12Features);
+
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure) &&
+                    physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
+                {
+                    AppendVkStruct(deviceInfo, { &accelerationStructureFeatures, &rayTracingPipelineFeatures });
+
+                    if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
+                    {
+                        rayQueryFeatures = physicalDevice.GetRayQueryFeatures();
+                        rayQueryFeatures.pNext = nullptr;
+
+                        AppendVkStruct(deviceInfo, &rayQueryFeatures);
+                    }
+                }
+                else
+                {
+                    // make sure all ray tracing extensions are disabled
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::AccelerationStructure);
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::RayTracingPipeline);
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::RayQuery);
+                }
             }
             else
             {
@@ -363,12 +439,79 @@ namespace AZ
                 separateDepthStencil.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
                 separateDepthStencil.separateDepthStencilLayouts = physicalDevice.GetPhysicalDeviceSeparateDepthStencilFeatures().separateDepthStencilLayouts;
 
-                shaderAtomicInt64.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
-                shaderAtomicInt64.shaderBufferInt64Atomics = physicalDevice.GetShaderAtomicInt64Features().shaderBufferInt64Atomics;
-                shaderAtomicInt64.shaderSharedInt64Atomics = physicalDevice.GetShaderAtomicInt64Features().shaderSharedInt64Atomics;
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderFloat16Int8))
+                {
+                    AppendVkStruct(deviceInfo, &float16Int8);
+                }
 
-                AppendVkStruct(chainInit, { &float16Int8, &separateDepthStencil, &shaderAtomicInt64, &timelineSemaphore });
-                deviceInfo.pNext = &chainInit;
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SeparateDepthStencilLayouts))
+                {
+                    AppendVkStruct(deviceInfo, &separateDepthStencil);
+                }
+
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DescriptorIndexing))
+                {
+                    descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
+                    const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& physicalDeviceDescriptorIndexingFeatures =
+                        physicalDevice.GetPhysicalDeviceDescriptorIndexingFeatures();
+                    descriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing;
+                    descriptorIndexingFeatures.shaderUniformTexelBufferArrayDynamicIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderUniformTexelBufferArrayDynamicIndexing;
+                    descriptorIndexingFeatures.shaderStorageTexelBufferArrayDynamicIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderStorageTexelBufferArrayDynamicIndexing;
+                    descriptorIndexingFeatures.shaderUniformBufferArrayNonUniformIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderUniformBufferArrayNonUniformIndexing;
+                    descriptorIndexingFeatures.shaderSampledImageArrayNonUniformIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderSampledImageArrayNonUniformIndexing;
+                    descriptorIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing;
+                    descriptorIndexingFeatures.shaderStorageImageArrayNonUniformIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderStorageImageArrayNonUniformIndexing;
+                    descriptorIndexingFeatures.shaderInputAttachmentArrayNonUniformIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderInputAttachmentArrayNonUniformIndexing;
+                    descriptorIndexingFeatures.shaderUniformTexelBufferArrayNonUniformIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderUniformTexelBufferArrayNonUniformIndexing;
+                    descriptorIndexingFeatures.shaderStorageTexelBufferArrayNonUniformIndexing =
+                        physicalDeviceDescriptorIndexingFeatures.shaderStorageTexelBufferArrayNonUniformIndexing;
+                    descriptorIndexingFeatures.descriptorBindingPartiallyBound =
+                        physicalDeviceDescriptorIndexingFeatures.descriptorBindingPartiallyBound;
+                    descriptorIndexingFeatures.descriptorBindingVariableDescriptorCount =
+                        physicalDeviceDescriptorIndexingFeatures.descriptorBindingVariableDescriptorCount;
+                    descriptorIndexingFeatures.runtimeDescriptorArray = physicalDeviceDescriptorIndexingFeatures.runtimeDescriptorArray;
+                    descriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind =
+                        physicalDeviceDescriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind;
+                    descriptorIndexingFeatures.descriptorBindingStorageImageUpdateAfterBind =
+                        physicalDeviceDescriptorIndexingFeatures.descriptorBindingStorageImageUpdateAfterBind;
+                    descriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind =
+                        physicalDeviceDescriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind;
+
+                    AppendVkStruct(deviceInfo, &descriptorIndexingFeatures);
+                }
+
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::BufferDeviceAddress))
+                {
+                    bufferDeviceAddressFeatures = physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures();
+                    bufferDeviceAddressFeatures.pNext = nullptr;
+
+                    AppendVkStruct(deviceInfo, &bufferDeviceAddressFeatures);
+                }
+
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderAtomicInt64))
+                {
+                    shaderAtomicInt64 = physicalDevice.GetShaderAtomicInt64Features();
+                    shaderAtomicInt64.pNext = nullptr;
+
+                    AppendVkStruct(deviceInfo, &shaderAtomicInt64);
+                }
+
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore))
+                {
+                    timelineSemaphore = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures();
+                    timelineSemaphore.pNext = nullptr;
+
+                    AppendVkStruct(deviceInfo, &timelineSemaphore);
+                }
             }
 
 #if defined(USE_NSIGHT_AFTERMATH)
@@ -387,6 +530,9 @@ namespace AZ
             aftermathInfo.pNext = deviceInfo.pNext;
             deviceInfo.pNext = &aftermathInfo;
 #endif
+
+            RawStringList optionalExtensions = physicalDevice.FilterSupportedOptionalExtensions(false);
+            requiredExtensions.insert(requiredExtensions.end(), optionalExtensions.begin(), optionalExtensions.end());
 
             deviceInfo.flags = 0;
             deviceInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreationInfo.size());
@@ -1229,6 +1375,11 @@ namespace AZ
 
         void Device::InitFeaturesAndLimits(const PhysicalDevice& physicalDevice)
         {
+            uint32_t physicalDeviceVersion = physicalDevice.GetVulkanVersion();
+            uint32_t majorVersion = VK_VERSION_MAJOR(physicalDeviceVersion);
+            uint32_t minorVersion = VK_VERSION_MINOR(physicalDeviceVersion);
+            auto vulkan12{ majorVersion >= 1 && minorVersion >= 2 };
+
             m_features.m_geometryShader = (m_enabledDeviceFeatures.geometryShader == VK_TRUE);
             m_features.m_computeShader = true;
             m_features.m_independentBlend = (m_enabledDeviceFeatures.independentBlend == VK_TRUE);
@@ -1290,14 +1441,17 @@ namespace AZ
             // to determine if ray tracing is supported on this device
             StringList deviceExtensions = physicalDevice.GetDeviceExtensionNames();
             StringList::iterator itRayTracingExtension = AZStd::find(deviceExtensions.begin(), deviceExtensions.end(), VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
-            m_features.m_unboundedArrays = physicalDevice.GetPhysicalDeviceDescriptorIndexingFeatures().shaderStorageTexelBufferArrayNonUniformIndexing;
+            m_features.m_unboundedArrays = vulkan12
+                ? physicalDevice.GetPhysicalDeviceVulkan12Features().shaderStorageTexelBufferArrayNonUniformIndexing
+                : physicalDevice.GetPhysicalDeviceDescriptorIndexingFeatures().shaderStorageTexelBufferArrayNonUniformIndexing;
             if (m_features.m_unboundedArrays)
             {
                 // Ray tracing needs raytracing extensions and unbounded arrays to work
                 m_features.m_rayTracing = (itRayTracingExtension != deviceExtensions.end());
             }
 
-            m_features.m_float16 = physicalDevice.GetPhysicalDeviceFloat16Int8Features().shaderFloat16;
+            m_features.m_float16 = vulkan12 ? physicalDevice.GetPhysicalDeviceVulkan12Features().shaderFloat16
+                                            : physicalDevice.GetPhysicalDeviceFloat16Int8Features().shaderFloat16;
 
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentShadingRate))
             {
@@ -1357,7 +1511,8 @@ namespace AZ
 #ifdef DISABLE_TIMELINE_SEMAPHORES
             m_features.m_signalFenceFromCPU = false;
 #else
-            m_features.m_signalFenceFromCPU = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore;
+            m_features.m_signalFenceFromCPU = vulkan12 ? physicalDevice.GetPhysicalDeviceVulkan12Features().timelineSemaphore
+                                                       : physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore;
 #endif
             // These are two nested ifs instead of one because MSVC complains about a missing contexpr otherwise
             // The warning is C4127, but we can't add a constexpr when doing (constexpr && non-constexpr)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -247,7 +247,6 @@ namespace AZ
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DepthClipEnable))
             {
                 depthClipEnabled = physicalDevice.GetPhysicalDeviceDepthClipEnableFeatures();
-                depthClipEnabled.pNext = nullptr;
 
                 deviceInfoAppender.append(depthClipEnabled);
             }
@@ -255,7 +254,6 @@ namespace AZ
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderImageAtomicInt64))
             {
                 shaderImageAtomicInt64 = physicalDevice.GetShaderImageAtomicInt64Features();
-                shaderImageAtomicInt64.pNext = nullptr;
 
                 deviceInfoAppender.append(shaderImageAtomicInt64);
             }
@@ -264,7 +262,6 @@ namespace AZ
             {
                 robustness2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
                 robustness2.nullDescriptor = physicalDevice.GetPhysicalDeviceRobustness2Features().nullDescriptor;
-                robustness2.pNext = nullptr;
 
                 deviceInfoAppender.append(robustness2);
             }
@@ -278,14 +275,13 @@ namespace AZ
 #if !defined(AZ_RELEASE_BUILD)
                 subpassMergeFeedback.subpassMergeFeedback = false;
 #endif
-                if (!subpassMergeFeedback.subpassMergeFeedback)
+                if (subpassMergeFeedback.subpassMergeFeedback)
                 {
-                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::SubpassMergeFeedback);
+                    deviceInfoAppender.append(subpassMergeFeedback);
                 }
                 else
                 {
-                    subpassMergeFeedback.pNext = nullptr;
-                    deviceInfoAppender.append(subpassMergeFeedback);
+                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::SubpassMergeFeedback);
                 }
             }
 
@@ -300,7 +296,6 @@ namespace AZ
                 {
                     // Must disable the "FragmentDensityMap" usage if "attachmentFragmentShadingRate" is enabled.
                     physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentDensityMap);
-                    fragmentShadingRateFeatures.pNext = nullptr;
                     deviceInfoAppender.append(fragmentShadingRateFeatures);
                 }
                 else
@@ -318,7 +313,6 @@ namespace AZ
 
                 if (fragmentDensityMapFeatures.fragmentDensityMap && fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages)
                 {
-                    fragmentDensityMapFeatures.pNext = nullptr;
                     deviceInfoAppender.append(fragmentDensityMapFeatures);
                 }
                 else
@@ -335,8 +329,7 @@ namespace AZ
             VkPhysicalDeviceRayTracingPipelineFeaturesKHR rayTracingPipelineFeatures = {};
 
             VkPhysicalDeviceTimelineSemaphoreFeatures timelineSemaphore;
-            // If we are running Vulkan >= 1.2, then we must use VkPhysicalDeviceVulkan12Features instead
-            // of VkPhysicalDeviceShaderFloat16Int8FeaturesKHR or VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR.
+            // If we are running Vulkan >= 1.2, then we must use VkPhysicalDeviceVulkan12Features instead the respective extensions.
             if (majorVersion >= 1 && minorVersion >= 2)
             {
                 const auto& physicalDeviceVulkan12Features = physicalDevice.GetPhysicalDeviceVulkan12Features();
@@ -401,37 +394,11 @@ namespace AZ
                     physicalDeviceVulkan12Features.descriptorBindingUpdateUnusedWhilePending;
                 vulkan12Features.shaderOutputViewportIndex = physicalDeviceVulkan12Features.shaderOutputViewportIndex;
                 vulkan12Features.shaderOutputLayer = physicalDeviceVulkan12Features.shaderOutputLayer;
+#ifndef DISABLE_TIMELINE_SEMAPHORES
                 vulkan12Features.timelineSemaphore = physicalDeviceVulkan12Features.timelineSemaphore;
-
-                accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
-                accelerationStructureFeatures.accelerationStructure = physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;
-
-                rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
-                rayTracingPipelineFeatures.rayTracingPipeline = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipeline;
-                rayTracingPipelineFeatures.rayTracingPipelineTraceRaysIndirect = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipelineTraceRaysIndirect;
+#endif
 
                 deviceInfoAppender.append(vulkan12Features);
-
-                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure) &&
-                    physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
-                {
-                    deviceInfoAppender.append({ &accelerationStructureFeatures, &rayTracingPipelineFeatures });
-
-                    if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
-                    {
-                        rayQueryFeatures = physicalDevice.GetRayQueryFeatures();
-                        rayQueryFeatures.pNext = nullptr;
-
-                        deviceInfoAppender.append(rayQueryFeatures);
-                    }
-                }
-                else
-                {
-                    // make sure all ray tracing extensions are disabled
-                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::AccelerationStructure);
-                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::RayTracingPipeline);
-                    physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::RayQuery);
-                }
             }
             else
             {
@@ -494,7 +461,6 @@ namespace AZ
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::BufferDeviceAddress))
                 {
                     bufferDeviceAddressFeatures = physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures();
-                    bufferDeviceAddressFeatures.pNext = nullptr;
 
                     deviceInfoAppender.append(bufferDeviceAddressFeatures);
                 }
@@ -502,18 +468,53 @@ namespace AZ
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderAtomicInt64))
                 {
                     shaderAtomicInt64 = physicalDevice.GetShaderAtomicInt64Features();
-                    shaderAtomicInt64.pNext = nullptr;
 
                     deviceInfoAppender.append(shaderAtomicInt64);
                 }
 
+#ifdef DISABLE_TIMELINE_SEMAPHORES
+                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::TimelineSempahore);
+#else
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore))
                 {
                     timelineSemaphore = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures();
-                    timelineSemaphore.pNext = nullptr;
 
                     deviceInfoAppender.append(timelineSemaphore);
                 }
+#endif
+            }
+
+            if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure))
+            {
+                accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
+                accelerationStructureFeatures.accelerationStructure =
+                    physicalDevice.GetPhysicalDeviceAccelerationStructureFeatures().accelerationStructure;
+
+                deviceInfoAppender.append(accelerationStructureFeatures);
+
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
+                {
+                    rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
+                    rayTracingPipelineFeatures.rayTracingPipeline =
+                        physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipeline;
+                    rayTracingPipelineFeatures.rayTracingPipelineTraceRaysIndirect =
+                        physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipelineTraceRaysIndirect;
+
+                    deviceInfoAppender.append(rayTracingPipelineFeatures);
+                }
+
+                if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
+                {
+                    rayQueryFeatures = physicalDevice.GetRayQueryFeatures();
+
+                    deviceInfoAppender.append(rayQueryFeatures);
+                }
+            }
+            else
+            {
+                // make sure all ray tracing extensions are disabled
+                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::RayTracingPipeline);
+                physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::RayQuery);
             }
 
             deviceInfoAppender.finish();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -242,12 +242,14 @@ namespace AZ
 
             VkPhysicalDeviceRobustness2FeaturesEXT robustness2 = {};
 
+            StructAppender deviceInfoAppender(deviceInfo);
+
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DepthClipEnable))
             {
                 depthClipEnabled = physicalDevice.GetPhysicalDeviceDepthClipEnableFeatures();
                 depthClipEnabled.pNext = nullptr;
 
-                AppendVkStruct(deviceInfo, &depthClipEnabled);
+                deviceInfoAppender.append(depthClipEnabled);
             }
 
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderImageAtomicInt64))
@@ -255,7 +257,7 @@ namespace AZ
                 shaderImageAtomicInt64 = physicalDevice.GetShaderImageAtomicInt64Features();
                 shaderImageAtomicInt64.pNext = nullptr;
 
-                AppendVkStruct(deviceInfo, &shaderImageAtomicInt64);
+                deviceInfoAppender.append(shaderImageAtomicInt64);
             }
 
             if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::Robustness2))
@@ -264,7 +266,7 @@ namespace AZ
                 robustness2.nullDescriptor = physicalDevice.GetPhysicalDeviceRobustness2Features().nullDescriptor;
                 robustness2.pNext = nullptr;
 
-                AppendVkStruct(deviceInfo, &robustness2);
+                deviceInfoAppender.append(robustness2);
             }
 
             VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT subpassMergeFeedback;
@@ -283,7 +285,7 @@ namespace AZ
                 else
                 {
                     subpassMergeFeedback.pNext = nullptr;
-                    AppendVkStruct(deviceInfo, &subpassMergeFeedback);
+                    deviceInfoAppender.append(subpassMergeFeedback);
                 }
             }
 
@@ -299,7 +301,7 @@ namespace AZ
                     // Must disable the "FragmentDensityMap" usage if "attachmentFragmentShadingRate" is enabled.
                     physicalDevice.DisableOptionalDeviceExtension(OptionalDeviceExtension::FragmentDensityMap);
                     fragmentShadingRateFeatures.pNext = nullptr;
-                    AppendVkStruct(deviceInfo, &fragmentShadingRateFeatures);
+                    deviceInfoAppender.append(fragmentShadingRateFeatures);
                 }
                 else
                 {
@@ -317,7 +319,7 @@ namespace AZ
                 if (fragmentDensityMapFeatures.fragmentDensityMap && fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages)
                 {
                     fragmentDensityMapFeatures.pNext = nullptr;
-                    AppendVkStruct(deviceInfo, &fragmentDensityMapFeatures);
+                    deviceInfoAppender.append(fragmentDensityMapFeatures);
                 }
                 else
                 {
@@ -408,19 +410,19 @@ namespace AZ
                 rayTracingPipelineFeatures.rayTracingPipeline = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipeline;
                 rayTracingPipelineFeatures.rayTracingPipelineTraceRaysIndirect = physicalDevice.GetPhysicalDeviceRayTracingPipelineFeatures().rayTracingPipelineTraceRaysIndirect;
 
-                AppendVkStruct(deviceInfo, &vulkan12Features);
+                deviceInfoAppender.append(vulkan12Features);
 
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure) &&
                     physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
                 {
-                    AppendVkStruct(deviceInfo, { &accelerationStructureFeatures, &rayTracingPipelineFeatures });
+                    deviceInfoAppender.append({ &accelerationStructureFeatures, &rayTracingPipelineFeatures });
 
                     if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
                     {
                         rayQueryFeatures = physicalDevice.GetRayQueryFeatures();
                         rayQueryFeatures.pNext = nullptr;
 
-                        AppendVkStruct(deviceInfo, &rayQueryFeatures);
+                        deviceInfoAppender.append(rayQueryFeatures);
                     }
                 }
                 else
@@ -441,12 +443,12 @@ namespace AZ
 
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderFloat16Int8))
                 {
-                    AppendVkStruct(deviceInfo, &float16Int8);
+                    deviceInfoAppender.append(float16Int8);
                 }
 
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SeparateDepthStencilLayouts))
                 {
-                    AppendVkStruct(deviceInfo, &separateDepthStencil);
+                    deviceInfoAppender.append(separateDepthStencil);
                 }
 
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DescriptorIndexing))
@@ -486,7 +488,7 @@ namespace AZ
                     descriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind =
                         physicalDeviceDescriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind;
 
-                    AppendVkStruct(deviceInfo, &descriptorIndexingFeatures);
+                    deviceInfoAppender.append(descriptorIndexingFeatures);
                 }
 
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::BufferDeviceAddress))
@@ -494,7 +496,7 @@ namespace AZ
                     bufferDeviceAddressFeatures = physicalDevice.GetPhysicalDeviceBufferDeviceAddressFeatures();
                     bufferDeviceAddressFeatures.pNext = nullptr;
 
-                    AppendVkStruct(deviceInfo, &bufferDeviceAddressFeatures);
+                    deviceInfoAppender.append(bufferDeviceAddressFeatures);
                 }
 
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderAtomicInt64))
@@ -502,7 +504,7 @@ namespace AZ
                     shaderAtomicInt64 = physicalDevice.GetShaderAtomicInt64Features();
                     shaderAtomicInt64.pNext = nullptr;
 
-                    AppendVkStruct(deviceInfo, &shaderAtomicInt64);
+                    deviceInfoAppender.append(shaderAtomicInt64);
                 }
 
                 if (physicalDevice.IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore))
@@ -510,9 +512,11 @@ namespace AZ
                     timelineSemaphore = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures();
                     timelineSemaphore.pNext = nullptr;
 
-                    AppendVkStruct(deviceInfo, &timelineSemaphore);
+                    deviceInfoAppender.append(timelineSemaphore);
                 }
             }
+
+            deviceInfoAppender.finish();
 
 #if defined(USE_NSIGHT_AFTERMATH)
             requiredExtensions.push_back(VK_NV_DEVICE_DIAGNOSTICS_CONFIG_EXTENSION_NAME);
@@ -531,7 +535,7 @@ namespace AZ
             deviceInfo.pNext = &aftermathInfo;
 #endif
 
-            RawStringList optionalExtensions = physicalDevice.FilterSupportedOptionalExtensions(false);
+            RawStringList optionalExtensions = physicalDevice.GetEnabledOptionalExtensions();
             requiredExtensions.insert(requiredExtensions.end(), optionalExtensions.begin(), optionalExtensions.end());
 
             deviceInfo.flags = 0;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -7,6 +7,7 @@
  */
 #include <Atom/RHI.Reflect/Vulkan/Conversion.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
+#include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/set.h>
 #include <AzCore/std/string/conversions.h>
 #include <RHI/Instance.h>
@@ -320,7 +321,8 @@ namespace AZ
             m_features.set(
                 static_cast<size_t>(DeviceFeature::DescriptorIndexing), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_descriptor_indexing));
             m_features.set(
-                static_cast<size_t>(DeviceFeature::BufferDeviceAddress), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_buffer_device_address));
+                static_cast<size_t>(DeviceFeature::BufferDeviceAddress),
+                VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_buffer_device_address) && m_bufferDeviceAddressFeatures.bufferDeviceAddress);
             // Disable memory budget extension for now since it's crashing the driver when the VkPhysicalDeviceMemoryBudgetPropertiesEXT
             // structure is included in the pNext chain of VkPhysicalDeviceMemoryProperties2
             m_features.set(
@@ -334,7 +336,7 @@ namespace AZ
         }
 
         // The order must match the enum OptionalDeviceExtensions
-        static constexpr std::array<const char*, AZStd::to_underlying(OptionalDeviceExtension::Count)> OptionalDeviceExtensionNames{
+        static constexpr AZStd::array<const char*, AZStd::to_underlying(OptionalDeviceExtension::Count)> OptionalDeviceExtensionNames{
             VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
             VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME,
             VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
@@ -373,7 +375,7 @@ namespace AZ
         {
             RawStringList optionalExtensions;
 
-            for (auto i{ 0 }; i < AZStd::to_underlying(OptionalDeviceExtension::Count); ++i)
+            for (auto i{ 0U }; i < AZStd::to_underlying(OptionalDeviceExtension::Count); ++i)
             {
                 if (m_optionalExtensions.test(i))
                 {
@@ -394,7 +396,7 @@ namespace AZ
 
             StringList deviceExtensions = GetDeviceExtensionNames();
 
-            for (auto i{ 0 }; i < optionalExtensionCount; ++i)
+            for (auto i{ 0U }; i < optionalExtensionCount; ++i)
             {
                 if (AZStd::find(deviceExtensions.begin(), deviceExtensions.end(), OptionalDeviceExtensionNames[i]) !=
                     deviceExtensions.end())
@@ -537,18 +539,6 @@ namespace AZ
                 if (majorVersion >= 1 && minorVersion >= 2)
                 {
                     deviceFeaturesAppender.append(m_vulkan12Features);
-
-                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure) &&
-                        IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
-                    {
-                        deviceFeaturesAppender.append({ &m_accelerationStructureFeatures, &m_rayTracingPipelineFeatures });
-                        devicePropsAppender.append({ &m_accelerationStructureProperties, &m_rayTracingPipelineProperties });
-
-                        if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
-                        {
-                            deviceFeaturesAppender.append(m_rayQueryFeatures);
-                        }
-                    }
                 }
                 else
                 {
@@ -572,9 +562,28 @@ namespace AZ
                         deviceFeaturesAppender.append(m_shaderAtomicInt64Features);
                     }
 
+#ifndef DISABLE_TIMELINE_SEMAPHORES
                     if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore))
                     {
                         deviceFeaturesAppender.append(m_timelineSemaphoreFeatures);
+                    }
+#endif
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure))
+                {
+                    deviceFeaturesAppender.append(m_accelerationStructureFeatures);
+                    devicePropsAppender.append(m_accelerationStructureProperties);
+
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
+                    {
+                        deviceFeaturesAppender.append(m_rayTracingPipelineFeatures);
+                        devicePropsAppender.append(m_rayTracingPipelineProperties);
+                    }
+
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
+                    {
+                        deviceFeaturesAppender.append(m_rayQueryFeatures);
                     }
                 }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -99,7 +99,7 @@ namespace AZ
 
         const VkPhysicalDeviceDepthClipEnableFeaturesEXT& PhysicalDevice::GetPhysicalDeviceDepthClipEnableFeatures() const
         {
-            return m_dephClipEnableFeatures;
+            return m_depthClipEnableFeatures;
         }
 
         const VkPhysicalDeviceRobustness2FeaturesEXT& PhysicalDevice::GetPhysicalDeviceRobustness2Features() const
@@ -109,7 +109,7 @@ namespace AZ
 
         const VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR& PhysicalDevice::GetPhysicalDeviceSeparateDepthStencilFeatures() const
         {
-            return m_separateDepthStencilFeatures;
+            return m_separateDepthStencilLayoutsFeatures;
         }
 
         const VkPhysicalDeviceShaderAtomicInt64Features& PhysicalDevice::GetShaderAtomicInt64Features() const
@@ -149,7 +149,7 @@ namespace AZ
 
         const VkPhysicalDeviceFragmentShadingRateFeaturesKHR& PhysicalDevice::GetPhysicalDeviceFragmentShadingRateFeatures() const
         {
-            return m_shadingRateFeatures;
+            return m_fragmentShadingRateFeatures;
         }
 
         const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& PhysicalDevice::GetPhysicalDeviceFragmentDensityMapFeatures() const
@@ -169,7 +169,7 @@ namespace AZ
 
         const VkPhysicalDeviceShaderFloat16Int8FeaturesKHR& PhysicalDevice::GetPhysicalDeviceFloat16Int8Features() const
         {
-            return m_float16Int8Features;
+            return m_shaderFloat16Int8Features;
         }
 
         const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& PhysicalDevice::GetPhysicalDeviceDescriptorIndexingFeatures() const
@@ -194,7 +194,7 @@ namespace AZ
 
         const VkPhysicalDeviceExternalMemoryHostPropertiesEXT& PhysicalDevice::GetExternalMemoryHostProperties() const
         {
-            return m_externalHostMemoryFeatures;
+            return m_externalMemoryHostProperties;
         }
 
         const VkPhysicalDeviceVulkan12Features& PhysicalDevice::GetPhysicalDeviceVulkan12Features() const
@@ -292,20 +292,37 @@ namespace AZ
             uint32_t minorVersion = VK_VERSION_MINOR(GetVulkanVersion());
 
             m_features.reset();
-            m_features.set(static_cast<size_t>(DeviceFeature::Compatible2dArrayTexture), (majorVersion >= 1 && minorVersion >= 1) || VK_DEVICE_EXTENSION_SUPPORTED(context, KHR_maintenance1));
-            m_features.set(static_cast<size_t>(DeviceFeature::CustomSampleLocation), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_sample_locations));
-            m_features.set(static_cast<size_t>(DeviceFeature::Predication), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_conditional_rendering));
-            m_features.set(static_cast<size_t>(DeviceFeature::ConservativeRaster), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_conservative_rasterization));
-            m_features.set(static_cast<size_t>(DeviceFeature::DepthClipEnable), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_depth_clip_enable) && m_dephClipEnableFeatures.depthClipEnable);
-            m_features.set(static_cast<size_t>(DeviceFeature::DrawIndirectCount), (majorVersion >= 1 && minorVersion >= 2 && m_vulkan12Features.drawIndirectCount) || VK_DEVICE_EXTENSION_SUPPORTED(context, KHR_draw_indirect_count));
-            m_features.set(static_cast<size_t>(DeviceFeature::NullDescriptor), m_robustness2Features.nullDescriptor && VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_robustness2));
-            m_features.set(static_cast<size_t>(DeviceFeature::SeparateDepthStencil),
-                (m_separateDepthStencilFeatures.separateDepthStencilLayouts && VK_DEVICE_EXTENSION_SUPPORTED(context, KHR_separate_depth_stencil_layouts)) ||
-                (m_vulkan12Features.separateDepthStencilLayouts));
-            m_features.set(static_cast<size_t>(DeviceFeature::DescriptorIndexing), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_descriptor_indexing));
-            m_features.set(static_cast<size_t>(DeviceFeature::BufferDeviceAddress), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_buffer_device_address));
-            // Disable memory budget extension for now since it's crashing the driver when the VkPhysicalDeviceMemoryBudgetPropertiesEXT structure
-            // is included in the pNext chain of VkPhysicalDeviceMemoryProperties2
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::Compatible2dArrayTexture),
+                (majorVersion >= 1 && minorVersion >= 1) || VK_DEVICE_EXTENSION_SUPPORTED(context, KHR_maintenance1));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::CustomSampleLocation), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_sample_locations));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::Predication), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_conditional_rendering));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::ConservativeRaster),
+                VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_conservative_rasterization));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::DepthClipEnable),
+                VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_depth_clip_enable) && m_depthClipEnableFeatures.depthClipEnable);
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::DrawIndirectCount),
+                (majorVersion >= 1 && minorVersion >= 2 && m_vulkan12Features.drawIndirectCount) ||
+                    VK_DEVICE_EXTENSION_SUPPORTED(context, KHR_draw_indirect_count));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::NullDescriptor),
+                m_robustness2Features.nullDescriptor && VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_robustness2));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::SeparateDepthStencil),
+                (m_separateDepthStencilLayoutsFeatures.separateDepthStencilLayouts &&
+                 VK_DEVICE_EXTENSION_SUPPORTED(context, KHR_separate_depth_stencil_layouts)) ||
+                    (m_vulkan12Features.separateDepthStencilLayouts));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::DescriptorIndexing), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_descriptor_indexing));
+            m_features.set(
+                static_cast<size_t>(DeviceFeature::BufferDeviceAddress), VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_buffer_device_address));
+            // Disable memory budget extension for now since it's crashing the driver when the VkPhysicalDeviceMemoryBudgetPropertiesEXT
+            // structure is included in the pNext chain of VkPhysicalDeviceMemoryProperties2
             m_features.set(
                 static_cast<size_t>(DeviceFeature::MemoryBudget),
                 VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_memory_budget) && m_deviceProperties.vendorID != VendorID_Intel);
@@ -316,7 +333,7 @@ namespace AZ
                 VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_load_store_op_none) || (majorVersion >= 1 && minorVersion >= 3));
         }
 
-        RawStringList PhysicalDevice::FilterSupportedOptionalExtensions()
+        RawStringList PhysicalDevice::FilterSupportedOptionalExtensions(bool enableSupported)
         {
             // The order must match the enum OptionalDeviceExtensions
             RawStringList optionalExtensions = { { VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
@@ -349,11 +366,14 @@ namespace AZ
                                                    VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME,
                                                    VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
                                                    VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME,
+                                                   VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME,
                                                    ExternalSemaphoreExtensionName } };
 
             [[maybe_unused]] uint32_t optionalExtensionCount = aznumeric_cast<uint32_t>(optionalExtensions.size());
 
-            AZ_Assert(optionalExtensionCount == static_cast<uint32_t>(OptionalDeviceExtension::Count), "The order and size must match the enum OptionalDeviceExtensions.");
+            AZ_Assert(
+                optionalExtensionCount == static_cast<uint32_t>(OptionalDeviceExtension::Count),
+                "The order and size must match the enum OptionalDeviceExtensions.");
 
             // Optional device extensions are filtered based on what the device support.
             // It returns in the same order as in the original list.
@@ -362,14 +382,28 @@ namespace AZ
 
             // Mark the supported optional extensions in the bitset for faster look up compared to string search.
             uint32_t originalIndex = 0;
-            for (const auto& extension : filteredOptionalExtensions)
+            int stepSize = 1;
+            for (auto it{ filteredOptionalExtensions.begin() }; it != filteredOptionalExtensions.end(); it += stepSize)
             {
-                AZ_Assert(originalIndex < optionalExtensionCount, "Out of range index. Check FilterList algorithm if list is returned in the original order.");
+                const auto& extension{ *it };
+                stepSize = 1;
+
+                AZ_Assert(
+                    originalIndex < optionalExtensionCount,
+                    "Out of range index. Check FilterList algorithm if list is returned in the original order.");
                 while (strcmp(extension, optionalExtensions[originalIndex]) != 0)
                 {
                     ++originalIndex;
                 }
-                m_optionalExtensions.set(originalIndex);
+                if (enableSupported)
+                {
+                    m_optionalExtensions.set(originalIndex);
+                }
+                else if (!m_optionalExtensions.test(originalIndex))
+                {
+                    it = filteredOptionalExtensions.erase(it);
+                    stepSize = 0;
+                }
                 ++originalIndex;
             }
 
@@ -406,49 +440,40 @@ namespace AZ
             m_vkPhysicalDevice = vkPhysicalDevice;
             const auto& context = Instance::GetInstance().GetContext();
 
+            // getting the device properties preliminarily to get the Vulkan version
+            context.GetPhysicalDeviceProperties(vkPhysicalDevice, &m_deviceProperties);
+            // We need to consider the application's vulkan version, since we cannot use a higher version than that, even though
+            // the physical device might support a higher one.
+            m_vulkanVersion = AZStd::min(Instance::GetInstance().GetVkAppInfo().apiVersion, m_deviceProperties.apiVersion);
+
             if (VK_INSTANCE_EXTENSION_SUPPORTED(context, KHR_get_physical_device_properties2))
             {
+                uint32_t majorVersion = VK_VERSION_MAJOR(m_vulkanVersion);
+                uint32_t minorVersion = VK_VERSION_MINOR(m_vulkanVersion);
+
+                // need to call this for IsOptionalDeviceExtensionSupported to work
+                FilterSupportedOptionalExtensions(true);
+
                 // Features
                 m_descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
                 m_bufferDeviceAddressFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT;
-                m_dephClipEnableFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;
+                m_depthClipEnableFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT;
                 m_shaderAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
                 m_shaderImageAtomicInt64Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT;
                 m_rayQueryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR;
                 m_robustness2Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT;
-                m_float16Int8Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR;
-                m_separateDepthStencilFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
+                m_shaderFloat16Int8Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR;
+                m_separateDepthStencilLayoutsFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES;
                 m_vulkan12Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
                 m_accelerationStructureFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR;
                 m_rayTracingPipelineFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
-                m_shadingRateFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR;
+                m_fragmentShadingRateFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR;
                 m_fragmentDensityMapFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT;
                 m_timelineSemaphoreFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
                 m_subpassMergeFeedbackFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT;
 
                 VkPhysicalDeviceFeatures2 deviceFeatures2 = {};
                 deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-                AppendVkStruct(
-                    deviceFeatures2,
-                    { &m_descriptorIndexingFeatures,
-                      &m_bufferDeviceAddressFeatures,
-                      &m_dephClipEnableFeatures,
-                      &m_shaderAtomicInt64Features,
-                      &m_shaderImageAtomicInt64Features,
-                      &m_rayQueryFeatures,
-                      &m_robustness2Features,
-                      &m_float16Int8Features,
-                      &m_separateDepthStencilFeatures,
-                      &m_vulkan12Features,
-                      &m_accelerationStructureFeatures,
-                      &m_rayTracingPipelineFeatures,
-                      &m_shadingRateFeatures,
-                      &m_fragmentDensityMapFeatures,
-                      &m_timelineSemaphoreFeatures,
-                      &m_subpassMergeFeedbackFeatures });
-
-                context.GetPhysicalDeviceFeatures2KHR(vkPhysicalDevice, &deviceFeatures2);
-                m_deviceFeatures = deviceFeatures2.features;
 
                 // Properties
                 m_conservativeRasterProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT;
@@ -456,18 +481,108 @@ namespace AZ
                 m_accelerationStructureProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR;
                 m_fragmentDensityMapProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT;
                 m_fragmentShadingRateProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR;
-                m_externalHostMemoryFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT;
+                m_externalMemoryHostProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT;
 
                 VkPhysicalDeviceProperties2 deviceProps2 = {};
                 deviceProps2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
-                AppendVkStruct(
-                    deviceProps2,
-                    { &m_conservativeRasterProperties,
-                      &m_rayTracingPipelineProperties,
-                      &m_accelerationStructureProperties,
-                      &m_fragmentDensityMapProperties,
-                      &m_fragmentShadingRateProperties,
-                      &m_externalHostMemoryFeatures });
+
+                // Extensions
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DepthClipEnable))
+                {
+                    AppendVkStruct(deviceFeatures2, &m_depthClipEnableFeatures);
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderImageAtomicInt64))
+                {
+                    AppendVkStruct(deviceFeatures2, &m_shaderImageAtomicInt64Features);
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::Robustness2))
+                {
+                    AppendVkStruct(deviceFeatures2, &m_robustness2Features);
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SubpassMergeFeedback))
+                {
+                    AppendVkStruct(deviceFeatures2, &m_subpassMergeFeedbackFeatures);
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentShadingRate))
+                {
+                    AppendVkStruct(deviceFeatures2, &m_fragmentShadingRateFeatures);
+                    AppendVkStruct(deviceProps2, &m_fragmentShadingRateProperties);
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentDensityMap))
+                {
+                    AppendVkStruct(deviceFeatures2, &m_fragmentDensityMapFeatures);
+                    AppendVkStruct(deviceProps2, &m_fragmentDensityMapProperties);
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ConservativeRasterization))
+                {
+                    AppendVkStruct(deviceProps2, &m_conservativeRasterProperties);
+                }
+
+                if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ExternalMemoryHost))
+                {
+                    AppendVkStruct(deviceProps2, &m_externalMemoryHostProperties);
+                }
+
+                // this is handled through Vulkan 1.2 but we still need to get these features because some drivers (e.g. Intel) don't report
+                // any features of buffer device address through the "PhysicalDeviceVulkan12Features"
+                if ((majorVersion >= 1 && minorVersion >= 2) ||
+                    IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::BufferDeviceAddress))
+                {
+                    AppendVkStruct(deviceFeatures2, &m_bufferDeviceAddressFeatures);
+                }
+
+                if (majorVersion >= 1 && minorVersion >= 2)
+                {
+                    AppendVkStruct(deviceFeatures2, &m_vulkan12Features);
+
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure) &&
+                        IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
+                    {
+                        AppendVkStruct(deviceFeatures2, { &m_accelerationStructureFeatures, &m_rayTracingPipelineFeatures });
+                        AppendVkStruct(deviceProps2, { &m_accelerationStructureProperties, &m_rayTracingPipelineProperties });
+
+                        if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
+                        {
+                            AppendVkStruct(deviceFeatures2, &m_rayQueryFeatures);
+                        }
+                    }
+                }
+                else
+                {
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DescriptorIndexing))
+                    {
+                        AppendVkStruct(deviceFeatures2, &m_descriptorIndexingFeatures);
+                    }
+
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SeparateDepthStencilLayouts))
+                    {
+                        AppendVkStruct(deviceFeatures2, &m_separateDepthStencilLayoutsFeatures);
+                    }
+
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderFloat16Int8))
+                    {
+                        AppendVkStruct(deviceFeatures2, &m_shaderFloat16Int8Features);
+                    }
+
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderAtomicInt64))
+                    {
+                        AppendVkStruct(deviceFeatures2, &m_shaderAtomicInt64Features);
+                    }
+
+                    if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore))
+                    {
+                        AppendVkStruct(deviceFeatures2, &m_timelineSemaphoreFeatures);
+                    }
+                }
+
+                context.GetPhysicalDeviceFeatures2KHR(vkPhysicalDevice, &deviceFeatures2);
+                m_deviceFeatures = deviceFeatures2.features;
 
                 context.GetPhysicalDeviceProperties2KHR(vkPhysicalDevice, &deviceProps2);
                 m_deviceProperties = deviceProps2.properties;
@@ -528,7 +643,9 @@ namespace AZ
             for (uint32_t heapIndex : heapIndicesDevice)
             {
                 const VkMemoryHeap& heap = m_memoryProperty.memoryHeaps[heapIndex];
-                AZ_Assert(RHI::CheckBitsAny(heap.flags, static_cast<VkMemoryHeapFlags>(VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)), "Device local heap does not have device local bit.");
+                AZ_Assert(
+                    RHI::CheckBitsAny(heap.flags, static_cast<VkMemoryHeapFlags>(VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)),
+                    "Device local heap does not have device local bit.");
                 memsize_device += heap.size;
             }
 
@@ -536,15 +653,14 @@ namespace AZ
             for (uint32_t heapIndex : heapIndicesHost)
             {
                 const VkMemoryHeap& heap = m_memoryProperty.memoryHeaps[heapIndex];
-                AZ_Assert(!RHI::CheckBitsAny(heap.flags, static_cast<VkMemoryHeapFlags>(VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)), "Host heap have device local bit.");
+                AZ_Assert(
+                    !RHI::CheckBitsAny(heap.flags, static_cast<VkMemoryHeapFlags>(VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)),
+                    "Host heap have device local bit.");
                 memsize_host += heap.size;
             }
 
             m_descriptor.m_heapSizePerLevel[static_cast<size_t>(RHI::HeapMemoryLevel::Device)] = static_cast<size_t>(memsize_device);
             m_descriptor.m_heapSizePerLevel[static_cast<size_t>(RHI::HeapMemoryLevel::Host)] = static_cast<size_t>(memsize_host);
-            // We need to consider the application's vulkan version, since we cannot use a higher version than that, even though
-            // the physical device might support a higher one.
-            m_vulkanVersion = AZStd::min(Instance::GetInstance().GetVkAppInfo().apiVersion, m_deviceProperties.apiVersion);
         }
 
         void PhysicalDevice::Shutdown()
@@ -572,5 +688,5 @@ namespace AZ
             AZ_Assert(index < m_optionalExtensions.size(), "Invalid feature %d", index);
             m_optionalExtensions.set(index, false);
         }
-    }
-}
+    } // namespace Vulkan
+} // namespace AZ

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -333,81 +333,75 @@ namespace AZ
                 VK_DEVICE_EXTENSION_SUPPORTED(context, EXT_load_store_op_none) || (majorVersion >= 1 && minorVersion >= 3));
         }
 
-        RawStringList PhysicalDevice::FilterSupportedOptionalExtensions(bool enableSupported)
+        // The order must match the enum OptionalDeviceExtensions
+        static constexpr std::array<const char*, AZStd::to_underlying(OptionalDeviceExtension::Count)> OptionalDeviceExtensionNames{
+            VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
+            VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME,
+            VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
+            VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME,
+            VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,
+            VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,
+            VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME,
+            VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
+            VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,
+            VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME,
+            VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME,
+
+            // ray tracing extensions
+            VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+            VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
+            VK_KHR_RAY_QUERY_EXTENSION_NAME,
+            VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
+            VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
+            VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
+            VK_KHR_SPIRV_1_4_EXTENSION_NAME,
+            VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME,
+
+            VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME,
+            VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME,
+            VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
+            VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+            VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME,
+            VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME,
+            VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
+            VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME,
+            VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME,
+            ExternalSemaphoreExtensionName
+        };
+
+        RawStringList PhysicalDevice::GetEnabledOptionalExtensions()
         {
-            // The order must match the enum OptionalDeviceExtensions
-            RawStringList optionalExtensions = { { VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
-                                                   VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME,
-                                                   VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
-                                                   VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME,
-                                                   VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,
-                                                   VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME,
-                                                   VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME,
-                                                   VK_EXT_ROBUSTNESS_2_EXTENSION_NAME,
-                                                   VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,
-                                                   VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME,
-                                                   VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME,
+            RawStringList optionalExtensions;
 
-                                                   // ray tracing extensions
-                                                   VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
-                                                   VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
-                                                   VK_KHR_RAY_QUERY_EXTENSION_NAME,
-                                                   VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
-                                                   VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
-                                                   VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
-                                                   VK_KHR_SPIRV_1_4_EXTENSION_NAME,
-                                                   VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME,
-
-                                                   VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME,
-                                                   VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME,
-                                                   VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
-                                                   VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
-                                                   VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME,
-                                                   VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME,
-                                                   VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
-                                                   VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME,
-                                                   VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME,
-                                                   ExternalSemaphoreExtensionName } };
-
-            [[maybe_unused]] uint32_t optionalExtensionCount = aznumeric_cast<uint32_t>(optionalExtensions.size());
-
-            AZ_Assert(
-                optionalExtensionCount == static_cast<uint32_t>(OptionalDeviceExtension::Count),
-                "The order and size must match the enum OptionalDeviceExtensions.");
-
-            // Optional device extensions are filtered based on what the device support.
-            // It returns in the same order as in the original list.
-            StringList deviceExtensions = GetDeviceExtensionNames();
-            RawStringList filteredOptionalExtensions = FilterList(optionalExtensions, deviceExtensions);
-
-            // Mark the supported optional extensions in the bitset for faster look up compared to string search.
-            uint32_t originalIndex = 0;
-            int stepSize = 1;
-            for (auto it{ filteredOptionalExtensions.begin() }; it != filteredOptionalExtensions.end(); it += stepSize)
+            for (auto i{ 0 }; i < AZStd::to_underlying(OptionalDeviceExtension::Count); ++i)
             {
-                const auto& extension{ *it };
-                stepSize = 1;
-
-                AZ_Assert(
-                    originalIndex < optionalExtensionCount,
-                    "Out of range index. Check FilterList algorithm if list is returned in the original order.");
-                while (strcmp(extension, optionalExtensions[originalIndex]) != 0)
+                if (m_optionalExtensions.test(i))
                 {
-                    ++originalIndex;
+                    optionalExtensions.emplace_back(OptionalDeviceExtensionNames[i]);
                 }
-                if (enableSupported)
-                {
-                    m_optionalExtensions.set(originalIndex);
-                }
-                else if (!m_optionalExtensions.test(originalIndex))
-                {
-                    it = filteredOptionalExtensions.erase(it);
-                    stepSize = 0;
-                }
-                ++originalIndex;
             }
 
-            return filteredOptionalExtensions;
+            return optionalExtensions;
+        }
+
+        void PhysicalDevice::EnableSupportedOptionalExtensions()
+        {
+            uint32_t optionalExtensionCount = AZStd::to_underlying(OptionalDeviceExtension::Count);
+
+            AZ_Assert(
+                optionalExtensionCount == aznumeric_cast<uint32_t>(OptionalDeviceExtensionNames.size()),
+                "The order and size must match the enum OptionalDeviceExtensions.");
+
+            StringList deviceExtensions = GetDeviceExtensionNames();
+
+            for (auto i{ 0 }; i < optionalExtensionCount; ++i)
+            {
+                if (AZStd::find(deviceExtensions.begin(), deviceExtensions.end(), OptionalDeviceExtensionNames[i]) !=
+                    deviceExtensions.end())
+                {
+                    m_optionalExtensions.set(i);
+                }
+            }
         }
 
         AZStd::vector<VkTimeDomainEXT> PhysicalDevice::GetCalibratedTimeDomains(const GladVulkanContext& context) const
@@ -446,13 +440,12 @@ namespace AZ
             // the physical device might support a higher one.
             m_vulkanVersion = AZStd::min(Instance::GetInstance().GetVkAppInfo().apiVersion, m_deviceProperties.apiVersion);
 
+            EnableSupportedOptionalExtensions();
+
             if (VK_INSTANCE_EXTENSION_SUPPORTED(context, KHR_get_physical_device_properties2))
             {
                 uint32_t majorVersion = VK_VERSION_MAJOR(m_vulkanVersion);
                 uint32_t minorVersion = VK_VERSION_MINOR(m_vulkanVersion);
-
-                // need to call this for IsOptionalDeviceExtensionSupported to work
-                FilterSupportedOptionalExtensions(true);
 
                 // Features
                 m_descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
@@ -475,6 +468,8 @@ namespace AZ
                 VkPhysicalDeviceFeatures2 deviceFeatures2 = {};
                 deviceFeatures2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 
+                StructAppender deviceFeaturesAppender(deviceFeatures2);
+
                 // Properties
                 m_conservativeRasterProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT;
                 m_rayTracingPipelineProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
@@ -486,47 +481,49 @@ namespace AZ
                 VkPhysicalDeviceProperties2 deviceProps2 = {};
                 deviceProps2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
 
+                StructAppender devicePropsAppender(deviceProps2);
+
                 // Extensions
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DepthClipEnable))
                 {
-                    AppendVkStruct(deviceFeatures2, &m_depthClipEnableFeatures);
+                    deviceFeaturesAppender.append(m_depthClipEnableFeatures);
                 }
 
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderImageAtomicInt64))
                 {
-                    AppendVkStruct(deviceFeatures2, &m_shaderImageAtomicInt64Features);
+                    deviceFeaturesAppender.append(m_shaderImageAtomicInt64Features);
                 }
 
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::Robustness2))
                 {
-                    AppendVkStruct(deviceFeatures2, &m_robustness2Features);
+                    deviceFeaturesAppender.append(m_robustness2Features);
                 }
 
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SubpassMergeFeedback))
                 {
-                    AppendVkStruct(deviceFeatures2, &m_subpassMergeFeedbackFeatures);
+                    deviceFeaturesAppender.append(m_subpassMergeFeedbackFeatures);
                 }
 
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentShadingRate))
                 {
-                    AppendVkStruct(deviceFeatures2, &m_fragmentShadingRateFeatures);
-                    AppendVkStruct(deviceProps2, &m_fragmentShadingRateProperties);
+                    deviceFeaturesAppender.append(m_fragmentShadingRateFeatures);
+                    devicePropsAppender.append(m_fragmentShadingRateProperties);
                 }
 
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::FragmentDensityMap))
                 {
-                    AppendVkStruct(deviceFeatures2, &m_fragmentDensityMapFeatures);
-                    AppendVkStruct(deviceProps2, &m_fragmentDensityMapProperties);
+                    deviceFeaturesAppender.append(m_fragmentDensityMapFeatures);
+                    devicePropsAppender.append(m_fragmentDensityMapProperties);
                 }
 
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ConservativeRasterization))
                 {
-                    AppendVkStruct(deviceProps2, &m_conservativeRasterProperties);
+                    devicePropsAppender.append(m_conservativeRasterProperties);
                 }
 
                 if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ExternalMemoryHost))
                 {
-                    AppendVkStruct(deviceProps2, &m_externalMemoryHostProperties);
+                    devicePropsAppender.append(m_externalMemoryHostProperties);
                 }
 
                 // this is handled through Vulkan 1.2 but we still need to get these features because some drivers (e.g. Intel) don't report
@@ -534,22 +531,22 @@ namespace AZ
                 if ((majorVersion >= 1 && minorVersion >= 2) ||
                     IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::BufferDeviceAddress))
                 {
-                    AppendVkStruct(deviceFeatures2, &m_bufferDeviceAddressFeatures);
+                    deviceFeaturesAppender.append(m_bufferDeviceAddressFeatures);
                 }
 
                 if (majorVersion >= 1 && minorVersion >= 2)
                 {
-                    AppendVkStruct(deviceFeatures2, &m_vulkan12Features);
+                    deviceFeaturesAppender.append(m_vulkan12Features);
 
                     if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::AccelerationStructure) &&
                         IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayTracingPipeline))
                     {
-                        AppendVkStruct(deviceFeatures2, { &m_accelerationStructureFeatures, &m_rayTracingPipelineFeatures });
-                        AppendVkStruct(deviceProps2, { &m_accelerationStructureProperties, &m_rayTracingPipelineProperties });
+                        deviceFeaturesAppender.append({ &m_accelerationStructureFeatures, &m_rayTracingPipelineFeatures });
+                        devicePropsAppender.append({ &m_accelerationStructureProperties, &m_rayTracingPipelineProperties });
 
                         if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::RayQuery))
                         {
-                            AppendVkStruct(deviceFeatures2, &m_rayQueryFeatures);
+                            deviceFeaturesAppender.append(m_rayQueryFeatures);
                         }
                     }
                 }
@@ -557,33 +554,35 @@ namespace AZ
                 {
                     if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::DescriptorIndexing))
                     {
-                        AppendVkStruct(deviceFeatures2, &m_descriptorIndexingFeatures);
+                        deviceFeaturesAppender.append(m_descriptorIndexingFeatures);
                     }
 
                     if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::SeparateDepthStencilLayouts))
                     {
-                        AppendVkStruct(deviceFeatures2, &m_separateDepthStencilLayoutsFeatures);
+                        deviceFeaturesAppender.append(m_separateDepthStencilLayoutsFeatures);
                     }
 
                     if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderFloat16Int8))
                     {
-                        AppendVkStruct(deviceFeatures2, &m_shaderFloat16Int8Features);
+                        deviceFeaturesAppender.append(m_shaderFloat16Int8Features);
                     }
 
                     if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::ShaderAtomicInt64))
                     {
-                        AppendVkStruct(deviceFeatures2, &m_shaderAtomicInt64Features);
+                        deviceFeaturesAppender.append(m_shaderAtomicInt64Features);
                     }
 
                     if (IsOptionalDeviceExtensionSupported(OptionalDeviceExtension::TimelineSempahore))
                     {
-                        AppendVkStruct(deviceFeatures2, &m_timelineSemaphoreFeatures);
+                        deviceFeaturesAppender.append(m_timelineSemaphoreFeatures);
                     }
                 }
 
+                deviceFeaturesAppender.finish();
                 context.GetPhysicalDeviceFeatures2KHR(vkPhysicalDevice, &deviceFeatures2);
                 m_deviceFeatures = deviceFeatures2.features;
 
+                devicePropsAppender.finish();
                 context.GetPhysicalDeviceProperties2KHR(vkPhysicalDevice, &deviceProps2);
                 m_deviceProperties = deviceProps2.properties;
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -70,6 +70,7 @@ namespace AZ
             CalibratedTimestamps,
             ExternalMemoryHost,
             ExternalSemaphore,
+            SeparateDepthStencilLayouts,
             Count
         };
 
@@ -122,7 +123,7 @@ namespace AZ
             bool IsFormatSupported(RHI::Format format, VkImageTiling tiling, VkFormatFeatureFlags features) const;
             void LoadSupportedFeatures(const GladVulkanContext& context);
             //! Filter optional extensions based on what the physics device support.
-            RawStringList FilterSupportedOptionalExtensions();
+            RawStringList FilterSupportedOptionalExtensions(bool enableSupported);
             //! Returns the supported vulkan version of the physical device.
             uint32_t GetVulkanVersion() const;
             //! Query the set of available time domains for timestamp calibration
@@ -144,12 +145,12 @@ namespace AZ
             VkPhysicalDeviceFeatures m_deviceFeatures{};
             VkPhysicalDeviceProperties m_deviceProperties{};
             VkPhysicalDeviceConservativeRasterizationPropertiesEXT m_conservativeRasterProperties{};
-            VkPhysicalDeviceDepthClipEnableFeaturesEXT m_dephClipEnableFeatures{};
+            VkPhysicalDeviceDepthClipEnableFeaturesEXT m_depthClipEnableFeatures{};
             VkPhysicalDeviceRobustness2FeaturesEXT m_robustness2Features{};
-            VkPhysicalDeviceShaderFloat16Int8FeaturesKHR m_float16Int8Features{};
+            VkPhysicalDeviceShaderFloat16Int8FeaturesKHR m_shaderFloat16Int8Features{};
             VkPhysicalDeviceDescriptorIndexingFeaturesEXT m_descriptorIndexingFeatures{};
             VkPhysicalDeviceBufferDeviceAddressFeaturesEXT m_bufferDeviceAddressFeatures{};
-            VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR m_separateDepthStencilFeatures{};
+            VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR m_separateDepthStencilLayoutsFeatures{};
             VkPhysicalDeviceShaderAtomicInt64Features m_shaderAtomicInt64Features{};
             VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT m_shaderImageAtomicInt64Features{};
             VkPhysicalDeviceAccelerationStructurePropertiesKHR m_accelerationStructureProperties{};
@@ -158,13 +159,13 @@ namespace AZ
             VkPhysicalDeviceRayTracingPipelineFeaturesKHR m_rayTracingPipelineFeatures{};
             VkPhysicalDeviceRayQueryFeaturesKHR m_rayQueryFeatures{};
             VkPhysicalDeviceVulkan12Features m_vulkan12Features{};
-            VkPhysicalDeviceFragmentShadingRateFeaturesKHR m_shadingRateFeatures{};
+            VkPhysicalDeviceFragmentShadingRateFeaturesKHR m_fragmentShadingRateFeatures{};
             VkPhysicalDeviceFragmentDensityMapFeaturesEXT m_fragmentDensityMapFeatures{};
             VkPhysicalDeviceFragmentDensityMapPropertiesEXT m_fragmentDensityMapProperties{};
             VkPhysicalDeviceFragmentShadingRatePropertiesKHR m_fragmentShadingRateProperties{};
             VkPhysicalDeviceTimelineSemaphoreFeatures m_timelineSemaphoreFeatures{};
             VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT m_subpassMergeFeedbackFeatures{};
-            VkPhysicalDeviceExternalMemoryHostPropertiesEXT m_externalHostMemoryFeatures{};
+            VkPhysicalDeviceExternalMemoryHostPropertiesEXT m_externalMemoryHostProperties{};
             uint32_t m_vulkanVersion = 0;
         };
     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -7,9 +7,9 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI/PhysicalDevice.h>
 #include <AzCore/std/containers/bitset.h>
-#include <Atom/RHI.Reflect/Format.h>
 #include <RHI/Vulkan.h>
 
 namespace AZ
@@ -40,6 +40,7 @@ namespace AZ
             Count // Must be last
         };
 
+        // If you change this enum, you also have to update OptionalDeviceExtensionNames in the cpp file!
         enum class OptionalDeviceExtension : uint32_t
         {
             SampleLocation = 0,
@@ -74,8 +75,7 @@ namespace AZ
             Count
         };
 
-        class PhysicalDevice final
-            : public RHI::PhysicalDevice
+        class PhysicalDevice final : public RHI::PhysicalDevice
         {
             using Base = RHI::PhysicalDevice;
         public:
@@ -123,7 +123,7 @@ namespace AZ
             bool IsFormatSupported(RHI::Format format, VkImageTiling tiling, VkFormatFeatureFlags features) const;
             void LoadSupportedFeatures(const GladVulkanContext& context);
             //! Filter optional extensions based on what the physics device support.
-            RawStringList FilterSupportedOptionalExtensions(bool enableSupported);
+            RawStringList GetEnabledOptionalExtensions();
             //! Returns the supported vulkan version of the physical device.
             uint32_t GetVulkanVersion() const;
             //! Query the set of available time domains for timestamp calibration
@@ -136,6 +136,8 @@ namespace AZ
             // RHI::PhysicalDevice
             void Shutdown() override;
            ///////////////////////////////////////////////////////////////////
+
+            void EnableSupportedOptionalExtensions();
 
             VkPhysicalDevice m_vkPhysicalDevice = VK_NULL_HANDLE;
             VkPhysicalDeviceMemoryProperties m_memoryProperty{};

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
@@ -98,7 +98,6 @@ namespace AZ
 
                     VkRenderPassCreateInfoType createInfo{};
                     createInfo.sType = VkRenderPassCreateInfoTraits::struct_type;
-                    createInfo.pNext = nullptr;
                     createInfo.flags = 0;
                     createInfo.attachmentCount = static_cast<uint32_t>(attachmentDescriptions.size());
                     createInfo.pAttachments = attachmentDescriptions.empty() ? nullptr : attachmentDescriptions.data();
@@ -106,6 +105,8 @@ namespace AZ
                     createInfo.pSubpasses = subpassDescriptions.empty() ? nullptr : subpassDescriptions.data();
                     createInfo.dependencyCount = static_cast<uint32_t>(subpassDependencies.size());
                     createInfo.pDependencies = subpassDependencies.empty() ? nullptr : subpassDependencies.data();
+
+                    StructAppender createInfoAppender{ createInfo };
 
                     // Fragment shade attachments are declared at a renderpass level (same for all subpasses), so we need to
                     // check if we have one as part of the renderpass declaration. We check if the first subpass contains the shading rate attachment,
@@ -127,7 +128,7 @@ namespace AZ
                             fdmAttachmentCreateInfo.fragmentDensityMapAttachment.attachment = fragmentDensityReference.attachment;
                             fdmAttachmentCreateInfo.fragmentDensityMapAttachment.layout = fragmentDensityReference.layout;
 
-                            AppendVkStruct(createInfo, &fdmAttachmentCreateInfo);
+                            createInfoAppender.append(fdmAttachmentCreateInfo);
                         }
                     }
 
@@ -138,8 +139,10 @@ namespace AZ
                         renderPassCreationFeedbackCreateInfo = {};
                         renderPassCreationFeedbackCreateInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_FEEDBACK_CREATE_INFO_EXT;
                         renderPassCreationFeedbackCreateInfo.pRenderPassFeedback = &renderPassCreationFeedbackInfo;
-                        AppendVkStruct(createInfo, &renderPassCreationFeedbackCreateInfo);
+                        createInfoAppender.append(renderPassCreationFeedbackCreateInfo);
                     }
+
+                    createInfoAppender.finish();
 
                     RenderPassResult result = Create<VkRenderPassCreateInfoType>(createInfo);
                     if (m_collectSubpassMergeInfo)
@@ -357,7 +360,8 @@ namespace AZ
                             subpassFeedbackInfo.first.sType = VK_STRUCTURE_TYPE_RENDER_PASS_SUBPASS_FEEDBACK_CREATE_INFO_EXT;
                             subpassFeedbackInfo.second = {};
                             subpassFeedbackInfo.first.pSubpassFeedback = &subpassFeedbackInfo.second;
-                            AppendVkStruct(desc, &subpassFeedbackInfo.first);
+                            reinterpret_cast<VkBaseOutStructure*>(&desc)->pNext =
+                                reinterpret_cast<VkBaseOutStructure*>(&subpassFeedbackInfo.first);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #18433.

## What does this PR do?

Only add structs to the pNext chain during device initialization and feature/property queries for extensions that are actually enabled/supported.

## How was this PR tested?

Ran the editor to make sure everything is still working.
