### PR TITLE
Fix crash when accessing unbound textures in materials

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Materials/SceneMaterialSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Materials/SceneMaterialSrg.azsli
@@ -15,6 +15,9 @@
 ShaderResourceGroup SceneMaterialSrg : SRG_PerMaterial
 {
     ByteAddressBuffer m_materialTypeBufferIndices;
+    // fallback texture index for GetMaterialTexture() in case the texture index is negative.
+    uint m_nullTextureIndex;
+
 #ifdef AZ_TRAITS_MATERIALS_USE_SAMPLER_ARRAY
     // sampler 0 is the default linear wrap sampler, the others are initialized by the MaterialSystem as needed
     Sampler m_samplers[SCENE_MATERIALS_MAX_SAMPLERS];
@@ -39,10 +42,9 @@ Texture2D GetMaterialTexture(const int readIndex)
     int localReadIndex = readIndex; 
     if (localReadIndex < 0)
     {
-        // TODO: choose a suitable fallback texture here.
-        localReadIndex = 0;
+        localReadIndex = SceneMaterialSrg::m_nullTextureIndex;
     }
-    return Bindless::GetTexture2D(readIndex);
+    return Bindless::GetTexture2D(localReadIndex);
 }
 
 const MaterialParameters GetMaterialParameters(const int materialTypeId, const int materialInstanceId)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Materials/SingleMaterialSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Materials/SingleMaterialSrg.azsli
@@ -21,7 +21,8 @@
 ShaderResourceGroup MaterialSrg : SRG_PerMaterial
 {
     MaterialParameters m_params;
-
+    // fallback texture index for GetMaterialTexture() in case the texture index is negative.
+    int m_nullTextureIndex;
 #ifdef AZ_TRAIT_SINGLE_MATERIAL_USE_TEXTURE_ARRAY
     // the MaterialParameters - struct can only contain texture indices, and no Texture2D directly.
     // if we can't use the bindless SRG at all, we register the Textures in this fixed-size array, and the texture-indices refer to this array 
@@ -53,13 +54,12 @@ Texture2D GetMaterialTexture(const int readIndex)
     int localReadIndex = readIndex; 
     if (localReadIndex < 0)
     {
-        // TODO: choose a suitable fallback texture here.
-        localReadIndex = 0;
+        localReadIndex = MaterialSrg::m_nullTextureIndex;
     }
 #ifdef AZ_TRAIT_SINGLE_MATERIAL_USE_TEXTURE_ARRAY
     if (localReadIndex >= SINGLE_MATERIAL_MAX_TEXTURES)
     {
-        localReadIndex = 0;
+        localReadIndex = MaterialSrg::m_nullTextureIndex;
     }
     return MaterialSrg::m_textures[localReadIndex];
 #else

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
@@ -118,6 +118,9 @@ namespace AZ::RPI
         Data::Asset<ShaderAsset> m_sceneMaterialSrgShaderAsset;
         Data::Instance<ShaderResourceGroup> m_sceneMaterialSrg;
 
+        RHI::ShaderInputNameIndex m_nullTextureIndexInputIndex = { "m_nullTextureIndex" };
+        Data::Instance<RPI::Image> m_nullTexture;
+
         // Texture samplers shared between all materials that use the SceneMaterialSrg
         TextureSamplerRegistry m_sceneTextureSamplers;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
@@ -127,6 +127,7 @@ namespace AZ::RPI
         Data::Instance<Buffer> m_materialTypeBufferIndicesBuffer;
         bool m_bufferReadIndicesDirty = false;
         bool m_sharedSamplerStatesDirty = false;
+        bool m_initialized = false;
     };
 
 } // namespace AZ::RPI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialTextureRegistry.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialTextureRegistry.h
@@ -18,10 +18,11 @@ namespace AZ::RPI
     {
     public:
         // The first sampler will be the default sampler state, and will not be released
-        void Init(const uint32_t maxTextures);
+        void Init(const uint32_t maxTextures, const Data::Instance<Image>& nullTexture);
         int32_t RegisterMaterialTexture(const Data::Instance<Image>& image);
         void ReleaseMaterialTexture(int32_t textureIndex);
         AZStd::vector<const RHI::ImageView*> CollectTextureViews();
+        int32_t GetNullTextureIndex();
 
     private:
         uint32_t m_maxTextures{ 0 };
@@ -29,6 +30,7 @@ namespace AZ::RPI
         AZStd::vector<int32_t> m_materialTexturesReferenceCount;
         AZStd::unordered_map<Data::AssetId, int32_t> m_materialTexturesMap;
         PersistentIndexAllocator<int32_t> m_textureIndices;
+        int32_t m_nullTextureIndex{ -1 };
     };
 
 } // namespace AZ::RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
@@ -269,7 +269,7 @@ namespace AZ::RPI
                 // get the size of the m_samplers[] array from the SRG layout
                 auto materialTexturesIndex =
                     instanceData.m_shaderResourceGroup->GetLayout()->FindShaderInputImageIndex(AZ::Name{ "m_textures" });
-                if (materialTexturesIndex.IsValid())
+                if (materialTexturesIndex.IsValid() && m_nullTexture)
                 {
                     auto desc = instanceData.m_shaderResourceGroup->GetLayout()->GetShaderInput(materialTexturesIndex);
                     instanceData.m_materialTextureRegistry = AZStd::make_unique<MaterialTextureRegistry>();
@@ -479,7 +479,7 @@ namespace AZ::RPI
                         // register the sampler array if the material requires it
                         auto nullTextureIndex =
                             instanceData.m_shaderResourceGroup->FindShaderInputConstantIndex(AZ::Name{ "m_nullTextureIndex" });
-                        if (nullTextureIndex.IsValid())
+                        if (nullTextureIndex.IsValid() && m_nullTexture)
                         {
 #ifdef AZ_TRAIT_REGISTER_TEXTURES_PER_MATERIAL
                             instanceData.m_shaderResourceGroup->SetConstant(
@@ -650,9 +650,11 @@ namespace AZ::RPI
             // register the buffer in the SRG and compile it
             m_sceneMaterialSrg->SetBuffer(m_materialTypeBufferInputIndex, m_materialTypeBufferIndicesBuffer);
 
-            // Register the bindless read index of the Null-Texture
-            m_sceneMaterialSrg->SetConstant(m_nullTextureIndexInputIndex, m_nullTexture->GetImageView()->GetBindlessReadIndex());
-
+            if (m_nullTexture)
+            {
+                // Register the bindless read index of the Null-Texture
+                m_sceneMaterialSrg->SetConstant(m_nullTextureIndexInputIndex, m_nullTexture->GetImageView()->GetBindlessReadIndex());
+            }
             return true;
         }
         return false;
@@ -708,8 +710,11 @@ namespace AZ::RPI
             m_sceneTextureSamplers.Init(AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS, defaultSampler);
         }
 
+        auto imageSystem = AZ::RPI::ImageSystemInterface::Get();
+        AZ_Assert(imageSystem, "ImageSystem needs to be initialized before the MaterialSystem.");
+        if (imageSystem)
         {
-            auto pool = AZ::RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
+            auto pool = imageSystem->GetSystemAttachmentPool();
             auto bindFlags = RHI::GetImageBindFlags(RHI::ScopeAttachmentUsage::Shader, RHI::ScopeAttachmentAccess::Read);
             // create a 8x8 image with the RGBA values (0, 0, 0, 1) to use a similar behaviour as the robustness2 extension when reading a
             // null texture.
@@ -719,10 +724,16 @@ namespace AZ::RPI
             m_nullTexture = AZ::RPI::AttachmentImage::Create(
                 *pool.get(), nullImageDesc, AZ_NAME_LITERAL("MaterialNullTexture"), &nullImageClearValue, &imageViewDesc);
         }
+        m_initialized = true;
     }
 
     void MaterialSystem::Shutdown()
     {
+        if (!m_initialized)
+        {
+            return;
+        }
+
         if (m_sceneMaterialSrgShaderAsset)
         {
             AZ::Data::AssetBus::Handler::BusDisconnect(m_sceneMaterialSrgShaderAsset.GetId());
@@ -737,8 +748,15 @@ namespace AZ::RPI
             m_materialTypeBufferIndicesBuffer.reset();
         }
         m_materialTypeData.clear();
+        if (m_nullTexture)
+        {
+            m_nullTexture.reset();
+        }
+
         MaterialInstanceHandlerInterface::Unregister(this);
         Data::InstanceDatabase<Material>::Destroy();
+
+        m_initialized = false;
     }
 
 } // namespace AZ::RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <Atom/RPI.Public/Image/AttachmentImage.h>
+#include <Atom/RPI.Public/Image/AttachmentImagePool.h>
 #include <Atom/RPI.Public/Material/Material.h>
 #include <Atom/RPI.Public/Material/MaterialInstanceHandler.h>
 #include <Atom/RPI.Public/Material/MaterialSystem.h>
@@ -16,9 +18,8 @@
 #include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
 #include <Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h>
 #include <AtomCore/Instance/InstanceDatabase.h>
-#include <AzCore/Name/NameDictionary.h>
-
 #include <Atom_RPI_Traits_Platform.h>
+#include <AzCore/Name/NameDictionary.h>
 
 #ifndef AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS
 #define AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS 0
@@ -270,7 +271,7 @@ namespace AZ::RPI
                 {
                     auto desc = instanceData.m_shaderResourceGroup->GetLayout()->GetShaderInput(materialTexturesIndex);
                     instanceData.m_materialTextureRegistry = AZStd::make_unique<MaterialTextureRegistry>();
-                    instanceData.m_materialTextureRegistry->Init(desc.m_count);
+                    instanceData.m_materialTextureRegistry->Init(desc.m_count, m_nullTexture);
                 }
 #endif
             }
@@ -473,6 +474,19 @@ namespace AZ::RPI
                             instanceData.m_materialTexturesDirty = false;
                         }
 #endif
+                        // register the sampler array if the material requires it
+                        auto nullTextureIndex =
+                            instanceData.m_shaderResourceGroup->FindShaderInputConstantIndex(AZ::Name{ "m_nullTextureIndex" });
+                        if (nullTextureIndex.IsValid())
+                        {
+#ifdef AZ_TRAIT_REGISTER_TEXTURES_PER_MATERIAL
+                            instanceData.m_shaderResourceGroup->SetConstant(
+                                nullTextureIndex, instanceData.m_materialTextureRegistry->GetNullTextureIndex());
+#else
+                            instanceData.m_shaderResourceGroup->SetConstant(
+                                nullTextureIndex, m_nullTexture->GetImageView()->GetBindlessReadIndex());
+#endif
+                        }
 
                         // register the sampler array if the material requires it
                         auto samplerIndex = instanceData.m_shaderResourceGroup->FindShaderInputSamplerIndex(AZ::Name{ "m_samplers" });
@@ -633,6 +647,10 @@ namespace AZ::RPI
 
             // register the buffer in the SRG and compile it
             m_sceneMaterialSrg->SetBuffer(m_materialTypeBufferInputIndex, m_materialTypeBufferIndicesBuffer);
+
+            // Register the bindless read index of the Null-Texture
+            m_sceneMaterialSrg->SetConstant(m_nullTextureIndexInputIndex, m_nullTexture->GetImageView()->GetBindlessReadIndex());
+
             return true;
         }
         return false;
@@ -682,9 +700,23 @@ namespace AZ::RPI
         };
         Data::InstanceDatabase<Material>::Create(azrtti_typeid<MaterialAsset>(), handler);
 
-        auto defaultSampler = RHI::SamplerState::Create(RHI::FilterMode::Linear, RHI::FilterMode::Linear, RHI::AddressMode::Wrap);
-        defaultSampler.m_anisotropyMax = 16;
-        m_sceneTextureSamplers.Init(AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS, defaultSampler);
+        {
+            auto defaultSampler = RHI::SamplerState::Create(RHI::FilterMode::Linear, RHI::FilterMode::Linear, RHI::AddressMode::Wrap);
+            defaultSampler.m_anisotropyMax = 16;
+            m_sceneTextureSamplers.Init(AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS, defaultSampler);
+        }
+
+        {
+            auto pool = AZ::RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
+            auto bindFlags = RHI::GetImageBindFlags(RHI::ScopeAttachmentUsage::Shader, RHI::ScopeAttachmentAccess::Read);
+            // create a 8x8 image with the RGBA values (0, 0, 0, 1) to use a similar behaviour as the robustness2 extension when reading a
+            // null texture.
+            auto nullImageDesc = RHI::ImageDescriptor::Create2D(bindFlags, 8, 8, RHI::Format::R8G8B8A8_UNORM);
+            auto imageViewDesc = RHI::ImageViewDescriptor::Create(RHI::Format::R8G8B8A8_UNORM, 0, 0);
+            RHI::ClearValue nullImageClearValue = RHI::ClearValue::CreateVector4Uint(0, 0, 0, 1);
+            m_nullTexture = AZ::RPI::AttachmentImage::Create(
+                *pool.get(), nullImageDesc, AZ_NAME_LITERAL("MaterialNullTexture"), &nullImageClearValue, &imageViewDesc);
+        }
     }
 
     void MaterialSystem::Shutdown()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
@@ -8,6 +8,7 @@
 
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
 #include <Atom/RPI.Public/Image/AttachmentImagePool.h>
+#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
 #include <Atom/RPI.Public/Material/Material.h>
 #include <Atom/RPI.Public/Material/MaterialInstanceHandler.h>
 #include <Atom/RPI.Public/Material/MaterialSystem.h>
@@ -20,6 +21,7 @@
 #include <AtomCore/Instance/InstanceDatabase.h>
 #include <Atom_RPI_Traits_Platform.h>
 #include <AzCore/Name/NameDictionary.h>
+
 
 #ifndef AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS
 #define AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS 0

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialTextureRegistry.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialTextureRegistry.cpp
@@ -10,13 +10,21 @@
 
 namespace AZ::RPI
 {
-    void MaterialTextureRegistry::Init(const uint32_t maxTextures)
+    void MaterialTextureRegistry::Init(const uint32_t maxTextures, const Data::Instance<Image>& nullTexture)
     {
         // we might be re-using this registry, so reset everything
         *this = {};
         m_maxTextures = maxTextures;
         m_materialTextures.resize(maxTextures, nullptr);
         m_materialTexturesReferenceCount.resize(maxTextures, 0);
+
+        // make sure one of the images is a null-texture, so we can have a fallback texture in case we attempt to sample an unbound texture
+        m_nullTextureIndex = RegisterMaterialTexture(nullTexture);
+    }
+
+    int32_t MaterialTextureRegistry::GetNullTextureIndex()
+    {
+        return m_nullTextureIndex;
     }
 
     AZStd::vector<const RHI::ImageView*> MaterialTextureRegistry::CollectTextureViews()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -484,6 +484,7 @@ namespace AZ
             m_rhiSystem.Init();
             m_imageSystem.Init(m_descriptor.m_imageSystemDescriptor);
             m_bufferSystem.Init();
+            m_materialSystem.Init();
 
             // Assets aren't actually available or needed for tests, but the m_systemAssetsInitialized flag still needs to be flipped.
             m_systemAssetsInitialized = true;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -97,7 +97,6 @@ namespace AZ
             m_assetHandlers.emplace_back(MakeAssetHandler<ResourcePoolAssetHandler>());
             m_assetHandlers.emplace_back(MakeAssetHandler<AnyAssetHandler>());
 
-            m_materialSystem.Init();
             m_modelSystem.Init();
             m_shaderSystem.Init();
             m_passSystem.Init();
@@ -452,6 +451,8 @@ namespace AZ
             m_dynamicDraw.Init(m_descriptor.m_dynamicDrawSystemDescriptor);
 
             m_passSystem.InitPassTemplates();
+
+            m_materialSystem.Init();
 
             m_systemAssetsInitialized = true;
             AZ_TracePrintf("RPI system", "System assets initialized\n");

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
@@ -11,6 +11,7 @@
 #include <Tests/GradientSignalTestHelpers.h>
 
 #include <Atom/RPI.Public/Image/ImageSystem.h>
+#include <Atom/RPI.Public/Material/MaterialSystem.h>
 #include <Atom/RPI.Public/RPISystem.h>
 #include <Common/RHI/Factory.h>
 #include <Common/RHI/Stubs.h>
@@ -123,10 +124,14 @@ namespace UnitTest
         AZ::RPI::ImageSystemDescriptor imageSystemDescriptor;
         m_imageSystem = AZStd::make_unique<AZ::RPI::ImageSystem>();
         m_imageSystem->Init(imageSystemDescriptor);
+
+        m_materialSystem = AZStd::make_unique<AZ::RPI::MaterialSystem>();
+        m_materialSystem->Init();
     }
 
     void GradientSignalBaseFixture::TearDownCoreSystems()
     {
+        m_materialSystem->Shutdown();
         m_imageSystem->Shutdown();
         m_rpiSystem->Shutdown();
 

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
@@ -21,6 +21,7 @@ namespace AZ::RPI
 {
     class RPISystem;
     class ImageSystem;
+    class MaterialSystem;
 } // namespace AZ::RPI
 
 namespace UnitTest
@@ -109,6 +110,7 @@ namespace UnitTest
         AZStd::unique_ptr<UnitTest::StubRHI::Factory> m_rhiFactory;
         AZStd::unique_ptr<AZ::RPI::RPISystem> m_rpiSystem;
         AZStd::unique_ptr<AZ::RPI::ImageSystem> m_imageSystem;
+        AZStd::unique_ptr<AZ::RPI::MaterialSystem> m_materialSystem;
     };
 
     struct GradientSignalTest


### PR DESCRIPTION
## What does this PR do?

Potential fix for [PR 19208](https://github.com/o3de/o3de/issues/19208)

When a material accesses a texture that is not bound, it currently accesses whatever texture is bound at bindless read index 0.
If there is nothing bound, vulkan systems are likely to crash.

This PR explicitly binds a Null - texture and propagates the bindless read index to the materials.

Note that this required a manual re-processing of all material shaders, since changing the MaterialSRG - files did not trigger any rebuilds automatically.

## How was this PR tested?

Vulkan / DX12 on Windows only. I was not able to reproduce the linked issue, since that occurs only on linux.