### PR TITLE
Set emissive.enabled material property for emissive materials

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialConverterSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialConverterSystemComponent.cpp
@@ -196,6 +196,10 @@ namespace AZ
                     Name{ "roughness.factor" }, aznumeric_cast<float>(pow(2.0f / (materialData.GetShininess() + 2.0f), 0.25)));
             }
 
+            if (!materialData.GetEmissiveColor().IsZero())
+            {
+                sourceData.SetPropertyValue(Name{ "emissive.enable" }, true);
+            }
             handleTexture("emissive", "textureMap", SceneAPI::DataTypes::IMaterialData::TextureMapType::Emissive);
             sourceData.SetPropertyValue(Name{"emissive.color"}, toColor(materialData.GetEmissiveColor()));
             applyOptionalPropertiesFunc("emissive", "intensity", materialData.GetEmissiveIntensity());


### PR DESCRIPTION
## What does this PR do?

This PR sets the `emissive.enable` material property to true when an emissive color is set for the material. Currently, emissive properties are set for the material, but ignored at runtime unless emissive is enabled manually (eg. in the material instance editor for a material slot).

## How was this PR tested?

I ran across this problem when implementing a [path tracing gem](https://github.com/mapret/O3DEPathTracing) (repository not really ready for public consumption yet), which uses emissive geometry as light source. Without this change, an imported scene (eg. a cornell box imported from fbx or gltf) does not light up unless the emissive property of the light material is enable explicitly in the material instance editor. With this change, the same scene works as expected out of the box.