### PR TITLE
Ensure MeshInfoManager::m_meshInfoBuffer is updated when at least one update callback returns true

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Material/FallbackPBRMaterialManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/FallbackPBRMaterialManager.cpp
@@ -262,7 +262,7 @@ namespace AZ::Render
             }
             if (entry)
             {
-                m_bufferNeedsUpdate = updateFunction(entry.get());
+                m_bufferNeedsUpdate |= updateFunction(entry.get());
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInfoManager.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInfoManager.cpp
@@ -228,7 +228,7 @@ namespace AZ::Render
         }
         if (entry)
         {
-            m_meshInfoNeedsUpdate = updateFunction(entry.get());
+            m_meshInfoNeedsUpdate |= updateFunction(entry.get());
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

When calling `MeshFeatureProcessorInterface::UpdateMeshInfoEntry`, the return value of the callback function should indicate whether the underlying GPU buffer needs to be updated, but currently the `MeshInfoManager::m_meshInfoNeedsUpdate` field is always set to the return value of the most-recent callback invocation, meaning that if multiple mesh info entries are updated and the last one returns false in the callback function, the GPU buffer will not be updated in the next prepare-frame event.

## How was this PR tested?

No tests performed, just an observation from looking at the code.
