### PR TITLE
FrameGraphExecuter: Limit commandListCount to estimatedItemCount

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -151,7 +151,8 @@ namespace AZ
                     else
                     {
                         // And then create a new group for the current scope with dedicated [1, N] command lists.
-                        const uint32_t commandListCount = AZStd::max(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u);
+                        const uint32_t commandListCount =
+                            AZStd::clamp(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u, estimatedItemCount);
 
                         FrameGraphExecuteGroup* scopeContextGroup = AddGroup<FrameGraphExecuteGroup>();
                         scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -172,7 +172,8 @@ namespace AZ
                     else
                     {
                         // And then create a new group for the current scope with dedicated [1, N] command lists.
-                        const AZ::u32 commandListCount = AZStd::max(RHI::DivideByMultiple(totalScopeCost, CommandListCostThreshold), 1u);
+                        const AZ::u32 commandListCount =
+                            AZStd::clamp(RHI::DivideByMultiple(totalScopeCost, CommandListCostThreshold), 1u, estimatedItemCount);
 
                         FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
                         scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -178,7 +178,8 @@ namespace AZ
                     else
                     {
                         // And then create a new group for the current scope with dedicated [1, N] secondary command lists
-                        const uint32_t commandListCount = AZStd::max(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u);
+                        const uint32_t commandListCount =
+                            AZStd::clamp(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u, estimatedItemCount);
                         FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
                         scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
                     }


### PR DESCRIPTION
## What does this PR do?

The number of command lists per scope is computed from the costs computed from various scope parameters.
We had a case were a complex `FullscreenTrianglePass` got 2 command lists while only having one `DrawItem`. This led to the fullscreen `DrawItem` being submitted twice.
This PR limits the number of command lists to the `estimatedItemCount` of the scope.

## How was this PR tested?

Tested on Windows with DX12 and Vulkan with the MainPipeline and a custom render pipeline that triggers the bug
