### PR TITLE
Fixes the "Jobs dependency" error on Jenkins.

### DIFF
--- a/Gems/OpenParticleSystem/Code/Source/Builder/ParticleBuilder.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Builder/ParticleBuilder.cpp
@@ -94,8 +94,6 @@ namespace OpenParticle
             return;
         }
 
-        AssetBuilderSDK::JobDescriptor descriptor;
-        descriptor.m_jobKey = jobKey;
         AZStd::string fullSourcePath;
         AZStd::set<AZStd::string> dependencyPaths;
         AzFramework::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), fullSourcePath, true);
@@ -108,6 +106,8 @@ namespace OpenParticle
 
         for (const AssetBuilderSDK::PlatformInfo& platformInfo : request.m_enabledPlatforms)
         {
+            AssetBuilderSDK::JobDescriptor descriptor;
+            descriptor.m_jobKey = jobKey;
             descriptor.SetPlatformIdentifier(platformInfo.m_identifier.c_str());
             descriptor.m_critical = false;
             descriptor.m_priority = 1; // since this is an entry point asset, we should prioritize it above the background


### PR DESCRIPTION

## What does this PR do?

```
  Jobs can only depend on the "common" platform or other jobs for the same platform.
  This is a code error, not a problem with the assets - please modify the builder to emit job`
  dependencies correctly.
    Source Job: (platform "server", job Key: "Particle Builder")
    Depends on: (platform "pc", job Key: "Material Builder", source file: "SourceFileDependency UUID: ...
```

The job item being constructed was being reused in the loop and thus the vector of deps would be filled with multiple copies of the same job item.


## How was this PR tested?

Cleaned assets, built with `pc,server,android` repro'd the error
Fixed the issue, rebuilt all assets, no issue.
