### PR TITLE
Fix monolithic builds trying to build dummy O3DE Launcher app

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -43,7 +43,10 @@ set(launcher_generator_LY_PROJECTS ${LY_PROJECTS})
 # and the prebuilt installer always operates on a project, so will generally only happen
 # when building an installer from the o3de source code, or just compiling O3DE itself with no
 # project specified.
-if (NOT launcher_generator_LY_PROJECTS)
+if (NOT launcher_generator_LY_PROJECTS AND NOT LY_MONOLITHIC_GAME)
+    # do not generate a stub O3DE Launcher in monolithic mode.
+    # This stub O3DE Generic Launcher is only for script-only mode, which cannot function in monolithic
+    # linkage mode, since it does not have a linker.
     set(launcher_generator_LY_PROJECTS ":PROJECT_PATH_ONLY_FOR_GENERIC_LAUNCHER")
     set(O3DE_PROJECTS_NAME "O3DE")
     set(launcher_generator_BUILD_GENERIC TRUE) # used to skip the asset processing step

--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -1162,7 +1162,11 @@ function(ly_setup_o3de_install)
     ly_setup_cmake_install()
     ly_setup_runtime_dependencies()
     ly_setup_assets()
-    ly_setup_3p_dependencies()
+    
+    # script only mode and monolithic mode are mutually exclusive
+    if(NOT LY_MONOLITHIC_GAME)
+        ly_setup_3p_dependencies()
+    endif()
 
     # Misc
     cmake_path(SET current_folder_normalized NORMALIZE ".")


### PR DESCRIPTION
## What does this PR do?

The O3DE.GameLauncher target is a sort of universal empty application script-only-mode uses to launch the game (using `O3DE.GameLauncher.exe --project-path=xxx` where the gamelauncher then reads the project configuration to find out what gems to load and load them.

Because script-only mode cannot use a compiler or linker, it cannot use monolithic mode.  It makes no sense to generate these targets in monolithic mode, as they would be missing all the gems that they depend on and they are only used for script-only mode.

## How was this PR tested?

Building release monolithic installer.
