### PR TITLE
Set initial position in hinge articulation within limits; Add IsRootArticulation to bus

### DIFF
--- a/Gems/PhysX/Core/Code/Include/PhysX/ArticulationJointBus.h
+++ b/Gems/PhysX/Core/Code/Include/PhysX/ArticulationJointBus.h
@@ -77,7 +77,7 @@ namespace PhysX
         //! The target will be a position in meters for a linear degree of freedom, or an angle in radians for a rotational degree of
         //! freedom.
         virtual float GetDriveTarget(ArticulationJointAxis jointAxis) const = 0;
-        
+
         //! Set the target velocity for the motion associated with the given axis.
         //! The target velocity will be a linear velocity in meters per second for a linear degree of freedom, or an angular velocity in
         //! radians per second for a rotational degree of freedom.
@@ -106,7 +106,8 @@ namespace PhysX
         //! Get the current joint position.
         virtual float GetJointVelocity(ArticulationJointAxis jointAxis) const = 0;
 
-
+        //! Get whether this joint is the root of an articulation.
+        virtual bool IsRootArticulation() const = 0;
     };
 
     using ArticulationJointRequestBus = AZ::EBus<ArticulationJointRequests>;

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
@@ -226,7 +226,7 @@ namespace PhysX
         AZ_Warning("ArticulationLinkComponent", IsRootArticulation(), "Pose can be adjusted only for the root articulation link.");
         if (m_articulation && IsRootArticulation())
         {
-            physx::PxArticulationKinematicFlags kinematicFlag {};
+            physx::PxArticulationKinematicFlags kinematicFlag{};
             kinematicFlag.raise(physx::PxArticulationKinematicFlag::ePOSITION);
             m_articulation->setRootGlobalPose(PxMathConvert(world));
             m_articulation->updateKinematic(kinematicFlag);
@@ -268,8 +268,7 @@ namespace PhysX
             if (linkActorData)
             {
                 const auto entityId = linkActorData->GetEntityId();
-                if (auto iterator = m_sensorIndicesByEntityId.find(entityId);
-                    iterator != m_sensorIndicesByEntityId.end())
+                if (auto iterator = m_sensorIndicesByEntityId.find(entityId); iterator != m_sensorIndicesByEntityId.end())
                 {
                     iterator->second.push_back(sensor->getIndex());
                 }
@@ -352,8 +351,8 @@ namespace PhysX
             AZ::Interface<AzPhysics::SceneInterface>::Get()->AddSimulatedBody(m_attachedSceneHandle, &articulationLinkConfiguration);
         if (articulationLinkHandle == AzPhysics::InvalidSimulatedBodyHandle)
         {
-            AZ_Error("PhysX", false, "Failed to create a simulated body for the articulation link at root %s",
-                GetEntity()->GetName().c_str());
+            AZ_Error(
+                "PhysX", false, "Failed to create a simulated body for the articulation link at root %s", GetEntity()->GetName().c_str());
             return;
         }
 
@@ -392,8 +391,7 @@ namespace PhysX
                         articulationLinkConfiguration.m_angularLimitNegative, articulationLinkConfiguration.m_angularLimitPositive));
 
                     // From PhysX documentation: If the limits should be equal, use PxArticulationMotion::eLOCKED
-                    constexpr float epsilon = 1e-9;
-                    if (AZ::IsClose(limits.low, limits.high, epsilon))
+                    if (AZ::IsClose(limits.low, limits.high, AZ::Constants::FloatEpsilon))
                     {
                         inboundJoint->setMotion(physx::PxArticulationAxis::eTWIST, physx::PxArticulationMotion::eLOCKED);
                     }
@@ -408,13 +406,13 @@ namespace PhysX
                         (limits.low < 0.0 && limits.high > 0.0),
                         "The initial position of joint %s is outside joint limits, moving joint to avoid instability.",
                         thisPxLink->getName());
-                    if (limits.low > 0.0 && limits.low + epsilon < limits.high)
+                    if (limits.low > 0.0 && limits.low + AZ::Constants::FloatEpsilon < limits.high)
                     {
-                        inboundJoint->setJointPosition(physx::PxArticulationAxis::eTWIST, limits.low + epsilon);
+                        inboundJoint->setJointPosition(physx::PxArticulationAxis::eTWIST, limits.low + AZ::Constants::FloatEpsilon);
                     }
-                    else if (limits.high < 0.0 && limits.high - epsilon > limits.low)
+                    else if (limits.high < 0.0 && limits.high - AZ::Constants::FloatEpsilon > limits.low)
                     {
-                        inboundJoint->setJointPosition(physx::PxArticulationAxis::eTWIST, limits.high - epsilon);
+                        inboundJoint->setJointPosition(physx::PxArticulationAxis::eTWIST, limits.high - AZ::Constants::FloatEpsilon);
                     }
 
                     inboundJoint->setLimitParams(physx::PxArticulationAxis::eTWIST, limits);
@@ -590,8 +588,7 @@ namespace PhysX
 
     physx::PxArticulationLink* ArticulationLinkComponent::GetArticulationLink(const AZ::EntityId entityId)
     {
-        if (const auto iterator = m_articulationLinksByEntityId.find(entityId);
-            iterator != m_articulationLinksByEntityId.end())
+        if (const auto iterator = m_articulationLinksByEntityId.find(entityId); iterator != m_articulationLinksByEntityId.end())
         {
             return iterator->second;
         }
@@ -603,8 +600,7 @@ namespace PhysX
 
     const AZStd::vector<AZ::u32> ArticulationLinkComponent::GetSensorIndices(const AZ::EntityId entityId)
     {
-        if (const auto iterator = m_sensorIndicesByEntityId.find(entityId);
-            iterator != m_sensorIndicesByEntityId.end())
+        if (const auto iterator = m_sensorIndicesByEntityId.find(entityId); iterator != m_sensorIndicesByEntityId.end())
         {
             return iterator->second;
         }
@@ -857,7 +853,7 @@ namespace PhysX
         }
         return 0.0f;
     }
-    
+
     bool ArticulationLinkComponent::IsRootArticulation() const
     {
         return IsRootArticulationEntity<ArticulationLinkComponent>(GetEntity());
@@ -868,7 +864,11 @@ namespace PhysX
         if (sensorIndex >= m_sensorIndices.size())
         {
             AZ_ErrorOnce(
-                "Articulation Link Component", false, "Invalid sensor index (%i) for entity %s", sensorIndex, GetEntity()->GetName().c_str());
+                "Articulation Link Component",
+                false,
+                "Invalid sensor index (%i) for entity %s",
+                sensorIndex,
+                GetEntity()->GetName().c_str());
             return nullptr;
         }
 
@@ -1026,10 +1026,20 @@ namespace PhysX
     }
 
 #else
-    void ArticulationLinkComponent::Activate() {}
-    void ArticulationLinkComponent::Deactivate() {}
-    void ArticulationLinkComponent::CreateArticulation() {}
-    void ArticulationLinkComponent::DestroyArticulation() {}
-    void ArticulationLinkComponent::InitPhysicsTickHandler() {}
+    void ArticulationLinkComponent::Activate()
+    {
+    }
+    void ArticulationLinkComponent::Deactivate()
+    {
+    }
+    void ArticulationLinkComponent::CreateArticulation()
+    {
+    }
+    void ArticulationLinkComponent::DestroyArticulation()
+    {
+    }
+    void ArticulationLinkComponent::InitPhysicsTickHandler()
+    {
+    }
 #endif
 } // namespace PhysX

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
@@ -160,18 +160,18 @@ namespace PhysX
                 auto* rootArticulationLinkComponent = articulationRootEntity->FindComponent<ArticulationLinkComponent>();
                 AZ_Assert(rootArticulationLinkComponent, "Articulation root has to have ArticulationLinkComponent");
 
-                     m_link = rootArticulationLinkComponent->GetArticulationLink(GetEntityId());
-                     AZ_Assert(m_link, "Scene not found for the root articulation link component");
+                m_link = rootArticulationLinkComponent->GetArticulationLink(GetEntityId());
+                AZ_Assert(m_link, "Scene not found for the root articulation link component");
 
-                     AzPhysics::Scene* scene = sceneInterface->GetScene(rootArticulationLinkComponent->m_attachedSceneHandle);
-                     AZ_Assert(scene, "Scene not found for the root articulation link component");
+                AzPhysics::Scene* scene = sceneInterface->GetScene(rootArticulationLinkComponent->m_attachedSceneHandle);
+                AZ_Assert(scene, "Scene not found for the root articulation link component");
 
-                     auto* pxScene = static_cast<physx::PxScene*>(scene->GetNativePointer());
-                     if (m_link && pxScene)
-                     {
-                         PHYSX_SCENE_READ_LOCK(pxScene);
-                         m_driveJoint = m_link->getInboundJoint()->is<physx::PxArticulationJointReducedCoordinate>();
-                     }
+                auto* pxScene = static_cast<physx::PxScene*>(scene->GetNativePointer());
+                if (m_link && pxScene)
+                {
+                    PHYSX_SCENE_READ_LOCK(pxScene);
+                    m_driveJoint = m_link->getInboundJoint()->is<physx::PxArticulationJointReducedCoordinate>();
+                }
 
                 m_sensorIndices = rootArticulationLinkComponent->GetSensorIndices(GetEntityId());
             }
@@ -251,7 +251,6 @@ namespace PhysX
 
         physx::PxPhysics* pxPhysics = GetPhysXSystem()->GetPxPhysics();
         m_articulation = pxPhysics->createArticulationReducedCoordinate();
-
 
         const auto& rootLinkConfiguration = m_articulationLinkData->m_articulationLinkConfiguration;
         SetRootSpecificProperties(rootLinkConfiguration);
@@ -398,7 +397,8 @@ namespace PhysX
                         articulationLinkConfiguration.m_angularLimitNegative, articulationLinkConfiguration.m_angularLimitPositive));
 
                     // From PhysX documentation: If the limits should be equal, use PxArticulationMotion::eLOCKED
-                    if (limits.low == limits.high)
+                    constexpr float epsilon = 1e-9;
+                    if (AZ::IsClose(limits.low, limits.high, epsilon))
                     {
                         inboundJoint->setMotion(physx::PxArticulationAxis::eTWIST, physx::PxArticulationMotion::eLOCKED);
                     }
@@ -407,6 +407,21 @@ namespace PhysX
                         inboundJoint->setMotion(
                             physx::PxArticulationAxis::eTWIST, physx::PxArticulationMotion::eLIMITED); // limit the x rotation axis (eTWIST)
                     }
+
+                    AZ_Warning(
+                        "ArticulationLinkComponent",
+                        (limits.low < 0.0 && limits.high > 0.0),
+                        "The initial position of joint %s is outside joint limits, moving joint to avoid instability.",
+                        thisPxLink->getName());
+                    if (limits.low > 0.0 && limits.low + epsilon < limits.high)
+                    {
+                        inboundJoint->setJointPosition(physx::PxArticulationAxis::eTWIST, limits.low + epsilon);
+                    }
+                    else if (limits.high < 0.0 && limits.high - epsilon > limits.low)
+                    {
+                        inboundJoint->setJointPosition(physx::PxArticulationAxis::eTWIST, limits.high - epsilon);
+                    }
+
                     inboundJoint->setLimitParams(physx::PxArticulationAxis::eTWIST, limits);
                 }
                 else
@@ -512,7 +527,6 @@ namespace PhysX
             CreateChildArticulationLinks(thisPxLink, *childLink);
         }
     }
-
 
     void ArticulationLinkComponent::DestroyArticulation()
     {
@@ -927,7 +941,6 @@ namespace PhysX
         return AZ::Vector3::CreateZero();
     }
 
-
     const AzPhysics::SimulatedBody* ArticulationLinkComponent::GetSimulatedBodyConst() const
     {
         const AZ::Entity* rootEntity = GetArticulationRootEntity();
@@ -977,7 +990,7 @@ namespace PhysX
 
     void ArticulationLinkComponent::EnablePhysics()
     {
-        if(m_enabled == true)
+        if (m_enabled == true)
         {
             return;
         }
@@ -988,14 +1001,13 @@ namespace PhysX
 
     void ArticulationLinkComponent::DisablePhysics()
     {
-        if(m_enabled == false)
+        if (m_enabled == false)
         {
             return;
         }
         m_enabled = false;
         PHYSX_SCENE_WRITE_LOCK(m_link->getScene());
         m_link->setActorFlag(physx::PxActorFlag::eDISABLE_SIMULATION, true);
-
     }
 
     bool ArticulationLinkComponent::IsPhysicsEnabled() const

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
@@ -67,11 +67,6 @@ namespace PhysX
     {
     }
 
-    bool ArticulationLinkComponent::IsRootArticulation() const
-    {
-        return IsRootArticulationEntity<ArticulationLinkComponent>(GetEntity());
-    }
-
     const AZ::Entity* ArticulationLinkComponent::GetArticulationRootEntity() const
     {
         bool rootFound = false;
@@ -861,6 +856,11 @@ namespace PhysX
             return joint->getMaxJointVelocity();
         }
         return 0.0f;
+    }
+    
+    bool ArticulationLinkComponent::IsRootArticulation() const
+    {
+        return IsRootArticulationEntity<ArticulationLinkComponent>(GetEntity());
     }
 
     const physx::PxArticulationSensor* ArticulationLinkComponent::GetSensor(AZ::u32 sensorIndex) const

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.h
@@ -28,7 +28,7 @@ namespace physx
 {
     class PxArticulationReducedCoordinate;
     class PxArticulationJointReducedCoordinate;
-}
+} // namespace physx
 
 namespace PhysX
 {
@@ -80,6 +80,7 @@ namespace PhysX
         float GetMaxJointVelocity() const override;
         float GetJointPosition(ArticulationJointAxis jointAxis) const override;
         float GetJointVelocity(ArticulationJointAxis jointAxis) const override;
+        bool IsRootArticulation() const override;
         // ArticulationSensorRequestBus overrides ...
         AZ::Transform GetSensorTransform(AZ::u32 sensorIndex) const override;
         void SetSensorTransform(AZ::u32 sensorIndex, const AZ::Transform& sensorTransform) override;
@@ -98,7 +99,6 @@ namespace PhysX
         AzPhysics::SceneQueryHit RayCast(const AzPhysics::RayCastRequest& request) override;
 #endif
 
-
         physx::PxArticulationLink* GetArticulationLink(const AZ::EntityId entityId);
         const AZStd::vector<AZ::u32> GetSensorIndices(const AZ::EntityId entityId);
         const physx::PxArticulationJointReducedCoordinate* GetDriveJoint() const;
@@ -108,7 +108,6 @@ namespace PhysX
         ArticulationLinkConfiguration m_config;
 
     private:
-        bool IsRootArticulation() const;
         const AZ::Entity* GetArticulationRootEntity() const;
 
         void CreateArticulation();

--- a/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
@@ -7,15 +7,15 @@
  */
 
 #include <AzCore/Serialization/EditContext.h>
-#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 
+#include <AzFramework/Physics/NameConstants.h>
 #include <Editor/EditorJointCommon.h>
 #include <Source/ArticulationLinkComponent.h>
 #include <Source/EditorArticulationLinkComponent.h>
 #include <Source/EditorColliderComponent.h>
-#include <AzFramework/Physics/NameConstants.h>
 
 namespace PhysX
 {
@@ -23,7 +23,7 @@ namespace PhysX
     {
         const float LocalRotationMax = 360.0f;
         const float LocalRotationMin = -360.0f;
-    }
+    } // namespace
 
     void EditorArticulationLinkConfiguration::Reflect(AZ::ReflectContext* context)
     {
@@ -188,7 +188,7 @@ namespace PhysX
                         0, &ArticulationLinkConfiguration::m_angularLimitNegative, "Lower Angular Limit", "Lower limit of angular motion.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::HingePropertiesVisible)
                     ->DataElement(
-                        0, &ArticulationLinkConfiguration::m_angularLimitPositive, "Upper Angular Limit", "Lower limit of angular motion.")
+                        0, &ArticulationLinkConfiguration::m_angularLimitPositive, "Upper Angular Limit", "Upper limit of angular motion.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::HingePropertiesVisible)
                     ->EndGroup()
 


### PR DESCRIPTION
## What does this PR do?

There are two main changes in this PR in the `ArticulationLilnk` Component, solving problems or possible problems. Both did exist before, but it is better to solve the issue in 2510 than wait for another release. The changes are small and are not likely to introduce new issues.

First, a logic to set a hinge joint position to be within the limits was added. 
Although the names of variables in serialized context suggest otherwise (_positive_ and _negative_ limit),  we allow any limits for hinge joints in articulation joints. E.g., it is possible to set up a hinge joint operating between -30 and -10 deg. The original code would create a joint initialized at 0 deg. At the first tick of the physics, the joint would be forced to the operating limits, getting a momentum that might influence other dynamic bodies. This change sets the initial position to min+epsilon or max-epsilon (depending on the limits) before the physics starts. In the optimal solution, the initial value could be selected by the user, to ensure the rest of the joint's parameters is fulfilled, but this should be considered a feature and should be added to the `development` branch rather than `stabilization`. Note: the names of the variables in serialized context were not changed to ensure the old prefabs can load without any changes.

A second change, the addition of existing method `IsRootArticulation` to the bus, allows other parties to check if the articulation is a root. This is needed in other Gems. Currently, it is either solved by a code duplication (checking if the parent entity has the articulation link) or by checking if the articulation has the degree of freedom for the specified axis. The latter throws an error:
```
Articulation root does not have an inbound joint.
```
when called for a root articulation, which is not the best user experience. It is important to add, that the current implementation of the method should be refactored, as it causes issues in some cases (e.g. copying the component). But this will be fixed separately, on the `development` branch.

Additionally:
- one description in the edit context was fixed (copy paste error)
- few lines of code were re-formatted to follow the formatting rules (not all lines were formatted to ensure PR was not too big)

## How was this PR tested?

- built and run the code with `PhysX` and `PhysX5` Gems
- tested articulations with positive only and negative only hinge limits

An example of the first problem: _knees_ of the Spot can bend between -116 and -14 deg. The body of the robot is in fixed position and the legs are moved only by the gravity (motors are off).

Before:
![spot_before](https://github.com/user-attachments/assets/2495b5ab-8770-4b66-a0e1-d27b3ec14dba)

After:
![spot_after](https://github.com/user-attachments/assets/0e4638fb-7c9a-43c6-8491-517a404b1917)
