### PR TITLE
Find Python in $USERPROFILE

### DIFF
--- a/python/python.sh
+++ b/python/python.sh
@@ -77,7 +77,7 @@ fi
 
 # Set the expected location of the python venv for this engine and the locations of the critical scripts/executables 
 # needed to run python within the venv properly
-PYTHON_VENV=$HOME/.o3de/Python/venv/$ENGINE_ID
+PYTHON_VENV=${USERPROFILE:-"$HOME"}/.o3de/Python/venv/$ENGINE_ID
 if [[ "$OSTYPE" == "msys" ]];  #git bash on windows
 then
     PYTHON_VENV_ACTIVATE=$PYTHON_VENV/Scripts/activate


### PR DESCRIPTION
## What does this PR do?

Python could not be found if `$USERPROFILE` was used because it was search for only in `$HOME/.o3de/...`

## How was this PR tested?

- `cd $BUILD_DIR}`, `/media/gael/linux/home/gael/80-build/22.04/o3de` in my case.
- `export USERPROFILE=$(pwd)/venv`
- `python/get_python.sh`

This returned 
```
Using cmake located at: /usr/bin/cmake
cmake version 3.22.1 CMake suite maintained and supported by Kitware (kitware.com/cmake).
-- Downloading package into /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/packages/python-3.10.13-rev2-linux
'/usr/bin/cmake' '-E' 'tar' 'xf' '/media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/downloaded_packages/python-3.10.13-rev2-linux.tar.xz'
-- Installed And Validated package at /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/packages/python-3.10.13-rev2-linux - OK
-- Using package /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/packages/python-3.10.13-rev2-linux
-- Creating Python venv at /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd
'/media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/packages/python-3.10.13-rev2-linux/python/bin/python' '-m' 'venv' '/media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd' '--without-pip' '--clear'
-- Installing pip into venv at /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd (/media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd/python/bin)
'/media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd/bin/python' '-m' 'ensurepip' '--upgrade' '--default-pip' '-v'
Using pip 23.0.1 from /tmp/tmpmi9liu5m/pip-23.0.1-py3-none-any.whl/pip (python 3.10)
Looking in links: /tmp/tmpmi9liu5m
Processing /tmp/tmpmi9liu5m/setuptools-65.5.0-py3-none-any.whl
Processing /tmp/tmpmi9liu5m/pip-23.0.1-py3-none-any.whl
Installing collected packages: setuptools, pip
  changing mode of /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd/bin/pip to 775
  changing mode of /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd/bin/pip3 to 775
  changing mode of /media/gael/linux/home/gael/80-build/22.04/o3de/venv/.o3de/Python/venv/f7f639dd/bin/pip3.10 to 775
Successfully installed pip-23.0.1 setuptools-65.5.0
installing via pip...
/media/gael/linux/home/gael/04-sources/o3de/o3de/python /media/gael/linux/home/gael/04-sources/o3de/o3de
Python has not been downloaded/configured yet.
Try running /media/gael/linux/home/gael/04-sources/o3de/o3de/python/get_python.sh first.
/media/gael/linux/home/gael/04-sources/o3de/o3de
Failed to install the packages listed in /media/gael/linux/home/gael/04-sources/o3de/o3de/python/requirements.txt.  Check the log above!```
