### PR TITLE
Replaces name fields of assets in Particle with Asset References

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.cpp
@@ -9,6 +9,7 @@
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Asset/AssetSystemBus.h>
  
 AZ_INSTANTIATE_EBUS_SINGLE_ADDRESS(AZTF_API, AzToolsFramework::AssetSystem::AssetSystemNotifications);
 AZ_INSTANTIATE_EBUS_SINGLE_ADDRESS(AZTF_API, AzToolsFramework::AssetSystem::AssetSystemRequest);
@@ -36,6 +37,118 @@ namespace AzToolsFramework
                 case JobStatus::Missing: return "Missing";
             }
             return "";
+        }
+
+        AZ::Data::AssetId FindAssetIdFromFileName(const char* fileName, AZ::Data::AssetType assetTypeId)
+        {
+            using namespace AZ::Data;
+            using assetSystemBus = AzFramework::AssetSystemRequestBus;
+            AssetId assetId;
+            if ((!fileName)||(!fileName[0]))
+            {
+                return assetId;
+            }
+
+            // source search string is the given file name, made into a lexically normal path
+            AZStd::string sourceSearchString = AZ::IO::PathView(fileName).LexicallyNormal().String();
+            // product search string is the same, but lowercased.
+            AZStd::string productSearchString = sourceSearchString;
+            AZStd::to_lower(productSearchString.begin(), productSearchString.end());
+          
+            auto CheckCatalogFn = [](const AZStd::string& searchString, const AssetType& typeId) -> AssetId
+            {
+                // the fastest possible match is when the filename is a known asset file and is already available:
+                AssetId retVal;
+                AssetCatalogRequestBus::BroadcastResult(retVal, &AssetCatalogRequests::GetAssetIdByPath, searchString.c_str(), typeId, false);
+                if (retVal.IsValid())
+                {
+                    if (typeId.IsNull())
+                    {
+                        return retVal;
+                    }
+                    // if we found an asset, but we also have an expected type, make sure it matches:
+                    AssetInfo assetInfo;
+                    AssetCatalogRequestBus::BroadcastResult(assetInfo, &AssetCatalogRequests::GetAssetInfoById, retVal);
+                    if (assetInfo.m_assetType == typeId)
+                    {
+                        return retVal;
+                    }
+                }
+                return {};
+            };
+
+            assetId = CheckCatalogFn(productSearchString, assetTypeId);
+            if (assetId.IsValid())
+            {
+                return assetId;
+            }
+
+            // if we get here, three possibilities remain, and we'll tackle them in this order since each additional
+            // number below introduces more delay time:
+            // 1. the file is a source file, not a product file (asking for "blah.material" instead of "blah.azmaterial")
+            // 2. the file is a product file, but the asset catalog is not up to date
+            // 3. the file is missing entirely (it will never appear).
+
+            using toolsAssetBus = AzToolsFramework::AssetSystemRequestBus;
+            AZ::Data::AssetInfo sourceInfo;
+            AZStd::string watchFolder; // this is the root folder the asset was found in, like, which Gem it belongs to for example
+            toolsAssetBus::Broadcast(&toolsAssetBus::Events::GetSourceInfoBySourcePath, sourceSearchString.c_str(), sourceInfo, watchFolder);
+            if (sourceInfo.m_assetId.IsValid())
+            {
+                // make sure its compiled, so that it has produced its products:
+                assetSystemBus::Broadcast(&assetSystemBus::Events::CompileAssetSyncById, sourceInfo.m_assetId);
+                // Get the asset id that the above source asset ("blah.material") produces, ie, "blah.azmaterial"
+                AZStd::vector<AZ::Data::AssetInfo> producedAssets;
+                toolsAssetBus::Broadcast(&toolsAssetBus::Events::GetAssetsProducedBySourceUUID, sourceInfo.m_assetId.m_guid, producedAssets);
+                if (!assetTypeId.IsNull())
+                {
+                    // filter the list down to only those that match the expected type:
+                    AZStd::erase_if(
+                        producedAssets,
+                        [assetTypeId](const AssetInfo& info)
+                        {
+                            return info.m_assetType != assetTypeId;
+                        });
+                }
+                // find the best match for the given file name by checking the longest matching path portion
+                // without case sensitivity and without slash direction sensitivity:
+                size_t bestMatchLen = 0;
+                for (const auto& product : producedAssets)
+                {
+                    AZStd::string pathString = AZ::IO::PathView(product.m_relativePath).LexicallyNormal().String();
+                    AZStd::to_lower(pathString.begin(), pathString.end());
+                    // find the length of the longest common prefix between the two strings:
+                    size_t maxCompareLen = AZStd::min(pathString.size(), productSearchString.size());
+                    size_t matchLen = 0;
+                    for (size_t i = 0; i < maxCompareLen; ++i)
+                    {
+                        if (pathString[i] != productSearchString[i])
+                        {
+                            break;
+                        }
+                        matchLen++;
+                    }
+                    if (matchLen > bestMatchLen)
+                    {
+                        bestMatchLen = matchLen;
+                        assetId = product.m_assetId;
+                    }
+                }
+                return assetId;
+            }
+            else
+            {
+                // its not a source file name.  Last resort is to try to compile it and check it again:
+                assetSystemBus::Broadcast(&assetSystemBus::Events::CompileAssetSync, productSearchString.c_str());
+                assetId = CheckCatalogFn(productSearchString, assetTypeId);
+                if (assetId.IsValid())
+                {
+                    return assetId;
+                }
+                // note that if this "else" happens, its the most expensive case, but once it passes, the next time
+                // it will be fast since the asset will be compiled and in the catalog.
+            }
+            return {};
         }
 
         JobInfo::JobInfo()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.cpp
@@ -39,12 +39,12 @@ namespace AzToolsFramework
             return "";
         }
 
-        AZ::Data::AssetId FindAssetIdFromFileName(const char* fileName, AZ::Data::AssetType assetTypeId)
+        AZ::Data::AssetId FindAssetIdFromFileName(AZStd::string_view fileName, AZ::Data::AssetType assetTypeId)
         {
             using namespace AZ::Data;
             using assetSystemBus = AzFramework::AssetSystemRequestBus;
             AssetId assetId;
-            if ((!fileName)||(!fileName[0]))
+            if (fileName.empty())
             {
                 return assetId;
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.h
@@ -141,6 +141,23 @@ namespace AzToolsFramework
             virtual bool ClearFingerprintForAsset(const AZStd::string& sourcePath) = 0;
         };
 
+        //! Given a file name and expected asset type, try to find the asset id for it using a heuristic approach.
+        //! * First, it will try to look for an exact known match in the catalog for that actual file name.
+        //! * If that fails, it will look for a source file with that name and see if it produces assets of the given type.
+        //!   If that succeeds, it will check the returned list of assets and find the one that best matches with the given
+        //!   file name and type.
+        //! This function should only be used to convert legacy data that used file names to refer to assets.
+        //! It is not necessary to use this function if you already have an asset id or uuid, and asset references
+        //! should always be preferred if possible, since this function can fail, especially if the file name requested
+        //! is unrelated to the actual source file name that produces this asset (for example, a passing in a product file
+        //! name like "sphere.azmodel" when the actual source file is "shapes.fbx", there simply is not enough information
+        //! in just that string to know what the source file is unless it has already been compiled and is in the catalog).
+        //! @param fileName The file name to look for.  Source file, product file, use relative paths though.
+        //! @param assetTypeId The expected type of the asset.  A null typeid will accept any asset type.
+        //!        If you specify a typeId, it will only return a valid asset id if the type matches, even if it finds an asset
+        //!        in the catalog with the exact name.
+        AZTF_API AZ::Data::AssetId FindAssetIdFromFileName(const char* fileName, AZ::Data::AssetType assetTypeId);
+
         //! AssetSystemBusTraits
         //! This bus is for events that concern individual assets and is addressed by file extension
         class AssetSystemNotifications 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.h
@@ -15,6 +15,7 @@
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/PlatformDef.h>
 #include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 namespace AZ
@@ -156,7 +157,7 @@ namespace AzToolsFramework
         //! @param assetTypeId The expected type of the asset.  A null typeid will accept any asset type.
         //!        If you specify a typeId, it will only return a valid asset id if the type matches, even if it finds an asset
         //!        in the catalog with the exact name.
-        AZTF_API AZ::Data::AssetId FindAssetIdFromFileName(const char* fileName, AZ::Data::AssetType assetTypeId);
+        AZTF_API AZ::Data::AssetId FindAssetIdFromFileName(AZStd::string_view fileName, AZ::Data::AssetType assetTypeId);
 
         //! AssetSystemBusTraits
         //! This bus is for events that concern individual assets and is addressed by file extension

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -22,6 +22,8 @@
 
 namespace AssetProcessor
 {
+    bool ConvertDatabaseProductPathToProductFilename(AZStd::string_view dbPath, QString& productFileName);
+
     AssetCatalog::AssetCatalog(QObject* parent, AssetProcessor::PlatformConfiguration* platformConfiguration)
         : QObject(parent)
         , m_platformConfig(platformConfiguration)
@@ -1217,6 +1219,11 @@ namespace AssetProcessor
                     AZ::Data::AssetInfo assetInfo;
                     assetInfo.m_assetId = AZ::Data::AssetId(sourceUuid, product.m_subID);
                     assetInfo.m_assetType = product.m_assetType;
+                    QString productFileName;
+                    if (ConvertDatabaseProductPathToProductFilename(product.m_productName, productFileName))
+                    {
+                        assetInfo.m_relativePath = productFileName.toUtf8().constData();
+                    }
                     productsAssetInfo.emplace_back(assetInfo);
                 }
             }

--- a/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/Asset/ParticleArchive.h
+++ b/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/Asset/ParticleArchive.h
@@ -26,6 +26,18 @@
 
 namespace OpenParticle
 {
+    //! ParticleArchive is responsible for storing (and fixing up after load) the runtime
+    //! data for the particle systems.
+    //! Instead of storing the objects using serialize, it memcpys the image of the data into a buffer,
+    //! and then stores the offset into that buffer which they can be found.
+    //! So for example, EmitterInfo below has a AZ::u32 member called `m_config`.  This member is not the
+    //! actual config, but represents the offset in the buffer that the memory image of a
+    //! ParticleSystem::Config struct can be found.
+    //! This implies that all data in all such objects must be essentially memcpyable.
+    //! The >> operator can copy from a SimuCore::ParticleCore::ParticleSystem object into a ParticleArchive.
+    //! The << operator copies the buffers from a ParticleArchive into a SimuCore::ParticleCore::ParticleSystem object
+    //! Note that the ParticleSystem object uses these buffers in-place without unpacking them - it copies the buffers
+    //! and the offset of the object in the buffer, then uses them in-place.
     class ParticleArchive
     {
     public:

--- a/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/EditorParticleSystemComponentRequestBus.h
+++ b/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/EditorParticleSystemComponentRequestBus.h
@@ -8,11 +8,11 @@
  
 #pragma once
 
-#include <AzCore/EBus/EBus.h>
-#include <AzCore/std/string/string.h>
-#include <AzCore/std/containers/vector.h>
-#include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
 
 namespace OpenParticle
 {

--- a/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/EditorParticleSystemComponentRequestBus.h
+++ b/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/EditorParticleSystemComponentRequestBus.h
@@ -10,6 +10,9 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
+#include <AzCore/Asset/AssetCommon.h>
 
 namespace OpenParticle
 {
@@ -42,6 +45,8 @@ namespace OpenParticle
         virtual AZStd::vector<AZ::TypeId> GetDefaultSpawnTypes() const = 0;
 
         virtual AZ::TypeId GetDefaultRenderType() const = 0;
+
+        virtual AZ::Data::AssetId GetDefaultEmitterMaterialId() const = 0;
     };
     using EditorParticleSystemComponentRequestBus = AZ::EBus<EditorParticleSystemComponentRequests>;
 

--- a/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/Serializer/ParticleAssetData.h
+++ b/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/Serializer/ParticleAssetData.h
@@ -42,9 +42,9 @@ namespace OpenParticle
             AZStd::string m_name;
             AZStd::any m_config;
             AZStd::any m_renderConfig;
-            AZStd::string m_material;
-            AZStd::string m_model;
-            AZStd::string m_skeletonModel;
+            AZ::Data::Asset<AZ::RPI::MaterialAsset> m_material;
+            AZ::Data::Asset<AZ::RPI::ModelAsset> m_model;
+            AZ::Data::Asset<AZ::RPI::ModelAsset> m_skeletonModel;
             AZStd::list<AZStd::any> m_emitModules;
             AZStd::list<AZStd::any> m_spawnModules;
             AZStd::list<AZStd::any> m_updateModules;

--- a/Gems/OpenParticleSystem/Code/Source/Editor/EditorSystemComponent.h
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/EditorSystemComponent.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzToolsFramework/Viewport/ActionBus.h>
 #include <Editor/ParticleBrowserInteractions.h>
 #include <OpenParticleSystem/EditorParticleSystemComponentRequestBus.h>
@@ -47,6 +48,8 @@ namespace OpenParticle
 
         AZ::TypeId GetDefaultRenderType() const override;
 
+        AZ::Data::AssetId GetDefaultEmitterMaterialId() const override;
+
         EditorSystemComponent() = default;
         ~EditorSystemComponent() = default;
 
@@ -60,9 +63,14 @@ namespace OpenParticle
         void OpenParticleEditor(const AZStd::string& sourcePath) override;
 
         void ResetMenu();
+        void OnCriticalAssetsCompiled();
 
     private:
         QAction* m_openParticleEditorAction = nullptr;
+        AZ::Data::AssetId m_cachedDefaultEmitterMaterialAssetId;
         AZStd::unique_ptr<ParticleBrowserInteractions> m_particleBrowserInteractions;
+
+        // invoked when assets are ready to query.
+        AZ::SettingsRegistryInterface::NotifyEventHandler m_criticalAssetsHandler;
     };
 } // namespace OpenParticle

--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
@@ -11,6 +11,9 @@
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <OpenParticleSystem/ParticleConfigurationRequestBus.h>
 #include <OpenParticleSystem/ParticleEditDataConfig.h>
+#include <OpenParticleSystem/EditorParticleSystemComponentRequestBus.h>
+#include <AzFramework/Asset/AssetSystemBus.h>
+#include <API/EditorAssetSystemAPI.h>
 
 namespace OpenParticle
 {
@@ -506,6 +509,57 @@ namespace OpenParticle
         }
     }
 
+    // convert an old field, which is the file name of a source or product file (like "Blah.Material" or "mesh.azmodel")
+    // into the new format, an actual asset, ie, Asset<MaterialAsset> refcounted smart pointer.
+    // If its already an object, we can just load it normally.
+    template<class T>
+    JSR::ResultCode ParticleBaseSerializer::ConvertSourceFileNameToAsset(
+        AZ::Data::Asset<T>& destField,
+        const rapidjson::Value& inputValue,
+        const char* fieldName,
+        AZ::Data::AssetLoadBehavior loadBehavior,
+        AZ::JsonDeserializerContext& context)
+    {
+        AZ::Data::AssetType typeId = azrtti_typeid<T>();
+        destField.Reset(); // make sure any old ones are cleared out.
+        // Convert old string names to Assets.
+        auto iterator = inputValue.FindMember(fieldName);
+        if (iterator == inputValue.MemberEnd())
+        {
+            return JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::Skipped);
+        }
+
+        if (iterator->value.IsObject())
+        {
+            // if its an object, then its in the new format, an actual AZ::Asset<T> type, so just load it normally:
+            auto returnCode = ContinueLoadingFromJsonObjectField(
+                &destField, azrtti_typeid<AZ::Data::Asset<T>>(), inputValue, rapidjson::GenericStringRef<char>(fieldName), context);
+            return returnCode;
+        }
+
+        if (iterator->value.IsString())
+        {
+            AZStd::string sourceAssetPath = iterator->value.GetString();
+            if (sourceAssetPath.empty())
+            {
+                return JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::Skipped);
+            }
+
+            AZ::Data::AssetId resultId = AzToolsFramework::AssetSystem::FindAssetIdFromFileName(sourceAssetPath.c_str(), typeId);
+            if (resultId.IsValid())
+            {
+                destField = AZ::Data::AssetManager::Instance().FindOrCreateAsset<T>(resultId, loadBehavior);
+            }
+        }
+
+        if (destField.GetId().IsValid())
+        {
+            return JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::Success);
+        }
+
+        return JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::DefaultsUsed);
+    }
+
     AZ::JsonSerializationResult::Result ParticleEmitterInfoSerializer::Load(
         void* outputValue,
         const AZ::Uuid& outputValueTypeId,
@@ -524,12 +578,11 @@ namespace OpenParticle
         emitInfo->m_config = context.GetSerializeContext()->CreateAny(configId);
         resultCode.Combine(
             ContinueLoadingFromJsonObjectField(AZStd::any_cast<void>(&emitInfo->m_config), configId, inputValue, "config", context));
-        resultCode.Combine(
-            ContinueLoadingFromJsonObjectField(&emitInfo->m_material, azrtti_typeid<AZStd::string>(), inputValue, "material", context));
-        resultCode.Combine(
-            ContinueLoadingFromJsonObjectField(&emitInfo->m_model, azrtti_typeid<AZStd::string>(), inputValue, "model", context));
-        resultCode.Combine(ContinueLoadingFromJsonObjectField(
-            &emitInfo->m_skeletonModel, azrtti_typeid<AZStd::string>(), inputValue, "skeleton model", context));
+
+        AZ::Data::AssetLoadBehavior loadBehavior = AZ::Data::AssetLoadBehavior::PreLoad;
+        resultCode.Combine(ConvertSourceFileNameToAsset(emitInfo->m_material, inputValue, "material", loadBehavior, context));
+        resultCode.Combine(ConvertSourceFileNameToAsset(emitInfo->m_model, inputValue, "model", loadBehavior, context));
+        resultCode.Combine(ConvertSourceFileNameToAsset(emitInfo->m_skeletonModel, inputValue, "skeleton model", loadBehavior, context));
 
         AZStd::unordered_map<AZ::TypeId, VersionConvertor> emits = {
             { azrtti_typeid<OpenParticle::EmitBurstList>(),        nullptr },
@@ -625,24 +678,34 @@ namespace OpenParticle
         resultCode.Combine(
             ContinueStoringToJsonObjectField(outputValue, "config", AZStd::any_cast<void>(&config), nullptr, configId, context));
 
-        auto mat = info->m_material;
-        if (info->m_material.empty())
+        // its not necessary to load the asset just to check its id or to store the id.
+        auto mat = info->m_material; 
+        if (!info->m_material.GetId().IsValid()) 
         {
-            mat = AZStd::string("Materials/OpenParticle/ParticleSpriteEmit.material");
+            AZ::Data::AssetId defaultSpriteEmitMaterialId;
+            using editorBus = EditorParticleSystemComponentRequestBus;
+            using editorBusEvents = EditorParticleSystemComponentRequestBus::Events;
+            editorBus::BroadcastResult(defaultSpriteEmitMaterialId, &editorBusEvents::GetDefaultEmitterMaterialId);
+            if (defaultSpriteEmitMaterialId.IsValid())
+            {
+                // we don't actually have to load the asset, just want to place it into a struct for serialize.
+                mat = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::MaterialAsset>(
+                    defaultSpriteEmitMaterialId, AZ::Data::AssetLoadBehaviorNamespace::NoLoad);
+            }
         }
-        resultCode.Combine(
-            ContinueStoringToJsonObjectField(outputValue, "material", &mat, nullptr, azrtti_typeid<AZStd::string>(), context));
 
-        if (!info->m_model.empty())
+        auto materialAssetType = azrtti_typeid<AZ::Data::Asset<AZ::RPI::MaterialAsset>>();
+        auto modelAssetType = azrtti_typeid<AZ::Data::Asset<AZ::RPI::ModelAsset>>();
+        resultCode.Combine(ContinueStoringToJsonObjectField(outputValue, "material", &mat, nullptr, materialAssetType, context));
+
+        if (!info->m_model)
         {
-            resultCode.Combine(
-                ContinueStoringToJsonObjectField(outputValue, "model", &info->m_model, nullptr, azrtti_typeid<AZStd::string>(), context));
+            resultCode.Combine(ContinueStoringToJsonObjectField(outputValue, "model", &info->m_model, nullptr, modelAssetType, context));
         }
 
-        if (!info->m_skeletonModel.empty())
+        if (!info->m_skeletonModel)
         {
-            resultCode.Combine(ContinueStoringToJsonObjectField(
-                outputValue, "skeleton model", &info->m_skeletonModel, nullptr, azrtti_typeid<AZStd::string>(), context));
+            resultCode.Combine(ContinueStoringToJsonObjectField(outputValue, "skeleton model", &info->m_skeletonModel, nullptr, modelAssetType, context));
         }
 
         if (!info->m_renderConfig.empty())

--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
@@ -8,12 +8,12 @@
 
 #include "ParticleSystemSerializer.h"
 
+#include <API/EditorAssetSystemAPI.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzFramework/Asset/AssetSystemBus.h>
+#include <OpenParticleSystem/EditorParticleSystemComponentRequestBus.h>
 #include <OpenParticleSystem/ParticleConfigurationRequestBus.h>
 #include <OpenParticleSystem/ParticleEditDataConfig.h>
-#include <OpenParticleSystem/EditorParticleSystemComponentRequestBus.h>
-#include <AzFramework/Asset/AssetSystemBus.h>
-#include <API/EditorAssetSystemAPI.h>
 
 namespace OpenParticle
 {

--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.h
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.h
@@ -11,6 +11,12 @@
 #include <AzCore/Serialization/Json/BaseJsonSerializer.h>
 #include <OpenParticleSystem/Serializer/ParticleSourceData.h>
 
+namespace AZ::Data
+{
+    template<typename T>
+    class Asset;
+};
+
 namespace OpenParticle
 {
     class ParticleBaseSerializer
@@ -22,6 +28,15 @@ namespace OpenParticle
 
         template<typename T>
         void ConvertOldModule(AZStd::any& module, const rapidjson::Value& inputValue, AZ::JsonDeserializerContext& context);
+
+        //! Helper function to convert a source file name(string) to an asset reference(Asset<T>)
+        template<typename T>
+        AZ::JsonSerializationResult::ResultCode ConvertSourceFileNameToAsset(
+            AZ::Data::Asset<T>& destField,
+            const rapidjson::Value& inputValue,
+            const char* fieldName,
+            AZ::Data::AssetLoadBehavior loadBehavior,
+            AZ::JsonDeserializerContext& context);
 
         // Convert Type: float -> ValueFloatObj / AZ::Vector3 -> ValueVec3Obj / AZ::Color -> ValueObjColor
         template<typename T, size_t size>

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/AssetWidget.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/AssetWidget.h
@@ -15,32 +15,30 @@
 #endif
 #include <QWidget>
 
+namespace AzToolsFramework
+{
+    class PropertyAssetCtrl;
+}
+
 namespace OpenParticleSystemEditor
 {
-    using AssetChangeCB = AZStd::function<void(const char*)>;
+    using AssetChangeCB = AZStd::function<void(AZ::Data::AssetId)>;
     class AssetWidget
         : public QWidget
     {
         Q_OBJECT;
 
     public:
-        AssetWidget(const AZStd::string& label, const AZ::Data::AssetType& assetType, const AZStd::string& extention, QWidget* parent = nullptr);
+        AssetWidget(const AZStd::string& label, const AZ::Data::AssetType& assetType, QWidget* parent = nullptr);
         ~AssetWidget() override {}
-        void SetAssetPath(const AZStd::string& path);
         void Clear();
-        
-        void OnAssetSelectionChanged(AssetChangeCB funcPtr)
-        {
-            m_AssetSelectionChanged = funcPtr;
-        }
+        void SetAssetId(const AZ::Data::AssetId& newId);
+
+        void SetOnAssetSelectionChangedCallback(AssetChangeCB funcPtr);
 
     private:
-        void PopupAssetPicker();
-
-        AZStd::string m_title;
-        AZ::Data::AssetType m_assetType;
-        AZStd::string m_extention;
-        AzQtComponents::BrowseEdit* m_assetPathBrowseEdit;
+        AzToolsFramework::PropertyAssetCtrl* m_assetCtrl = nullptr;
         AssetChangeCB m_AssetSelectionChanged;
+
     };
 } // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
@@ -16,7 +16,6 @@
 #include <QtWidgets/QComboBox>
 #include <OpenParticleSystem/Serializer/ParticleSourceData.h>
 #include <ParticleCommonData.h>
-#include <Window/AssetWidget.h>
 #include <QVBoxLayout>
 #include <QCoreApplication>
 #endif
@@ -31,7 +30,18 @@ namespace OpenParticleSystemEditor
     const QString SHAPE_LABEL = QCoreApplication::translate("ComboBoxWidget", "Shape");
     const QString RENDERER_LABEL = QCoreApplication::translate("ComboBoxWidget", "Renderer");
 
-    using AssetChangeCB = AZStd::function<void(const char*)>;
+    class AssetWidget;
+
+    using AssetChangeCB = AZStd::function<void(AZ::Data::AssetId)>;
+    //! ComboBoxWidget represents a widget that has a drop down combo at the top which lets you select a class of objects
+    //! and depending on what you pick, changes the rest of the UI.
+    //! It consists of a ReflectedPropertyEditor control (showing a list of properties that you can edit) and below that,
+    //! a series of asset picker controls.  Depending on the selected class, it changes what properties, and which asset
+    //! controls are visible.
+    //! For example, it shows up when you select an emitter's shape class, and lets ou pick from "Point", "Box", "Sphere",
+    //! "Torus", "Cylinder", or "Mesh".
+    //! If you pick "mesh", then the "mesh" asset control appears for you to pick a mesh.  Otherwise, that asset control
+    //! is hidden.
     class ComboBoxWidget
         : public QWidget
     {
@@ -40,7 +50,7 @@ namespace OpenParticleSystemEditor
     public:
         ComboBoxWidget(
             const AZStd::string& className,
-            OpenParticle::ParticleSourceData::DetailInfo* m_detail,
+            OpenParticle::ParticleSourceData::DetailInfo* detail,
             AZ::SerializeContext* serializeContext,
             AzToolsFramework::IPropertyEditorNotify* pnotify,
             QWidget* parent = nullptr);
@@ -49,10 +59,23 @@ namespace OpenParticleSystemEditor
         void Clear();
         void Refresh();
         void Refresh(AZStd::any* instance);
-        void SetAssetWidget(AZStd::string& materialAsset, AZStd::string& modelAsset, AZStd::string& skeletonModelAsset);
+
+        // connects the asset widgets to the given asset pointers.
+        // Note that these asset pointers are in the "detail" object that was passed in the constructor,
+        // and the actual asset<T> lives on the particle source data object.
+        void SetAssetWidget(
+            AZ::Data::Asset<AZ::RPI::MaterialAsset>* materialAsset,
+            AZ::Data::Asset<AZ::RPI::ModelAsset>* modelAsset,
+            AZ::Data::Asset<AZ::RPI::ModelAsset>* skeletonModelAsset);
 
     private slots:
         void OnIndexChanged(const QString& curString);
+
+    Q_SIGNALS:
+        // signal that the assets have been changed in the editor.
+        void OnMaterialChanged();
+        void OnModelChanged();
+        void OnSkeletonModelChanged();
 
     private:
         void SetAssetWidgetVisible();

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.h
@@ -100,5 +100,10 @@ namespace OpenParticleSystemEditor
         AZStd::any m_preWarm;
         OpenParticle::UpdateRotateAroundPoint m_updateRotateAroundPoint;
         AZ::Vector3 m_lastAxis;
+
+    private Q_SLOTS:
+        void OnComboBoxMaterialChanged();
+        void OnComboBoxModelChanged();
+        void OnComboBoxSkeletonModelChanged();
     };
 } // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleGraphicsView.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleGraphicsView.cpp
@@ -263,7 +263,7 @@ namespace OpenParticleSystemEditor
         OpenParticle::ParticleSourceData::DetailInfo* detail, bool setCurMousePos, const AZStd::string& itemName)
     {
         ParticleItemWidget* itemWidget = new ParticleItemWidget(m_viewDetail, detail, m_SourceData, m_busID);
-        itemWidget->GetBtnParticleName()->setText(detail->m_name->data());
+        itemWidget->GetBtnParticleName()->setText(QString::fromUtf8(detail->m_name.c_str()));
         bool bCheckParticleName = false;
         for (auto& iter : detail->m_modules)
         {
@@ -429,7 +429,7 @@ namespace OpenParticleSystemEditor
         {
             if (m_viewDetail != nullptr)
             {
-                if (*detail->m_name == m_viewDetail->m_ui->particleName->text().toLatin1().data())
+                if (QString detailName = QString::fromUtf8(detail->m_name.c_str()); detailName == m_viewDetail->m_ui->particleName->text())
                 {
                     m_viewDetail->Init(m_busID);
                 }
@@ -458,7 +458,7 @@ namespace OpenParticleSystemEditor
 
         QGraphicsProxyWidget* itemProxyWidget = dynamic_cast<QGraphicsProxyWidget*>(graphicsItem);
         ParticleItemWidget* itemWidget = dynamic_cast<ParticleItemWidget*>(itemProxyWidget->widget());
-        AZStd::string emitterName = *itemWidget->m_detail->m_name;
+        AZStd::string emitterName = itemWidget->m_detail->m_name;
         OpenParticle::ParticleSourceData::DetailInfo* detail = nullptr;
         EBUS_EVENT_ID_RESULT(detail, m_busID, ParticleDocumentRequestBus, CopyDetail, emitterName);
         // tell every document which widget prepare to be pasted
@@ -482,7 +482,7 @@ namespace OpenParticleSystemEditor
         OpenParticle::ParticleSourceData::DetailInfo* destDetail = nullptr;
         EBUS_EVENT_ID_RESULT(destDetail, m_busID, ParticleDocumentRequestBus, SetEmitterAndDetail, sourceEmitter, sourceDetail);
 
-        NewItem(destDetail, false, destDetail->m_name->c_str());
+        NewItem(destDetail, false, destDetail->m_name);
         
         AZStd::vector<AZStd::string> itemNames = GetItemNamesByOrder();
         for (auto& detailName : itemNames)
@@ -552,7 +552,7 @@ namespace OpenParticleSystemEditor
                 if (itemWidget != nullptr)
                 {
                     auto pos = item->scenePos();
-                    auto info = AZStd::make_pair(static_cast<float>(pos.x()), *itemWidget->m_detail->m_name);
+                    auto info = AZStd::make_pair(static_cast<float>(pos.x()), itemWidget->m_detail->m_name);
                     itemsInfo.push_back(info);
                 }
             }
@@ -593,7 +593,7 @@ namespace OpenParticleSystemEditor
             }
             if (except)
             {
-                if (name.compare(*itemWidget->m_detail->m_name) == 0)
+                if (name.compare(itemWidget->m_detail->m_name) == 0)
                 {
                     continue;
                 }
@@ -601,7 +601,7 @@ namespace OpenParticleSystemEditor
             }
             else
             {
-                if (len == 0 || name.compare(*itemWidget->m_detail->m_name) == 0)
+                if (len == 0 || name.compare(itemWidget->m_detail->m_name) == 0)
                 {
                     AZStd::invoke(SetCheckedFun, itemWidget, solo, checked);
                     if (len != 0)
@@ -658,7 +658,7 @@ namespace OpenParticleSystemEditor
                 ParticleItemWidget* itemWidget = dynamic_cast<ParticleItemWidget*>(itemProxyWidget->widget());
                 if (itemWidget != nullptr)
                 {
-                    widgets[*(itemWidget->m_detail->m_name)] = itemWidget;
+                    widgets[itemWidget->m_detail->m_name] = itemWidget;
                 }
             }
         }
@@ -687,7 +687,7 @@ namespace OpenParticleSystemEditor
                 {
                     auto pos = item->scenePos();
                     auto sz = itemWidget->size();
-                    auto name = *itemWidget->m_detail->m_name;
+                    auto name = itemWidget->m_detail->m_name;
 
                     QRectF rect(pos.x(), pos.y(), sz.width(), sz.height());
                     if (rect.contains(scenePt))

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleItemWidget.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleItemWidget.cpp
@@ -54,7 +54,7 @@ namespace OpenParticleSystemEditor
         this->setStyleSheet("background-color: #333333; border-radius: 8px;");
         SetLineWidgetIndex();
         SetLineWidgetParent();
-        m_pSourceData->SelectClass(*m_detail->m_name, PARTICLE_LINE_NAMES[WIDGET_LINE_EMITTER]);
+        m_pSourceData->SelectClass(m_detail->m_name, PARTICLE_LINE_NAMES[WIDGET_LINE_EMITTER]);
         OnRelease();
 
         QObject::connect(m_ui->btnParticleName, SIGNAL(clicked()), this, SLOT(OnClickParticleName()));
@@ -99,7 +99,7 @@ namespace OpenParticleSystemEditor
     {
         AZStd::vector<AZStd::string> itemNames;
         EBUS_EVENT_ID_RESULT(itemNames, m_graphParentTitle, ParticleGraphicsViewRequestsBus, GetItemNamesByOrder);
-        AZStd::string currDetailName = *m_detail->m_name;
+        AZStd::string currDetailName = m_detail->m_name;
         if (checked)
         {
             for (auto& detailName : itemNames)
@@ -146,12 +146,12 @@ namespace OpenParticleSystemEditor
             }
             AZStd::vector<AZStd::string> itemNames;
             EBUS_EVENT_ID_RESULT(itemNames, m_graphParentTitle, ParticleGraphicsViewRequestsBus, GetItemNamesByOrder);
-            m_pSourceData->SelectDetail(*m_detail->m_name);
+            m_pSourceData->SelectDetail(m_detail->m_name);
             m_pSourceData->SortEmitters(itemNames);
         }
         else
         {
-            m_pSourceData->UnselectDetail(*m_detail->m_name);
+            m_pSourceData->UnselectDetail(m_detail->m_name);
         }
         EBUS_EVENT(LevelOfDetailInspectorNotifyBus, ReloadLevel, m_graphParentTitle);
         EBUS_EVENT_ID(m_graphParentTitle, ParticleDocumentRequestBus, NotifyParticleSourceDataModified);
@@ -166,11 +166,11 @@ namespace OpenParticleSystemEditor
     {
         if (check)
         {
-            m_pSourceData->SelectClass(*m_detail->m_name, className);
+            m_pSourceData->SelectClass(m_detail->m_name, className);
         }
         else
         {
-            m_pSourceData->UnselectClass(*m_detail->m_name, className);
+            m_pSourceData->UnselectClass(m_detail->m_name, className);
         }
         EBUS_EVENT_ID(m_graphParentTitle, ParticleDocumentRequestBus, NotifyParticleSourceDataModified);
         ClickLineWidget(index);
@@ -292,7 +292,7 @@ namespace OpenParticleSystemEditor
 
     void ParticleItemWidget::UpdateParticleName()
     {
-        m_ui->btnParticleName->setText(m_detail->m_name->data());
+        m_ui->btnParticleName->setText(QString::fromUtf8(m_detail->m_name.c_str()));
     }
 
     QToolButton* ParticleItemWidget::GetBtnParticleName()


### PR DESCRIPTION
## What does this PR do?

The product file data (as in, the compiled asset) was always using asset references (`AZ::Data::Asset<Material> etc`) but the source json files were using string path names like `"material" = "Atom/Examples/Blah.material"`.

This made it much more expensive at compile time and validation time, for example, if you assign "Sphere.azmodel" it was previously trying to make sure that "sphere.fbx" was compiled,by replacing the extension "azmodel" with "fbx" and establishing a dependency on that.  However, its possible that "sphere.azmodel" came from "sphere.obj", or "sphere.usd", or any other model format.

It's also possible that "sphere.azmodel" came from a model that was not named "sphere" at all, for example, if you had a model named "shapes.fbx", that contained a cube, and a sphere.  There simply is not enough information in a product file name alone to know what file to compile or depend on to produce it.  (Same goes for materials, since they could be generated ones).

This change makes it so that the source files (`.particle` files) also use Asset References in json, which means that the Asset Processor can directly validate that the asset exists, and that it is of the correct type, and does not need to do any guessing based on file names.   It makes the compile job only depend on the material (and it only depends on that for validating that the material type is ok, which is something we could probably revisit).  It does not load the model at any point during the job anymore, as all it needs is the ID, not the asset data.

It also replaces the custom asset control used in the ComboBox widget, with the standard `AZ::ToolsFramework` asset line control and picker, as well as uses the tools busses to convert from the old "name" format to the new "asset reference" format, so all old assets still function as before.

In order to convert them, I needed to make 2 changes to the core: the first is there was simply a bug where the API to look up Asset products by the source file name - the function was not actually filling out the entire response structure, leaving the file name empty.

The second is a new API convenience function to do a best guess conversion of a file name to an asset reference, by doing a series of lookups from the fastest most reliable to the slowest "Guess".  Given a file name of either a source or product, it can do its best to find what the thing is looking for.  This is used when loading the particle json file, if it discovers the old format.

## How was this PR tested?

* Loading the old data into the editor and the runtime, after these changes, to make sure the old data still worked.
* Rebuilding all the assets in asset processor, loading the new processed assets, making sure no issues with the asset jobs.
* Altering, and then saving the data, so that it would be the new format, then repeating the above two tests.
* Renaming an emitter, changing its materials, meshes, skeleton mesh, then repeating the first two bullet points.

