### PR TITLE
Add EditorSystemBus

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorSystemBus.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorSystemBus.cpp
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// #include "EditorSystemBus.h"
+
+
+// DECLARE_EBUS_INSTANTIATION(EditorSystemRequests);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorSystemBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/EditorSystemBus.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <CryCommon/ISystem.h> // Only until ISystem can be ported to non-Cry
+
+struct ISystem;
+struct SSystemInitParams;
+
+namespace AzToolsFramework
+{
+    /*!
+    * Events from EditorSystem
+    */
+    class EditorSystemEvents
+        : public AZ::EBusTraits
+    {
+    public:
+        //! ISystem has been created and is about to initialize.
+        virtual void OnEditorSystemPreInitialize(ISystem&, const SSystemInitParams&) {}
+
+        //! ISystem and IConsole has been created but the cfg files have not been parsed
+        virtual void OnEditorSystemCVarRegistry() {}
+
+        //! ISystem has been created and initialized.
+        virtual void OnEditorSystemInitialized(ISystem&, const SSystemInitParams&) {}
+
+        //! In-Editor systems have been created and initialized.
+        virtual void OnEditorInitialized() {}
+
+        //! Editor has started a level export
+        virtual void OnEditorBeginLevelExport() {}
+
+        //! Editor has finished a level export
+        virtual void OnEditorEndLevelExport(bool /*success*/) {}
+
+        //! ISystem is about to begin shutting down
+        virtual void OnEditorSystemShutdown(ISystem&) {}
+
+        //! ISystem has shut down.
+        virtual void OnEditorSystemPostShutdown() {}
+
+        //! Sent when a new level is being created.
+        virtual void OnEditorBeginCreate() {}
+
+        //! Sent after a new level has been created.
+        virtual void OnEditorEndCreate() {}
+
+        //! Sent when a level is about to be loaded.
+        virtual void OnEditorBeginLoad() {}
+
+        //! Sent after a level has been loaded.
+        virtual void OnEditorEndLoad() {}
+
+        //! Sent when the document is about to close.
+        virtual void OnEditorCloseScene() {}
+
+        //! Sent when the document is closed.
+        virtual void OnEditorSceneClosed() {}
+    };
+    using EditorSystemEventBus = AZ::EBus<EditorSystemEvents>;
+
+    /*!
+    * Requests to EditorSystem
+    */
+    class EditorSystemRequests
+        : public AZ::EBusTraits
+    {
+    public:
+        //! Get EditorSystem
+        virtual ISystem* GetEditorSystem() = 0;
+    };
+    using EditorSystemRequestBus = AZ::EBus<EditorSystemRequests>;
+
+}
+DECLARE_EBUS_EXTERN(AzToolsFramework::EditorSystemRequests);

--- a/Code/Framework/AzToolsFramework/CMakeLists.txt
+++ b/Code/Framework/AzToolsFramework/CMakeLists.txt
@@ -53,6 +53,7 @@ ly_add_target(
         PRIVATE
             3rdParty::SQLite
             AZ::AzCore
+            Legacy::CryCommon # Temporary, until ISystem is converted for EditorSystemBus
         PUBLIC
             3rdParty::Qt::Core
             3rdParty::Qt::Gui

--- a/Code/Legacy/CryCommon/CrySystemBus.h
+++ b/Code/Legacy/CryCommon/CrySystemBus.h
@@ -15,65 +15,84 @@ struct SSystemInitParams;
 
 /*!
  * Events from CrySystem
+ *  use AzToolsFramework::EditorSystemEvents instead
  */
 class CrySystemEvents
     : public AZ::EBusTraits
 {
 public:
     //! ISystem has been created and is about to initialize.
+    // [[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorSystemPreInitialize instead")]]
     virtual void OnCrySystemPreInitialize(ISystem&, const SSystemInitParams&) {}
 
     //! ISystem and IConsole has been created but the cfg files have not been parsed
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorSystemCVarRegistry instead")]]
     virtual void OnCrySystemCVarRegistry() {}
 
     //! ISystem has been created and initialized.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorSystemInitialized instead")]]
     virtual void OnCrySystemInitialized(ISystem&, const SSystemInitParams&) {}
 
     //! In-Editor systems have been created and initialized.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorInitialized instead")]]
     virtual void OnCryEditorInitialized() {}
 
     //! Editor has started a level export
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorBeginLevelExport instead")]]
     virtual void OnCryEditorBeginLevelExport() {}
 
     //! Editor has finished a level export
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorEndLevelExport instead")]]
     virtual void OnCryEditorEndLevelExport(bool /*success*/) {}
 
     //! ISystem is about to begin shutting down
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorSystemPreShutdown instead")]]
     virtual void OnCrySystemShutdown(ISystem&) {}
 
     //! ISystem has shut down.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorSystemShutdown instead")]]
     virtual void OnCrySystemPostShutdown() {}
 
     //! Sent when a new level is being created.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorBeginCreate instead")]]
     virtual void OnCryEditorBeginCreate() {}
 
     //! Sent after a new level has been created.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorEndCreate instead")]]
     virtual void OnCryEditorEndCreate() {}
 
     //! Sent when a level is about to be loaded.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorBeginLoad instead")]]
     virtual void OnCryEditorBeginLoad() {}
 
     //! Sent after a level has been loaded.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorEndLoad instead")]]
     virtual void OnCryEditorEndLoad() {}
 
     //! Sent when the document is about to close.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorCloseScene instead")]]
     virtual void OnCryEditorCloseScene() {}
 
     //! Sent when the document is closed.
+    //[[deprecated("use AzToolsFramework::EditorSystemRequestBus::OnEditorSceneClosed instead")]]
     virtual void OnCryEditorSceneClosed() {}
 };
+
 using CrySystemEventBus = AZ::EBus<CrySystemEvents>;
 
 /*!
  * Requests to CrySystem
+ *  use AzToolsFramework::EditorSystemRequests instead
  */
 class CrySystemRequests
     : public AZ::EBusTraits
 {
 public:
     //! Get CrySystem
+    //[[deprecated("use AzToolsFramework::EditorSystemRequests::GetEditorSystem")]]
     virtual ISystem* GetCrySystem() = 0;
 };
+
 using CrySystemRequestBus = AZ::EBus<CrySystemRequests>;
 
 DECLARE_EBUS_EXTERN(CrySystemRequests);

--- a/Gems/AssetValidation/Code/Source/AssetValidationSystemComponent.cpp
+++ b/Gems/AssetValidation/Code/Source/AssetValidationSystemComponent.cpp
@@ -72,7 +72,7 @@ namespace AssetValidation
 
     void AssetValidationSystemComponent::Activate()
     {
-        CrySystemEventBus::Handler::BusConnect();
+        EditorSystemEventBus::Handler::BusConnect();
         AssetValidationRequestBus::Handler::BusConnect();
     }
 
@@ -83,7 +83,7 @@ namespace AssetValidation
             AZ::IO::ArchiveNotificationBus::Handler::BusDisconnect();
         }
         AssetValidationRequestBus::Handler::BusDisconnect();
-        CrySystemEventBus::Handler::BusDisconnect();
+        EditorSystemEventBus::Handler::BusDisconnect();
     }
 
     void AssetValidationSystemComponent::ConsoleCommandSeedMode([[maybe_unused]] IConsoleCmdArgs* pCmdArgs)
@@ -130,7 +130,7 @@ namespace AssetValidation
         AssetValidationNotificationBus::Broadcast(&AssetValidationNotificationBus::Events::SetSeedMode, m_seedMode);
     }
 
-    void AssetValidationSystemComponent::OnCrySystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams)
+    void AssetValidationSystemComponent::OnEditorSystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams)
     {
         AZ_UNUSED(systemInitParams);
 

--- a/Gems/AssetValidation/Code/Source/AssetValidationSystemComponent.h
+++ b/Gems/AssetValidation/Code/Source/AssetValidationSystemComponent.h
@@ -18,17 +18,17 @@
 #include <AzCore/Outcome/Outcome.h>
 #include <AssetSystemTestCommands.h>
 
-#include <CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 #include <AzFramework/Archive/ArchiveBus.h>
 
-struct IConsoleCmdArgs; 
+struct IConsoleCmdArgs;
 
 namespace AssetValidation
 {
     class AssetValidationSystemComponent
         : public AZ::Component
         , protected AssetValidationRequestBus::Handler
-        , public CrySystemEventBus::Handler
+        , public AzToolsFramework::EditorSystemEventBus::Handler
         , public AZ::IO::ArchiveNotificationBus::Handler
     {
     public:
@@ -58,7 +58,7 @@ namespace AssetValidation
         void SeedMode() override;
 
         bool AddSeedPath(const char* fileName) override;
-       
+
         bool RemoveSeedPath(const char* fileName) override;
 
         void ListKnownAssets() override;
@@ -81,7 +81,7 @@ namespace AssetValidation
         static void ConsoleCommandKnownAssets(IConsoleCmdArgs* pCmdArgs);
         static void ConsoleCommandTogglePrintExcluded(IConsoleCmdArgs* pCmdArgs);
 
-        void OnCrySystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams) override;
+        void OnEditorSystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams) override;
 
         ////////////////////////////////////////////////////////////////////////
         // AZ::Component interface implementation
@@ -106,7 +106,7 @@ namespace AssetValidation
         bool RemoveSeedsFor(const AzFramework::AssetSeedList& seedList, AZ::u32 sourceId);
         bool AddSeedListHelper(const char* seedPath);
     private:
-        
+
         bool m_seedMode{ false };
         bool m_printExcluded{ false };
 

--- a/Gems/AtomLyIntegration/AtomFont/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/AtomFont/Code/CMakeLists.txt
@@ -23,7 +23,7 @@ ly_add_target(
             3rdParty::Freetype
             AZ::AzCore
             AZ::AtomCore
-            Legacy::CryCommon
+            AZ::AzToolsFramework
             Gem::Atom_RHI.Reflect
             Gem::Atom_RPI.Public
         PUBLIC
@@ -62,4 +62,3 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         LABELS REQUIRES_tiaf
     )
 endif()
-

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFontSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFontSystemComponent.cpp
@@ -62,12 +62,12 @@ namespace AZ
 
         void AtomFontSystemComponent::Activate()
         {
-            CrySystemEventBus::Handler::BusConnect();
+            AzToolsFramework::EditorSystemEventBus::Handler::BusConnect();
         }
 
         void AtomFontSystemComponent::Deactivate()
         {
-            CrySystemEventBus::Handler::BusDisconnect();
+            AzToolsFramework::EditorSystemEventBus::Handler::BusDisconnect();
         }
 
         void LoadFont(ICryFont& cryFont, const AZStd::string& fontName)
@@ -82,7 +82,7 @@ namespace AZ
             }
         }
 
-        void AtomFontSystemComponent::OnCrySystemInitialized(ISystem& system, const SSystemInitParams&)
+        void AtomFontSystemComponent::OnEditorSystemInitialized(ISystem& system, const SSystemInitParams&)
         {
 #if !defined(AZ_MONOLITHIC_BUILD)
             // When module is linked dynamically, we must set our gEnv pointer.
@@ -106,7 +106,7 @@ namespace AZ
             }
         }
 
-        void AtomFontSystemComponent::OnCrySystemShutdown([[maybe_unused]] ISystem& system)
+        void AtomFontSystemComponent::OnEditorSystemShutdown([[maybe_unused]] ISystem& system)
         {
 #if !defined(AZ_MONOLITHIC_BUILD)
             gEnv = nullptr;

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFontSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFontSystemComponent.h
@@ -9,7 +9,7 @@
 
 #include <AzCore/Component/Component.h>
 
-#include <CryCommon/CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 
 namespace AZ
 {
@@ -17,7 +17,7 @@ namespace AZ
     {
         class AtomFontSystemComponent
             : public AZ::Component
-            , private CrySystemEventBus::Handler
+            , private AzToolsFramework::EditorSystemEventBus::Handler
         {
         public:
             AZ_COMPONENT(AtomFontSystemComponent, "{29DC7010-CF2A-4EE4-91F8-8E3C8BE65F41}");
@@ -37,13 +37,13 @@ namespace AZ
             ////////////////////////////////////////////////////////////////////////
 
             ////////////////////////////////////////////////////////////////////////
-            // CrySystemEventBus
-            void OnCrySystemInitialized(ISystem& system, const SSystemInitParams& initParams) override;
+            // EditorSystemEventBus
+            void OnEditorSystemInitialized(ISystem& system, const SSystemInitParams& initParams) override;
             ////////////////////////////////////////////////////////////////////////
 
             ////////////////////////////////////////////////////////////////////////
-            // CrySystemEventBus
-            void OnCrySystemShutdown(ISystem& system) override;
+            // EditorSystemEventBus
+            void OnEditorSystemShutdown(ISystem& system) override;
             ////////////////////////////////////////////////////////////////////////
         };
     } // namespace Render

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/CMakeLists.txt
@@ -20,6 +20,7 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
             AZ::AtomCore
+            AZ::AzToolsFramework
             Legacy::CryCommon
             Gem::Atom_RHI.Reflect
             Gem::Atom_RPI.Public
@@ -61,4 +62,3 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         LABELS REQUIRES_tiaf
     )
 endif()
-

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
@@ -9,7 +9,7 @@
 
 #include <AzCore/Component/Component.h>
 
-#include <CryCommon/CrySystemBus.h>
+// #include <CryCommon/CrySystemBus.h>
 #include <AzCore/Script/ScriptTimePoint.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Font/FontInterface.h>

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/CMakeLists.txt
@@ -145,6 +145,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::AtomToolsFramework.Editor
                 AZ::SceneCore
                 AZ::SceneData
+                AZ::AzToolsFramework
                 Legacy::Editor.Headers
                 Legacy::EditorCommon
                 Legacy::CryCommon

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkinnedMesh/SkinnedMeshDebugDisplay.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkinnedMesh/SkinnedMeshDebugDisplay.cpp
@@ -22,20 +22,20 @@ namespace AZ
     {
         SkinnedMeshDebugDisplay::SkinnedMeshDebugDisplay()
         {
-            CrySystemEventBus::Handler::BusConnect();
+            AzToolsFramework::EditorSystemEventBus::Handler::BusConnect();
             AZ::Render::Bootstrap::NotificationBus::Handler::BusConnect();
         }
 
         SkinnedMeshDebugDisplay::~SkinnedMeshDebugDisplay()
         {
             AZ::Render::Bootstrap::NotificationBus::Handler::BusDisconnect();
-            CrySystemEventBus::Handler::BusDisconnect();
+            AzToolsFramework::EditorSystemEventBus::Handler::BusDisconnect();
             AzFramework::ViewportDebugDisplayEventBus::Handler::BusDisconnect();
         }
 
-        void SkinnedMeshDebugDisplay::OnCrySystemInitialized(ISystem& system, [[maybe_unused]] const SSystemInitParams& systemInitParams)
+        void SkinnedMeshDebugDisplay::OnEditorSystemInitialized(ISystem& system, [[maybe_unused]] const SSystemInitParams& systemInitParams)
         {
-            // Once CrySystem is initialized, we can register cvars
+            // Once EditorSystem is initialized, we can register cvars
             if (system.GetGlobalEnvironment() && system.GetGlobalEnvironment()->pConsole)
             {
                 system.GetGlobalEnvironment()->pConsole->Register("r_skinnedMeshDisplaySceneStats", &r_skinnedMeshDisplaySceneStats, 0, VF_NULL,
@@ -49,7 +49,7 @@ namespace AZ
             }
         }
 
-        void SkinnedMeshDebugDisplay::OnCrySystemShutdown(ISystem& system)
+        void SkinnedMeshDebugDisplay::OnEditorSystemShutdown(ISystem& system)
         {
             if (system.GetGlobalEnvironment() && system.GetGlobalEnvironment()->pConsole)
             {
@@ -61,7 +61,7 @@ namespace AZ
             }
         }
 
-        void SkinnedMeshDebugDisplay::OnCryEditorInitialized()
+        void SkinnedMeshDebugDisplay::OnEditorInitialized()
         {
             // Once the editor is initialized, listen to ViewportDebugDisplayEventBus
             AzFramework::EntityContextId editorEntityContextId = AzFramework::EntityContextId::CreateNull();
@@ -73,7 +73,7 @@ namespace AZ
         {
             if (r_skinnedMeshDisplaySceneStats == 1)
             {
-                // Get scene id when DisplayViewport2d is called. The RPI Scene may not be ready when OnCryEditorInitialized was called
+                // Get scene id when DisplayViewport2d is called. The RPI Scene may not be ready when OnEditorInitialized was called
                 SkinnedMeshSceneStats stats{};
                 SkinnedMeshStatsRequestBus::EventResult(stats, m_sceneId, &SkinnedMeshStatsRequestBus::Events::GetSceneStats);
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkinnedMesh/SkinnedMeshDebugDisplay.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkinnedMesh/SkinnedMeshDebugDisplay.h
@@ -10,7 +10,7 @@
 
 #include <Atom/RPI.Public/Base.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
-#include <CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 #include <Atom/Bootstrap/BootstrapNotificationBus.h>
 
 
@@ -21,7 +21,7 @@ namespace AZ
         //! This class is responsible for displaying stats about Atom's SkinnedMesh feature
         class SkinnedMeshDebugDisplay
             : private AzFramework::ViewportDebugDisplayEventBus::Handler
-            , private CrySystemEventBus::Handler
+            , private AzToolsFramework::EditorSystemEventBus::Handler
             , private AZ::Render::Bootstrap::NotificationBus::Handler
         {
         public:
@@ -30,11 +30,11 @@ namespace AZ
 
         private:
 
-            // CrySystemEventBus::Handler overrides
+            // AzToolsFramework::EditorSystemEventBus::Handler overrides
             // Register the r_skinnedMeshDisplaySceneStats cvar
-            void OnCrySystemInitialized(ISystem&, const SSystemInitParams&) override;
-            void OnCrySystemShutdown(ISystem&) override;
-            void OnCryEditorInitialized() override;
+            void OnEditorSystemInitialized(ISystem&, const SSystemInitParams&) override;
+            void OnEditorSystemShutdown(ISystem&) override;
+            void OnEditorInitialized() override;
 
             // AzFramework::ViewportDebugDisplayEventBus overrides
             // Display the debug text if r_skinnedMeshDisplaySceneStats = 1

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/CMakeLists.txt
@@ -69,6 +69,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PRIVATE
                 AZ::AzCore
                 AZ::AzFramework
+                AZ::AzToolsFramework
                 Gem::${gem_name}.Static
                 Gem::EMotionFX.Editor.Static
                 Gem::AtomToolsFramework.Static

--- a/Gems/EMotionFX/Code/CMakeLists.txt
+++ b/Gems/EMotionFX/Code/CMakeLists.txt
@@ -31,6 +31,7 @@ ly_add_target(
         PUBLIC
             AZ::AzCore
             AZ::AzFramework
+            AZ::AzToolsFramework
             Legacy::CryCommon
         PUBLIC
             AZ::AtomCore
@@ -80,7 +81,7 @@ ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS ${gem_name})
 ly_create_alias(NAME ${gem_name}.Unified NAMESPACE Gem TARGETS ${gem_name})
 
 if (PAL_TRAIT_BUILD_HOST_TOOLS)
-    
+
     ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
@@ -136,6 +137,8 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
                 EMotionFX/Tools
                 EMotionFX/Pipeline
         BUILD_DEPENDENCIES
+            PUBLIC
+                AZ::AzToolsFramework
             PRIVATE
                 Gem::${gem_name}.Editor.Static
         RUNTIME_DEPENDENCIES
@@ -182,6 +185,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzTest
                 AZ::AzFramework
                 AZ::AzTestShared
+                AZ::AzToolsFramework
                 Gem::${gem_name}.Static
                 Gem::${gem_name}.Tests.Static
     )

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -500,7 +500,7 @@ namespace EMotionFX
 
             SystemRequestBus::Handler::BusConnect();
             AZ::TickBus::Handler::BusConnect();
-            CrySystemEventBus::Handler::BusConnect();
+            AzToolsFramework::EditorSystemEventBus::Handler::BusConnect();
             EMotionFXRequestBus::Handler::BusConnect();
             EnableRayRequests();
 
@@ -548,7 +548,7 @@ namespace EMotionFX
             m_eventHandler.reset();
 
             AZ::TickBus::Handler::BusDisconnect();
-            CrySystemEventBus::Handler::BusDisconnect();
+            AzToolsFramework::EditorSystemEventBus::Handler::BusDisconnect();
             EMotionFXRequestBus::Handler::BusDisconnect();
             DisableRayRequests();
 
@@ -576,7 +576,7 @@ namespace EMotionFX
         }
 
         //////////////////////////////////////////////////////////////////////////
-        void SystemComponent::OnCrySystemInitialized([[maybe_unused]] ISystem& system, const SSystemInitParams&)
+        void SystemComponent::OnEditorSystemInitialized([[maybe_unused]] ISystem& system, const SSystemInitParams&)
         {
 #if !defined(AZ_MONOLITHIC_BUILD)
             // When module is linked dynamically, we must set our gEnv pointer.
@@ -591,7 +591,7 @@ namespace EMotionFX
         }
 
         //////////////////////////////////////////////////////////////////////////
-        void SystemComponent::OnCrySystemShutdown(ISystem&)
+        void SystemComponent::OnEditorSystemShutdown(ISystem&)
         {
             gEnv->pConsole->UnregisterVariable("emfx_updateEnabled");
             gEnv->pConsole->UnregisterVariable("emfx_ragdollManipulatorsEnabled");

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
@@ -17,7 +17,7 @@
 #include <Integration/EMotionFXBus.h>
 #include <Integration/Rendering/RenderBackendManager.h>
 
-#include <CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 
 #if defined (EMOTIONFXANIMATION_EDITOR)
 #   include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
@@ -51,7 +51,7 @@ namespace EMotionFX
             : public AZ::Component
             , private SystemRequestBus::Handler
             , private AZ::TickBus::Handler
-            , private CrySystemEventBus::Handler
+            , private AzToolsFramework::EditorSystemEventBus::Handler
             , private EMotionFXRequestBus::Handler
             , private IRaycastRequests
 #if defined (EMOTIONFXANIMATION_EDITOR)
@@ -94,9 +94,9 @@ namespace EMotionFX
             ////////////////////////////////////////////////////////////////////////
 
             ////////////////////////////////////////////////////////////////////////
-            // CrySystemEventBus
-            void OnCrySystemInitialized(ISystem&, const SSystemInitParams&) override;
-            void OnCrySystemShutdown(ISystem&) override;
+            // EditorSystemEventBus
+            void OnEditorSystemInitialized(ISystem&, const SSystemInitParams&) override;
+            void OnEditorSystemShutdown(ISystem&) override;
             ////////////////////////////////////////////////////////////////////////
 
             ////////////////////////////////////////////////////////////////////////

--- a/Gems/EMotionFX/Code/Tests/UI/ClothColliderTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/ClothColliderTests.cpp
@@ -27,7 +27,7 @@ namespace EMotionFX
     class SystemComponent
         : public AZ::Component
         //        , public SystemRequestBus::Handler
-        //        , protected CrySystemEventBus::Handler
+        //        , protected EditorSystemEventBus::Handler
     {
     public:
         AZ_COMPONENT(SystemComponent, "{89DF5C48-64AC-4B8E-9E61-0D4C7A7B5491}");

--- a/Gems/GameStateSamples/Code/Source/GameStateSamplesModule.cpp
+++ b/Gems/GameStateSamples/Code/Source/GameStateSamplesModule.cpp
@@ -39,7 +39,7 @@ namespace GameStateSamples
     ////////////////////////////////////////////////////////////////////////////////////////////////
     //! This Gem provides a set of sample game states that can be overridden (or replaced entirely)
     //! in order to customize the functionality as needed for your game. To circumvent this default
-    //! set of game states, push a custom game state before GameStateModule::OnCrySystemInitialized
+    //! set of game states, push a custom game state before GameStateModule::OnEditorSystemInitialized
     //! is called, or just don't enable this Gem for your project (only the GameState Gem is needed
     //! if you plan on creating entirely custom game states). The flow of the sample game states in
     //! this Gem is roughly as follows:
@@ -95,16 +95,16 @@ namespace GameStateSamples
         }
 
     protected:
-        void OnCrySystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams) override
+        void OnEditorSystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams) override
         {
-            CryHooksModule::OnCrySystemInitialized(system, systemInitParams);
+            CryHooksModule::OnEditorSystemInitialized(system, systemInitParams);
 
             AZ::TickBus::Handler::BusConnect();
         }
 
         void OnTick([[maybe_unused]]float deltaTime, [[maybe_unused]]AZ::ScriptTimePoint scriptTimePoint) override
         {
-            // Ideally this would be called at startup (either above in OnCrySystemInitialized, or better during AZ system component
+            // Ideally this would be called at startup (either above in OnEditorSystemInitialized, or better during AZ system component
             // initialisation), but because the initial game state depends on loading a UI canvas using LYShine we need to wait until
             // the first tick, because LyShine in turn is not properly initialized until UiRenderer::OnBootstrapSceneReady has been
             // called, which doesn't happen until a queued tick event that gets called right at the end of initialisation before we

--- a/Gems/LandscapeCanvas/Code/CMakeLists.txt
+++ b/Gems/LandscapeCanvas/Code/CMakeLists.txt
@@ -29,7 +29,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 3rdParty::Qt::Widgets
                 AZ::AzCore
                 AZ::AzToolsFramework
-                Legacy::CryCommon
                 Legacy::Editor.Headers
                 Legacy::EditorCommon
                 Gem::GraphModel.Editor.Static

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -476,7 +476,7 @@ namespace LandscapeCanvasEditor
     }
 
     AzFramework::EntityContextId MainWindow::s_editorEntityContextId = AzFramework::EntityContextId::CreateNull();
-    
+
     MainWindow::MainWindow(QWidget* parent)
         : GraphModelIntegration::EditorMainWindow(GetDefaultConfig(), parent)
     {
@@ -509,7 +509,7 @@ namespace LandscapeCanvasEditor
         AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
         AzToolsFramework::Prefab::PrefabFocusNotificationBus::Handler::BusConnect(AzToolsFramework::GetEntityContextId());
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusConnect();
-        CrySystemEventBus::Handler::BusConnect();
+        EditorSystemEventBus::Handler::BusConnect();
         AZ::EntitySystemBus::Handler::BusConnect();
 
         // Listen for Entity notifications if a level is already loaded
@@ -538,7 +538,7 @@ namespace LandscapeCanvasEditor
     MainWindow::~MainWindow()
     {
         AZ::EntitySystemBus::Handler::BusDisconnect();
-        CrySystemEventBus::Handler::BusDisconnect();
+        EditorSystemEventBus::Handler::BusDisconnect();
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::Prefab::PrefabFocusNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect();
@@ -1745,7 +1745,7 @@ namespace LandscapeCanvasEditor
             InitialEntityGraph(entityId, graphId);
         }
         // Otherwise, we were able to load a previously saved graph so we just need to update the
-        // connections 
+        // connections
         else
         {
             GraphModel::NodePtrList nodes;
@@ -2844,26 +2844,26 @@ namespace LandscapeCanvasEditor
         m_queuedEntityRefresh.clear();
     }
 
-    void MainWindow::OnCryEditorEndCreate()
+    void MainWindow::OnEditorEndCreate()
     {
         UpdateGraphEnabled();
     }
 
-    void MainWindow::OnCryEditorEndLoad()
+    void MainWindow::OnEditorEndLoad()
     {
         UpdateGraphEnabled();
 
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
     }
 
-    void MainWindow::OnCryEditorCloseScene()
+    void MainWindow::OnEditorCloseScene()
     {
         UpdateGraphEnabled();
 
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
     }
 
-    void MainWindow::OnCryEditorSceneClosed()
+    void MainWindow::OnEditorSceneClosed()
     {
         UpdateGraphEnabled();
 
@@ -3713,7 +3713,7 @@ namespace LandscapeCanvasEditor
                                 GraphModelIntegration::GraphControllerRequestBus::EventResult(slotId, graphId, &GraphModelIntegration::GraphControllerRequests::ExtendSlot, node, slotName);
                                 success = slotId.IsValid();
                             }
-                            
+
                             if (!success)
                             {
                                 return nullptr;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
@@ -9,9 +9,9 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <CrySystemBus.h>
 
 // AZ
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 #include <AzCore/Component/EntityBus.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/PlatformDef.h>
@@ -95,7 +95,7 @@ namespace LandscapeCanvasEditor
         , private AzToolsFramework::ToolsApplicationNotificationBus::Handler
         , private AzToolsFramework::Prefab::PrefabFocusNotificationBus::Handler
         , private AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
-        , private CrySystemEventBus::Handler
+        , private AzToolsFramework::EditorSystemEventBus::Handler
     {
         Q_OBJECT
 
@@ -210,11 +210,11 @@ namespace LandscapeCanvasEditor
         void OnPrefabInstancePropagationEnd() override;
 
         ////////////////////////////////////////////////////////////////////////
-        // CrySystemEventBus overrides
-        void OnCryEditorEndCreate() override;
-        void OnCryEditorEndLoad() override;
-        void OnCryEditorCloseScene() override;
-        void OnCryEditorSceneClosed() override;
+        // AzToolsFramework::EditorSystemEventBus overrides
+        void OnEditorEndCreate() override;
+        void OnEditorEndLoad() override;
+        void OnEditorCloseScene() override;
+        void OnEditorSceneClosed() override;
         ////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////
@@ -310,4 +310,4 @@ namespace LandscapeCanvasEditor
 
         QAction* m_fileNewAction = nullptr;
     };
-} 
+}

--- a/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
+++ b/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
@@ -100,7 +100,7 @@ namespace LyShine
                 ->Event("SetUiCursorPosition", &UiCursorBus::Events::SetUiCursorPosition)
                 ;
         }
-        
+
         LyShineFeatureProcessor::Reflect(context);
     }
 
@@ -154,7 +154,7 @@ namespace LyShine
         UiSystemBus::Handler::BusConnect();
         UiSystemToolsBus::Handler::BusConnect();
         UiFrameworkBus::Handler::BusConnect();
-        CrySystemEventBus::Handler::BusConnect();
+        EditorSystemEventBus::Handler::BusConnect();
 
         // register all the component types internal to the LyShine module
         // These are registered in the order we want them to appear in the Add Component menu
@@ -203,7 +203,7 @@ namespace LyShine
         // Setup handler for load pass template mappings
         m_loadTemplatesHandler = AZ::RPI::PassSystemInterface::OnReadyLoadTemplatesEvent::Handler([this]() { this->LoadPassTemplateMappings(); });
         AZ::RPI::PassSystemInterface::Get()->ConnectEvent(m_loadTemplatesHandler);
-        
+
         // Register feature processor
         AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<LyShineFeatureProcessor>();
 #endif
@@ -213,14 +213,14 @@ namespace LyShine
     void LyShineSystemComponent::Deactivate()
     {
 #if !defined(LYSHINE_BUILDER) && !defined(LYSHINE_TESTS)
-        m_loadTemplatesHandler.Disconnect();        
+        m_loadTemplatesHandler.Disconnect();
         AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<LyShineFeatureProcessor>();
 #endif
 
         UiSystemBus::Handler::BusDisconnect();
         UiSystemToolsBus::Handler::BusDisconnect();
         UiFrameworkBus::Handler::BusDisconnect();
-        CrySystemEventBus::Handler::BusDisconnect();
+        EditorSystemEventBus::Handler::BusDisconnect();
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -289,7 +289,7 @@ namespace LyShine
         UiCanvasFileObject* canvasFileObject = static_cast<UiCanvasFileObject*>(canvas);
         AZ::Entity* oldRootSliceEntity = canvasFileObject->m_rootSliceEntity;
         AZ::EntityId idToReuse = oldRootSliceEntity->GetId();
-        
+
         AZ::Entity* newRootSliceEntity = aznew AZ::Entity(idToReuse, AZStd::to_string(static_cast<AZ::u64>(idToReuse)).c_str());
         newRootSliceEntity->AddComponent(newSliceComponent);
         canvasFileObject->m_rootSliceEntity = newRootSliceEntity;
@@ -383,7 +383,7 @@ namespace LyShine
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    void LyShineSystemComponent::OnCrySystemInitialized(ISystem& system, [[maybe_unused]] const SSystemInitParams& startupParams)
+    void LyShineSystemComponent::OnEditorSystemInitialized(ISystem& system, [[maybe_unused]] const SSystemInitParams& startupParams)
     {
 #if !defined(AZ_MONOLITHIC_BUILD)
         // When module is linked dynamically, we must set our gEnv pointer.
@@ -404,7 +404,7 @@ namespace LyShine
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    void LyShineSystemComponent::OnCrySystemShutdown(ISystem& system)
+    void LyShineSystemComponent::OnEditorSystemShutdown(ISystem& system)
     {
         system.GetILevelSystem()->RemoveListener(this);
 

--- a/Gems/LyShine/Code/Source/LyShineSystemComponent.h
+++ b/Gems/LyShine/Code/Source/LyShineSystemComponent.h
@@ -31,7 +31,7 @@ namespace LyShine
         , protected UiSystemBus::Handler
         , protected UiSystemToolsBus::Handler
         , protected UiFrameworkBus::Handler
-        , protected CrySystemEventBus::Handler
+        , protected EditorSystemEventBus::Handler
         , public ILevelSystemListener
     {
     public:
@@ -83,9 +83,9 @@ namespace LyShine
         void HandleEditorOnlyEntities(const EntityList& exportSliceEntities, const EntityIdSet& editorOnlyEntityIds) override;
         ////////////////////////////////////////////////////////////////////////
 
-        // CrySystemEventBus ///////////////////////////////////////////////////////
-        void OnCrySystemInitialized(ISystem& system, const SSystemInitParams&) override;
-        void OnCrySystemShutdown(ISystem&) override;
+        // EditorSystemEventBus ///////////////////////////////////////////////////////
+        void OnEditorSystemInitialized(ISystem& system, const SSystemInitParams&) override;
+        void OnEditorSystemShutdown(ISystem&) override;
         ////////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////

--- a/Gems/Maestro/Code/CMakeLists.txt
+++ b/Gems/Maestro/Code/CMakeLists.txt
@@ -19,6 +19,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             Legacy::CryCommon
+            AZ::AzToolsFramework
         PUBLIC
             Gem::Atom_Bootstrap.Headers
             Gem::Atom_RHI.Public
@@ -40,6 +41,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             Legacy::CryCommon
+            AZ::AzToolsFramework
             Gem::${gem_name}.Static
         PUBLIC
             Gem::Atom_Bootstrap.Headers
@@ -128,6 +130,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             PRIVATE
                 AZ::AzTest
                 Legacy::CryCommon
+                AZ::AzToolsFramework
                 Gem::${gem_name}.Static
     )
     ly_add_googletest(

--- a/Gems/Maestro/Code/Source/MaestroSystemComponent.cpp
+++ b/Gems/Maestro/Code/Source/MaestroSystemComponent.cpp
@@ -86,17 +86,17 @@ namespace Maestro
     void MaestroSystemComponent::Activate()
     {
         MaestroRequestBus::Handler::BusConnect();
-        CrySystemEventBus::Handler::BusConnect();
+        AzToolsFramework::EditorSystemEventBus::Handler::BusConnect();
     }
 
     void MaestroSystemComponent::Deactivate()
     {
         MaestroRequestBus::Handler::BusDisconnect();
-        CrySystemEventBus::Handler::BusDisconnect();
+        AzToolsFramework::EditorSystemEventBus::Handler::BusDisconnect();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    void MaestroSystemComponent::OnCrySystemInitialized(ISystem& system, const SSystemInitParams& startupParams)
+    void MaestroSystemComponent::OnEditorSystemInitialized(ISystem& system, const SSystemInitParams& startupParams)
     {
         if (!startupParams.bSkipMovie)
         {
@@ -105,7 +105,7 @@ namespace Maestro
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    void MaestroSystemComponent::OnCrySystemShutdown([[maybe_unused]] ISystem& system)
+    void MaestroSystemComponent::OnEditorSystemShutdown([[maybe_unused]] ISystem& system)
     {
         m_movieSystem.reset();
     }

--- a/Gems/Maestro/Code/Source/MaestroSystemComponent.h
+++ b/Gems/Maestro/Code/Source/MaestroSystemComponent.h
@@ -9,7 +9,7 @@
 
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/Component/Component.h>
-#include <CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 
 #include "Cinematics/Movie.h"
 #include "Maestro/MaestroBus.h"
@@ -35,7 +35,7 @@ namespace Maestro
     class MaestroSystemComponent
         : public AZ::Component
         , protected MaestroRequestBus::Handler
-        , protected CrySystemEventBus::Handler
+        , protected AzToolsFramework::EditorSystemEventBus::Handler
     {
     public:
         AZ_COMPONENT(MaestroSystemComponent, "{47991994-4417-4CD7-AE0B-FEF1C8720766}");
@@ -57,9 +57,9 @@ namespace Maestro
 
         ////////////////////////////////////////////////////////////////////////
 
-        // CrySystemEventBus ///////////////////////////////////////////////////////
-        void OnCrySystemInitialized(ISystem& system, const SSystemInitParams&) override;
-        virtual void OnCrySystemShutdown(ISystem&) override;
+        // AzToolsFramework::EditorSystemEventBus /////////////////////////////////////////
+        void OnEditorSystemInitialized(ISystem& system, const SSystemInitParams&) override;
+        virtual void OnEditorSystemShutdown(ISystem&) override;
         ////////////////////////////////////////////////////////////////////////////
 
         ////////////////////////////////////////////////////////////////////////

--- a/Gems/PhysX/Debug/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Debug/Code/Source/SystemComponent.cpp
@@ -177,7 +177,7 @@ namespace PhysXDebug
         }
     }
 
-    void SystemComponent::OnCrySystemInitialized([[maybe_unused]] ISystem& system, const SSystemInitParams&)
+    void SystemComponent::OnEditorSystemInitialized([[maybe_unused]] ISystem& system, const SSystemInitParams&)
     {
         InitPhysXColorMappings();
         ConfigurePhysXVisualizationParameters();
@@ -217,7 +217,7 @@ namespace PhysXDebug
     {
         PhysXDebugRequestBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
-        CrySystemEventBus::Handler::BusConnect();
+        AzToolsFramework::EditorSystemEventBus::Handler::BusConnect();
 #ifdef IMGUI_ENABLED
         ImGui::ImGuiUpdateListenerBus::Handler::BusConnect();
 #endif // IMGUI_ENABLED
@@ -238,7 +238,7 @@ namespace PhysXDebug
 #ifdef IMGUI_ENABLED
         ImGui::ImGuiUpdateListenerBus::Handler::BusDisconnect();
 #endif // IMGUI_ENABLED
-        CrySystemEventBus::Handler::BusDisconnect();
+        AzToolsFramework::EditorSystemEventBus::Handler::BusDisconnect();
         AZ::TickBus::Handler::BusDisconnect();
         PhysXDebugRequestBus::Handler::BusDisconnect();
     }

--- a/Gems/PhysX/Debug/Code/Source/SystemComponent.h
+++ b/Gems/PhysX/Debug/Code/Source/SystemComponent.h
@@ -16,7 +16,7 @@
 #include <PhysXDebug/PhysXDebugBus.h>
 #include <PxPhysicsAPI.h>
 
-#include <CryCommon/CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 
 #include <AzFramework/Physics/SystemBus.h>
 
@@ -102,7 +102,7 @@ namespace PhysXDebug
         : public AZ::Component
         , protected PhysXDebugRequestBus::Handler
         , public AZ::TickBus::Handler
-        , public CrySystemEventBus::Handler
+        , public AzToolsFramework::EditorSystemEventBus::Handler
 #ifdef IMGUI_ENABLED
         , public ImGui::ImGuiUpdateListenerBus::Handler
 #endif // IMGUI_ENABLED
@@ -141,8 +141,8 @@ namespace PhysXDebug
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
         int GetTickOrder() override { return AZ::ComponentTickBus::TICK_FIRST + 1; }
 
-        // CrySystemEvents
-        void OnCrySystemInitialized(ISystem&, const SSystemInitParams&) override;
+        // EditorSystemEvents
+        void OnEditorSystemInitialized(ISystem&, const SSystemInitParams&) override;
 
     private:
 

--- a/Gems/PhysX/Debug/PhysX4/CMakeLists.txt
+++ b/Gems/PhysX/Debug/PhysX4/CMakeLists.txt
@@ -46,6 +46,7 @@ ly_add_target(
         PUBLIC
             ${physxdebug_dependency}
             Legacy::CryCommon
+            AZ::AzToolsFramework
             Gem::PhysX
             Gem::ImGui.imguilib
             Gem::ImGui

--- a/Gems/PhysX/Debug/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Debug/PhysX5/CMakeLists.txt
@@ -46,6 +46,7 @@ ly_add_target(
         PUBLIC
             ${physxdebug_dependency}
             Legacy::CryCommon
+            AZ::AzToolsFramework
             Gem::PhysX5
             Gem::ImGui.imguilib
             Gem::ImGui

--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 
 
-set(SCRIPT_CANVAS_COMMON_DEFINES 
+set(SCRIPT_CANVAS_COMMON_DEFINES
     SCRIPTCANVAS
     ENABLE_EXTENDED_MATH_SUPPORT=0
 )
@@ -183,9 +183,10 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Editor
                 Tools
                 ${SCRIPT_CANVAS_AUTOGEN_BUILD_DIR}
-        BUILD_DEPENDENCIES  
+        BUILD_DEPENDENCIES
             PUBLIC
                 Legacy::CryCommon
+                AZ::AzToolsFramework
                 AZ::AzCore
                 AZ::AssetBuilderSDK
                 ${additional_dependencies}
@@ -291,7 +292,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 
     ly_set_gem_variant_to_load(TARGETS ${gem_name}Application VARIANTS Tools)
-    
+
     # Add build dependency to Editor for the ScriptCanvas application since
     # Editor opens up the ScriptCanvas
     ly_add_dependencies(Editor Gem::${gem_name}Application)

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Model.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Model.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <AzCore/Asset/AssetManagerBus.h>
-#include <CryCommon/CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 #include <Editor/View/Windows/Tools/UpgradeTool/Model.h>
 #include <IConsole.h>
 #include <ISystem.h>
@@ -25,7 +25,7 @@ namespace ScriptCanvasEditor
         EditorKeepAlive::EditorKeepAlive()
         {
             ISystem* system = nullptr;
-            CrySystemRequestBus::BroadcastResult(system, &CrySystemRequestBus::Events::GetCrySystem);
+            AzToolsFramework::EditorSystemRequestBus::BroadcastResult(system, &AzToolsFramework::EditorSystemRequestBus::Events::GetEditorSystem);
 
             if (system)
             {

--- a/Gems/Vegetation/Code/CMakeLists.txt
+++ b/Gems/Vegetation/Code/CMakeLists.txt
@@ -25,6 +25,7 @@ ly_add_target(
             Gem::LmbrCentral.API
             Gem::SurfaceData.Static
             Legacy::CryCommon
+            AZ::AzToolsFramework
         PUBLIC
             Gem::CommonFeaturesAtom.Static
 )
@@ -43,6 +44,7 @@ ly_add_target(
         PRIVATE
             Gem::${gem_name}.Static
             Legacy::CryCommon
+            AZ::AzToolsFramework
     RUNTIME_DEPENDENCIES
         Gem::LmbrCentral
         Gem::GradientSignal
@@ -126,6 +128,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 Gem::${gem_name}.Static
                 Gem::LmbrCentral.Mocks
                 Legacy::CryCommon
+                AZ::AzToolsFramework
     )
     ly_add_googletest(
         NAME Gem::${gem_name}.Tests

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
@@ -313,7 +313,7 @@ namespace Vegetation
                 ;
             }
         }
-        
+
         AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
         if (behaviorContext)
         {
@@ -355,7 +355,7 @@ namespace Vegetation
         AreaSystemRequestBus::Handler::BusConnect();
         GradientSignal::SectorDataRequestBus::Handler::BusConnect();
         SystemConfigurationRequestBus::Handler::BusConnect();
-        CrySystemEventBus::Handler::BusConnect();
+        AzToolsFramework::EditorSystemEventBus::Handler::BusConnect();
         AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusConnect();
         SurfaceData::SurfaceDataSystemNotificationBus::Handler::BusConnect();
 
@@ -376,7 +376,7 @@ namespace Vegetation
         AreaSystemRequestBus::Handler::BusDisconnect();
         GradientSignal::SectorDataRequestBus::Handler::BusDisconnect();
         SystemConfigurationRequestBus::Handler::BusDisconnect();
-        CrySystemEventBus::Handler::BusDisconnect();
+        AzToolsFramework::EditorSystemEventBus::Handler::BusDisconnect();
         AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusDisconnect();
         SurfaceData::SurfaceDataSystemNotificationBus::Handler::BusDisconnect();
 
@@ -555,7 +555,7 @@ namespace Vegetation
                     AreaNotificationBus::Event(area.m_id, &AreaNotificationBus::Events::OnAreaRefreshed);
                 }
 
-                // Set all existing sectors as needing to be rebuilt.  
+                // Set all existing sectors as needing to be rebuilt.
                 const auto& cachedMainThreadData = context->GetCachedMainThreadData();
                 vegTasks->MarkDirtySectors(AZ::Aabb::CreateNull(), threadData->m_dirtySectorContents,
                                              cachedMainThreadData.m_worldToSector, cachedMainThreadData.m_currViewRect);
@@ -945,13 +945,13 @@ namespace Vegetation
         InstanceSystemRequestBus::Broadcast(&InstanceSystemRequestBus::Events::Cleanup);
     }
 
-    void AreaSystemComponent::OnCrySystemInitialized(ISystem& system, [[maybe_unused]] const SSystemInitParams& systemInitParams)
+    void AreaSystemComponent::OnEditorSystemInitialized(ISystem& system, [[maybe_unused]] const SSystemInitParams& systemInitParams)
     {
         m_system = &system;
         m_system->GetISystemEventDispatcher()->RegisterListener(this);
     }
 
-    void AreaSystemComponent::OnCrySystemShutdown([[maybe_unused]] ISystem& system)
+    void AreaSystemComponent::OnEditorSystemShutdown([[maybe_unused]] ISystem& system)
     {
         if (m_system)
         {
@@ -960,7 +960,7 @@ namespace Vegetation
         }
     }
 
-    void AreaSystemComponent::OnCryEditorBeginLevelExport()
+    void AreaSystemComponent::OnEditorBeginLevelExport()
     {
         // We need to free all our instances before exporting a level to ensure that none of the dynamic vegetation data
         // gets exported into the static vegetation data files.
@@ -969,13 +969,13 @@ namespace Vegetation
         ReleaseData();
     }
 
-    void AreaSystemComponent::OnCryEditorEndLevelExport(bool /*success*/)
+    void AreaSystemComponent::OnEditorEndLevelExport(bool /*success*/)
     {
         // We don't need to do anything here.  When the vegetation game components reactivate themselves after the level export completes,
         // (see EditorVegetationComponentBase.h) they will trigger a refresh of the vegetation areas which will produce all our instances again.
     }
 
-    void AreaSystemComponent::OnCryEditorCloseScene()
+    void AreaSystemComponent::OnEditorCloseScene()
     {
         // Clear all our spawned vegetation data
         ReleaseData();

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.h
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.h
@@ -17,7 +17,7 @@
 #include <AzCore/std/parallel/thread.h>
 #include <GradientSignal/Ebuses/SectorDataRequestBus.h>
 #include <SurfaceData/SurfaceDataSystemNotificationBus.h>
-#include <CrySystemBus.h>
+#include <AzToolsFramework/Editor/EditorSystemBus.h>
 #include <ISystem.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 
@@ -80,7 +80,7 @@ namespace Vegetation
         , private AreaSystemRequestBus::Handler
         , private GradientSignal::SectorDataRequestBus::Handler
         , private SystemConfigurationRequestBus::Handler
-        , private CrySystemEventBus::Handler
+        , private AzToolsFramework::EditorSystemEventBus::Handler
         , private ISystemEventListener
         , private SurfaceData::SurfaceDataSystemNotificationBus::Handler
         , private AzFramework::Terrain::TerrainDataNotificationBus::Handler
@@ -142,12 +142,12 @@ namespace Vegetation
 
 
         ////////////////////////////////////////////////////////////////////////////
-        // CrySystemEvents
-        void OnCrySystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams) override;
-        void OnCrySystemShutdown(ISystem& system) override;
-        void OnCryEditorBeginLevelExport() override;
-        void OnCryEditorEndLevelExport(bool /*success*/) override;
-        void OnCryEditorCloseScene() override;
+        // AzToolsFramework::EditorSystemEvents
+        void OnEditorSystemInitialized(ISystem& system, const SSystemInitParams& systemInitParams) override;
+        void OnEditorSystemShutdown(ISystem& system) override;
+        void OnEditorBeginLevelExport() override;
+        void OnEditorEndLevelExport(bool /*success*/) override;
+        void OnEditorCloseScene() override;
 
         //////////////////////////////////////////////////////////////////////////
         // ISystemEventListener

--- a/Gems/Vegetation/Code/Source/DebugSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/DebugSystemComponent.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
-#include <CrySystemBus.h>
+// #include <AzToolsFramework/Editor/EditorSystemBus.h>
 
 namespace Vegetation
 {


### PR DESCRIPTION
## What does this PR do?

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

_Please add links to any issues, RFCs or other items that are relevant to this PR._

In digging through the various Canvas gems, I noticed they were using the legacy CrySystemBus. It seemed a pretty easy move to update the EventBus itself to a non-legacy EditorEventBus. The purpose of this is to make the touch point for other gems a stable, modern interface sooner rather than later, minimizing the number of listener code that needs altered when someone refactors the underlying CrySystem logic.

[Discord discussion](https://discord.com/channels/805939474655346758/816043622558335046/1415920901228335206)

## How was this PR tested?

_Please describe any testing performed._
