### PR TITLE
Fix order of two Vulkan OptionalDeviceExtensionNames entries

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -367,8 +367,8 @@ namespace AZ
             VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME,
             VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
             VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME,
+            ExternalSemaphoreExtensionName,
             VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME,
-            ExternalSemaphoreExtensionName
         };
 
         RawStringList PhysicalDevice::GetEnabledOptionalExtensions()


### PR DESCRIPTION
## What does this PR do?

In the Vulkan RHI implementation there is the enum [`OptionalDeviceExtension`](https://github.com/o3de/o3de/blob/3f129b283c9516be2c4f9b5786edf632fda1caa6/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h#L44), and a separate [`OptionalDeviceExtensionNames`](https://github.com/o3de/o3de/blob/3f129b283c9516be2c4f9b5786edf632fda1caa6/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp#L339) array. The last two entries in the names array seem to be in the wrong order, which could lead to problems with these two optional extensions.

## How was this PR tested?

No testing was performed (other than starting the Editor), since I did not perceive any problems before, so I can also not really verify if it is more correct now. I assume it would be a problem if only one of those last two listed optional extensions is available.
