### PR TITLE
Fix mapping of buffers that are not on all devices

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -292,6 +292,11 @@ namespace AZ::RHI
 
         ResultCode resultCode = IterateObjects<DeviceBufferPool>([&](auto deviceIndex, auto deviceBufferPool)
         {
+            if (!AZ::RHI::CheckBit(request.m_buffer->GetDeviceMask(), deviceIndex))
+            {
+                return ResultCode::Success;
+            }
+
             deviceMapRequest.m_buffer = request.m_buffer->GetDeviceBuffer(deviceIndex).get();
             auto resultCode = deviceBufferPool->MapBuffer(deviceMapRequest, deviceMapResponse);
 
@@ -321,7 +326,10 @@ namespace AZ::RHI
         {
             IterateObjects<DeviceBufferPool>([&buffer](auto deviceIndex, auto deviceBufferPool)
             {
-                deviceBufferPool->UnmapBuffer(*buffer.GetDeviceBuffer(deviceIndex));
+                if (AZ::RHI::CheckBit(buffer.GetDeviceMask(), deviceIndex))
+                {
+                    deviceBufferPool->UnmapBuffer(*buffer.GetDeviceBuffer(deviceIndex));
+                }
             });
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes the `BufferPool::MapBuffer` and `UnmapBuffer` functions for buffers that are not on all devices the `BufferPool` is on.

## How was this PR tested?

Tested on Windows with Vulkan and DX12
