### PR TITLE
Deferred Fullscreen Draw Items

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/bitset.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/bitset.h
@@ -8,6 +8,7 @@
 #ifndef AZSTD_BITSET_H
 #define AZSTD_BITSET_H
 
+#include <AzCore/std/string/fixed_string.h>
 #include <AzCore/std/string/string.h>
 
 namespace AZStd
@@ -293,27 +294,38 @@ namespace AZStd
         template<class Element, class Traits>
         inline basic_string<Element, Traits, AZStd::allocator> to_string(Element zero = (Element)'0') const
         {
-            basic_string<Element, Traits, AZStd::allocator> str;
-            AZStd::size_t pos;
-            str.reserve(NumBits);
-            for (pos = NumBits; 0 < pos; )
-            {
-                str += (Element)(zero + (int)test(--pos));
-            }
-            return str;
+            return to_string<Element, Traits, AZStd::allocator>(zero);
         }
 
         template<class Element>
         inline basic_string<Element, AZStd::char_traits<Element>, AZStd::allocator> to_string(Element zero = (Element)'0') const
         {
-            basic_string<Element, AZStd::char_traits<Element>, AZStd::allocator> str;
-            AZStd::size_t pos;
-            str.reserve(NumBits);
-            for (pos = NumBits; 0 < pos; )
+            return to_string<Element, AZStd::char_traits<Element>, AZStd::allocator>(zero);
+        }
+
+        template<class Element, class Traits, class Allocator>
+        inline basic_string<Element, Traits, Allocator> to_hex_string() const
+        {
+            basic_string<Element, Traits, Allocator> str;
+            str.reserve(NumWords * 4 + 1);
+            for (const auto& word : m_bits)
             {
-                str += (Element)(zero + (int)test(--pos));
+                auto text = AZStd::basic_string<Element, Traits, Allocator>::format("%04x", word);
+                str.append(text);
             }
             return str;
+        }
+
+        template<class Element, class Traits>
+        inline basic_string<Element, Traits, AZStd::allocator> to_hex_string() const
+        {
+            return to_hex_string<Element, Traits, AZStd::allocator>();
+        }
+
+        template<class Element>
+        inline basic_string<Element, AZStd::char_traits<Element>, AZStd::allocator> to_hex_string() const
+        {
+            return to_hex_string<Element, AZStd::char_traits<Element>, AZStd::allocator>();
         }
 
         inline AZStd::size_t count() const

--- a/Gems/Atom/Feature/Common/Assets/Materials/ReflectionProbe/ReflectionProbeVisualization.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/ReflectionProbe/ReflectionProbeVisualization.azsli
@@ -86,6 +86,11 @@
         return surface;
     }
 
+    Surface EvaluateSurface(VsOutput IN, VsSystemValues SV, PixelGeometryData geoData, const MaterialParameters params, float4 dxdy, bool useCustomDerivatives)
+    {
+        return EvaluateSurface(IN, SV, geoData, params);
+    }
+
     // use the lighting model (lightingData, BRDF - function and ApplyLights) from the BasePBR
 
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli>

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/FallbackPBRMaterial/MaterialInfoUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/FallbackPBRMaterial/MaterialInfoUtil.azsli
@@ -11,6 +11,18 @@
 #include <Atom/Features/Bindless.azsli>
 #include <Atom/Features/ColorManagement/TransformColor.azsli>
 
+bool HasMaterialInfoEntry(int index)
+{
+    uint numStructs;
+    uint stride;
+    SceneSrg::m_fallbackPBRMaterial.GetDimensions(numStructs, stride);
+    if (index < 0 || index >= numStructs)
+    {
+        return false;
+    }
+    return true;
+}
+
 bool GetMaterialInfoEntry(int index, inout MaterialInfo materialInfo)
 {
 #if DEFENSIVE_BINDLESS_ACCESS

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MeshInfo/MeshInfoUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MeshInfo/MeshInfoUtil.azsli
@@ -60,3 +60,36 @@ void LoadInterpolatedVertexData(const MeshInfo meshInfo, const uint triangleId, 
 #endif
 }
 
+float4 CalculateUvDxDy(const MeshInfo meshInfo, const uint triangleId, const float3 barycentrics, const float3 barycentricsDx, const float3 barycentricsDy, const int uvChannel)
+{
+    float4 result = float4(0, 0, 0, 0);
+#if MATERIAL_USES_VERTEX_UV
+    uint3 triangleIndices = LoadIndex(meshInfo, triangleId);
+    float2 vertexUv[3];
+
+    if (uvChannel == 0) {
+        [unroll]
+        for (int index = 0; index < 3; ++index)
+        {
+            vertexUv[index] = LoadUv0(meshInfo, triangleIndices[index]);
+        }
+    }
+    else if (uvChannel == 1)
+    {
+        [unroll]
+        for (int index = 0; index < 3; ++index)
+        {
+            vertexUv[index] = LoadUv1(meshInfo, triangleIndices[index]);
+        }
+    }
+    float2 uv = vertexUv[0] * barycentrics[0] + vertexUv[1] * barycentrics[1] + vertexUv[2] * barycentrics[2];
+    float2 uvDx = vertexUv[0] * (barycentrics[0] + barycentricsDx[0]) + vertexUv[1] * (barycentrics[1] + barycentricsDx[1]) + vertexUv[2] *(barycentrics[2] + barycentricsDx[2]);
+    result.xy = uv - uvDx;
+
+    float2 uvDy = vertexUv[0] * (barycentrics[0] + barycentricsDy[0]) + vertexUv[1] * (barycentrics[1] + barycentricsDy[1]) + vertexUv[2] *(barycentrics[2] + barycentricsDy[2]);
+    result.zw = uv - uvDy;
+#endif /* MATERIAL_USES_VERTEX_UV */
+    return result;
+}
+
+

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MeshInfo/MeshInfoUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MeshInfo/MeshInfoUtil.azsli
@@ -83,10 +83,16 @@ float4 CalculateUvDxDy(const MeshInfo meshInfo, const uint triangleId, const flo
         }
     }
 
-    // this is the same as:
+    // Calculate the UV screenspace derivatives. We have to do this manually in a deferred pipeline because 
+    // - ddx(uv) is only available in pixel shaders, and
+    // - it uses the values of the neighboring thread / pixel, and we cannot assume that these values are from the same mesh
+    // Get the uv coords of the pixel center:
     // uv = sum(vertexUv_i * barycentrics_i)
+    // Get the uv coords of the neighbor screenspace pixel center
     // uvDx = sum(vertexUv_i * (barycentrics_i + barycentricsDx_i))
+    // screenspace derivatives of the uv coords:
     // dx = uv - uvDx
+    // Note this collapses to dx = -(sum(vertexUv_i * barycentricsDx_i))
     float2 uvDx = vertexUv[0] * barycentricsDx[0] + vertexUv[1] * barycentricsDx[1] + vertexUv[2] * barycentricsDx[2];
     result.xy = -uvDx;
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MeshInfo/MeshInfoUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/MeshInfo/MeshInfoUtil.azsli
@@ -82,12 +82,16 @@ float4 CalculateUvDxDy(const MeshInfo meshInfo, const uint triangleId, const flo
             vertexUv[index] = LoadUv1(meshInfo, triangleIndices[index]);
         }
     }
-    float2 uv = vertexUv[0] * barycentrics[0] + vertexUv[1] * barycentrics[1] + vertexUv[2] * barycentrics[2];
-    float2 uvDx = vertexUv[0] * (barycentrics[0] + barycentricsDx[0]) + vertexUv[1] * (barycentrics[1] + barycentricsDx[1]) + vertexUv[2] *(barycentrics[2] + barycentricsDx[2]);
-    result.xy = uv - uvDx;
 
-    float2 uvDy = vertexUv[0] * (barycentrics[0] + barycentricsDy[0]) + vertexUv[1] * (barycentrics[1] + barycentricsDy[1]) + vertexUv[2] *(barycentrics[2] + barycentricsDy[2]);
-    result.zw = uv - uvDy;
+    // this is the same as:
+    // uv = sum(vertexUv_i * barycentrics_i)
+    // uvDx = sum(vertexUv_i * (barycentrics_i + barycentricsDx_i))
+    // dx = uv - uvDx
+    float2 uvDx = vertexUv[0] * barycentricsDx[0] + vertexUv[1] * barycentricsDx[1] + vertexUv[2] * barycentricsDx[2];
+    result.xy = -uvDx;
+
+    float2 uvDy = vertexUv[0] * barycentricsDy[0] + vertexUv[1] * barycentricsDy[1] + vertexUv[2] * barycentricsDy[2];
+    result.zw = -uvDy;
 #endif /* MATERIAL_USES_VERTEX_UV */
     return result;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredDrawSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredDrawSrg.azsli
@@ -15,7 +15,7 @@ ShaderResourceGroup DrawSrg : SRG_PerDraw
     // Material-Type ID of the current draw-item. 
     int m_materialTypeId;
 
-    // Note: The indended use-case is that a Visibility-(Raster-)pass writes at least the meshInfoIndex of the mesh visible on a 
+    // Note: The intended use-case is that a Visibility-(Raster-)pass writes at least the meshInfoIndex of the mesh visible on a 
     // screenspace-pixel to the VBuffer, and the deferred pass renders one fullscreen-triangle for each material-type and shader option combination,
     // using the meshInfoIndex from the VBuffer to figure out if any given pixel needs to be rendered with the current draw-call, or can be skipped.
     // Since the draw-packet IDs can be different for a mesh for different deferred DrawListTags, we provide the drawPacketIds for all meshes for the 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredDrawSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredDrawSrg.azsli
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+ShaderResourceGroup DrawSrg : SRG_PerDraw
+{
+    // Material-Type ID of the current draw-item. 
+    int m_materialTypeId;
+
+    // Note: The indended use-case is that a Visibility-(Raster-)pass writes at least the meshInfoIndex of the mesh visible on a 
+    // screenspace-pixel to the VBuffer, and the deferred pass renders one fullscreen-triangle for each material-type and shader option combination,
+    // using the meshInfoIndex from the VBuffer to figure out if any given pixel needs to be rendered with the current draw-call, or can be skipped.
+    // Since the draw-packet IDs can be different for a mesh for different deferred DrawListTags, we provide the drawPacketIds for all meshes for the 
+    // current DrawListTag
+
+    // Id of the current draw-packet. This is a unique id from the combination of the Material-Type-Id and the actual Shader Options
+    int m_drawPacketId;
+
+    // List of draw-packet - Ids for each mesh with the current drawListTag. Indexed with the MeshInfo - Index.
+    Buffer<int> m_drawPacketIds;
+
+};

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredDrawSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredDrawSrg.azsli
@@ -22,9 +22,9 @@ ShaderResourceGroup DrawSrg : SRG_PerDraw
     // current DrawListTag
 
     // Id of the current draw-packet. This is a unique id from the combination of the Material-Type-Id and the actual Shader Options
-    int m_drawPacketId;
+    uint m_drawPacketId;
 
     // List of draw-packet - Ids for each mesh with the current drawListTag. Indexed with the MeshInfo - Index.
-    Buffer<int> m_drawPacketIds;
+    Buffer<uint> m_drawPacketIds;
 
 };

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassEvaluateLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassEvaluateLighting.azsli
@@ -17,7 +17,7 @@
 #include <Atom/Features/Pipeline/Forward/ForwardPassDecals.azsli>
 #include <Atom/Features/Pipeline/Deferred/DeferredPassIbl.azsli>
 
-LightingData EvaluateLighting_DeferredPass(Surface surface, float4 screenPosition, float3 viewPositions[MAX_SHADING_VIEWS])
+LightingData EvaluateLighting_DeferredPass(Surface surface, float4 screenPosition, float3 viewPositions[MAX_SHADING_VIEWS], int reflectionProbeCubeMapIndex, ReflectionProbeData reflectionProbeData)
 {
     LightingData lightingData;
     InitializeLightingData(surface, viewPositions, lightingData);
@@ -37,7 +37,7 @@ LightingData EvaluateLighting_DeferredPass(Surface surface, float4 screenPositio
     ApplyDirectLighting_ForwardPass(surface, lightingData, screenPosition, tileIterator);
 
     // Apply Image Based Lighting (IBL) for deferred
-    ApplyIbl_DeferredPass(surface, lightingData);
+    ApplyIbl_DeferredPass(surface, lightingData, reflectionProbeCubeMapIndex, reflectionProbeData);
 
     FinalizeLightingData(surface, lightingData);
     return lightingData;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassEvaluateLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassEvaluateLighting.azsli
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#ifndef EvaluateLighting
+#define EvaluateLighting EvaluateLighting_DeferredPass
+#endif
+
+#include <Atom/Features/Debug.azsli>
+#include <Atom/Features/Pipeline/Forward/ForwardPassDirectLighting.azsli>
+#include <Atom/Features/Pipeline/Forward/ForwardPassDecals.azsli>
+#include <Atom/Features/Pipeline/Deferred/DeferredPassIbl.azsli>
+
+LightingData EvaluateLighting_DeferredPass(Surface surface, float4 screenPosition, float3 viewPositions[MAX_SHADING_VIEWS])
+{
+    LightingData lightingData;
+    InitializeLightingData(surface, viewPositions, lightingData);
+
+    // Light iterator
+    LightCullingTileIterator tileIterator;
+#if ENABLE_LIGHT_CULLING
+    tileIterator.Init(screenPosition, PassSrg::m_lightListRemapped, PassSrg::m_tileLightData);
+#else
+    tileIterator.InitNoCulling();
+#endif
+
+    // Apply Decals (same as the ForwardPass)
+    ApplyDecals_ForwardPass(tileIterator, surface);
+
+    // Apply Direct Lighting (same as the ForwardPass)
+    ApplyDirectLighting_ForwardPass(surface, lightingData, screenPosition, tileIterator);
+
+    // Apply Image Based Lighting (IBL) for deferred
+    ApplyIbl_DeferredPass(surface, lightingData);
+
+    FinalizeLightingData(surface, lightingData);
+    return lightingData;
+}
+

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassIbl.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassIbl.azsli
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// This file provides exentions to Ibl.azsli that are specific to deferred render pipelines.
+#include <Atom/Features/PBR/Lights/Ibl.azsli>
+
+// These options have 'Forward' in the name, but we still use them for the deferred pass, since
+// we would have to expose new options in the material otherwise
+option bool o_meshUseForwardPassIBLSpecular = false;
+option bool o_materialUseForwardPassIBLSpecular = false;
+
+void ApplyIbl_DeferredPass(Surface surface, inout LightingData lightingData)
+{
+#if FORCE_IBL_IN_FORWARD_PASS
+    bool useDiffuseIbl = true;
+    bool useSpecularIbl = true;
+#else
+    #if FORCE_OPAQUE
+        bool isTransparent = false;
+    #else
+        bool isTransparent = (o_opacity_mode == OpacityMode::Blended || o_opacity_mode == OpacityMode::TintedTransparent);
+    #endif
+    bool useDiffuseIbl = isTransparent;
+    bool useSpecularIbl = (isTransparent || o_meshUseForwardPassIBLSpecular || o_materialUseForwardPassIBLSpecular);
+#endif
+
+    // Apply Image Based Lighting (IBL)
+    // TODO(Deferred): Reflection Probes are not supported currently
+    ReflectionProbeData unusedReflectionProbe;
+    unusedReflectionProbe.m_useReflectionProbe = false;
+    TextureCube unusedReflectionProbeCubeMap;
+    ApplyIBL(surface, lightingData, useDiffuseIbl, useSpecularIbl, unusedReflectionProbe, unusedReflectionProbeCubeMap);
+}

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassIbl.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassIbl.azsli
@@ -16,7 +16,7 @@
 option bool o_meshUseForwardPassIBLSpecular = false;
 option bool o_materialUseForwardPassIBLSpecular = false;
 
-void ApplyIbl_DeferredPass(Surface surface, inout LightingData lightingData)
+void ApplyIbl_DeferredPass(Surface surface, inout LightingData lightingData, int reflectionProbeCubeMapIndex, ReflectionProbeData reflectionProbeData)
 {
 #if FORCE_IBL_IN_FORWARD_PASS
     bool useDiffuseIbl = true;
@@ -31,10 +31,6 @@ void ApplyIbl_DeferredPass(Surface surface, inout LightingData lightingData)
     bool useSpecularIbl = (isTransparent || o_meshUseForwardPassIBLSpecular || o_materialUseForwardPassIBLSpecular);
 #endif
 
-    // Apply Image Based Lighting (IBL)
-    // TODO(Deferred): Reflection Probes are not supported currently
-    ReflectionProbeData unusedReflectionProbe;
-    unusedReflectionProbe.m_useReflectionProbe = false;
-    TextureCube unusedReflectionProbeCubeMap;
-    ApplyIBL(surface, lightingData, useDiffuseIbl, useSpecularIbl, unusedReflectionProbe, unusedReflectionProbeCubeMap);
+    TextureCube reflectionProbeCubeMap = Bindless::GetTextureCube(reflectionProbeCubeMapIndex);
+    ApplyIBL(surface, lightingData, useDiffuseIbl, useSpecularIbl, reflectionProbeData, reflectionProbeCubeMap);
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassSrg.azsli
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+// this PassSrg of the DeferredPass looks almost the same as the PassSrg of the ForwardPass.
+// The only difference is that it requires the Visibility-Buffer textures as input
+ShaderResourceGroup PassSrg : SRG_PerPass
+{
+    Texture2D m_brdfMap;
+    Texture2D<float> m_fullscreenShadow;
+
+    // [GFX TODO][ATOM-2012] adapt to multiple shadowmaps
+    Texture2DArray<float> m_directionalLightShadowmap;
+    Texture2DArray<float> m_directionalLightExponentialShadowmap;
+    Texture2DArray<float> m_projectedShadowmaps;
+    Texture2DArray<float> m_projectedExponentialShadowmap;
+
+
+    Sampler LinearSampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    Sampler PointSampler
+    {
+        MinFilter = Point;
+        MagFilter = Point;
+        MipFilter = Point;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+    
+    Texture2D<uint4> m_tileLightData;
+    StructuredBuffer<uint> m_lightListRemapped;
+
+    Texture2D<float4> m_visibilityBuffer_0;
+    Texture2D<float4> m_visibilityBuffer_1;
+}
+
+
+
+

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassSrg.azsli
@@ -47,6 +47,8 @@ ShaderResourceGroup PassSrg : SRG_PerPass
     Texture2D<uint4> m_tileLightData;
     StructuredBuffer<uint> m_lightListRemapped;
 
+    // The Visibility buffer (as implemented in VisibilityBuffer.azsli) is packed into two float4 textures, 
+    // mostly because the screenspace derivatives of the barycentrics use one entire float4
     Texture2D<float4> m_visibilityBuffer_0;
     Texture2D<float4> m_visibilityBuffer_1;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassVertexData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/DeferredPassVertexData.azsli
@@ -136,8 +136,6 @@ struct VsSystemValues_DeferredPass
     uint m_instanceId;
     uint m_lightingChannelMask;
     uint m_objectId;
-    int m_materialTypeId;
-    int m_materialInstanceId;
     uint m_uvStreamTangentBitmask;
 };
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
@@ -2,9 +2,7 @@
 
 struct VisibilityBuffer
 {
-    // object-id of the mesh
-    // TODO: with the 'm_isFrontFace' - flag, this can't be -1
-    int m_meshInfoIndex;     
+    int m_meshInfoIndex;      // MeshInfoIndex of the mesh (max 30 bit)
     uint m_triangleId;        // rasterized triangle ID
     bool m_isFrontFace;       // stored in the first bit of the meshInfoIndex
 
@@ -23,8 +21,8 @@ void packVisibilityBuffer(VisibilityBuffer vbuffer, inout float4 first, inout fl
     flagsAndMeshInfoIndex = (((1 << 30) -1) & vbuffer.m_meshInfoIndex);
 
     // highest bit: m_meshInfoIndex is invalid
-    // note: this would have been set already if the meshInfoIndex is negative, but
-    // we make it explicit for clarity
+    // We need to store this explicitly, since we strip the highest 2 bit of the m_meshInfoIndex so we can
+    // fit the VBuffer-Data into 2 float4 - textures
     flagsAndMeshInfoIndex |= (vbuffer.m_meshInfoIndex < 0) << 31;
     
     // second highest bit: triangle is frontfacing
@@ -41,6 +39,9 @@ void packVisibilityBuffer(VisibilityBuffer vbuffer, inout float4 first, inout fl
 
 bool GetMeshInfoIndex(const float4 first, inout int meshInfoIndex)
 {
+    // The visibility buffer has two invalid states: 
+    // - It is initialized with float4("NAN", 0, 0, 0): No mesh is visible at this pixel
+    // - The m_meshInfoIndex is negative: This can happen if the MeshInfo-Buffer and the Draw-Srg are not (yet) fully updated 
     if (isfinite(first.x))
     {
         uint flagsAndMeshInfoIndex = asuint(first.x);
@@ -57,7 +58,7 @@ bool GetMeshInfoIndex(const float4 first, inout int meshInfoIndex)
             // mask out the first two bits
             meshInfoIndex = (((1 << 30) - 1) & flagsAndMeshInfoIndex);
         }
-        return meshInfoIndex >= 0;
+        return !meshInfoIndexInvalid;
     }
     return false;
 }
@@ -102,8 +103,6 @@ bool unpackVisibilityBuffer(float4 first, float4 second, inout VisibilityBuffer 
     // calc the dy value for the third coord
     vbuffer.m_barycentricsDy.z = barycentricsY.z - vbuffer.m_barycentrics.z;
  
-    // inf: all bits of the exponent (bits 22 - 30) are set, but other bits are zero. (-inf: msb is set)
-    // nan: all bits of the exponent are set, and 
-    return isfinite(first.x);
+    return isfinite(first.x) && !meshInfoIndexInvalid;
 }
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
@@ -76,7 +76,8 @@ bool unpackVisibilityBuffer(float4 first, float4 second, inout VisibilityBuffer 
     {
         vbuffer.m_meshInfoIndex = -1;
     }
-    else {
+    else 
+    {
         // mask out the first two bits
         vbuffer.m_meshInfoIndex = (((1 << 30) - 1) & flagsAndMeshInfoIndex);
     }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
@@ -50,9 +50,9 @@ void packVisibilityBuffer(VisibilityBuffer vbuffer, inout float4 first, inout fl
 bool GetMeshInfoIndex(const float4 first, inout int meshInfoIndex)
 {
     // The visibility buffer has two invalid states: 
-    // - It is initialized with float4("NAN", 0, 0, 0): No mesh is visible at this pixel
+    // - It is initialized with float4(-0.0, 0.0, 0.0, 0.0): No mesh is visible at this pixel
     // - The m_meshInfoIndex is negative: This can happen if the MeshInfo-Buffer and the Draw-Srg are not (yet) fully updated 
-    if (isfinite(first.x))
+    if (first.x != -0.0f)
     {
         uint flagsAndMeshInfoIndex = asuint(first.x);
         // first flag
@@ -108,6 +108,6 @@ bool unpackVisibilityBuffer(float4 first, float4 second, inout VisibilityBuffer 
     // calc the dy value for the third coord
     vbuffer.m_barycentricsDy.z = barycentricsY.z - vbuffer.m_barycentrics.z;
  
-    return isfinite(first.x) && !meshInfoIndexInvalid;
+    return first.x != -0.0 && !meshInfoIndexInvalid;
 }
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
@@ -12,21 +12,31 @@ struct VisibilityBuffer
     float3 m_barycentricsDy;
 };
 
+#define MESHINFO_BITS 30
+#define MAX_MESHINFO (1 << MESHINFO_BITS)
+#define MESHINFO_MASK (MAX_MESHINFO - 1)
+#define MESHINFO_INVALID_BIT 31
+#define MESHINFO_INVALID_MASK (1 << MESHINFO_INVALID_BIT)
+#define FRONTFACE_BIT 30
+#define FRONTFACE_MASK (1 << FRONTFACE_BIT)
+
+
+
 // packing and unpacking is mostly for convenience
 void packVisibilityBuffer(VisibilityBuffer vbuffer, inout float4 first, inout float4 second)
 {
-    uint flagsAndMeshInfoIndex;
+    uint flagsAndMeshInfoIndex = 0;
 
-    // mask out the two highest bits, they will be used for flags
-    flagsAndMeshInfoIndex = (((1 << 30) -1) & vbuffer.m_meshInfoIndex);
+    // remove the top n bits from the meshinfo, we need space for flags
+    flagsAndMeshInfoIndex = MESHINFO_MASK & vbuffer.m_meshInfoIndex;
 
-    // highest bit: m_meshInfoIndex is invalid
-    // We need to store this explicitly, since we strip the highest 2 bit of the m_meshInfoIndex so we can
-    // fit the VBuffer-Data into 2 float4 - textures
-    flagsAndMeshInfoIndex |= (vbuffer.m_meshInfoIndex < 0) << 31;
+    // First flag: m_meshInfoIndex is invalid
+    // Note: an invalid meshInfoIndex is usually -1, so this flag would already be set, but we strip the top bits, so we have to re-add it
+    bool meshInfoInvalid = vbuffer.m_meshInfoIndex < 0;
+    flagsAndMeshInfoIndex |= meshInfoInvalid << MESHINFO_INVALID_BIT;
     
-    // second highest bit: triangle is frontfacing
-    flagsAndMeshInfoIndex |= vbuffer.m_isFrontFace << 30;
+    // second flag: triangle is frontfacing
+    flagsAndMeshInfoIndex |= vbuffer.m_isFrontFace << FRONTFACE_BIT;
 
     first.x = asfloat(flagsAndMeshInfoIndex);
     first.y = asfloat(vbuffer.m_triangleId);
@@ -45,18 +55,15 @@ bool GetMeshInfoIndex(const float4 first, inout int meshInfoIndex)
     if (isfinite(first.x))
     {
         uint flagsAndMeshInfoIndex = asuint(first.x);
-        // first bit
-        bool meshInfoIndexInvalid = (1 << 31 & flagsAndMeshInfoIndex) >> 31;
-        // second bit
-        bool isFrontFace = (1 << 30 & flagsAndMeshInfoIndex) >> 30;
+        // first flag
+        bool meshInfoIndexInvalid = (MESHINFO_INVALID_MASK & flagsAndMeshInfoIndex) > 0u;
+        // meshInfoIndex
+        meshInfoIndex = (MESHINFO_MASK & flagsAndMeshInfoIndex);
 
+        // if the meshInfoIndex was invalid, we need to make it negative
         if (meshInfoIndexInvalid)
         {
-            meshInfoIndex = -1;
-        }
-        else {
-            // mask out the first two bits
-            meshInfoIndex = (((1 << 30) - 1) & flagsAndMeshInfoIndex);
+            meshInfoIndex *= -1;
         }
         return !meshInfoIndexInvalid;
     }
@@ -67,19 +74,16 @@ bool GetMeshInfoIndex(const float4 first, inout int meshInfoIndex)
 bool unpackVisibilityBuffer(float4 first, float4 second, inout VisibilityBuffer vbuffer)
 {
     uint flagsAndMeshInfoIndex = asuint(first.x);
-    // first bit
-    bool meshInfoIndexInvalid = (1 << 31 & flagsAndMeshInfoIndex) >> 31;
-    // second bit
-    vbuffer.m_isFrontFace = (1 << 30 & flagsAndMeshInfoIndex) >> 30;
+    // first flag
+    bool meshInfoIndexInvalid = (MESHINFO_INVALID_MASK & flagsAndMeshInfoIndex) > 0u;
+    // second flag
+    vbuffer.m_isFrontFace = (FRONTFACE_MASK & flagsAndMeshInfoIndex) > 0u;
+
+    vbuffer.m_meshInfoIndex = (MESHINFO_MASK & flagsAndMeshInfoIndex);
 
     if (meshInfoIndexInvalid)
     {
-        vbuffer.m_meshInfoIndex = -1;
-    }
-    else 
-    {
-        // mask out the first two bits
-        vbuffer.m_meshInfoIndex = (((1 << 30) - 1) & flagsAndMeshInfoIndex);
+        vbuffer.m_meshInfoIndex *= -1;
     }
   
     vbuffer.m_triangleId = asuint(first.y);

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Deferred/VisibilityBuffer.azsli
@@ -1,0 +1,109 @@
+#pragma once
+
+struct VisibilityBuffer
+{
+    // object-id of the mesh
+    // TODO: with the 'm_isFrontFace' - flag, this can't be -1
+    int m_meshInfoIndex;     
+    uint m_triangleId;        // rasterized triangle ID
+    bool m_isFrontFace;       // stored in the first bit of the meshInfoIndex
+
+    float3 m_barycentrics;    // barycentrics for the triangle
+    // dx / dy of the barycentrics, needed to calculate the mip-level for the various UV channels 
+    float3 m_barycentricsDx;   
+    float3 m_barycentricsDy;
+};
+
+// packing and unpacking is mostly for convenience
+void packVisibilityBuffer(VisibilityBuffer vbuffer, inout float4 first, inout float4 second)
+{
+    uint flagsAndMeshInfoIndex;
+
+    // mask out the two highest bits, they will be used for flags
+    flagsAndMeshInfoIndex = (((1 << 30) -1) & vbuffer.m_meshInfoIndex);
+
+    // highest bit: m_meshInfoIndex is invalid
+    // note: this would have been set already if the meshInfoIndex is negative, but
+    // we make it explicit for clarity
+    flagsAndMeshInfoIndex |= (vbuffer.m_meshInfoIndex < 0) << 31;
+    
+    // second highest bit: triangle is frontfacing
+    flagsAndMeshInfoIndex |= vbuffer.m_isFrontFace << 30;
+
+    first.x = asfloat(flagsAndMeshInfoIndex);
+    first.y = asfloat(vbuffer.m_triangleId);
+
+    // we can reconstruct the third barycentric coordinate
+    first.zw = vbuffer.m_barycentrics.xy;
+    second.xy = vbuffer.m_barycentricsDx.xy;
+    second.zw = vbuffer.m_barycentricsDy.xy;
+}
+
+bool GetMeshInfoIndex(const float4 first, inout int meshInfoIndex)
+{
+    if (isfinite(first.x))
+    {
+        uint flagsAndMeshInfoIndex = asuint(first.x);
+        // first bit
+        bool meshInfoIndexInvalid = (1 << 31 & flagsAndMeshInfoIndex) >> 31;
+        // second bit
+        bool isFrontFace = (1 << 30 & flagsAndMeshInfoIndex) >> 30;
+
+        if (meshInfoIndexInvalid)
+        {
+            meshInfoIndex = -1;
+        }
+        else {
+            // mask out the first two bits
+            meshInfoIndex = (((1 << 30) - 1) & flagsAndMeshInfoIndex);
+        }
+        return meshInfoIndex >= 0;
+    }
+    return false;
+}
+
+
+bool unpackVisibilityBuffer(float4 first, float4 second, inout VisibilityBuffer vbuffer)
+{
+    uint flagsAndMeshInfoIndex = asuint(first.x);
+    // first bit
+    bool meshInfoIndexInvalid = (1 << 31 & flagsAndMeshInfoIndex) >> 31;
+    // second bit
+    vbuffer.m_isFrontFace = (1 << 30 & flagsAndMeshInfoIndex) >> 30;
+
+    if (meshInfoIndexInvalid)
+    {
+        vbuffer.m_meshInfoIndex = -1;
+    }
+    else {
+        // mask out the first two bits
+        vbuffer.m_meshInfoIndex = (((1 << 30) - 1) & flagsAndMeshInfoIndex);
+    }
+  
+    vbuffer.m_triangleId = asuint(first.y);
+
+    vbuffer.m_barycentrics.xy = first.zw;
+    // reconstruct the third barycentric coordinate
+    vbuffer.m_barycentrics.z = 1.0f - (vbuffer.m_barycentrics.x + vbuffer.m_barycentrics.y);
+
+    vbuffer.m_barycentricsDx.xy = second.xy;
+    // create the neighboring barycentrics in x
+    float3 barycentricsX = float3(vbuffer.m_barycentrics.x + vbuffer.m_barycentricsDx.x, vbuffer.m_barycentrics.y + vbuffer.m_barycentricsDx.y, 1.0f);
+    // reconstruct the third barycentric coord of the neighbor
+    barycentricsX.z -= (barycentricsX.x + barycentricsX.y);
+    // calc the dx value for the third coord
+    vbuffer.m_barycentricsDx.z = barycentricsX.z - vbuffer.m_barycentrics.z; 
+
+    vbuffer.m_barycentricsDy.xy = second.zw;
+    // create the neighboring barycentrics in y
+    float3 barycentricsY = float3(vbuffer.m_barycentrics.x + vbuffer.m_barycentricsDy.x, vbuffer.m_barycentrics.y + vbuffer.m_barycentricsDy.y, 1.0f);
+    // reconstruct the third barycentric coord of the neighbor
+    barycentricsY.z -= (barycentricsY.x + barycentricsY.y);
+    // calc the dy value for the third coord
+    vbuffer.m_barycentricsDy.z = barycentricsY.z - vbuffer.m_barycentrics.z;
+ 
+    // inf: all bits of the exponent (bits 22 - 30) are set, but other bits are zero. (-inf: msb is set)
+    // nan: all bits of the exponent are set, and 
+    return isfinite(first.x);
+}
+

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/FallbackPBRMaterial/SceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/FallbackPBRMaterial/SceneSrg.azsli
@@ -15,4 +15,5 @@
 partial ShaderResourceGroup SceneSrg
 {
     StructuredBuffer<MaterialInfo> m_fallbackPBRMaterial;
+    uint m_nullCubeMapIndex;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DeferredPassSrg.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DeferredPassSrg.azsl
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// This shader is not used for rendering.
+// The only purpose of this shader is to have a shader asset that can be used
+// at runtime to find the PassSrg required by most Passes.
+
+#include <Atom/Features/Pipeline/Deferred/DeferredPassSrg.azsli>
+#include <Atom/RPI/DummyEntryFunctions.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DeferredPassSrg.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DeferredPassSrg.shader
@@ -1,0 +1,40 @@
+{ 
+    "Source" : "DeferredPassSrg.azsl",
+
+    "DepthStencilState" : 
+    {
+        "Depth" : 
+        { 
+            "Enable" : false 
+        },
+        "Stencil" :
+        {
+            "Enable" : false
+        }
+    },
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+    },
+    
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "RemoveBuildArguments": {
+                "azslc": ["--strip-unused-srgs"]
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DeferredMaterial/DeferredMaterialFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DeferredMaterial/DeferredMaterialFeatureProcessorInterface.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RHI.Reflect/FrameCountMaxRingBuffer.h>
+#include <Atom/RPI.Public/PipelineState.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Reflect/Shader/ShaderVariantKey.h>
+
+#include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
+
+namespace AZ::Render
+{
+    // forward declaration
+    class ModelDataInstanceInterface;
+
+    //! This feature processor manages Deferred DrawPackages for a Scene
+    class DeferredMaterialFeatureProcessorInterface : public RPI::FeatureProcessor
+    {
+    public:
+        AZ_RTTI(AZ::Render::DeferredMaterialFeatureProcessorInterface, "{27B1C9E5-99D9-4DEC-AE66-5F0131B20BE3}", RPI::FeatureProcessor);
+
+        using ModelId = AZ::Uuid;
+        //! Create a deferred draw-item for the referenced material types, if they don't exist yet
+        virtual void AddModel(const ModelId& uuid, ModelDataInstanceInterface* meshHandle, const Data::Instance<RPI::Model>& model) = 0;
+
+        //! Removes a mesh and potentially the draw-item for the material type.
+        virtual void RemoveModel(const ModelId& uuid) = 0;
+
+        //! A buffer with the DrawPacketId for the given deferred DrawListTag.
+        //! This buffer contains one entry for every mesh in the scene, with the id of the deferred fullscreen-DrawItem that is
+        //! responsible for that mesh. The buffer is kept in sync with the MeshInfoBuffer, and can be indexed using the meshInfoIndex.
+        virtual AZ::Data::Instance<AZ::RPI::Buffer> GetDrawPacketIdBuffer(const RHI::DrawListTag& drawListTag) = 0;
+
+        virtual bool IsEnabled() = 0;
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -22,66 +22,67 @@
 #include <TransformService/TransformServiceFeatureProcessor.h>
 #include <CubeMapCapture/CubeMapCaptureFeatureProcessor.h>
 
-#include <ImageBasedLights/ImageBasedLightFeatureProcessor.h>
-#include <DisplayMapper/AcesOutputTransformLutPass.h>
-#include <DisplayMapper/AcesOutputTransformPass.h>
-#include <DisplayMapper/ApplyShaperLookupTablePass.h>
-#include <DisplayMapper/BakeAcesOutputTransformLutPass.h>
-#include <DisplayMapper/DisplayMapperPass.h>
-#include <DisplayMapper/DisplayMapperFullScreenPass.h>
-#include <DisplayMapper/OutputTransformPass.h>
-#include <Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h>
 #include <Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h>
+#include <Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h>
 #include <Atom/Feature/LightingChannel/LightingChannelConfiguration.h>
 #include <Atom/Feature/RayTracing/RayTracingPass.h>
 #include <Atom/Feature/RayTracing/RayTracingPassData.h>
+#include <Atom/Feature/SkyBox/SkyBoxFogSettings.h>
 #include <Atom/Feature/SplashScreen/SplashScreenSettings.h>
 #include <Atom/Feature/Utils/LightingPreset.h>
 #include <Atom/Feature/Utils/ModelPreset.h>
-#include <Atom/Feature/SkyBox/SkyBoxFogSettings.h>
 #include <AuxGeom/AuxGeomFeatureProcessor.h>
 #include <ColorGrading/LutGenerationPass.h>
 #include <Debug/RayTracingDebugFeatureProcessor.h>
 #include <Debug/RenderDebugFeatureProcessor.h>
+#include <DeferredMaterial/DeferredMaterialFeatureProcessor.h>
+#include <DisplayMapper/AcesOutputTransformLutPass.h>
+#include <DisplayMapper/AcesOutputTransformPass.h>
+#include <DisplayMapper/ApplyShaperLookupTablePass.h>
+#include <DisplayMapper/BakeAcesOutputTransformLutPass.h>
+#include <DisplayMapper/DisplayMapperFullScreenPass.h>
+#include <DisplayMapper/DisplayMapperPass.h>
+#include <DisplayMapper/OutputTransformPass.h>
+#include <ImageBasedLights/ImageBasedLightFeatureProcessor.h>
 #include <Mesh/MeshFeatureProcessor.h>
-#include <Silhouette/SilhouetteFeatureProcessor.h>
-#include <Silhouette/SilhouetteCompositePass.h>
 #include <PostProcess/PostProcessFeatureProcessor.h>
 #include <PostProcessing/BlendColorGradingLutsPass.h>
+#include <PostProcessing/BloomBlurPass.h>
+#include <PostProcessing/BloomCompositePass.h>
+#include <PostProcessing/BloomDownsamplePass.h>
 #include <PostProcessing/BloomParentPass.h>
-#include <PostProcessing/HDRColorGradingPass.h>
-#include <PostProcessing/DepthUpsamplePass.h>
-#include <PostProcessing/DepthOfFieldCompositePass.h>
+#include <PostProcessing/ChromaticAberrationPass.h>
 #include <PostProcessing/DepthOfFieldBokehBlurPass.h>
+#include <PostProcessing/DepthOfFieldCompositePass.h>
 #include <PostProcessing/DepthOfFieldMaskPass.h>
 #include <PostProcessing/DepthOfFieldParentPass.h>
 #include <PostProcessing/DepthOfFieldReadBackFocusDepthPass.h>
 #include <PostProcessing/DepthOfFieldWriteFocusDepthFromGpuPass.h>
-#include <PostProcessing/NewDepthOfFieldPasses.h>
+#include <PostProcessing/DepthUpsamplePass.h>
 #include <PostProcessing/EyeAdaptationPass.h>
-#include <PostProcessing/LuminanceHistogramGeneratorPass.h>
 #include <PostProcessing/FastDepthAwareBlurPasses.h>
+#include <PostProcessing/FilmGrainPass.h>
+#include <PostProcessing/HDRColorGradingPass.h>
 #include <PostProcessing/LookModificationCompositePass.h>
 #include <PostProcessing/LookModificationTransformPass.h>
-#include <PostProcessing/SMAAFeatureProcessor.h>
-#include <PostProcessing/SMAAEdgeDetectionPass.h>
+#include <PostProcessing/LuminanceHistogramGeneratorPass.h>
+#include <PostProcessing/MotionBlurPass.h>
+#include <PostProcessing/NewDepthOfFieldPasses.h>
+#include <PostProcessing/PaniniProjectionPass.h>
 #include <PostProcessing/SMAABlendingWeightCalculationPass.h>
+#include <PostProcessing/SMAAEdgeDetectionPass.h>
+#include <PostProcessing/SMAAFeatureProcessor.h>
 #include <PostProcessing/SMAANeighborhoodBlendingPass.h>
 #include <PostProcessing/SsaoPasses.h>
 #include <PostProcessing/SubsurfaceScatteringPass.h>
 #include <PostProcessing/TaaPass.h>
-#include <PostProcessing/BloomDownsamplePass.h>
-#include <PostProcessing/BloomBlurPass.h>
-#include <PostProcessing/BloomCompositePass.h>
-#include <PostProcessing/ChromaticAberrationPass.h>
-#include <PostProcessing/MotionBlurPass.h>
-#include <PostProcessing/PaniniProjectionPass.h>
-#include <PostProcessing/FilmGrainPass.h>
-#include <PostProcessing/WhiteBalancePass.h>
 #include <PostProcessing/VignettePass.h>
+#include <PostProcessing/WhiteBalancePass.h>
 #include <RayTracing/RayTracingFeatureProcessor.h>
 #include <ScreenSpace/DeferredFogPass.h>
 #include <Shadows/ProjectedShadowFeatureProcessor.h>
+#include <Silhouette/SilhouetteCompositePass.h>
+#include <Silhouette/SilhouetteFeatureProcessor.h>
 #include <SkyAtmosphere/SkyAtmosphereFeatureProcessor.h>
 #include <SkyAtmosphere/SkyAtmosphereParentPass.h>
 #include <SkyBox/SkyBoxFeatureProcessor.h>
@@ -156,6 +157,7 @@ namespace AZ
             LightingPreset::Reflect(context);
             ModelPreset::Reflect(context);
             RayTracingFeatureProcessor::Reflect(context);
+            DeferredMaterialFeatureProcessor::Reflect(context);
             OcclusionCullingPlaneFeatureProcessor::Reflect(context);
             LightingChannelConfiguration::Reflect(context);
 
@@ -218,6 +220,8 @@ namespace AZ
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<CubeMapCaptureFeatureProcessor, CubeMapCaptureFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<SMAAFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<RayTracingFeatureProcessor, RayTracingFeatureProcessorInterface>();
+                AZ::RPI::FeatureProcessorFactory::Get()
+                    ->RegisterFeatureProcessorWithInterface<DeferredMaterialFeatureProcessor, DeferredMaterialFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<OcclusionCullingPlaneFeatureProcessor, OcclusionCullingPlaneFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<SplashScreenFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<SilhouetteFeatureProcessor>();
@@ -357,6 +361,7 @@ namespace AZ
             if (!appType.IsHeadless())
             {
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<RayTracingFeatureProcessor>();
+                AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<DeferredMaterialFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SMAAFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<ReflectionProbeFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SpecularReflectionsFeatureProcessor>();

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
@@ -12,52 +12,48 @@
 #include <DeferredMaterial/DeferredDrawPacket.h>
 #include <DeferredMaterial/DeferredDrawPacketManager.h>
 
-namespace AZ
+namespace AZ::Render
 {
-    namespace Render
-    {
-        DeferredDrawPacket::DeferredDrawPacket(
-            DeferredDrawPacketManager* drawPacketManager,
-            const RPI::Scene* scene,
-            RPI::Material* material,
-            const Name& materialPipelineName,
-            const RPI::ShaderCollection::Item& shaderItem,
+    DeferredDrawPacket::DeferredDrawPacket(
+        DeferredDrawPacketManager* drawPacketManager,
+        const RPI::Scene* scene,
+        RPI::Material* material,
+        const Name& materialPipelineName,
+        const RPI::ShaderCollection::Item& shaderItem,
         const uint32_t drawPacketId)
-            : m_drawPacketManager(drawPacketManager)
-            , m_drawPacketId(drawPacketId)
-        {
-            Init(scene, material, materialPipelineName, shaderItem);
-        }
+        : m_drawPacketManager(drawPacketManager)
+        , m_drawPacketId(drawPacketId)
+        , m_useCount(0)
+    {
+        Init(scene, material, materialPipelineName, shaderItem);
+    }
 
-        DeferredDrawPacket::~DeferredDrawPacket()
-        {
-            AZ::RPI::ShaderReloadNotificationBus::Handler::BusDisconnect();
-        }
+    DeferredDrawPacket::~DeferredDrawPacket()
+    {
+        AZ::RPI::ShaderReloadNotificationBus::Handler::BusDisconnect();
+    }
 
-        // ShaderReloadNotificationBus::Handler overrides...
-        void DeferredDrawPacket::OnShaderReinitialized([[maybe_unused]] const RPI::Shader& shader)
-        {
-            m_needsRebuild = true;
-            m_drawPacketManager->SetNeedsUpdate(true);
-        }
-        void DeferredDrawPacket::OnShaderAssetReinitialized([[maybe_unused]] const Data::Asset<RPI::ShaderAsset>& shaderAsset)
-        {
-            m_needsRebuild = true;
-            m_drawPacketManager->SetNeedsUpdate(true);
-        }
-        void DeferredDrawPacket::OnShaderVariantReinitialized([[maybe_unused]] const RPI::ShaderVariant& shaderVariant)
-        {
-            m_needsRebuild = true;
-            m_drawPacketManager->SetNeedsUpdate(true);
-        }
+    // ShaderReloadNotificationBus::Handler overrides...
+    void DeferredDrawPacket::OnShaderReinitialized([[maybe_unused]] const RPI::Shader& shader)
+    {
+        m_needsRebuild = true;
+        m_drawPacketManager->SetNeedsUpdate(true);
+    }
+    void DeferredDrawPacket::OnShaderAssetReinitialized([[maybe_unused]] const Data::Asset<RPI::ShaderAsset>& shaderAsset)
+    {
+        m_needsRebuild = true;
+        m_drawPacketManager->SetNeedsUpdate(true);
+    }
+    void DeferredDrawPacket::OnShaderVariantReinitialized([[maybe_unused]] const RPI::ShaderVariant& shaderVariant)
+    {
+        m_needsRebuild = true;
+        m_drawPacketManager->SetNeedsUpdate(true);
+    }
 
-        void DeferredDrawPacket::Init(
-            const RPI::Scene* scene,
-            RPI::Material* material,
-            const Name& materialPipelineName,
-            const RPI::ShaderCollection::Item& shaderItem)
-        {
-            auto materialAsset = material->GetAsset();
+    void DeferredDrawPacket::Init(
+        const RPI::Scene* scene, RPI::Material* material, const Name& materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
+    {
+        auto materialAsset = material->GetAsset();
 
 #ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
             m_instigatingMaterialAsset =
@@ -195,7 +191,7 @@ namespace AZ
             drawPacketBuilder.AddDrawItem(drawRequest);
 
             m_drawPacket = drawPacketBuilder.End();
-        }
+    }
 
         void DeferredDrawPacket::CompileDrawSrg(Data::Instance<RPI::Buffer> drawPacketIdBuffer)
         {
@@ -206,5 +202,4 @@ namespace AZ
             m_drawSrg->Compile();
         }
 
-    } // namespace Render
-} // namespace AZ
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
@@ -35,17 +35,17 @@ namespace AZ
         }
 
         // ShaderReloadNotificationBus::Handler overrides...
-        void DeferredDrawPacket::OnShaderReinitialized(const RPI::Shader& shader)
+        void DeferredDrawPacket::OnShaderReinitialized([[maybe_unused]] const RPI::Shader& shader)
         {
             m_needsRebuild = true;
             m_drawPacketManager->SetNeedsUpdate(true);
         }
-        void DeferredDrawPacket::OnShaderAssetReinitialized(const Data::Asset<RPI::ShaderAsset>& shaderAsset)
+        void DeferredDrawPacket::OnShaderAssetReinitialized([[maybe_unused]] const Data::Asset<RPI::ShaderAsset>& shaderAsset)
         {
             m_needsRebuild = true;
             m_drawPacketManager->SetNeedsUpdate(true);
         }
-        void DeferredDrawPacket::OnShaderVariantReinitialized(const RPI::ShaderVariant& shaderVariant)
+        void DeferredDrawPacket::OnShaderVariantReinitialized([[maybe_unused]] const RPI::ShaderVariant& shaderVariant)
         {
             m_needsRebuild = true;
             m_drawPacketManager->SetNeedsUpdate(true);
@@ -97,7 +97,7 @@ namespace AZ
 
             if (!scene->HasOutputForPipelineState(m_drawListTag))
             {
-                auto tagRegistry = RHI::GetDrawListTagRegistry();
+                [[maybe_unused]] auto tagRegistry = RHI::GetDrawListTagRegistry();
                 AZ_Info(
                     "DeferredDrawPacket",
                     "Scene has no output for drawListTag %s, don't create a deferred draw package",

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Atom/Feature/RenderCommon.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
+#include <Atom/RHI/RHIUtils.h>
+#include <Atom/RPI.Reflect/Material/MaterialTypeAsset.h>
+#include <DeferredMaterial/DeferredDrawPacket.h>
+#include <DeferredMaterial/DeferredDrawPacketManager.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        DeferredDrawPacket::DeferredDrawPacket(
+            DeferredDrawPacketManager* drawPacketManager,
+            const RPI::Scene* scene,
+            RPI::Material* material,
+            const Name& materialPipelineName,
+            const RPI::ShaderCollection::Item& shaderItem,
+            const int32_t drawPacketId)
+            : m_drawPacketManager(drawPacketManager)
+            , m_drawPacketId(drawPacketId)
+        {
+            Init(scene, material, materialPipelineName, shaderItem);
+        }
+
+        DeferredDrawPacket::~DeferredDrawPacket()
+        {
+            AZ::RPI::ShaderReloadNotificationBus::Handler::BusDisconnect();
+        }
+
+        // ShaderReloadNotificationBus::Handler overrides...
+        void DeferredDrawPacket::OnShaderReinitialized(const RPI::Shader& shader)
+        {
+            m_needsRebuild = true;
+            m_drawPacketManager->SetNeedsUpdate(true);
+        }
+        void DeferredDrawPacket::OnShaderAssetReinitialized(const Data::Asset<RPI::ShaderAsset>& shaderAsset)
+        {
+            m_needsRebuild = true;
+            m_drawPacketManager->SetNeedsUpdate(true);
+        }
+        void DeferredDrawPacket::OnShaderVariantReinitialized(const RPI::ShaderVariant& shaderVariant)
+        {
+            m_needsRebuild = true;
+            m_drawPacketManager->SetNeedsUpdate(true);
+        }
+
+        void DeferredDrawPacket::Init(
+            const RPI::Scene* scene,
+            RPI::Material* material,
+            const Name& materialPipelineName,
+            const RPI::ShaderCollection::Item& shaderItem)
+        {
+            auto materialAsset = material->GetAsset();
+
+#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
+            m_instigatingMaterialAsset =
+                Data::Asset<RPI::MaterialAsset>(materialAsset.GetId(), materialAsset.GetType(), materialAsset.GetHint());
+            // the draw-packet can outlast the original material asset it was created for, so don't keep a real reference to the asset
+            m_instigatingMaterialAsset.SetAutoLoadBehavior(Data::AssetLoadBehavior::NoLoad);
+
+            auto materialTypeAsset = materialAsset->GetMaterialTypeAsset();
+            m_instigatingMaterialTypeAsset =
+                Data::Asset<RPI::MaterialTypeAsset>(materialTypeAsset.GetId(), materialTypeAsset.GetType(), materialTypeAsset.GetHint());
+            m_instigatingMaterialTypeAsset.SetAutoLoadBehavior(Data::AssetLoadBehavior::NoLoad);
+#endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
+
+            RPI::ShaderOptionGroup shaderOptions = *shaderItem.GetShaderOptions();
+            shaderOptions.SetUnspecifiedToDefaultValues();
+            m_shaderVariantId = shaderOptions.GetShaderVariantId();
+
+            m_shader = RPI::Shader::FindOrCreate(shaderItem.GetShaderAsset());
+            if (!m_shader)
+            {
+                AZ_Error(
+                    "DeferredDrawPacket",
+                    false,
+                    "Shader '%s' of material %s:. Failed to find or create instance",
+                    shaderItem.GetShaderAsset()->GetName().GetCStr(),
+                    materialAsset.GetHint().c_str());
+                return;
+            }
+
+            AZ::RPI::ShaderReloadNotificationBus::Handler::BusConnect(m_shader->GetAssetId());
+
+            m_drawListTag = shaderItem.GetDrawListTagOverride();
+            if (!m_drawListTag.IsValid())
+            {
+                m_drawListTag = m_shader->GetDrawListTag();
+            }
+
+            if (!scene->HasOutputForPipelineState(m_drawListTag))
+            {
+                auto tagRegistry = RHI::GetDrawListTagRegistry();
+                AZ_Info(
+                    "DeferredDrawPacket",
+                    "Scene has no output for drawListTag %s, don't create a deferred draw package",
+                    tagRegistry->GetName(m_drawListTag).GetCStr());
+                return;
+            }
+
+            // Shader - Variant and pipeline-State
+            const AZ::RPI::ShaderVariant& variant = m_shader->GetVariant(m_shaderVariantId);
+
+            // Deferred Draw-SRG: Holds the shaderOptions, the material-Type - ID and the shaderDrawPacketId
+            m_drawSrg = m_shader->CreateDrawSrgForShaderVariant(shaderOptions, false);
+            if (!m_drawSrg)
+            {
+                AZ_Assert(false, "Failed to create deferred drawSrg");
+                return;
+            }
+            {
+                // material-Type ID to make sure the Materialparameter - layout matches
+                RHI::ShaderInputNameIndex materialTypeIdIndex{ "m_materialTypeId" };
+                m_drawSrg->SetConstant(materialTypeIdIndex, material->GetMaterialTypeId());
+
+                // mapping from the meshInfoIndex written by the Visibility-buffer to the material-type + shader options
+                RHI::ShaderInputNameIndex shaderDrawPacketIdIndex{ "m_drawPacketId" };
+                m_drawSrg->SetConstant(shaderDrawPacketIdIndex, m_drawPacketId);
+
+                // don't compile the draw-srg yet, we still need the DrawPacketIds-buffer
+            }
+
+            m_materialSrg = material->GetShaderResourceGroup();
+            m_materialPipelineName = materialPipelineName;
+            m_shaderTag = shaderItem.GetShaderTag();
+
+            AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
+            variant.ConfigurePipelineState(pipelineStateDescriptor, shaderOptions);
+
+            // Render states need to merge the runtime variation.
+            // This allows materials to customize the render states that the shader uses.
+            const RHI::RenderStates& renderStatesOverlay = *shaderItem.GetRenderStatesOverlay();
+            RHI::MergeStateInto(renderStatesOverlay, pipelineStateDescriptor.m_renderStates);
+
+            // Render a single fullscreen triangle
+            RHI::InputStreamLayout inputStreamLayout;
+            inputStreamLayout.SetTopology(RHI::PrimitiveTopology::TriangleList);
+            inputStreamLayout.Finalize();
+
+            pipelineStateDescriptor.m_inputStreamLayout = inputStreamLayout;
+
+            scene->ConfigurePipelineState(m_drawListTag, pipelineStateDescriptor);
+
+            // This draw item purposefully does not reference any geometry buffers.
+            // Instead it's expected that the vertex shader generates a full-screen triangle completely from vertex ids.
+            m_geometryView = AZStd::make_shared<RHI::GeometryView>(RHI::GeometryView{ RHI::MultiDevice::AllDevices });
+            RHI::DrawLinear draw = RHI::DrawLinear();
+            draw.m_vertexCount = 3;
+            m_geometryView->SetDrawArguments(RHI::DrawLinear(3, 0));
+
+            m_rootConstantsLayout = pipelineStateDescriptor.m_pipelineLayoutDescriptor->GetRootConstantsLayout();
+            bool hasRootConstants = m_rootConstantsLayout && m_rootConstantsLayout->GetDataSize() > 0;
+            if (hasRootConstants)
+            {
+                m_rootConstants.resize(m_rootConstantsLayout->GetDataSize());
+            }
+
+            m_pipelineState = m_shader->AcquirePipelineState(pipelineStateDescriptor);
+            if (!(m_pipelineState && m_pipelineState->GetType() == AZ::RHI::PipelineStateType::Draw))
+            {
+                AZ_Error("DeferredDrawPacket", false, "Failed to create pipelineState");
+                return;
+            }
+
+            RHI::DrawPacketBuilder::DrawRequest drawRequest;
+            drawRequest.m_listTag = m_drawListTag;
+            drawRequest.m_pipelineState = m_pipelineState;
+            // TODO: why do i need a stencil ref here?
+            // drawRequest.m_stencilRef = StencilRefs::UseIBLSpecularPass;
+            // Note: this doesn't do anything, since the geometry-view doesn't have any stream-buffers
+            drawRequest.m_streamIndices = m_geometryView->GetFullStreamBufferIndices();
+            drawRequest.m_sortKey = 0;
+            drawRequest.m_uniqueShaderResourceGroup = m_drawSrg->GetRHIShaderResourceGroup();
+
+            if (m_materialPipelineName != RPI::MaterialPipelineNone)
+            {
+                RHI::DrawFilterTag pipelineTag = scene->GetDrawFilterTagRegistry()->AcquireTag(m_materialPipelineName);
+                AZ_Assert(pipelineTag.IsValid(), "Could not acquire pipeline filter tag '%s'.", m_materialPipelineName.GetCStr());
+                drawRequest.m_drawFilterMask = 1 << pipelineTag.GetIndex();
+            }
+
+            AZ::RHI::DrawPacketBuilder drawPacketBuilder{ AZ::RHI::MultiDevice::AllDevices };
+            drawPacketBuilder.Begin(nullptr);
+            drawPacketBuilder.SetGeometryView(m_geometryView.get());
+            if (hasRootConstants)
+            {
+                drawPacketBuilder.SetRootConstants(m_rootConstants);
+            }
+            drawPacketBuilder.AddShaderResourceGroup(m_materialSrg->GetRHIShaderResourceGroup());
+            drawPacketBuilder.AddDrawItem(drawRequest);
+
+            m_drawPacket = drawPacketBuilder.End();
+        }
+
+        void DeferredDrawPacket::CompileDrawSrg(Data::Instance<RPI::Buffer> drawPacketIdBuffer)
+        {
+            // unique id for combination of the material type and shader options
+            RHI::ShaderInputNameIndex shaderDrawPacketIds{ "m_drawPacketIds" };
+            m_drawSrg->SetBuffer(shaderDrawPacketIds, drawPacketIdBuffer);
+
+            m_drawSrg->Compile();
+        }
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
@@ -172,8 +172,6 @@ namespace AZ
             RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = m_drawListTag;
             drawRequest.m_pipelineState = m_pipelineState;
-            // TODO: why do i need a stencil ref here?
-            // drawRequest.m_stencilRef = StencilRefs::UseIBLSpecularPass;
             // Note: this doesn't do anything, since the geometry-view doesn't have any stream-buffers
             drawRequest.m_streamIndices = m_geometryView->GetFullStreamBufferIndices();
             drawRequest.m_sortKey = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.cpp
@@ -22,7 +22,7 @@ namespace AZ
             RPI::Material* material,
             const Name& materialPipelineName,
             const RPI::ShaderCollection::Item& shaderItem,
-            const int32_t drawPacketId)
+        const uint32_t drawPacketId)
             : m_drawPacketManager(drawPacketManager)
             , m_drawPacketId(drawPacketId)
         {

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.h
@@ -19,73 +19,80 @@
 #include <Atom/RPI.Reflect/Material/ShaderCollection.h>
 #include <AzCore/std/smart_ptr/intrusive_base.h>
 
-namespace AZ
+namespace AZ::Render
 {
-    namespace Render
+    // Forward declaration
+    class DeferredDrawPacketManager;
+    // This is a drawpacket with a single fullscreen draw item for one material-type and it's unique set of shader options
+    class DeferredDrawPacket
+        : public AZStd::intrusive_base
+        , private RPI::ShaderReloadNotificationBus::Handler
     {
-
-        // Forward declaration
-        class DeferredDrawPacketManager;
-        // This is a drawpacket with a single fullscreen draw item for one material-type and it's unique set of shader options
-        class DeferredDrawPacket
-            : public AZStd::intrusive_base
-            , private RPI::ShaderReloadNotificationBus::Handler
-        {
-        public:
-            DeferredDrawPacket() = default;
-            ~DeferredDrawPacket();
-            DeferredDrawPacket(
-                DeferredDrawPacketManager* drawPacketManager,
-                const RPI::Scene* scene,
-                RPI::Material* material,
-                const Name& materialPipelineName,
-                const RPI::ShaderCollection::Item& shaderItem,
+    public:
+        DeferredDrawPacket() = default;
+        ~DeferredDrawPacket();
+        DeferredDrawPacket(
+            DeferredDrawPacketManager* drawPacketManager,
+            const RPI::Scene* scene,
+            RPI::Material* material,
+            const Name& materialPipelineName,
+            const RPI::ShaderCollection::Item& shaderItem,
             const uint32_t drawPacketId);
 
-            void CompileDrawSrg(Data::Instance<RPI::Buffer> drawPacketIdBuffer);
+        void CompileDrawSrg(Data::Instance<RPI::Buffer> drawPacketIdBuffer);
 
-            const RHI::DrawPacket* GetRHIDrawPacket()
-            {
-                return m_drawPacket.get();
-            }
-            const RHI::DrawPacket* GetRHIDrawPacket() const
-            {
-                return m_drawPacket.get();
-            }
-            const RHI::ConstPtr<RHI::ConstantsLayout> GetRootConstantsLayout() const
-            {
-                return m_rootConstantsLayout;
-            }
+        const RHI::DrawPacket* GetRHIDrawPacket()
+        {
+            return m_drawPacket.get();
+        }
+        const RHI::DrawPacket* GetRHIDrawPacket() const
+        {
+            return m_drawPacket.get();
+        }
+        const RHI::ConstPtr<RHI::ConstantsLayout> GetRootConstantsLayout() const
+        {
+            return m_rootConstantsLayout;
+        }
 
-            RHI::DrawListTag GetDrawListTag() const
-            {
-                return m_drawListTag;
-            }
+        RHI::DrawListTag GetDrawListTag() const
+        {
+            return m_drawListTag;
+        }
 
-            int32_t GetDrawPacketId() const
-            {
-                return m_drawPacketId;
-            }
+        int32_t GetDrawPacketId() const
+        {
+            return m_drawPacketId;
+        }
 
-            size_t GetUseCount() const
-            {
-                return use_count();
-            }
+        void IncreaseUseCount()
+        {
+            m_useCount++;
+        }
 
-            bool NeedsRebuild() const
-            {
-                return m_needsRebuild;
-            }
+        void DecreaseUseCount()
+        {
+            m_useCount--;
+        }
 
-            bool IsInitialized() const
-            {
-                return m_drawPacket != nullptr;
-            }
+        int32_t GetUseCount() const
+        {
+            return m_useCount;
+        }
 
-            RPI::ShaderVariantId GetShaderVariantId() const
-            {
-                return m_shaderVariantId;
-            }
+        bool NeedsRebuild() const
+        {
+            return m_needsRebuild;
+        }
+
+        bool IsInitialized() const
+        {
+            return m_drawPacket != nullptr;
+        }
+
+        RPI::ShaderVariantId GetShaderVariantId() const
+        {
+            return m_shaderVariantId;
+        }
 
 #ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
             const Data::Asset<RPI::MaterialAsset>& GetInstigatingMaterialAsset() const
@@ -118,6 +125,8 @@ namespace AZ
             // unique Id of the draw-packet
             uint32_t m_drawPacketId;
 
+            int32_t m_useCount = 0;
+
 #ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
             // Non-valid Reference to the material-Asset that was used to create this DeferredDrawPacket.
             // Useful for debugging / logprints, but this should never be used to load the asset
@@ -146,7 +155,6 @@ namespace AZ
             void OnShaderReinitialized(const RPI::Shader& shader) override;
             void OnShaderAssetReinitialized(const Data::Asset<RPI::ShaderAsset>& shaderAsset) override;
             void OnShaderVariantReinitialized(const RPI::ShaderVariant& shaderVariant) override;
-        };
+    };
 
-    } // namespace Render
-} // namespace AZ
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Reflect/Material/MaterialTypeAsset.h>
+#include <Atom/RHI/DrawList.h>
+#include <Atom/RHI/DrawPacket.h>
+#include <Atom/RPI.Public/Material/Material.h>
+#include <Atom/RPI.Public/PipelineState.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
+#include <Atom/RPI.Reflect/Material/ShaderCollection.h>
+#include <AzCore/std/smart_ptr/intrusive_base.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+
+        // Forward declaration
+        class DeferredDrawPacketManager;
+        // This is a drawpacket with a single fullscreen draw item for one material-type and it's unique set of shader options
+        class DeferredDrawPacket
+            : public AZStd::intrusive_base
+            , private RPI::ShaderReloadNotificationBus::Handler
+        {
+        public:
+            DeferredDrawPacket() = default;
+            ~DeferredDrawPacket();
+            DeferredDrawPacket(
+                DeferredDrawPacketManager* drawPacketManager,
+                const RPI::Scene* scene,
+                RPI::Material* material,
+                const Name& materialPipelineName,
+                const RPI::ShaderCollection::Item& shaderItem,
+                const int32_t drawPacketId);
+
+            void CompileDrawSrg(Data::Instance<RPI::Buffer> drawPacketIdBuffer);
+
+            const RHI::DrawPacket* GetRHIDrawPacket()
+            {
+                return m_drawPacket.get();
+            }
+            const RHI::DrawPacket* GetRHIDrawPacket() const
+            {
+                return m_drawPacket.get();
+            }
+            const RHI::ConstPtr<RHI::ConstantsLayout> GetRootConstantsLayout() const
+            {
+                return m_rootConstantsLayout;
+            }
+
+            RHI::DrawListTag GetDrawListTag() const
+            {
+                return m_drawListTag;
+            }
+
+            int32_t GetDrawPacketId() const
+            {
+                return m_drawPacketId;
+            }
+
+            size_t GetUseCount() const
+            {
+                return use_count();
+            }
+
+            bool NeedsRebuild() const
+            {
+                return m_needsRebuild;
+            }
+
+            bool IsInitialized() const
+            {
+                return m_drawPacket != nullptr;
+            }
+
+            RPI::ShaderVariantId GetShaderVariantId() const
+            {
+                return m_shaderVariantId;
+            }
+
+#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
+            const Data::Asset<RPI::MaterialAsset>& GetInstigatingMaterialAsset() const
+            {
+                return m_instigatingMaterialAsset;
+            }
+            const Data::Asset<RPI::MaterialTypeAsset>& GetInstigatingMaterialTypeAsset() const
+            {
+                return m_instigatingMaterialTypeAsset;
+            }
+#endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
+
+            // TODO: Who sets shader-options for what?
+            // We can only draw multiple meshes with one deferred draw-call if they have the same shader-options,
+            // so if these shader-options are somehow linked to a mesh, that mesh needs a different draw-packet.
+            // But if these are global (e.g. DebugRendering), this might still be useful
+            // bool SetShaderOption(const Name& shaderOptionName, RPI::ShaderOptionValue value);
+            // bool UnsetShaderOption(const Name& shaderOptionName);
+            // void ClearShaderOptions();
+
+        private:
+            void Init(
+                const RPI::Scene* scene,
+                RPI::Material* material,
+                const Name& MaterialPipelineName,
+                const RPI::ShaderCollection::Item& shaderItem);
+
+            DeferredDrawPacketManager* m_drawPacketManager;
+
+            // unique Id of the draw-packet
+            int32_t m_drawPacketId;
+
+#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
+            // Non-valid Reference to the material-Asset that was used to create this DeferredDrawPacket.
+            // Useful for debugging / logprints, but this should never be used to load the asset
+            Data::Asset<RPI::MaterialAsset> m_instigatingMaterialAsset;
+            Data::Asset<RPI::MaterialTypeAsset> m_instigatingMaterialTypeAsset;
+#endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
+
+            Data::Instance<RPI::Shader> m_shader;
+            RPI::ShaderVariantId m_shaderVariantId;
+            RPI::ShaderOptionGroup m_shaderOptions;
+            Name m_materialPipelineName;
+            Name m_shaderTag;
+            RHI::DrawListTag m_drawListTag;
+            const RHI::PipelineState* m_pipelineState;
+            Data::Instance<RPI::ShaderResourceGroup> m_materialSrg;
+            Data::Instance<RPI::ShaderResourceGroup> m_drawSrg;
+            RHI::ConstPtr<RHI::ConstantsLayout> m_rootConstantsLayout;
+            AZStd::vector<uint8_t> m_rootConstants;
+            AZStd::shared_ptr<RHI::GeometryView> m_geometryView;
+
+            RHI::ConstPtr<RHI::DrawPacket> m_drawPacket;
+
+            bool m_needsRebuild = false;
+
+            // ShaderReloadNotificationBus::Handler overrides...
+            void OnShaderReinitialized(const RPI::Shader& shader) override;
+            void OnShaderAssetReinitialized(const Data::Asset<RPI::ShaderAsset>& shaderAsset) override;
+            void OnShaderVariantReinitialized(const RPI::ShaderVariant& shaderVariant) override;
+        };
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacket.h
@@ -40,7 +40,7 @@ namespace AZ
                 RPI::Material* material,
                 const Name& materialPipelineName,
                 const RPI::ShaderCollection::Item& shaderItem,
-                const int32_t drawPacketId);
+            const uint32_t drawPacketId);
 
             void CompileDrawSrg(Data::Instance<RPI::Buffer> drawPacketIdBuffer);
 
@@ -116,7 +116,7 @@ namespace AZ
             DeferredDrawPacketManager* m_drawPacketManager;
 
             // unique Id of the draw-packet
-            int32_t m_drawPacketId;
+            uint32_t m_drawPacketId;
 
 #ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
             // Non-valid Reference to the material-Asset that was used to create this DeferredDrawPacket.

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
@@ -97,7 +97,6 @@ namespace AZ
 #ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
             else
             {
-#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
                 AZ_Info(
                     "DeferredDrawPacketManager",
                     "Material %s, shader %s: -> Use draw-packet from Material %s (MaterialTypeId %d)",
@@ -105,7 +104,6 @@ namespace AZ
                     shaderItem.GetShaderAsset().GetHint().c_str(),
                     drawPacket->GetInstigatingMaterialAsset().GetHint().c_str(),
                     material->GetMaterialTypeId());
-#endif
             }
 #endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
             return drawPacket;

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
@@ -9,82 +9,80 @@
 #include <Atom/RPI.Reflect/Shader/ShaderVariantKey.h>
 #include <DeferredMaterial/DeferredDrawPacketManager.h>
 
-namespace AZ
+namespace AZ::Render
 {
-    namespace Render
+    auto DeferredDrawPacketManager::CalculateDrawPacketId(const RPI::Material* material, const RPI::ShaderCollection::Item& shaderItem)
+        -> DeferredDrawPacketId
     {
-        auto DeferredDrawPacketManager::CalculateDrawPacketId(const RPI::Material* material, const RPI::ShaderCollection::Item& shaderItem)
-            -> DeferredDrawPacketId
-        {
-            RPI::ShaderOptionGroup shaderOptions = *shaderItem.GetShaderOptions();
-            shaderOptions.SetUnspecifiedToDefaultValues();
-            auto requestedShaderVariantId = shaderOptions.GetShaderVariantId();
+        RPI::ShaderOptionGroup shaderOptions = *shaderItem.GetShaderOptions();
+        shaderOptions.SetUnspecifiedToDefaultValues();
+        auto requestedShaderVariantId = shaderOptions.GetShaderVariantId();
 
         size_t seed{};
-            AZStd::hash_combine(seed, material->GetMaterialTypeId());
-            AZStd::hash_combine(seed, requestedShaderVariantId);
+        AZStd::hash_combine(seed, material->GetMaterialTypeId());
+        AZStd::hash_combine(seed, requestedShaderVariantId);
 
         // we use only the lower 32 bits, which should be enough
         DeferredDrawPacketId drawPacketId(static_cast<uint32_t>(seed));
 
         return drawPacketId;
-        }
+    }
 
-        auto DeferredDrawPacketManager::GetDeferredDrawPacket(DeferredDrawPacketId id) const -> Data::Instance<DeferredDrawPacket>
+    auto DeferredDrawPacketManager::GetDeferredDrawPacket(DeferredDrawPacketId id) const -> Data::Instance<DeferredDrawPacket>
+    {
+        if (HasDeferredDrawPacket(id))
         {
-            if (HasDeferredDrawPacket(id))
+            return m_deferredDrawPackets.at(id);
+        }
+        return {};
+    }
+
+    bool DeferredDrawPacketManager::HasDeferredDrawPacket(DeferredDrawPacketId id) const
+    {
+        return m_deferredDrawPackets.contains(id);
+    }
+
+    bool DeferredDrawPacketManager::HasDrawPacketForDrawList(const RHI::DrawListTag tag) const
+    {
+        return m_drawListsWithDrawPackets[tag.GetIndex()];
+    }
+
+    void DeferredDrawPacketManager::PruneUnusedDrawPackets()
+    {
+        m_drawListsWithDrawPackets.reset();
+        AZStd::vector<DeferredDrawPacketId> toDelete;
+
+        for (auto& [key, data] : m_deferredDrawPackets)
+        {
+            if (data->GetUseCount() <= 0 || !data->IsInitialized())
             {
-                return m_deferredDrawPackets.at(id);
+                toDelete.push_back(key);
             }
-            return {};
-        }
-
-        bool DeferredDrawPacketManager::HasDeferredDrawPacket(DeferredDrawPacketId id) const
-        {
-            return m_deferredDrawPackets.contains(id);
-        }
-
-        bool DeferredDrawPacketManager::HasDrawPacketForDrawList(const RHI::DrawListTag tag) const
-        {
-            return m_drawListsWithDrawPackets[tag.GetIndex()];
-        }
-
-        void DeferredDrawPacketManager::PruneUnusedDrawPackets()
-        {
-            m_drawListsWithDrawPackets.reset();
-            AZStd::vector<DeferredDrawPacketId> toDelete;
-
-            for (auto& [key, data] : m_deferredDrawPackets)
+            else
             {
-                if (data->GetUseCount() == 1 || !data->IsInitialized())
-                {
-                    toDelete.push_back(key);
-                }
-                else
-                {
-                    m_drawListsWithDrawPackets[data->GetDrawListTag().GetIndex()] = true;
-                }
-            }
-            for (auto key : toDelete)
-            {
-                m_deferredDrawPackets.erase(key);
+                m_drawListsWithDrawPackets[data->GetDrawListTag().GetIndex()] = true;
             }
         }
-
-        auto DeferredDrawPacketManager::GetOrCreateDeferredDrawPacket(
-            RPI::Scene* scene, RPI::Material* material, const Name materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
-            -> Data::Instance<DeferredDrawPacket>
+        for (auto key : toDelete)
         {
-            auto uniqueId = CalculateDrawPacketId(material, shaderItem);
-            auto drawPacket = GetDeferredDrawPacket(uniqueId);
+            m_deferredDrawPackets.erase(key);
+        }
+    }
 
-            // the deferred draw-packets don't really support rebuilding, so just create a new one
-            if (drawPacket == nullptr || drawPacket->NeedsRebuild())
-            {
+    auto DeferredDrawPacketManager::GetOrCreateDeferredDrawPacket(
+        RPI::Scene* scene, RPI::Material* material, const Name materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
+        -> Data::Instance<DeferredDrawPacket>
+    {
+        auto uniqueId = CalculateDrawPacketId(material, shaderItem);
+        auto drawPacket = GetDeferredDrawPacket(uniqueId);
+
+        // the deferred draw-packets don't really support rebuilding, so just create a new one
+        if (drawPacket == nullptr || drawPacket->NeedsRebuild())
+        {
             drawPacket = aznew DeferredDrawPacket{ this, scene, material, materialPipelineName, shaderItem, uniqueId };
 
-                m_deferredDrawPackets[uniqueId] = drawPacket;
-                m_drawListsWithDrawPackets[drawPacket->GetDrawListTag().GetIndex()] = true;
+            m_deferredDrawPackets[uniqueId] = drawPacket;
+            m_drawListsWithDrawPackets[drawPacket->GetDrawListTag().GetIndex()] = true;
 #ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
                 AZ_Info(
                     "DeferredDrawPacketManager",
@@ -93,7 +91,7 @@ namespace AZ
                     shaderItem.GetShaderAsset().GetHint().c_str(),
                     material->GetMaterialTypeId());
 #endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
-            }
+        }
 #ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
             else
             {
@@ -106,7 +104,7 @@ namespace AZ
                     material->GetMaterialTypeId());
             }
 #endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
+            drawPacket->IncreaseUseCount();
             return drawPacket;
-        }
-    } // namespace Render
-} // namespace AZ
+    }
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
@@ -20,11 +20,14 @@ namespace AZ
             shaderOptions.SetUnspecifiedToDefaultValues();
             auto requestedShaderVariantId = shaderOptions.GetShaderVariantId();
 
-            DeferredDrawPacketId seed{};
+        size_t seed{};
             AZStd::hash_combine(seed, material->GetMaterialTypeId());
             AZStd::hash_combine(seed, requestedShaderVariantId);
 
-            return seed;
+        // we use only the lower 32 bits, which should be enough
+        DeferredDrawPacketId drawPacketId(static_cast<uint32_t>(seed));
+
+        return drawPacketId;
         }
 
         auto DeferredDrawPacketManager::GetDeferredDrawPacket(DeferredDrawPacketId id) const -> Data::Instance<DeferredDrawPacket>
@@ -78,10 +81,7 @@ namespace AZ
             // the deferred draw-packets don't really support rebuilding, so just create a new one
             if (drawPacket == nullptr || drawPacket->NeedsRebuild())
             {
-                // reuse the drawPacketId if we recreate the drawpacket
-                auto drawPacketId = drawPacket ? drawPacket->GetDrawPacketId() : static_cast<int32_t>(m_deferredDrawPackets.size());
-
-                drawPacket = aznew DeferredDrawPacket{ this, scene, material, materialPipelineName, shaderItem, drawPacketId };
+            drawPacket = aznew DeferredDrawPacket{ this, scene, material, materialPipelineName, shaderItem, uniqueId };
 
                 m_deferredDrawPackets[uniqueId] = drawPacket;
                 m_drawListsWithDrawPackets[drawPacket->GetDrawListTag().GetIndex()] = true;

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Reflect/Shader/ShaderVariantKey.h>
+#include <DeferredMaterial/DeferredDrawPacketManager.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        auto DeferredDrawPacketManager::CalculateDrawPacketId(const RPI::Material* material, const RPI::ShaderCollection::Item& shaderItem)
+            -> DeferredDrawPacketId
+        {
+            RPI::ShaderOptionGroup shaderOptions = *shaderItem.GetShaderOptions();
+            shaderOptions.SetUnspecifiedToDefaultValues();
+            auto requestedShaderVariantId = shaderOptions.GetShaderVariantId();
+
+            DeferredDrawPacketId seed{};
+            AZStd::hash_combine(seed, material->GetMaterialTypeId());
+            AZStd::hash_combine(seed, requestedShaderVariantId);
+
+            return seed;
+        }
+
+        auto DeferredDrawPacketManager::GetDeferredDrawPacket(DeferredDrawPacketId id) const -> Data::Instance<DeferredDrawPacket>
+        {
+            if (HasDeferredDrawPacket(id))
+            {
+                return m_deferredDrawPackets.at(id);
+            }
+            return {};
+        }
+
+        bool DeferredDrawPacketManager::HasDeferredDrawPacket(DeferredDrawPacketId id) const
+        {
+            return m_deferredDrawPackets.contains(id);
+        }
+
+        bool DeferredDrawPacketManager::HasDrawPacketForDrawList(const RHI::DrawListTag tag) const
+        {
+            return m_drawListsWithDrawPackets[tag.GetIndex()];
+        }
+
+        void DeferredDrawPacketManager::PruneUnusedDrawPackets()
+        {
+            m_drawListsWithDrawPackets.reset();
+            AZStd::vector<DeferredDrawPacketId> toDelete;
+
+            for (auto& [key, data] : m_deferredDrawPackets)
+            {
+                if (data->GetUseCount() == 1 || !data->IsInitialized())
+                {
+                    toDelete.push_back(key);
+                }
+                else
+                {
+                    m_drawListsWithDrawPackets[data->GetDrawListTag().GetIndex()] = true;
+                }
+            }
+            for (auto key : toDelete)
+            {
+                m_deferredDrawPackets.erase(key);
+            }
+        }
+
+        auto DeferredDrawPacketManager::GetOrCreateDeferredDrawPacket(
+            RPI::Scene* scene, RPI::Material* material, const Name materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
+            -> Data::Instance<DeferredDrawPacket>
+        {
+            auto uniqueId = CalculateDrawPacketId(material, shaderItem);
+            auto drawPacket = GetDeferredDrawPacket(uniqueId);
+
+            // the deferred draw-packets don't really support rebuilding, so just create a new one
+            if (drawPacket == nullptr || drawPacket->NeedsRebuild())
+            {
+                // reuse the drawPacketId if we recreate the drawpacket
+                auto drawPacketId = drawPacket ? drawPacket->GetDrawPacketId() : static_cast<int32_t>(m_deferredDrawPackets.size());
+
+                drawPacket = aznew DeferredDrawPacket{ this, scene, material, materialPipelineName, shaderItem, drawPacketId };
+
+                m_deferredDrawPackets[uniqueId] = drawPacket;
+                m_drawListsWithDrawPackets[drawPacket->GetDrawListTag().GetIndex()] = true;
+#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
+                AZ_Info(
+                    "DeferredDrawPacketManager",
+                    "Material %s, shader %s: -> Create new draw-packet (MaterialTypeId %d)",
+                    material->GetAsset().GetHint().c_str(),
+                    shaderItem.GetShaderAsset().GetHint().c_str(),
+                    material->GetMaterialTypeId());
+#endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
+            }
+#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
+            else
+            {
+#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
+                AZ_Info(
+                    "DeferredDrawPacketManager",
+                    "Material %s, shader %s: -> Use draw-packet from Material %s (MaterialTypeId %d)",
+                    material->GetAsset().GetHint().c_str(),
+                    shaderItem.GetShaderAsset().GetHint().c_str(),
+                    drawPacket->GetInstigatingMaterialAsset().GetHint().c_str(),
+                    material->GetMaterialTypeId());
+#endif
+            }
+#endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
+            return drawPacket;
+        }
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+#include <DeferredMaterial/DeferredDrawPacket.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        // the DeferredDrawPacketManager holds all DeferredDrawPackets of the scene, and deduplicates
+        // the Drawpackets from the Meshes
+        class DeferredDrawPacketManager
+        {
+        public:
+            using DeferredDrawPacketId = size_t;
+
+            static auto CalculateDrawPacketId(const RPI::Material* material, const RPI::ShaderCollection::Item& shaderItem)
+                -> DeferredDrawPacketId;
+
+            auto GetDeferredDrawPacket(DeferredDrawPacketId id) const -> Data::Instance<DeferredDrawPacket>;
+
+            bool HasDeferredDrawPacket(DeferredDrawPacketId id) const;
+
+            auto GetOrCreateDeferredDrawPacket(
+                RPI::Scene* scene, RPI::Material* material, const Name materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
+                -> Data::Instance<DeferredDrawPacket>;
+
+            bool HasDrawPacketForDrawList(const RHI::DrawListTag tag) const;
+
+            auto GetDrawPackets() -> AZStd::unordered_map<DeferredDrawPacketId, Data::Instance<DeferredDrawPacket>>&
+            {
+                return m_deferredDrawPackets;
+            }
+            void SetNeedsUpdate(const bool needsUpdate)
+            {
+                m_needsUpdate = needsUpdate;
+            }
+            bool GetNeedsUpdate() const
+            {
+                return m_needsUpdate;
+            }
+
+            void PruneUnusedDrawPackets();
+
+            Data::Instance<RPI::ShaderResourceGroup> CreatePassSrg(RHI::DrawListTag drawListTag);
+
+        private:
+            AZStd::unordered_map<DeferredDrawPacketId, Data::Instance<DeferredDrawPacket>> m_deferredDrawPackets;
+            RHI::DrawListMask m_drawListsWithDrawPackets;
+            bool m_needsUpdate = false;
+        };
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.h
@@ -18,7 +18,7 @@ namespace AZ
         class DeferredDrawPacketManager
         {
         public:
-            using DeferredDrawPacketId = size_t;
+        using DeferredDrawPacketId = uint32_t;
 
             static auto CalculateDrawPacketId(const RPI::Material* material, const RPI::ShaderCollection::Item& shaderItem)
                 -> DeferredDrawPacketId;

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredDrawPacketManager.h
@@ -9,51 +9,48 @@
 #pragma once
 #include <DeferredMaterial/DeferredDrawPacket.h>
 
-namespace AZ
+namespace AZ::Render
 {
-    namespace Render
+    // the DeferredDrawPacketManager holds all DeferredDrawPackets of the scene, and deduplicates
+    // the Drawpackets from the Meshes
+    class DeferredDrawPacketManager
     {
-        // the DeferredDrawPacketManager holds all DeferredDrawPackets of the scene, and deduplicates
-        // the Drawpackets from the Meshes
-        class DeferredDrawPacketManager
-        {
-        public:
+    public:
         using DeferredDrawPacketId = uint32_t;
 
-            static auto CalculateDrawPacketId(const RPI::Material* material, const RPI::ShaderCollection::Item& shaderItem)
-                -> DeferredDrawPacketId;
+        static auto CalculateDrawPacketId(const RPI::Material* material, const RPI::ShaderCollection::Item& shaderItem)
+            -> DeferredDrawPacketId;
 
-            auto GetDeferredDrawPacket(DeferredDrawPacketId id) const -> Data::Instance<DeferredDrawPacket>;
+        auto GetDeferredDrawPacket(DeferredDrawPacketId id) const -> Data::Instance<DeferredDrawPacket>;
 
-            bool HasDeferredDrawPacket(DeferredDrawPacketId id) const;
+        bool HasDeferredDrawPacket(DeferredDrawPacketId id) const;
 
-            auto GetOrCreateDeferredDrawPacket(
-                RPI::Scene* scene, RPI::Material* material, const Name materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
-                -> Data::Instance<DeferredDrawPacket>;
+        auto GetOrCreateDeferredDrawPacket(
+            RPI::Scene* scene, RPI::Material* material, const Name materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
+            -> Data::Instance<DeferredDrawPacket>;
 
-            bool HasDrawPacketForDrawList(const RHI::DrawListTag tag) const;
+        bool HasDrawPacketForDrawList(const RHI::DrawListTag tag) const;
 
-            auto GetDrawPackets() -> AZStd::unordered_map<DeferredDrawPacketId, Data::Instance<DeferredDrawPacket>>&
-            {
-                return m_deferredDrawPackets;
-            }
-            void SetNeedsUpdate(const bool needsUpdate)
-            {
-                m_needsUpdate = needsUpdate;
-            }
-            bool GetNeedsUpdate() const
-            {
-                return m_needsUpdate;
-            }
+        auto GetDrawPackets() -> AZStd::unordered_map<DeferredDrawPacketId, Data::Instance<DeferredDrawPacket>>&
+        {
+            return m_deferredDrawPackets;
+        }
+        void SetNeedsUpdate(const bool needsUpdate)
+        {
+            m_needsUpdate = needsUpdate;
+        }
+        bool GetNeedsUpdate() const
+        {
+            return m_needsUpdate;
+        }
 
-            void PruneUnusedDrawPackets();
+        void PruneUnusedDrawPackets();
 
-            Data::Instance<RPI::ShaderResourceGroup> CreatePassSrg(RHI::DrawListTag drawListTag);
+        Data::Instance<RPI::ShaderResourceGroup> CreatePassSrg(RHI::DrawListTag drawListTag);
 
-        private:
-            AZStd::unordered_map<DeferredDrawPacketId, Data::Instance<DeferredDrawPacket>> m_deferredDrawPackets;
-            RHI::DrawListMask m_drawListsWithDrawPackets;
-            bool m_needsUpdate = false;
-        };
-    } // namespace Render
-} // namespace AZ
+    private:
+        AZStd::unordered_map<DeferredDrawPacketId, Data::Instance<DeferredDrawPacket>> m_deferredDrawPackets;
+        RHI::DrawListMask m_drawListsWithDrawPackets;
+        bool m_needsUpdate = false;
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "DeferredMaterialFeatureProcessor.h"
+#include <Atom/Feature/RenderCommon.h>
+#include <Atom/RHI/RHIUtils.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Mesh/MeshFeatureProcessor.h>
+
+namespace AZ::Render
+{
+
+    AZ_CVAR(
+        bool,
+        r_deferredRenderingEnabled,
+        false,
+        nullptr,
+        AZ::ConsoleFunctorFlags::Null,
+        "Enable deferred material draw calls in the MeshFeatureProcessor and the DeferredMaterialFeatureProcessor.");
+
+    constexpr static size_t MeshInfoMinEntries = 32;
+
+    // Helper class that iterates over all meshes in all lods of either a RPI::Model or a DeferredMaterialFeatureProcessor::ModelData.
+    class MeshIterator
+    {
+    public:
+        static void ForEachLodMesh(
+            const Data::Instance<RPI::Model>& model,
+            AZStd::function<bool(const uint32_t, const uint32_t, const RPI::ModelLodAsset::Mesh&, const RPI::ModelLod::Mesh&)> callback)
+        {
+            const auto& modelAsset = model->GetModelAsset();
+            const AZStd::span<const Data::Asset<RPI::ModelLodAsset>>& modelLodAssets = modelAsset->GetLodAssets();
+            const AZStd::span<const Data::Instance<RPI::ModelLod>>& modelLods = model->GetLods();
+            const auto lodCount = static_cast<uint32_t>(model->GetLodCount());
+
+            for (auto lod = 0; lod < lodCount; lod++)
+            {
+                const Data::Instance<RPI::ModelLod>& modelLod = modelLods[lod];
+                const Data::Asset<RPI::ModelLodAsset>& modelLodAsset = modelLodAssets[lod];
+                const auto meshCount = static_cast<uint32_t>(modelLodAsset->GetMeshes().size());
+
+                for (uint32_t meshIndex = 0; meshIndex < meshCount; ++meshIndex)
+                {
+                    const auto assetMeshes = modelLodAsset->GetMeshes();
+                    const RPI::ModelLodAsset::Mesh& assetMesh = assetMeshes[meshIndex];
+
+                    const auto meshes = modelLod->GetMeshes();
+                    const RPI::ModelLod::Mesh& mesh = meshes[meshIndex];
+
+                    if (!callback(lod, meshIndex, assetMesh, mesh))
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+
+        static void ForEachLodMesh(
+            DeferredMaterialFeatureProcessor::ModelData& modelData,
+            AZStd::function<bool(
+                const uint32_t, const uint32_t, DeferredMaterialFeatureProcessor::ModelData&, DeferredMaterialFeatureProcessor::MeshData&)>
+                callback)
+        {
+            auto lodCount = static_cast<uint32_t>(modelData.m_lodData.size());
+            for (auto lod = 0; lod < lodCount; lod++)
+            {
+                auto& modelLodData = modelData.m_lodData[lod];
+                auto meshCount = static_cast<uint32_t>(modelLodData.m_meshData.size());
+                for (auto meshIndex = 0; meshIndex < meshCount; meshIndex++)
+                {
+                    auto& mesh = modelLodData.m_meshData[meshIndex];
+                    if (!callback(lod, meshIndex, modelData, mesh))
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+    };
+
+    void DeferredMaterialFeatureProcessor::Reflect(ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+        {
+            serializeContext->Class<DeferredMaterialFeatureProcessor, FeatureProcessor>()->Version(1);
+        }
+    }
+
+    template<typename T>
+    void CreateOrResizeBuffer(Data::Instance<RPI::Buffer>& buffer, const AZStd::string& name, const size_t minNumEntries)
+    {
+        // we need one entry per meshinfo-entry, so we can use the same Min number of entries
+        const auto numEntries = AlignUpToPowerOfTwo(AZStd::max(minNumEntries, MeshInfoMinEntries));
+        auto constexpr elementSize = sizeof(T);
+        auto const bufferSize = numEntries * elementSize;
+
+        if (buffer == nullptr)
+        {
+            // Create an empty RPI buffer, it will be updated with data later
+            AZ::RPI::CommonBufferDescriptor desc;
+            //! Note: If this buffer is bound to a StructuredBuffer, the format has to be unknown.
+            //! or we get the error message Buffer Input 'm_meshInfoBuffer[0]': Does not match expected type 'Structured'
+            desc.m_elementFormat = AZ::RHI::Format::Unknown;
+            //! needs to be ReadWrite, or it can't be bound to RPI Slots for some reason
+            desc.m_poolType = AZ::RPI::CommonBufferPoolType::ReadWrite;
+            desc.m_elementSize = static_cast<uint32_t>(elementSize);
+            desc.m_bufferName = name;
+            // allocate size for a few objects
+            desc.m_byteCount = bufferSize;
+            buffer = AZ::RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
+        }
+        else if (buffer->GetBufferSize() < bufferSize)
+        {
+            buffer->Resize(bufferSize);
+        }
+    }
+
+    RPI::RingBuffer& DeferredMaterialFeatureProcessor::GetOrCreateDrawPacketIdRingBuffer(const RHI::DrawListTag& drawListTag)
+    {
+        auto ringBufferIt = m_drawPacketIdBuffers.find(drawListTag);
+        if (ringBufferIt == m_drawPacketIdBuffers.end())
+        {
+            auto tagRegistry = RHI::GetDrawListTagRegistry();
+            auto name = AZStd::string::format("drawPacketIdBuffer_%s", tagRegistry->GetName(drawListTag).GetCStr());
+            auto [newIt, inserted] = m_drawPacketIdBuffers.emplace(
+                AZStd::make_pair(drawListTag, RPI::RingBuffer{ name, RPI::CommonBufferPoolType::ReadOnly, RHI::Format::R32_SINT }));
+            return newIt->second;
+        }
+        return ringBufferIt->second;
+    }
+
+    void DeferredMaterialFeatureProcessor::UpdateDrawPacketIdBuffers()
+    {
+        // figure out which drawListTags are currently in use
+        auto tagRegistry = RHI::GetDrawListTagRegistry();
+        AZStd::vector<RHI::DrawListTag> drawListTags;
+
+        tagRegistry->VisitTags(
+            [&](AZ::Name drawListTagName, RHI::DrawListTag tag)
+            {
+                if (m_drawPacketManager.HasDrawPacketForDrawList(tag))
+                {
+                    drawListTags.emplace_back(tag);
+                }
+            });
+
+        auto* mfp = GetParentScene()->GetFeatureProcessor<MeshFeatureProcessor>();
+        const auto numEntries = AZStd::max(mfp->GetMeshInfoManager().GetMaxMeshInfoIndex(), 1);
+
+        // create one entry per mesh for each DrawListTag
+        for (auto& drawListTag : drawListTags)
+        {
+            AZStd::vector<int32_t> drawPacketIds;
+            drawPacketIds.resize(numEntries, -1);
+            for (auto& [modelId, modelData] : m_modelData)
+            {
+                MeshIterator::ForEachLodMesh(
+                    modelData,
+                    [&, drawListTag = drawListTag](
+                        const uint32_t lod,
+                        const uint32_t meshIndex,
+                        DeferredMaterialFeatureProcessor::ModelData& modelData,
+                        DeferredMaterialFeatureProcessor::MeshData& meshData)
+                    {
+                        auto drawPacket = meshData.m_meshDrawPacket.GetDeferredDrawPacket(drawListTag);
+                        if (drawPacket)
+                        {
+                            drawPacketIds[meshData.m_meshInfoIndex] = drawPacket->GetDrawPacketId();
+                        }
+                        else
+                        {
+                            drawPacketIds[meshData.m_meshInfoIndex] = -1;
+                        }
+                        return true;
+                    });
+            }
+
+            GetOrCreateDrawPacketIdRingBuffer(drawListTag).AdvanceCurrentBufferAndUpdateData(drawPacketIds);
+        }
+    }
+
+    void DeferredMaterialFeatureProcessor::AddModel(
+        const ModelId& modelId, ModelDataInstanceInterface* meshHandle, const Data::Instance<RPI::Model>& model)
+    {
+        if (!m_enabled)
+        {
+            return;
+        }
+
+        AZStd::scoped_lock lock(m_updateMutex);
+
+        if (m_modelData.find(modelId) != m_modelData.end())
+        {
+            return;
+        }
+
+        auto& modelData = m_modelData[modelId];
+        if (modelData.m_lodData.empty())
+        {
+            modelData.m_lodData.resize(model->GetLodCount());
+        }
+
+        m_needsUpdate = true;
+
+        MeshIterator::ForEachLodMesh(
+            model,
+            [&](const uint32_t lod, const uint32_t meshIndex, const RPI::ModelLodAsset::Mesh& assetMesh, const RPI::ModelLod::Mesh& mesh)
+            {
+                auto& modelLodData = modelData.m_lodData[lod];
+
+                // retrieve the material
+                const CustomMaterialId customMaterialId(lod, mesh.m_materialSlotStableId);
+                const auto& customMaterialInfo = meshHandle->GetCustomMaterialWithFallback(customMaterialId);
+
+                const auto modelLod = model->GetLods()[lod];
+
+                auto drawPacket = DeferredMeshDrawPacket{ modelLod, meshIndex, customMaterialInfo.m_material };
+
+                modelLodData.m_meshData.emplace_back(MeshData{ meshHandle->GetMeshInfoIndex(lod, meshIndex), drawPacket });
+                return true;
+            });
+    }
+
+    void DeferredMaterialFeatureProcessor::RemoveModel(const ModelId& modelId)
+    {
+        if (!m_enabled)
+        {
+            return;
+        }
+
+        AZStd::scoped_lock lock(m_updateMutex);
+
+        if (m_modelData.find(modelId) != m_modelData.end())
+        {
+            m_modelData.erase(modelId);
+        }
+        m_needsUpdate = true;
+    }
+
+    AZ::Data::Instance<AZ::RPI::Buffer> DeferredMaterialFeatureProcessor::GetDrawPacketIdBuffer(const RHI::DrawListTag& drawListTag)
+    {
+        auto bufferIt = m_drawPacketIdBuffers.find(drawListTag);
+        if (bufferIt != m_drawPacketIdBuffers.end() && bufferIt->second.IsCurrentBufferValid())
+        {
+            return bufferIt->second.GetCurrentBuffer();
+        }
+        return nullptr;
+    }
+
+    void DeferredMaterialFeatureProcessor::UpdateMeshDrawPackets(bool forceRebuild)
+    {
+        for (auto& [modelId, modelData] : m_modelData)
+        {
+            MeshIterator::ForEachLodMesh(
+                modelData,
+                [&](const uint32_t lod,
+                    const uint32_t meshIndex,
+                    DeferredMaterialFeatureProcessor::ModelData& modelData,
+                    DeferredMaterialFeatureProcessor::MeshData& meshData)
+                {
+                    meshData.m_meshDrawPacket.Update(GetParentScene(), &m_drawPacketManager, forceRebuild);
+                    return true;
+                });
+        }
+    }
+
+    void DeferredMaterialFeatureProcessor::Render(const RenderPacket& renderPacket)
+    {
+        if (!m_enabled)
+        {
+            return;
+        }
+
+        if (m_needsUpdate || m_drawPacketManager.GetNeedsUpdate() || m_forceRebuild)
+        {
+            // Refresh the references from the MeshDrawPacket to the DeferredDrawPackets and create them on demand
+            UpdateMeshDrawPackets(m_forceRebuild);
+
+            // Remove DeferredDrawPackets that aren't referenced anymore
+            m_drawPacketManager.PruneUnusedDrawPackets();
+
+            // recreate the drawPacketId - buffers: This needs the draw-Packet ID from the prepared draw Packets
+            UpdateDrawPacketIdBuffers();
+
+            // Finalize the deferred draw-packets: This needs the drawPacket ID buffer in the Draw-Srg
+            UpdateDrawSrgs();
+            m_needsUpdate = false;
+            m_forceRebuild = false;
+            m_drawPacketManager.SetNeedsUpdate(false);
+
+#ifdef DEFERRED_DRAWPACKET_DEBUG_PRINT
+            AZ_Info(
+                "DeferredMaterialFeatureProcessor",
+                "Currently %lld active deferred draw-packets",
+                m_drawPacketManager.GetDrawPackets().size());
+            for (auto& [unique_id, drawPacket] : m_drawPacketManager.GetDrawPackets())
+            {
+                AZ_Info(
+                    "DeferredMaterialFeatureProcessor",
+                    "    Id %lld, MaterialType %s, Instigating Material %s",
+                    unique_id,
+                    drawPacket->GetInstigatingMaterialTypeAsset().GetHint().c_str(),
+                    drawPacket->GetInstigatingMaterialAsset().GetHint().c_str());
+            }
+#endif /* DEFERRED_DRAWPACKET_DEBUG_PRINT */
+        }
+
+        for (const AZ::RPI::ViewPtr& view : renderPacket.m_views)
+        {
+            if (view->GetUsageFlags() & AZ::RPI::View::UsageCamera)
+            {
+                for (auto& [_, drawPacket] : m_drawPacketManager.GetDrawPackets())
+                {
+                    auto rhiDrawPacket = drawPacket->GetRHIDrawPacket();
+                    if (rhiDrawPacket)
+                    {
+                        view->AddDrawPacket(rhiDrawPacket);
+                    }
+                }
+            }
+        }
+    }
+
+    void DeferredMaterialFeatureProcessor::OnRenderPipelineChanged(
+        RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType)
+    {
+        // force a rebuild of the draw packets and update the buffers
+        m_forceRebuild = true;
+    }
+
+    void DeferredMaterialFeatureProcessor::UpdateDrawSrgs()
+    {
+        for (auto& [key, drawPacketData] : m_drawPacketManager.GetDrawPackets())
+        {
+            auto drawListTag = drawPacketData->GetDrawListTag();
+            drawPacketData->CompileDrawSrg(GetDrawPacketIdBuffer(drawListTag));
+        }
+    }
+
+    void DeferredMaterialFeatureProcessor::Activate()
+    {
+        if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
+        {
+            console->GetCvarValue("r_deferredRenderingEnabled", m_enabled);
+        }
+        if (m_enabled)
+        {
+            m_handleGlobalShaderOptionUpdate =
+                RPI::ShaderSystemInterface::GlobalShaderOptionUpdatedEvent::Handler{ [this](const AZ::Name&, RPI::ShaderOptionValue)
+                                                                                     {
+                                                                                         m_forceRebuild = true;
+                                                                                     } };
+            RPI::ShaderSystemInterface::Get()->Connect(m_handleGlobalShaderOptionUpdate);
+
+            EnableSceneNotification();
+        }
+    }
+
+    void DeferredMaterialFeatureProcessor::Deactivate()
+    {
+        if (m_enabled)
+        {
+            DisableSceneNotification();
+        }
+    }
+
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
@@ -128,7 +128,7 @@ namespace AZ::Render
             auto tagRegistry = RHI::GetDrawListTagRegistry();
             auto name = AZStd::string::format("drawPacketIdBuffer_%s", tagRegistry->GetName(drawListTag).GetCStr());
             auto [newIt, inserted] = m_drawPacketIdBuffers.emplace(
-                AZStd::make_pair(drawListTag, RPI::RingBuffer{ name, RPI::CommonBufferPoolType::ReadOnly, RHI::Format::R32_SINT }));
+                AZStd::make_pair(drawListTag, RPI::RingBuffer{ name, RPI::CommonBufferPoolType::ReadOnly, RHI::Format::R32_UINT }));
             return newIt->second;
         }
         return ringBufferIt->second;
@@ -155,7 +155,7 @@ namespace AZ::Render
         // create one entry per mesh for each DrawListTag
         for (auto& drawListTag : drawListTags)
         {
-            AZStd::vector<int32_t> drawPacketIds;
+            AZStd::vector<uint32_t> drawPacketIds;
             drawPacketIds.resize(numEntries, -1);
             for (auto& [modelId, modelData] : m_modelData)
             {
@@ -174,7 +174,7 @@ namespace AZ::Render
                         }
                         else
                         {
-                            drawPacketIds[meshData.m_meshInfoIndex] = -1;
+                            drawPacketIds[meshData.m_meshInfoIndex] = AZStd::numeric_limits<uint32_t>::max();
                         }
                         return true;
                     });
@@ -224,7 +224,7 @@ namespace AZ::Render
 
                 auto drawPacket = DeferredMeshDrawPacket{ modelLod, meshIndex, customMaterialInfo.m_material };
 
-                modelLodData.m_meshData.emplace_back(MeshData{ meshHandle->GetMeshInfoIndex(lod, meshIndex), drawPacket });
+                modelLodData.m_meshData.emplace_back(MeshData{ meshHandle->GetMeshInfoIndex(lod, meshIndex), AZStd::move(drawPacket) });
                 return true;
             });
     }
@@ -238,10 +238,13 @@ namespace AZ::Render
 
         AZStd::scoped_lock lock(m_updateMutex);
 
-        if (m_modelData.find(modelId) != m_modelData.end())
+        auto modelDataIter = m_modelData.find(modelId);
+
+        if (modelDataIter != m_modelData.end())
         {
-            m_modelData.erase(modelId);
+            m_modelData.erase(modelDataIter);
         }
+
         m_needsUpdate = true;
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
@@ -38,7 +38,7 @@ namespace AZ::Render
             const AZStd::span<const Data::Instance<RPI::ModelLod>>& modelLods = model->GetLods();
             const auto lodCount = static_cast<uint32_t>(model->GetLodCount());
 
-            for (auto lod = 0; lod < lodCount; lod++)
+            for (auto lod = 0u; lod < lodCount; lod++)
             {
                 const Data::Instance<RPI::ModelLod>& modelLod = modelLods[lod];
                 const Data::Asset<RPI::ModelLodAsset>& modelLodAsset = modelLodAssets[lod];
@@ -67,11 +67,11 @@ namespace AZ::Render
                 callback)
         {
             auto lodCount = static_cast<uint32_t>(modelData.m_lodData.size());
-            for (auto lod = 0; lod < lodCount; lod++)
+            for (auto lod = 0u; lod < lodCount; lod++)
             {
                 auto& modelLodData = modelData.m_lodData[lod];
                 auto meshCount = static_cast<uint32_t>(modelLodData.m_meshData.size());
-                for (auto meshIndex = 0; meshIndex < meshCount; meshIndex++)
+                for (auto meshIndex = 0u; meshIndex < meshCount; meshIndex++)
                 {
                     auto& mesh = modelLodData.m_meshData[meshIndex];
                     if (!callback(lod, meshIndex, modelData, mesh))
@@ -141,7 +141,7 @@ namespace AZ::Render
         AZStd::vector<RHI::DrawListTag> drawListTags;
 
         tagRegistry->VisitTags(
-            [&](AZ::Name drawListTagName, RHI::DrawListTag tag)
+            [&]([[maybe_unused]] AZ::Name drawListTagName, RHI::DrawListTag tag)
             {
                 if (m_drawPacketManager.HasDrawPacketForDrawList(tag))
                 {
@@ -162,9 +162,9 @@ namespace AZ::Render
                 MeshIterator::ForEachLodMesh(
                     modelData,
                     [&, drawListTag = drawListTag](
-                        const uint32_t lod,
-                        const uint32_t meshIndex,
-                        DeferredMaterialFeatureProcessor::ModelData& modelData,
+                        [[maybe_unused]] const uint32_t lod,
+                        [[maybe_unused]] const uint32_t meshIndex,
+                        [[maybe_unused]] DeferredMaterialFeatureProcessor::ModelData& modelData,
                         DeferredMaterialFeatureProcessor::MeshData& meshData)
                     {
                         auto drawPacket = meshData.m_meshDrawPacket.GetDeferredDrawPacket(drawListTag);
@@ -209,7 +209,10 @@ namespace AZ::Render
 
         MeshIterator::ForEachLodMesh(
             model,
-            [&](const uint32_t lod, const uint32_t meshIndex, const RPI::ModelLodAsset::Mesh& assetMesh, const RPI::ModelLod::Mesh& mesh)
+            [&](const uint32_t lod,
+                const uint32_t meshIndex,
+                [[maybe_unused]] const RPI::ModelLodAsset::Mesh& assetMesh,
+                const RPI::ModelLod::Mesh& mesh)
             {
                 auto& modelLodData = modelData.m_lodData[lod];
 
@@ -258,9 +261,9 @@ namespace AZ::Render
         {
             MeshIterator::ForEachLodMesh(
                 modelData,
-                [&](const uint32_t lod,
-                    const uint32_t meshIndex,
-                    DeferredMaterialFeatureProcessor::ModelData& modelData,
+                [&]([[maybe_unused]] const uint32_t lod,
+                    [[maybe_unused]] const uint32_t meshIndex,
+                    [[maybe_unused]] DeferredMaterialFeatureProcessor::ModelData& modelData,
                     DeferredMaterialFeatureProcessor::MeshData& meshData)
                 {
                     meshData.m_meshDrawPacket.Update(GetParentScene(), &m_drawPacketManager, forceRebuild);
@@ -327,7 +330,7 @@ namespace AZ::Render
     }
 
     void DeferredMaterialFeatureProcessor::OnRenderPipelineChanged(
-        RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType)
+        [[maybe_unused]] RPI::RenderPipeline* renderPipeline, [[maybe_unused]] RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
         // force a rebuild of the draw packets and update the buffers
         m_forceRebuild = true;

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
@@ -156,7 +156,7 @@ namespace AZ::Render
         for (auto& drawListTag : drawListTags)
         {
             AZStd::vector<uint32_t> drawPacketIds;
-            drawPacketIds.resize(numEntries, -1);
+            drawPacketIds.resize(numEntries, AZStd::numeric_limits<uint32_t>::max());
             for (auto& [modelId, modelData] : m_modelData)
             {
                 MeshIterator::ForEachLodMesh(

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMaterialFeatureProcessor.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/DeferredMaterial/DeferredMaterialFeatureProcessorInterface.h>
+
+#include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
+#include <DeferredMaterial/DeferredDrawPacketManager.h>
+#include <DeferredMaterial/DeferredMeshDrawPacket.h>
+
+#include <Atom/RHI.Reflect/FrameCountMaxRingBuffer.h>
+#include <Atom/RPI.Public/Material/PersistentIndexAllocator.h>
+#include <Atom/RPI.Public/PipelineState.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Reflect/Shader/ShaderVariantKey.h>
+
+namespace AZ::Render
+{
+    class MeshIterator;
+
+    //! This feature processor manages Deferred DrawPackages for a Scene
+    class DeferredMaterialFeatureProcessor : public DeferredMaterialFeatureProcessorInterface
+    {
+        friend class MeshIterator;
+
+    public:
+        AZ_CLASS_ALLOCATOR(DeferredMaterialFeatureProcessor, AZ::SystemAllocator)
+
+        using ModelId = DeferredMaterialFeatureProcessorInterface::ModelId;
+        using MaterialTypeShaderId = AZStd::pair<int32_t, RPI::ShaderVariantId>;
+
+        AZ_RTTI(
+            AZ::Render::DeferredMaterialFeatureProcessor,
+            "{9CA50AFC-206B-4F8A-80E8-2592CF1244B0}",
+            AZ::Render::DeferredMaterialFeatureProcessorInterface);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        DeferredMaterialFeatureProcessor() = default;
+        virtual ~DeferredMaterialFeatureProcessor() = default;
+
+        //! Create a deferred draw-item for the referenced material types, if they don't exist yet
+        void AddModel(const ModelId& uuid, ModelDataInstanceInterface* meshHandle, const Data::Instance<RPI::Model>& model) override;
+
+        //! Removes a mesh and potentially the draw-item for the material type.
+        void RemoveModel(const ModelId& uuid) override;
+
+        //! A buffer with the DrawPacketId for the given deferred DrawListTag.
+        //! This buffer contains one entry for every mesh in the scene, with the id of the deferred fullscreen-DrawItem that is
+        //! responsible for that mesh. The buffer is kept in sync with the MeshInfoBuffer, and can be indexed using the meshInfoIndex.
+        AZ::Data::Instance<AZ::RPI::Buffer> GetDrawPacketIdBuffer(const RHI::DrawListTag& drawListTag) override;
+
+        //! Wheter Deferred rendering was enabled at startup, controlled by CVAR r_deferredRenderingEnabled
+        bool IsEnabled() override
+        {
+            return m_enabled;
+        }
+
+        // FeatureProcessor overrides
+        void Activate() override;
+        void Deactivate() override;
+        void Render(const RenderPacket&) override;
+        void OnRenderPipelineChanged(
+            RPI::RenderPipeline* renderPipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
+
+    private:
+        AZ_DISABLE_COPY_MOVE(DeferredMaterialFeatureProcessor);
+
+        DeferredDrawPacketManager m_drawPacketManager;
+
+        struct MeshData
+        {
+            int32_t m_meshInfoIndex;
+            DeferredMeshDrawPacket m_meshDrawPacket;
+        };
+
+        struct ModelLodData
+        {
+            AZStd::vector<MeshData> m_meshData;
+        };
+
+        struct ModelData
+        {
+            AZStd::vector<ModelLodData> m_lodData;
+        };
+
+        RPI::RingBuffer& GetOrCreateDrawPacketIdRingBuffer(const RHI::DrawListTag& drawListTag);
+        void UpdateMeshDrawPackets(bool forceRebuild);
+        void UpdateDrawPacketIdBuffers();
+        void UpdateDrawSrgs();
+
+        AZStd::unordered_map<ModelId, ModelData> m_modelData;
+
+        AZStd::unordered_map<RHI::DrawListTag, RPI::RingBuffer> m_drawPacketIdBuffers;
+
+        AZ::RPI::ShaderSystemInterface::GlobalShaderOptionUpdatedEvent::Handler m_handleGlobalShaderOptionUpdate;
+
+        bool m_needsUpdate = false;
+        bool m_forceRebuild = false;
+        bool m_enabled = false;
+        AZStd::mutex m_updateMutex;
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RPI.Public/Material/Material.h>
+#include <DeferredMaterial/DeferredMeshDrawPacket.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+
+        DeferredMeshDrawPacket::DeferredMeshDrawPacket(
+            Data::Instance<RPI::ModelLod> modelLod, size_t modelLodMeshIndex, Data::Instance<RPI::Material> materialOverride)
+        {
+            m_modelLod = modelLod;
+            m_modelLodMeshIndex = modelLodMeshIndex;
+
+            if (materialOverride != nullptr)
+            {
+                m_material = materialOverride;
+            }
+            else
+            {
+                const RPI::ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[modelLodMeshIndex];
+                m_material = mesh.m_material;
+            }
+        }
+
+        auto DeferredMeshDrawPacket::GetDeferredDrawPacket(const RHI::DrawListTag& drawListTag) -> RHI::Ptr<DeferredDrawPacket>
+        {
+            if (m_deferredDrawPackets.contains(drawListTag))
+            {
+                return m_deferredDrawPackets.at(drawListTag);
+            }
+            return {};
+        }
+
+        void DeferredMeshDrawPacket::Update(RPI::Scene* scene, DeferredDrawPacketManager* manager, bool forceRebuild)
+        {
+            if (m_materialChangeId == m_material->GetCurrentChangeId() && forceRebuild == false)
+            {
+                return;
+            }
+
+            // This doesn't mean the draw-packets will be recreated, since the manager keeps a reference to them
+            // But if our material changed sufficiently enough, we will get a new one
+            m_deferredDrawPackets.clear();
+
+            m_material->ApplyGlobalShaderOptions();
+
+            m_material->ForAllShaderItems(
+                [&](const Name& materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
+                {
+                    if (shaderItem.IsEnabled() && shaderItem.GetDrawItemType() == RPI::ShaderCollection::Item::DrawItemType::Deferred)
+                    {
+                        auto deferredDrawPacket =
+                            manager->GetOrCreateDeferredDrawPacket(scene, m_material.get(), materialPipelineName, shaderItem);
+                        m_deferredDrawPackets[deferredDrawPacket->GetDrawListTag()] = deferredDrawPacket;
+                    }
+                    return true;
+                });
+            m_materialChangeId = m_material->GetCurrentChangeId();
+            return;
+        }
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.cpp
@@ -9,64 +9,73 @@
 #include <Atom/RPI.Public/Material/Material.h>
 #include <DeferredMaterial/DeferredMeshDrawPacket.h>
 
-namespace AZ
+namespace AZ::Render
 {
-    namespace Render
+    DeferredMeshDrawPacket::DeferredMeshDrawPacket(
+        Data::Instance<RPI::ModelLod> modelLod, size_t modelLodMeshIndex, Data::Instance<RPI::Material> materialOverride)
     {
+        m_modelLod = modelLod;
+        m_modelLodMeshIndex = modelLodMeshIndex;
 
-        DeferredMeshDrawPacket::DeferredMeshDrawPacket(
-            Data::Instance<RPI::ModelLod> modelLod, size_t modelLodMeshIndex, Data::Instance<RPI::Material> materialOverride)
+        if (materialOverride != nullptr)
         {
-            m_modelLod = modelLod;
-            m_modelLodMeshIndex = modelLodMeshIndex;
-
-            if (materialOverride != nullptr)
-            {
-                m_material = materialOverride;
-            }
-            else
-            {
-                const RPI::ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[modelLodMeshIndex];
-                m_material = mesh.m_material;
-            }
+            m_material = materialOverride;
         }
-
-        auto DeferredMeshDrawPacket::GetDeferredDrawPacket(const RHI::DrawListTag& drawListTag) -> RHI::Ptr<DeferredDrawPacket>
+        else
         {
-            if (m_deferredDrawPackets.contains(drawListTag))
-            {
-                return m_deferredDrawPackets.at(drawListTag);
-            }
-            return {};
+            const RPI::ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[modelLodMeshIndex];
+            m_material = mesh.m_material;
         }
+    }
 
-        void DeferredMeshDrawPacket::Update(RPI::Scene* scene, DeferredDrawPacketManager* manager, bool forceRebuild)
+    DeferredMeshDrawPacket::~DeferredMeshDrawPacket()
+    {
+        for (auto& drawPacket : m_deferredDrawPackets)
         {
-            if (m_materialChangeId == m_material->GetCurrentChangeId() && forceRebuild == false)
-            {
-                return;
-            }
+            drawPacket.second->DecreaseUseCount();
+        }
+        m_deferredDrawPackets.clear();
+    }
 
-            // This doesn't mean the draw-packets will be recreated, since the manager keeps a reference to them
-            // But if our material changed sufficiently enough, we will get a new one
-            m_deferredDrawPackets.clear();
+    auto DeferredMeshDrawPacket::GetDeferredDrawPacket(const RHI::DrawListTag& drawListTag) -> RHI::Ptr<DeferredDrawPacket>
+    {
+        if (m_deferredDrawPackets.contains(drawListTag))
+        {
+            return m_deferredDrawPackets.at(drawListTag);
+        }
+        return {};
+    }
 
-            m_material->ApplyGlobalShaderOptions();
-
-            m_material->ForAllShaderItems(
-                [&](const Name& materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
-                {
-                    if (shaderItem.IsEnabled() && shaderItem.GetDrawItemType() == RPI::ShaderCollection::Item::DrawItemType::Deferred)
-                    {
-                        auto deferredDrawPacket =
-                            manager->GetOrCreateDeferredDrawPacket(scene, m_material.get(), materialPipelineName, shaderItem);
-                        m_deferredDrawPackets[deferredDrawPacket->GetDrawListTag()] = deferredDrawPacket;
-                    }
-                    return true;
-                });
-            m_materialChangeId = m_material->GetCurrentChangeId();
+    void DeferredMeshDrawPacket::Update(RPI::Scene* scene, DeferredDrawPacketManager* manager, bool forceRebuild)
+    {
+        if (m_materialChangeId == m_material->GetCurrentChangeId() && forceRebuild == false)
+        {
             return;
         }
 
-    } // namespace Render
-} // namespace AZ
+        // This doesn't mean the draw-packets will be recreated, since the manager keeps a reference to them
+        // But if our material changed sufficiently enough, we will get a new one
+        for (auto& drawPacket : m_deferredDrawPackets)
+        {
+            drawPacket.second->DecreaseUseCount();
+        }
+        m_deferredDrawPackets.clear();
+
+        m_material->ApplyGlobalShaderOptions();
+
+        m_material->ForAllShaderItems(
+            [&](const Name& materialPipelineName, const RPI::ShaderCollection::Item& shaderItem)
+            {
+                if (shaderItem.IsEnabled() && shaderItem.GetDrawItemType() == RPI::ShaderCollection::Item::DrawItemType::Deferred)
+                {
+                    auto deferredDrawPacket =
+                        manager->GetOrCreateDeferredDrawPacket(scene, m_material.get(), materialPipelineName, shaderItem);
+                    m_deferredDrawPackets[deferredDrawPacket->GetDrawListTag()] = deferredDrawPacket;
+                }
+                return true;
+            });
+        m_materialChangeId = m_material->GetCurrentChangeId();
+        return;
+    }
+
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.h
@@ -1,0 +1,48 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Public/Model/ModelLod.h>
+#include <DeferredMaterial/DeferredDrawPacket.h>
+#include <DeferredMaterial/DeferredDrawPacketManager.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        // the DeferredMeshDrawPacket is not a draw-packet as such, but it holds a reference to the actual
+        // deferred Drawpacket for the Material, since that is generally shared between multiple meshes
+        // We use the reference count to figure out if the DeferredDrawPacket is still needed.
+        class DeferredMeshDrawPacket
+        {
+        public:
+            DeferredMeshDrawPacket() = default;
+            DeferredMeshDrawPacket(
+                Data::Instance<RPI::ModelLod> modelLod, size_t modelLodMeshIndex, Data::Instance<RPI::Material> materialOverride);
+
+            AZ_DEFAULT_COPY(DeferredMeshDrawPacket);
+            AZ_DEFAULT_MOVE(DeferredMeshDrawPacket);
+
+            auto GetDeferredDrawPacket(const RHI::DrawListTag& drawList) -> Data::Instance<DeferredDrawPacket>;
+
+            void Update(RPI::Scene* scene, DeferredDrawPacketManager* manager, bool forceRebuild);
+
+        private:
+            // a mesh can have a DeferredDrawPacket for multiple DrawListTags
+            AZStd::unordered_map<RHI::DrawListTag, Data::Instance<DeferredDrawPacket>> m_deferredDrawPackets;
+            Data::Instance<RPI::ModelLod> m_modelLod;
+            size_t m_modelLodMeshIndex;
+            Data::Instance<RPI::Material> m_material;
+            // Tracks whether the Material has change since the DrawPacket was last built
+            RPI::Material::ChangeId m_materialChangeId = RPI::Material::DEFAULT_CHANGE_ID;
+        };
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DeferredMaterial/DeferredMeshDrawPacket.h
@@ -13,36 +13,40 @@
 #include <DeferredMaterial/DeferredDrawPacket.h>
 #include <DeferredMaterial/DeferredDrawPacketManager.h>
 
-namespace AZ
+namespace AZ::Render
 {
-    namespace Render
+    // the DeferredMeshDrawPacket is not a draw-packet as such, but it holds a reference to the actual
+    // deferred Drawpacket for the Material, since that is generally shared between multiple meshes
+    // We use the reference count to figure out if the DeferredDrawPacket is still needed.
+    class DeferredMeshDrawPacket
     {
-        // the DeferredMeshDrawPacket is not a draw-packet as such, but it holds a reference to the actual
-        // deferred Drawpacket for the Material, since that is generally shared between multiple meshes
-        // We use the reference count to figure out if the DeferredDrawPacket is still needed.
-        class DeferredMeshDrawPacket
-        {
-        public:
-            DeferredMeshDrawPacket() = default;
-            DeferredMeshDrawPacket(
-                Data::Instance<RPI::ModelLod> modelLod, size_t modelLodMeshIndex, Data::Instance<RPI::Material> materialOverride);
+    public:
+        DeferredMeshDrawPacket() = default;
+        DeferredMeshDrawPacket(
+            Data::Instance<RPI::ModelLod> modelLod, size_t modelLodMeshIndex, Data::Instance<RPI::Material> materialOverride);
 
-            AZ_DEFAULT_COPY(DeferredMeshDrawPacket);
-            AZ_DEFAULT_MOVE(DeferredMeshDrawPacket);
+        ~DeferredMeshDrawPacket();
 
-            auto GetDeferredDrawPacket(const RHI::DrawListTag& drawList) -> Data::Instance<DeferredDrawPacket>;
+        // disable copy
+        DeferredMeshDrawPacket(const DeferredMeshDrawPacket&) = delete;
+        DeferredMeshDrawPacket& operator=(const DeferredMeshDrawPacket&) = delete;
 
-            void Update(RPI::Scene* scene, DeferredDrawPacketManager* manager, bool forceRebuild);
+        // allow move
+        DeferredMeshDrawPacket(DeferredMeshDrawPacket&&) = default;
+        DeferredMeshDrawPacket& operator=(DeferredMeshDrawPacket&&) = default;
 
-        private:
-            // a mesh can have a DeferredDrawPacket for multiple DrawListTags
-            AZStd::unordered_map<RHI::DrawListTag, Data::Instance<DeferredDrawPacket>> m_deferredDrawPackets;
-            Data::Instance<RPI::ModelLod> m_modelLod;
-            size_t m_modelLodMeshIndex;
-            Data::Instance<RPI::Material> m_material;
-            // Tracks whether the Material has change since the DrawPacket was last built
-            RPI::Material::ChangeId m_materialChangeId = RPI::Material::DEFAULT_CHANGE_ID;
-        };
+        auto GetDeferredDrawPacket(const RHI::DrawListTag& drawList) -> Data::Instance<DeferredDrawPacket>;
 
-    } // namespace Render
-} // namespace AZ
+        void Update(RPI::Scene* scene, DeferredDrawPacketManager* manager, bool forceRebuild);
+
+    private:
+        // a mesh can have a DeferredDrawPacket for multiple DrawListTags
+        AZStd::unordered_map<RHI::DrawListTag, Data::Instance<DeferredDrawPacket>> m_deferredDrawPackets;
+        Data::Instance<RPI::ModelLod> m_modelLod;
+        size_t m_modelLodMeshIndex;
+        Data::Instance<RPI::Material> m_material;
+        // Tracks whether the Material has change since the DrawPacket was last built
+        RPI::Material::ChangeId m_materialChangeId = RPI::Material::DEFAULT_CHANGE_ID;
+    };
+
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/Material/FallbackPBRMaterialManager.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/FallbackPBRMaterialManager.h
@@ -57,6 +57,7 @@ namespace AZ::Render
 
             void UpdateFallbackPBRMaterial();
             void UpdateFallbackPBRMaterialBuffer();
+            void InitNullCubeMap();
 
             // reflection probe
             struct ReflectionProbe
@@ -77,6 +78,8 @@ namespace AZ::Render
             bool m_bufferNeedsUpdate;
 
             RHI::ShaderInputNameIndex m_fallbackPBRMaterialIndex = "m_fallbackPBRMaterial";
+            RHI::ShaderInputNameIndex m_nullCubeMapIndex = "m_nullCubeMapIndex";
+            Data::Instance<RPI::Image> m_nullCubeMapTexture;
             RPI::Scene::PrepareSceneSrgEvent::Handler m_updateSceneSrgHandler;
             ReflectionProbeFeatureProcessorInterface* m_rpfp = nullptr;
         };

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Feature/DeferredMaterial/DeferredMaterialFeatureProcessorInterface.h>
 #include <Atom/Feature/Material/FallbackPBRMaterial.h>
 #include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
 #include <Atom/Feature/Mesh/MeshInfo.h>
@@ -135,6 +136,8 @@ namespace AZ
             void SetRayTracingData(MeshFeatureProcessor* meshFeatureProcessor);
             void RemoveRayTracingData(RayTracingFeatureProcessor* rayTracingFeatureProcessor);
             void SetSortKey(MeshFeatureProcessor* meshFeatureProcessor, RHI::DrawItemSortKey sortKey);
+            void SetDeferredMaterialData(MeshFeatureProcessor* meshFeatureProcessor);
+            void RemoveDeferredMaterialData(MeshFeatureProcessor* meshFeatureProcessor);
             RHI::DrawItemSortKey GetSortKey() const;
             void SetLightingChannelMask(MeshFeatureProcessor* meshFeatureProcessor, uint32_t lightingChannelMask);
             void SetMeshLodConfiguration(RPI::Cullable::LodConfiguration meshLodConfig);
@@ -297,6 +300,7 @@ namespace AZ
             // Quick functions to get other relevant feature processors that have already been cached by the MeshFeatureProcessor
             // without needing to go through the RPI's list of feature processors
             RayTracingFeatureProcessor* GetRayTracingFeatureProcessor() const;
+            DeferredMaterialFeatureProcessorInterface* GetDeferredMaterialFeatureProcessor() const;
             ReflectionProbeFeatureProcessor* GetReflectionProbeFeatureProcessor() const;
             TransformServiceFeatureProcessor* GetTransformServiceFeatureProcessor() const;
 
@@ -406,6 +410,7 @@ namespace AZ
             
             TransformServiceFeatureProcessor* m_transformService = nullptr;
             RayTracingFeatureProcessor* m_rayTracingFeatureProcessor = nullptr;
+            DeferredMaterialFeatureProcessorInterface* m_deferredMaterialFeatureProcessor = nullptr;
             ReflectionProbeFeatureProcessor* m_reflectionProbeFeatureProcessor = nullptr;
             AZ::RPI::ShaderSystemInterface::GlobalShaderOptionUpdatedEvent::Handler m_handleGlobalShaderOptionUpdate;
             RPI::MeshDrawPacketLods m_emptyDrawPacketLods;

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
@@ -101,6 +101,14 @@ set(FILES
     Source/Decals/AsyncLoadTracker.h
     Source/Decals/DecalTextureArrayFeatureProcessor.h
     Source/Decals/DecalTextureArrayFeatureProcessor.cpp    
+    Source/DeferredMaterial/DeferredDrawPacket.h
+    Source/DeferredMaterial/DeferredDrawPacket.cpp
+    Source/DeferredMaterial/DeferredDrawPacketManager.h
+    Source/DeferredMaterial/DeferredDrawPacketManager.cpp
+    Source/DeferredMaterial/DeferredMeshDrawPacket.h
+    Source/DeferredMaterial/DeferredMeshDrawPacket.cpp   
+    Source/DeferredMaterial/DeferredMaterialFeatureProcessor.cpp
+    Source/DeferredMaterial/DeferredMaterialFeatureProcessor.h
     Source/DisplayMapper/AcesOutputTransformPass.cpp
     Source/DisplayMapper/AcesOutputTransformLutPass.cpp
     Source/DisplayMapper/ApplyShaperLookupTablePass.cpp

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -36,6 +36,7 @@ set(FILES
     Include/Atom/Feature/Debug/RenderDebugParams.inl
     Include/Atom/Feature/Debug/RenderDebugSettingsInterface.h
     Include/Atom/Feature/Decals/DecalFeatureProcessorInterface.h
+    Include/Atom/Feature/DeferredMaterial/DeferredMaterialFeatureProcessorInterface.h
     Include/Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h
     Include/Atom/Feature/DisplayMapper/DisplayMapperFeatureProcessorInterface.h
     Include/Atom/Feature/ImGui/ImGuiUtils.h

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Animated.azsli
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Animated.azsli
@@ -63,6 +63,11 @@ void CalcPositions(const MaterialParameters params, float3 inPosition, VsSystemV
         return surface;
     }
 
+    Surface EvaluateSurface(VsOutput IN, VsSystemValues SV, PixelGeometryData geoData, const MaterialParameters params, float4 dxdy, bool useCustomDerivatives)
+    {
+        return EvaluateSurface(IN, SV, geoData, params);
+    }
+
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingBrdf.azsli>
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli>
 

--- a/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Empty.azsli
+++ b/Gems/AtomContent/TestData/Assets/TestData/Materials/Types/MaterialPipelineTest_Empty.azsli
@@ -58,6 +58,11 @@ void CalcPositions(float3 inPosition, VsSystemValues SV, out float3 worldPos, ou
         return surface;
     }
 
+    Surface EvaluateSurface(VsOutput IN, VsSystemValues SV, PixelGeometryData geoData, const MaterialParameters params, float4 dxdy, bool useCustomDerivatives)
+    {
+        return EvaluateSurface(IN, SV, geoData, params);
+    }
+
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingBrdf.azsli>
     #include <Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_LightingEval.azsli>
 


### PR DESCRIPTION
## What does this PR do?

This PR replaces [PR 18740](https://github.com/o3de/o3de/pull/18740), since that PR had several impactful changes that were merged in separate PRs since.

This PR adds the `DeferredMaterialFeatureProcessor`, that generates and manages fullscreen draw items for unique combinations of material-type and shader-options based on mesh-materials in the scene.

The functionality can be controlled with the `r_deferredMaterialRenderingEnabled` cvar, and is disabled by default.

The draw-items are generated only for material shader-items with `DrawItemType::Deferred`, and they use the same `DrawListTag` - functionality as the other Draw-Items, and are therefore executed by a normal `RasterPass` with the matching tag. 

Although the input-assembly is set up for a single fullscreen triangle, and the draw-item assumes that the shader-code for the vertex-shader is also set up accordingly.

Note that this does not add a new render pipeline, and updates only a few shader files: The deferred render pipeline is demonstrated in the Atom Sample Viewer, in the RPI->Mesh - sample, as a new render pipeline type, in [ASV PR 700](https://github.com/o3de/o3de-atom-sampleviewer/pull/700).
 
## How was this PR tested?
This was tested with the Atom Sample viewer on windows and vulkan.

Results from the sample: This is a material-canvas material that writes a color based on the world-position into the emissive channel, which doesn't work with the old deferred pipeline, since that only evaluates the base-color of the material.

**default (forward+) pipeline:**
![small_default_pipeline_material_canvas](https://github.com/user-attachments/assets/43e34f7d-c2dc-4f5c-9f40-771bdaa4d81e)
**old deferred pipeline:**
![small_old_deferred-pipeline_material_canvas](https://github.com/user-attachments/assets/0cec9a0c-19d9-4090-9dc1-dbf82baf3b12)
**new deferred pipeline:**
![small_new_deferred_pipeline_material_canvas](https://github.com/user-attachments/assets/cc6b7d55-3bff-495b-9124-9ff21c4db086)


