### PR TITLE
RenderPass: Drop early-out for passes without attachments

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -164,10 +164,6 @@ namespace AZ
             RHI::RenderAttachmentLayoutBuilder builder;
             auto* layoutBuilder = builder.AddSubpass();
             BuildSubpassLayout(*layoutBuilder);
-            if (!layoutBuilder->HasAttachments())
-            {
-                return;
-            }
 
             RHI::RenderAttachmentLayout subpassLayout;
             [[maybe_unused]] RHI::ResultCode result = builder.End(subpassLayout);
@@ -616,7 +612,7 @@ namespace AZ
 
             // This scope query implementation should be replaced by
             // [ATOM-5407] [RHI][Core] - Add GPU timestamp and pipeline statistic support for scopes
-            
+
             // For timestamp query, it's okay to execute across different command lists
             if (context.GetCommandListIndex() == context.GetCommandListCount() - 1)
             {


### PR DESCRIPTION
## What does this PR do?

After #18237 we are no longer able to use render passes without output attachments (i.e. raster passes that only write to sideband buffers) following an assert inside `GetRenderAttachmentConfiguration()`.  This was supposedly explicitly supported before and seems to be caused by an unneeded early-out when an empty attachment configuration was supposed to be built inside `BuildRenderAttachmentConfiguration()`.

## How was this PR tested?

We have removed a "phantom" `"SlotType": "Output", "ScopeAttachmentUsage": "RenderTarget"` from our render pass such that it only has `"ScopeAttachmentUsage": "Shader"` outputs.  Before, that would trigger the assertion inside `GetRenderAttachmentConfiguration()`, but with this change the pass still runs successfully and writes to the attached output storage buffers.

CC @antonmic 
