### PR TITLE
Add a reference to the Product Asset to the MeshHandle for animated meshes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -98,6 +98,10 @@ namespace AZ
             virtual ~ModelDataInstanceInterface() = default;
 
             virtual const Data::Instance<RPI::Model>& GetModel() = 0;
+
+            //! If this is a skinned mesh, ProductModelAssetId is the asset-id of the original, non-animated asset.
+            //! Returns a invalid Asset for non-skinned meshes.
+            virtual const Data::Asset<RPI::ModelAsset>& GetProductModelAsset() = 0;
             virtual const RPI::Cullable& GetCullable() = 0;
 
             virtual const uint32_t GetLightingChannelMask() = 0;
@@ -168,6 +172,9 @@ namespace AZ
 
             AZ::EntityId m_entityId{ AZ::EntityId::InvalidEntityId };
             Data::Asset<RPI::ModelAsset> m_modelAsset;
+            // If the mesh is a skinned mesh, the m_productModelAsset refers to the original, non-animated mesh asset.
+            // Otherwhise this is empty.
+            Data::Asset<RPI::ModelAsset> m_productModelAsset;
             bool m_isRayTracingEnabled = true;
             bool m_useForwardPassIblSpecular = false;
             bool m_isAlwaysDynamic = false;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.h
@@ -46,6 +46,11 @@ namespace AZ
             {
                 return m_model;
             }
+            const Data::Asset<RPI::ModelAsset>& GetProductModelAsset() override
+            {
+                return m_descriptor.m_productModelAsset;
+            }
+
             const RPI::Cullable& GetCullable() override
             {
                 return m_cullable;

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -694,6 +694,7 @@ namespace AZ::Render
             MeshHandleDescriptor meshDescriptor;
             meshDescriptor.m_entityId = m_entityId;
             meshDescriptor.m_modelAsset = m_skinnedMeshInstance->m_model->GetModelAsset();
+            meshDescriptor.m_productModelAsset = m_actorAsset->GetActor()->GetMeshAsset();
             meshDescriptor.m_customMaterials = ConvertToCustomMaterialMap(materials);
             meshDescriptor.m_isRayTracingEnabled = m_rayTracingEnabled;
             meshDescriptor.m_isAlwaysDynamic = true;


### PR DESCRIPTION
## What does this PR do?

Currently for animated meshes, the mesh-asset in the `meshHandle` held by the `MeshFeatureProcessor` is an asset that was created at runtime, and does not reference the actual asset produced by the `AssetProcessor`.

The current alternative method is to use the `GetActorInstance()` event of the `ActorComponentRequestBus` with the Entity-ID to get the right `ActorInstance`, which contains the product-asset, but that is not feasible for rendering-only gems that generally are not aware of any Entity-IDs.

## How was this PR tested?

Use a custom gem that loads additional data per mesh from the disk, referenced by the product asset-id, and try it in a scene with animated meshes.

Generally, this adds a new interface function and has no impact on the existing functionality.
