### PR TITLE
Integrate Component Creation GUI into O3DE Editor

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -264,6 +264,28 @@ void EditorActionsHandler::OnActionRegistrationHook()
         m_hotKeyManagerInterface->SetActionHotKey("o3de.action.file.new", "Ctrl+N");
     }
 
+    // New Component
+    {
+        constexpr AZStd::string_view actionIdentifier = "o3de.action.file.newComponent";
+        AzToolsFramework::ActionProperties actionProperties;
+        actionProperties.m_name = "New Component";
+        actionProperties.m_description = "Create a new C++ component";
+        actionProperties.m_category = "Tools";
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
+
+        m_actionManagerInterface->RegisterAction(
+            EditorIdentifiers::MainWindowActionContextIdentifier,
+            actionIdentifier,
+            actionProperties,
+            [cryEdit = m_cryEditApp]
+            {
+                cryEdit->OnNewComponent();
+            });
+
+        // This action is only accessible outside of Component Modes
+        m_actionManagerInterface->AssignModeToAction(AzToolsFramework::DefaultActionContextModeIdentifier, actionIdentifier);
+    }
+
     // Open Level
     {
         constexpr AZStd::string_view actionIdentifier = "o3de.action.file.open";
@@ -1794,6 +1816,7 @@ void EditorActionsHandler::OnMenuBindingHook()
     // File
     {
         m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::FileMenuIdentifier, "o3de.action.file.new", 100);
+        m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::FileMenuIdentifier, "o3de.action.file.newComponent", 110);
         m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::FileMenuIdentifier, "o3de.action.file.open", 200);
         m_menuManagerInterface->AddSubMenuToMenu(EditorIdentifiers::FileMenuIdentifier, EditorIdentifiers::RecentFilesMenuIdentifier, 300);
         {

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -54,6 +54,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzCore/EBus/IEventScheduler.h>
 #include <AzCore/Name/Name.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/IO/Path/Path.h>
 
 // AzFramework
 #include <AzFramework/Components/CameraBus.h>
@@ -2773,6 +2774,27 @@ bool CCryEditApp::CreateLevel(bool& wasCreateLevelOperationCancelled)
     m_levelErrorsHaveBeenDisplayed = false;
 
     return true;
+}
+
+//////////////////////////////////////////////////////////////////////////
+void CCryEditApp::OnNewComponent()
+{
+    AZ::IO::FixedMaxPath enginePath = AZ::Utils::GetEnginePath();
+    AZ::IO::FixedMaxPath projectPath = AZ::Utils::GetProjectPath();
+    AZ::IO::FixedMaxPath scriptPath = enginePath / "Tools" / "ClassCreationWizard" / "ClassWizard.py";
+
+    if (!AZ::IO::SystemFile::Exists(scriptPath.c_str()))
+    {
+        AZ_Error("ClassWizard", false, "ClassWizard.py script not found at: %s", scriptPath.c_str());
+        return;
+    }
+
+    AZStd::vector<AZStd::string_view> scriptArgs = { "--engine-path", enginePath.c_str(), "--project-path", projectPath.c_str() };
+
+    AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(
+        &AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilenameWithArgs,
+        AZStd::string_view(scriptPath.c_str()),
+        scriptArgs);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -343,6 +343,7 @@ private:
     void OnOpenTrackView();
     void OnOpenAudioControlsEditor();
     void OnOpenUICanvasEditor();
+    void OnNewComponent();
 
     // @param files: A list of file paths, separated by '|';
     void OpenExternalLuaDebugger(AZStd::string_view luaDebuggerUri, AZStd::string_view enginePath, AZStd::string_view projectPath, const char * files);


### PR DESCRIPTION
## What does this PR do?

This PR integrates the Component Creation GUI (introduced in [PR #19203](https://github.com/o3de/o3de/pull/19203)) directly into the O3DE Editor. Users can now launch the GUI from the Editor via the "New Component" menu option.

## How was this PR tested?

- Verified that the "New Component" menu item appears in the Editor.
- Confirmed that clicking the menu item launches the GUI tool successfully.
- Tested on Windows and Linux.