### PR TITLE
solution for atom hair that doesn't render

### DIFF
--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
@@ -197,5 +197,7 @@ float4 PPLLFillPS(PS_INPUT_HAIR input) : SV_Target0
         strandColor.xyz, 
         input.Position.z
     );
+
+// Keep `float4`. The value is unused here, but PS stages are expected to return a color value.
 return float4(0.0, 0.0, 0.0, 0.0);
 }

--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
@@ -148,7 +148,7 @@ struct PSOutput
 // First pass of PPLL implementation
 // Builds up the linked list of hair fragments
 [earlydepthstencil]
-void PPLLFillPS(PS_INPUT_HAIR input)
+float4 PPLLFillPS(PS_INPUT_HAIR input) : SV_Target0
 {
     // Strand Color read in is either the BaseMatColor, or BaseMatColor modulated with a color read 
     // from texture in the vertex shader for base color along with modulation by the tip color  
@@ -197,4 +197,5 @@ void PPLLFillPS(PS_INPUT_HAIR input)
         strandColor.xyz, 
         input.Position.z
     );
+return float4(0.0, 0.0, 0.0, 0.0);
 }

--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
@@ -198,6 +198,6 @@ float4 PPLLFillPS(PS_INPUT_HAIR input) : SV_Target0
         input.Position.z
     );
 
-// Keep `float4`. The value is unused here, but PS stages are expected to return a color value.
-return float4(0.0, 0.0, 0.0, 0.0);
+    // Keep `float4`. The value is unused here, but PS stages are expected to return a color value.
+    return float4(0.0, 0.0, 0.0, 0.0);
 }


### PR DESCRIPTION
"ShaderBuilderUtility: Failed to parse output layout. Could not create the output contract for the fragment function PPLLFillPS"

The fragment shader is returning 'void' for transparency. I just updated the function semantic and made it return a RGBA (0, 0, 0, 0).