### PR TITLE
Remove erroneously added auto-generated source file

### DIFF
--- a/Code/Framework/AzNetworking/Azcg/Temp/AzNetworking_input_files.txt
+++ b/Code/Framework/AzNetworking/Azcg/Temp/AzNetworking_input_files.txt
@@ -1,1 +1,0 @@
-AzNetworking/AutoGen/AutoPacketDispatcher_Header.jinja;AzNetworking/AutoGen/AutoPacketDispatcher_Inline.jinja;AzNetworking/AutoGen/AutoPackets_Header.jinja;AzNetworking/AutoGen/AutoPackets_Inline.jinja;AzNetworking/AutoGen/AutoPackets_Source.jinja;AzNetworking/AutoGen/CorePackets.AutoPackets.xml


### PR DESCRIPTION
## What does this PR do?

This PR removes the file `AzNetworking_input_files.txt` from the source tree, which was erroneously added in #19280. This file is generated by a custom Cmake rule as part of the build, so it should not be checked in to git. Also, this file should normally be in the build folder (`${CMAKE_CURRENT_BINARY_DIR}/Azcg/Temp`), so not sure how this was possible; maybe with an in-source build, which could be mitigated in the future by adding .gitignore rules for autogenerated files/folders for this configuration?

Surprisingly, the mentioned PR has 4 approvals (3 with this change, the first review was before this file was added), but none of them spotted this file, which is a bit disappointing.

## How was this PR tested?

No testing performed
