### PR TITLE
Merge from stabilization25100 to development (1)

### DIFF
--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ClothComponentMesh.cpp
@@ -565,7 +565,7 @@ namespace NvCloth
             const auto& destTangentsData = destTangents.GetBuffer();
             const auto& destBitangentsData = destBitangents.GetBuffer();
 
-            if (!destVerticesData.empty())
+            if (destVerticesData.empty())
             {
                 AZ_Error("ClothComponentMesh", AZ::RHI::IsNullRHI(),
                     "Invalid vertex position buffer obtained from the render mesh to be modified.");

--- a/cmake/PatchIfNotAlreadyPatched.cmake
+++ b/cmake/PatchIfNotAlreadyPatched.cmake
@@ -27,8 +27,15 @@ set(PATCH_ALREADY_APPLIED "")
 # Check if the patch has already been applied.
 # if this command returns 0 it means that reversing the patch was successful
 # which means the patch was already applied.
+
+find_package(Git)
+
+if (NOT Git_FOUND)
+    message(FATAL_ERROR "Git executable not found.  Please make sure `git` is in your PATH")
+endif()
+
 execute_process(
-    COMMAND git apply --check --reverse "${PATCH_FILE_NAME}"
+    COMMAND ${GIT_EXECUTABLE} apply --check --reverse "${PATCH_FILE_NAME}"
     RESULT_VARIABLE PATCH_ALREADY_APPLIED
     OUTPUT_QUIET
     ERROR_QUIET
@@ -38,11 +45,11 @@ if (PATCH_ALREADY_APPLIED STREQUAL "0")
     message(STATUS "Skipping already applied patch ${PATCH_FILE_NAME} in dir ${CMAKE_BINARY_DIR}")
 else()
     message(STATUS "Cleaning directory before patch...")
-    execute_process(COMMAND git restore .)
-    execute_process(COMMAND git clean -fdx)
+    execute_process(COMMAND ${GIT_EXECUTABLE} restore .)
+    execute_process(COMMAND ${GIT_EXECUTABLE} clean -fdx)
     message(STATUS "Applying patch ${PATCH_FILE_NAME} at ${CMAKE_BINARY_DIR}...")
     execute_process(
-        COMMAND git apply --ignore-whitespace "${PATCH_FILE_NAME}"
+        COMMAND ${GIT_EXECUTABLE} apply --ignore-whitespace "${PATCH_FILE_NAME}"
         RESULT_VARIABLE PATCH_RESULT
     )
     if (NOT PATCH_RESULT EQUAL 0)


### PR DESCRIPTION
## What does this PR do?

Merges 2 bugfixes from `stabilization/25100` to `development`

    * See the listed commits below
    * c8ddab2c76 Fixes cloth simulation rendering. (#19183)
    * 777968c98e  When patching a 3rd party library, check for git
      to exist and show an appropriate error message instead of failing
      mysteriously.

## Testing

No new testing, the two changes did pass AR and PR in stabilization already, and GHA will do additional tests below.