### PR TITLE
Add Windows platform tab with Graphics API and validation settings

### DIFF
--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings.h
@@ -11,3 +11,4 @@
 #include "PlatformSettings_Android.h"
 #include "PlatformSettings_Base.h"
 #include "PlatformSettings_Ios.h"
+#include "PlatformSettings_Windows.h"

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Windows.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Windows.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "PlatformSettings_Windows.h"
+
+#include "PlatformSettings_common.h"
+#include "Validators.h"
+
+#include <AzCore/IO/FileIO.h>
+
+namespace ProjectSettingsTool
+{
+    void WindowsGraphics::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serialize)
+        {
+            serialize->Class<WindowsGraphics>()
+                ->Version(1)
+                ->Field("graphicsAPI", &WindowsGraphics::m_graphicsAPI)
+                ->Field("validationMode", &WindowsGraphics::m_validationMode);
+
+            AZ::EditContext* editContext = serialize->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<WindowsGraphics>("", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::ComboBox,
+                        &WindowsGraphics::m_graphicsAPI,
+                        "Graphics API", "Select the primary graphics API")
+                    ->Attribute(
+                        AZ::Edit::Attributes::StringList,
+                        []()
+                        {
+                            return AZStd::vector<AZStd::string>{ "DX12", "Vulkan" };
+                        })
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::ComboBox,
+                        &WindowsGraphics::m_validationMode,
+                        "Validation Layers", "Set the validation mode for the RHI.")
+                    ->Attribute(
+                        AZ::Edit::Attributes::EnumValues,
+                        AZStd::vector<AZ::Edit::EnumConstant<ValidationMode>>{
+                            AZ::Edit::EnumConstant<ValidationMode>(
+                                ValidationMode::Disabled, "Disabled"),
+                            AZ::Edit::EnumConstant<ValidationMode>(
+                                ValidationMode::Enabled, "Enabled  (Shows warnings and error messages)"),
+                            AZ::Edit::EnumConstant<ValidationMode>(
+                                ValidationMode::Verbose, "Verbose  (Shows warnings, errors, and informational messages)"),
+                            AZ::Edit::EnumConstant<ValidationMode>(
+                                ValidationMode::GPU, "GPU"),
+                        });
+            }
+        }
+    }
+
+    const char* WindowsGraphics::ValidationModeToString(ValidationMode mode)
+    {
+        switch (mode)
+        {
+        case ValidationMode::Disabled:
+            return "disable";
+        case ValidationMode::Enabled:
+            return "enable";
+        case ValidationMode::Verbose:
+            return "verbose";
+        case ValidationMode::GPU:
+            return "gpu";
+        default:
+            return "disable";
+        }
+    }
+
+    void WindowsGraphics::SaveRHISettings(const AZ::IO::Path& settingsPath) const
+    {
+        AZStd::string jsonContent = AZStd::string::format(
+            "{\n"
+            "    \"O3DE\": {\n"
+            "        \"Atom\": {\n"
+            "            \"RHI\": {\n"
+            "                \"FactoryManager\": {\n"
+            "                    \"factoriesPriority\": [\n"
+            "                        \"%s\",\n"
+            "                        \"%s\"\n"
+            "                    ]\n"
+            "                }\n"
+            "            },\n"
+            "            \"rhi-device-validation\": \"%s\"\n"
+            "        }\n"
+            "    }\n"
+            "}",
+            m_graphicsAPI.c_str(),
+            (m_graphicsAPI == "Vulkan") ? "DX12" : "Vulkan",
+            ValidationModeToString(m_validationMode));
+
+        AZ::IO::FileIOStream fileStream(settingsPath.c_str(), AZ::IO::OpenMode::ModeWrite);
+        if (fileStream.IsOpen())
+        {
+            fileStream.Write(jsonContent.size(), jsonContent.c_str());
+            fileStream.Close();
+        }
+    }
+
+    void WindowsSettings::Reflect(AZ::ReflectContext* context)
+    {
+        WindowsGraphics::Reflect(context);
+
+        AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serialize)
+        {
+            serialize->Class<WindowsSettings>()
+                ->Version(1)
+                ->Field("graphics", &WindowsSettings::m_graphics);
+
+            AZ::EditContext* editContext = serialize->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<WindowsSettings>("Windows Settings", "Configure settings for Windows platform")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &WindowsSettings::m_graphics,
+                        "Graphics Settings",
+                        "Configure Graphics settings for Windows platform");
+            }
+        }
+    }
+} // namespace ProjectSettingsTool

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Windows.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Windows.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Serialization/EditContext.h>
+
+namespace ProjectSettingsTool
+{
+    enum class ValidationMode
+    {
+        Disabled,
+        Enabled,
+        Verbose,
+        GPU
+    };
+
+    class WindowsGraphics
+    {
+    public:
+        AZ_TYPE_INFO(WindowsGraphics, "{D9E6C2BD-0A10-4E36-B9E4-7F8F7D8F0C11}");
+        AZ_CLASS_ALLOCATOR(WindowsGraphics, AZ::SystemAllocator);
+
+        WindowsGraphics()
+            : m_graphicsAPI("DX12")
+            , m_validationMode(ValidationMode::Disabled)
+        {
+        }
+
+        static void Reflect(AZ::ReflectContext* context);
+        void SaveRHISettings(const AZ::IO::Path& rhiRegistryPath) const;
+        static const char* ValidationModeToString(ValidationMode mode);
+
+        AZStd::string m_graphicsAPI;
+        ValidationMode m_validationMode;
+    };
+
+    class WindowsSettings
+    {
+    public:
+        AZ_TYPE_INFO(WindowsSettings, "{9F84B3EE-D077-4693-86A0-C43AA455C90A}");
+        AZ_CLASS_ALLOCATOR(WindowsSettings, AZ::SystemAllocator);
+
+        WindowsSettings() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        WindowsGraphics m_graphics;
+    };
+} // namespace ProjectSettingsTool

--- a/Code/Editor/Plugins/ProjectSettingsTool/Platforms.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/Platforms.h
@@ -15,6 +15,7 @@ namespace ProjectSettingsTool
         Base,
         Android,
         Ios,
+        Windows,
 
         NumPlatformIds
     };
@@ -37,7 +38,8 @@ namespace ProjectSettingsTool
     {
         Platform{ PlatformId::Base, PlatformDataType::ProjectJson },
         Platform{ PlatformId::Android, PlatformDataType::PlatformResource },
-        Platform{ PlatformId::Ios, PlatformDataType::PlatformResource }
+        Platform{ PlatformId::Ios, PlatformDataType::PlatformResource },
+        Platform{ PlatformId::Windows, PlatformDataType::PlatformResource }
     };
     
 } // namespace ProjectSettingsTool

--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWidget.ui
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWidget.ui
@@ -106,6 +106,15 @@
                    </attribute>
                    <layout class="QGridLayout" name="gridLayout_9"/>
                   </widget>
+                  <widget class="QWidget" name="windowsTab">
+                   <attribute name="title">
+                    <string>Windows</string>
+                   </attribute>
+                   <property name="maximumHeight">
+                    <number>70</number>
+                   </property>
+                   <layout class="QGridLayout" name="gridLayout_10"/>
+                  </widget>
                  </widget>
                 </item>
                </layout>

--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.h
@@ -46,6 +46,7 @@ namespace ProjectSettingsTool
         BaseSettings base;
         AndroidSettings android;
         IosSettings ios;
+        WindowsSettings windows;
     };
 
     // Main window for Project Settings tool

--- a/Code/Editor/Plugins/ProjectSettingsTool/projectsettingstool_files.cmake
+++ b/Code/Editor/Plugins/ProjectSettingsTool/projectsettingstool_files.cmake
@@ -22,6 +22,8 @@ set(FILES
     PlatformSettings_common.h
     PlatformSettings_Ios.cpp
     PlatformSettings_Ios.h
+    PlatformSettings_Windows.cpp
+    PlatformSettings_Windows.h
     PlistDictionary.cpp
     PlistDictionary.h
     ProjectSettingsContainer.cpp


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new tab widget dedicated to **Windows**-specific platform settings 
in the ProjectSettingsTool (`Editor->File->Edit Platform Settings->Windows`).

It adds configuration options for Graphics API selection and validation mode, 
which are persisted to the `rhi.setreg` file.

- Introduced a dedicated tab for Windows platform settings.

- Added a dropdown allowing users to select either **DX12** or **Vulkan** as the preferred graphics API.

- Introduced a dropdown to set the validation mode, with options:

        Disabled
        Enabled (warnings and errors)
        Verbose (warnings, errors, and info)
        GPU

New settings are encapsulated in `WindowsGraphics`, part of the `WindowsSettings` class.
    Settings are serialized via Reflect() and exposed in the editor UI using combo boxes.
    `SaveRHISettings()` writes the selected configuration to `rhi.setreg` at:
    (**<user_project>/Registry/rhi.setreg**)

Example:
```
{
    "O3DE": {
        "Atom": {
            "RHI": {
                "FactoryManager": {
                    "factoriesPriority": [
                        "Vulkan",
                        "DX12"
                    ]
                }
            },
            "rhi-device-validation": "enable"
        }
    }
}
```
This file is read at startup by both the `Editor` and `GameLauncher` to configure the RHI.

These settings are also serialized to the platform-specific project file:
**<user_project>/Platform/Windows/windows_project.json**

Example:
```
{
    "Tags": [
        "Windows"
    ],
    "windows_settings": {
        "graphics": {
            "graphicsAPI": "Vulkan",
            "validationMode": 0
        }
    }
}
```

## How was this PR tested?
_Editor Build & Launch_
Successfully built the editor with the new Windows tab widget included.
Launched the editor and navigated to the `File->Edit Platform Settings->Windows`

_Verified UI Integration_ 
Confirmed the Windows tab appears correctly alongside Android and iOS tabs
Checked that the Graphics API and Validation Mode dropdowns were visible and correctly populated.

_Changed Settings and Saved_
Selected different combinations of Graphics API (DX12/Vulkan) and Validation Mode (disable, enable, verbose, gpu). 
Saved the settings and confirmed no errors occurred during serialization.

_Inspected rhi.settings File_ 
Navigated to the location where rhi.setreg is saved. 
Verified that the selected values were correctly written.

_Restarted Editor/GameLauncher_ 
Relaunched both tools and confirmed that the RHI system initialized with the configured settings.

