### PR TITLE
Fixes a compile issue specific to clang 18

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/utility/expected.h
+++ b/Code/Framework/AzCore/AzCore/std/utility/expected.h
@@ -92,7 +92,7 @@ namespace AZStd
             /* constraint checks */ ((is_void_v<T> && is_void_v<U>) || is_constructible_v<T, add_lvalue_reference_t<const U>>)
             && is_constructible_v<E, const G&>
             && Internal::not_convertible_or_constructible_from_other_std_expected_v<T, E, U, G>>>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<add_lvalue_reference_t<const U>, T> || !is_convertible_v<const G&, E>)
 #endif
         constexpr expected(const expected<U, G>& rhs);
@@ -104,7 +104,7 @@ namespace AZStd
             /* constraint checks */ ((is_void_v<T> && is_void_v<U>) || is_constructible_v<T, U>)
             && is_constructible_v<E, G>
             && Internal::not_convertible_or_constructible_from_other_std_expected_v<T, E, U, G>>>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<U, T> || !is_convertible_v<G, E>)
 #endif
         constexpr expected(expected<U, G>&& rhs);
@@ -115,21 +115,21 @@ namespace AZStd
             && !is_same_v<expected, remove_cvref_t<U>>
             && !Internal::is_std_unexpected_specialization_v<remove_cvref_t<U>>
             && is_constructible_v<T, U> >>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<U, T>)
 #endif
         constexpr expected(U&& v);
 
         // Direct non-list initialization for error type
         template<class G, class = enable_if_t<is_constructible_v<E, const G&> >>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<const G&, E>)
 #endif
         constexpr expected(const unexpected<G>& err);
 
 
         template<class G, class = enable_if_t<is_constructible_v<E, G> >>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<G, E>)
 #endif
         constexpr expected(unexpected<G>&& err);

--- a/Code/Framework/AzCore/AzCore/std/utility/pair.h
+++ b/Code/Framework/AzCore/AzCore/std/utility/pair.h
@@ -196,34 +196,34 @@ namespace AZStd
                 , bool_constant<!Internal::is_subrange<P>>
                 , bool_constant<Internal::is_pair_like_constructible_for_t<pair, P>>
             >>>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<decltype(get<0, P>), T1> || !is_convertible_v<decltype(get<1, P>), T2>)
 #endif
         constexpr pair(P&& pairLike);
 
         // construct from compatible pair
         template<class U1, class U2, class = enable_if_t<is_constructible_v<T1, const U1&> && is_constructible_v<T2, const U2&>>>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<U1, T1> || !is_convertible_v<U2, T2>)
 #endif
         constexpr pair(const pair<U1, U2>& rhs);
 
         // move constructor from rvalue pair
         template<class U1, class U2, class = enable_if_t<is_constructible_v<T1, U1> && is_constructible_v<T2, U2>>>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<U1, T1> || !is_convertible_v<U2, T2>)
 #endif
         constexpr pair(pair<U1, U2>&& rhs);
 
         // C++23 non-const lvalue constructor
         template<class U1, class U2, class = enable_if_t<is_constructible_v<T1, U1&> && is_constructible_v<T2, U2&>>>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<U1, T1> || !is_convertible_v<U2, T2>)
 #endif
         constexpr pair(pair<U1, U2>& rhs);
         // C++23 const rvalue constructor
         template<class U1, class U2, class = enable_if_t<is_constructible_v<T1, U1> && is_constructible_v<T2, U2>>>
-#if __cpp_conditional_explicit >= 201806L
+#if !defined(O3DE_DISABLE_CONDITIONAL_EXPLICIT) && __cpp_conditional_explicit >= 201806L
         explicit(!is_convertible_v<U1, T1> || !is_convertible_v<U2, T2>)
 #endif
         constexpr pair(const pair<U1, U2>&& rhs);

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -27,6 +27,17 @@ set(O3DE_COMPILE_OPTION_DISABLE_WARNINGS PRIVATE -w)
 # This is problematic if 3rd-party libraries use such operations in header files.
 set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE -Wno-deprecated-enum-enum-conversion)
 
+
+
+# A known bug in clang18 prevents __cpp_conditional_explicit from working correctly.
+# see https://github.com/llvm/llvm-project/pull/70548 and other reports.
+# this causes it to evaluate #if __cpp_conditional_explicit >= 201806L as true, but
+# can trip over code that uses it, such as in AZStd::pair.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18.0 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
+    message(STATUS "Clang 18 detected, adding workaround for __cpp_conditional_explicit bug")
+    add_compile_definitions(O3DE_DISABLE_CONDITIONAL_EXPLICIT=1)
+endif()
+
 ly_append_configurations_options(
     DEFINES_PROFILE
         _FORTIFY_SOURCE=2

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -29,11 +29,17 @@ set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE -Wno-dep
 
 
 
-# A known bug in clang18 prevents __cpp_conditional_explicit from working correctly.
+# A known bug in clang18 and below prevents __cpp_conditional_explicit from working correctly.
 # see https://github.com/llvm/llvm-project/pull/70548 and other reports.
 # this causes it to evaluate #if __cpp_conditional_explicit >= 201806L as true, but
 # can trip over code that uses it, such as in AZStd::pair.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 18.0 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
+# It seems a bug was introduced when Clang introduced this feature, and it was fixed in clang19.
+# Clangs from before the feature was introduced would not declare __cpp_conditional_explicit and thus
+# won't run the code anyway.  Clangs after the feature was introduced but before it was fixed will
+# incorrectly evaluate the condition and run the code, but trip over the bug.  Since we know its fixed
+# in 19.0 and later, disable it for clang18 and earlier.  (This feature is not necessary for O3DE
+# to actually function)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0)
     message(STATUS "Clang 18 detected, adding workaround for __cpp_conditional_explicit bug")
     add_compile_definitions(O3DE_DISABLE_CONDITIONAL_EXPLICIT=1)
 endif()


### PR DESCRIPTION
## What does this PR do?

There is an issue with clang 18 where it does not
compile correctly when using conditional explicit.

This bug was fixed above clang 19, but affects clang 18 including versions of the android NDK.

This switches off the use of that feature specifically for clang 18.

## How was this PR tested?
compilation on clang on windows

msvc 2019
msvc 2022
clang 15

clang 18
clang 19
clang 20.

All compiled without issue with this change.  I was able to build editor automated testing from scratch, and run it.  Clang15 has other executable issues that are not related to this (seems to be something with windows firewall actually).