### PR TITLE
Use setup-gradle to ensure that Github Actions uses the right version of Gradle

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -179,7 +179,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Setup gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 #v4.4.2
         with:
           gradle-version: '8.12'
       - name: Configure environment

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -177,7 +177,11 @@ jobs:
       - name: Set MSBuild options
         # Configuire VS environment variables through the developer command prompt for MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-                
+
+      - name: Setup gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.12'
       - name: Configure environment
         # Install dependencies for gradle and clang builds from the NDK
         continue-on-error: true
@@ -196,7 +200,7 @@ jobs:
           echo "LY_NDK_DIR=$env:ANDROID_HOME\ndk\${{ env.NDK_VERSION }}" >> $env:GITHUB_ENV
           echo "JDK_HOME=$env:JAVA_HOME_17_X64" >> $env:GITHUB_ENV
           echo "JAVA_HOME=$env:JAVA_HOME_17_X64" >> $env:GITHUB_ENV
-          echo "GRADLE_BUILD_HOME=$env:GRADLE_HOME" >> $env:GITHUB_ENV
+          echo "USE_GRADLE_FROM_PATH=1" >> $env:GITHUB_ENV
           
       - name: Build ${{ inputs.type }}
         # Builds with presets in ../scripts/build/Platform/Android/build_config.json


### PR DESCRIPTION
## What does this PR do?
We can use the setup-gradle action to make sure we're on a pinned version of gradle instead of relying on the one that is auto installed in GHA runners.

REcently, Github Actions (GHA) runners were upgraded to gradle 9, but that requires a newer NDK than the software compiles on.

Once we can get it working again, we can consider upgrading to gradle9 by fixing the software compile issues.
## How was this PR tested?

* Locally, by echoing my exact environment to be gradle GHA runner and seeing the same errors.
* Testing here, using the real GHA runners.
