### PR TITLE
Add operator[] for vector and matrix types.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.h
@@ -193,6 +193,12 @@ namespace AZ
         bool operator==(const Matrix3x3& rhs) const;
         bool operator!=(const Matrix3x3& rhs) const;
 
+        //! Access the row vector.
+        //! @{
+        Vector3& operator[](const size_t row);
+        const Vector3& operator[](const size_t row) const;
+        //! @}
+
         //! Transpose calculation, flips the rows and columns.
         //! @{
         Matrix3x3 GetTranspose() const;

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x3.inl
@@ -451,6 +451,18 @@ namespace AZ
         return !(*this == rhs);
     }
 
+    AZ_MATH_INLINE Vector3& Matrix3x3::operator[](const size_t row)
+    {
+        AZ_MATH_ASSERT(row < RowCount, "Accessing index out of bound!");
+        return m_rows[row];
+    }
+
+    AZ_MATH_INLINE const Vector3& Matrix3x3::operator[](const size_t row) const
+    {
+        AZ_MATH_ASSERT(row < RowCount, "Accessing index out of bound!");
+        return m_rows[row];
+    }
+
     AZ_MATH_INLINE Matrix3x3 Matrix3x3::GetTranspose() const
     {
         Matrix3x3 result;

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.h
@@ -260,6 +260,12 @@ namespace AZ
         //! Operator for transforming a Vector4.
         [[nodiscard]] Vector4 operator*(const Vector4& rhs) const;
 
+        //! Access the row vector.
+        //! @{
+        [[nodiscard]] Vector4& operator[](const size_t row);
+        [[nodiscard]] const Vector4& operator[](const size_t row) const;
+        //! @}
+
         //! Post-multiplies the matrix by a vector, using only the 3x3 part of the matrix.
         [[nodiscard]] Vector3 Multiply3x3(const Vector3& rhs) const;
 

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.inl
@@ -509,6 +509,18 @@ namespace AZ
         );
     }
 
+    AZ_MATH_INLINE Vector4& Matrix3x4::operator[](const size_t row)
+    {
+        AZ_MATH_ASSERT(row < RowCount, "Accessing index out of bound!");
+        return m_rows[row];
+    }
+
+    AZ_MATH_INLINE const Vector4& Matrix3x4::operator[](const size_t row) const
+    {
+        AZ_MATH_ASSERT(row < RowCount, "Accessing index out of bound!");
+        return m_rows[row];
+    }
+
     AZ_MATH_INLINE Vector3 Matrix3x4::Multiply3x3(const Vector3& rhs) const
     {
         return Vector3

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.h
@@ -200,6 +200,12 @@ namespace AZ
         //! Operator for negating all matrix's elements
         [[nodiscard]] Matrix4x4 operator-() const;
 
+        //! Access the row vector.
+        //! @{
+        [[nodiscard]] Vector4& operator[](const size_t row);
+        [[nodiscard]] const Vector4& operator[](const size_t row) const;
+        //! @}
+
         //! Post-multiplies the matrix by a vector.
         //! Assumes that the w-component of the Vector3 is 1.0.
         Vector3 operator*(const Vector3& rhs) const;

--- a/Code/Framework/AzCore/AzCore/Math/Matrix4x4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix4x4.inl
@@ -509,6 +509,18 @@ namespace AZ
         return Vector4(Simd::Vec4::Mat4x4TransformVector(GetSimdValues(), rhs.GetSimdValue()));
     }
 
+    AZ_MATH_INLINE Vector4& Matrix4x4::operator[](const size_t row)
+    {
+        AZ_MATH_ASSERT(row < RowCount, "Accessing index out of bound!");
+        return m_rows[row];
+    }
+
+    AZ_MATH_INLINE const Vector4& Matrix4x4::operator[](const size_t row) const
+    {
+        AZ_MATH_ASSERT(row < RowCount, "Accessing index out of bound!");
+        return m_rows[row];
+    }
+
     AZ_MATH_INLINE Vector3 Matrix4x4::TransposedMultiply3x3(const Vector3& v) const
     {
         const Simd::Vec3::FloatType rows[3] = { Simd::Vec4::ToVec3(m_rows[0].GetSimdValue()), Simd::Vec4::ToVec3(m_rows[1].GetSimdValue()), Simd::Vec4::ToVec3(m_rows[2].GetSimdValue()) };

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.h
@@ -216,6 +216,8 @@ namespace AZ
         Vector2 operator*(float multiplier) const;
         Vector2 operator/(float divisor) const;
         Vector2 operator/(const Vector2& rhs) const;
+        float& operator[](const size_t i);
+        const float& operator[](const size_t i) const;
 
         //! Gets the sine of each component.
         Vector2 GetSin() const;

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.inl
@@ -479,6 +479,18 @@ namespace AZ
         return Vector2(Simd::Vec2::Div(m_value, rhs.m_value));
     }
 
+    AZ_MATH_INLINE float& Vector2::operator[](const size_t i)
+    {
+        AZ_MATH_ASSERT(i < 2, "Accessing index out of bound!");
+        return m_values[i];
+    }
+
+    AZ_MATH_INLINE const float& Vector2::operator[](const size_t i) const
+    {
+        AZ_MATH_ASSERT(i < 2, "Accessing index out of bound!");
+        return m_values[i];
+    }
+
     AZ_MATH_INLINE Vector2 Vector2::GetSin() const
     {
         return Vector2(Simd::Vec2::Sin(m_value));

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.h
@@ -247,6 +247,8 @@ namespace AZ
         Vector3& operator/=(const Vector3& rhs);
         Vector3& operator*=(float multiplier);
         Vector3& operator/=(float divisor);
+        float& operator[](const size_t i);
+        const float& operator[](const size_t i) const;
 
         //! Gets the sine of each component.
         Vector3 GetSin() const;

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.inl
@@ -546,6 +546,18 @@ namespace AZ
         return *this;
     }
 
+    AZ_MATH_INLINE float& Vector3::operator[](const size_t i)
+    {
+        AZ_MATH_ASSERT(i < 3, "Accessing index out of bound!");
+        return m_values[i];
+    }
+
+    AZ_MATH_INLINE const float& Vector3::operator[](const size_t i) const
+    {
+        AZ_MATH_ASSERT(i < 3, "Accessing index out of bound!");
+        return m_values[i];
+    }
+
     AZ_MATH_INLINE Vector3 Vector3::GetSin() const
     {
         return Vector3(Simd::Vec3::Sin(m_value));

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.h
@@ -256,6 +256,8 @@ namespace AZ
         Vector4& operator/=(const Vector4& rhs);
         Vector4& operator*=(float multiplier);
         Vector4& operator/=(float divisor);
+        float& operator[](const size_t i);
+        const float& operator[](const size_t i) const;
 
         //! Gets the sine of each component.
         Vector4 GetSin() const;

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.inl
@@ -585,6 +585,18 @@ namespace AZ
         return *this;
     }
 
+    AZ_MATH_INLINE float& Vector4::operator[](const size_t i)
+    {
+        AZ_MATH_ASSERT(i < 4, "Accessing index out of bound!");
+        return m_values[i];
+    }
+
+    AZ_MATH_INLINE const float& Vector4::operator[](const size_t i) const
+    {
+        AZ_MATH_ASSERT(i < 4, "Accessing index out of bound!");
+        return m_values[i];
+    }
+
     AZ_MATH_INLINE Vector4 Vector4::GetSin() const
     {
         return Vector4(Simd::Vec4::Sin(m_value));


### PR DESCRIPTION
## What does this PR do?

This PR simply add operator[] to Vector{2,3,4} and Matrix{3,4}x{3,4} types so that matrix elements can be accessed through something like matrix[2][3] in addition to GetElement/SetElement

## How was this PR tested?

Manually tested
