### PR TITLE
Fix component selection display in Inspector window on Linux 

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
@@ -43,8 +43,6 @@ namespace AzQtComponents
         template <typename T, typename ...Args>
         void repolishWhenPropertyChanges(T* widget, void (T::*signal)(Args...))
         {
-#if !defined(AZ_PLATFORM_LINUX)
-
             QObject::connect(widget, signal, widget, [widget]() {
                 // Prevent asserts in Unit Tests
                 if (!StyleManager::isInstanced())
@@ -61,8 +59,6 @@ namespace AzQtComponents
                     styleSheet->repolish(widget);
                 }
             });
-
-#endif // !defined(AZ_PLATFORM_LINUX)
         }
 
         /* StyleHelpers::findParent<T> is an utility function to find recursively a parent object of


### PR DESCRIPTION
...and possibly some other issues that I didn't notice.

## What does this PR do?

The function `AzQtComponents::StyleHelpers::repolishWhenPropertyChanges` was effectively disabled on Linux because its implementation was wrapped entirely in a macro. As a result, the selection outline inside the Inspector window did not appear when selecting components. Removing the macro restored the expected behavior:

<img width="505" height="801" alt="image" src="https://github.com/user-attachments/assets/e678d72e-b52b-4408-bac7-44e5c7aba5e0" />


## How was this PR tested?

The fix was verified by selecting multiple components in the Inspector window and confirming that the selection outline displayed correctly.
