### PR TITLE
Make BufferViewIndexAndOffset/IndexBufferViewIndexAndOffset creation arguments const

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshInfo.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshInfo.h
@@ -60,7 +60,7 @@ namespace AZ::Render
         }
 
         // utility function to create an entry from a Streambuffer
-        static BufferViewIndexAndOffset Create(RHI::StreamBufferView& streamBufferView, const RHI::VertexFormat vertexFormat)
+        static BufferViewIndexAndOffset Create(const RHI::StreamBufferView& streamBufferView, const RHI::VertexFormat vertexFormat)
         {
             auto rhiBuffer = streamBufferView.GetBuffer();
             auto result = BufferViewIndexAndOffset::CreateInternal(rhiBuffer, streamBufferView.GetByteOffset(), vertexFormat);
@@ -101,7 +101,7 @@ namespace AZ::Render
         AZStd::unordered_map<int, uint32_t> m_bindlessReadIndex = {};
 
         // utility function to create an entry from an IndexBufferView
-        static IndexBufferViewIndexAndOffset Create(AZ::RHI::IndexBufferView& indexBufferView)
+        static IndexBufferViewIndexAndOffset Create(const AZ::RHI::IndexBufferView& indexBufferView)
         {
             uint32_t byteCount = static_cast<uint32_t>(indexBufferView.GetBuffer()->GetDescriptor().m_byteCount);
             // The 'raw' bufferview is for a ByteAddresBuffer, which has to be R32_UINT.

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInfoManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInfoManager.cpp
@@ -390,14 +390,12 @@ namespace AZ::Render
             // - The bindless read-index of this new BufferView
             // - The start-offset inside the new BufferView
             const auto semantic = inputContract.m_streamChannels[streamIndex].m_semantic;
-            auto& streamBuffer = const_cast<RHI::StreamBufferView&>(streamIter[static_cast<u16>(streamIndex)]);
+            auto& streamBuffer = streamIter[static_cast<u16>(streamIndex)];
             entry->m_meshBuffers[semantic] =
                 BufferViewIndexAndOffset::Create(streamBuffer, RHI::ConvertToVertexFormat(inputChannelFormat[streamIndex]));
         }
 
         // Register the Index buffer
-        auto& indexBuffer = const_cast<RHI::IndexBufferView&>(mesh.GetIndexBufferView());
-        entry->m_indexBuffer = IndexBufferViewIndexAndOffset::Create(indexBuffer);
+        entry->m_indexBuffer = IndexBufferViewIndexAndOffset::Create(mesh.GetIndexBufferView());
     }
-
 } // namespace AZ::Render


### PR DESCRIPTION
## What does this PR do?

This PR makes the first parameter of the `AZ::Render::BufferViewIndexAndOffset/IndexBufferViewIndexAndOffset` creation functions `const`, such that they can be used with temporary and const arguments.

## How was this PR tested?

Compile with MSVC and Clang on Windows, AR
