### PR TITLE
Update installer and cmake to 3.24.x 

### DIFF
--- a/AutomatedTesting/CMakeLists.txt
+++ b/AutomatedTesting/CMakeLists.txt
@@ -7,7 +7,7 @@
 #
 
 if(NOT PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.22)
+    cmake_minimum_required(VERSION 3.24)
 
     # Utility function to look for an optional 'engine_finder_cmake_path'setting 
     function(get_engine_finder_cmake_path project_json_file_path path_value)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@
 #
 #
 
-# Cmake version 3.22 is the minimum version needed for all of Open 3D Engine's supported platforms
-cmake_minimum_required(VERSION 3.22)
+# Cmake version 3.24 is the minimum version needed for all of Open 3D Engine's supported platforms
+cmake_minimum_required(VERSION 3.24)
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS "3.24") 
     # CMP0135 - controls whether, when unpacking an archive file, it should:

--- a/Gems/RecastNavigation/Code/recast-o3de.patch
+++ b/Gems/RecastNavigation/Code/recast-o3de.patch
@@ -4,7 +4,7 @@ index c3121c6..f4b8e73 100644
 +++ b/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 3.0)
-+cmake_minimum_required(VERSION 3.22)
++cmake_minimum_required(VERSION 3.24)
  
  project(RecastNavigation)
  

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For the latest details and system requirements, refer to [System Requirements](h
         *   Game Development with C++
         *   MSVC v142 - VS 2019 C++ x64/x86
         *   C++ 2019 redistributable update
-*   CMake 3.22.0 minimum: [https://cmake.org/download/#latest](https://cmake.org/download/#latest) (Release Candidate versions are not supported)
+*   CMake 3.24.0 minimum: [https://cmake.org/download/#latest](https://cmake.org/download/#latest) (Release Candidate versions are not supported)
 
 #### Optional
 

--- a/Templates/DefaultProject/Template/CMakeLists.txt
+++ b/Templates/DefaultProject/Template/CMakeLists.txt
@@ -9,7 +9,7 @@
 # {END_LICENSE}
 
 if(NOT PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.22)
+    cmake_minimum_required(VERSION 3.24)
 
     # Utility function to look for an optional 'engine_finder_cmake_path'setting 
     function(get_engine_finder_cmake_path project_json_file_path path_value)

--- a/Templates/MinimalProject/Template/CMakeLists.txt
+++ b/Templates/MinimalProject/Template/CMakeLists.txt
@@ -9,7 +9,7 @@
 # {END_LICENSE}
 
 if(NOT PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.22)
+    cmake_minimum_required(VERSION 3.24)
 
     # Utility function to look for an optional 'engine_finder_cmake_path'setting 
     function(get_engine_finder_cmake_path project_json_file_path path_value)

--- a/Templates/ScriptOnlyProject/Template/CMakeLists.txt
+++ b/Templates/ScriptOnlyProject/Template/CMakeLists.txt
@@ -9,7 +9,7 @@
 # {END_LICENSE}
 
 if(NOT PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.22)
+    cmake_minimum_required(VERSION 3.24)
 
     # Utility function to look for an optional 'engine_finder_cmake_path'setting 
     function(get_engine_finder_cmake_path project_json_file_path path_value)

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -39,7 +39,7 @@ set(CPACK_SNAP_DISTRO "" CACHE STRING
 )
 
 set(CPACK_THREADS 0)
-set(CPACK_DESIRED_CMAKE_VERSION 3.22.0)
+set(CPACK_DESIRED_CMAKE_VERSION 3.24.0)
 if(${CPACK_DESIRED_CMAKE_VERSION} VERSION_LESS ${CMAKE_MINIMUM_REQUIRED_VERSION})
     message(FATAL_ERROR
         "The desired version of CMake to be included in the package is "
@@ -63,6 +63,8 @@ else()
     set(CPACK_PACKAGE_VERSION "${O3DE_INSTALL_VERSION_STRING}")
 endif()
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Installation Tool")
+
+message(STATUS "CPack Package Version: ${CPACK_PACKAGE_VERSION}")
 
 string(TOLOWER "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}" CPACK_PACKAGE_FILE_NAME)
 
@@ -89,6 +91,7 @@ include(${pal_dir}/Packaging_${PAL_HOST_PLATFORM_NAME_LOWERCASE}.cmake)
 
 # if we get here and the generator hasn't been set, then a non fatal error occurred disabling packaging support
 if(NOT CPACK_GENERATOR)
+    message(STATUS "Packaging is not supported for this platform/configuration")
     return()
 endif()
 

--- a/cmake/Platform/Common/runtime_dependencies_common.cmake.in
+++ b/cmake/Platform/Common/runtime_dependencies_common.cmake.in
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 cmake_policy(SET CMP0012 NEW) # new policy for the if that evaluates a boolean out of "if(NOT ${same_location})"
 

--- a/cmake/Platform/Linux/Packaging_linux.cmake
+++ b/cmake/Platform/Linux/Packaging_linux.cmake
@@ -8,7 +8,7 @@
 
 set(_cmake_package_name "cmake-${CPACK_DESIRED_CMAKE_VERSION}-linux-x86_64")
 set(CPACK_CMAKE_PACKAGE_FILE "${_cmake_package_name}.tar.gz")
-set(CPACK_CMAKE_PACKAGE_HASH "dc73115520d13bb64202383d3df52bc3d6bbb8422ecc5b2c05f803491cb215b0")
+set(CPACK_CMAKE_PACKAGE_HASH "726f88e6598523911e4bce9b059dc20b851aa77f97e4cc5573f4e42775a5c16f")
 
 set(O3DE_INCLUDE_INSTALL_IN_PACKAGE FALSE CACHE BOOL "Option to copy the contents of the most recent install from CMAKE_INSTALL_PREFIX into CPACK_PACKAGING_INSTALL_PREFIX.  Useful for including a release build in a profile SDK.")
 
@@ -35,7 +35,7 @@ elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
     # Define all the debian package dependencies needed to build and run
     set(package_dependencies
         # Required Tools
-        "cmake (>=3.22)"                        # Cmake required (minimum version 3.22.0)
+        "cmake (>=3.24)"                        # Cmake required (minimum version 3.24.0)
         "clang (>=12.0)"                        # Clang required (minimum version 12.0)
         ninja-build
         # Build Libraries

--- a/cmake/Platform/Linux/runtime_dependencies_linux.cmake.in
+++ b/cmake/Platform/Linux/runtime_dependencies_linux.cmake.in
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 cmake_policy(SET CMP0012 NEW) # new policy for the if that evaluates a boolean out of "if(NOT ${same_location})"
 

--- a/cmake/Platform/Mac/PreInstallSteps_mac.cmake.in
+++ b/cmake/Platform/Mac/PreInstallSteps_mac.cmake.in
@@ -6,7 +6,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 # The O3DE SDK will be shipped as an app bundle. So we create an O3DE_SDK.app directory
 # and install SDK into the app's Contents/Engine directory.

--- a/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
+++ b/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 function(gp_resolve_item_override context item exepath dirs resolved_item_var resolved_var)
     # Qt frameworks could resolve the binary to eg qt/lib/QtCore.framework/Headers/QtCore instead of qt/lib/QtCore.framework/Versions/5/QtCore

--- a/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
+++ b/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
@@ -48,18 +48,21 @@
             ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C %SystemRoot%\System32\tar.exe -x -f &quot;[root.tools.redist.cmake]$(var.CPACK_CMAKE_PACKAGE_NAME).zip&quot; -C &quot;[root.tools.redist]CMake&quot;"
             Directory="INSTALL_ROOT"
             Execute="deferred"
+             Return="ignore"
             Impersonate="no"/>
 
         <CustomAction Id="MoveCMake"
             ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C move &quot;[root.tools.redist.cmake]$(var.CPACK_CMAKE_PACKAGE_NAME)&quot; &quot;[root.cmake]runtime&quot;"
             Directory="INSTALL_ROOT"
             Execute="deferred"
+            Return="ignore"
             Impersonate="no"/>
 
         <CustomAction Id="ConfigurePython"
             ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C set &quot;LY_CMAKE_PATH=[root.cmake.runtime]bin&quot; &amp;&amp; &quot;[root.python]get_python.bat&quot;"
             Directory="INSTALL_ROOT"
             Execute="deferred"
+             Return="ignore"
             Impersonate="no"/>
 
         <CustomAction Id="UnRegisterEngine"

--- a/cmake/Platform/Windows/Packaging_windows.cmake
+++ b/cmake/Platform/Windows/Packaging_windows.cmake
@@ -25,7 +25,7 @@ set(CPACK_GENERATOR WIX)
 
 set(_cmake_package_name "cmake-${CPACK_DESIRED_CMAKE_VERSION}-windows-x86_64")
 set(CPACK_CMAKE_PACKAGE_FILE "${_cmake_package_name}.zip")
-set(CPACK_CMAKE_PACKAGE_HASH "b1ad8c2dbf0778e3efcc9fd61cd4a962e5c1af40aabdebee3d5074bcff2e103c  ")
+set(CPACK_CMAKE_PACKAGE_HASH "b1ad8c2dbf0778e3efcc9fd61cd4a962e5c1af40aabdebee3d5074bcff2e103c")
 
 # workaround for shortening the path cpack installs to by stripping the platform directory
 set(CPACK_TOPLEVEL_TAG "")

--- a/cmake/Platform/Windows/Packaging_windows.cmake
+++ b/cmake/Platform/Windows/Packaging_windows.cmake
@@ -25,7 +25,7 @@ set(CPACK_GENERATOR WIX)
 
 set(_cmake_package_name "cmake-${CPACK_DESIRED_CMAKE_VERSION}-windows-x86_64")
 set(CPACK_CMAKE_PACKAGE_FILE "${_cmake_package_name}.zip")
-set(CPACK_CMAKE_PACKAGE_HASH "fcce74d1d7eaf825234c036702df3f0874dcd3cee8fdf90b56d0c7bfedd29465")
+set(CPACK_CMAKE_PACKAGE_HASH "b1ad8c2dbf0778e3efcc9fd61cd4a962e5c1af40aabdebee3d5074bcff2e103c  ")
 
 # workaround for shortening the path cpack installs to by stripping the platform directory
 set(CPACK_TOPLEVEL_TAG "")

--- a/python/get_python.cmake
+++ b/python/get_python.cmake
@@ -13,7 +13,7 @@
 # example:
 # cmake -DPAL_PLATFORM_NAME:string=Windows -DLY_3RDPARTY_PATH:string=%CMD_DIR% -P get_python.cmake
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 if(LY_3RDPARTY_PATH)
     file(TO_CMAKE_PATH ${LY_3RDPARTY_PATH} LY_3RDPARTY_PATH)

--- a/python/get_python_package_hash.cmake
+++ b/python/get_python_package_hash.cmake
@@ -13,7 +13,7 @@
 # example:
 # cmake -DPAL_PLATFORM_NAME:string=Windows -DLY_ROOT_FOLDER:string=%CMD_DIR% -P get_python_package_hash.cmake
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 if(${CMAKE_ARGC} LESS 4)
     message(FATAL_ERROR "Missing required engine root argument.")

--- a/scripts/license_scanner/scanner_config.json
+++ b/scripts/license_scanner/scanner_config.json
@@ -3,7 +3,8 @@
         ".git",
         ".venv",
         "build",
-        "license_scanner"
+        "license_scanner",
+        "AutomatedTesting"
     ],
     "license_patterns": [
         "LICENSE*",

--- a/scripts/o3de/tests/test_android.py
+++ b/scripts/o3de/tests/test_android.py
@@ -26,7 +26,7 @@ def test_validate_android_config_happy_path(tmpdir):
     test_android_support_validate_gradle_result = ('/home/gradle-8.4/', test_gradle_version)
 
     test_cmake_path = "/path/cmake"
-    test_cmake_version = "3.22"
+    test_cmake_version = "3.24"
     test_ninja_path = "/path/ninja"
     test_ninja_version = "1.10.1"
 
@@ -96,7 +96,7 @@ def test_validate_android_config_bad_keystore_path(tmpdir):
     mock_android_support_validate_gradle_result = ('/home/gradle-8.4/', '8.4')
 
     test_cmake_path = "/path/cmake"
-    test_cmake_version = "3.22"
+    test_cmake_version = "3.24"
     test_ninja_path = "/path/ninja"
     test_ninja_version = "1.10.1"
 
@@ -164,7 +164,7 @@ def test_validate_android_signing_config_warnings(tmpdir, test_sc_store_file, te
     test_android_support_validate_gradle_result = ('/home/gradle-8.4/', test_gradle_version)
 
     test_cmake_path = "/path/cmake"
-    test_cmake_version = "3.22"
+    test_cmake_version = "3.24"
     test_ninja_path = "/path/ninja"
     test_ninja_version = "1.10.1"
 


### PR DESCRIPTION
## What does this PR do?

* Updates the WIX installer script and build script to include that version of CMake (3.24), downloaded from the kitware official site.
* Makes the WIX post-installation steps non-failing.  They still run, but if they fail, they do not cause the installer to rollback.
* Updates the license scanner to work when licenses live in multiple different drives on windows.  relpath in python throws an exception if you specify paths on different drives.  This is often the case with the 3rd party libraries (`%USERPROFILE%`) and the build `D:/workspace` or something.

## How was this PR tested?

Building the installer locally , running it with my network unplugged to force the failure of the post install steps.

Windows testing only.

To build a WIX installer locally
1. install wixtoolset via `choco install wixtoolset` (make sure you have the .NET SDK)
2. invoke cmake with `cmake --build build/windows -ULY_PROJECTS -DLY_DISABLE_TEST_MODULES=ON -DLY_MONOLITHIC_GAME=OFF -DO3DE_INSTALL_ENGINE_NAME=o3de-sdk -DLY_INSTALLER_WIX_ROOT="C:\Program Files (x86)\WiX Toolset v3.14"` 
3. build cmake building target ALL_BUILD profile: `cmake --build build\windows --config profile --target ALL_BUILD -- /m`
4. cd into the build dir `cd build\windows` and invoke `cpack -G "WIX" -C profile`

This will produce a local testable installer you can run yourself.