### PR TITLE
Revert "Delay viewport resize to prevent freezing the editor on contnuous resize (#19033)"

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <QWidget>
-#include <QTimer>
 #include <QElapsedTimer>
 #include <Atom/RPI.Public/Base.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
@@ -162,7 +161,5 @@ namespace AtomToolsFramework
         AzToolsFramework::QtEventToAzInputMapper* m_inputChannelMapper = nullptr;
         // Implementation of ViewportInteractionRequests (handles viewport picking operations).
         AZStd::unique_ptr<ViewportInteractionImpl> m_viewportInteractionImpl;
-        // Allow to delay the resize event to prevent freezing the editor on continuous mouse drag
-        QTimer m_resizeEventCooldown;
     };
 } //namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -31,9 +31,6 @@ namespace AtomToolsFramework
         : QWidget(parent)
         , AzFramework::InputChannelEventListener(AzFramework::InputChannelEventListener::GetPriorityDefault())
     {
-        m_resizeEventCooldown.setSingleShot(true);
-        connect(&m_resizeEventCooldown, &QTimer::timeout, this, &RenderViewportWidget::SendWindowResizeEvent);
-
         if (shouldInitializeViewportContext)
         {
             InitializeViewportContext();
@@ -231,11 +228,11 @@ namespace AtomToolsFramework
     {
         switch (event->type()) 
         {
-            case QEvent::Resize: [[fallthrough]];
+            case QEvent::Resize:
 
             // This event exists to capture the case where a resize event is missed "after" the underlying surface is 
             // modified by Qt (Seen during level load in Editor)
-            case QEvent::ShowToParent: [[fallthrough]];
+            case QEvent::ShowToParent:  
 
             // Qt is sending this event as the final events after a viewport change. The resize signal is sent multiple
             // times per viewport (one for ShowToParent, one for Resize). The final resize will correctly set the
@@ -244,8 +241,7 @@ namespace AtomToolsFramework
             // after the UpdateLater event to force this.
             case QEvent::UpdateLater:   
             {
-                // Only try to resize the viewport once per 150ms. Calling start will reset the previous timer.
-                m_resizeEventCooldown.start(150);
+                SendWindowResizeEvent();
                 break;
             }
             case QEvent::PlatformSurface:


### PR DESCRIPTION

## What does this PR do?

This reverts commit cd4745ca350727b5c8982fc51bf469eac94a1cee.

See https://github.com/o3de/o3de/issues/19212 - it causes crash of the device under Vulkan.


## How was this PR tested?

* CI Build tests
* Local testing with `--rhi-vulkan` and then resizing
*
