### PR TITLE
EmotionFX: Ability for SimpleMotionComponent & AnimGraphComponent to exist on same entity

### DIFF
--- a/Gems/EMotionFX/Code/Include/Integration/AnimGraphComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/AnimGraphComponentBus.h
@@ -194,6 +194,12 @@ namespace EMotionFX
 
             /// Set the name of the active motion set.
             virtual void SetActiveMotionSet(const char* activeMotionSetName) = 0;
+            
+            /// Starts updating an anim graph instance
+            virtual void StartAnimGraph() = 0;
+
+            /// Stops updating an anim graph instance and resets its state
+            virtual void StopAnimGraph() = 0;
         };
 
         using AnimGraphComponentRequestBus = AZ::EBus<AnimGraphComponentRequests>;

--- a/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
@@ -181,7 +181,10 @@ namespace EMotionFX
                     // Anim Graph Sync
                     ->Event("SyncAnimGraph", &AnimGraphComponentRequestBus::Events::SyncAnimGraph)
                     ->Event("DesyncAnimGraph", &AnimGraphComponentRequestBus::Events::DesyncAnimGraph)
-                ;
+
+                    ->Event("StartAnimGraph", &AnimGraphComponentRequestBus::Events::StartAnimGraph)
+                    ->Event("StopAnimGraph", &AnimGraphComponentRequestBus::Events::StopAnimGraph)
+                    ;
 
                 behaviorContext->EBus<AnimGraphComponentNotificationBus>("AnimGraphComponentNotificationBus")
                     ->Handler<AnimGraphComponentNotificationBehaviorHandler>()
@@ -1255,6 +1258,30 @@ namespace EMotionFX
         {
             m_configuration.m_activeMotionSetName = activeMotionSetName;
             CheckCreateAnimGraphInstance();
+        }
+
+        void AnimGraphComponent::StartAnimGraph()
+        {
+            if (m_animGraphInstance)
+            {
+                if (m_actorInstance)
+                {
+                    m_actorInstance->SetAnimGraphInstance(m_animGraphInstance.get());
+                }
+                m_animGraphInstance->Start();
+            }
+        }
+
+        void AnimGraphComponent::StopAnimGraph()
+        {
+            if (m_animGraphInstance)
+            {
+                m_animGraphInstance->Stop();
+                if (m_actorInstance)
+                {
+                    m_actorInstance->SetAnimGraphInstance(nullptr);
+                }
+            }
         }
     } // namespace Integration
 } // namespace EMotionFXAnimation

--- a/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.h
@@ -142,6 +142,8 @@ namespace EMotionFX
             void SyncAnimGraph(AZ::EntityId leaderEntityId) override;
             void DesyncAnimGraph(AZ::EntityId leaderEntityId) override;
             void SetActiveMotionSet(const char* activeMotionSetName) override;
+            void StartAnimGraph() override;
+            void StopAnimGraph() override;
             //////////////////////////////////////////////////////////////////////////
 
             //////////////////////////////////////////////////////////////////////////
@@ -180,7 +182,6 @@ namespace EMotionFX
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
             {
                 incompatible.push_back(AZ_CRC_CE("EMotionFXAnimGraphService"));
-                incompatible.push_back(AZ_CRC_CE("EMotionFXSimpleMotionService"));
             }
 
             static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
@@ -84,7 +84,6 @@ namespace EMotionFX
             }
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
             {
-                incompatible.push_back(AZ_CRC_CE("EMotionFXAnimGraphService"));
                 incompatible.push_back(AZ_CRC_CE("EMotionFXSimpleMotionService"));
                 incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
             }

--- a/Gems/EMotionFX/Code/Tests/Integration/CanAddSimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Tests/Integration/CanAddSimpleMotionComponent.cpp
@@ -82,6 +82,6 @@ namespace EMotionFX
             &AzToolsFramework::EditorComponentAPIRequests::IsComponentEnabled,
             componentOutcome.GetValue().at(0)
         );
-        EXPECT_FALSE(isActive);
+        EXPECT_TRUE(isActive);
     }
 } // namespace EMotionFX


### PR DESCRIPTION
## What does this PR do?

This PR is a revival of https://github.com/aws/lumberyard/pull/540, I revived it so that I can play an animation clip on the editor without having to disable or enable the simple motion component.

## How was this PR tested?

Manually tested