### PR TITLE
Add AZStd::format

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.h
@@ -10,6 +10,7 @@
 #include <AzCore/PlatformDef.h>
 #include <AzCore/base.h>
 #include <cstdarg>
+#include <format>
 
 namespace AZStd
 {
@@ -126,6 +127,18 @@ namespace AZ
             virtual void OutputToRawAndDebugger(const char* window, const char* message)
             {
                 RawOutput(window, message);
+            }
+
+            template<class... _Types>
+            void Print(const char* window, const std::format_string<_Types...> _Fmt, _Types&&... _Args)
+            {
+                // We use std::format_to_n instead of AZStd::format_to_n here because including format.h wants to include this header
+                // indirectly, leading to a circular include
+                char message[s_maxMessageLength];
+                std::format_to_n(message, s_maxMessageLength, _Fmt, std::forward<_Types>(_Args)...);
+                // Calling Printf here because its a virtual function that might be changed in the implementation
+                // Creating a virtual Print function is not possible because it needs to be a template function
+                Printf(window, "%s", message);
             }
 
             virtual void PrintCallstack(const char* /*window*/, unsigned int /*suppressCount*/ = 0, void* /*nativeContext*/ = nullptr) {}
@@ -429,6 +442,7 @@ namespace AZ
 #endif  // AZ_ENABLE_TRACING
 
 #define AZ_Printf(window, ...)       AZ::Debug::Trace::Instance().Printf(window, __VA_ARGS__);
+#define AZ_Print(window, ...) AZ::Debug::Trace::Instance().Print(window, __VA_ARGS__);
 
 #if !defined(RELEASE)
 // Unconditional critical error log, enabled up to Performance config

--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -175,6 +175,7 @@ set(FILES
     string/fixed_string.cpp
     string/fixed_string.h
     string/fixed_string.inl
+    string/format.h
     string/memorytoascii.h
     string/memorytoascii.cpp
     string/regex.h

--- a/Code/Framework/AzCore/AzCore/std/string/format.h
+++ b/Code/Framework/AzCore/AzCore/std/string/format.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <format>
+#include <utility>
+
+#include <AzCore/std/string/string.h>
+
+namespace AZStd
+{
+    using std::format_string;
+    using std::format_to;
+    using std::format_to_n;
+    using std::wformat_string;
+
+    template<class... _Types>
+    _NODISCARD string format(const format_string<_Types...> _Fmt, _Types&&... _Args)
+    {
+        string result;
+        format_to(std::back_inserter(result), _Fmt, std::forward<_Types>(_Args)...);
+        return result;
+    }
+
+    template<class... _Types>
+    _NODISCARD wstring format(const wformat_string<_Types...> _Fmt, _Types&&... _Args)
+    {
+        wstring result;
+        format_to(std::back_inserter(result), _Fmt, std::forward<_Types>(_Args)...);
+        return result;
+    }
+
+    template<int n, class... _Types>
+    _NODISCARD fixed_string<n> format_fixed_string(const format_string<_Types...> _Fmt, _Types&&... _Args)
+    {
+        fixed_string<n> result;
+        format_to_n(std::back_inserter(result), n, _Fmt, std::forward<_Types>(_Args)...);
+        return result;
+    }
+
+    template<int n, class... _Types>
+    _NODISCARD fixed_wstring<n> format_fixed_string(const wformat_string<_Types...> _Fmt, _Types&&... _Args)
+    {
+        fixed_wstring<n> result;
+        format_to_n(std::back_inserter(result), n, _Fmt, std::forward<_Types>(_Args)...);
+        return result;
+    }
+} // namespace AZStd

--- a/Code/Framework/AzCore/Tests/AZStd/String.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/String.cpp
@@ -7,23 +7,24 @@
  */
 #include "UserTypes.h"
 
-#include <AzCore/std/string/string.h>
-#include <AzCore/std/string/conversions.h>
-#include <AzCore/std/string/tokenize.h>
-#include <AzCore/std/string/alphanum.h>
-#include <AzCore/std/sort.h>
+#include <AzCore/Serialization/Locale.h> // for locale-independent string to float conversions
 #include <AzCore/std/allocator_stateless.h>
+#include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/containers/set.h>
-#include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/span.h>
 #include <AzCore/std/ranges/join_view.h>
 #include <AzCore/std/ranges/transform_view.h>
-#include <AzCore/std/string/regex.h>
-#include <AzCore/std/string/wildcard.h>
+#include <AzCore/std/sort.h>
+#include <AzCore/std/string/alphanum.h>
+#include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/fixed_string.h>
+#include <AzCore/std/string/format.h>
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/tokenize.h>
+#include <AzCore/std/string/wildcard.h>
 #include <AzCore/std/typetraits/is_convertible.h>
-#include <AzCore/Serialization/Locale.h> // for locale-independent string to float conversions
 
 // we need this for AZ_TEST_FLOAT compare
 #include <cinttypes>
@@ -2513,6 +2514,20 @@ namespace UnitTest
             AZStd::basic_string testString(testView, 1, 3);
             EXPECT_EQ("ell", testString);
         }
+    }
+
+    TEST_F(String, String_Format_Test)
+    {
+        EXPECT_EQ(AZStd::format("{} {} {}", "test", 1, 15.1), "test 1 15.1");
+        EXPECT_EQ(AZStd::format(L"{} {} {}", L"test", 1, 15.1), L"test 1 15.1");
+    }
+
+    TEST_F(String, String_Format_Fixed_Test)
+    {
+        EXPECT_EQ(AZStd::format_fixed_string<1>("{}", "test"), "t");
+        EXPECT_EQ(AZStd::format_fixed_string<1>(L"{}", L"test"), L"t");
+        EXPECT_EQ(AZStd::format_fixed_string<10>("{}{}", "test", 1), "test1");
+        EXPECT_EQ(AZStd::format_fixed_string<10>(L"{}{}", L"test", 1), L"test1");
     }
 
     template <typename StringType>


### PR DESCRIPTION
## What does this PR do?

Adds [std::format](https://en.cppreference.com/w/cpp/utility/format/format.html) to `AZStd`.
Also adds the `AZ_Print` macro which is similar to `AZ_Printf`, but with the `std::format` syntax (Like [std::print](https://en.cppreference.com/w/cpp/io/print.html) is similar to `printf`)
This is not used anywhere in the code yet.

I considered adding `AZ_Warning`,`AZ_Error`,... equivalents too, but could not find a good naming scheme for these functions.

## How was this PR tested?

Tested on Windows with the provided  tests
