### PR TITLE
Fixes a missing target for compiling from install

### DIFF
--- a/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
+++ b/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
@@ -116,7 +116,7 @@ foreach(decoder_plugin libopus libvorbis)
 
 # if you use opus, you will have to add it here, if opus has the same issue about installing without being
 # able to disable installation, and thus requiring EXCLUDE_FROM_ALL
-add_dependencies(miniaudio_libvorbis vorbisfile)
+add_dependencies(miniaudio_libvorbis vorbisfile vorbisenc)
 
 # signal that find_package(MiniAudio) has succeeded.
 # we have to set it on the PARENT_SCOPE since we're in a function


### PR DESCRIPTION
## What does this PR do?
The miniaudio target was missing a dependnecy
on vorbisenc - this causes it not to build it,
despite it wanting to deploy / copy it.

## How was this PR tested?

Windows:  I built the installer in debug, profile, and monolithic release.
Then I built a project based on it, in each of those, and verified it compiled/linked and the libraries were there.

