### PR TITLE
Remove not implemented function declarations in Atom gem

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.h
@@ -55,9 +55,6 @@ namespace ImageProcessingAtomEditor
         AZStd::unordered_set<ImageProcessingAtom::PresetName> m_presetList;
         EditorTextureSetting* m_textureSetting;
         QScopedPointer<PresetInfoPopup> m_presetPopup;
-        void SetPresetConvention(const ImageProcessingAtom::PresetSettings* presetSettings);
         void SetCheckBoxReadOnly(QCheckBox* checkBox, bool readOnly);
-
-        bool m_listAllPresets = true;
     };
 } //namespace ImageProcessingAtomEditor

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.h
@@ -68,7 +68,6 @@ namespace ImageProcessingAtomEditor
         bool m_validImage = true;
 
         void SaveTextureSetting(AZStd::string outputPath);
-        void DeleteLegacySetting();
     };
 } //namespace ImageProcessingAtomEditor
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.h
@@ -61,12 +61,6 @@ namespace ImageProcessingAtom
         bool BuildMipChainAsset(const Data::AssetId& chainAssetId, uint32_t startMip, uint32_t mipLevels,
             Data::Asset<RPI::ImageMipChainAsset>& outAsset, bool saveAsProduct);
 
-        // Generate all job products which can be used for AssetProcessor job response
-        void GenerateJobProducts();
-
-        // Save all generated assets to files
-        void SaveAssetsToFile();
-
         // Generate product assets' full path
         AZStd::string GenerateAssetFullPath(ImageAssetType assetType, uint32_t assetSubId);
 

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/CommonFiles/CommonTypes.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/CommonFiles/CommonTypes.h
@@ -107,8 +107,6 @@ namespace AZ
         {
             AZStd::string                  m_id;
             AZStd::vector<StructParameter> m_members;
-
-            AZStd::vector<Variable>        BuildTypeIdPairs() const;
         };
 
         // Textures

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/PrecompiledShaderBuilder.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/PrecompiledShaderBuilder.h
@@ -34,9 +34,6 @@ namespace AZ
         // AssetBuilderSDK::AssetBuilderCommandBus interface
         void ShutDown() override;
 
-        /// Register to builder and listen to builder command
-        void RegisterBuilder();
-
     private:
         template<typename T>
         T* LoadSourceAsset(SerializeContext* context, const AZStd::string& shaderAssetPath) const;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Surfaces/StandardSurface.azsli
@@ -75,9 +75,6 @@ class Surface
     real diffuseAmbientOcclusion; //!< Diffuse ambient occlusion factor - [0, 1] :: [Dark, Bright]
     real specularOcclusion;       //!< Specular occlusion factor - [0, 1] :: [Dark, Bright]
 
-    //! Applies specular anti-aliasing to roughnessA2 
-    void ApplySpecularAA();
-
     //! Calculates roughnessA and roughnessA2 after roughness has been set
     void CalculateRoughnessA();
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.h
@@ -80,9 +80,6 @@ namespace AZ
             // RPI::RasterPass overrides...
             void SubmitDrawItems(const RHI::FrameGraphExecuteContext& context, uint32_t startIndex, uint32_t endIndex, uint32_t indexOffset) const override;
 
-            // Gets the number of expected draws, taking into account if this shadow is static.
-            uint32_t GetNumDraws() const;
-
             RHI::ConstPtr<RHI::DrawPacket> m_clearShadowDrawPacket;
             RHI::Handle<uint32_t> m_casterMovedBit;
             uint16_t m_arraySlice = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/MotionBlurPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/MotionBlurPass.h
@@ -33,8 +33,6 @@ namespace AZ
 
         private:
             MotionBlurPass(const RPI::PassDescriptor& descriptor);
-            void InitializeShaderVariant();
-            void UpdateCurrentShaderVariant();
 
             AZ::RHI::ShaderInputNameIndex m_constantsIndex = "m_constants";
         };

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.h
@@ -70,9 +70,6 @@ namespace AZ
             // Readback the results from the ScopeQueries
             void ReadbackScopeQueryResults();
 
-            // Used to set some build options for the TLASes
-            static AZ::RHI::RayTracingAccelerationStructureBuildFlags CreateRayTracingAccelerationStructureBuildFlags(bool isSkinnedMesh);
-
             // buffer view descriptor for the TLAS
             RHI::BufferViewDescriptor m_tlasBufferViewDescriptor;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageSubresource.h
@@ -65,9 +65,6 @@ namespace AZ::RHI
         //! Constructs a range that covers the same region as the image view.
         explicit ImageSubresourceRange(const ImageViewDescriptor& descriptor);
 
-        //! Constructs a range from a single subresource.
-        ImageSubresourceRange(ImageSubresource subresource);
-
         //! Returns the hash of the view.
         HashValue64 GetHash(HashValue64 seed = HashValue64{ 0 }) const;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPoolBase.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceBufferPoolBase.h
@@ -43,9 +43,6 @@ namespace AZ::RHI
     private:
         using DeviceResourcePool::InitResource;
 
-        /// Returns whether there are any mapped buffers.
-        bool ValidateNoMappedBuffers() const;
-
         /// Debug reference count used to track map / unmap operations across all buffers in the pool.
         AZStd::atomic_uint m_mapRefCount = {0};
     };

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImage.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceImage.h
@@ -66,11 +66,6 @@ namespace AZ::RHI
         //! is the highest detailed mip.
         uint32_t GetResidentMipLevel() const;
             
-        //! Returns the set of queue classes that are supported for usage as an attachment on the frame scheduler.
-        //! Effectively, for a scope of a specific hardware class to use the image as an attachment, the queue must
-        //! be present in this mask. This does not apply to non-attachment images on the Compute / Graphics queue.
-        HardwareQueueClassMask GetSupportedQueueMask() const;
-            
         //! Returns the image frame attachment if the image is currently attached. This is assigned when the image
         //! is imported into the frame scheduler (which is reset every frame). This value will be null for non-attachment
         //! images.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/FrameScheduler.h
@@ -183,9 +183,6 @@ namespace AZ::RHI
         //! Adds a DeviceRayTracingShaderTable to be built this frame
         void QueueRayTracingShaderTableForBuild(DeviceRayTracingShaderTable* rayTracingShaderTable);
 
-        //! Returns PhysicalDeviceDescriptor which can be used to extract vendor/driver information
-        const PhysicalDeviceDescriptor& GetPhysicalDeviceDescriptor();
-
     private:
         AZStd::unordered_map<int, ScopeId> m_rootScopeIds;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Image.h
@@ -67,11 +67,6 @@ namespace AZ::RHI
         //!      [Optional] If specified, will be filled with the total size necessary to contain all subresources.
         void GetSubresourceLayout(ImageSubresourceLayout& subresourceLayout, ImageAspectFlags aspectFlags = ImageAspectFlags::All) const;
 
-        //! Returns the set of queue classes that are supported for usage as an attachment on the frame scheduler.
-        //! Effectively, for a scope of a specific hardware class to use the image as an attachment, the queue must
-        //! be present in this mask. This does not apply to non-attachment images on the Compute / Graphics queue.
-        HardwareQueueClassMask GetSupportedQueueMask() const;
-
         //! Returns the image frame attachment if the image is currently attached. This is assigned when the image
         //! is imported into the frame scheduler (which is reset every frame). This value will be null for non-attachment
         //! images.

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Buffer.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Buffer.h
@@ -39,10 +39,6 @@ namespace AZ
             // The initial state for the graph compiler to use when compiling the resource transition chain.
             D3D12_RESOURCE_STATES m_initialAttachmentState = D3D12_RESOURCE_STATE_COMMON;
 
-            // Override that returns the DX12 device.
-            Device& GetDevice();
-            const Device& GetDevice() const;
-
         private:
             Buffer() = default;
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueue.h
@@ -90,9 +90,6 @@ namespace AZ
             void ShutdownInternal() override;
             void* GetNativeQueue() override;
             //////////////////////////////////////////////////////////////////////////
-
-            void ProcessQueue();
-
             
             void UpdateTileMappings(CommandList& commandList);
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/ImagePool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/ImagePool.h
@@ -35,9 +35,6 @@ namespace AZ
 
             ImagePoolResolver* GetResolver();
 
-            void AddMemoryUsage(size_t bytesToAdd);
-            void SubtractMemoryUsage(size_t bytesToSubtract);
-
             //////////////////////////////////////////////////////////////////////////
             // RHI::DeviceImagePool
             RHI::ResultCode InitInternal(RHI::Device&, const RHI::ImagePoolDescriptor&) override;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderResourceGroupPool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderResourceGroupPool.h
@@ -89,7 +89,6 @@ namespace AZ
             void CacheGpuHandlesForViews(ShaderResourceGroup& group);
             
             DescriptorTable GetBufferTable(DescriptorTable descriptorTable, RHI::ShaderInputBufferIndex bufferIndex) const;
-            DescriptorTable GetBufferTableUnbounded(DescriptorTable descriptorTable, RHI::ShaderInputBufferIndex bufferIndex) const;
             DescriptorTable GetImageTable(DescriptorTable descriptorTable, RHI::ShaderInputImageIndex imageIndex) const;
             DescriptorTable GetSamplerTable(DescriptorTable descriptorTable, RHI::ShaderInputSamplerIndex samplerInputIndex) const;
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.h
@@ -232,8 +232,6 @@ namespace AZ
             void SetNameInternal(const AZStd::string_view& name) override;
             //////////////////////////////////////////////////////////////////////////
 
-            void GenerateSubresourceLayouts();
-
             void SetInitalQueueOwner();
 
             VkImage m_vkImage = VK_NULL_HANDLE;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Shader/ShaderVariantAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Shader/ShaderVariantAssetCreator.h
@@ -42,11 +42,6 @@ namespace AZ
             /////////////////////////////////////////////////////////////////////
             // Methods for all shader variant types
 
-            //! Set the timestamp value when the ProcessJob() started.
-            //! This is needed to synchronize between the ShaderAsset and ShaderVariantAsset when hot-reloading shaders.
-            //! The idea is that this timestamp must be greater or equal than the ShaderAsset. 
-            void SetBuildTimestamp(AZ::u64 buildTimestamp);
-
             //! Assigns a shaderStageFunction, which contains the byte code, to the slot dictated by the shader stage.
             void SetShaderFunction(RHI::ShaderStage shaderStage, RHI::Ptr<RHI::ShaderStageFunction> shaderStageFunction);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialShaderParameterLayout.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialShaderParameterLayout.h
@@ -75,11 +75,6 @@ namespace AZ::RPI
         Index AddParameterFromPropertyConnection(const AZ::Name& name, const MaterialPropertyDataType dataType);
         Index AddParameterFromFunctor(const AZStd::string& name, const AZStd::string& typeName, const size_t typeSize = 0);
 
-        Index AddMaterialParameter(
-            const AZStd::string_view& name,
-            const MaterialPropertyDataType dataType,
-            const bool isPseudoParam = false,
-            const size_t count = 1);
         Index AddTypedMaterialParameter(
             const AZStd::string_view& name,
             const AZStd::string_view& typeName,

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
@@ -62,7 +62,6 @@ namespace AZ::RPI
         bool UpdateSharedSamplerStates();
         void PrepareMaterialParameterBuffers();
         void UpdateChangedMaterialParameters();
-        void CreateTextureSamplers(const AZStd::vector<RHI::SamplerState>& samplers, Data::Instance<ShaderResourceGroup> srg);
 
         //  Data::AssetBus Interface
         void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
@@ -66,10 +66,6 @@ namespace AZ
             void CompileResources(const RHI::FrameGraphCompileContext& context) override;
             void BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context) override;
 
-            // Calculates the group counts for the dispatch item using the target image dimensions
-            // and the number of threads per group (group size)
-            void MatchDimensionsToOutput();
-
             // The compute shader that will be used by the pass
             Data::Instance<Shader> m_shader = nullptr;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -544,5 +544,20 @@ namespace AZ
             return false;
         }
 
+        template <typename T>
+        T ShaderResourceGroup::GetConstant(RHI::ShaderInputConstantIndex inputIndex, uint32_t arrayIndex) const
+        {
+            return m_data.GetConstant<T>(inputIndex, arrayIndex);
+        }
+
+        template <typename T>
+        T ShaderResourceGroup::GetConstant(RHI::ShaderInputNameIndex& inputIndex, uint32_t arrayIndex) const
+        {
+            if (inputIndex.ValidateOrFindConstantIndex(GetLayout()))
+            {
+                return GetConstant<T>(inputIndex.GetConstantIndex(), arrayIndex);
+            }
+            return false;
+        }
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/LuaMaterialFunctor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/LuaMaterialFunctor.h
@@ -385,13 +385,7 @@ namespace AZ
                 friend LuaMaterialFunctorAPI::RenderStates;
                 friend LuaMaterialFunctorAPI::ShaderItem;
             public:
-                static void Reflect(BehaviorContext* behaviorContext);
                 static constexpr char const DebugName[] = "LuaMaterialFunctor";
-
-            private:
-                static void Script_Error(const AZStd::string& message);
-                static void Script_Warning(const AZStd::string& message);
-                static void Script_Print(const AZStd::string& message);
             };
 
         } // namespace LuaMaterialFunctorAPI

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.h
@@ -35,7 +35,6 @@ namespace AZ
             AZStd::vector<FrameAttachmentVisualizeInfo>& GetFrameAttachments();
             void Init(RHI::Device* device);
             void Draw(bool& draw);
-            void DrawTreeView();
             void Reset();
         protected:
             AZStd::vector<FrameAttachmentVisualizeInfo> m_framesAttachments;


### PR DESCRIPTION
## What does this PR do?

This PR removes some function declarations in Atom which have no implementation. These occurrences were found by the IDEs code inspection, which showed that the function `RayTracingAccelerationStructurePass::CreateRayTracingAccelerationStructureBuildFlags` was not implemented, so I wondered if there are any further occurrences of this (Clion -> Inspect Code -> C++ -> Not implemented functions). I added an implementation for the two-parameter template function `ShaderResourceGroup::GetConstant`, since this seemed to make more sense than deleting the declaration.
In engine code outside of Atom there are also quite a few such dangling function declarations, but they are not part of this RP.

## How was this PR tested?

Compile on Windows with Clang and MSVC, AR
