### PR TITLE
Fix AssetProcessor getting stuck with assets still pending

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
@@ -226,7 +226,8 @@ namespace AssetProcessor
 
     bool RCController::IsIdle()
     {
-        return ((!m_RCQueueSortModel.GetNextPendingJob()) && (m_RCJobListModel.jobsInFlight() == 0));
+        bool queueIsEmpty = m_RCQueueSortModel.rowCount() == 0;
+        return (queueIsEmpty && (m_RCJobListModel.jobsInFlight() == 0));
     }
 
     void RCController::JobSubmitted(JobDetails details)


### PR DESCRIPTION
## What does this PR do?

Assets that depend on other assets that never appear, either becuase the dependency is cyclic, or becuase they are simply missing, were stuck at the end, and never started, would wait for their dependencies forever.

An example of this is the new OpenParticle gem declared that` .particle` depended on `Atom Material Builder` but the name of the material builder was instead `Material Builder`.  So these jobs stuck in pending forever and never processed. 

This unblocks them by processing them anyway, even though they are missing their dependencies.  This allows the individual builder for those assets to react appropriately, for example, showing errors and so on, listing problems, instead of not even trying.

It unblocks the jobs one at a time, in case there is a cyclic dependency. They will still process last, just in case the file they were waiting for appears.

## How was this PR tested?

Live testing, using the OpenParticle PR which 100% reproduced the issue.

After applying this fix, the AP displayed the warning message, and unblocked those files.

