### PR TITLE
Remove some no longer necessary const_cast expressions in Atom

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
@@ -256,7 +256,7 @@ namespace ImageProcessingAtom
             return STRING_OUTCOME_ERROR(AZStd::string::format("TextureSettings preset [%s] does not have override for platform [%s]",
                 baseTextureSettings.m_preset.GetCStr(), platformName.c_str()));
         }
-        AZ::DataPatch& platformOverride = const_cast<AZ::DataPatch&>(overrideIter->second);
+        const AZ::DataPatch& platformOverride = overrideIter->second;
 
         // Update settings instance with override values.
         if (platformOverride.IsData())

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/StreamBufferViewsBuilder.cpp
@@ -259,7 +259,7 @@ namespace AZ
             for (AZ::u8 streamIdx = 0; streamIdx < streamCount; streamIdx++)
             {
                 auto shaderSemantic = streamChannels[streamIdx].m_semantic;
-                AZ::RHI::Buffer* rhiBuffer = const_cast<AZ::RHI::Buffer*>(streamIter[streamIdx].GetBuffer());
+                auto* rhiBuffer = streamIter[streamIdx].GetBuffer();
 
                 // REMARK: The reason we are not doing this, is that most RHIs need the Offset in a BufferView to be aligned to 16 bytes,
                 // which is not case for most sub meshes. To avoid this potential error, we map the whole buffer,
@@ -334,7 +334,7 @@ namespace AZ
             indexBufferDescriptor.m_elementSize = indexElementSize;
             indexBufferDescriptor.m_elementFormat =
                 indexBufferView.GetIndexFormat() == AZ::RHI::IndexFormat::Uint16 ? AZ::RHI::Format::R16_UINT : AZ::RHI::Format::R32_UINT;
-            auto* rhiBuffer = const_cast<AZ::RHI::Buffer*>(indexBufferView.GetBuffer());
+            auto* rhiBuffer = indexBufferView.GetBuffer();
 
 #if DEBUG_LOG_BUFFERVIEWS
             AZ_Printf(

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
@@ -124,8 +124,7 @@ namespace AZ
                     RHI::BufferViewDescriptor descriptor =
                         CreateInputViewDescriptor(streamInfo->m_enum, streamInfo->m_elementFormat, streamBufferView);
 
-                    AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView =
-                        const_cast<RHI::Buffer*>(streamBufferView.GetBuffer())->GetBufferView(descriptor);
+                    AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView = streamBufferView.GetBuffer()->GetBufferView(descriptor);
                     {
                         // Initialize the buffer view
                         AZStd::string bufferViewName = AZStd::string::format(

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceDrawPacket.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceDrawPacket.cpp
@@ -93,10 +93,9 @@ namespace AZ::RHI
     {
         for (size_t drawItemIndex = 0; drawItemIndex < m_drawItemCount; ++drawItemIndex)
         {
-            const DeviceDrawItem* drawItemConst = m_drawItems + drawItemIndex;
+            DeviceDrawItem* drawItem = m_drawItems + drawItemIndex;
             // Need to mutate for mesh instancing.
             // This should be used after cloning the draw packet from DeviceDrawPacketBuilder.
-            DeviceDrawItem* drawItem = const_cast<DeviceDrawItem*>(drawItemConst);
             drawItem->m_drawInstanceArgs.m_instanceCount = instanceCount;
         }
     }

--- a/Gems/Atom/RHI/Code/Tests/DrawPacketTests.cpp
+++ b/Gems/Atom/RHI/Code/Tests/DrawPacketTests.cpp
@@ -462,7 +462,7 @@ namespace UnitTest
             RHI::DeviceDrawPacketBuilder builder;
             const RHI::DeviceDrawPacket* drawPacket = drawPacketData.Build(builder);
             RHI::DeviceDrawPacketBuilder builder2;
-            RHI::DeviceDrawPacket* drawPacketClone = const_cast<RHI::DeviceDrawPacket*>(builder2.Clone(drawPacket));
+            RHI::DeviceDrawPacket* drawPacketClone = builder2.Clone(drawPacket);
 
             uint8_t drawItemCount = drawPacketClone->m_drawItemCount;
 
@@ -499,7 +499,7 @@ namespace UnitTest
             RHI::DeviceDrawPacketBuilder builder;
             const RHI::DeviceDrawPacket* drawPacket = drawPacketData.Build(builder);
             RHI::DeviceDrawPacketBuilder builder2;
-            RHI::DeviceDrawPacket* drawPacketClone = const_cast<RHI::DeviceDrawPacket*>(builder2.Clone(drawPacket));
+            RHI::DeviceDrawPacket* drawPacketClone = builder2.Clone(drawPacket);
 
             AZStd::array<uint8_t, sizeof(unsigned int) * 4> rootConstantOld;
             EXPECT_EQ(sizeof(unsigned int) * 4, drawPacketClone->m_rootConstantSize);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RenderPass.cpp
@@ -253,7 +253,7 @@ namespace AZ
                     // in this single template member function
                     if constexpr (type == AttachmentType::Preserve)
                     {
-                        auto& subpassDescriptor = const_cast<RenderPass::SubpassDescriptor&>(m_descriptor->m_subpassDescriptors[subpassIndex]);
+                        const auto& subpassDescriptor = m_descriptor->m_subpassDescriptors[subpassIndex];
                         AZStd::vector<uint32_t>& attachmentReferenceList = subpassInfo.m_preserveAttachments;
                         attachmentReferenceList.insert(
                             attachmentReferenceList.end(),

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
@@ -89,7 +89,7 @@ namespace AZ::RPI
         {
             imageViewDescriptor.m_mipSliceMin = static_cast<uint16_t>(mipIndex);
             imageViewDescriptor.m_mipSliceMax = static_cast<uint16_t>(mipIndex);
-            Ptr<RHI::ImageView> imageView = const_cast<RHI::Image*>(rhiImage)->GetImageView(imageViewDescriptor);
+            Ptr<RHI::ImageView> imageView = rhiImage->GetImageView(imageViewDescriptor);
             srg.SetImageView(m_imageDestinationIndex, imageView.get(), mipIndex);
             m_imageViews[mipIndex] = imageView;
         }


### PR DESCRIPTION
## What does this PR do?

This PR removes some no longer necessary `const_cast` expressions in the Atom gem, some of which were made possible due to [PR19211](https://github.com/o3de/o3de/pull/19211), others for unrelated reasons.

## How was this PR tested?

Compile on Windows with MSVC and Clang
