### PR TITLE
Update UpdateForce.cpp

### DIFF
--- a/Gems/OpenParticleSystem/Code/SimuCore/modules/particle/core/src/update/UpdateForce.cpp
+++ b/Gems/OpenParticleSystem/Code/SimuCore/modules/particle/core/src/update/UpdateForce.cpp
@@ -72,7 +72,7 @@ namespace SimuCore::ParticleCore {
         Vector3 direction = data->useLocalSpace ?
             info.emitterTrans.TransformPoint(data->position) - particle.globalPosition :
             data->position - particle.globalPosition;
-        if (float lengthSq = direction.GetLengthSq() > 0.f)
+        if (direction.GetLengthSq() > 0.f)
         {
             particle.velocity += direction / direction.GetLength() * (data->force * info.tickTime);
         }


### PR DESCRIPTION

## What does this PR do?

float lengthSq is not used!

Notice direction.GetLengthSq() and direction.GetLength() are very similar. You could probably get way with:

```
float lengthSq = direction.GetLengthSq();
if (lengthSq > 0.f)
{
    particle.velocity += direction / AZStd::sqrt(lengthSq) * (data->force * info.tickTime);
}
```

This is potentially more efficient than the direct fix of the PR. But I am not sure which one would you prefer...

#19272

## How was this PR tested?

Allowing warnings to be treated as errors breaks the build.

This will allow the build to proceed without any issues
