### PR TITLE
Fixes crashes and ASAN errors in AzCore benchmarks

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -634,10 +634,26 @@ namespace AZ
         // The /O3DE/Application/LifecycleEvents array contains a valid set of lifecycle events
         // Those lifecycle events are normally read from the <engine-root>/Registry
         // which isn't merged until ComponentApplication::Create invokes MergeSettingsToRegistry
-        // So pre-populate the valid lifecycle even entries
+        // So pre-populate the valid lifecycle event entries which are invoked before the settings registry is
+        // fully populated (e.g. loaded from every gem, for example).
         ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "SystemAllocatorCreated");
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "SystemAllocatorPendingDestruction");
+
         ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "SettingsRegistryAvailable");
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "SettingsRegistryUnavailable");
+
         ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "ConsoleAvailable");
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "ConsoleUnavailable");
+        
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "ReflectionManagerAvailable");
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "ReflectionManagerUnavailable");
+
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "GemsLoaded");
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "GemsUnloaded");
+
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "SystemComponentsActivated");
+        ComponentApplicationLifecycle::RegisterEvent(settingsRegistry, "SystemComponentsDeactivated");
+
         ComponentApplicationLifecycle::SignalEvent(settingsRegistry, "SystemAllocatorCreated", R"({})");
         ComponentApplicationLifecycle::SignalEvent(settingsRegistry, "SettingsRegistryAvailable", R"({})");
     }

--- a/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
@@ -37,9 +37,9 @@ namespace UnitTest
 
         LeakDetectionBase() = default;
         LeakDetectionBase(const LeakDetectionBase&) = default;
-        LeakDetectionBase(LeakDetectionBase&&) = default;
-        LeakDetectionBase& operator=(const LeakDetectionBase&) = default;
-        LeakDetectionBase& operator=(LeakDetectionBase&&) = default;
+        LeakDetectionBase(LeakDetectionBase&&) = delete;
+        LeakDetectionBase& operator=(const LeakDetectionBase&) = delete;
+        LeakDetectionBase& operator=(LeakDetectionBase&&) = delete;
         virtual ~LeakDetectionBase() = default;
 
         AllocatedSizesMap GetAllocatedSizes()
@@ -139,39 +139,61 @@ namespace UnitTest
     {
     public:
         //Benchmark interface
-        void SetUp(const ::benchmark::State&) override
+
+        // Note that the "this" pointer is going to be a singleton, but this function gets called once per thread
+        // and is done overlapping with other threads calling the same function on the same `this` pointer, so
+        // do things that are thread-safe here, and only initialize things once.
+        void SetUp(const ::benchmark::State& state) override
+        {
+            
+            AZ::AllocatorManager::Instance().SetDefaultProfilingState(true);
+            AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_FULL);
+            AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_FULL);
+
+            if (state.thread_index() == 0)
+            {
+                AZ::AllocatorManager::Instance().EnterProfilingMode();
+                m_allocatedSizes = GetAllocatedSizes();
+            }
+        }
+        void SetUp(::benchmark::State& state) override
         {
             AZ::AllocatorManager::Instance().EnterProfilingMode();
             AZ::AllocatorManager::Instance().SetDefaultProfilingState(true);
             AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_FULL);
             AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_FULL);
-            m_allocatedSizes = GetAllocatedSizes();
-        }
-        void SetUp(::benchmark::State&) override
-        {
-            AZ::AllocatorManager::Instance().EnterProfilingMode();
-            AZ::AllocatorManager::Instance().SetDefaultProfilingState(true);
-            AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_FULL);
-            AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_FULL);
-            m_allocatedSizes = GetAllocatedSizes();
+            if (state.thread_index() == 0)
+            {
+                AZ::AllocatorManager::Instance().EnterProfilingMode();
+                m_allocatedSizes = GetAllocatedSizes();
+            }
         }
 
-        void TearDown(const ::benchmark::State&) override
+        void TearDown(const ::benchmark::State& state) override
         {
-            CheckAllocatorsForLeaks();
-            AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
-            AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
-            AZ::AllocatorManager::Instance().SetDefaultProfilingState(false);
-            AZ::AllocatorManager::Instance().ExitProfilingMode();
+            if (state.thread_index() == 0)
+            {
+                CheckAllocatorsForLeaks();
+                AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
+                AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
+                AZ::AllocatorManager::Instance().SetDefaultProfilingState(false);
+                AZ::AllocatorManager::Instance().ExitProfilingMode();
+                m_allocatedSizes = {};
+            }
         }
 
-        void TearDown(::benchmark::State&) override
+        void TearDown(::benchmark::State& state) override
         {
-            CheckAllocatorsForLeaks();
-            AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
-            AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
-            AZ::AllocatorManager::Instance().SetDefaultProfilingState(false);
-            AZ::AllocatorManager::Instance().ExitProfilingMode();
+            if (state.thread_index() == 0)
+            {
+                CheckAllocatorsForLeaks();
+                AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
+                AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
+                AZ::AllocatorManager::Instance().SetDefaultProfilingState(false);
+                AZ::AllocatorManager::Instance().ExitProfilingMode();
+                m_allocatedSizes = {};
+            }
+
         }
     };
 

--- a/Code/Framework/AzCore/AzCore/std/allocator_stateless.h
+++ b/Code/Framework/AzCore/AzCore/std/allocator_stateless.h
@@ -21,10 +21,6 @@ namespace AZStd
 
         AZ_ALLOCATOR_DEFAULT_TRAITS
 
-        stateless_allocator() = default;
-        stateless_allocator(const stateless_allocator& rhs) = default;
-        stateless_allocator& operator=(const stateless_allocator& rhs) = default;
-
         pointer allocate(size_type byteSize, align_type alignment = 1);
         void deallocate(pointer ptr, size_type byteSize = 0, align_type alignment = 0);
         pointer reallocate(pointer ptr, size_type newSize, align_type alignment = 1);

--- a/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
@@ -25,25 +25,42 @@ namespace AZ::Dom::Tests
 
     void DomBenchmarkFixture::SetUp(const ::benchmark::State& st)
     {
+        // note that the `this` pointer is going to be a singleton, but this function gets called once per thread
+        // and is done overlapping with other threads calling the same function on the same `this` pointer, so
+        // do things that are thread-safe here, and only initialize things once.
+
         UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-        SetUpHarness();
+        if (st.thread_index() == 0)
+        {
+            SetUpHarness();
+        }
+        
     }
 
     void DomBenchmarkFixture::SetUp(::benchmark::State& st)
     {
         UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-        SetUpHarness();
+        if (st.thread_index() == 0)
+        {
+            SetUpHarness();
+        }
     }
 
     void DomBenchmarkFixture::TearDown(::benchmark::State& st)
     {
-        TearDownHarness();
+        if (st.thread_index() == 0)
+        {
+            TearDownHarness();
+        }
         UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
     }
 
     void DomBenchmarkFixture::TearDown(const ::benchmark::State& st)
     {
-        TearDownHarness();
+        if (st.thread_index() == 0)
+        {
+            TearDownHarness();
+        }
         UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
     }
 

--- a/Code/Framework/AzCore/Tests/Math/MatrixMxNPerformanceTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/MatrixMxNPerformanceTests.cpp
@@ -30,6 +30,11 @@ namespace Benchmark
             m_matrix2 = AZ::MatrixMxN();
             m_vector1 = AZ::VectorN();
             m_vector2 = AZ::VectorN();
+
+            m_result1 = AZ::MatrixMxN();
+            m_result2 = AZ::MatrixMxN();
+            m_result3 = AZ::VectorN();
+            m_result4 = AZ::VectorN();
         }
     public:
         void SetUp(const benchmark::State&) override

--- a/Code/Framework/AzCore/Tests/Name/NameBenchmarks.cpp
+++ b/Code/Framework/AzCore/Tests/Name/NameBenchmarks.cpp
@@ -16,27 +16,43 @@ namespace AZ::NameBenchmarks
     class NameBenchmarkFixture : public UnitTest::AllocatorsBenchmarkFixture
     {
     public:
+        AZ_DISABLE_COPY_MOVE(NameBenchmarkFixture);
+        NameBenchmarkFixture() = default;
+
         void SetUp(const ::benchmark::State& st) override
         {
+            // note that the `this` pointer is going to be a singleton, but this function gets called once per thread
             UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-            AZ::NameDictionary::Create();
+            if (st.thread_index() == 0)
+            {
+                AZ::NameDictionary::Create();
+            }
         }
 
         void SetUp(::benchmark::State& st) override
         {
             UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-            AZ::NameDictionary::Create();
+            if (st.thread_index() == 0)
+            {
+                AZ::NameDictionary::Create();
+            }
         }
 
         void TearDown(::benchmark::State& st) override
         {
-            AZ::NameDictionary::Destroy();
+            if (st.thread_index() == 0)
+            {
+                AZ::NameDictionary::Destroy();
+            }
             UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
         }
 
         void TearDown(const ::benchmark::State& st) override
         {
-            AZ::NameDictionary::Destroy();
+            if (st.thread_index() == 0)
+            {
+                AZ::NameDictionary::Destroy();
+            }
             UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
         }
 

--- a/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
@@ -1171,6 +1171,8 @@ namespace Benchmark
             AZ::IO::FileIOBase::SetInstance(m_previousFileIO);
             delete m_fileIO;
             m_fileIO = nullptr;
+            AZ::TaskExecutor::SetInstance(nullptr);
+            m_taskExecutor.reset();
         }
     public:
         constexpr static const char* TestFileName = "StreamerBenchmark.bin";
@@ -1184,6 +1186,9 @@ namespace Benchmark
             m_previousFileIO = AZ::IO::FileIOBase::GetInstance();
             AZ::IO::FileIOBase::SetInstance(nullptr);
             AZ::IO::FileIOBase::SetInstance(m_fileIO);
+
+            m_taskExecutor = AZStd::make_unique<AZ::TaskExecutor>(8);
+            AZ::TaskExecutor::SetInstance(m_taskExecutor.get());
 
             SystemFile file;
             file.Open(TestFileName, SystemFile::OpenMode::SF_OPEN_CREATE | SystemFile::OpenMode::SF_OPEN_READ_WRITE);
@@ -1260,6 +1265,7 @@ namespace Benchmark
         AZ::IO::Streamer* m_streamer{};
         AZ::IO::FileIOBase* m_previousFileIO{};
         UnitTest::TestFileIOBase* m_fileIO{};
+        AZStd::unique_ptr<AZ::TaskExecutor> m_taskExecutor;
     };
 
     BENCHMARK_DEFINE_F(StorageDriveWindowsFixture, ReadsBaseline)(benchmark::State& state)

--- a/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Windows/Tests/IO/Streamer/StorageDriveTests_Windows.cpp
@@ -1171,8 +1171,6 @@ namespace Benchmark
             AZ::IO::FileIOBase::SetInstance(m_previousFileIO);
             delete m_fileIO;
             m_fileIO = nullptr;
-            AZ::TaskExecutor::SetInstance(nullptr);
-            m_taskExecutor.reset();
         }
     public:
         constexpr static const char* TestFileName = "StreamerBenchmark.bin";
@@ -1186,9 +1184,6 @@ namespace Benchmark
             m_previousFileIO = AZ::IO::FileIOBase::GetInstance();
             AZ::IO::FileIOBase::SetInstance(nullptr);
             AZ::IO::FileIOBase::SetInstance(m_fileIO);
-
-            m_taskExecutor = AZStd::make_unique<AZ::TaskExecutor>(8);
-            AZ::TaskExecutor::SetInstance(m_taskExecutor.get());
 
             SystemFile file;
             file.Open(TestFileName, SystemFile::OpenMode::SF_OPEN_CREATE | SystemFile::OpenMode::SF_OPEN_READ_WRITE);
@@ -1265,7 +1260,6 @@ namespace Benchmark
         AZ::IO::Streamer* m_streamer{};
         AZ::IO::FileIOBase* m_previousFileIO{};
         UnitTest::TestFileIOBase* m_fileIO{};
-        AZStd::unique_ptr<AZ::TaskExecutor> m_taskExecutor;
     };
 
     BENCHMARK_DEFINE_F(StorageDriveWindowsFixture, ReadsBaseline)(benchmark::State& state)

--- a/Code/Framework/AzCore/Tests/UUIDTests.cpp
+++ b/Code/Framework/AzCore/Tests/UUIDTests.cpp
@@ -410,24 +410,36 @@ namespace UnitTest
         void SetUp(::benchmark::State& st) override
         {
             AllocatorsBenchmarkFixture::SetUp(st);
-            SetUpInternal();
+            if (st.thread_index() == 0)
+            {
+                SetUpInternal();
+            }
         }
 
         void SetUp(const ::benchmark::State& st) override
         {
             AllocatorsBenchmarkFixture::SetUp(st);
-            SetUpInternal();
+            if (st.thread_index() == 0)
+            {
+                SetUpInternal();
+            }
         }
 
         void TearDown(::benchmark::State& st) override
         {
-            TearDownInternal();
+            if (st.thread_index() == 0)
+            {
+                TearDownInternal();
+            }
             AllocatorsBenchmarkFixture::TearDown(st);
         }
 
         void TearDown(const ::benchmark::State& st) override
         {
-            TearDownInternal();
+            if (st.thread_index() == 0)
+            {
+                TearDownInternal();
+            }
             AllocatorsBenchmarkFixture::TearDown(st);
         }
 

--- a/Gems/PhysX/Core/Code/Tests/Benchmarks/PhysXSceneQueryBenchmarks.cpp
+++ b/Gems/PhysX/Core/Code/Tests/Benchmarks/PhysXSceneQueryBenchmarks.cpp
@@ -55,6 +55,14 @@ namespace PhysX::Benchmarks
         //! \state.range(1) - max radius
         void internalSetUp(const ::benchmark::State& state)
         {
+            // Note that the `this` pointer is going to be a singleton, but this function gets called once per thread
+            // and is done overlapping with other threads calling the same function on the same `this` pointer, so
+            // do things that are thread-safe here, and only initialize things once.
+            if (state.thread_index() != 0)
+            {
+                return;
+            }
+            
             PhysX::GenericPhysicsFixture::SetUpInternal();
 
             m_random = AZ::SimpleLcgRandom(SceneQueryConstants::Seed);
@@ -116,12 +124,21 @@ namespace PhysX::Benchmarks
             internalSetUp(state);
         }
 
-        void TearDown(const benchmark::State&) override
+        void TearDown(const benchmark::State& state) override
         {
+            if (state.thread_index() != 0)
+            {
+                return;
+            }
+            
             internalTearDown();
         }
-        void TearDown(benchmark::State&) override
+        void TearDown(benchmark::State& state) override
         {
+            if (state.thread_index() != 0)
+            {
+                return;
+            }
             internalTearDown();
         }
 


### PR DESCRIPTION

## What does this PR do?

I was trying to benchmark the streamer stuff to compare it for the new PR that improves it, and found these benchmarks to be horribly broken and full of memory problems.

After these fixes, you can run the benchmarks in debug or profile, ASAN or not ASAN, and it will run to the end.

Note that the majority of these changes are releated to benchmark threading - that is, you can run a benchmark with multiple threads.  If you do, it creates ONE of your fixtures, but invokes SetUp repeatedly from different threads, passing in a `state` object that indicates the thread index (0 to n).  

The tests didn't seem to understand this and were doing global teardown and creation on every thread instead of just thread 0, things like creating and destroying global objects like the allocators.

## How was this PR tested?

Running the benchmarks, compiling and running the CI build.