### PR TITLE
Trigger template reload on new procprefab 

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
@@ -60,7 +60,7 @@ namespace AzToolsFramework
              * in the source file.
              * @param relativePath A Prefab Template relative file path.
              */
-            void ReloadTemplateFromFile(AZ::IO::PathView relativePath);
+            void ReloadTemplateFromFile(AZ::IO::PathView relativePath) override;
 
             /**
              * Load Prefab Template from given content string to memory and return the id of loaded Template.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoaderInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoaderInterface.h
@@ -8,11 +8,10 @@
 
 #pragma once
 
-#include <AzToolsFramework/AzToolsFrameworkAPI.h>
-
 #include <AzCore/IO/Path/Path.h>
-#include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
+#include <AzToolsFramework/AzToolsFrameworkAPI.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
 
 namespace AzToolsFramework
@@ -45,6 +44,13 @@ namespace AzToolsFramework
             virtual TemplateId LoadTemplateFromFile(AZ::IO::PathView filePath) = 0;
 
             /**
+             * Reloads Prefab Template from given file path and updates values that are changed
+             * in the source file.
+             * @param relativePath A Prefab Template relative file path.
+             */
+            virtual void ReloadTemplateFromFile(AZ::IO::PathView relativePath) = 0;
+
+            /**
              * Load Prefab Template from given content string to memory and return the id of loaded Template.
              * Converts .prefab form into Prefab Template form by expanding source path and patch info
              * into fully formed nested template info.
@@ -55,12 +61,12 @@ namespace AzToolsFramework
             virtual TemplateId LoadTemplateFromString(AZStd::string_view content, AZ::IO::PathView originPath = GeneratePath()) = 0;
 
             /**
-            * Saves a Prefab Template to the the source path registered with the template.
-            * Converts Prefab Template form into Prefab Asset form by collapsing nested Template info
-            * into a source path and patches.
-            * @param templateId Id of the template to be saved
-            * @return bool on whether the operation succeeded or not
-            */
+             * Saves a Prefab Template to the the source path registered with the template.
+             * Converts Prefab Template form into Prefab Asset form by collapsing nested Template info
+             * into a source path and patches.
+             * @param templateId Id of the template to be saved
+             * @return bool on whether the operation succeeded or not
+             */
             virtual bool SaveTemplate(TemplateId templateId) = 0;
 
             /**
@@ -74,13 +80,13 @@ namespace AzToolsFramework
             virtual bool SaveTemplateToFile(TemplateId templateId, AZ::IO::PathView absolutePath) = 0;
 
             /**
-            * Saves a Prefab Template into the provided output string.
-            * Converts Prefab Template form into .prefab form by collapsing nested Template info
-            * into a source path and patches.
-            * @param templateId Id of the template to be saved
-            * @param outputJson Will contain the serialized template json on success
-            * @return bool on whether the operation succeeded or not
-            */
+             * Saves a Prefab Template into the provided output string.
+             * Converts Prefab Template form into .prefab form by collapsing nested Template info
+             * into a source path and patches.
+             * @param templateId Id of the template to be saved
+             * @param outputJson Will contain the serialized template json on success
+             * @return bool on whether the operation succeeded or not
+             */
             virtual bool SaveTemplateToString(TemplateId templateId, AZStd::string& outputJson) = 0;
 
             //! Converts path into full absolute path. This will be used by loading/save IO operations.
@@ -97,7 +103,6 @@ namespace AzToolsFramework
             virtual void SetSaveAllPrefabsPreference(SaveAllPrefabsPreference saveAllPrefabsPreference) = 0;
 
         protected:
-
             // Generates a new path
             static AZ::IO::Path GeneratePath();
         };
@@ -108,4 +113,3 @@ namespace AZ
 {
     AZ_TYPE_INFO_SPECIALIZE(AzToolsFramework::Prefab::SaveAllPrefabsPreference, "{7E61EA82-4DE4-4A3F-945F-C8FEDC1114B5}");
 }
-

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/ProceduralPrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/ProceduralPrefabSystemComponent.cpp
@@ -93,11 +93,17 @@ namespace AzToolsFramework
                     return;
                 }
 
-                AZ::IO::Path relativePath = AZ::Interface<PrefabLoaderInterface>::Get()->GenerateRelativePath(assetPath.c_str());
-                PrefabDomPath sourcePath = PrefabDomPath((AZStd::string("/") + PrefabDomUtils::SourceName).c_str());
-                sourcePath.Set(readPrefabFileResult.GetValue(), relativePath.Native().c_str());
+                auto* prefabLoaderInterface = AZ::Interface<PrefabLoaderInterface>::Get();
+                if (prefabLoaderInterface == nullptr)
+                {
+                    AZ_Error(
+                        "Prefab", false, "ProceduralPrefabSystemComponent::OnCatalogAssetChanged - Failed to get PrefabLoaderInterface");
+                    return;
+                }
 
-                prefabSystemComponentInterface->UpdatePrefabTemplate(templateId, readPrefabFileResult.TakeValue());
+                AZ::IO::Path relativePath = prefabLoaderInterface->GenerateRelativePath(assetPath.c_str());
+                prefabLoaderInterface->ReloadTemplateFromFile(relativePath);
+                prefabSystemComponentInterface->PropagateTemplateChanges(templateId);
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This PR allows procedural prefabs to correctly refresh if they contain any child Instances.
Currently after when .procprefab is updated by AssetProcessor any child Instances do not have patches correctly applied.

I also created a branch with the same changes based on __2505.1__ called __mw/procprefab-reload-2505__

Following changes in the codebase were made:
- Format __PrefabLoaderInterface.h__
- Make __ReloadTemplateFromFile__ a public function in __PrefabLoaderInterface__
- Change logic of __ProceduralPrefabSystemComponent__ to reload entire template which causes update of child Instances present.

## How was this PR tested?

Used private AssetBuilder that produces .procprefab files with other prefabs as Instances.
Before the change all child Instances lost their parents on asset reload, after the change procprefab can add, remove, change Instances without any problems. 



