### PR TITLE
Clang19 and higher Linux build issue fix.

### DIFF
--- a/Gems/Atom/RPI/Code/External/MaskedOcclusionCulling/CompilerSpecific.inl
+++ b/Gems/Atom/RPI/Code/External/MaskedOcclusionCulling/CompilerSpecific.inl
@@ -76,10 +76,12 @@
 		free(ptr);
 	}
 
+#if !defined(__clang__) || (__clang_major__ < 19)
 	FORCE_INLINE void __cpuidex(int* cpuinfo, int function, int subfunction)
 	{
 		__cpuid_count(function, subfunction, cpuinfo[0], cpuinfo[1], cpuinfo[2], cpuinfo[3]);
 	}
+#endif
 
 #if !defined(_xgetbv)
 	FORCE_INLINE unsigned long long _xgetbv(unsigned int index)


### PR DESCRIPTION
## What does this PR do?

Clang 19 and newer have `__cpuidex` implemented in `cpuid.h` so this leads to a redefinition compile error on linux.

## How was this PR tested?

Compiled with clang 20.1.8 and checked when the function was implemented in clang.