### PR TITLE
Fixes release only clang compiler error due to unused variable in xcb

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -542,7 +542,7 @@ namespace AzFramework
     bool XcbNativeWindow::ValidateXcbResult(xcb_void_cookie_t cookie)
     {
         bool result = true;
-        if (xcb_generic_error_t* error = xcb_request_check(m_xcbConnection, cookie))
+        if ([[maybe_unused]]xcb_generic_error_t* error = xcb_request_check(m_xcbConnection, cookie))
         {
             AZ_TracePrintf("Error", "Error code %d", error->error_code);
             result = false;


### PR DESCRIPTION
## What does this PR do?

Fixes the following compile error

```
XcbNativeWindow.cpp:545:34: error: variable 'error' set but not used [-Werror,-Wunused-but-set-variable]
  545 |         if (xcb_generic_error_t* error = xcb_request_check(m_xcbConnection, cookie))
      |                                  ^
```

This is due to the AZ_Error macro being a no-op in release monolithic builds.

## How was this PR tested?

Ubuntu 25.04 latest, compiling the `installer` in release monolithic under clang.
Its a compile fix, doesn't compile without this change.
