### PR TITLE
Cherry-pick from `stabilization/25100` to `development` (splash screen and ciso646)

### DIFF
--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:976e2fb0779423cc59d3e4a7f6c638f03348255f91109632247ce3f1fad158dc
-size 3334160
+oid sha256:39c933de9edf7d666ee7a59e28dc636b738594787a8e19fab561aece303915d4
+size 2968529

--- a/Gems/NvCloth/Code/CMakeLists.txt
+++ b/Gems/NvCloth/Code/CMakeLists.txt
@@ -26,6 +26,7 @@ ly_add_target(
             Source
     BUILD_DEPENDENCIES
         PUBLIC
+            ciso646-include
             3rdParty::NvCloth
             AZ::AzFramework
             Gem::CommonFeaturesAtom.Public

--- a/Gems/PhysX/Core/PhysX4/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX4/CMakeLists.txt
@@ -18,7 +18,8 @@ o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLAT
 include(${pal_source_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake) # for PAL_TRAIT_PHYSX_SUPPORTED
 
 if(PAL_TRAIT_PHYSX_SUPPORTED)
-    set(physx_dependency 3rdParty::PhysX4)
+    ly_add_target(NAME physx_4_dependency NAMESPACE Gem INTERFACE BUILD_DEPENDENCIES INTERFACE ciso646-include 3rdParty::PhysX4)
+    set(physx_dependency physx_4_dependency)
     set(physx_files ../Code/physx_files.cmake)
     set(physx_module_files physx_module_files.cmake)
     set(physx_shared_files ../Code/physx_shared_files.cmake)

--- a/Gems/PhysX/Core/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX5/CMakeLists.txt
@@ -18,7 +18,8 @@ o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLAT
 include(${pal_source_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake) # for PAL_TRAIT_PHYSX_SUPPORTED
 
 if(PAL_TRAIT_PHYSX_SUPPORTED)
-    set(physx_dependency 3rdParty::PhysX5)
+    ly_add_target(NAME physx_5_dependency NAMESPACE Gem INTERFACE BUILD_DEPENDENCIES INTERFACE ciso646-include 3rdParty::PhysX5)
+    set(physx_dependency physx_5_dependency)
     set(physx_files ../Code/physx_files.cmake)
     set(physx_module_files physx_module_files.cmake)
     set(physx_shared_files ../Code/physx_shared_files.cmake)

--- a/Gems/PhysX/Debug/PhysX4/CMakeLists.txt
+++ b/Gems/PhysX/Debug/PhysX4/CMakeLists.txt
@@ -19,7 +19,7 @@ o3de_pal_dir(physx_pal_source_dir ${physx_gem_path}/Source/Platform/${PAL_PLATFO
 include(${physx_pal_source_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake) # for PAL_TRAIT_PHYSX_SUPPORTED
 
 if(PAL_TRAIT_PHYSX_SUPPORTED)
-    set(physxdebug_dependency 3rdParty::PhysX4)
+    set(physxdebug_dependency physx_4_dependency)
     set(physxdebug_files ../Code/physxdebug_files.cmake)
     set(physxdebug_module_files physxdebug_module_files.cmake)
     set(physxdebug_editor_files ../Code/physxdebug_editor_files.cmake)

--- a/Gems/PhysX/Debug/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Debug/PhysX5/CMakeLists.txt
@@ -19,7 +19,7 @@ o3de_pal_dir(physx_pal_source_dir ${physx_gem_path}/Source/Platform/${PAL_PLATFO
 include(${physx_pal_source_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake) # for PAL_TRAIT_PHYSX_SUPPORTED
 
 if(PAL_TRAIT_PHYSX_SUPPORTED)
-    set(physxdebug_dependency 3rdParty::PhysX5)
+    set(physxdebug_dependency physx_5_dependency)
     set(physxdebug_files ../Code/physxdebug_files.cmake)
     set(physxdebug_module_files physxdebug_module_files.cmake)
     set(physxdebug_editor_files ../Code/physxdebug_editor_files.cmake)

--- a/cmake/Platform/Common/Configurations_common.cmake
+++ b/cmake/Platform/Common/Configurations_common.cmake
@@ -78,3 +78,9 @@ check_pie_supported()
 
 # Determine if lld is installed to use as a default linker by supported platforms/configurations
 find_program(LLD_LINKER_INSTALLED lld)
+
+if (NOT TARGET ciso646-include)
+    # Temporarily gets around the inclusion of <ciso646> in some 3rd party libraries.
+    add_library(ciso646-include INTERFACE)
+    target_include_directories(ciso646-include INTERFACE ${CMAKE_CURRENT_LIST_DIR}/ciso646-include)
+endif()

--- a/cmake/Platform/Common/ciso646-include/ciso646
+++ b/cmake/Platform/Common/ciso646-include/ciso646
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// the library <ciso646> has been deprecated in C++17 and removed in C++20
+// however PhysX still includes it in some of their headers
+// NvCloth, Physx4, and Physx5 until we update it.
+
+// By providing this file on GCC and Clang we can avoid the include errors
+// without having to modify the PhysX or NvCloth source code
+
+// Note that the long term plan is to upgrade or remove libraries that depend on ciso646
+// so this is only a temporary fix
+
+// to use this file in a target add a dependency on ciso646-include.
+


### PR DESCRIPTION
## What does this PR do?

Cherry-picks the two commits listed below this block into development, from stabilization/25100

These two changes are the fix for clang20 compile (dummy ciso646 header) and the new splash screen for O3DE.

## How was this PR tested?

No testing (both of these changes work fine in stabilization), but we will do AR testing.
