### PR TITLE
Make GetBufferView/GetImageView functions const

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Buffer.h
@@ -42,7 +42,7 @@ namespace AZ::RHI
         //! Returns the buffer frame attachment if the buffer is currently attached.
         const BufferFrameAttachment* GetFrameAttachment() const;
 
-        Ptr<BufferView> GetBufferView(const BufferViewDescriptor& bufferViewDescriptor);
+        Ptr<BufferView> GetBufferView(const BufferViewDescriptor& bufferViewDescriptor) const;
 
         //! Get the hash associated with the Buffer
         const HashValue64 GetHash() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBuffer.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBuffer.h
@@ -37,7 +37,7 @@ namespace AZ::RHI
         /// Returns the buffer frame attachment if the buffer is currently attached.
         const BufferFrameAttachment* GetFrameAttachment() const;
 
-        Ptr<DeviceBufferView> GetBufferView(const BufferViewDescriptor& bufferViewDescriptor);
+        Ptr<DeviceBufferView> GetBufferView(const BufferViewDescriptor& bufferViewDescriptor) const;
 
         // Get the hash associated with the DeviceBuffer
         const HashValue64 GetHash() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImage.h
@@ -76,7 +76,7 @@ namespace AZ::RHI
         //! images.
         const ImageFrameAttachment* GetFrameAttachment() const;
             
-        Ptr<DeviceImageView> GetImageView(const ImageViewDescriptor& imageViewDescriptor);
+        Ptr<DeviceImageView> GetImageView(const ImageViewDescriptor& imageViewDescriptor) const;
 
         //! Returns the aspects that are included in the image.
         ImageAspectFlags GetAspectFlags() const;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
@@ -51,7 +51,7 @@ namespace AZ::RHI
         const ImageDescriptor& GetDescriptor() const;
 
         //! Returns the multi-device DeviceImageView
-        Ptr<ImageView> GetImageView(const ImageViewDescriptor& imageViewDescriptor);
+        Ptr<ImageView> GetImageView(const ImageViewDescriptor& imageViewDescriptor) const;
 
         //! Computes the subresource layouts and total size of the image contents, if represented linearly. Effectively,
         //! this data represents how to store the image in a buffer resource. Naturally, if the image contents

--- a/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Buffer.cpp
@@ -33,7 +33,7 @@ namespace AZ::RHI
         return static_cast<const BufferFrameAttachment*>(Resource::GetFrameAttachment());
     }
 
-    Ptr<BufferView> Buffer::GetBufferView(const BufferViewDescriptor& bufferViewDescriptor)
+    Ptr<BufferView> Buffer::GetBufferView(const BufferViewDescriptor& bufferViewDescriptor) const
     {
         return Base::GetResourceView(bufferViewDescriptor);
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceBuffer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceBuffer.cpp
@@ -36,7 +36,7 @@ namespace AZ::RHI
         bufferStats->m_sizeInBytes = descriptor.m_byteCount;
     }
     
-    Ptr<DeviceBufferView> DeviceBuffer::GetBufferView(const BufferViewDescriptor& bufferViewDescriptor)
+    Ptr<DeviceBufferView> DeviceBuffer::GetBufferView(const BufferViewDescriptor& bufferViewDescriptor) const
     {
         return Base::GetResourceView(bufferViewDescriptor);
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceImage.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceImage.cpp
@@ -64,7 +64,7 @@ namespace AZ::RHI
         imageStats->m_minimumSizeInBytes = imageStats->m_minimumSizeInBytes;
     }
     
-    Ptr<DeviceImageView> DeviceImage::GetImageView(const ImageViewDescriptor& imageViewDescriptor)
+    Ptr<DeviceImageView> DeviceImage::GetImageView(const ImageViewDescriptor& imageViewDescriptor) const
     {
         return Base::GetResourceView(imageViewDescriptor);
     }

--- a/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Image.cpp
@@ -44,7 +44,7 @@ namespace AZ::RHI
         return static_cast<const ImageFrameAttachment*>(Resource::GetFrameAttachment());
     }
 
-    Ptr<ImageView> Image::GetImageView(const ImageViewDescriptor& imageViewDescriptor)
+    Ptr<ImageView> Image::GetImageView(const ImageViewDescriptor& imageViewDescriptor) const
     {
         return Base::GetResourceView(imageViewDescriptor);
     }


### PR DESCRIPTION
## What does this PR do?

This PR adds the `const` qualifier to the `GetBufferView` and `GetImageView` (single and multi-device) functions of `RHI::Buffer` and `RHI::Image`, which makes const-correctness in downstream usage of these functions easier (Eg. usages of `const_cast` in [`MeshFeatureProcessor`](https://github.com/o3de/o3de/blob/676860e35d39005bb00fafcfe150d49ef4133c38/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp#L2427) could be removed, but I did not change that in this PR since this specific line will be moved elsewhere in [PR19123](https://github.com/o3de/o3de/pull/19123)).

## How was this PR tested?

Compile on Windows, AR
