### PR TITLE
[Linux] Do not hide mouse cursor when debugger is present

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -427,6 +427,11 @@ namespace AzFramework
 
     void XcbInputDeviceMouse::ShowCursor(xcb_window_t window, bool show)
     {
+        if (!show && AZ::Debug::Trace::Instance().IsDebuggerPresent())
+        {
+            return;
+        }
+
         xcb_void_cookie_t cookie;
         if (show)
         {


### PR DESCRIPTION
## What does this PR do?

Currently, when debugging on Linux the cursor is hidden which makes it hard to use any IDE while debugging the engine.
This PR will prevent the engine to hide the cursor when the debugger is present. Not sure if there is any other trick on Linux I am not aware of to prevent this , if someone knows, please let me know, else how about this PR?




