### PR TITLE
Cherry pick more changes from qt6 branch

### DIFF
--- a/Code/Editor/ConsoleDialog.cpp
+++ b/Code/Editor/ConsoleDialog.cpp
@@ -25,7 +25,7 @@ CConsoleDialog::CConsoleDialog(QWidget* parent)
 {
     QVBoxLayout* outterLayout = new QVBoxLayout(this);
     outterLayout->addWidget(m_consoleWidget);
-    outterLayout->setMargin(0);
+    outterLayout->setContentsMargins(0, 0, 0, 0);
 
     setWindowTitle(LyViewPane::Console);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);

--- a/Code/Editor/Controls/FolderTreeCtrl.cpp
+++ b/Code/Editor/Controls/FolderTreeCtrl.cpp
@@ -17,6 +17,7 @@
 #include <QRegularExpression>
 
 #include <AzCore/std/algorithm.h>
+#include <AzCore/std/string/wildcard.h>
 #include <AzCore/IO/SystemFile.h>
 
 #include <AzQtComponents/Utilities/DesktopUtilities.h> // for AzQtComponents::ShowFileOnDesktop
@@ -243,8 +244,7 @@ void CFolderTreeCtrl::AddItem(const QString& path)
     AZ::IO::FixedMaxPath fileNameWithoutExtension = folder.Stem();
     folder = folder.ParentPath();
 
-    auto regex = QRegularExpression(m_fileNameSpec, QRegularExpression::PatternOption::CaseInsensitiveOption);
-    if (regex.match(path).hasMatch())
+    if (AZStd::wildcard_match(qPrintable(m_fileNameSpec), qPrintable(path)))
     {
         CTreeItem* folderTreeItem = CreateFolderItems(QString::fromUtf8(folder.c_str(), static_cast<int>(folder.Native().size())));
         if(folderTreeItem)

--- a/Code/Editor/Controls/FolderTreeCtrl.cpp
+++ b/Code/Editor/Controls/FolderTreeCtrl.cpp
@@ -14,6 +14,7 @@
 #include <QMenu>
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
+#include <QRegularExpression>
 
 #include <AzCore/std/algorithm.h>
 #include <AzCore/IO/SystemFile.h>
@@ -242,8 +243,8 @@ void CFolderTreeCtrl::AddItem(const QString& path)
     AZ::IO::FixedMaxPath fileNameWithoutExtension = folder.Stem();
     folder = folder.ParentPath();
 
-    auto regex = QRegExp(m_fileNameSpec, Qt::CaseInsensitive, QRegExp::Wildcard);
-    if (regex.exactMatch(path))
+    auto regex = QRegularExpression(m_fileNameSpec, QRegularExpression::PatternOption::CaseInsensitiveOption);
+    if (regex.match(path).hasMatch())
     {
         CTreeItem* folderTreeItem = CreateFolderItems(QString::fromUtf8(folder.c_str(), static_cast<int>(folder.Native().size())));
         if(folderTreeItem)

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
@@ -1245,7 +1245,6 @@ PropertyCard::PropertyCard([[maybe_unused]] QWidget* parent /*= nullptr*/)
     m_propertyEditor->setProperty("ComponentDisabl", true); // used by stylesheet
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    mainLayout->setMargin(0);
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->addWidget(m_header);
     mainLayout->addWidget(m_propertyEditor);

--- a/Code/Editor/ErrorReportTableModel.cpp
+++ b/Code/Editor/ErrorReportTableModel.cpp
@@ -10,6 +10,7 @@
 
 #include "ErrorReportTableModel.h"
 #include <QIcon>
+#include <QRegularExpression>
 
 // Editor
 #include "ErrorReport.h"
@@ -27,16 +28,16 @@ bool GetPositionFromString(QString er, float* x, float* y, float* z)
     if (ind >= 0)
     {
         er = er.mid(ind + shift);
-        er.remove(QRegExp("^ *"));
+        er.remove(QRegularExpression("^ *"));
         if (er[0] == '(')
         {
             er = er.mid(1);
-            er.remove(QRegExp("^ *"));
+            er.remove(QRegularExpression("^ *"));
             ind = er.indexOf(")");
             if (ind > 0)
             {
                 er = er.mid(0, ind);
-                er.remove(QRegExp(" *$"));
+                er.remove(QRegularExpression(" *$"));
 
                 ind = er.indexOf(" ");
                 int ind2 = er.indexOf(",");
@@ -48,7 +49,7 @@ bool GetPositionFromString(QString er, float* x, float* y, float* z)
                 {
                     *x = er.mid(0, ind).toFloat();
                     er = er.mid(ind);
-                    er.remove(QRegExp("^[ ,]*"));
+                    er.remove(QRegularExpression("^[ ,]*"));
 
                     ind = er.indexOf(" ");
                     ind2 = er.indexOf(",");
@@ -60,7 +61,7 @@ bool GetPositionFromString(QString er, float* x, float* y, float* z)
                     {
                         *y = er.mid(0, ind).toFloat();
                         er = er.mid(ind);
-                        er.remove(QRegExp("^[ ,]*"));
+                        er.remove(QRegularExpression("^[ ,]*"));
                         if (er.length())
                         {
                             *z = er.toFloat();

--- a/Code/Editor/LevelFileDialog.cpp
+++ b/Code/Editor/LevelFileDialog.cpp
@@ -16,6 +16,7 @@
 // Qt
 #include <QMessageBox>
 #include <QInputDialog>
+#include <QRegularExpression>
 
 // Editor
 #include "LevelTreeModel.h"
@@ -82,7 +83,7 @@ CLevelFileDialog::CLevelFileDialog(bool openDialog, QWidget* parent)
     }
 
     // reject invalid file names
-    ui->nameLineEdit->setValidator(new QRegExpValidator(QRegExp("^[a-zA-Z0-9_\\-./]*$"), ui->nameLineEdit));
+    ui->nameLineEdit->setValidator(new QRegularExpressionValidator(QRegularExpression("^[a-zA-Z0-9_\\-./]*$"), ui->nameLineEdit));
 
     ReloadTree();
     LoadLastUsedLevelPath();

--- a/Code/Editor/LevelTreeModel.cpp
+++ b/Code/Editor/LevelTreeModel.cpp
@@ -127,7 +127,7 @@ void LevelTreeModel::ReloadTree(QStandardItem* root, bool recurseIfNoLevels)
         QDir currentDir(parentFullPath);
         currentDir.setFilter(QDir::NoDot | QDir::NoDotDot | QDir::Dirs);
         const QStringList subFolders = currentDir.entryList();
-        foreach (const QString &subFolder, subFolders)
+        for (const QString& subFolder : subFolders)
         {
             auto child = new QStandardItem(subFolder);
             child->setData(parentFullPath + "/" + subFolder, FullPathRole);
@@ -142,7 +142,7 @@ void LevelTreeModel::ReloadTree(QStandardItem* root, bool recurseIfNoLevels)
         // Support for legacy folder structure: Multiple cry files in level folder
         if (recurseIfNoLevels && levelFiles.size() > 1)
         {
-            foreach (const QString &levelFile, levelFiles)
+            for (const QString& levelFile : levelFiles)
             {
                 auto child = new QStandardItem(levelFile);
                 child->setData(root->data(FullPathRole).toString() + "/" + levelFile, FullPathRole);

--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -19,6 +19,7 @@
 #include <QTimer>
 #include <QToolButton>
 #include <QListWidgetItem>
+#include <QRegularExpression>
 
 #include <ui_NewLevelDialog.h>
 
@@ -73,8 +74,8 @@ CNewLevelDialog::CNewLevelDialog(QWidget* pParent /*=nullptr*/)
     InitTemplateListWidget();
 
     // Level name only supports ASCII characters
-    QRegExp rx("[_a-zA-Z0-9-]+");
-    QValidator* validator = new QRegExpValidator(rx, this);
+    QRegularExpression rx("[_a-zA-Z0-9-]+");
+    QValidator* validator = new QRegularExpressionValidator(rx, this);
     ui->LEVEL->setValidator(validator);
 
     validator = new LevelFolderValidator(this);
@@ -294,7 +295,7 @@ void CNewLevelDialog::OnLevelNameChange()
 {
     UpdateData(true);
 
-    // QRegExpValidator means the string will always be valid as long as it's not empty:
+    // QRegularExpressionValidator means the string will always be valid as long as it's not empty:
     bool valid = !m_level.isEmpty() && ValidateLevel();
     if (valid)
     {

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/CMakeLists.txt
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/CMakeLists.txt
@@ -15,7 +15,6 @@ ly_add_target(
     NAMESPACE Legacy
     OUTPUT_SUBDIRECTORY EditorPlugins
     AUTOMOC
-    AUTORCC
     FILES_CMAKE
         componententityeditorplugin_files.cmake
     COMPILE_DEFINITIONS

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
@@ -11,8 +11,11 @@
 #include "AssetCatalogModel.h"
 
 #include <IEditor.h>
+
 #include <qevent.h>
 #include <qmimedata.h>
+#include <QTimer>
+#include <QRegularExpression>
 
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/RTTI/TypeInfo.h>
@@ -31,8 +34,6 @@
 #include <AzToolsFramework/ToolsComponents/ComponentAssetMimeDataContainer.h>
 #include <AzToolsFramework/ToolsComponents/ScriptEditorComponent.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
-
-#include <QTimer>
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -360,7 +361,7 @@ AssetCatalogEntry* AssetCatalogModel::AddAsset(QString assetPath, AZ::Data::Asse
         asset = assetPath.mid(slashIdx + 1);
     }
 
-    QRegExp mipMapExtension("\\.dds\\.\\d+a?$");    // Files that end with ".dds.#", with an optional "a"
+    QRegularExpression mipMapExtension("\\.dds\\.\\d+a?$");    // Files that end with ".dds.#", with an optional "a"
     if (asset.contains(mipMapExtension))
     {
         //  Mip map files should be ignored by the file browser.
@@ -628,12 +629,13 @@ void AssetCatalogModel::BuildFilter(QStringList& criteriaList, AzToolsFramework:
                 filter += "(?=.*" + text + ")"; //  Using Lookaheads to produce an "and" effect.
             }
 
-            SetFilterRegExp(tag.toStdString().c_str(), QRegExp(filter, Qt::CaseInsensitive));
+            SetFilterRegExp(
+                tag.toStdString().c_str(), QRegularExpression(filter, QRegularExpression::PatternOption::CaseInsensitiveOption));
         }
     }
 }
 
-void AssetCatalogModel::SetFilterRegExp(const AZStd::string& filterType, const QRegExp& regExp)
+void AssetCatalogModel::SetFilterRegExp(const AZStd::string& filterType, const QRegularExpression& regExp)
 {
     m_filtersRegExp[filterType] = regExp;
 }
@@ -644,12 +646,12 @@ void AssetCatalogModel::ClearFilterRegExp(const AZStd::string& filterType)
     {
         for (auto& it : m_filtersRegExp)
         {
-            it.second = QRegExp();
+            it.second = QRegularExpression();
         }
     }
     else
     {
-        m_filtersRegExp[filterType] = QRegExp();
+        m_filtersRegExp[filterType] = QRegularExpression();
     }
 }
 
@@ -666,7 +668,7 @@ void AssetCatalogModel::ApplyFilter(QStandardItem* parent)
     for (int i = 0; i < parent->rowCount(); i++)
     {
         QStandardItem* child = parent->child(i);
-        if (m_filtersRegExp["name"].isEmpty())
+        if (m_filtersRegExp["name"].pattern().isEmpty())
         {
             child->setData(true, AssetCatalogEntry::VisibilityRole);
         }

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.h
@@ -18,6 +18,8 @@
 #include <AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx>
 #endif
 
+class QRegularExpression;
+
 ///////////////////////////////////////////////////////////////////////////////
 struct DatabaseEntry
 {
@@ -107,7 +109,7 @@ protected:
 
     void BuildFilter(QStringList& criteriaList, AzToolsFramework::FilterOperatorType filterOperator);
     void InvalidateFilter();
-    void SetFilterRegExp(const AZStd::string& filterType, const QRegExp& regExp);
+    void SetFilterRegExp(const AZStd::string& filterType, const QRegularExpression& regExp);
     void ClearFilterRegExp(const AZStd::string& filterType = AZStd::string());
 
     AZ::Data::AssetType GetAssetType(const QString &filename) const;

--- a/Code/Editor/Plugins/EditorCommon/CMakeLists.txt
+++ b/Code/Editor/Plugins/EditorCommon/CMakeLists.txt
@@ -26,7 +26,6 @@ ly_add_target(
     NAME EditorCommon SHARED
     NAMESPACE Legacy
     AUTOMOC
-    AUTORCC
     FILES_CMAKE
         editorcommon_files.cmake
     INCLUDE_DIRECTORIES

--- a/Code/Editor/QtViewPaneManager.cpp
+++ b/Code/Editor/QtViewPaneManager.cpp
@@ -1645,7 +1645,8 @@ QtViewPane* QtViewPaneManager::GetFirstVisiblePaneMatching(const QString& name)
     auto it = std::find_if(m_registeredPanes.begin(), m_registeredPanes.end(),
             [pattern](const QtViewPane& pane)
         {
-            return pattern.match(pane.m_name).hasMatch() && pane.IsVisible();
+            QRegularExpressionMatch match = pattern.match(pane.m_name);
+            return match.hasMatch() && match.capturedLength() == pane.m_name.length() && pane.IsVisible();
         });
 
     QtViewPane* foundPane = ((it == m_registeredPanes.end()) ? nullptr : it);
@@ -1658,7 +1659,8 @@ QtViewPane* QtViewPaneManager::GetFirstVisiblePaneMatching(const QString& name)
             m_registeredPanes.end(),
             [pattern](const QtViewPane& pane)
             {
-                return pattern.match(pane.m_options.saveKeyName).hasMatch() && pane.IsVisible();
+                QRegularExpressionMatch match = pattern.match(pane.m_options.saveKeyName);
+                return match.hasMatch() && match.capturedLength() == pane.m_name.length() && pane.IsVisible();
             });
 
         foundPane = ((optionsIt == m_registeredPanes.end()) ? nullptr : optionsIt);

--- a/Code/Editor/QtViewPaneManager.cpp
+++ b/Code/Editor/QtViewPaneManager.cpp
@@ -27,6 +27,8 @@
 #include <QCursor>
 #include <QTimer>
 #include <QGraphicsOpacityEffect>
+#include <QRegularExpression>
+
 #include "MainWindow.h"
 
 #include <algorithm>
@@ -1635,15 +1637,15 @@ QtViewPane* QtViewPaneManager::GetFirstVisiblePaneMatching(const QString& name)
     QString baseName = name;
 
     // Strip away any enumeration.
-    baseName = baseName.remove(QRegExp("\\([0-9]+\\)$"));
+    baseName = baseName.remove(QRegularExpression("\\([0-9]+\\)$"));
 
     // Build a regexp which will match just the name, or the name followed by a number in parentheses.
-    QRegExp pattern(name + "([ ]*\\([0-9]+\\))*");
+    QRegularExpression pattern(name + "([ ]*\\([0-9]+\\))*");
 
     auto it = std::find_if(m_registeredPanes.begin(), m_registeredPanes.end(),
             [pattern](const QtViewPane& pane)
         {
-            return pattern.exactMatch(pane.m_name) && pane.IsVisible();
+            return pattern.match(pane.m_name).hasMatch() && pane.IsVisible();
         });
 
     QtViewPane* foundPane = ((it == m_registeredPanes.end()) ? nullptr : it);
@@ -1651,11 +1653,13 @@ QtViewPane* QtViewPaneManager::GetFirstVisiblePaneMatching(const QString& name)
     if (foundPane == nullptr)
     {
         // if we couldn't find the pane based on the name (which will be the title), look it up by saveKeyName next
-        auto optionsIt = std::find_if(m_registeredPanes.begin(), m_registeredPanes.end(),
+        auto optionsIt = std::find_if(
+            m_registeredPanes.begin(),
+            m_registeredPanes.end(),
             [pattern](const QtViewPane& pane)
-        {
-            return pattern.exactMatch(pane.m_options.saveKeyName) && pane.IsVisible();
-        });
+            {
+                return pattern.match(pane.m_options.saveKeyName).hasMatch() && pane.IsVisible();
+            });
 
         foundPane = ((optionsIt == m_registeredPanes.end()) ? nullptr : optionsIt);
     }

--- a/Code/Editor/QtViewPaneManager.cpp
+++ b/Code/Editor/QtViewPaneManager.cpp
@@ -1218,7 +1218,7 @@ void QtViewPaneManager::SaveLayout(QString layoutName)
     layoutName = layoutName.trimmed();
 
     ViewLayoutState state;
-    foreach(const QtViewPane &pane, m_registeredPanes)
+    for (const QtViewPane& pane : m_registeredPanes)
     {
         // Include all visible and tabbed panes in our layout, since tabbed panes
         // won't be visible if they aren't the active tab, but still need to be
@@ -1340,7 +1340,7 @@ ViewLayoutState QtViewPaneManager::GetLayout() const
 {
     ViewLayoutState state;
 
-    foreach(const QtViewPane &pane, m_registeredPanes)
+    for (const QtViewPane& pane : m_registeredPanes)
     {
         // Include all visible and tabbed panes in our layout, since tabbed panes
         // won't be visible if they aren't the active tab, but still need to be

--- a/Code/Editor/TrackView/TrackViewCurveEditor.cpp
+++ b/Code/Editor/TrackView/TrackViewCurveEditor.cpp
@@ -21,7 +21,7 @@ TrackViewCurveEditorDialog::TrackViewCurveEditorDialog(QWidget* parent)
 {
     m_widget = new CTrackViewCurveEditor(this);
     QVBoxLayout* l = new QVBoxLayout;
-    l->setMargin(0);
+    l->setContentsMargins(0, 0, 0, 0);
     l->addWidget(m_widget);
     setLayout(l);
 }

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -213,7 +213,7 @@ bool CTrackViewDialog::OnInitDialog()
 
     QWidget* w = new QWidget();
     QVBoxLayout* l = new QVBoxLayout;
-    l->setMargin(0);
+    l->setContentsMargins(0, 0, 0, 0);
 
     m_wndSplitter = new QSplitter(w);
     m_wndSplitter->setOrientation(Qt::Horizontal);

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -1844,8 +1844,10 @@ void CTrackViewDialog::SaveLayouts()
     settings.setValue("layout", stateData);
     settings.setValue("lastViewMode", (int)m_lastMode);
     QStringList sl;
-    foreach(int i, m_wndSplitter->sizes())
-    sl << QString::number(i);
+    for (int i : m_wndSplitter->sizes())
+    {
+        sl << QString::number(i);
+    }
     settings.setValue("splitter", sl.join(","));
     settings.endGroup();
     settings.sync();

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
@@ -43,7 +43,7 @@ CTrackViewKeyPropertiesDlg::CTrackViewKeyPropertiesDlg(QWidget* hParentWnd)
     , m_sequence(nullptr)
 {
     QVBoxLayout* l = new QVBoxLayout();
-    l->setMargin(0);
+    l->setContentsMargins(0, 0, 0, 0);
     m_wndTrackProps = new CTrackViewTrackPropsDlg(this);
     l->addWidget(m_wndTrackProps);
     m_wndProps = new ReflectedPropertyControl(this);

--- a/Code/Editor/Util/AutoDirectoryRestoreFileDialog.cpp
+++ b/Code/Editor/Util/AutoDirectoryRestoreFileDialog.cpp
@@ -42,7 +42,7 @@ int CAutoDirectoryRestoreFileDialog::exec()
     while ((result = QFileDialog::exec()) == QDialog::Accepted)
     {
         bool problem = false;
-        foreach(const QString&fileName, selectedFiles())
+        for (const QString& fileName : selectedFiles())
         {
             QFileInfo info(fileName);
             if (!AZ::StringFunc::Path::IsValid(info.fileName().toStdString().c_str()))

--- a/Code/Editor/Util/ColumnGroupHeaderView.cpp
+++ b/Code/Editor/Util/ColumnGroupHeaderView.cpp
@@ -70,7 +70,7 @@ bool ColumnGroupHeaderView::event(QEvent* event)
         auto groups = m_groupModel->Groups();
 
         m_groups.clear();
-        foreach(int column, groups)
+        for (int column : groups)
         {
             const int width = sectionSize(column);
             const QRect r(xOffset, yOffset, width == 0 ? defaultSectionSize() : width, QHeaderView::sizeHint().height());
@@ -93,7 +93,7 @@ bool ColumnGroupHeaderView::event(QEvent* event)
         auto mouseEvent = static_cast<QMouseEvent*>(event);
         if (m_showGroups && m_groupModel)
         {
-            foreach(const Group &group, m_groups)
+            for (const Group& group : m_groups)
             {
                 if (group.rect.contains(mouseEvent->pos()))
                 {

--- a/Code/Editor/Util/ColumnGroupProxyModel.cpp
+++ b/Code/Editor/Util/ColumnGroupProxyModel.cpp
@@ -67,7 +67,7 @@ void ColumnGroupProxyModel::RemoveGroup(int column)
 void ColumnGroupProxyModel::SetGroups(const QVector<int>& columns)
 {
     m_groups.clear();
-    foreach(int col, columns)
+    for (int col : columns)
     {
         m_groups.push_back(col);
         m_sortModel->AddColumnWithoutSorting(col);
@@ -101,8 +101,11 @@ Qt::SortOrder ColumnGroupProxyModel::SortOrder(int col) const
 QStringList ColumnGroupProxyModel::GroupForSourceIndex(const QModelIndex& sourceIndex) const
 {
     QStringList group;
-    foreach(int column, m_groups)
-    group.push_back(QString::fromLatin1("%1: %2").arg(headerData(column, Qt::Horizontal).toString(), sourceIndex.sibling(sourceIndex.row(), column).data().toString()));
+    for (int column : m_groups)
+    {
+        group.push_back(QString::fromLatin1("%1: %2").arg(
+            headerData(column, Qt::Horizontal).toString(), sourceIndex.sibling(sourceIndex.row(), column).data().toString()));
+    }
     return group;
 }
 

--- a/Code/Editor/Util/ColumnSortProxyModel.cpp
+++ b/Code/Editor/Util/ColumnSortProxyModel.cpp
@@ -200,7 +200,7 @@ void ColumnSortProxyModel::RemoveColumnWithoutSorting(int column)
 void ColumnSortProxyModel::SetColumns(const QVector<int>& columns)
 {
     m_columns.clear();
-    foreach(int col, columns)
+    for (int col : columns)
     {
         m_columns.push_back({ col, Qt::AscendingOrder });
     }
@@ -239,7 +239,7 @@ void ColumnSortProxyModel::SortModel()
         m_mappingToSource[i] = i;
     }
 
-    foreach(Column col, m_columns)
+    for (Column col : m_columns)
     {
         if (col.sortOrder == Qt::AscendingOrder)
         {

--- a/Code/Editor/Util/FileChangeMonitor.cpp
+++ b/Code/Editor/Util/FileChangeMonitor.cpp
@@ -14,6 +14,7 @@
 // Qt
 #include <QDateTime>
 #include <QTimer>
+#include <QRegularExpression>
 
 
 CFileChangeMonitor* CFileChangeMonitor::s_pFileMonitorInstance = nullptr;
@@ -192,7 +193,7 @@ void CFileChangeMonitor::NotifyListeners(const QString &path, SFileChangeInfo::E
 {
     for (const auto &glob : m_ignoreMasks)
     {
-        QRegExp exp(glob, Qt::CaseInsensitive, QRegExp::Wildcard);
+        QRegularExpression exp(glob, QRegularExpression::PatternOption::CaseInsensitiveOption);
         if (path.contains(exp))
         {
             return; // mask matches, ignore event

--- a/Code/Editor/Util/FileChangeMonitor.cpp
+++ b/Code/Editor/Util/FileChangeMonitor.cpp
@@ -11,6 +11,8 @@
 
 #include "FileChangeMonitor.h"
 
+#include <AzCore/std/string/wildcard.h>
+
 // Qt
 #include <QDateTime>
 #include <QTimer>
@@ -193,9 +195,7 @@ void CFileChangeMonitor::NotifyListeners(const QString &path, SFileChangeInfo::E
 {
     for (const auto &glob : m_ignoreMasks)
     {
-        QString wildCard = QRegularExpression::wildcardToRegularExpression(glob);
-        QRegularExpression exp(wildCard, QRegularExpression::PatternOption::CaseInsensitiveOption);
-        if (path.contains(exp))
+        if (AZStd::wildcard_match(qPrintable(glob), qPrintable(path)))
         {
             return; // mask matches, ignore event
         }

--- a/Code/Editor/Util/FileChangeMonitor.cpp
+++ b/Code/Editor/Util/FileChangeMonitor.cpp
@@ -193,7 +193,8 @@ void CFileChangeMonitor::NotifyListeners(const QString &path, SFileChangeInfo::E
 {
     for (const auto &glob : m_ignoreMasks)
     {
-        QRegularExpression exp(glob, QRegularExpression::PatternOption::CaseInsensitiveOption);
+        QString wildCard = QRegularExpression::wildcardToRegularExpression(glob);
+        QRegularExpression exp(wildCard, QRegularExpression::PatternOption::CaseInsensitiveOption);
         if (path.contains(exp))
         {
             return; // mask matches, ignore event

--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -448,7 +448,7 @@ bool CFileUtil::SelectFiles(const QString& fileSpec, const QString& searchFolder
     if (dlg.exec())
     {
         const QStringList selected = dlg.selectedFiles();
-        foreach(const QString&file, selected)
+        for (const QString& file : selected)
         {
             files.push_back(file);
         }

--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
@@ -22,6 +22,8 @@
 #include <QDesktopWidget>
 #include <QTimer>
 #include <QDateTime>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 #include <AzCore/Utils/Utils.h>
 
@@ -172,7 +174,7 @@ bool WelcomeScreenDialog::IsValidLevelName(const QString& path)
         levelName = pathParts.at(pathParts.size() - 2);
     }
 
-    QRegExpValidator validator(QRegExp("^[a-zA-Z0-9_\\-./]*$"));
+    QRegularExpressionValidator validator(QRegularExpression("^[a-zA-Z0-9_\\-./]*$"));
 
     int pos = 0;
     return validator.validate(levelName, pos);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FilteredSearchWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FilteredSearchWidget.cpp
@@ -69,7 +69,6 @@ namespace AzQtComponents
     {
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         m_frameLayout = new QHBoxLayout(this);
-        m_frameLayout->setMargin(0);
         m_frameLayout->setContentsMargins(4, 1, 0, 1);
         m_frameLayout->setSpacing(0);
 
@@ -95,7 +94,6 @@ namespace AzQtComponents
     {
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         m_frameLayout = new QHBoxLayout(this);
-        m_frameLayout->setMargin(0);
         m_frameLayout->setContentsMargins(4, 1, 0, 1);
         m_frameLayout->setSpacing(0);
 
@@ -136,7 +134,6 @@ namespace AzQtComponents
     {
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         m_frameLayout = new QHBoxLayout(this);
-        m_frameLayout->setMargin(0);
         m_frameLayout->setContentsMargins(4, 1, 0, 1);
         m_frameLayout->setSpacing(0);
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FlowLayout.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FlowLayout.cpp
@@ -146,9 +146,10 @@ QSize FlowLayout::sizeHint() const
 QSize FlowLayout::minimumSize() const
 {
     QSize size;
-    QLayoutItem* item;
-    foreach(item, itemList)
-    size = size.expandedTo(item->minimumSize());
+    for (QLayoutItem* item : itemList)
+    {
+        size = size.expandedTo(item->minimumSize());
+    }
 
     size += QSize(2 * margin(), 2 * margin());
     return size;
@@ -163,8 +164,8 @@ int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
     int y = effectiveRect.y();
     int lineHeight = 0;
 
-    QLayoutItem* item;
-    foreach(item, itemList) {
+    for (QLayoutItem* item : itemList)
+    {
         QWidget* wid = item->widget();
         int spaceX = horizontalSpacing();
         if (spaceX == -1)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleSheetCache.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleSheetCache.h
@@ -19,10 +19,10 @@
 #include <QSet>
 #include <QStack>
 #include <QMap>
+#include <QRegularExpression>
 #endif
 
 class QFileSystemWatcher;
-class QRegExp;
 
 namespace AzQtComponents
 {
@@ -71,7 +71,7 @@ namespace AzQtComponents
 
         QFileSystemWatcher* m_fileWatcher;
 
-        QScopedPointer<QRegExp> m_importExpression;
+        QScopedPointer<QRegularExpression> m_importExpression;
 
         QSet<QString> m_prefixes;
         QMap<QString, QString> m_diskToQrcMap;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyledSpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyledSpinBox.cpp
@@ -14,6 +14,7 @@
 #include <QIntValidator>
 #include <QLineEdit>
 #include <QSignalBlocker>
+#include <QRegularExpression>
 
 namespace AzQtComponents
 {
@@ -145,7 +146,7 @@ namespace AzQtComponents
             // it for us
             QChar zeroDigit = locale().zeroDigit();
             QString trailingZeros = QString("%1+$").arg(zeroDigit);
-            stringValue.remove(QRegExp(trailingZeros));
+            stringValue.remove(QRegularExpression(trailingZeros));
 
             // It's possible we could be left with a decimal point on the end
             // if we stripped the trailing zeros, so if that's the case, then

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/TagSelector.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/TagSelector.cpp
@@ -59,7 +59,7 @@ namespace AzQtComponents
         , m_widget(nullptr)
     {
         m_layout = new QVBoxLayout();
-        m_layout->setMargin(0);
+        m_layout->setContentsMargins(0, 0, 0, 0);
         setLayout(m_layout);
 
         m_width = 250;
@@ -88,7 +88,7 @@ namespace AzQtComponents
 
         QVBoxLayout* vLayout = new QVBoxLayout();
         vLayout->setAlignment(Qt::AlignLeft);
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
 
         QHBoxLayout* hLayout = nullptr;
         int usedSpaceInRow = 0;
@@ -114,7 +114,7 @@ namespace AzQtComponents
                 // Add a new row for the current tag widget.
                 hLayout = new QHBoxLayout();
                 hLayout->setAlignment(Qt::AlignLeft);
-                hLayout->setMargin(0);
+                hLayout->setContentsMargins(0, 0, 0, 0);
                 vLayout->addLayout(hLayout);
 
                 // Reset the used space in the row.
@@ -223,7 +223,7 @@ namespace AzQtComponents
     void TagSelector::Init()
     {
         QVBoxLayout* layout = new QVBoxLayout(this);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         // Add the tag widget container representing the currently selected tags.
         m_tagWidgets = new TagWidgetContainer();

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/ToolButtonWithWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/ToolButtonWithWidget.cpp
@@ -29,7 +29,7 @@ namespace AzQtComponents
     {
         auto layout = new QHBoxLayout(this);
         layout->setSpacing(0);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->addWidget(m_button);
         layout->addWidget(m_widget);
         m_button->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/VectorEdit.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/VectorEdit.cpp
@@ -26,7 +26,7 @@ namespace AzQtComponents
         auto layout = new QHBoxLayout(this);
         layout->addWidget(m_label);
         layout->addWidget(m_lineEdit);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(3);
 
         m_lineEdit->setValidator(new QDoubleValidator(this));
@@ -111,12 +111,12 @@ namespace AzQtComponents
 
         // Two layouts so we can have smaller spacing between icon label and line edits
         auto outterLayout = new QHBoxLayout(this);
-        outterLayout->setMargin(0);
+        outterLayout->setContentsMargins(0, 0, 0, 0);
         outterLayout->setSpacing(5);
         auto container = new QWidget();
         auto layout = new QHBoxLayout(container);
 
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(15);
         setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/VectorEdit.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/VectorEdit.cpp
@@ -236,7 +236,7 @@ namespace AzQtComponents
         }
 
         m_flavor = flavor;
-        foreach(auto edit, m_editElements)
+        for (auto edit : m_editElements)
         {
             edit->setFlavor(flavor);
         }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/ColorHexEdit.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/ColorHexEdit.cpp
@@ -17,6 +17,8 @@
 #include <QMenu>
 #include <QApplication>
 #include <QClipboard>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 #include <functional>
 
@@ -68,7 +70,7 @@ ColorHexEdit::ColorHexEdit(QWidget* parent)
 
     m_edit = new QLineEdit(QStringLiteral("000000"), this);
     m_edit->setObjectName(QStringLiteral("colorhexedit"));
-    m_edit->setValidator(new QRegExpValidator(QRegExp(QStringLiteral("^[0-9A-Fa-f]{1,6}$")), this));
+    m_edit->setValidator(new QRegularExpressionValidator(QRegularExpression(QStringLiteral("^[0-9A-Fa-f]{1,6}$")), this));
     m_edit->setFixedWidth(52);
     LineEdit::setErrorIconEnabled(m_edit, false);
     connect(m_edit, &QLineEdit::textChanged, this, &ColorHexEdit::textChanged);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
@@ -15,6 +15,7 @@
 #include <QTextCursor>
 #include <QTextDocument>
 
+
 namespace AzQtComponents
 {
     ElidingLabel::ElidingLabel(const QString& text, QWidget* parent /* = nullptr */)
@@ -205,7 +206,7 @@ namespace AzQtComponents
     void ElidingLabel::setFilter(const QString& filter)
     {
         m_filterString = filter;
-        m_filterRegex = QRegExp(m_filterString, Qt::CaseInsensitive);
+        m_filterRegex = QRegularExpression(m_filterString, QRegularExpression::PatternOption::CaseInsensitiveOption);
     }
 
     bool ElidingLabel::TextMatchesFilter() const

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
@@ -11,6 +11,7 @@
 #include <AzQtComponents/AzQtComponentsAPI.h>
 
 #include <QLabel>
+#include <QRegularExpression>
 #endif
 
 namespace AzQtComponents
@@ -122,7 +123,7 @@ namespace AzQtComponents
         void requestElide(bool updateGeometry);
 
         QString m_filterString;
-        QRegExp m_filterRegex;
+        QRegularExpression m_filterRegex;
 
     private:
         void elide();

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
@@ -1571,7 +1571,7 @@ namespace internal
             return;
 
         QList<QInputMethodEvent::Attribute> attributes;
-        foreach (const QTextLayout::FormatRange& fr, formats)
+        for (const QTextLayout::FormatRange& fr : formats)
         {
             QInputMethodEvent::AttributeType type = QInputMethodEvent::TextFormat;
             int start = fr.start;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.cpp
@@ -252,7 +252,6 @@ VectorInput::VectorInput(QWidget* parent, int elementCount, int elementsPerRow, 
 {
     // Set up Qt layout
     QGridLayout* pLayout = new QGridLayout(this);
-    pLayout->setMargin(0);
     pLayout->setSpacing(2);
     pLayout->setContentsMargins(1, 0, 1, 0);
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/Conversions.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/Conversions.cpp
@@ -8,7 +8,9 @@
 
 #include <AzQtComponents/Utilities/Conversions.h>
 #include <AzCore/Math/MathUtils.h>
+
 #include <QLocale>
+#include <QRegularExpression>
 
 namespace AzQtComponents
 {
@@ -70,7 +72,7 @@ namespace AzQtComponents
             // Remove trailing zeros, since the locale conversion won't do
             // it for us
             QString trailingZeros = QString("%1+$").arg(zeroDigit);
-            retValue.remove(QRegExp(trailingZeros));
+            retValue.remove(QRegularExpression(trailingZeros));
 
             // It's possible we could be left with a decimal point on the end
             // if we stripped the trailing zeros, so if that's the case, then

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserEntityInspectorWidget.cpp
@@ -125,7 +125,7 @@ namespace AzToolsFramework
             auto emptyLayout = new QVBoxLayout(m_emptyLayoutWidget);
             auto emptyLabel = new QLabel(m_emptyLayoutWidget);
             emptyLabel->setWordWrap(true);
-            emptyLabel->setMargin(4);
+            emptyLabel->setContentsMargins(4, 4, 4, 4);
             emptyLabel->setText(QObject::tr("Select an asset to view its properties in the inspector."));
             emptyLayout->addWidget(emptyLabel);
             emptyLayout->addStretch(1);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
@@ -12,7 +12,7 @@
 
 #if !defined(Q_MOC_RUN)
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
-#include <QRegExp>
+#include <QRegularExpression>
 AZ_POP_DISABLE_WARNING
 #endif
 
@@ -231,7 +231,7 @@ namespace AzToolsFramework
             return selection;
         }
 
-        AssetSelectionModel AssetSelectionModel::SourceAssetTypeSelection(const QRegExp& pattern, bool multiselect)
+        AssetSelectionModel AssetSelectionModel::SourceAssetTypeSelection(const QRegularExpression& pattern, bool multiselect)
         {
             QSharedPointer<RegExpFilter> patternFilter(new RegExpFilter());
             patternFilter->SetFilterPattern(pattern);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
@@ -17,6 +17,8 @@
 
 #include <QString>
 
+class QRegularExpression;
+
 using namespace AzToolsFramework::AssetBrowser;
 
 namespace AzToolsFramework
@@ -67,7 +69,7 @@ namespace AzToolsFramework
                 const char* assetTypeName, bool multiselect = false, bool supportSelectingSources = false);
             static AssetSelectionModel AssetTypeSelection(
                 const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect = false, bool supportSelectingSources = false);
-            static AssetSelectionModel SourceAssetTypeSelection(const QRegExp& pattern, bool multiselect = false);
+            static AssetSelectionModel SourceAssetTypeSelection(const QRegularExpression& pattern, bool multiselect = false);
             static AssetSelectionModel EverythingSelection(bool multiselect = false);
 
         private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
@@ -228,7 +228,8 @@ namespace AzToolsFramework
         {
             // Return true if the filter is empty or the display name matches.
             QRegularExpressionMatch match = m_filterPattern.match(entry->GetDisplayName());
-            return m_filterPattern.pattern().isEmpty() || match.hasMatch();
+            const bool exactMatch = match.hasMatch() && match.capturedLength() == entry->GetDisplayName().size();
+            return m_filterPattern.pattern().isEmpty() || exactMatch;
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
@@ -213,7 +213,7 @@ namespace AzToolsFramework
             return clone;
         }
 
-        void RegExpFilter::SetFilterPattern(const QRegExp& filterPattern)
+        void RegExpFilter::SetFilterPattern(const QRegularExpression& filterPattern)
         {
             m_filterPattern = filterPattern;
             Q_EMIT updatedSignal();
@@ -227,7 +227,8 @@ namespace AzToolsFramework
         bool RegExpFilter::MatchInternal(const AssetBrowserEntry* entry) const
         {
             // Return true if the filter is empty or the display name matches.
-            return m_filterPattern.isEmpty() || m_filterPattern.exactMatch(entry->GetDisplayName());
+            QRegularExpressionMatch match = m_filterPattern.match(entry->GetDisplayName());
+            return m_filterPattern.pattern().isEmpty() || match.hasMatch();
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
@@ -17,6 +17,7 @@
 #include <QObject>
 #include <QSharedPointer>
 #include <QString>
+#include <QRegularExpression>
 #endif
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
@@ -155,14 +156,14 @@ namespace AzToolsFramework
             ~RegExpFilter() override = default;
             AssetBrowserEntryFilter* Clone() const override;
 
-            void SetFilterPattern(const QRegExp& filterPattern);
+            void SetFilterPattern(const QRegularExpression& filterPattern);
 
         protected:
             QString GetNameInternal() const override;
             bool MatchInternal(const AssetBrowserEntry* entry) const override;
 
         private:
-            QRegExp m_filterPattern;
+            QRegularExpression m_filterPattern;
         };
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
@@ -36,7 +36,7 @@ namespace AzToolsFramework::Prefab
         m_textLabel->setStyleSheet(QString("[%1=\"true\"] { font-weight: bold }").arg(OverriddenPropertyName));
 
         QHBoxLayout* layout = new QHBoxLayout(this);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(0);
         layout->addWidget(m_iconButton);
         layout->addWidget(m_textLabel);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.cpp
@@ -157,7 +157,7 @@ namespace AzToolsFramework
             return ContainsEditableComponents(serializeContext, componentFilter, serviceFilter, incompatibleServices);
         }
 
-        QRegExp BuildFilterRegExp(QStringList& criteriaList, AzToolsFramework::FilterOperatorType filterOperator)
+        QRegularExpression BuildFilterRegExp(QStringList& criteriaList, AzToolsFramework::FilterOperatorType filterOperator)
         {
             // Go through the list of items and show/hide as needed due to filter.
             QString filter;
@@ -183,7 +183,7 @@ namespace AzToolsFramework
                 }
             }
 
-            return QRegExp(filter, Qt::CaseInsensitive, QRegExp::RegExp);
+            return QRegularExpression(filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.hxx
@@ -13,7 +13,9 @@
 #include <AzCore/std/containers/map.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/UI/SearchWidget/SearchWidgetTypes.hxx>
+
 #include <QString>
+#include <QRegularExpression>
 
 namespace AZ
 {
@@ -63,6 +65,6 @@ namespace AzToolsFramework
             AZStd::span<const AZ::ComponentServiceType> serviceFilter
         );
 
-        AZTF_API QRegExp BuildFilterRegExp(QStringList& criteriaList, AzToolsFramework::FilterOperatorType filterOperator);
+        AZTF_API QRegularExpression BuildFilterRegExp(QStringList& criteriaList, AzToolsFramework::FilterOperatorType filterOperator);
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteWidget.cpp
@@ -67,7 +67,7 @@ namespace AzToolsFramework
         m_searchText->setClearButtonEnabled(true);
         AzQtComponents::LineEdit::applySearchStyle(m_searchText);
 
-        m_searchRegExp = QRegExp("", Qt::CaseInsensitive, QRegExp::RegExp);
+        m_searchRegExp = QRegularExpression("", QRegularExpression::PatternOption::CaseInsensitiveOption);
 
         searchLayout->addWidget(m_searchText);
         m_searchFrame->setLayout(searchLayout);
@@ -133,7 +133,7 @@ namespace AzToolsFramework
         AZ_PROFILE_FUNCTION(AzToolsFramework);
         m_componentModel->clear();
 
-        bool applyRegExFilter = !m_searchRegExp.isEmpty();
+        bool applyRegExFilter = !m_searchRegExp.pattern().isEmpty();
 
         // Gather all components that match our filter and group by category.
         ComponentPaletteUtil::ComponentDataTable componentDataTable;
@@ -322,7 +322,7 @@ namespace AzToolsFramework
     void ComponentPaletteWidget::UpdateSearch()
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
-        m_searchRegExp = QRegExp(m_searchText->text(), Qt::CaseInsensitive, QRegExp::RegExp);
+        m_searchRegExp = QRegularExpression(m_searchText->text(), QRegularExpression::PatternOption::CaseInsensitiveOption);
         m_searchText->setFocus();
         UpdateContent();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteWidget.hxx
@@ -19,6 +19,7 @@ AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option") // 4244: conversi
                                                                // 4251: class '...' needs to have dll-interface to be used by clients of class '...'
 #include <QFrame>
 #include <QString>
+#include <QRegularExpression>
 AZ_POP_DISABLE_WARNING
 #endif
 
@@ -78,7 +79,7 @@ namespace AzToolsFramework
         bool BranchHasNoChildren(QStandardItem* item);
         void SetExpanded(QModelIndex itemIndex);
 
-        QRegExp m_searchRegExp;
+        QRegularExpression m_searchRegExp;
         QFrame* m_searchFrame = nullptr;
         QLineEdit* m_searchText = nullptr;
         QTreeView* m_componentTree = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
@@ -698,8 +698,7 @@ namespace AzToolsFramework
             m_painterLabel = new QLabel(pParent);
             m_painterLabel->setTextFormat(Qt::RichText);
             m_painterLabel->setAutoFillBackground(false);
-            m_painterLabel->setContentsMargins(4, 0, 4, 0);
-            m_painterLabel->setMargin(0);
+            m_painterLabel->setContentsMargins(0, 0, 0, 0);
             m_painterLabel->setIndent(0);
             m_painterLabel->hide();
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.cpp
@@ -103,7 +103,8 @@ namespace AzToolsFramework
         // parse newText.
         QRegularExpression hexes("(0x)?([0-9a-fA-F]{1,8})", QRegularExpression::PatternOption::CaseInsensitiveOption);
         QRegularExpressionMatch match = hexes.match(newText);
-        if (match.hasMatch() && match.lastCapturedIndex() > 1)
+        const bool exactMatch = match.hasMatch() && match.capturedLength() == newText.size();
+        if (exactMatch && match.lastCapturedIndex() > 1)
         {
             QString actualCap = match.captured(2);
             // this will be a string like FF11BB

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.cpp
@@ -10,8 +10,8 @@
 
 #include <AzCore/Math/Crc.h>
 
-#include <QRegExp>
-#include <QRegExpValidator>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 #include <QLineEdit>
 #include <QHBoxLayout>
 #include <QString>
@@ -24,8 +24,8 @@ namespace AzToolsFramework
     {
         setFocusPolicy(Qt::StrongFocus);
         
-        QRegExp hexes("(0x)?([0-9a-fA-F]{1,8})", Qt::CaseInsensitive);
-        QRegExpValidator *validator = new QRegExpValidator(hexes, this);
+        QRegularExpression hexes("(0x)?([0-9a-fA-F]{1,8})", QRegularExpression::PatternOption::CaseInsensitiveOption);
+        QRegularExpressionValidator* validator = new QRegularExpressionValidator(hexes, this);
 
         m_lineEdit = new QLineEdit(this);
         m_lineEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -101,10 +101,11 @@ namespace AzToolsFramework
     void PropertyCRCCtrl::onLineEditChange(QString newText)
     {
         // parse newText.
-        QRegExp hexes("(0x)?([0-9a-fA-F]{1,8})", Qt::CaseInsensitive);
-        if (hexes.exactMatch(newText) && hexes.captureCount() > 1)
+        QRegularExpression hexes("(0x)?([0-9a-fA-F]{1,8})", QRegularExpression::PatternOption::CaseInsensitiveOption);
+        QRegularExpressionMatch match = hexes.match(newText);
+        if (match.hasMatch() && match.lastCapturedIndex() > 1)
         {
-            QString actualCap = hexes.cap(2);
+            QString actualCap = match.captured(2);
             // this will be a string like FF11BB
             bool ok = false;
             AZ::u32 newValue = actualCap.toUInt(&ok, 16);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -19,7 +19,7 @@ AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
 #include <QPainter> 
 AZ_POP_DISABLE_WARNING
 #include <QtWidgets/QToolButton>
-#include <QtGui/QRegExpValidator>
+#include <QRegularExpressionValidator>
 
 namespace AzToolsFramework
 {
@@ -156,7 +156,7 @@ namespace AzToolsFramework
         }
     }
 
-    QRegExpValidator* PropertyColorCtrl::CreateTextEditValidator()
+    QRegularExpressionValidator* PropertyColorCtrl::CreateTextEditValidator()
     {
         /*Use regex to validate the input
         *\d\d?    Match 0-99
@@ -173,7 +173,7 @@ namespace AzToolsFramework
             R"(^\s*((25[0-5]|2[0-4]\d|1\d\d|\d\d?)\s*,\s*){%1}(25[0-5]|2[0-4]\d|1\d\d|\d\d?)\s*$)"
         ).arg(numInitialChannelComponents);
 
-        return new QRegExpValidator(QRegExp(regex), this);
+        return new QRegularExpressionValidator(QRegularExpression(regex), this);
     }
 
     void PropertyColorCtrl::CreateColorDialog()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx
@@ -32,7 +32,7 @@ class QLineEdit;
 class QPushButton;
 class QToolButton;
 class QLabel;
-class QRegExpValidator;
+class QRegularExpressionValidator;
 
 namespace AzToolsFramework
 {
@@ -97,7 +97,7 @@ namespace AzToolsFramework
         AZ::Color TransformColor(const AZ::Color& color, uint32_t fromColorSpaceId, uint32_t toColorSpaceId) const;
         QColor TransformColor(const QColor& color, uint32_t fromColorSpaceId, uint32_t toColorSpaceId) const;
 
-        QRegExpValidator* CreateTextEditValidator();
+        QRegularExpressionValidator* CreateTextEditValidator();
 
         QToolButton* m_pDefaultButton;
         AzQtComponents::ColorPicker* m_pColorDialog;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.cpp
@@ -57,7 +57,6 @@ namespace AzToolsFramework
         setMinimumSize(60, 24);
 
         QHBoxLayout* frameLayout = new QHBoxLayout(this);
-        frameLayout->setMargin(0);
         frameLayout->setSpacing(4);
         frameLayout->setContentsMargins(4, 1, 4, 1);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx
@@ -11,6 +11,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <QtWidgets/QFrame>
+#include <QRegularExpression>
 
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/functional.h>
@@ -148,5 +149,5 @@ Q_SIGNALS:
         QString                m_defaultTag;
     };
 
-    using FilterByCategoryMap = AZStd::unordered_map<AZStd::string, QRegExp>;
+    using FilterByCategoryMap = AZStd::unordered_map<AZStd::string, QRegularExpression>;
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.cpp
@@ -2925,7 +2925,7 @@ namespace AzToolsFramework
                 }
                 }
                 statusIconLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
-                statusIconLabel->setMargin(3);
+                statusIconLabel->setContentsMargins(3, 3, 3, 3);
                 statusIconLabel->setAlignment(Qt::AlignCenter);
 
                 QLabel* statusLabel = new QLabel();

--- a/Code/Tools/AssetBundler/source/models/AssetBundlerFileTableFilterModel.cpp
+++ b/Code/Tools/AssetBundler/source/models/AssetBundlerFileTableFilterModel.cpp
@@ -11,6 +11,7 @@
 #include <source/models/AssetBundlerAbstractFileTableModel.h>
 
 #include <QDateTime>
+#include <QRegularExpression>
 
 namespace AssetBundler
 {
@@ -31,7 +32,7 @@ namespace AssetBundler
     {
         // Override the default implemention since we want to define custom rules here 
         QModelIndex index = sourceModel()->index(sourceRow, m_displayNameCol, sourceParent);
-        QRegExp filter(filterRegExp());
+        QRegularExpression filter(filterRegularExpression());
 
         return sourceModel()->data(index).toString().toLower().contains(filter);
     }

--- a/Code/Tools/AssetProcessor/CMakeLists.txt
+++ b/Code/Tools/AssetProcessor/CMakeLists.txt
@@ -19,7 +19,6 @@ ly_add_target(
     NAME AssetProcessor.Static STATIC
     NAMESPACE AZ
     AUTOMOC
-    AUTORCC
     FILES_CMAKE
         assetprocessor_static_files.cmake
         Platform/${PAL_PLATFORM_NAME}/assetprocessor_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -8,6 +8,7 @@
 #include <QStringList>
 #include <QCoreApplication>
 #include <QElapsedTimer>
+#include <QRegularExpression>
 
 #include <AzCore/Casting/lossy_cast.h>
 
@@ -5989,7 +5990,7 @@ namespace AssetProcessor
         {
             // Remove invalid characters
             QString sourcePath = entry.c_str();
-            sourcePath.remove(QRegExp("[\\n\\r]"));
+            sourcePath.remove(QRegularExpression("[\\n\\r]"));
 
             QString scanFolderName;
             QString relativePathToFile;

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.cpp
@@ -689,7 +689,8 @@ namespace AssetProcessor
         for (const QString& patternsToSkip : s_filePatternsToSkip)
         {
             QRegularExpression skipRegex(patternsToSkip, QRegularExpression::CaseInsensitiveOption);
-            if (skipRegex.match(outputFilename).hasMatch())
+            QRegularExpressionMatch match = skipRegex.match(outputFilename);
+            if (match.hasMatch() && match.capturedLength() == outputFilename.length())
             {
                 return true;
             }

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.cpp
@@ -10,6 +10,7 @@
 
 #include <QElapsedTimer>
 #include <QCoreApplication>
+#include <QRegularExpression>
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -687,8 +688,8 @@ namespace AssetProcessor
 
         for (const QString& patternsToSkip : s_filePatternsToSkip)
         {
-            QRegExp skipRegex(patternsToSkip, Qt::CaseInsensitive, QRegExp::RegExp);
-            if (skipRegex.exactMatch(outputFilename))
+            QRegularExpression skipRegex(patternsToSkip, QRegularExpression::CaseInsensitiveOption);
+            if (skipRegex.match(outputFilename).hasMatch())
             {
                 return true;
             }

--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.cpp
@@ -10,6 +10,8 @@
 
 #include "AssetTreeItem.h"
 
+#include <QRegularExpression>
+
 namespace AssetProcessor
 {
 
@@ -45,8 +47,8 @@ namespace AssetProcessor
             }
         }
 
-        QRegExp filter(filterRegExp());
-        if (filter.isEmpty())
+        QRegularExpression filter(filterRegularExpression());
+        if (filter.isValid())
         {
             return true;
         }
@@ -70,9 +72,9 @@ namespace AssetProcessor
         return DescendantMatchesFilter(*assetTreeItem, filter, filterAsUuid);
     }
 
-    bool AssetTreeFilterModel::DescendantMatchesFilter(const AssetTreeItem& assetTreeItem, const QRegExp& filter, const AZ::Uuid& filterAsUuid) const
+    bool AssetTreeFilterModel::DescendantMatchesFilter(const AssetTreeItem& assetTreeItem, const QRegularExpression& filter, const AZ::Uuid& filterAsUuid) const
     {
-        if (filter.isEmpty())
+        if (filter.isValid())
         {
             // Match everything if there is no filter.
             return true;

--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.cpp
@@ -48,7 +48,7 @@ namespace AssetProcessor
         }
 
         QRegularExpression filter(filterRegularExpression());
-        if (filter.isValid())
+        if (filter.pattern().isEmpty())
         {
             return true;
         }
@@ -74,7 +74,7 @@ namespace AssetProcessor
 
     bool AssetTreeFilterModel::DescendantMatchesFilter(const AssetTreeItem& assetTreeItem, const QRegularExpression& filter, const AZ::Uuid& filterAsUuid) const
     {
-        if (filter.isValid())
+        if (filter.pattern().isEmpty())
         {
             // Match everything if there is no filter.
             return true;

--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.h
@@ -14,6 +14,8 @@
 #include <QSortFilterProxyModel>
 #endif
 
+class QRegularExpression;
+
 namespace AZ
 {
     struct Uuid;
@@ -41,7 +43,7 @@ namespace AssetProcessor
         bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
         bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
-        bool DescendantMatchesFilter(const AssetTreeItem& assetTreeItem, const QRegExp& filter, const AZ::Uuid& filterAsUuid) const;
+        bool DescendantMatchesFilter(const AssetTreeItem& assetTreeItem, const QRegularExpression& filter, const AZ::Uuid& filterAsUuid) const;
 
         AZStd::list<AZStd::shared_ptr<AssetTreeItemData>> m_pathToForceVisibleAsset;
     };

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -59,6 +59,8 @@
 #include <QWidgetAction>
 #include <QKeyEvent>
 #include <QFileDialog>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 static const QString g_jobFilteredSearchWidgetState = QStringLiteral("jobFilteredSearchWidget");
 static const qint64 AssetTabFilterUpdateIntervalMs = 5000;
@@ -296,13 +298,13 @@ void MainWindow::Activate()
     connect(ui->allowedListToRejectedListToolButton, &QToolButton::clicked, this, &MainWindow::OnToRejectedListButtonClicked);
 
     //set the input validator for ip addresses on the add address line edit
-    QRegExp validHostName("^((?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|\\b-){0,61}[0-9A-Za-z])?(?:\\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|\\b-){0,61}[0-9A-Za-z])?)*\\.?)$");
-    QRegExp validIP("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?$|^((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?$");
+    QRegularExpression validHostName("^((?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|\\b-){0,61}[0-9A-Za-z])?(?:\\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|\\b-){0,61}[0-9A-Za-z])?)*\\.?)$");
+    QRegularExpression validIP("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?$|^((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?$");
 
-    QRegExpValidator* hostNameValidator = new QRegExpValidator(validHostName, this);
+    QRegularExpressionValidator* hostNameValidator = new QRegularExpressionValidator(validHostName, this);
     ui->allowedListAddHostNameLineEdit->setValidator(hostNameValidator);
 
-    QRegExpValidator* ipValidator = new QRegExpValidator(validIP, this);
+    QRegularExpressionValidator* ipValidator = new QRegularExpressionValidator(validIP, this);
     ui->allowedListAddIPLineEdit->setValidator(ipValidator);
 
     //Job view
@@ -1216,7 +1218,8 @@ void MainWindow::OnAllowedListCheckBoxToggled()
 void MainWindow::OnAddHostNameAllowedListButtonClicked()
 {
     QString text = ui->allowedListAddHostNameLineEdit->text();
-    const QRegExpValidator *hostnameValidator = static_cast<const QRegExpValidator *>(ui->allowedListAddHostNameLineEdit->validator());
+    const QRegularExpressionValidator* hostnameValidator =
+        static_cast<const QRegularExpressionValidator*>(ui->allowedListAddHostNameLineEdit->validator());
     int pos;
     QValidator::State state = hostnameValidator->validate(text, pos);
     if (state == QValidator::Acceptable)
@@ -1237,7 +1240,8 @@ void MainWindow::OnAddHostNameAllowedListButtonClicked()
 void MainWindow::OnAddIPAllowedListButtonClicked()
 {
     QString text = ui->allowedListAddIPLineEdit->text();
-    const QRegExpValidator *ipValidator = static_cast<const QRegExpValidator *>(ui->allowedListAddIPLineEdit->validator());
+    const QRegularExpressionValidator* ipValidator =
+        static_cast<const QRegularExpressionValidator*>(ui->allowedListAddIPLineEdit->validator());
     int pos;
     QValidator::State state = ipValidator->validate(text, pos);
     if (state== QValidator::Acceptable)

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -66,7 +66,7 @@ namespace
         binaryDir.setNameFilters(QStringList() << applicationBase);
         binaryDir.setFilter(QDir::Files);
         // iterate all matching
-        foreach(QString tempFile, binaryDir.entryList())
+        for (QString tempFile : binaryDir.entryList())
         {
             binaryDir.remove(tempFile);
         }

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1175,8 +1175,8 @@ namespace AssetProcessor
                 auto scanFolderMatch = [watchFolderQt = QString::fromUtf8(scanFolderEntry.m_watchPath.c_str(),
                     aznumeric_cast<int>(scanFolderEntry.m_watchPath.Native().size()))](const QString& scanFolderPattern)
                 {
-                    QRegExp nameMatch(scanFolderPattern, Qt::CaseInsensitive, QRegExp::Wildcard);
-                    return nameMatch.exactMatch(watchFolderQt);
+                    QRegularExpression nameMatch(scanFolderPattern, QRegularExpression::CaseInsensitiveOption);
+                    return nameMatch.match(watchFolderQt).hasMatch();
                 };
                 if (!scanFolderPatterns.empty() && AZStd::none_of(scanFolderPatterns.begin(), scanFolderPatterns.end(), scanFolderMatch))
                 {
@@ -1688,7 +1688,7 @@ namespace AssetProcessor
         QString posixRelativeName = QDir::fromNativeSeparators(relativeName);
 
         QStringList returnList;
-        QRegExp nameMatch{ posixRelativeName, Qt::CaseInsensitive, QRegExp::Wildcard };
+        QRegularExpression nameMatch{ posixRelativeName, QRegularExpression::CaseInsensitiveOption };
         QDirIterator dirIterator(
             sourceFolderDir.path(), QDir::AllEntries | QDir::NoSymLinks | QDir::NoDotAndDotDot,
             recursiveSearch ? QDirIterator::Subdirectories : QDirIterator::NoIteratorFlags);
@@ -1701,7 +1701,7 @@ namespace AssetProcessor
                 continue;
             }
             QString pathMatch{ sourceFolderDir.relativeFilePath(dirIterator.filePath()) };
-            if (nameMatch.exactMatch(pathMatch))
+            if (nameMatch.match(pathMatch).hasMatch())
             {
                 returnList.append(QDir::fromNativeSeparators(dirIterator.filePath()));
             }
@@ -1726,7 +1726,7 @@ namespace AssetProcessor
         QString posixRelativeName = QDir::fromNativeSeparators(relativeName);
 
         QStringList returnList;
-        QRegExp nameMatch{ posixRelativeName, Qt::CaseInsensitive, QRegExp::Wildcard };
+        QRegularExpression nameMatch{ posixRelativeName, QRegularExpression::CaseInsensitiveOption };
         AZStd::stack<QString> dirs;
         dirs.push(sourceFolderDir.absolutePath());
 
@@ -1760,7 +1760,7 @@ namespace AssetProcessor
                 }
 
                 QString pathMatch{ sourceFolderDir.relativeFilePath(dirIterator.filePath()) };
-                if (nameMatch.exactMatch(pathMatch))
+                if (nameMatch.match(pathMatch).hasMatch())
                 {
                     returnList.append(QDir::fromNativeSeparators(dirIterator.filePath()));
                 }

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/std/string/wildcard.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Gem/GemInfo.h>
 #include <AzToolsFramework/Asset/AssetUtils.h>
@@ -1175,8 +1176,8 @@ namespace AssetProcessor
                 auto scanFolderMatch = [watchFolderQt = QString::fromUtf8(scanFolderEntry.m_watchPath.c_str(),
                     aznumeric_cast<int>(scanFolderEntry.m_watchPath.Native().size()))](const QString& scanFolderPattern)
                 {
-                    QRegularExpression nameMatch(scanFolderPattern, QRegularExpression::CaseInsensitiveOption);
-                    return nameMatch.match(watchFolderQt).hasMatch();
+                    const bool match = AZStd::wildcard_match(qPrintable(scanFolderPattern), qPrintable(watchFolderQt));
+                    return match;
                 };
                 if (!scanFolderPatterns.empty() && AZStd::none_of(scanFolderPatterns.begin(), scanFolderPatterns.end(), scanFolderMatch))
                 {
@@ -1688,7 +1689,7 @@ namespace AssetProcessor
         QString posixRelativeName = QDir::fromNativeSeparators(relativeName);
 
         QStringList returnList;
-        QRegularExpression nameMatch{ posixRelativeName, QRegularExpression::CaseInsensitiveOption };
+
         QDirIterator dirIterator(
             sourceFolderDir.path(), QDir::AllEntries | QDir::NoSymLinks | QDir::NoDotAndDotDot,
             recursiveSearch ? QDirIterator::Subdirectories : QDirIterator::NoIteratorFlags);
@@ -1701,7 +1702,7 @@ namespace AssetProcessor
                 continue;
             }
             QString pathMatch{ sourceFolderDir.relativeFilePath(dirIterator.filePath()) };
-            if (nameMatch.match(pathMatch).hasMatch())
+            if (AZStd::wildcard_match(qPrintable(posixRelativeName), qPrintable(pathMatch)))
             {
                 returnList.append(QDir::fromNativeSeparators(dirIterator.filePath()));
             }
@@ -1726,7 +1727,7 @@ namespace AssetProcessor
         QString posixRelativeName = QDir::fromNativeSeparators(relativeName);
 
         QStringList returnList;
-        QRegularExpression nameMatch{ posixRelativeName, QRegularExpression::CaseInsensitiveOption };
+
         AZStd::stack<QString> dirs;
         dirs.push(sourceFolderDir.absolutePath());
 
@@ -1760,7 +1761,7 @@ namespace AssetProcessor
                 }
 
                 QString pathMatch{ sourceFolderDir.relativeFilePath(dirIterator.filePath()) };
-                if (nameMatch.match(pathMatch).hasMatch())
+                if (AZStd::wildcard_match(qPrintable(posixRelativeName), qPrintable(pathMatch)))
                 {
                     returnList.append(QDir::fromNativeSeparators(dirIterator.filePath()));
                 }

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
@@ -13,7 +13,7 @@
 #include <QString>
 #include <QObject>
 #include <QHash>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QPair>
 #include <QVector>
 #include <QSet>
@@ -136,7 +136,7 @@ namespace AssetProcessor
     public:
         AZ_RTTI(PlatformConfiguration, "{9F0C465D-A3A6-417E-B69C-62CBD22FD950}", RecognizerConfiguration, IPathConversion);
 
-        typedef QPair<QRegExp, QString> RCSpec;
+        typedef QPair<QRegularExpression, QString> RCSpec;
         typedef QVector<RCSpec> RCSpecList;
 
     public:

--- a/Code/Tools/LuaIDE/CMakeLists.txt
+++ b/Code/Tools/LuaIDE/CMakeLists.txt
@@ -17,7 +17,6 @@ ly_add_target(
     NAMESPACE AZ
     AUTOMOC
     AUTOUIC
-    AUTORCC
     FILES_CMAKE
         lua_ide_files.cmake
         ${pal_dir}/lua_ide_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -22,6 +22,7 @@
 #include <QListWidgetItem>
 #include <QTextDocument>
 #include <QTimer>
+#include <QRegularExpression>
 
 namespace LUAEditorInternal
 {
@@ -602,7 +603,10 @@ namespace LUAEditor
                     ResultEntry entry;
                     entry.m_lineText = dLines[line];
 
-                    QRegExp regex(m_FIFData.m_SearchText, m_FIFData.m_bCaseSensitiveIsChecked ? Qt::CaseSensitive : Qt::CaseInsensitive);
+                    QRegularExpression regex(
+                        m_FIFData.m_SearchText,
+                        m_FIFData.m_bCaseSensitiveIsChecked ? QRegularExpression::NoPatternOption
+                                                            : QRegularExpression::CaseInsensitiveOption);
                     int index = 0;
                     if (m_FIFData.m_bRegExIsChecked || m_FIFData.m_bWholeWordIsChecked)
                     {
@@ -630,7 +634,7 @@ namespace LUAEditor
                         {
                             if (m_FIFData.m_bRegExIsChecked || m_FIFData.m_bWholeWordIsChecked)
                             {
-                                entry.m_matches.push_back(AZStd::make_pair(index, regex.matchedLength()));
+                                entry.m_matches.push_back(AZStd::make_pair(index, regex.captureCount()));
                             }
                             else
                             {
@@ -739,7 +743,7 @@ namespace LUAEditor
                             ResultEntry entry;
                             entry.m_lineText = dLines[line];
 
-                            QRegExp regex(m_FIFData.m_SearchText, m_FIFData.m_bCaseSensitiveIsChecked ? Qt::CaseSensitive : Qt::CaseInsensitive);
+                            QRegularExpression regex(m_FIFData.m_SearchText, m_FIFData.m_bCaseSensitiveIsChecked ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption);
                             int index = 0;
                             if(m_FIFData.m_bRegExIsChecked || m_FIFData.m_bWholeWordIsChecked)
                                 index = entry.m_lineText.indexOf(regex, index);
@@ -1103,7 +1107,7 @@ namespace LUAEditor
                         for(AZStd::size_t line=0; line<dLines.size(); ++line)
                         {
                             QString str(dLines[line]);
-                            QRegExp regex(m_RIFData.m_SearchText, m_bCaseSensitiveIsChecked ? Qt::CaseSensitive : Qt::CaseInsensitive);
+                            QRegularExpression regex(m_RIFData.m_SearchText, m_bCaseSensitiveIsChecked ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption);
                             int index = 0;
                             if(m_bRegExIsChecked || m_bWholeWordIsChecked)
                                 index = str.indexOf(regex, index);

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -630,25 +630,29 @@ namespace LUAEditor
                         entry.m_lineNumber = line + 1;
                         entry.m_lineText = entry.m_lineText.trimmed();
 
-                        while (index > -1)
+                        if (m_FIFData.m_bRegExIsChecked || m_FIFData.m_bWholeWordIsChecked)
                         {
-                            if (m_FIFData.m_bRegExIsChecked || m_FIFData.m_bWholeWordIsChecked)
+                            QRegularExpressionMatch match = regex.match(entry.m_lineText);
+                            index = match.capturedStart();
+                            while (match.hasMatch())
                             {
-                                entry.m_matches.push_back(AZStd::make_pair(index, regex.captureCount()));
+                                const int length = match.capturedLength();
+                                entry.m_matches.push_back(AZStd::make_pair(index, length));
+
+                                match = regex.match(entry.m_lineText, index + length);
+                                index = match.capturedStart();
                             }
-                            else
+                        }
+                        else
+                        {
+                            while (index > -1)
                             {
                                 entry.m_matches.push_back(AZStd::make_pair(index, m_FIFData.m_SearchText.length()));
-                            }
-
-                            index++;
-                            if (m_FIFData.m_bRegExIsChecked || m_FIFData.m_bWholeWordIsChecked)
-                            {
-                                index = entry.m_lineText.indexOf(regex, index);
-                            }
-                            else
-                            {
-                                index = entry.m_lineText.indexOf(m_FIFData.m_SearchText, index, m_FIFData.m_bCaseSensitiveIsChecked ? Qt::CaseSensitive : Qt::CaseInsensitive);
+                                index++;
+                                index = entry.m_lineText.indexOf(
+                                    m_FIFData.m_SearchText,
+                                    index,
+                                    m_FIFData.m_bCaseSensitiveIsChecked ? Qt::CaseSensitive : Qt::CaseInsensitive);
                             }
                         }
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindResults.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindResults.cpp
@@ -53,38 +53,32 @@ namespace LUAEditor
                 setFormat(0, block.length(), textFormat);
 
                 textFormat.setForeground(colors->GetFindResultsMatchColor());
-                QRegularExpression regex(
-                    m_searchString, m_caseSensitive ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption);
-                int index = 0;
                 if (m_regEx || m_wholeWord)
                 {
-                    index = text.indexOf(regex, index);
+                    QRegularExpression regex(
+                        m_searchString, m_caseSensitive ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption);
+                    QRegularExpressionMatch match = regex.match(text);
+                    int index = match.capturedStart();
+                    while (match.hasMatch())
+                    {
+                        const int length = match.capturedLength();
+                        setFormat(index, length, textFormat);
+
+                        match = regex.match(text, index + length);
+                        index = match.capturedStart();
+                    }
                 }
                 else
                 {
-                    index = text.indexOf(m_searchString, index, m_caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
-                }
-                while (index > 1)
-                {
-                    if (m_regEx || m_wholeWord)
-                    {
-                        setFormat(index, regex.captureCount(), textFormat);
-                    }
-                    else
+                    int index = text.indexOf(m_searchString, m_caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+                    while (index > 1)
                     {
                         setFormat(index, m_searchString.length(), textFormat);
-                    }
-
-                    ++index;
-                    if (m_regEx || m_wholeWord)
-                    {
-                        index = text.indexOf(regex, index);
-                    }
-                    else
-                    {
+                        ++index;
                         index = text.indexOf(m_searchString, index, m_caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
                     }
                 }
+ 
             }
         }
     }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindResults.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindResults.cpp
@@ -11,8 +11,9 @@
 #include "LUAEditorBlockState.h"
 
 #include <Source/LUA/moc_LUAEditorFindResults.cpp>
-
 #include <Source/LUA/ui_LUAEditorFindResults.h>
+
+#include <QRegularExpression>
 
 namespace LUAEditor
 {
@@ -52,7 +53,8 @@ namespace LUAEditor
                 setFormat(0, block.length(), textFormat);
 
                 textFormat.setForeground(colors->GetFindResultsMatchColor());
-                QRegExp regex(m_searchString, m_caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+                QRegularExpression regex(
+                    m_searchString, m_caseSensitive ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption);
                 int index = 0;
                 if (m_regEx || m_wholeWord)
                 {
@@ -66,7 +68,7 @@ namespace LUAEditor
                 {
                     if (m_regEx || m_wholeWord)
                     {
-                        setFormat(index, regex.matchedLength(), textFormat);
+                        setFormat(index, regex.captureCount(), textFormat);
                     }
                     else
                     {

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorGoToLineDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorGoToLineDialog.cpp
@@ -14,8 +14,8 @@
 #include <QDialogButtonBox>
 #include <QLineEdit>
 #include <QPushButton>
-#include <QRegExp>
-#include <QRegExpValidator>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 namespace LUAEditor
 {
@@ -29,8 +29,8 @@ namespace LUAEditor
         m_gui->setupUi(this);
         this->setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
 
-        const QRegExp rx(GotoLineDialogRegEx);
-        QRegExpValidator* const validator = new QRegExpValidator(rx, this);
+        const QRegularExpression rx(GotoLineDialogRegEx);
+        QRegularExpressionValidator* const validator = new QRegularExpressionValidator(rx, this);
         m_gui->lineNumber->setValidator(validator);
 
         connect(m_gui->lineNumber, &QLineEdit::textChanged, this, &LUAEditorGoToLineDialog::handleLineNumberInput);

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -561,7 +561,7 @@ namespace LUAEditor
         luaViewWidget->installEventFilter(this);
 
         m_ptrPerforceStatusWidget = new QLabel(tr("Pending Status"), this);
-        m_ptrPerforceStatusWidget->setMargin(2);
+        m_ptrPerforceStatusWidget->setContentsMargins(2, 2, 2, 2);
         m_ptrPerforceStatusWidget->setStyleSheet(QString("background: rgba(192,192,192,255); color: black;  border-style: inset;\nborder-width: 1px;\nborder-color: rgba(100,100,100,255);\nborder-radius: 8px;"));
         m_ptrPerforceStatusWidget->setAutoFillBackground(true);
         m_ptrPerforceStatusWidget->setTextInteractionFlags(Qt::NoTextInteraction);

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
@@ -682,13 +682,16 @@ namespace LUAEditor
         QTextCharFormat spaceFormat = QTextCharFormat();
         spaceFormat.setForeground(colors->GetTextWhitespaceColor());
 
-        QRegExp tabsAndSpaces("( |\t)+");
-        int index = tabsAndSpaces.indexIn(text);
-        while (index >= 0)
+        QRegularExpression tabsAndSpaces("( |\t)+");
+        QRegularExpressionMatch match = tabsAndSpaces.match(text);
+        int index = match.capturedStart();
+        while (match.hasMatch())
         {
-            int length = tabsAndSpaces.matchedLength();
+            const int length = match.capturedLength();
             setFormat(index, length, spaceFormat);
-            index = tabsAndSpaces.indexIn(text, index + length);
+
+            match = tabsAndSpaces.match(text, index + length);
+            index = match.capturedStart();
         }
 
         QTBlockState prevState;

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
@@ -26,6 +26,7 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QRegularExpression>
 
 namespace LUAEditor
 {
@@ -851,9 +852,10 @@ namespace LUAEditor
 
         if (operation.m_impl->m_isRegularExpression)
         {
-            QRegExp regEx;
-            regEx.setCaseSensitivity(operation.m_impl->m_isCaseSensitiveSearch ? Qt::CaseSensitivity::CaseSensitive : Qt::CaseSensitivity::CaseInsensitive);
-            regEx.setPattern(operation.m_impl->m_searchString);
+            QRegularExpression regEx(
+                operation.m_impl->m_searchString,
+                operation.m_impl->m_isCaseSensitiveSearch ? QRegularExpression::CaseInsensitiveOption
+                                                          : QRegularExpression::NoPatternOption);
             operation.m_impl->m_cursor = m_gui->m_luaTextEdit->document()->find(regEx, operation.m_impl->m_cursor, static_cast<QTextDocument::FindFlag>(flags));
             if (!operation && operation.m_impl->m_wrap)
             {

--- a/Code/Tools/ProjectManager/Source/EngineSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/EngineSettingsScreen.cpp
@@ -96,7 +96,7 @@ namespace O3DE::ProjectManager
 
         QVBoxLayout* mainLayout = new QVBoxLayout();
         mainLayout->setAlignment(Qt::AlignTop);
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->addWidget(scrollArea);
         setLayout(mainLayout);
     }

--- a/Code/Tools/ProjectManager/Source/ExternalLinkDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/ExternalLinkDialog.cpp
@@ -30,12 +30,12 @@ namespace O3DE::ProjectManager
         setModal(true);
 
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(30);
+        hLayout->setContentsMargins(30, 30, 30, 30);
         hLayout->setAlignment(Qt::AlignTop);
         setLayout(hLayout);
 
         QVBoxLayout* warningLayout = new QVBoxLayout();
-        warningLayout->setMargin(0);
+        warningLayout->setContentsMargins(0, 0, 0, 0);
         warningLayout->setAlignment(Qt::AlignTop);
         hLayout->addLayout(warningLayout);
 
@@ -46,7 +46,7 @@ namespace O3DE::ProjectManager
         warningLayout->addStretch();
 
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setAlignment(Qt::AlignTop);
         hLayout->addLayout(layout);
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
@@ -36,7 +36,7 @@ namespace O3DE::ProjectManager
 
         m_layout = new QVBoxLayout();
         m_layout->setSpacing(0);
-        m_layout->setMargin(5);
+        m_layout->setContentsMargins(5, 5, 5, 5);
         m_layout->setAlignment(Qt::AlignTop);
         setLayout(m_layout);
         setMinimumHeight(400);
@@ -189,7 +189,7 @@ namespace O3DE::ProjectManager
         downloadingGemsWidget->setObjectName("GemCatalogCartOverlayGemDownloadHeader");
         layout->addWidget(downloadingGemsWidget);
         QVBoxLayout* gemDownloadLayout = new QVBoxLayout();
-        gemDownloadLayout->setMargin(0);
+        gemDownloadLayout->setContentsMargins(0, 0, 0, 0);
         gemDownloadLayout->setAlignment(Qt::AlignTop);
         downloadingGemsWidget->setLayout(gemDownloadLayout);
         QLabel* processingQueueLabel = new QLabel("Processing Queue");
@@ -383,7 +383,7 @@ namespace O3DE::ProjectManager
         , m_downloadController(downloadController)
     {
         m_layout = new QHBoxLayout();
-        m_layout->setMargin(0);
+        m_layout->setContentsMargins(0, 0, 0, 0);
         setLayout(m_layout);
 
         QPushButton* iconButton = new QPushButton();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -63,7 +63,7 @@ namespace O3DE::ProjectManager
         m_proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
 
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->setSpacing(0);
         setLayout(vLayout);
 
@@ -87,7 +87,7 @@ namespace O3DE::ProjectManager
         }
 
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->addLayout(hLayout);
 
         m_rightPanelStack = new QStackedWidget(this);
@@ -111,7 +111,7 @@ namespace O3DE::ProjectManager
         QWidget* filterWidget = new QWidget(this);
         filterWidget->setFixedWidth(sidePanelWidth);
         m_filterWidgetLayout = new QVBoxLayout();
-        m_filterWidgetLayout->setMargin(0);
+        m_filterWidgetLayout->setContentsMargins(0, 0, 0, 0);
         m_filterWidgetLayout->setSpacing(0);
         filterWidget->setLayout(m_filterWidgetLayout);
 
@@ -146,14 +146,14 @@ namespace O3DE::ProjectManager
         m_gemListView = new GemListView(m_proxyModel, m_proxyModel->GetSelectionModel(), listHeaderWidget, m_readOnly, this);
 
         QHBoxLayout* listHeaderLayout = new QHBoxLayout();
-        listHeaderLayout->setMargin(0);
+        listHeaderLayout->setContentsMargins(0, 0, 0, 0);
         listHeaderLayout->setSpacing(0);
         listHeaderLayout->addSpacing(GemItemDelegate::s_itemMargins.left());
         listHeaderLayout->addWidget(listHeaderWidget);
         listHeaderLayout->addSpacing(GemItemDelegate::s_itemMargins.right() + verticalScrollBarWidth);
 
         QVBoxLayout* middleVLayout = new QVBoxLayout();
-        middleVLayout->setMargin(0);
+        middleVLayout->setContentsMargins(0, 0, 0, 0);
         middleVLayout->setSpacing(0);
         middleVLayout->addWidget(catalogHeaderWidget);
         middleVLayout->addLayout(listHeaderLayout);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemDependenciesDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemDependenciesDialog.cpp
@@ -27,7 +27,7 @@ namespace O3DE::ProjectManager
 
         QVBoxLayout* layout = new QVBoxLayout();
         // layout margin/alignment cannot be set with qss
-        layout->setMargin(15);
+        layout->setContentsMargins(15, 15, 15, 15);
         layout->setAlignment(Qt::AlignTop);
         setLayout(layout);
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.cpp
@@ -51,7 +51,7 @@ namespace O3DE::ProjectManager
         : QWidget(parent)
     {
         m_layout = new QHBoxLayout();
-        m_layout->setMargin(0);
+        m_layout->setContentsMargins(0, 0, 0, 0);
         m_layout->setSpacing(0);
         setLayout(m_layout);
     }
@@ -69,7 +69,7 @@ namespace O3DE::ProjectManager
 
         QHBoxLayout* hLayout = new QHBoxLayout();
         hLayout->setAlignment(Qt::AlignLeft);
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         hLayout->setSpacing(8);
 
         for(const QString& tag : tags)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
@@ -56,14 +56,14 @@ namespace O3DE::ProjectManager
             vLayout->addWidget(m_mainWidget);
 
             QVBoxLayout* mainLayout = new QVBoxLayout();
-            mainLayout->setMargin(0);
+            mainLayout->setContentsMargins(0, 0, 0, 0);
             mainLayout->setAlignment(Qt::AlignTop);
             m_mainWidget->setLayout(mainLayout);
 
             // Elements
             QVBoxLayout* elementsLayout = new QVBoxLayout();
             m_elementsWidget = new QWidget();
-            elementsLayout->setMargin(0);
+            elementsLayout->setContentsMargins(0, 0, 0, 0);
             m_elementsWidget->setLayout(elementsLayout);
             mainLayout->addWidget(m_elementsWidget);
 
@@ -106,7 +106,7 @@ namespace O3DE::ProjectManager
         {
             QWidget* elementWidget = new QWidget();
             QHBoxLayout* elementLayout = new QHBoxLayout();
-            elementLayout->setMargin(0);
+            elementLayout->setContentsMargins(0, 0, 0, 0);
             elementWidget->setLayout(elementLayout);
 
             QCheckBox* checkbox = new QCheckBox(name);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
@@ -69,7 +69,7 @@ namespace O3DE::ProjectManager
         setWidget(m_mainWidget);
 
         m_mainLayout = new QVBoxLayout();
-        m_mainLayout->setMargin(15);
+        m_mainLayout->setContentsMargins(15, 15, 15, 15);
         m_mainLayout->setAlignment(Qt::AlignTop);
         m_mainWidget->setLayout(m_mainLayout);
 
@@ -372,10 +372,10 @@ namespace O3DE::ProjectManager
             m_versionWidget = new QWidget();
             m_versionWidget->setObjectName("GemCatalogVersion");
             auto versionVLayout = new QVBoxLayout();
-            versionVLayout->setMargin(0);
+            versionVLayout->setContentsMargins(0, 0, 0, 0);
             versionVLayout->addSpacing(5);
             auto versionHLayout = new QHBoxLayout();
-            versionHLayout->setMargin(0);
+            versionHLayout->setContentsMargins(0, 0, 0, 0);
             versionVLayout->addLayout(versionHLayout);
             m_versionWidget->setLayout(versionVLayout);
             m_mainLayout->addWidget(m_versionWidget);
@@ -438,7 +438,7 @@ namespace O3DE::ProjectManager
         // License
         {
             QHBoxLayout* licenseHLayout = new QHBoxLayout();
-            licenseHLayout->setMargin(0);
+            licenseHLayout->setContentsMargins(0, 0, 0, 0);
             licenseHLayout->setAlignment(Qt::AlignLeft);
             m_mainLayout->addLayout(licenseHLayout);
 
@@ -454,7 +454,7 @@ namespace O3DE::ProjectManager
         // Directory and documentation links
         {
             QHBoxLayout* linksHLayout = new QHBoxLayout();
-            linksHLayout->setMargin(0);
+            linksHLayout->setContentsMargins(0, 0, 0, 0);
             m_mainLayout->addLayout(linksHLayout);
 
             linksHLayout->addStretch();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemListHeaderWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemListHeaderWidget.cpp
@@ -22,7 +22,7 @@ namespace O3DE::ProjectManager
         : QFrame(parent)
     {
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         setLayout(vLayout);
 
         setStyleSheet("background-color: #333333;");
@@ -32,7 +32,7 @@ namespace O3DE::ProjectManager
         // Top section
         QHBoxLayout* topLayout = new QHBoxLayout();
         topLayout->addSpacing(16);
-        topLayout->setMargin(0);
+        topLayout->setContentsMargins(0, 0, 0, 0);
 
         auto* tagWidget = new FilterTagWidgetContainer();
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemRequirementDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemRequirementDialog.cpp
@@ -27,13 +27,12 @@ namespace O3DE::ProjectManager
         setAttribute(Qt::WA_DeleteOnClose);
 
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
         vLayout->setContentsMargins(25, 10, 25, 10);
         vLayout->setSizeConstraint(QLayout::SetFixedSize);
         setLayout(vLayout);
 
         QHBoxLayout* instructionLayout = new QHBoxLayout();
-        instructionLayout->setMargin(0);
+        instructionLayout->setContentsMargins(0, 0, 0, 0);
 
         QLabel* instructionIconLabel = new QLabel();
         instructionIconLabel->setPixmap(QIcon(":/Info.svg").pixmap(32, 32));

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemUninstallDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemUninstallDialog.cpp
@@ -25,7 +25,7 @@ namespace O3DE::ProjectManager
         setModal(true);
 
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(30);
+        layout->setContentsMargins(30, 30, 30, 30);
         layout->setAlignment(Qt::AlignTop);
         setLayout(layout);
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemUpdateDialog.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemUpdateDialog.cpp
@@ -25,7 +25,7 @@ namespace O3DE::ProjectManager
         setModal(true);
 
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(30);
+        layout->setContentsMargins(30, 30, 30, 30);
         layout->setAlignment(Qt::AlignTop);
         setLayout(layout);
 

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
@@ -36,7 +36,7 @@ namespace O3DE::ProjectManager
         setWidget(m_mainWidget);
 
         m_mainLayout = new QVBoxLayout();
-        m_mainLayout->setMargin(15);
+        m_mainLayout->setContentsMargins(15, 15, 15, 15);
         m_mainLayout->setAlignment(Qt::AlignTop);
         m_mainWidget->setLayout(m_mainLayout);
 

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
@@ -42,7 +42,7 @@ namespace O3DE::ProjectManager
         connect(m_gemRepoModel, &GemRepoModel::ShowToastNotification, this, &GemRepoScreen::ShowStandardToastNotification);
 
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->setSpacing(0);
         setLayout(vLayout);
 
@@ -301,7 +301,7 @@ namespace O3DE::ProjectManager
 
         QVBoxLayout* vLayout = new QVBoxLayout();
         vLayout->setAlignment(Qt::AlignHCenter);
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->setSpacing(0);
         contentFrame->setLayout(vLayout);
 
@@ -316,7 +316,7 @@ namespace O3DE::ProjectManager
 
         // Size hint for button is wrong so horizontal layout with stretch is used to center it
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         hLayout->setSpacing(0);
 
         hLayout->addStretch();
@@ -346,20 +346,20 @@ namespace O3DE::ProjectManager
         QFrame* contentFrame = new QFrame(this);
 
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         hLayout->setSpacing(0);
         contentFrame->setLayout(hLayout);
 
         hLayout->addSpacing(middleLayoutIndent);
 
         QVBoxLayout* middleVLayout = new QVBoxLayout();
-        middleVLayout->setMargin(0);
+        middleVLayout->setContentsMargins(0, 0, 0, 0);
         middleVLayout->setSpacing(0);
 
         middleVLayout->addSpacing(30);
 
         QHBoxLayout* topMiddleHLayout = new QHBoxLayout();
-        topMiddleHLayout->setMargin(0);
+        topMiddleHLayout->setContentsMargins(0, 0, 0, 0);
         topMiddleHLayout->setSpacing(0);
 
         m_lastAllUpdateLabel = new QLabel(tr("Last Updated: Never"), this);

--- a/Code/Tools/ProjectManager/Source/GemsSubWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemsSubWidget.cpp
@@ -20,7 +20,7 @@ namespace O3DE::ProjectManager
     {
         auto layout = new QVBoxLayout();
         layout->setAlignment(Qt::AlignTop);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         setLayout(layout);
 
         m_titleLabel = new QLabel();

--- a/Code/Tools/ProjectManager/Source/ProjectExportWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectExportWorker.cpp
@@ -13,7 +13,7 @@
 
 #include <QDir>
 #include <QFile>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QProcess>
 #include <QProcessEnvironment>
 #include <QTextStream>
@@ -233,14 +233,14 @@ namespace O3DE::ProjectManager
 
         // Fetch the output directory from the logs if the process was successful
         // Use regex to collect that directory, and collect the slice of the word surrounded in quotes
-        
-        QRegExp quotedDirRegex("Project exported to '([^']*)'\\.");
-        int pos = quotedDirRegex.indexIn(exportOutput);
-        if (pos > -1)
+
+        QRegularExpression quotedDirRegex("Project exported to '([^']*)'\\.");
+        QRegularExpressionMatch match = quotedDirRegex.match(exportOutput);
+        if (match.hasMatch())
         {
-            m_expectedOutputDir = quotedDirRegex.cap(1);
+            m_expectedOutputDir = match.captured(1);
         }
-        
+
         return AZ::Success();
     }
 

--- a/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
@@ -41,7 +41,7 @@ namespace O3DE::ProjectManager
         scrollArea->setWidget(scrollWidget);
 
         m_verticalLayout = new QVBoxLayout();
-        m_verticalLayout->setMargin(0);
+        m_verticalLayout->setContentsMargins(0, 0, 0, 0);
         m_verticalLayout->setAlignment(Qt::AlignTop);
         scrollWidget->setLayout(m_verticalLayout);
 

--- a/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
@@ -108,7 +108,9 @@ namespace O3DE::ProjectManager
             // this validation should roughly match the utils.validate_identifier which the cli
             // uses to validate project names
             QRegularExpression validProjectNameRegex("[A-Za-z][A-Za-z0-9_-]{0,63}");
-            const bool result = validProjectNameRegex.match(m_projectName->lineEdit()->text()).hasMatch();
+            const QString& text = m_projectName->lineEdit()->text();
+            QRegularExpressionMatch match = validProjectNameRegex.match(text);
+            const bool result = match.hasMatch() && match.capturedLength() == text.length();
             if (!result)
             {
                 projectNameIsValid = false;

--- a/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
@@ -19,6 +19,7 @@
 #include <QLineEdit>
 #include <QStandardPaths>
 #include <QScrollArea>
+#include <QRegularExpression>
 
 namespace O3DE::ProjectManager
 {
@@ -106,8 +107,8 @@ namespace O3DE::ProjectManager
         {
             // this validation should roughly match the utils.validate_identifier which the cli
             // uses to validate project names
-            QRegExp validProjectNameRegex("[A-Za-z][A-Za-z0-9_-]{0,63}");
-            const bool result = validProjectNameRegex.exactMatch(m_projectName->lineEdit()->text());
+            QRegularExpression validProjectNameRegex("[A-Za-z][A-Za-z0-9_-]{0,63}");
+            const bool result = validProjectNameRegex.match(m_projectName->lineEdit()->text()).hasMatch();
             if (!result)
             {
                 projectNameIsValid = false;

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -633,7 +633,7 @@ namespace O3DE::ProjectManager
             QTextEdit* detailTextEdit = new QTextEdit(commandOutput, &dialog);
             detailTextEdit->setReadOnly(true);
             layout->addWidget(detailTextEdit);
-            layout->setMargin(0);
+            layout->setContentsMargins(0, 0, 0, 0);
             progressLabel->setLayout(layout);
             progressLabel->setMinimumHeight(150);
             dialog.setLabel(progressLabel);

--- a/Code/Tools/ProjectManager/Source/TagWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/TagWidget.cpp
@@ -42,7 +42,7 @@ namespace O3DE::ProjectManager
     {
         Clear();
 
-        foreach (const QString& tag, tags)
+        for (const QString& tag : tags)
         {
             TagWidget* tagWidget = new TagWidget({tag, tag});
             connect(tagWidget, &TagWidget::TagClicked, this, [this](const Tag& clickedTag){ emit TagClicked(clickedTag); });
@@ -54,7 +54,7 @@ namespace O3DE::ProjectManager
     {
         Clear();
 
-        foreach (const Tag& tag, tags)
+        for (const Tag& tag : tags)
         {
             TagWidget* tagWidget = new TagWidget(tag);
             connect(tagWidget, &TagWidget::TagClicked, this, [this](const Tag& clickedTag){ emit TagClicked(clickedTag); });

--- a/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
@@ -91,7 +91,7 @@ namespace O3DE::ProjectManager
             m_verticalLayout->addWidget(m_advancedSettingWidget);
 
             QVBoxLayout* advancedSettingsLayout = new QVBoxLayout();
-            advancedSettingsLayout->setMargin(0);
+            advancedSettingsLayout->setContentsMargins(0, 0, 0, 0);
             advancedSettingsLayout->setAlignment(Qt::AlignTop);
             m_advancedSettingWidget->setLayout(advancedSettingsLayout);
 

--- a/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/ExportJobProcessingHandler.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/Handlers/ProcessingHandlers/ExportJobProcessingHandler.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
 #include <AzToolsFramework/UI/Logging/LogEntry.h>

--- a/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/RowWidgets/TransformRowWidget.cpp
@@ -105,7 +105,7 @@ namespace AZ
             {
                 m_containerWidget = new QWidget();
                 QGridLayout* layout = new QGridLayout();
-                layout->setMargin(0);
+                layout->setContentsMargins(0, 0, 0, 0);
                 QGridLayout* layout2 = new QGridLayout();
                 setLayout(layout);
                 AzToolsFramework::PropertyRowWidget* parentWidget = static_cast<AzToolsFramework::PropertyRowWidget*>(parent);

--- a/Gems/AFR/Code/CMakeLists.txt
+++ b/Gems/AFR/Code/CMakeLists.txt
@@ -94,7 +94,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             afr_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/Archive/Code/CMakeLists.txt
+++ b/Gems/Archive/Code/CMakeLists.txt
@@ -141,7 +141,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             archive_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePresetSelectionWidget.cpp
@@ -54,7 +54,7 @@ namespace ImageProcessingAtomEditor
         m_presetList = BuilderSettingManager::Instance()->GetFullPresetList();
 
         QStringList stringList;
-        foreach (const auto& presetName, m_presetList)
+        for (const auto& presetName : m_presetList)
         {
             stringList.append(QString(presetName.GetCStr()));
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/CMakeLists.txt
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/CMakeLists.txt
@@ -55,7 +55,6 @@ ly_add_target(
 
     NAMESPACE Gem
     AUTOMOC
-    AUTORCC
     FILES_CMAKE
         atomtoolsframework_shared_files.cmake
     INCLUDE_DIRECTORIES

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -18,7 +18,7 @@
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QFileInfo>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 AZ_POP_DISABLE_WARNING

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionGrid.cpp
@@ -150,12 +150,12 @@ namespace AtomToolsFramework
         QWidget* itemWidget = new QWidget(m_ui->m_assetList);
         itemWidget->setLayout(new QVBoxLayout(itemWidget));
         itemWidget->layout()->setSpacing(0);
-        itemWidget->layout()->setMargin(0);
+        itemWidget->layout()->setContentsMargins(0, 0, 0, 0);
 
         AzQtComponents::ElidingLabel* header = new AzQtComponents::ElidingLabel(itemWidget);
         header->setText(uniqueTitle);
         header->setFixedSize(QSize(m_tileSize.width(), headerHeight));
-        header->setMargin(0);
+        header->setContentsMargins(0, 0, 0, 0);
         header->setStyleSheet("background-color: rgb(35, 35, 35)");
         AzQtComponents::Text::addPrimaryStyle(header);
         AzQtComponents::Text::addLabelStyle(header);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorGroupHeaderWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorGroupHeaderWidget.cpp
@@ -26,7 +26,7 @@ namespace AtomToolsFramework
         setStyleSheet("background-color: #333333; border-style: solid; border-color: #1B1B1B; border-width: 1px; border-left: none; border-right: none;");
         setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
         setFixedHeight(24);
-        setMargin(0);
+        setContentsMargins(0, 0, 0, 0);
     }
 
     void InspectorGroupHeaderWidget::SetExpanded(bool expand)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -47,6 +47,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 #include <QProcess>
 #include <QTimer>
 #include <QVBoxLayout>
+#include <QRegularExpression>
 AZ_POP_DISABLE_WARNING
 
 namespace AtomToolsFramework
@@ -124,19 +125,19 @@ namespace AtomToolsFramework
     {
         QString symbolName(text.c_str());
         // Remove all leading whitespace
-        symbolName.replace(QRegExp("^\\s+"), "");
+        symbolName.replace(QRegularExpression("^\\s+"), "");
         // Remove all trailing whitespace
-        symbolName.replace(QRegExp("\\s+$"), "");
+        symbolName.replace(QRegularExpression("\\s+$"), "");
         // Replace non alphanumeric characters with _
-        symbolName.replace(QRegExp("[^a-zA-Z\\d]"), "_");
+        symbolName.replace(QRegularExpression("[^a-zA-Z\\d]"), "_");
         // Insert a _ between a lowercase or numeric character followed by an uppercase character
-        symbolName.replace(QRegExp("([a-z\\d])([A-Z])"), "\\1_\\2");
+        symbolName.replace(QRegularExpression("([a-z\\d])([A-Z])"), "\\1_\\2");
         // Insert an underscore at the beginning of the string if it starts with a digit
-        symbolName.replace(QRegExp("^(\\d)"), "_\\1");
+        symbolName.replace(QRegularExpression("^(\\d)"), "_\\1");
         // Replace every sequence of whitespace characters with underscores
-        symbolName.replace(QRegExp("\\s+"), "_");
+        symbolName.replace(QRegularExpression("\\s+"), "_");
         // Replace Sequences of _ with a single _
-        symbolName.replace(QRegExp("_+"), "_");
+        symbolName.replace(QRegularExpression("_+"), "_");
         return symbolName.toLower().toUtf8().constData();
     }
 
@@ -144,15 +145,15 @@ namespace AtomToolsFramework
     {
         QString displayName(text.c_str());
         // Remove all leading whitespace
-        displayName.replace(QRegExp("^\\s+"), "");
+        displayName.replace(QRegularExpression("^\\s+"), "");
         // Remove all trailing whitespace
-        displayName.replace(QRegExp("\\s+$"), "");
+        displayName.replace(QRegularExpression("\\s+$"), "");
         // Replace non alphanumeric characters with space
-        displayName.replace(QRegExp("[^a-zA-Z\\d]"), " ");
+        displayName.replace(QRegularExpression("[^a-zA-Z\\d]"), " ");
         // Insert a space between a lowercase or numeric character followed by an uppercase character
-        displayName.replace(QRegExp("([a-z\\d])([A-Z])"), "\\1 \\2");
+        displayName.replace(QRegularExpression("([a-z\\d])([A-Z])"), "\\1 \\2");
         // Tokenize the string where separated by whitespace
-        QStringList displayNameParts = displayName.split(QRegExp("\\s"), Qt::SkipEmptyParts);
+        QStringList displayNameParts = displayName.split(QRegularExpression("\\s"), Qt::SkipEmptyParts);
         for (QString& part : displayNameParts)
         {
             // Capitalize the first character of every token

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -49,7 +49,6 @@ namespace AtomToolsFramework
 
         auto centralWidget = new QWidget(this);
         auto centralWidgetLayout = new QVBoxLayout(centralWidget);
-        centralWidgetLayout->setMargin(0);
         centralWidgetLayout->setContentsMargins(0, 0, 0, 0);
         centralWidget->setLayout(centralWidgetLayout);
         setCentralWidget(centralWidget);

--- a/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/MaterialCanvas/Code/Source/Window/MaterialCanvasMainWindow.cpp
@@ -70,7 +70,6 @@ namespace MaterialCanvas
         auto viewPortAndToolbar = new QWidget(this);
         viewPortAndToolbar->setLayout(new QVBoxLayout(viewPortAndToolbar));
         viewPortAndToolbar->layout()->setContentsMargins(0, 0, 0, 0);
-        viewPortAndToolbar->layout()->setMargin(0);
         viewPortAndToolbar->layout()->setSpacing(0);
         viewPortAndToolbar->layout()->addWidget(m_toolBar);
         viewPortAndToolbar->layout()->addWidget(m_materialViewport);

--- a/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
+++ b/Gems/Atom/Tools/PassCanvas/Code/Source/Window/PassCanvasMainWindow.cpp
@@ -57,7 +57,6 @@ namespace PassCanvas
         auto viewPortAndToolbar = new QWidget(this);
         viewPortAndToolbar->setLayout(new QVBoxLayout(viewPortAndToolbar));
         viewPortAndToolbar->layout()->setContentsMargins(0, 0, 0, 0);
-        viewPortAndToolbar->layout()->setMargin(0);
         viewPortAndToolbar->layout()->setSpacing(0);
         viewPortAndToolbar->layout()->addWidget(m_toolBar);
         viewPortAndToolbar->layout()->addWidget(m_passViewport);

--- a/Gems/AtomLyIntegration/AtomRenderOptions/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/AtomRenderOptions/Code/CMakeLists.txt
@@ -10,7 +10,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
         NAMESPACE Gem
-        AUTORCC
         FILES_CMAKE
             atomrenderoptions_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
@@ -104,7 +104,7 @@ namespace EMStudio
         QVBoxLayout* verticalLayout = new QVBoxLayout(m_innerWidget);
         verticalLayout->setSizeConstraint(QLayout::SetNoConstraint);
         verticalLayout->setSpacing(1);
-        verticalLayout->setMargin(0);
+        verticalLayout->setContentsMargins(0, 0, 0, 0);
 
         // Add the viewport widget
         m_animViewportWidget = new AnimViewportWidget(this);

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/CMakeLists.txt
@@ -28,7 +28,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTORCC
         FILES_CMAKE
             editormodefeedback_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Code/CMakeLists.txt
@@ -66,7 +66,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         ly_add_target(
             NAME ${gem_name}.Editor GEM_MODULE
             NAMESPACE Gem
-            AUTOMOC
             FILES_CMAKE
                 dccscriptinginterface_editor_shared_files.cmake
             INCLUDE_DIRECTORIES

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsLoader.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsLoader.cpp
@@ -24,6 +24,7 @@
 #include <Util/UndoUtil.h>
 
 #include <QStandardItem>
+#include <QRegularExpression>
 
 namespace AudioControls
 {
@@ -189,7 +190,7 @@ namespace AudioControls
     //-------------------------------------------------------------------------------------------//
     QStandardItem* CAudioControlsLoader::AddUniqueFolderPath(QStandardItem* parentItem, const QString& path)
     {
-        QStringList folderNames = path.split(QRegExp("(\\\\|\\/)"), Qt::SkipEmptyParts);
+        QStringList folderNames = path.split(QRegularExpression("(\\\\|\\/)"), Qt::SkipEmptyParts);
         const int size = folderNames.length();
         for (int i = 0; i < size; ++i)
         {

--- a/Gems/AudioSystem/Code/Source/Editor/InspectorPanel.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/InspectorPanel.cpp
@@ -18,6 +18,7 @@
 #include <QMimeData>
 #include <QDropEvent>
 #include <QKeyEvent>
+#include <QRegularExpression>
 
 
 namespace AudioControls
@@ -38,7 +39,7 @@ namespace AudioControls
         connect(m_autoLoadCheckBox, SIGNAL(clicked(bool)), this, SLOT(SetAutoLoadForCurrentControl(bool)));
 
         // data validators
-        m_nameLineEditor->setValidator(new QRegExpValidator(QRegExp("^[a-zA-Z0-9_]*$"), m_nameLineEditor));
+        m_nameLineEditor->setValidator(new QRegularExpressionValidator(QRegularExpression("^[a-zA-Z0-9_]*$"), m_nameLineEditor));
 
         m_atlControlsModel->AddListener(this);
 

--- a/Gems/Compression/Code/CMakeLists.txt
+++ b/Gems/Compression/Code/CMakeLists.txt
@@ -130,7 +130,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             compression_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/DockWidgetPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/DockWidgetPlugin.cpp
@@ -124,7 +124,7 @@ namespace EMStudio
     {
         QWidget* widget = new QWidget();
         QHBoxLayout* layout = new QHBoxLayout();
-        layout->setMargin(32);
+        layout->setContentsMargins(32, 32, 32, 32);
         widget->setLayout(layout);
 
         QLabel* label = new QLabel(errorMessage);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/KeyboardShortcutsWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/KeyboardShortcutsWindow.cpp
@@ -74,13 +74,13 @@ namespace EMStudio
 
         // build the layout
         m_hLayout = new QHBoxLayout();
-        m_hLayout->setMargin(0);
+        m_hLayout->setContentsMargins(0, 0, 0, 0);
         m_hLayout->setAlignment(Qt::AlignLeft);
 
         m_hLayout->addWidget(m_listWidget);
 
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->addWidget(m_tableWidget);
 
         QLabel* label = new QLabel("Double-click to adjust shortcut");
@@ -365,7 +365,7 @@ namespace EMStudio
         layout->addWidget(m_conflictKeyLabel);
 
         QHBoxLayout* buttonLayout = new QHBoxLayout();
-        buttonLayout->setMargin(0);
+        buttonLayout->setContentsMargins(0, 0, 0, 0);
 
         m_okButton = new QPushButton("OK");
         buttonLayout->addWidget(m_okButton);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/LoadActorSettingsWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/LoadActorSettingsWindow.cpp
@@ -33,7 +33,7 @@ namespace EMStudio
         topLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         QVBoxLayout* topLayout = new QVBoxLayout();
         topLayout->addWidget(topLabel);
-        topLayout->setMargin(0);
+        topLayout->setContentsMargins(0, 0, 0, 0);
 
         // open the load actor settings file
         
@@ -170,7 +170,7 @@ namespace EMStudio
         layout->addWidget(settingsLayoutWidget);
         layout->addWidget(buttonLayoutWidget);
         layout->setSpacing(0);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         // set the layout
         setLayout(layout);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -108,7 +108,7 @@ namespace EMStudio
         : QDialog(parent)
     {
         QHBoxLayout* mainLayout = new QHBoxLayout();
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
 
         m_textEdit = new QTextEdit();
         m_textEdit->setTextInteractionFlags(Qt::NoTextInteraction | Qt::TextSelectableByMouse);
@@ -293,7 +293,7 @@ namespace EMStudio
         menuWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
 
         QHBoxLayout* menuLayout = new QHBoxLayout(menuWidget);
-        menuLayout->setMargin(0);
+        menuLayout->setContentsMargins(0, 0, 0, 0);
         menuLayout->setSpacing(0);
 
         QMenuBar* menuBar = new QMenuBar(menuWidget);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MotionSetHierarchyWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MotionSetHierarchyWidget.cpp
@@ -39,7 +39,7 @@ namespace EMStudio
         }
 
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         // create the display button group
         m_searchWidget = new AzQtComponents::FilteredSearchWidget(this);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/NodeHierarchyWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/NodeHierarchyWidget.cpp
@@ -52,7 +52,7 @@ namespace EMStudio
         m_characterIcon  = new QIcon(iconFilename("Character.svg"));
 
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         m_searchWidget = new AzQtComponents::FilteredSearchWidget(this);
         m_searchWidget->setEnabledFiltersVisible(false);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/ResetSettingsDialog.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/ResetSettingsDialog.cpp
@@ -56,10 +56,10 @@ namespace EMStudio
         topLabel->setStyleSheet("background-color: rgb(40, 40, 40); padding: 6px;");
         topLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         vLayout->addWidget(topLabel);
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
 
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(5);
+        layout->setContentsMargins(5, 5, 5, 5);
         layout->setSpacing(4);
         vLayout->addLayout(layout);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphEditor.cpp
@@ -42,7 +42,7 @@ namespace EMotionFX
         
         QVBoxLayout* vLayout = new QVBoxLayout();
         QHBoxLayout* filenameLayout = new QHBoxLayout();
-        filenameLayout->setMargin(2);
+        filenameLayout->setContentsMargins(2, 2, 2, 2);
         vLayout->addLayout(filenameLayout);
         m_filenameLabel = new QLabel();
         m_filenameLabel->setStyleSheet("font-weight: bold;");
@@ -75,7 +75,7 @@ namespace EMotionFX
 
         // Motion set combo box
         QHBoxLayout* motionSetLayout = new QHBoxLayout();
-        motionSetLayout->setMargin(2);
+        motionSetLayout->setContentsMargins(2, 2, 2, 2);
         motionSetLayout->setSpacing(0);
         vLayout->addLayout(motionSetLayout);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphHierarchyWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphHierarchyWidget.cpp
@@ -28,7 +28,7 @@ namespace EMStudio
         : QWidget(parent)
     {
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         // Create the display button group.
         QHBoxLayout* displayLayout = new QHBoxLayout();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AttributesWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AttributesWindow.cpp
@@ -47,7 +47,7 @@ namespace EMStudio
         m_scrollArea             = new QScrollArea();
 
         QVBoxLayout* mainLayout = new QVBoxLayout();
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->setSpacing(1);
         setLayout(mainLayout);
 
@@ -64,7 +64,7 @@ namespace EMStudio
             QVBoxLayout* verticalLayout = new QVBoxLayout();
             m_mainReflectedWidget->setLayout(verticalLayout);
             verticalLayout->setAlignment(Qt::AlignTop);
-            verticalLayout->setMargin(0);
+            verticalLayout->setContentsMargins(0, 0, 0, 0);
             verticalLayout->setSpacing(0);
             verticalLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
 
@@ -103,12 +103,12 @@ namespace EMStudio
                 m_conditionsWidget->setLayout(conditionsVerticalLayout);
                 m_conditionsWidget->setObjectName("EMFX.AttributesWindowWidget.NodeTransition.ConditionsWidget");
                 conditionsVerticalLayout->setAlignment(Qt::AlignTop);
-                conditionsVerticalLayout->setMargin(0);
+                conditionsVerticalLayout->setContentsMargins(0, 0, 0, 0);
                 conditionsVerticalLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
 
                 m_conditionsLayout = new QVBoxLayout();
                 m_conditionsLayout->setAlignment(Qt::AlignTop);
-                m_conditionsLayout->setMargin(0);
+                m_conditionsLayout->setContentsMargins(0, 0, 0, 0);
                 m_conditionsLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
                 conditionsVerticalLayout->addLayout(m_conditionsLayout);
 
@@ -129,12 +129,12 @@ namespace EMStudio
                 QVBoxLayout* actionVerticalLayout = new QVBoxLayout();
                 m_actionsWidget->setLayout(actionVerticalLayout);
                 actionVerticalLayout->setAlignment(Qt::AlignTop);
-                actionVerticalLayout->setMargin(0);
+                actionVerticalLayout->setContentsMargins(0, 0, 0, 0);
                 actionVerticalLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
 
                 m_actionsLayout = new QVBoxLayout();
                 m_actionsLayout->setAlignment(Qt::AlignTop);
-                m_actionsLayout->setMargin(0);
+                m_actionsLayout->setContentsMargins(0, 0, 0, 0);
                 m_actionsLayout->setSizeConstraint(QLayout::SetMinAndMaxSize);
                 actionVerticalLayout->addLayout(m_actionsLayout);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.cpp
@@ -427,7 +427,7 @@ namespace EMStudio
         QVBoxLayout* verticalLayout = new QVBoxLayout(this);
         verticalLayout->setSizeConstraint(QLayout::SetNoConstraint);
         verticalLayout->setSpacing(0);
-        verticalLayout->setMargin(2);
+        verticalLayout->setContentsMargins(2, 2, 2, 2);
 
         // Create toolbars
         CreateActions();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigateWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigateWidget.cpp
@@ -28,7 +28,7 @@ namespace EMStudio
         , m_plugin(plugin)
     {
         QVBoxLayout* mainLayout = new QVBoxLayout();
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->setSpacing(2);
         setLayout(mainLayout);
         mainLayout->setSizeConstraint(QLayout::SetNoConstraint);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.cpp
@@ -19,7 +19,6 @@ namespace EMStudio
         , m_plugin(plugin)
     {
         QHBoxLayout* mainLayout = new QHBoxLayout();
-        mainLayout->setMargin(0);
         mainLayout->setContentsMargins(2, 0, 0, 0);
         mainLayout->setSpacing(0);
         mainLayout->setSizeConstraint(QLayout::SetNoConstraint);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodePaletteWidget.cpp
@@ -66,7 +66,7 @@ namespace EMStudio
 
         // create the default layout
         m_layout = new QVBoxLayout();
-        m_layout->setMargin(0);
+        m_layout->setContentsMargins(0, 0, 0, 0);
         m_layout->setSpacing(0);
 
         // create the initial text
@@ -74,7 +74,7 @@ namespace EMStudio
         m_initialText->setAlignment(Qt::AlignCenter);
         m_initialText->setTextFormat(Qt::RichText);
         m_initialText->setMaximumSize(10000, 10000);
-        m_initialText->setMargin(0);
+        m_initialText->setContentsMargins(0, 0, 0, 0);
         m_initialText->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 
         // add the initial text in the layout
@@ -121,7 +121,7 @@ namespace EMStudio
         if (animGraph == nullptr)
         {
             // set the layout params
-            m_layout->setMargin(0);
+            m_layout->setContentsMargins(0, 0, 0, 0);
             m_layout->setSpacing(0);
 
             // set the widget visible or not
@@ -131,7 +131,7 @@ namespace EMStudio
         else
         {
             // set the layout params
-            m_layout->setMargin(2);
+            m_layout->setContentsMargins(2, 2, 2, 2);
             m_layout->setSpacing(2);
 
             // set the widget visible or not

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWidget.cpp
@@ -33,7 +33,7 @@ namespace EMStudio
         connect(m_searchWidget, &AzQtComponents::FilteredSearchWidget::TextFilterChanged, this, &ParameterWidget::OnTextFilterChanged);
 
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         // create the tree widget
         m_treeWidget = new QTreeWidget();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
@@ -211,7 +211,7 @@ namespace EMStudio
         m_verticalLayout = new QVBoxLayout();
         m_verticalLayout->setObjectName("StyledWidget");
         m_verticalLayout->setSpacing(2);
-        m_verticalLayout->setMargin(0);
+        m_verticalLayout->setContentsMargins(0, 0, 0, 0);
         m_verticalLayout->setAlignment(Qt::AlignTop);
         m_verticalLayout->addWidget(toolBar);
         m_verticalLayout->addWidget(m_treeWidget);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/ContentHeaderWidget.cpp
@@ -21,7 +21,7 @@ namespace EMStudio
         m_titleLabel->setStyleSheet("font-weight: bold;");
 
         QHBoxLayout* filenameLayout = new QHBoxLayout();
-        filenameLayout->setMargin(2);
+        filenameLayout->setContentsMargins(2, 2, 2, 2);
         filenameLayout->addWidget(m_titleLabel, 0, Qt::AlignTop);
 
         QVBoxLayout* vLayout = new QVBoxLayout();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/Inspector/InspectorWindow.cpp
@@ -86,7 +86,7 @@ namespace EMStudio
 
         QWidget* containerWidget = new QWidget();
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         containerWidget->setLayout(vLayout);
 
         for (const CardElement& cardElement : cardElements)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/LogWindow/LogWindowPlugin.cpp
@@ -56,7 +56,7 @@ namespace EMStudio
         // create the layout
         QVBoxLayout* windowWidgetLayout = new QVBoxLayout();
         windowWidgetLayout->setSpacing(3);
-        windowWidgetLayout->setMargin(3);
+        windowWidgetLayout->setContentsMargins(3, 3, 3, 3);
 
         // create the find widget
         m_searchWidget = new AzQtComponents::FilteredSearchWidget(windowWidget);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetEditWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetEditWindow.cpp
@@ -70,7 +70,7 @@ namespace EMStudio
 
         // create the buttons layout
         QHBoxLayout* buttonsLayout = new QHBoxLayout();
-        buttonsLayout->setMargin(0);
+        buttonsLayout->setContentsMargins(0, 0, 0, 0);
 
         // create the OK button
         QPushButton* OKButton = new QPushButton("OK");

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetGroupWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/MorphTargetGroupWidget.cpp
@@ -32,7 +32,7 @@ namespace EMStudio
         // create the layout
         QVBoxLayout* layout = new QVBoxLayout();
         layout->setSpacing(2);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         // checkbox to enable/disable manual mode for all morph targets
         m_selectAll = new QCheckBox("Select All");
@@ -49,7 +49,7 @@ namespace EMStudio
         topControlLayout->addWidget(m_selectAll);
         topControlLayout->addWidget(resetAll);
         topControlLayout->setSpacing(5);
-        topControlLayout->setMargin(0);
+        topControlLayout->setContentsMargins(0, 0, 0, 0);
 
         // add the top control layout in the main layout
         layout->addLayout(topControlLayout);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/PhonemeSelectionWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MorphTargetsWindow/PhonemeSelectionWindow.cpp
@@ -211,7 +211,7 @@ namespace EMStudio
 
         // create and fill the main layout
         QHBoxLayout* layout = new QHBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(0);
 
         QVBoxLayout* leftLayout     = new QVBoxLayout();
@@ -222,7 +222,7 @@ namespace EMStudio
         QWidget* labelHelperWidgetAdd = new QWidget();
         QVBoxLayout* labelHelperWidgetAddLayout = new QVBoxLayout();
         labelHelperWidgetAddLayout->setSpacing(0);
-        labelHelperWidgetAddLayout->setMargin(2);
+        labelHelperWidgetAddLayout->setContentsMargins(2, 2, 2, 2);
         labelHelperWidgetAdd->setLayout(labelHelperWidgetAddLayout);
         QLabel* labelAdd = new QLabel("- Use drag&drop or double click to add -");
         labelHelperWidgetAddLayout->addWidget(labelAdd);
@@ -252,7 +252,7 @@ namespace EMStudio
         QWidget* labelHelperWidgetRemove = new QWidget();
         QVBoxLayout* labelHelperWidgetRemoveLayout = new QVBoxLayout();
         labelHelperWidgetRemoveLayout->setSpacing(0);
-        labelHelperWidgetRemoveLayout->setMargin(2);
+        labelHelperWidgetRemoveLayout->setContentsMargins(2, 2, 2, 2);
         labelHelperWidgetRemove->setLayout(labelHelperWidgetRemoveLayout);
         QLabel* labelRemove = new QLabel("- Use drag&drop or double click to remove -");
         labelHelperWidgetRemoveLayout->addWidget(labelRemove);
@@ -278,9 +278,9 @@ namespace EMStudio
         helperWidgetRight->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
         leftLayout->setSpacing(0);
-        leftLayout->setMargin(0);
+        leftLayout->setContentsMargins(0, 0, 0, 0);
         rightLayout->setSpacing(0);
-        rightLayout->setMargin(0);
+        rightLayout->setContentsMargins(0, 0, 0, 0);
         helperWidgetLeft->setLayout(leftLayout);
         helperWidgetRight->setLayout(rightLayout);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/EventDataEditor.cpp
@@ -138,7 +138,6 @@ namespace EMStudio
 
         m_eventDataCardsContainer = new QWidget();
         QVBoxLayout* eventDataCardsLayout = new QVBoxLayout(m_eventDataCardsContainer);
-        eventDataCardsLayout->setMargin(0);
         eventDataCardsLayout->setContentsMargins(20, 0, 0, 0);
         eventDataCardsLayout->addWidget(m_emptyLabel);
 
@@ -150,7 +149,7 @@ namespace EMStudio
         m_topLevelEventDataCard->connect(m_topLevelEventDataCard, &AzQtComponents::Card::contextMenuRequested, this, [this](const QPoint& pos) { m_eventDataSelectionMenu->exec(pos); });
 
         QVBoxLayout* layout = new QVBoxLayout(this);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->addWidget(m_topLevelEventDataCard);
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventEditor.cpp
@@ -35,7 +35,7 @@ namespace EMStudio
         m_baseObjectEditor = new EMotionFX::ObjectEditor(context);
 
         QVBoxLayout* layout = new QVBoxLayout(this);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->addWidget(m_baseObjectEditor);
         layout->addWidget(&m_eventDataEditor);
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventPresetsWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventPresetsWidget.cpp
@@ -54,7 +54,7 @@ namespace EMStudio
         // create the layouts
         QVBoxLayout* layout = new QVBoxLayout();
         QHBoxLayout* ioButtonsLayout = new QHBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(2);
 
         // create the table widget

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionEvents/MotionEventWidget.cpp
@@ -32,7 +32,7 @@ namespace EMStudio
     void MotionEventWidget::Init()
     {
         QVBoxLayout* layout = new QVBoxLayout(this);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->addWidget(m_editor, 0, Qt::AlignTop);
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetManagementWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetManagementWindow.cpp
@@ -227,7 +227,7 @@ namespace EMStudio
         // create the main aidget and put it to the dialog stack
         QVBoxLayout* layout = new QVBoxLayout();
         setLayout(layout);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(2);
 
         m_motionSetsTree = new QTreeWidget();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
@@ -216,10 +216,10 @@ namespace EMStudio
         // create the main aidget and put it to the dialog stack
         QVBoxLayout* layout = new QVBoxLayout();
         setLayout(layout);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
 
         QVBoxLayout* tableLayout = new QVBoxLayout();
-        tableLayout->setMargin(0);
+        tableLayout->setContentsMargins(0, 0, 0, 0);
         tableLayout->setSpacing(2);
 
         QToolBar* toolBar = new QToolBar(this);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionPropertiesWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionWindow/MotionPropertiesWindow.cpp
@@ -21,7 +21,7 @@ namespace EMStudio
         : QWidget(parent)
     {
         QVBoxLayout* motionPropertiesLayout = new QVBoxLayout(this);
-        motionPropertiesLayout->setMargin(0);
+        motionPropertiesLayout->setContentsMargins(0, 0, 0, 0);
         motionPropertiesLayout->setSpacing(0);
 
         m_motionExtractionWindow = new MotionExtractionWindow(this);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/ActorPropertiesWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/ActorPropertiesWindow.cpp
@@ -31,12 +31,12 @@ namespace EMStudio
     void ActorPropertiesWindow::Init()
     {
         QVBoxLayout* mainVerticalLayout = new QVBoxLayout();
-        mainVerticalLayout->setMargin(0);
+        mainVerticalLayout->setContentsMargins(0, 0, 0, 0);
         setLayout(mainVerticalLayout);
 
         QGridLayout* layout = new QGridLayout();
         uint32 rowNr = 0;
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setVerticalSpacing(0);
         layout->setAlignment(Qt::AlignLeft);
         mainVerticalLayout->addLayout(layout);
@@ -52,7 +52,7 @@ namespace EMStudio
         rowNr++;
         QHBoxLayout* extractNodeLayout = new QHBoxLayout();
         extractNodeLayout->setDirection(QBoxLayout::LeftToRight);
-        extractNodeLayout->setMargin(0);
+        extractNodeLayout->setContentsMargins(0, 0, 0, 0);
 
         m_motionExtractionJointBrowseEdit = aznew ActorJointBrowseEdit(this);
         m_motionExtractionJointBrowseEdit->setToolTip("The joint used to drive the character's movement and rotation.");

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/ActorsWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/ActorsWindow.cpp
@@ -33,7 +33,7 @@ namespace EMStudio
 
         // create the layouts
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->setSpacing(2);
         vLayout->setAlignment(Qt::AlignTop);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/MirrorSetupWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/SceneManager/MirrorSetupWindow.cpp
@@ -60,16 +60,16 @@ namespace EMStudio
 
         // create the main layout
         QVBoxLayout* mainLayout = new QVBoxLayout();
-        mainLayout->setMargin(3);
+        mainLayout->setContentsMargins(3, 3, 3, 3);
         mainLayout->setSpacing(1);
         setLayout(mainLayout);
 
         // create the layout that contains the two listboxes next to each other, and in the middle the link button
         QHBoxLayout* topPartLayout = new QHBoxLayout();
-        topPartLayout->setMargin(0);
+        topPartLayout->setContentsMargins(0, 0, 0, 0);
 
         QHBoxLayout* toolBarLayout = new QHBoxLayout();
-        toolBarLayout->setMargin(0);
+        toolBarLayout->setContentsMargins(0, 0, 0, 0);
         toolBarLayout->setSpacing(0);
         mainLayout->addLayout(toolBarLayout);
         m_buttonOpen = new QPushButton();
@@ -103,7 +103,7 @@ namespace EMStudio
         leftRightLayout->addWidget(m_rightEdit, 0, Qt::AlignRight);
         leftRightLayout->addWidget(m_buttonGuess, 0, Qt::AlignRight);
         leftRightLayout->setSpacing(6);
-        leftRightLayout->setMargin(0);
+        leftRightLayout->setContentsMargins(0, 0, 0, 0);
 
         toolBarLayout->addLayout(leftRightLayout);
         /*  QWidget* spacerWidget = new QWidget();
@@ -121,7 +121,7 @@ namespace EMStudio
 
         // left listbox part
         QVBoxLayout* leftListLayout = new QVBoxLayout();
-        leftListLayout->setMargin(0);
+        leftListLayout->setContentsMargins(0, 0, 0, 0);
         leftListLayout->setSpacing(1);
         topPartLayout->addLayout(leftListLayout);
 
@@ -138,7 +138,7 @@ namespace EMStudio
         connect(m_searchWidgetCurrent, &AzQtComponents::FilteredSearchWidget::TextFilterChanged, this, &MirrorSetupWindow::OnCurrentTextFilterChanged);
         curSearchLayout->addWidget(m_searchWidgetCurrent);
         curSearchLayout->setSpacing(6);
-        curSearchLayout->setMargin(0);
+        curSearchLayout->setContentsMargins(0, 0, 0, 0);
 
         m_currentList = new QTableWidget();
         m_currentList->setAlternatingRowColors(true);
@@ -172,7 +172,7 @@ namespace EMStudio
 
         // add link button middle part
         QVBoxLayout* middleLayout = new QVBoxLayout();
-        middleLayout->setMargin(0);
+        middleLayout->setContentsMargins(0, 0, 0, 0);
         topPartLayout->addLayout(middleLayout);
         QPushButton* linkButton = new QPushButton("link");
         connect(linkButton, &QPushButton::clicked, this, &MirrorSetupWindow::OnLinkPressed);
@@ -180,7 +180,7 @@ namespace EMStudio
 
         // right listbox part
         QVBoxLayout* rightListLayout = new QVBoxLayout();
-        rightListLayout->setMargin(0);
+        rightListLayout->setContentsMargins(0, 0, 0, 0);
         rightListLayout->setSpacing(1);
         topPartLayout->addLayout(rightListLayout);
 
@@ -201,7 +201,7 @@ namespace EMStudio
         connect(m_searchWidgetSource, &AzQtComponents::FilteredSearchWidget::TextFilterChanged, this, &MirrorSetupWindow::OnSourceTextFilterChanged);
         sourceSearchLayout->addWidget(m_searchWidgetSource);
         sourceSearchLayout->setSpacing(6);
-        sourceSearchLayout->setMargin(0);
+        sourceSearchLayout->setContentsMargins(0, 0, 0, 0);
 
         m_sourceList = new QTableWidget();
         m_sourceList->setAlternatingRowColors(true);
@@ -234,12 +234,12 @@ namespace EMStudio
 
         // create the mapping table
         QVBoxLayout* lowerLayout = new QVBoxLayout();
-        lowerLayout->setMargin(0);
+        lowerLayout->setContentsMargins(0, 0, 0, 0);
         lowerLayout->setSpacing(3);
         lowerWidget->setLayout(lowerLayout);
 
         QHBoxLayout* mappingLayout = new QHBoxLayout();
-        mappingLayout->setMargin(0);
+        mappingLayout->setContentsMargins(0, 0, 0, 0);
         lowerLayout->addLayout(mappingLayout);
         mappingLayout->addWidget(new QLabel("Mapping:"), 0, Qt::AlignLeft | Qt::AlignVCenter);
         spacerWidget = new QWidget();

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TimeViewPlugin.cpp
@@ -142,7 +142,7 @@ namespace EMStudio
 
         // main content layout
         QGridLayout* mainLayout = new QGridLayout();
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->setSpacing(0);
 
         m_mainWidget->setLayout(mainLayout);
@@ -177,7 +177,7 @@ namespace EMStudio
         // scroll areas require an inner widget to hold the layout (instead of a layout directly).
         QWidget* innerWidget = new QWidget(bodyWidget);
         QHBoxLayout* bodyLayout = new QHBoxLayout();
-        bodyLayout->setMargin(0);
+        bodyLayout->setContentsMargins(0, 0, 0, 0);
         bodyLayout->setSpacing(0);
         innerWidget->setLayout(bodyLayout);
         bodyWidget->setWidget(innerWidget);
@@ -190,7 +190,7 @@ namespace EMStudio
         // Left
         auto* trackAndTrackDataWidget = new QWidget;
         QHBoxLayout* addTrackAndTrackDataLayout = new QHBoxLayout;
-        addTrackAndTrackDataLayout->setMargin(0);
+        addTrackAndTrackDataLayout->setContentsMargins(0, 0, 0, 0);
         addTrackAndTrackDataLayout->setSpacing(0);
         addTrackAndTrackDataLayout->addWidget(m_trackHeaderWidget->GetAddTrackWidget());
         m_trackHeaderWidget->GetAddTrackWidget()->setFixedWidth(175);
@@ -204,7 +204,7 @@ namespace EMStudio
         auto* contentContainer = new QWidget;
         auto* contentLayout = new QVBoxLayout;
         contentContainer->setLayout(contentLayout);
-        contentLayout->setMargin(0);
+        contentLayout->setContentsMargins(0, 0, 0, 0);
         contentLayout->setSpacing(0);
         contentLayout->addWidget(trackAndTrackDataWidget);
         contentLayout->addWidget(bodyWidget);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackHeaderWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackHeaderWidget.cpp
@@ -42,7 +42,7 @@ namespace EMStudio
 
         // create the main layout
         m_mainLayout = new QVBoxLayout();
-        m_mainLayout->setMargin(2);
+        m_mainLayout->setContentsMargins(2, 2, 2, 2);
         m_mainLayout->setSpacing(0);
         m_mainLayout->setAlignment(Qt::AlignTop);
 
@@ -77,7 +77,7 @@ namespace EMStudio
         QWidget* contentsWidget = new QWidget();
         QVBoxLayout* contentsLayout = new QVBoxLayout();
         contentsLayout->setSpacing(1);
-        contentsLayout->setMargin(0);
+        contentsLayout->setContentsMargins(0, 0, 0, 0);
         contentsWidget->setLayout(contentsLayout);
 
         m_nodeNamesCheckBox = new QCheckBox("Show Node Names");
@@ -180,7 +180,7 @@ namespace EMStudio
 
         m_trackWidget = new QWidget();
         m_trackLayout = new QVBoxLayout();
-        m_trackLayout->setMargin(0);
+        m_trackLayout->setContentsMargins(0, 0, 0, 0);
         m_trackLayout->setSpacing(1);
 
         const size_t numTracks = m_plugin->m_tracks.size();
@@ -212,7 +212,7 @@ namespace EMStudio
         m_plugin = parentPlugin;
 
         QHBoxLayout* mainLayout = new QHBoxLayout();
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->setSpacing(0);
 
         m_headerTrackWidget  = trackHeaderWidget;

--- a/Gems/EMotionFX/Code/MysticQt/Source/DialogStack.cpp
+++ b/Gems/EMotionFX/Code/MysticQt/Source/DialogStack.cpp
@@ -107,7 +107,7 @@ namespace MysticQt
         dialogLayout->setAlignment(Qt::AlignTop);
         dialogWidget->setLayout(dialogLayout);
         dialogLayout->setSpacing(0);
-        dialogLayout->setMargin(0);
+        dialogLayout->setContentsMargins(0, 0, 0, 0);
 
         // add the dialog widget
         // the splitter is hierarchical : {a, {b, c}}
@@ -233,7 +233,7 @@ namespace MysticQt
         QVBoxLayout* layout = new QVBoxLayout();
         layout->addWidget(widget, Qt::AlignTop | Qt::AlignLeft);
         layout->setSpacing(0);
-        layout->setMargin(3);
+        layout->setContentsMargins(3, 3, 3, 3);
 
         // set the frame layout
         frame->setLayout(layout);

--- a/Gems/EMotionFX/Code/Source/Editor/ColliderContainerWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ColliderContainerWidget.cpp
@@ -527,7 +527,7 @@ namespace EMotionFX
         , m_colliderIcon(colliderIcon)
     {
         m_layout = new QVBoxLayout();
-        m_layout->setMargin(0);
+        m_layout->setContentsMargins(0, 0, 0, 0);
         m_layout->setSpacing(s_layoutSpacing);
         setLayout(m_layout);
 

--- a/Gems/EMotionFX/Code/Source/Editor/InputDialogValidatable.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/InputDialogValidatable.cpp
@@ -8,17 +8,19 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <Editor/InputDialogValidatable.h>
+
 #include <QDialogButtonBox>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QPushButton>
 #include <QVBoxLayout>
+#include <QRegularExpression>
 
 namespace EMStudio
 {
     AZ_CLASS_ALLOCATOR_IMPL(InputDialogValidatable, AZ::SystemAllocator)
 
-    InputDialogValidatable::InputDialogValidatable(QWidget* parent, const QString& labelText, const QRegExp regExp)
+    InputDialogValidatable::InputDialogValidatable(QWidget* parent, const QString& labelText, const QRegularExpression& regExp)
         : QDialog(parent)
     {
         QVBoxLayout* layout = new QVBoxLayout();

--- a/Gems/EMotionFX/Code/Source/Editor/InputDialogValidatable.h
+++ b/Gems/EMotionFX/Code/Source/Editor/InputDialogValidatable.h
@@ -13,7 +13,8 @@
 #include <QDialog>
 #endif
 
-QT_FORWARD_DECLARE_CLASS(QDialogButtonBox)
+class QRegularExpression;
+class QDialogButtonBox;
 
 namespace EMStudio
 {
@@ -24,7 +25,7 @@ namespace EMStudio
     public:
         AZ_CLASS_ALLOCATOR_DECL
 
-        InputDialogValidatable(QWidget* parent, const QString& labelText, const QRegExp regExp = LineEditValidatable::s_defaultRegExp);
+        InputDialogValidatable(QWidget* parent, const QString& labelText, const QRegularExpression& regExp = LineEditValidatable::s_defaultRegExp);
         // When destructing clear the Validator which sets the LineEdit Validator to stop lambda validates being called
         ~InputDialogValidatable() { SetValidatorFunc(nullptr); }
 

--- a/Gems/EMotionFX/Code/Source/Editor/LineEditValidatable.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/LineEditValidatable.cpp
@@ -13,9 +13,9 @@ namespace EMStudio
 {
     AZ_CLASS_ALLOCATOR_IMPL(LineEditValidatable, AZ::SystemAllocator)
 
-    const QRegExp LineEditValidatable::s_defaultRegExp = QRegExp("(^[^{}\"%<>:\\\\/|?*]*$)");
+    const QRegularExpression LineEditValidatable::s_defaultRegExp = QRegularExpression("(^[^{}\"%<>:\\\\/|?*]*$)");
 
-    LineEditValidatable::LineEditValidatable(QWidget* parent, const QRegExp& regExp)
+    LineEditValidatable::LineEditValidatable(QWidget* parent, const QRegularExpression& regExp)
         : QLineEdit(parent)
         , m_validationExp(regExp)
         , m_lineValidator(m_validationExp, 0)

--- a/Gems/EMotionFX/Code/Source/Editor/LineEditValidatable.h
+++ b/Gems/EMotionFX/Code/Source/Editor/LineEditValidatable.h
@@ -12,7 +12,8 @@
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/std/functional.h>
 #include <QLineEdit>
-#include <QRegExpValidator>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 #endif
 
 namespace EMStudio
@@ -24,7 +25,7 @@ namespace EMStudio
     public:
         AZ_CLASS_ALLOCATOR_DECL
 
-        explicit LineEditValidatable(QWidget* parent, const QRegExp& regExp = s_defaultRegExp);
+        explicit LineEditValidatable(QWidget* parent, const QRegularExpression& regExp = s_defaultRegExp);
         ~LineEditValidatable() override = default;
 
         void SetPreviousText(const QString& previousText);
@@ -33,7 +34,7 @@ namespace EMStudio
         void SetValidatorFunc(const AZStd::function<bool()>& func) { m_validatorFunc = func; }
         bool IsValid() const;
 
-        static const QRegExp s_defaultRegExp;
+        static const QRegularExpression s_defaultRegExp;
 
     signals:
         void TextEditingFinished();
@@ -48,8 +49,8 @@ namespace EMStudio
 
         QString m_previousText;
 
-        QRegExp m_validationExp;
-        QRegExpValidator m_lineValidator;
+        QRegularExpression m_validationExp;
+        QRegularExpressionValidator m_lineValidator;
         AZStd::function<bool()> m_validatorFunc;
     };
 } // namespace EMStudio

--- a/Gems/EMotionFX/Code/Source/Editor/ObjectEditor.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ObjectEditor.cpp
@@ -34,7 +34,6 @@ namespace EMotionFX
 
         QVBoxLayout* mainLayout = new QVBoxLayout(this);
         mainLayout->setSizeConstraint(QLayout::SetMinimumSize);
-        mainLayout->setMargin(0);
         mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->addWidget(m_propertyEditor);
         setLayout(mainLayout);

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/ClothJointWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/ClothJointWidget.cpp
@@ -36,7 +36,7 @@ namespace EMotionFX
     {
         QWidget* result = new QWidget(parent);
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         result->setLayout(layout);
 
         // Colliders

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/HitDetectionJointWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/HitDetectionJointWidget.cpp
@@ -35,7 +35,7 @@ namespace EMotionFX
     {
         QWidget* result = new QWidget(parent);
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(ColliderContainerWidget::s_layoutSpacing);
         result->setLayout(layout);
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/JointPropertyWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/JointPropertyWidget.cpp
@@ -38,7 +38,6 @@ namespace EMotionFX
         : QWidget(parent)
     {
         auto* mainLayout = new QVBoxLayout;
-        mainLayout->setMargin(0);
         mainLayout->setContentsMargins(0, 5, 0, 0);
         mainLayout->setSpacing(0);
         auto* propertyCard = new AzQtComponents::Card;

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/RagdollNodeWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/RagdollNodeWidget.cpp
@@ -58,7 +58,7 @@ namespace EMotionFX
     {
         QWidget* result = new QWidget(parent);
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(ColliderContainerWidget::s_layoutSpacing);
         result->setLayout(layout);
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/SimulatedObjectColliderWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/ColliderWidgets/SimulatedObjectColliderWidget.cpp
@@ -38,7 +38,7 @@ namespace EMotionFX
     {
         QWidget* result = new QWidget(parent);
         QVBoxLayout* layout = new QVBoxLayout();
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->setSpacing(ColliderContainerWidget::s_layoutSpacing);
         result->setLayout(layout);
 
@@ -47,7 +47,7 @@ namespace EMotionFX
             m_ownershipWidget = new QWidget(result);
             QHBoxLayout* ownershipLayout = new QHBoxLayout(m_ownershipWidget);
             ownershipLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-            ownershipLayout->setMargin(0);
+            ownershipLayout->setContentsMargins(0, 0, 0, 0);
             ownershipLayout->setSpacing(0);
             m_ownershipWidget->setLayout(ownershipLayout);
 
@@ -69,7 +69,7 @@ namespace EMotionFX
             m_collideWithWidget = new QWidget(result);
             QHBoxLayout* collideWithLayout = new QHBoxLayout(m_collideWithWidget);
             collideWithLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-            collideWithLayout->setMargin(0);
+            collideWithLayout->setContentsMargins(0, 0, 0, 0);
             collideWithLayout->setSpacing(0);
             m_collideWithWidget->setLayout(collideWithLayout);
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollJointLimitWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollJointLimitWidget.cpp
@@ -60,13 +60,13 @@ namespace EMotionFX
 
         QVBoxLayout* vLayout  = new QVBoxLayout();
         vLayout->setAlignment(Qt::AlignTop);
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
 
         QWidget* innerWidget = new QWidget(this);
         innerWidget->setLayout(vLayout);
 
         QGridLayout* topLayout = new QGridLayout();
-        topLayout->setMargin(2);
+        topLayout->setContentsMargins(2, 2, 2, 2);
         topLayout->setAlignment(Qt::AlignLeft);
 
         // Has joint limit

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedJointWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedJointWidget.cpp
@@ -422,7 +422,7 @@ namespace EMotionFX
         QWidget* scrolledWidget = new QWidget();
         QVBoxLayout* mainLayout = new QVBoxLayout(scrolledWidget);
         mainLayout->setAlignment(Qt::AlignTop);
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->addWidget(m_contentsWidget);
         mainLayout->addWidget(m_colliderWidget);
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedObjectSelectionWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/SimulatedObject/SimulatedObjectSelectionWidget.cpp
@@ -44,7 +44,7 @@ namespace EMStudio
         m_treeWidget->header()->setSectionsMovable(false);
 
         QVBoxLayout* layout = new QVBoxLayout(this);
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         layout->addWidget(m_searchWidget);
         layout->addWidget(m_treeWidget);
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/SkeletonOutliner/SkeletonOutlinerPlugin.cpp
@@ -87,7 +87,7 @@ namespace EMotionFX
         m_headerWidget = new QWidget();
         QHBoxLayout* nodeLayout = new QHBoxLayout();
         m_headerWidget->setLayout(nodeLayout);
-        nodeLayout->setMargin(0);
+        nodeLayout->setContentsMargins(0, 0, 0, 0);
         nodeLayout->setSpacing(0);
         mainLayout->addWidget(m_headerWidget);
 

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/ActorGoalNodeHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/ActorGoalNodeHandler.cpp
@@ -25,7 +25,7 @@ namespace EMotionFX
         : QWidget(parent)
     {
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
 
         m_pickButton = new QPushButton(this);
         connect(m_pickButton, &QPushButton::clicked, this, &ActorGoalNodePicker::OnPickClicked);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/ActorJointHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/ActorJointHandler.cpp
@@ -40,7 +40,7 @@ namespace EMotionFX
         connect(m_resetButton, &QPushButton::clicked, this, &ActorJointPicker::OnResetClicked);
 
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         hLayout->addWidget(m_label);
         hLayout->addStretch();
         hLayout->addWidget(m_pickButton);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/ActorMorphTargetHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/ActorMorphTargetHandler.cpp
@@ -28,7 +28,7 @@ namespace EMotionFX
         , m_multiSelection(multiSelection)
     {
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
 
         m_pickButton = new QPushButton(this);
         connect(m_pickButton, &QPushButton::clicked, this, &ActorMorphTargetPicker::OnPickClicked);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphNodeHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphNodeHandler.cpp
@@ -30,7 +30,7 @@ namespace EMotionFX
         , m_showStatesOnly(false)
     {
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
 
         m_pickButton = new QPushButton(this);
         connect(m_pickButton, &QPushButton::clicked, this, &AnimGraphNodeIdPicker::OnPickClicked);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphParameterHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphParameterHandler.cpp
@@ -41,7 +41,7 @@ namespace EMotionFX
         , m_parameterMaskMode(parameterMaskMode)
     {
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
 
         m_pickButton = new QPushButton(this);
         connect(m_pickButton, &QPushButton::clicked, this, &AnimGraphParameterPicker::OnPickClicked);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphTransitionHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphTransitionHandler.cpp
@@ -189,14 +189,14 @@ namespace EMotionFX
         m_mainLayout->addWidget(m_widget);
 
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         m_widget->setLayout(vLayout);
 
         m_label = new QLabel();
         vLayout->addWidget(m_label);
 
         QGridLayout* transitionLayout = new QGridLayout();
-        transitionLayout->setMargin(0);
+        transitionLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->addLayout(transitionLayout);
         {
             m_removeButtons.clear();

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendNParamWeightsHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendNParamWeightsHandler.cpp
@@ -82,7 +82,7 @@ namespace EMotionFX
     {
         QHBoxLayout* hLayout = new QHBoxLayout(this);
 
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         setLayout(hLayout);
         m_sourceNodeNameLabel = new QLabel("element A", this);
         layout()->addWidget(m_sourceNodeNameLabel);
@@ -152,7 +152,7 @@ namespace EMotionFX
     {
         QVBoxLayout* vLayout = new QVBoxLayout(parent);
 
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         setLayout(vLayout);
 
         QHBoxLayout* hHeaderLayout = new QHBoxLayout(this);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionContainerHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionContainerHandler.cpp
@@ -169,7 +169,7 @@ namespace EMotionFX
     {
         QVBoxLayout* mainLayout = new QVBoxLayout();
         mainLayout->setSpacing(0);
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         setLayout(mainLayout);
     }
 
@@ -492,7 +492,7 @@ namespace EMotionFX
             QWidget* motionsWidget = new QWidget(m_containerWidget);
             motionsWidget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
             QGridLayout* motionsLayout = new QGridLayout();
-            motionsLayout->setMargin(0);
+            motionsLayout->setContentsMargins(0, 0, 0, 0);
 
             const size_t motionCount = m_motions.size();
             for (size_t i = 0; i < motionCount; ++i)

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendTreeRotationLimitHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendTreeRotationLimitHandler.cpp
@@ -27,7 +27,7 @@ namespace EMotionFX
 
         QHBoxLayout* hLayout = new QHBoxLayout(this);
 
-        hLayout->setMargin(2);
+        hLayout->setContentsMargins(2, 2, 2, 2);
         setLayout(hLayout);
         m_spinBoxMin = new AzQtComponents::DoubleSpinBox(this);
         layout()->addWidget(m_spinBoxMin);
@@ -147,7 +147,7 @@ namespace EMotionFX
     {
         QHBoxLayout* hLayout = new QHBoxLayout(this);
 
-        hLayout->setMargin(2);
+        hLayout->setContentsMargins(2, 2, 2, 2);
         setLayout(hLayout);
         QLabel* headerColumn1 = new QLabel("Min angle \xB0", this);
         layout()->addWidget(headerColumn1);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/MotionSetMotionIdHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/MotionSetMotionIdHandler.cpp
@@ -49,7 +49,7 @@ namespace EMotionFX
         QHBoxLayout* layoutX = new QHBoxLayout();
         layoutX->setAlignment(Qt::AlignRight);
         layoutX->setSpacing(2);
-        layoutX->setMargin(2);
+        layoutX->setContentsMargins(2, 2, 2, 2);
         m_randomWeightSpinbox = new AzQtComponents::DoubleSpinBox();
         m_randomWeightSpinbox->setSingleStep(0.1);
         m_randomWeightSpinbox->setDecimals(1);
@@ -145,7 +145,7 @@ namespace EMotionFX
         , m_displaySelectionWeights(displaySelectionWeights)
     {
         QVBoxLayout* vLayout = new QVBoxLayout();
-        vLayout->setMargin(0);
+        vLayout->setContentsMargins(0, 0, 0, 0);
         setLayout(vLayout);
     }
 

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/SimulatedObjectSelectionHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/SimulatedObjectSelectionHandler.cpp
@@ -22,7 +22,7 @@ namespace EMotionFX
         : QWidget(parent)
     {
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
 
         m_pickButton = new QPushButton(this);
         connect(m_pickButton, &QPushButton::clicked, this, &SimulatedObjectPicker::OnPickClicked);

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/TransitionStateFilterLocalHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/TransitionStateFilterLocalHandler.cpp
@@ -27,7 +27,7 @@ namespace EMotionFX
         , m_stateMachine(stateMachine)
     {
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
 
         m_pickButton = new QPushButton(this);
         connect(m_pickButton, &QPushButton::clicked, this, &TransitionStateFilterPicker::OnPickClicked);

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModelJointWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModelJointWidget.cpp
@@ -51,7 +51,7 @@ namespace EMotionFX
     void SkeletonModelJointWidget::CreateGUI()
     {
         QVBoxLayout* mainLayout = new QVBoxLayout();
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->setSizeConstraint(QLayout::SetMinimumSize);
         auto* separatorLayout = new HLineLayout;
         auto* separatorLayoutWidget = new QWidget;

--- a/Gems/EMotionFX/Code/Source/Editor/TagSelector.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/TagSelector.cpp
@@ -19,7 +19,7 @@ namespace EMotionFX
         : QWidget(parent)
     {
         QHBoxLayout* hLayout = new QHBoxLayout();
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
 
         m_tagSelector = new AzQtComponents::TagSelector(this);
         connect(m_tagSelector, &AzQtComponents::TagSelector::TagsChanged, this, &TagSelector::OnSelectedTagsChanged);

--- a/Gems/GraphCanvas/Code/CMakeLists.txt
+++ b/Gems/GraphCanvas/Code/CMakeLists.txt
@@ -62,7 +62,6 @@ ly_add_target(
     NAME ${gem_name}.Editor GEM_MODULE
     NAMESPACE Gem
     AUTOMOC
-    AUTORCC
     FILES_CMAKE
         graphcanvas_files.cmake
     INCLUDE_DIRECTORIES

--- a/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/NodePropertyDisplays/VectorNodePropertyDisplay.cpp
@@ -359,7 +359,6 @@ namespace GraphCanvas
 
             QHBoxLayout* layout = new QHBoxLayout(m_widgetContainer);
             layout->setAlignment(Qt::AlignLeft);
-            layout->setMargin(0);
             layout->setSpacing(0);
             layout->setContentsMargins(0, 0, 0, 0);
 

--- a/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasComboBox.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasComboBox.cpp
@@ -51,7 +51,7 @@ namespace GraphCanvas
     void GraphCanvasComboBoxFilterProxyModel::SetFilter(const QString& filter)
     {
         m_filter = filter;
-        m_testRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_testRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
         invalidateFilter();
 
         if (m_filter.isEmpty())

--- a/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasComboBox.h
+++ b/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasComboBox.h
@@ -16,6 +16,7 @@
 #include <QTableView>
 #include <QTimer>
 #include <QWidget>
+#include <QRegularExpression>
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/PlatformDef.h>
@@ -53,7 +54,7 @@ namespace GraphCanvas
 
     private:
         QString m_filter;
-        QRegExp m_testRegex;
+        QRegularExpression m_testRegex;
     };
 
     class GraphCanvasComboBoxMenu

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/Bookmarks/BookmarkTableModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/Bookmarks/BookmarkTableModel.cpp
@@ -530,7 +530,7 @@ namespace GraphCanvas
     void BookmarkTableSortProxyModel::SetFilter(const QString& filter)
     {
         m_filter = filter;
-        m_filterRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_filterRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
 
         invalidateFilter();
     }

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/Bookmarks/BookmarkTableModel.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/Bookmarks/BookmarkTableModel.h
@@ -12,7 +12,7 @@
 #include <qitemdelegate.h>
 #include <qobject.h>
 #include <qsortfilterproxymodel.h>
-#include <qregexp.h>
+#include <QRegularExpression>
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>
@@ -133,6 +133,6 @@ namespace GraphCanvas
     private:
 
         QString m_filter;
-        QRegExp m_filterRegex;
+        QRegularExpression m_filterRegex;
     };
 }

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphOutliner/GraphOutlinerTableModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphOutliner/GraphOutlinerTableModel.cpp
@@ -198,7 +198,7 @@ namespace GraphCanvas
     void NodeTableSortProxyModel::SetFilter(const QString& filter)
     {
         m_filter = filter;
-        m_filterRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_filterRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
 
         invalidateFilter();
     }

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphOutliner/GraphOutlinerTableModel.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphOutliner/GraphOutlinerTableModel.h
@@ -12,8 +12,8 @@
 #include <qabstractitemmodel.h>
 #include <qitemdelegate.h>
 #include <qobject.h>
-#include <qregexp.h>
 #include <qsortfilterproxymodel.h>
+#include <QRegularExpression>
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>
@@ -95,6 +95,6 @@ namespace GraphCanvas
 
     private:
         QString m_filter;
-        QRegExp m_filterRegex;
+        QRegularExpression m_filterRegex;
     };
 }

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <QRegExp>
 
 #include <GraphCanvas/Widgets/GraphCanvasTreeModel.h>
 
@@ -148,13 +147,12 @@ namespace GraphCanvas
         QString test = model->data(index).toString();
         
         bool showRow = false;
-        int regexIndex = m_filterRegex.indexIn(test);
-
-        if (regexIndex >= 0)
+        QRegularExpressionMatch match = m_filterRegex.match(test);
+        if (match.isValid())
         {
             showRow = true;
             
-            AZStd::pair<int, int> highlight(regexIndex, m_filterRegex.matchedLength());
+            AZStd::pair<int, int> highlight(match.capturedStart(), match.capturedLength());
             currentItem->SetHighlight(highlight);
         }
         else
@@ -344,20 +342,20 @@ namespace GraphCanvas
         // Example: "OnGraphStart" or "On Graph Start"
         m_filter = filter.simplified().replace(" ", "");
         
-        QString regExIgnoreWhitespace = QRegExp::escape(QString(m_filter[0]));
+        QString regExIgnoreWhitespace = QRegularExpression::escape(QString(m_filter[0]));
         for (int i = 1; i < m_filter.size(); ++i)
         {
             regExIgnoreWhitespace.append("\\s*");
-            regExIgnoreWhitespace.append(QRegExp::escape(QString(m_filter[i])));
+            regExIgnoreWhitespace.append(QRegularExpression::escape(QString(m_filter[i])));
         }
         
-        m_filterRegex = QRegExp(regExIgnoreWhitespace, Qt::CaseInsensitive);
+        m_filterRegex = QRegularExpression(regExIgnoreWhitespace, QRegularExpression::PatternOption::CaseInsensitiveOption);
     }
 
     void NodePaletteSortFilterProxyModel::ClearFilter()
     {
         m_filter.clear();
-        m_filterRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_filterRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
     }
 
     QCompleter* NodePaletteSortFilterProxyModel::GetCompleter()

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.h
@@ -10,6 +10,7 @@
 #if !defined(Q_MOC_RUN)
 #include <QCompleter>
 #include <QSortFilterProxyModel>
+#include <QRegularExpression>
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Memory/SystemAllocator.h>
@@ -92,6 +93,6 @@ namespace GraphCanvas
         AZStd::unordered_set<const GraphCanvas::GraphCanvasTreeItem*> m_sourceSlotFilter;
 
         QString m_filter;
-        QRegExp m_filterRegex;
+        QRegularExpression m_filterRegex;
     };
 }

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewCurveEditor.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewCurveEditor.cpp
@@ -42,7 +42,7 @@ UiAnimViewCurveEditorDialog::UiAnimViewCurveEditorDialog(QWidget* parent)
 {
     m_widget = new CUiAnimViewCurveEditor(this);
     QVBoxLayout* l = new QVBoxLayout;
-    l->setMargin(0);
+    l->setContentsMargins(0, 0, 0, 0);
     l->addWidget(m_widget);
     setLayout(l);
 }

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
@@ -540,7 +540,7 @@ void CUiAnimViewDialog::InitToolbar()
     ag->addAction(m_actions[ID_TV_MOVEKEY]);
     ag->addAction(m_actions[ID_TV_SLIDEKEY]);
     ag->addAction(m_actions[ID_TV_SCALEKEY]);
-    foreach(QAction* qaction2, ag->actions())
+    for (QAction* qaction2 : ag->actions())
     {
         qaction2->setCheckable(true);
     }
@@ -550,7 +550,7 @@ void CUiAnimViewDialog::InitToolbar()
     ag->addAction(m_actions[ID_TV_SNAP_MAGNET]);
     ag->addAction(m_actions[ID_TV_SNAP_FRAME]);
     ag->addAction(m_actions[ID_TV_SNAP_TICK]);
-    foreach(QAction* qaction2, ag->actions())
+    for (QAction* qaction2 : ag->actions())
     {
         qaction2->setCheckable(true);
     }
@@ -1538,8 +1538,10 @@ void CUiAnimViewDialog::SaveLayouts()
     settings.setValue("layout", stateData);
     settings.setValue("lastViewMode", static_cast<int>(m_lastMode));
     QStringList sl;
-    foreach(int i, m_wndSplitter->sizes())
-    sl << QString::number(i);
+    for (int i : m_wndSplitter->sizes())
+    {
+        sl << QString::number(i);
+    }
     settings.setValue("splitter", sl.join(","));
     settings.endGroup();
     settings.sync();
@@ -1562,7 +1564,7 @@ void CUiAnimViewDialog::ReadLayouts()
     {
         QStringList sl = settings.value("splitter").toString().split(",");
         QList<int> szl;
-        foreach (QString s, sl)
+        for (QString s : sl)
         {
             szl << s.toInt();
         }

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
@@ -226,7 +226,7 @@ BOOL CUiAnimViewDialog::OnInitDialog()
 
     QWidget* w = new QWidget();
     QVBoxLayout* l = new QVBoxLayout;
-    l->setMargin(0);
+    l->setContentsMargins(0, 0, 0, 0);
 
     m_wndSplitter = new QSplitter(w);
     m_wndSplitter->setOrientation(Qt::Horizontal);

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewKeyPropertiesDlg.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewKeyPropertiesDlg.cpp
@@ -69,7 +69,7 @@ CUiAnimViewKeyPropertiesDlg::CUiAnimViewKeyPropertiesDlg(QWidget* hParentWnd)
     , m_pLastTrackSelected(NULL)
 {
     QVBoxLayout* l = new QVBoxLayout();
-    l->setMargin(0);
+    l->setContentsMargins(0, 0, 0, 0);
     m_wndTrackProps = new CUiAnimViewTrackPropsDlg(this);
     l->addWidget(m_wndTrackProps);
     m_wndProps = new ReflectedPropertyControl(this);

--- a/Gems/LyShine/Code/Editor/Dialogs/SpriteBorderEditor/SpriteBorderEditor.cpp
+++ b/Gems/LyShine/Code/Editor/Dialogs/SpriteBorderEditor/SpriteBorderEditor.cpp
@@ -749,7 +749,8 @@ void SpriteBorderEditor::AddPropertiesSection(QGridLayout* gridLayout, int& rowN
 
                     // Only allow alphanumeric and whitespace chars
                     QRegularExpression re("([A-Z]|[a-z]|[0-9]|\\s)*");
-                    const bool containsOnlyAlphaNumeric = re.match(lineEditText).hasMatch();
+                    QRegularExpressionMatch match = re.match(lineEditText);
+                    const bool containsOnlyAlphaNumeric = match.hasMatch() && match.capturedLength() == lineEditText.length();
                     const bool hasValidLength = lineEditText.length() <= 128;
                     const bool lineEditTextValid = containsOnlyAlphaNumeric && hasValidLength;
                     if (lineEditTextValid)

--- a/Gems/LyShine/Code/Editor/Dialogs/SpriteBorderEditor/SpriteBorderEditor.cpp
+++ b/Gems/LyShine/Code/Editor/Dialogs/SpriteBorderEditor/SpriteBorderEditor.cpp
@@ -34,6 +34,7 @@
 #include <QPushButton>
 #include <QSpacerItem>
 #include <QString>
+#include <QRegularExpression>
 
 namespace
 {
@@ -747,8 +748,8 @@ void SpriteBorderEditor::AddPropertiesSection(QGridLayout* gridLayout, int& rowN
                     const QString lineEditText = m_cellAliasLineEdit->text().simplified();
 
                     // Only allow alphanumeric and whitespace chars
-                    QRegExp re("([A-Z]|[a-z]|[0-9]|\\s)*");
-                    const bool containsOnlyAlphaNumeric = re.exactMatch(lineEditText);
+                    QRegularExpression re("([A-Z]|[a-z]|[0-9]|\\s)*");
+                    const bool containsOnlyAlphaNumeric = re.match(lineEditText).hasMatch();
                     const bool hasValidLength = lineEditText.length() <= 128;
                     const bool lineEditTextValid = containsOnlyAlphaNumeric && hasValidLength;
                     if (lineEditTextValid)

--- a/Gems/Meshlets/Code/CMakeLists.txt
+++ b/Gems/Meshlets/Code/CMakeLists.txt
@@ -105,7 +105,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             meshlets_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/MiniAudio/Code/CMakeLists.txt
+++ b/Gems/MiniAudio/Code/CMakeLists.txt
@@ -143,7 +143,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             miniaudio_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/MotionMatching/Code/CMakeLists.txt
+++ b/Gems/MotionMatching/Code/CMakeLists.txt
@@ -81,7 +81,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         OUTPUT_NAME Gem.${gem_name}.Editor
         FILES_CMAKE
             motionmatching_editor_shared_files.cmake

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/Controls/InfoLineEdit.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/Controls/InfoLineEdit.cpp
@@ -57,7 +57,7 @@ namespace OpenParticleSystemEditor
 
         layout->setAlignment(Qt::AlignLeft);
         m_label = new QLabel();
-        m_label->setMargin(0);
+        m_label->setContentsMargins(0, 0, 0, 0);
         m_label->setMinimumWidth(32);
         m_label->setText(text);
         layout->addWidget(m_label);

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/Controls/InfoRadioButton.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/Controls/InfoRadioButton.cpp
@@ -30,7 +30,7 @@ namespace OpenParticleSystemEditor
         layout->setAlignment(Qt::AlignLeft);
 
         m_label = new QLabel();
-        m_label->setMargin(0);
+        m_label->setContentsMargins(0, 0, 0, 0);
         m_label->setMinimumWidth(32);
         m_label->setText(text);
         layout->addWidget(m_label);

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleGraphicsScence.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleGraphicsScence.cpp
@@ -41,7 +41,7 @@ namespace OpenParticleSystemEditor
         if (event->button() == Qt::LeftButton)
         {
             m_pItemSelected = nullptr;
-            foreach (QGraphicsItem* item, items(event->scenePos()))
+            for (QGraphicsItem* item : items(event->scenePos()))
             {
                 if (item->type() == QGraphicsProxyWidget::Type)
                 {

--- a/Gems/PhysX/Core/Code/Editor/CollisionGroupsWidget.cpp
+++ b/Gems/PhysX/Core/Code/Editor/CollisionGroupsWidget.cpp
@@ -248,7 +248,6 @@ namespace PhysX
             addNewGroup->setFixedSize(s_buttonWidth + s_rowHeaderWidthBuffer, s_rowHeight);
 
             m_mainLayout = new QVBoxLayout();
-            m_mainLayout->setMargin(0);
             m_mainLayout->setSpacing(0);
             m_mainLayout->setContentsMargins(0, 0, 0, 0);
             m_mainLayout->addLayout(m_gridLayout);

--- a/Gems/PhysX/Core/PhysX4/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX4/CMakeLists.txt
@@ -108,6 +108,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
+        AUTOMOC
         AUTOUIC
         FILES_CMAKE
             ${physx_editor_files}

--- a/Gems/PhysX/Core/PhysX4/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX4/CMakeLists.txt
@@ -108,7 +108,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
-        AUTOMOC
         AUTOUIC
         FILES_CMAKE
             ${physx_editor_files}

--- a/Gems/PhysX/Core/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX5/CMakeLists.txt
@@ -108,6 +108,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
+        AUTOMOC
         AUTOUIC
         FILES_CMAKE
             ${physx_editor_files}

--- a/Gems/PhysX/Core/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX5/CMakeLists.txt
@@ -108,7 +108,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
-        AUTOMOC
         AUTOUIC
         FILES_CMAKE
             ${physx_editor_files}

--- a/Gems/RecastNavigation/Code/CMakeLists.txt
+++ b/Gems/RecastNavigation/Code/CMakeLists.txt
@@ -235,7 +235,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             recastnavigation_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.cpp
@@ -393,7 +393,7 @@ namespace ScriptCanvasEditor
     void DataTypePaletteSortFilterProxyModel::SetFilter(const QString& filter)
     {
         m_filter = filter;
-        m_testRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_testRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
         invalidateFilter();
     }   
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.h
@@ -11,6 +11,7 @@
 #include <QAbstractItemModel>
 #include <QSortFilterProxyModel>
 #include <QTableView>
+#include <QRegularExpression>
 
 #include <AzCore/Memory/SystemAllocator.h>
 
@@ -96,6 +97,6 @@ namespace ScriptCanvasEditor
 
     private:
         QString m_filter;
-        QRegExp m_testRegex;
+        QRegularExpression m_testRegex;
     };
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowSession.cpp
@@ -53,7 +53,7 @@ namespace ScriptCanvasEditor
     void LoggingWindowFilterModel::SetFilter(const QString& filter)
     {
         m_filter = filter;
-        m_logFilter.m_filter = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_logFilter.m_filter = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
 
         invalidateFilter();
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowTreeItems.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LoggingWindowTreeItems.h
@@ -12,6 +12,7 @@ AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
 #include <QIcon>
 #include <QTime>
 #include <QTimer>
+#include <QRegularExpression>
 AZ_POP_DISABLE_WARNING
 
 #include <AzCore/Component/NamedEntityId.h>
@@ -35,11 +36,11 @@ namespace ScriptCanvasEditor
     class DebugLogFilter
     {
     public:
-        QRegExp m_filter;
+        QRegularExpression m_filter;
 
         bool IsEmpty() const
         {
-            return m_filter.isEmpty();
+            return m_filter.pattern().isEmpty();
         }
 
     };

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/PivotTree/PivotTreeWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/PivotTree/PivotTreeWidget.cpp
@@ -287,7 +287,7 @@ namespace ScriptCanvasEditor
     void PivotTreeSortProxyModel::SetFilter(const QString& filter)
     {
         m_filter = filter;
-        m_filterRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_filterRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
 
         invalidateFilter();
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/PivotTree/PivotTreeWidget.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/PivotTree/PivotTreeWidget.h
@@ -15,6 +15,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
 #include <QTimer>
 #include <QTreeView>
 #include <QSortFilterProxyModel>
+#include <QRegularExpression>
 AZ_POP_DISABLE_WARNING
 
 #include <AzCore/std/smart_ptr/unique_ptr.h>
@@ -163,7 +164,7 @@ namespace ScriptCanvasEditor
     private:
 
         QString m_filter;
-        QRegExp m_filterRegex;
+        QRegularExpression m_filterRegex;
     };
 
     class PivotTreeWidget

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -76,7 +76,7 @@ namespace ScriptCanvasEditor
         m_model->SetFilter(selection.GetDisplayFilter());
     }
 
-    void SourceHandlePropertyAssetCtrl::SetSourceAssetFilterPattern(const QRegExp& filterPattern)
+    void SourceHandlePropertyAssetCtrl::SetSourceAssetFilterPattern(const QRegularExpression& filterPattern)
     {
         m_sourceAssetFilterPattern = filterPattern;
     }
@@ -128,7 +128,8 @@ namespace ScriptCanvasEditor
             AZStd::string filterPattern;
             if (attrValue->Read<AZStd::string>(filterPattern))
             {
-                GUI->SetSourceAssetFilterPattern(QRegExp(filterPattern.c_str(), Qt::CaseInsensitive, QRegExp::Wildcard));
+                GUI->SetSourceAssetFilterPattern(
+                    QRegularExpression(filterPattern.c_str(), QRegularExpression::PatternOption::CaseInsensitiveOption));
             }
         }
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -128,8 +128,8 @@ namespace ScriptCanvasEditor
             AZStd::string filterPattern;
             if (attrValue->Read<AZStd::string>(filterPattern))
             {
-                GUI->SetSourceAssetFilterPattern(
-                    QRegularExpression(filterPattern.c_str(), QRegularExpression::PatternOption::CaseInsensitiveOption));
+                QString wildcard = QRegularExpression::wildcardToRegularExpression(filterPattern.c_str());
+                GUI->SetSourceAssetFilterPattern(QRegularExpression(wildcard, QRegularExpression::PatternOption::CaseInsensitiveOption));
             }
         }
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
@@ -11,6 +11,8 @@
 #if !defined(Q_MOC_RUN)
 #include <AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx>
 
+#include <QRegularExpression>
+
 #include <Core/Core.h>
 #endif
 
@@ -31,7 +33,7 @@ namespace ScriptCanvasEditor
         void ClearAssetInternal() override;
         void ConfigureAutocompleter() override;
 
-        void SetSourceAssetFilterPattern(const QRegExp& filterPattern);
+        void SetSourceAssetFilterPattern(const QRegularExpression& filterPattern);
 
         AZ::IO::Path GetSelectedSourcePath() const;
         void SetSelectedSourcePath(const AZ::IO::Path& sourcePath);
@@ -43,7 +45,7 @@ namespace ScriptCanvasEditor
         //! A regular expression pattern for filtering by source assets
         //! If this is set, the PropertyAssetCtrl will be dealing with source assets
         //! instead of a specific asset type
-        QRegExp m_sourceAssetFilterPattern;
+        QRegularExpression m_sourceAssetFilterPattern;
 
         AZ::IO::Path m_selectedSourcePath;
     };

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/StatisticsDialog/ScriptCanvasStatisticsDialog.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/StatisticsDialog/ScriptCanvasStatisticsDialog.cpp
@@ -139,7 +139,7 @@ namespace ScriptCanvasEditor
     void ScriptCanvasAssetNodeUsageFilterModel::SetFilter(const QString& filterName)
     {
         m_filter = filterName;
-        m_regex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_regex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
 
         invalidate();
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/StatisticsDialog/ScriptCanvasStatisticsDialog.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/StatisticsDialog/ScriptCanvasStatisticsDialog.h
@@ -11,6 +11,7 @@
 #include <QAbstractItemModel>
 #include <QDialog>
 #include <QSortFilterProxyModel>
+#include <QRegularExpression>
 
 #include <AzFramework/Asset/AssetCatalogBus.h>
 
@@ -51,7 +52,7 @@ namespace ScriptCanvasEditor
     private:
 
         QString m_filter;
-        QRegExp m_regex;
+        QRegularExpression m_regex;
 
         ScriptCanvas::NodeTypeIdentifier m_nodeIdentifier;
     };

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/UnitTestPanel/UnitTestTreeView.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/UnitTestPanel/UnitTestTreeView.h
@@ -10,7 +10,7 @@
 #if !defined(Q_MOC_RUN)
 #include <QCompleter>
 #include <QAbstractItemModel>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QSortFilterProxyModel>
 #include <QTreeView>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ValidationPanel/GraphValidationDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ValidationPanel/GraphValidationDockWidget.cpp
@@ -542,12 +542,12 @@ namespace ScriptCanvasEditor
 
     void GraphValidationSortFilterProxyModel::SetFilter(const QString& filterString)
     {
-        QString escapedString = QRegExp::escape(filterString);
+        QString escapedString = QRegularExpression::escape(filterString);
 
         if (m_filter != escapedString)
         {
             m_filter = escapedString;
-            m_regex = QRegExp(m_filter, Qt::CaseInsensitive);
+            m_regex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
 
             invalidateFilter();
         }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ValidationPanel/GraphValidationDockWidget.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ValidationPanel/GraphValidationDockWidget.h
@@ -11,6 +11,7 @@
 #include <QAbstractItemModel>
 #include <QIcon>
 #include <QSortFilterProxyModel>
+#include <QRegularExpression>
 
 #include <AzCore/Debug/TraceMessageBus.h>
 
@@ -178,7 +179,7 @@ namespace ScriptCanvasEditor
         ScriptCanvas::ValidationSeverity m_severityFilter;
 
         QString m_filter;
-        QRegExp m_regex;
+        QRegularExpression m_regex;
     };
 
     //! Owns the model for each currently opened graph

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -1005,8 +1005,8 @@ namespace ScriptCanvasEditor
 
     void GraphVariablesModelSortFilterProxyModel::SetFilter(const QString& filter)
     {
-        m_filter = QRegExp::escape(filter);
-        m_filterRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        m_filter = QRegularExpression::escape(filter);
+        m_filterRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
 
         invalidateFilter();
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.h
@@ -9,7 +9,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <QAbstractItemModel>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QSortFilterProxyModel>
 #include <QTableView>
@@ -129,7 +129,7 @@ namespace ScriptCanvasEditor
 
     private:
         QString m_filter;
-        QRegExp m_filterRegex;
+        QRegularExpression m_filterRegex;
 
         ScriptCanvas::GraphVariable::Comparator m_variableComparator;
     };

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariablePaletteTableView.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariablePaletteTableView.h
@@ -12,7 +12,7 @@
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
 #include <QCompleter>
 #include <QAbstractItemModel>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QString>
 #include <QSortFilterProxyModel>
 #include <QTableView>

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/EBusHandlerActionMenu.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/EBusHandlerActionMenu.cpp
@@ -224,7 +224,7 @@ namespace ScriptCanvasEditor
     EBusHandlerActionFilterProxyModel::EBusHandlerActionFilterProxyModel(QObject* parent)
         : QSortFilterProxyModel(parent)
     {
-        m_regex.setCaseSensitivity(Qt::CaseInsensitive);
+        m_regex.setPatternOptions(QRegularExpression::PatternOption::CaseInsensitiveOption);
     }
     
     void EBusHandlerActionFilterProxyModel::SetFilterSource(QLineEdit* lineEdit)

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/EBusHandlerActionMenu.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/EBusHandlerActionMenu.h
@@ -11,7 +11,7 @@
 #include <QAbstractListModel>
 #include <QAbstractItemView>
 #include <QMenu>
-#include <qregexp.h>
+#include <QRegularExpression>
 #include <QSortFilterProxyModel>
 
 #include <AzCore/Component/Entity.h>
@@ -91,7 +91,7 @@ namespace ScriptCanvasEditor
     private:
         QString m_filter;
 
-        QRegExp m_regex;
+        QRegularExpression m_regex;
     };
 
     class EBusHandlerActionMenu

--- a/Gems/Stars/Code/CMakeLists.txt
+++ b/Gems/Stars/Code/CMakeLists.txt
@@ -82,7 +82,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             stars_editor_shared_files.cmake
         INCLUDE_DIRECTORIES


### PR DESCRIPTION
## What does this PR do?

Related to :
- https://github.com/o3de/o3de/issues/19081

Cherry pick changes from [QT6 branch](https://github.com/o3de/o3de/tree/qt6) to ease review when it will come in action :
- Replace [QRegExp](https://doc.qt.io/qt-6/qregexp.html) with [QRegularExpression](https://doc.qt.io/qt-6/qregularexpression.html) 
- Replace setMargins with [setContentsMargins](https://doc.qt.io/qt-6/qlayout.html#setContentsMargins-1) (setMargins used setContentsMargins)
- Removed a deprecated `foreach` QT Macro
- Remove AutoMoc and AutoRCC from modules which are not using them

## How was this PR tested?

Local windows build
