### PR TITLE
Removes the spam during configure related to "restricted"

### DIFF
--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -93,11 +93,11 @@ macro(o3de_gem_setup) #default_gem_name)
 
     o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
     if(gem_restricted_path)
-        message(STATUS "Restricted found in ${gem_json}, using: ${gem_restricted_path}")
+        message(VERBOSE "Restricted found in ${gem_json}, using: ${gem_restricted_path}")
     else()
         # If the gem.json does not have a 'restricted' field use the gem dir and append /restricted
         set(gem_restricted_path "${gem_path}/restricted")
-        message(STATUS "No restricted found in ${gem_json}, using default: ${gem_restricted_path}")
+        message(VERBOSE "No restricted found in ${gem_json}, using default: ${gem_restricted_path}")
     endif()
 
     o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")

--- a/cmake/PAL.cmake
+++ b/cmake/PAL.cmake
@@ -256,7 +256,7 @@ o3de_restricted_path(${LY_ROOT_FOLDER}/engine.json O3DE_ENGINE_RESTRICTED_PATH)
 if(NOT O3DE_ENGINE_RESTRICTED_PATH)
     # If the engine.json does not have a 'restricted' field use the engine dir and append /restricted
     set(O3DE_ENGINE_RESTRICTED_PATH "${LY_ROOT_FOLDER}/restricted")
-    message(STATUS "No restricted path found in engine.json, using default: ${O3DE_ENGINE_RESTRICTED_PATH}")
+    message(VERBOSE "No restricted path found in engine.json, using default: ${O3DE_ENGINE_RESTRICTED_PATH}")
 endif()
 
 # detect platforms in the restricted path


### PR DESCRIPTION
## What does this PR do?

Removes the hundreds of lines of spam during configure relating to restricted objects.

Note that it changes the messages to have VERBOSE
status, which means you can still see them
if you configure with VERBOSE message level.

## How was this PR tested?

Just running CMAKE configure.  It is a harmless change, as it doesn't change anything else except for the display level of those messages.

Before: 

Configure generates tons of output like
```
--   No restricted found in D:/o3de-repos/o3de/Gems/GraphCanvas/gem.json, using default: D:/o3de-repos/o3de/Gems/GraphCanvas/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/GraphModel/gem.json, using default: D:/o3de-repos/o3de/Gems/GraphModel/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Atom/Tools/AtomToolsFramework/gem.json, using default: D:/o3de-repos/o3de/Gems/Atom/Tools/AtomToolsFramework/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/CommonFeatures/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/CommonFeatures/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/EditorModeFeedback/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/EditorModeFeedback/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Atom/Component/DebugCamera/gem.json, using default: D:/o3de-repos/o3de/Gems/Atom/Component/DebugCamera/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Atom/Tools/MaterialCanvas/gem.json, using default: D:/o3de-repos/o3de/Gems/Atom/Tools/MaterialCanvas/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Atom/Tools/MaterialEditor/gem.json, using default: D:/o3de-repos/o3de/Gems/Atom/Tools/MaterialEditor/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Atom/Tools/PassCanvas/gem.json, using default: D:/o3de-repos/o3de/Gems/Atom/Tools/PassCanvas/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Atom/Tools/ShaderManagementConsole/gem.json, using default: D:/o3de-repos/o3de/Gems/Atom/Tools/ShaderManagementConsole/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/ImguiAtom/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/ImguiAtom/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomImGuiTools/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomImGuiTools/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomRenderOptions/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomRenderOptions/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/EMotionFX/gem.json, using default: D:/o3de-repos/o3de/Gems/EMotionFX/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/EMotionFXAtom/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/EMotionFXAtom/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomFont/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomFont/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomViewportDisplayIcons/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomViewportDisplayIcons/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomBridge/gem.json, using default: D:/o3de-repos/o3de/Gems/AtomLyIntegration/AtomBridge/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Maestro/gem.json, using default: D:/o3de-repos/o3de/Gems/Maestro/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/Prefab/PrefabBuilder/gem.json, using default: D:/o3de-repos/o3de/Gems/Prefab/PrefabBuilder/restricted
--   No restricted found in D:/o3de-repos/o3de/Gems/SceneProcessing/gem.json, using default: D:/o3de-repos/o3de/Gems/SceneProcessing/restricted
```

After:  Just the same as it was before the restricted spam was introduced.