### PR TITLE
Cherry pick more changes from QT6 branch

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -14,10 +14,10 @@
 // Qt
 #include <QHeaderView>
 #include <QSortFilterProxyModel>
-#include <QtWidgets/QMenu>
-#include <QtWidgets/QScrollBar>
-#include <QtWidgets/QTableView>
-#include <QtGui/QSyntaxHighlighter>
+#include <QMenu>
+#include <QScrollBar>
+#include <QTableView>
+#include <QSyntaxHighlighter>
 
 // AzQtComponents
 #include <AzQtComponents/Components/StyledLineEdit.h>

--- a/Code/Editor/Controls/ConsoleSCB.h
+++ b/Code/Editor/Controls/ConsoleSCB.h
@@ -14,6 +14,8 @@
 #if !defined(Q_MOC_RUN)
 
 #include "Settings.h"
+#include "IConsole.h"
+#include "IEditor.h"
 #include <AzToolsFramework/Editor/EditorSettingsAPIBus.h>
 
 #include <QLineEdit>

--- a/Code/Editor/Controls/ReflectedPropertyControl/PropertyMiscCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/PropertyMiscCtrl.cpp
@@ -12,10 +12,10 @@
 
 // Qt
 #include <QHBoxLayout>
-#include <QtWidgets/QLabel>
+#include <QLabel>
 #include <QLineEdit>
-#include <QtWidgets/QToolButton>
-#include <QtCore/QTimer>
+#include <QToolButton>
+#include <QTimer>
 #include <QtUtilWin.h>
 
 // Editor

--- a/Code/Editor/Controls/SplineCtrlEx.h
+++ b/Code/Editor/Controls/SplineCtrlEx.h
@@ -16,7 +16,9 @@
 #include "Controls/WndGridHelper.h"
 #include "IKeyTimeSet.h"
 #include "Undo/IUndoObject.h"
+#include <Util/EditorUtils.h>
 #include <QWidget>
+#include <Range.h>
 #endif
 
 // Custom styles for this control.

--- a/Code/Editor/MainStatusBarItems.h
+++ b/Code/Editor/MainStatusBarItems.h
@@ -13,6 +13,7 @@
 #include <QMutex>
 #include <QString>
 #include <QSet>
+#include <QWidgetAction>
 
 #include <AzToolsFramework/SourceControl/SourceControlAPI.h>
 

--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -13,7 +13,7 @@
 #include "NewLevelDialog.h"
 
 // Qt
-#include <QtWidgets/QPushButton>
+#include <QPushButton>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QTimer>

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
@@ -11,11 +11,10 @@
 #include "AssetCatalogModel.h"
 
 #include <IEditor.h>
-
-#include <qevent.h>
-#include <qmimedata.h>
-#include <QTimer>
+#include <QEvent>
+#include <QMimeData>
 #include <QRegularExpression>
+#include <QTimer>
 
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/RTTI/TypeInfo.h>

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <QtGui/qstandarditemmodel.h>
+#include <QStandardItemModel>
 #include <QFileIconProvider>
 #include <QThread>
 #include <AzCore/Asset/AssetCommon.h>

--- a/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetBrowserContextProvider.cpp
@@ -8,7 +8,7 @@
 
 #include <AssetBrowserContextProvider.h>
 #include <AssetImporterPlugin.h>
-#include <QtCore/QMimeData>
+#include <QMimeData>
 #include <QMenu>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
 #include <SceneAPI/SceneCore/Events/AssetImportRequest.h>

--- a/Code/Editor/Plugins/ProjectSettingsTool/LastPathBus.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/LastPathBus.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/EBus/EBus.h>
 
-#include <QtCore/QString>
+#include <QString>
 
 namespace ProjectSettingsTool
 {

--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.h
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.h
@@ -16,6 +16,8 @@
 #include "ProjectSettingsSerialization.h"
 #include "ValidatorBus.h"
 
+#include <AzCore/Math/Guid.h>
+
 #include <QProcess>
 #include <QScopedPointer>
 #include <QWidget>

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -12,6 +12,8 @@
 #define CRYINCLUDE_EDITOR_SETTINGS_H
 #include "SettingsManager.h"
 
+#include "SandboxAPI.h"
+
 #include <QColor>
 #include <QFont>
 #include <QRect>

--- a/Code/Editor/SettingsManager.h
+++ b/Code/Editor/SettingsManager.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <QString>
+#include <IXml.h>
 
 class QByteArray;
 

--- a/Code/Editor/Undo/Undo.cpp
+++ b/Code/Editor/Undo/Undo.cpp
@@ -13,7 +13,6 @@
 
 #include "Settings.h"
 #include "IUndoManagerListener.h"
-#include <list>
 
 #include <QString>
 #include "QtUtilWin.h"
@@ -62,7 +61,7 @@ public:
 
 private:
     //! Undo steps included in this step.
-    std::vector<CUndoStep*> m_undoSteps;
+    AZStd::vector<CUndoStep*> m_undoSteps;
 };
 
 // Helper class for CUndoManager that monitors the Asset Manager and suspends undo recording while the Asset Manager
@@ -446,7 +445,7 @@ void CUndoManager::ClearRedoStack()
     }
     m_bClearRedoStackQueued = false;
 
-    for (std::list<CUndoStep*>::iterator it = m_redoStack.begin(); it != m_redoStack.end(); it++)
+    for (AZStd::list<CUndoStep*>::iterator it = m_redoStack.begin(); it != m_redoStack.end(); it++)
     {
         delete *it;
     }
@@ -458,7 +457,7 @@ void CUndoManager::ClearRedoStack()
 //////////////////////////////////////////////////////////////////////////
 void CUndoManager::ClearUndoStack()
 {
-    for (std::list<CUndoStep*>::iterator it = m_undoStack.begin(); it != m_undoStack.end(); it++)
+    for (AZStd::list<CUndoStep*>::iterator it = m_undoStack.begin(); it != m_undoStack.end(); it++)
     {
         delete *it;
     }
@@ -682,15 +681,15 @@ int CUndoManager::GetDatabaseSize()
 {
     int size = 0;
     {
-        for (std::list<CUndoStep*>::iterator it = m_undoStack.begin(); it != m_undoStack.end(); it++)
+        for (CUndoStep* step : m_undoStack)
         {
-            size += (*it)->GetSize();
+            size += step->GetSize();
         }
     }
     {
-        for (std::list<CUndoStep*>::iterator it = m_redoStack.begin(); it != m_redoStack.end(); it++)
+        for (CUndoStep* step : m_redoStack)
         {
-            size += (*it)->GetSize();
+            size += step->GetSize();
         }
     }
     return size;

--- a/Code/Editor/Undo/Undo.h
+++ b/Code/Editor/Undo/Undo.h
@@ -11,8 +11,12 @@
 #include "EditorCoreAPI.h"
 #include "IUndoManagerListener.h"
 #include "IUndoObject.h"
+
 #include <AzCore/Asset/AssetManager.h>
+#include <AzCore/std/containers/list.h>
+#include <AzCore/std/containers/vector.h>
 #include <CryCommon/StlUtils.h>
+#include <vector>
 
 struct IUndoObject;
 class CSuperUndoStep;
@@ -253,10 +257,10 @@ private: // ---------------------------------------------------------------
 
     AssetManagerUndoInterruptor* m_assetManagerUndoInterruptor;
 
-    std::list<CUndoStep*>      m_undoStack;
-    std::list<CUndoStep*>      m_redoStack;
+    AZStd::list<CUndoStep*>      m_undoStack;
+    AZStd::list<CUndoStep*>      m_redoStack;
 
-    std::vector<IUndoManagerListener*> m_listeners;
+    AZStd::vector<IUndoManagerListener*> m_listeners;
 };
 
 class CScopedSuspendUndo

--- a/Code/Editor/UndoDropDown.h
+++ b/Code/Editor/UndoDropDown.h
@@ -12,6 +12,8 @@
 #include "Undo/IUndoManagerListener.h"
 #endif
 
+#include <QObject>
+
 /// Turns IUndoManagerListener callbacks into signals
 class UndoStackStateAdapter
     : public QObject

--- a/Code/Editor/Util/Variable.h
+++ b/Code/Editor/Util/Variable.h
@@ -25,6 +25,7 @@ AZ_POP_DISABLE_WARNING
 #include <StlUtils.h>
 
 #include <AzCore/std/string/string.h>
+#include <AzCore/std/string/conversions.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>

--- a/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockFileIOBase.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockFileIOBase.h
@@ -26,7 +26,7 @@ namespace AZ
             : public FileIOBase
         {
         public:
-            static const AZ::IO::HandleType FakeFileHandle = AZ::IO::HandleType(1234);
+            static inline const AZ::IO::HandleType FakeFileHandle = AZ::IO::HandleType(1234);
 
             MOCK_METHOD3(Open,  Result(const char* filePath, OpenMode mode, HandleType & fileHandle));
             MOCK_METHOD1(Close, Result(HandleType fileHandle));

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FlowLayout.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FlowLayout.cpp
@@ -39,7 +39,7 @@
 ****************************************************************************/
 // Modified from original
 
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <AzQtComponents/Components/FlowLayout.h>
 
 FlowLayout::FlowLayout(QWidget* parent, int margin, int hSpacing, int vSpacing)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FlowLayout.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FlowLayout.h
@@ -42,9 +42,9 @@
 #ifndef FLOWLAYOUT_H
 #define FLOWLAYOUT_H
 
-#include <QtCore/QRect>
-#include <QtWidgets/QLayout>
-#include <QtWidgets/QStyle>
+#include <QRect>
+#include <QLayout>
+#include <QStyle>
 
 #include <AzQtComponents/AzQtComponentsAPI.h>
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StylesheetPreprocessor.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StylesheetPreprocessor.cpp
@@ -7,9 +7,9 @@
  */
 #include <AzCore/Debug/Trace.h>
 #include <AzQtComponents/Components/StylesheetPreprocessor.h>
-#include <QtCore/QObject>
-#include <QtCore/QJsonDocument>
-#include <QtCore/QJsonObject>
+#include <QObject>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QRegularExpression>
 
 namespace

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.cpp
@@ -18,7 +18,6 @@
 #include <QWindow>
 #include <QSurfaceFormat>
 #include <QTimer>
-#include <QWindow>
 
 #include <qdrawutil.h>
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScopedCleanup.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScopedCleanup.h
@@ -9,7 +9,7 @@
 #ifndef SCOPEDCLEANUP_H
 #define SCOPEDCLEANUP_H
 
-#include <QtCore/qglobal.h>
+#include <qglobal.h>
 
 /**
  * RAII-style class that executes a lambda when it goes out of scope.

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/SelectionProxyModel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/SelectionProxyModel.h
@@ -10,7 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzQtComponents/AzQtComponentsAPI.h>
-#include <QtCore/QItemSelectionModel>
+#include <QItemSelectionModel>
 #include <QVector>
 #endif
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_files.cmake
+++ b/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_files.cmake
@@ -290,7 +290,6 @@ set(FILES
     Utilities/MouseHider.h
     Utilities/PixmapScaleUtilities.cpp
     Utilities/PixmapScaleUtilities.h
-    Utilities/QtHash.h
     Utilities/QtPluginPaths.cpp
     Utilities/QtPluginPaths.h
     Utilities/QtWindowUtilities.cpp

--- a/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_files.cmake
+++ b/Code/Framework/AzQtComponents/AzQtComponents/azqtcomponents_files.cmake
@@ -290,6 +290,7 @@ set(FILES
     Utilities/MouseHider.h
     Utilities/PixmapScaleUtilities.cpp
     Utilities/PixmapScaleUtilities.h
+    Utilities/QtHash.h
     Utilities/QtPluginPaths.cpp
     Utilities/QtPluginPaths.h
     Utilities/QtWindowUtilities.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
@@ -17,6 +17,11 @@
 #include <AzToolsFramework/ActionManager/Action/EditorActionContext.h>
 #include <AzToolsFramework/ActionManager/Action/EditorWidgetAction.h>
 
+#include <QObject>
+
+class QKeyEvent;
+class QWidget;
+
 namespace AzToolsFramework
 {
     //! This class is used to mute KeyPress events that are triggered after a shortcut has fired.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <QIcon>
+#include <QObject>
 
 class QAction;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Menu/EditorMenu.cpp
@@ -14,6 +14,8 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 
+#include <QAction>
+#include <QActionGroup>
 #include <QCursor>
 #include <QMenu>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/Ticker.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/Ticker.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <QtCore/QObject>
-#include <QtCore/QTimer>
-#include <QtCore/QThread>
+#include <QObject>
+#include <QTimer>
+#include <QThread>
 
 #include <AzCore/Memory/SystemAllocator.h>
 #endif

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -88,7 +88,7 @@
 #include <Prefab/ProceduralPrefabSystemComponent.h>
 #include <AzToolsFramework/Metadata/UuidUtils.h>
 
-#include <QtWidgets/QMessageBox>
+#include <QMessageBox>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QFileInfo::d_ptr': class 'QSharedDataPointer<QFileInfoPrivate>' needs to have dll-interface to be used by clients of class 'QFileInfo'
 #include <QDir>
 AZ_POP_DISABLE_WARNING

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -25,7 +25,7 @@
 #include <AzQtComponents/Components/Widgets/FileDialog.h>
 
 #include <QFileInfo>
-#include <QtWidgets/QMessageBox>
+#include <QMessageBox>
 #include <QHBoxLayout>
 #include <QMimeData>
 #include <QTimer>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -391,10 +391,10 @@ namespace AzToolsFramework
         {
             if (m_thumbnailKey)
             {
-                disconnect(m_thumbnailKey.data(), nullptr, this, nullptr);
+                disconnect(m_thumbnailKey.get(), nullptr, this, nullptr);
             }
             m_thumbnailKey = thumbnailKey;
-            connect(m_thumbnailKey.data(), &ThumbnailKey::ThumbnailUpdated, this, &AssetBrowserEntry::SetThumbnailDirty);
+            connect(m_thumbnailKey.get(), &ThumbnailKey::ThumbnailUpdated, this, &AssetBrowserEntry::SetThumbnailDirty);
         }
 
         SharedThumbnailKey AssetBrowserEntry::GetThumbnailKey() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/ProductAssetBrowserEntry.cpp
@@ -7,6 +7,8 @@
  */
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Asset/AssetTypeInfoBus.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
 
 #include <AzFramework/StringFunc/StringFunc.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.cpp
@@ -145,10 +145,10 @@ namespace AzToolsFramework
         {
             if (m_sourceControlThumbnailKey)
             {
-                disconnect(m_sourceControlThumbnailKey.data(), nullptr, this, nullptr);
+                disconnect(m_sourceControlThumbnailKey.get(), nullptr, this, nullptr);
             }
             m_sourceControlThumbnailKey = MAKE_TKEY(SourceControlThumbnailKey, m_fullPath.c_str());
-            connect(m_sourceControlThumbnailKey.data(), &ThumbnailKey::ThumbnailUpdated, this, &AssetBrowserEntry::SetThumbnailDirty);
+            connect(m_sourceControlThumbnailKey.get(), &ThumbnailKey::ThumbnailUpdated, this, &AssetBrowserEntry::SetThumbnailDirty);
         }
 
         SharedThumbnailKey SourceAssetBrowserEntry::CreateThumbnailKey()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.cpp
@@ -45,7 +45,7 @@ namespace AzToolsFramework
         void FolderThumbnail::Load()
         {
             m_state = State::Loading;
-            AZ_Assert(azrtti_cast<const FolderThumbnailKey*>(m_key.data()), "Incorrect key type, excpected FolderThumbnailKey");
+            AZ_Assert(azrtti_cast<const FolderThumbnailKey*>(m_key.get()), "Incorrect key type, excpected FolderThumbnailKey");
 
             auto absoluteIconPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / FolderIconPath;
             m_pixmap.load(absoluteIconPath.c_str());
@@ -68,7 +68,7 @@ namespace AzToolsFramework
 
         bool FolderThumbnailCache::IsSupportedThumbnail(SharedThumbnailKey key) const
         {
-            return azrtti_istypeof<const FolderThumbnailKey*>(key.data());
+            return azrtti_istypeof<const FolderThumbnailKey*>(key.get());
         }
 
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.cpp
@@ -61,7 +61,7 @@ namespace AzToolsFramework
         {
             m_state = State::Loading;
 
-            auto productKey = azrtti_cast<const ProductThumbnailKey*>(m_key.data());
+            auto productKey = azrtti_cast<const ProductThumbnailKey*>(m_key.get());
             AZ_Assert(productKey, "Incorrect key type, excpected ProductThumbnailKey");
 
             QString iconPath;
@@ -116,7 +116,7 @@ namespace AzToolsFramework
 
         bool ProductThumbnailCache::IsSupportedThumbnail(Thumbnailer::SharedThumbnailKey key) const
         {
-            return azrtti_istypeof<const ProductThumbnailKey*>(key.data());
+            return azrtti_istypeof<const ProductThumbnailKey*>(key.get());
         }
 
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.cpp
@@ -63,7 +63,7 @@ namespace AzToolsFramework
         {
             m_state = State::Loading;
 
-            auto sourceKey = azrtti_cast<const SourceThumbnailKey*>(m_key.data());
+            auto sourceKey = azrtti_cast<const SourceThumbnailKey*>(m_key.get());
             AZ_Assert(sourceKey, "Incorrect key type, excpected SourceThumbnailKey");
 
             bool foundIt = false;
@@ -141,7 +141,7 @@ namespace AzToolsFramework
 
         bool SourceThumbnailCache::IsSupportedThumbnail(SharedThumbnailKey key) const
         {
-            return azrtti_istypeof<const SourceThumbnailKey*>(key.data());
+            return azrtti_istypeof<const SourceThumbnailKey*>(key.get());
         }
 
     } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserFolderWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserFolderWidget.cpp
@@ -12,6 +12,7 @@
 #include <AzQtComponents/Components/Widgets/BreadCrumbs.h>
 
 #include <QAction>
+#include <QActionGroup>
 #include <QComboBox>
 #include <QStackedWidget>
 #include <QToolBar>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -54,7 +54,7 @@
 #include <QPainter>
 #include <QPushButton>
 #include <QTimer>
-#include <QtWidgets/QMessageBox>
+#include <QMessageBox>
 #include <QAbstractButton>
 #include <QHBoxLayout>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.cpp
@@ -29,7 +29,7 @@
 #include <QPushButton>
 #include <QSettings>
 #include <QWidget>
-#include <QtWidgets/QMessageBox>
+#include <QMessageBox>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -29,7 +29,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
-#include <QtWidgets/QMessageBox>
+#include <QMessageBox>
 
 namespace
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
@@ -57,17 +57,17 @@
 #include <AzToolsFramework/Slice/SliceMetadataEntityContextBus.h>
 AZ_PUSH_DISABLE_WARNING(4251 4244, "-Wunknown-warning-option") // 4251: class '...' needs to have dll-interface to be used by clients of class '...'
                                                                // 4244: 'argument': conversion from 'int' to 'float', possible loss of data
-#include <QtWidgets/QApplication>
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QWidgetAction>
-#include <QtWidgets/QMenu>
-#include <QtWidgets/QDialog>
-#include <QtWidgets/QFileDialog>
-#include <QtWidgets/QMessageBox>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QErrorMessage>
-#include <QtWidgets/QVBoxLayout>
-#include <QtCore/QThread>
+#include <QApplication>
+#include <QWidget>
+#include <QWidgetAction>
+#include <QMenu>
+#include <QDialog>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QErrorMessage>
+#include <QVBoxLayout>
+#include <QThread>
 #include <QDialogButtonBox>
 AZ_POP_DISABLE_WARNING
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.cpp
@@ -86,7 +86,7 @@ namespace AzToolsFramework
         void SourceControlThumbnail::FileStatusChanged(const char* filename)
         {
             // when file status is changed, force instant update
-            auto sourceControlKey = azrtti_cast<const SourceControlThumbnailKey*>(m_key.data());
+            auto sourceControlKey = azrtti_cast<const SourceControlThumbnailKey*>(m_key.get());
             AZ_Assert(sourceControlKey, "Incorrect key type, excpected SourceControlThumbnailKey");
 
             AZStd::string myFileName(sourceControlKey->GetFileName());
@@ -99,7 +99,7 @@ namespace AzToolsFramework
 
         void SourceControlThumbnail::RequestSourceControlStatus()
         {
-            auto sourceControlKey = azrtti_cast<const SourceControlThumbnailKey*>(m_key.data());
+            auto sourceControlKey = azrtti_cast<const SourceControlThumbnailKey*>(m_key.get());
             AZ_Assert(sourceControlKey, "Incorrect key type, excpected SourceControlThumbnailKey");
 
             bool isSourceControlActive = false;
@@ -160,7 +160,7 @@ namespace AzToolsFramework
 
         bool SourceControlThumbnailCache::IsSupportedThumbnail(SharedThumbnailKey key) const
         {
-            return azrtti_istypeof<const SourceControlThumbnailKey*>(key.data());
+            return azrtti_istypeof<const SourceControlThumbnailKey*>(key.get());
         }
 
     } // namespace Thumbnailer

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/SourceControlThumbnail.h
@@ -94,8 +94,8 @@ namespace AzToolsFramework
             public:
                 bool operator()(const SharedThumbnailKey& val1, const SharedThumbnailKey& val2) const
                 {
-                    auto sourceThumbnailKey1 = azrtti_cast<const SourceControlThumbnailKey*>(val1.data());
-                    auto sourceThumbnailKey2 = azrtti_cast<const SourceControlThumbnailKey*>(val2.data());
+                    auto sourceThumbnailKey1 = azrtti_cast<const SourceControlThumbnailKey*>(val1.get());
+                    auto sourceThumbnailKey2 = azrtti_cast<const SourceControlThumbnailKey*>(val2.get());
                     if (!sourceThumbnailKey1 || !sourceThumbnailKey2)
                     {
                         return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/Thumbnail.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Component/TickBus.h>
@@ -59,9 +61,9 @@ namespace AzToolsFramework
             bool m_ready = false;
         };
 
-        typedef QSharedPointer<ThumbnailKey> SharedThumbnailKey;
+        typedef AZStd::shared_ptr<ThumbnailKey> SharedThumbnailKey;
 
-#define MAKE_TKEY(type, ...) QSharedPointer<type>(new type(__VA_ARGS__))
+#define MAKE_TKEY(type, ...) AZStd::make_shared<type>(__VA_ARGS__)
 
         //! Thumbnail is the base class in thumbnailer system.
         /*
@@ -128,7 +130,7 @@ namespace AzToolsFramework
             virtual const char* GetProviderName() const = 0;
         };
 
-        typedef QSharedPointer<ThumbnailProvider> SharedThumbnailProvider;
+        typedef AZStd::shared_ptr<ThumbnailProvider> SharedThumbnailProvider;
     } // namespace Thumbnailer
 } // namespace AzToolsFramework
 
@@ -151,7 +153,7 @@ namespace AZStd
             const AzToolsFramework::Thumbnailer::SharedThumbnailKey& left,
             const AzToolsFramework::Thumbnailer::SharedThumbnailKey& right) const
         {
-            return left->Equals(right.data());
+            return left->Equals(right.get());
         }
     };
 } // namespace AZStd
@@ -184,10 +186,8 @@ namespace AzToolsFramework
             virtual bool IsSupportedThumbnail(SharedThumbnailKey key) const = 0;
         };
 
-        #define MAKE_TCACHE(cacheType, ...) QSharedPointer<cacheType>(new cacheType(__VA_ARGS__))
+        #define MAKE_TCACHE(cacheType, ...) AZStd::make_shared<cacheType>(__VA_ARGS__)
     } // namespace Thumbnailer
 } // namespace AzToolsFramework
-
-Q_DECLARE_METATYPE(AzToolsFramework::Thumbnailer::SharedThumbnailKey)
 
 #include <AzToolsFramework/Thumbnails/Thumbnail.inl>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
@@ -34,16 +34,16 @@ namespace AzToolsFramework
         {
             if (m_key)
             {
-                disconnect(m_key.data(), nullptr, this, nullptr);
+                disconnect(m_key.get(), nullptr, this, nullptr);
             }
             m_key = key;
-            connect(m_key.data(), &ThumbnailKey::ThumbnailUpdated, this, &ThumbnailWidget::RepaintThumbnail);
+            connect(m_key.get(), &ThumbnailKey::ThumbnailUpdated, this, &ThumbnailWidget::RepaintThumbnail);
             repaint();
         }
 
         void ThumbnailWidget::ClearThumbnail()
         {
-            m_key.clear();
+            m_key.reset();
             repaint();
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerComponent.cpp
@@ -129,13 +129,13 @@ namespace AzToolsFramework
 
                         // The ThumbnailUpdated signal should be sent whenever the thumbnail has loaded or failed. In both cases,
                         // disconnect from all of the signals.
-                        QObject::connect(thumbnail.data(), &Thumbnail::ThumbnailUpdated, m_placeholderObject.get(), [this, key, thumbnail, busyLabel]()
+                        QObject::connect(thumbnail.get(), &Thumbnail::ThumbnailUpdated, m_placeholderObject.get(), [this, key, thumbnail, busyLabel]()
                             {
                                 QObject::disconnect(busyLabel, nullptr, m_placeholderObject.get(), nullptr);
-                                QObject::disconnect(thumbnail.data(), nullptr, key.data(), nullptr);
+                                QObject::disconnect(thumbnail.get(), nullptr, key.get(), nullptr);
 
-                                QObject::connect(thumbnail.data(), &Thumbnail::ThumbnailUpdated, key.data(), &ThumbnailKey::ThumbnailUpdated);
-                                QObject::connect(key.data(), &ThumbnailKey::ThumbnailUpdateRequested, thumbnail.data(), &Thumbnail::Update);
+                                QObject::connect(thumbnail.get(), &Thumbnail::ThumbnailUpdated, key.get(), &ThumbnailKey::ThumbnailUpdated);
+                                QObject::connect(key.get(), &ThumbnailKey::ThumbnailUpdateRequested, thumbnail.get(), &Thumbnail::Update);
 
                                 key->SetReady(true);
                                 m_thumbnailsBeingLoaded.erase(thumbnail);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentAssetMimeDataContainer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentAssetMimeDataContainer.cpp
@@ -14,7 +14,7 @@
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Serialization/ObjectStream.h>
 
-#include <QtCore/QMimeData>
+#include <QMimeData>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentAssetMimeDataContainer.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentAssetMimeDataContainer.h
@@ -15,7 +15,7 @@
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 
-#include <QtCore/QString>
+#include <QString>
 
 namespace AZ
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentMimeData.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ComponentMimeData.cpp
@@ -9,6 +9,7 @@
 #include <QMimeData>
 #include <QDataStream>
 #include <QClipboard>
+#include <QIODevice>
 #include <QApplication>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/IO/ByteContainerStream.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorAssetMimeDataContainer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorAssetMimeDataContainer.cpp
@@ -14,7 +14,7 @@
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Serialization/ObjectStream.h>
 
-#include <QtCore/QMimeData>
+#include <QMimeData>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorAssetMimeDataContainer.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorAssetMimeDataContainer.h
@@ -15,7 +15,7 @@
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 
-#include <QtCore/QString>
+#include <QString>
 
 namespace AZ
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -13,7 +13,7 @@
 #include <AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabAdapterInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
-#include <QtCore/QTimer>
+#include <QTimer>
 
 namespace AZ::DocumentPropertyEditor
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkAPI.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkAPI.cpp
@@ -11,7 +11,7 @@
 
 #include "EditorFrameworkAPI.h"
 
-#include <QtCore/QString>
+#include <QString>
 
 AZ_INSTANTIATE_EBUS_SINGLE_ADDRESS(AZTF_API, LegacyFramework::CoreMessages);
 AZ_INSTANTIATE_EBUS_SINGLE_ADDRESS(AZTF_API, LegacyFramework::FrameworkApplicationMessages);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
@@ -49,7 +49,7 @@ AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 'QFileInfo::d_ptr':
 AZ_POP_DISABLE_WARNING
 #include <QSharedMemory>
 #include <QStandardPaths>
-#include <QtWidgets/QApplication>
+#include <QApplication>
 
 namespace LegacyFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusAPI.h
@@ -12,7 +12,7 @@
 #include <AzCore/base.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Crc.h>
-#include <QtCore/QString>
+#include <QString>
 #include <AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusCommon.h>
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 #pragma once

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusComponent.cpp
@@ -9,7 +9,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/UI/LegacyFramework/UIFrameworkAPI.h>
-#include <QtWidgets/qaction.h>
+#include <QAction>
 #include "CustomMenusAPI.h"
 
 #include <QMenu>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/MainWindowSavedState.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/MainWindowSavedState.cpp
@@ -9,7 +9,7 @@
 
 #include "MainWindowSavedState.h"
 #include <AzCore/Serialization/SerializeContext.h>
-#include <QtCore/QByteArray>
+#include <QByteArray>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFramework.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFramework.cpp
@@ -23,9 +23,9 @@
 #include "MainWindowSavedState.h"
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // '...' needs to have dll-interface to be used by clients of class '...'
-#include <QtWidgets/QApplication>
-#include <QtCore/QTimer>
-#include <QtCore/QDir>
+#include <QApplication>
+#include <QTimer>
+#include <QDir>
 #include <QThread>
 #include <QAction>
 #include <QMenu>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFramework.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFramework.hxx
@@ -19,10 +19,10 @@
 #include <AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkAPI.h>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // '...' needs to have dll-interface to be used by clients of class '...'
-#include <QtCore/QObject>
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QTableView>
-#include <QtGui/QStandardItemModel>
+#include <QObject>
+#include <QWidget>
+#include <QTableView>
+#include <QStandardItemModel>
 AZ_POP_DISABLE_WARNING
 #endif
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFrameworkAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFrameworkAPI.h
@@ -19,7 +19,7 @@
 #include <AzCore/std/function/function_fwd.h>
 #include <AzCore/std/string/string.h>
 
-#include <QtGui/qwindowdefs.h>
+#include <qwindowdefs.h>
 
 class QMenu;
 class QToolBar;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFrameworkPreferences.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/UIFrameworkPreferences.cpp
@@ -8,9 +8,9 @@
 
 
 #include "UIFramework.hxx"
-#include <qaction.h>
-#include <qheaderview.h>
 
+#include <QAction>
+#include <QHeaderView>
 #include <QMessageBox>
 
 // split out the preferences implementation from the main UIFramework.cpp file

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogControl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogControl.cpp
@@ -19,7 +19,7 @@ AZ_POP_DISABLE_WARNING
 #include <QScrollBar>
 #include <QTableView>
 #include <QHeaderView>
-#include <QtWidgets/QApplication>
+#include <QApplication>
 
 #include "LogPanel_Panel.h"
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
@@ -32,8 +32,8 @@ AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: con
                                                                     // 4800 'QTextEngine *const ': forcing value to bool 'true' or 'false' (performance warning)
 #include <QAbstractTextDocumentLayout>
 AZ_POP_DISABLE_WARNING
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QApplication>
+#include <QLabel>
+#include <QApplication>
 
 #include <AzQtComponents/Components/Widgets/TabWidget.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerDisplayOptionsMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerDisplayOptionsMenu.cpp
@@ -8,6 +8,8 @@
 
 #include "EntityOutlinerDisplayOptionsMenu.h"
 
+#include <QActionGroup>
+#include <QAction>
 #include <QIcon>
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerSortFilterProxyModel.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerSortFilterProxyModel.hxx
@@ -12,7 +12,7 @@
  
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 #include <AzCore/Memory/SystemAllocator.h>
 #endif
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -38,7 +38,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4244, "-Wunknown-warning-option") // 4251: 'QInputE
                                                                // 4244: 'return': conversion from 'qreal' to 'int', possible loss of data
 #include <QContextMenuEvent>
 AZ_POP_DISABLE_WARNING
-#include <QtWidgets/QApplication>
+#include <QApplication>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.cpp
@@ -10,9 +10,9 @@
 
 #include <QDesktopServices>
 
-#include <QtWidgets/QHBoxLayout>
-#include <QtWidgets/QMenu>
-#include <QtWidgets/QPushButton>
+#include <QHBoxLayout>
+#include <QMenu>
+#include <QPushButton>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditorHeader.hxx
@@ -10,7 +10,7 @@
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 #if !defined(Q_MOC_RUN)
-#include <QtWidgets/QFrame>
+#include <QFrame>
 #include <AzCore/std/string/string.h>
 
 #include <AzQtComponents/Components/Widgets/CardHeader.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityIdQLabel.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityIdQLabel.hxx
@@ -16,7 +16,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/std/string/string_view.h>
 
-#include <QtWidgets/QLabel>
+#include <QLabel>
 #endif
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -40,8 +40,8 @@
 #include <AzQtComponents/Components/O3DEStylesheet.h>
 
 #include <QComboBox>
-#include <QtGui/QIcon>
-#include <QtWidgets/QWidget>
+#include <QIcon>
+#include <QWidget>
 #endif
 
 class QLabel;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.h
@@ -11,7 +11,7 @@
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 #if !defined(Q_MOC_RUN)
-#include <QtWidgets/QWidget>
+#include <QWidget>
 
 #include <AzCore/Math/Uuid.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.inl
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/GenericComboBoxCtrl.inl
@@ -9,7 +9,7 @@
 #pragma once
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
 
 #include <QPushButton>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -12,17 +12,17 @@
 #include "PropertyQTConstants.h"
 
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option")
-#include <QtWidgets/QHBoxLayout>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QMenu>
-#include <QtWidgets/QFileDialog>
-#include <QtWidgets/QMessageBox>
-#include <QtGui/QPixmapCache>
-#include <QtGui/QMouseEvent>
-#include <QtCore/QMimeData>
-#include <QtCore/QEvent>
-#include <QtCore/QTimer>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QMenu>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QPixmapCache>
+#include <QMouseEvent>
+#include <QMimeData>
+#include <QEvent>
+#include <QTimer>
 #include <QClipboard>
 #include <QListView>
 #include <QTableView>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrl.cpp
@@ -10,13 +10,13 @@
 #include <UI/PropertyEditor/PropertyAudioCtrl.h>
 #include <UI/PropertyEditor/PropertyQTConstants.h>
 
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QLineEdit>
-#include <QtWidgets/QToolButton>
+#include <QLabel>
+#include <QLineEdit>
+#include <QToolButton>
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option") // 4244: conversion from 'int' to 'float', possible loss of data
                                                                // 4251: 'QInputEvent::modState': class 'QFlags<Qt::KeyboardModifier>' needs to have dll-interface to be used by clients of class 'QInputEvent'
-#include <QtWidgets/QHBoxLayout>
-#include <QtGui/QMouseEvent>
+#include <QHBoxLayout>
+#include <QMouseEvent>
 AZ_POP_DISABLE_WARNING
 
 #include <AzCore/Component/ComponentApplicationBus.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolComboBoxCtrl.cpp
@@ -8,9 +8,9 @@
 #include "PropertyBoolComboBoxCtrl.hxx"
 #include "PropertyQTConstants.h"
 #include "DHQComboBox.hxx"
-#include <QtWidgets/QComboBox>
+#include <QComboBox>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolComboBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolComboBoxCtrl.hxx
@@ -13,7 +13,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <QToolButton>
 #include "PropertyEditorAPI.h"
 #include <UI/PropertyEditor/GenericComboBoxCtrl.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolRadioButtonsCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolRadioButtonsCtrl.cpp
@@ -12,7 +12,7 @@
 #include <QRadioButton>
 #include <QSignalBlocker>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolRadioButtonsCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyBoolRadioButtonsCtrl.hxx
@@ -16,7 +16,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #endif
 
 class QRadioButton;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyButtonCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyButtonCtrl.cpp
@@ -7,11 +7,11 @@
  */
 #include "PropertyButtonCtrl.hxx"
 #include "PropertyQTConstants.h"
-#include <QtWidgets/QPushButton>
+#include <QPushButton>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
-#include <QtCore/QEvent>
+#include <QEvent>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyButtonCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyButtonCtrl.hxx
@@ -13,7 +13,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include "PropertyEditorAPI.h"
 #endif
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCRCCtrl.h
@@ -13,7 +13,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Math/Crc.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 
 #include "PropertyEditorAPI.h"
 #endif

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.cpp
@@ -10,8 +10,8 @@
 #include "PropertyQTConstants.h"
 
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option")
-#include <QtWidgets/QCheckBox>
-#include <QtWidgets/QHBoxLayout>
+#include <QCheckBox>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
 
 
@@ -120,13 +120,6 @@ namespace AzToolsFramework
                 widget->setValue(value);
             }
         }
-    }
-
-    template<class ValueType>
-    void PropertyCheckBoxHandlerCommon<ValueType>::ConsumeAttribute(
-        PropertyCheckBoxCtrl* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
-    {
-        ConsumeAttributeCommon(widget, attrib, attrValue, debugName);
     }
 
     QWidget* BoolPropertyCheckBoxHandler::CreateGUI(QWidget* parent)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.cpp
@@ -122,6 +122,13 @@ namespace AzToolsFramework
         }
     }
 
+    template<class ValueType>
+    void PropertyCheckBoxHandlerCommon<ValueType>::ConsumeAttribute(
+        PropertyCheckBoxCtrl* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
+    {
+        ConsumeAttributeCommon(widget, attrib, attrValue, debugName);
+    }
+
     QWidget* BoolPropertyCheckBoxHandler::CreateGUI(QWidget* parent)
     {
         return CreateGUICommon(parent);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.hxx
@@ -14,7 +14,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include "PropertyEditorAPI.h"
 #endif
 class QCheckBox;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.hxx
@@ -76,10 +76,7 @@ namespace AzToolsFramework
         QWidget* GetLastInTabOrder(PropertyCheckBoxCtrl* widget) override { return widget->GetLastInTabOrder(); }
         void UpdateWidgetInternalTabbing(PropertyCheckBoxCtrl* widget) override { widget->UpdateTabOrder(); }
 
-        void ConsumeAttribute(PropertyCheckBoxCtrl* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override
-        {
-            ConsumeAttributeCommon(widget, attrib, attrValue, debugName);
-        }
+        void ConsumeAttribute(PropertyCheckBoxCtrl* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
     };
 
     class AZTF_API BoolPropertyCheckBoxHandler

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.hxx
@@ -9,7 +9,6 @@
 
 #pragma once
 
-
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 #if !defined(Q_MOC_RUN)
@@ -77,7 +76,10 @@ namespace AzToolsFramework
         QWidget* GetLastInTabOrder(PropertyCheckBoxCtrl* widget) override { return widget->GetLastInTabOrder(); }
         void UpdateWidgetInternalTabbing(PropertyCheckBoxCtrl* widget) override { widget->UpdateTabOrder(); }
 
-        void ConsumeAttribute(PropertyCheckBoxCtrl* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        void ConsumeAttribute(PropertyCheckBoxCtrl* widget, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override
+        {
+            ConsumeAttributeCommon(widget, attrib, attrValue, debugName);
+        }
     };
 
     class AZTF_API BoolPropertyCheckBoxHandler

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -10,15 +10,15 @@
 #include <AzQtComponents/Components/Widgets/ColorPicker.h>
 #include <AzQtComponents/Utilities/Conversions.h>
 #include <AzQtComponents/Utilities/ColorUtilities.h>
-#include <QtWidgets/QSlider>
-#include <QtWidgets/QLineEdit>
+#include <QSlider>
+#include <QLineEdit>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
 // 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 // qpainter.h(465): warning C4251: 'QPainter::d_ptr': class 'QScopedPointer<QPainterPrivate,QScopedPointerDeleter<T>>' needs to have dll-interface to be used by clients of class 'QPainter'
 #include <QPainter> 
 AZ_POP_DISABLE_WARNING
-#include <QtWidgets/QToolButton>
+#include <QToolButton>
 #include <QRegularExpressionValidator>
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx
@@ -23,7 +23,7 @@
 // 4251: class needs to have dll-interface to be used by clients of class 
 // 4800: forcing value to bool 'true' or 'false' (performance warning)
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
-#include <QtWidgets/QWidget>
+#include <QWidget>
 AZ_POP_DISABLE_WARNING
 #endif
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
@@ -9,7 +9,7 @@
 #include "PropertyDoubleSliderCtrl.hxx"
 #include "PropertyQTConstants.h"
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
 #include <AzCore/Math/MathUtils.h>
 #include <AzQtComponents/Components/Widgets/SpinBox.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.hxx
@@ -14,7 +14,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include "PropertyEditorAPI.h"
 #endif
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorApi.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorApi.cpp
@@ -6,7 +6,7 @@
  *
  */
 #include "PropertyEditorAPI.h"
-#include <QtWidgets/QDoubleSpinBox>
+#include <QDoubleSpinBox>
 
 #include <AzCore/Math/Crc.h>
 #include <AzCore/Serialization/EditContext.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
@@ -24,16 +24,16 @@
 #include <AzToolsFramework/ViewportSelection/EditorPickEntitySelection.h>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
-#include <QtCore/QMimeData>
+#include <QMimeData>
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option") // 4244: conversion from 'int' to 'float', possible loss of data
                                                                // 4251: 'QInputEvent::modState': class 'QFlags<Qt::KeyboardModifier>' needs to have dll-interface to be used by clients of class 'QInputEvent'
 #include <QDragEnterEvent>
 AZ_POP_DISABLE_WARNING
 #include <QDropEvent>
 #include <QToolButton>
-#include <QtWidgets/QApplication>
+#include <QApplication>
 
 //just a test to see how it would work to pop a dialog
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.hxx
@@ -17,7 +17,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzFramework/Entity/EntityContextBus.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <QIcon>
 #include "PropertyEditorAPI.h"
 #endif

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.cpp
@@ -8,9 +8,9 @@
 #include "PropertyEnumComboBoxCtrl.hxx"
 #include "PropertyQTConstants.h"
 #include "DHQComboBox.hxx"
-#include <QtWidgets/QComboBox>
+#include <QComboBox>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -13,7 +13,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyQTConstants.h>
 #include <AzToolsFramework/UI/PropertyEditor/QtWidgetLimits.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <QLocale> 
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.cpp
@@ -10,7 +10,7 @@
 #include <AzQtComponents/Components/Widgets/SpinBox.h>
 
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option")
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 #include <QSignalBlocker>
 AZ_POP_DISABLE_WARNING
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSpinCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSpinCtrl.cpp
@@ -8,11 +8,11 @@
 #include "PropertyIntSpinCtrl.hxx"
 #include "PropertyQTConstants.h"
 #include <AzQtComponents/Components/Widgets/SpinBox.h>
-#include <QtWidgets/QSlider>
+#include <QSlider>
 
 AZ_PUSH_DISABLE_WARNING(4251 4244, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
                                                                // 4244: conversion from 'int' to 'float', possible loss of data
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 #include <QFocusEvent>
 AZ_POP_DISABLE_WARNING
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -17,11 +17,11 @@
 AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: conversion from 'int' to 'float', possible loss of data
                                                                     // 4251: class '...' needs to have dll-interface to be used by clients of class 'QInputEvent'
                                                                     // 4800: QTextEngine *const ': forcing value to bool 'true' or 'false' (performance warning)
-#include <QtWidgets/QHBoxLayout>
-#include <QtWidgets/QWidget>
-#include <QtGui/QFontMetrics>
-#include <QtGui/QTextLayout>
-#include <QtGui/QPainter>
+#include <QHBoxLayout>
+#include <QWidget>
+#include <QFontMetrics>
+#include <QTextLayout>
+#include <QPainter>
 #include <QMessageBox>
 #include <QStylePainter>
 AZ_POP_DISABLE_WARNING

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -24,6 +24,7 @@ AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: con
 #include <QPainter>
 #include <QMessageBox>
 #include <QStylePainter>
+#include <QFile>
 AZ_POP_DISABLE_WARNING
 
 static const int LabelColumnStretch = 2;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.hxx
@@ -18,14 +18,14 @@ AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // class '...' needs t
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzQtComponents/Components/Widgets/ElidingLabel.h>
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QLayout>
-#include <QtWidgets/QToolButton>
-#include <QtWidgets/QCheckBox>
-#include <QtWidgets/QFrame>
-#include <QtCore/QPointer>
-#include <QtCore/QElapsedTimer>
+#include <QWidget>
+#include <QLabel>
+#include <QLayout>
+#include <QToolButton>
+#include <QCheckBox>
+#include <QFrame>
+#include <QPointer>
+#include <QElapsedTimer>
 AZ_POP_DISABLE_WARNING
 
 #include "PropertyEditorAPI.h"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
@@ -9,7 +9,7 @@
 #include "PropertyQTConstants.h"
 #include "DHQComboBox.hxx"
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
@@ -73,61 +73,6 @@ namespace AzToolsFramework
         setTabOrder(GetFirstInTabOrder(), GetLastInTabOrder());
     }
 
-    template<class ValueType>
-    void PropertyComboBoxHandlerCommon<ValueType>::ConsumeAttribute(PropertyStringComboBoxCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
-    {
-        if (attrib == AZ::Edit::Attributes::StringList)
-        {
-            AZStd::vector<AZStd::string> value;
-            if (attrValue->Read<AZStd::vector<AZStd::string> >(value))
-            {
-                GUI->Add(value);
-            }
-            else
-            {
-                (void)debugName;
-                AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'StringList' attribute from property '%s' into string combo box. Expected string vector.", debugName);
-            }
-        }
-        else if (attrib == AZ::Edit::Attributes::ComboBoxEditable)
-        {
-            bool value;
-            if (attrValue->Read<bool>(value))
-            {
-                GUI->GetComboBox()->setEditable(value);
-            }
-            else
-            {
-                // emit a warning!
-                AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'EditableCombBox' attribute from property '%s' into string combo box", debugName);
-            }
-            return;
-        }
-        else if (attrib == AZ_CRC_CE("EditButtonVisible"))
-        {
-            bool visible;
-            if (attrValue->Read<bool>(visible))
-            {
-                GUI->GetEditButton()->setVisible(visible);
-            }
-        }
-        else if (attrib == AZ_CRC_CE("EditButtonCallback"))
-        {
-            if (auto* editButtonInvokable = azrtti_cast<AZ::AttributeInvocable<GenericEditResultOutcome<AZStd::string>(AZStd::string)>*>(attrValue->GetAttribute()))
-            {
-                GUI->SetEditButtonCallBack(editButtonInvokable->GetCallable());
-            };
-        }
-        else if (attrib == AZ_CRC_CE("EditButtonToolTip"))
-        {
-            AZStd::string toolTip;
-            if (attrValue->Read<AZStd::string>(toolTip))
-            {
-                GUI->GetEditButton()->setToolTip(toolTip.c_str());
-            }
-        }
-    }
-
     QWidget* StringEnumPropertyComboBoxHandler::CreateGUI(QWidget* pParent)
     {
         PropertyStringComboBoxCtrl* newCtrl = aznew PropertyStringComboBoxCtrl(pParent);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
@@ -73,6 +73,61 @@ namespace AzToolsFramework
         setTabOrder(GetFirstInTabOrder(), GetLastInTabOrder());
     }
 
+    template<class ValueType>
+    void PropertyComboBoxHandlerCommon<ValueType>::ConsumeAttribute(PropertyStringComboBoxCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
+    {
+        if (attrib == AZ::Edit::Attributes::StringList)
+        {
+            AZStd::vector<AZStd::string> value;
+            if (attrValue->Read<AZStd::vector<AZStd::string> >(value))
+            {
+                GUI->Add(value);
+            }
+            else
+            {
+                (void)debugName;
+                AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'StringList' attribute from property '%s' into string combo box. Expected string vector.", debugName);
+            }
+        }
+        else if (attrib == AZ::Edit::Attributes::ComboBoxEditable)
+        {
+            bool value;
+            if (attrValue->Read<bool>(value))
+            {
+                GUI->GetComboBox()->setEditable(value);
+            }
+            else
+            {
+                // emit a warning!
+                AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'EditableCombBox' attribute from property '%s' into string combo box", debugName);
+            }
+            return;
+        }
+        else if (attrib == AZ_CRC_CE("EditButtonVisible"))
+        {
+            bool visible;
+            if (attrValue->Read<bool>(visible))
+            {
+                GUI->GetEditButton()->setVisible(visible);
+            }
+        }
+        else if (attrib == AZ_CRC_CE("EditButtonCallback"))
+        {
+            if (auto* editButtonInvokable = azrtti_cast<AZ::AttributeInvocable<GenericEditResultOutcome<AZStd::string>(AZStd::string)>*>(attrValue->GetAttribute()))
+            {
+                GUI->SetEditButtonCallBack(editButtonInvokable->GetCallable());
+            };
+        }
+        else if (attrib == AZ_CRC_CE("EditButtonToolTip"))
+        {
+            AZStd::string toolTip;
+            if (attrValue->Read<AZStd::string>(toolTip))
+            {
+                GUI->GetEditButton()->setToolTip(toolTip.c_str());
+            }
+        }
+    }
+
     QWidget* StringEnumPropertyComboBoxHandler::CreateGUI(QWidget* pParent)
     {
         PropertyStringComboBoxCtrl* newCtrl = aznew PropertyStringComboBoxCtrl(pParent);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
@@ -16,6 +16,9 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include "PropertyEditorAPI.h"
 #include <UI/PropertyEditor/GenericComboBoxCtrl.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
 
 #include <QWidget>
 #include <QToolButton>
@@ -49,13 +52,70 @@ namespace AzToolsFramework
         void UpdateTabOrder() override;
     };
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4661) // no suitable definition provided for explicit template instantiation request
+#endif
+
     template <class ValueType>
     class PropertyComboBoxHandlerCommon
         : public PropertyHandler<ValueType, PropertyStringComboBoxCtrl>
     {
         AZ::u32 GetHandlerName(void) const override  { return AZ::Edit::UIHandlers::ComboBox; }
         void UpdateWidgetInternalTabbing(PropertyStringComboBoxCtrl* widget) override { widget->UpdateTabOrder(); }
-        void ConsumeAttribute(PropertyStringComboBoxCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        void ConsumeAttribute(PropertyStringComboBoxCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override
+        {
+            if (attrib == AZ::Edit::Attributes::StringList)
+            {
+                AZStd::vector<AZStd::string> value;
+                if (attrValue->Read<AZStd::vector<AZStd::string> >(value))
+                {
+                    GUI->Add(value);
+                }
+                else
+                {
+                    (void)debugName;
+                    AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'StringList' attribute from property '%s' into string combo box. Expected string vector.", debugName);
+                }
+            }
+            else if (attrib == AZ::Edit::Attributes::ComboBoxEditable)
+            {
+                bool value;
+                if (attrValue->Read<bool>(value))
+                {
+                    GUI->GetComboBox()->setEditable(value);
+                }
+                else
+                {
+                    // emit a warning!
+                    AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'EditableCombBox' attribute from property '%s' into string combo box", debugName);
+                }
+                return;
+            }
+            else if (attrib == AZ_CRC_CE("EditButtonVisible"))
+            {
+                bool visible;
+                if (attrValue->Read<bool>(visible))
+                {
+                    GUI->GetEditButton()->setVisible(visible);
+                }
+            }
+            else if (attrib == AZ_CRC_CE("EditButtonCallback"))
+            {
+                if (auto* editButtonInvokable = azrtti_cast<AZ::AttributeInvocable<GenericEditResultOutcome<AZStd::string>(AZStd::string)>*>(attrValue->GetAttribute()))
+                {
+                    GUI->SetEditButtonCallBack(editButtonInvokable->GetCallable());
+                };
+            }
+            else if (attrib == AZ_CRC_CE("EditButtonToolTip"))
+            {
+                AZStd::string toolTip;
+                if (attrValue->Read<AZStd::string>(toolTip))
+                {
+                    GUI->GetEditButton()->setToolTip(toolTip.c_str());
+                }
+            }
+        }
     };
 
     class AZTF_API StringEnumPropertyComboBoxHandler
@@ -74,4 +134,8 @@ namespace AzToolsFramework
     };
 
     AZTF_API void RegisterStringComboBoxHandler();
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
@@ -52,70 +52,13 @@ namespace AzToolsFramework
         void UpdateTabOrder() override;
     };
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4661) // no suitable definition provided for explicit template instantiation request
-#endif
-
     template <class ValueType>
     class PropertyComboBoxHandlerCommon
         : public PropertyHandler<ValueType, PropertyStringComboBoxCtrl>
     {
         AZ::u32 GetHandlerName(void) const override  { return AZ::Edit::UIHandlers::ComboBox; }
         void UpdateWidgetInternalTabbing(PropertyStringComboBoxCtrl* widget) override { widget->UpdateTabOrder(); }
-        void ConsumeAttribute(PropertyStringComboBoxCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override
-        {
-            if (attrib == AZ::Edit::Attributes::StringList)
-            {
-                AZStd::vector<AZStd::string> value;
-                if (attrValue->Read<AZStd::vector<AZStd::string> >(value))
-                {
-                    GUI->Add(value);
-                }
-                else
-                {
-                    (void)debugName;
-                    AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'StringList' attribute from property '%s' into string combo box. Expected string vector.", debugName);
-                }
-            }
-            else if (attrib == AZ::Edit::Attributes::ComboBoxEditable)
-            {
-                bool value;
-                if (attrValue->Read<bool>(value))
-                {
-                    GUI->GetComboBox()->setEditable(value);
-                }
-                else
-                {
-                    // emit a warning!
-                    AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'EditableCombBox' attribute from property '%s' into string combo box", debugName);
-                }
-                return;
-            }
-            else if (attrib == AZ_CRC_CE("EditButtonVisible"))
-            {
-                bool visible;
-                if (attrValue->Read<bool>(visible))
-                {
-                    GUI->GetEditButton()->setVisible(visible);
-                }
-            }
-            else if (attrib == AZ_CRC_CE("EditButtonCallback"))
-            {
-                if (auto* editButtonInvokable = azrtti_cast<AZ::AttributeInvocable<GenericEditResultOutcome<AZStd::string>(AZStd::string)>*>(attrValue->GetAttribute()))
-                {
-                    GUI->SetEditButtonCallBack(editButtonInvokable->GetCallable());
-                };
-            }
-            else if (attrib == AZ_CRC_CE("EditButtonToolTip"))
-            {
-                AZStd::string toolTip;
-                if (attrValue->Read<AZStd::string>(toolTip))
-                {
-                    GUI->GetEditButton()->setToolTip(toolTip.c_str());
-                }
-            }
-        }
+        void ConsumeAttribute(PropertyStringComboBoxCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
     };
 
     class AZTF_API StringEnumPropertyComboBoxHandler
@@ -134,8 +77,4 @@ namespace AzToolsFramework
     };
 
     AZTF_API void RegisterStringComboBoxHandler();
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
@@ -10,7 +10,7 @@
 #include <AzQtComponents/Components/StyledLineEdit.h>
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option") // 4244: conversion from 'int' to 'float', possible loss of data
                                                                // 4251: 'QInputEvent::modState': class 'QFlags<Qt::KeyboardModifier>' needs to have dll-interface to be used by clients of class 'QInputEvent'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 #include <QFocusEvent>
 AZ_POP_DISABLE_WARNING
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
@@ -14,7 +14,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include "PropertyEditorAPI.h"
 #endif
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.cpp
@@ -9,9 +9,9 @@
 #include "PropertyQTConstants.h"
 #include <AzQtComponents/Components/Widgets/SpinBox.h>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QHBoxLayout>
+#include <QHBoxLayout>
 AZ_POP_DISABLE_WARNING
-#include <QtWidgets/QLabel>
+#include <QLabel>
 #include <AzCore/Math/Transform.h>
 #include <cmath>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.hxx
@@ -14,7 +14,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -13,18 +13,18 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Math/Sfmt.h>
 #include <AzToolsFramework/Slice/SliceUtilities.h>
-#include <QtWidgets/QMessageBox>
-#include <QtWidgets/QMenu>
-#include <QtWidgets/QDialogButtonBox>
-#include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QScrollArea>
-#include <QtWidgets/QApplication>
+#include <QMessageBox>
+#include <QMenu>
+#include <QDialogButtonBox>
+#include <QVBoxLayout>
+#include <QScrollArea>
+#include <QApplication>
 #include <QPainter>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 'QTextFormat::d': class 'QSharedDataPointer<QTextFormatPrivate>' needs to have dll-interface to be used by clients of class 'QTextFormat'
-#include <QtWidgets/QInputDialog>
+#include <QInputDialog>
 AZ_POP_DISABLE_WARNING
-#include <QtCore/QTimer>
-#include <QtCore/QSet>
+#include <QTimer>
+#include <QSet>
 #include <AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx>
 #include <AzCore/std/sort.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
@@ -15,8 +15,8 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzToolsFramework/UI/DocumentPropertyEditor/IPropertyEditor.h>
 #include "PropertyEditorAPI.h"
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QFrame>
+#include <QWidget>
+#include <QFrame>
 #endif
 
 class QScrollArea;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ThumbnailPropertyCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ThumbnailPropertyCtrl.cpp
@@ -75,7 +75,7 @@ namespace AzToolsFramework
 
     void ThumbnailPropertyCtrl::ClearThumbnail()
     {
-        m_key.clear();
+        m_key.reset();
         m_thumbnail->ClearThumbnail();
         m_thumbnailEnlarged->ClearThumbnail();
         UpdateVisibility();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.cpp
@@ -9,19 +9,19 @@
 #include <AzCore/PlatformDef.h>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
-#include <QtWidgets/QBoxLayout>
+#include <QBoxLayout>
 AZ_POP_DISABLE_WARNING
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QLayout>
-#include <QtWidgets/QLineEdit>
-#include <QtWidgets/QMenu>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QComboBox>
+#include <QLabel>
+#include <QLayout>
+#include <QLineEdit>
+#include <QMenu>
+#include <QPushButton>
+#include <QComboBox>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 'QFileInfo::d_ptr': class 'QSharedDataPointer<QFileInfoPrivate>' needs to have dll-interface to be used by clients of class 'QFileInfo'
-#include <QtWidgets/QFileDialog>
+#include <QFileDialog>
 AZ_POP_DISABLE_WARNING
-#include <QtWidgets/QMessageBox>
-#include <QtWidgets/QWidgetAction>
+#include <QMessageBox>
+#include <QWidgetAction>
 AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option") // 4144: conversion from 'int' to 'float', possible loss of data
                                                                // 4251: 'QInputEvent::modState': class 'QFlags<Qt::KeyboardModifier>' needs to have dll-interface to be used by clients of class 'QInputEvent'
 #include <QMouseEvent>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx
@@ -10,7 +10,7 @@
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 #if !defined(Q_MOC_RUN)
-#include <QtWidgets/QFrame>
+#include <QFrame>
 #include <QRegularExpression>
 
 #include <AzCore/std/string/string.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SliceOverridesNotificationWindow.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SliceOverridesNotificationWindow.hxx
@@ -9,7 +9,7 @@
 
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
-#include <QtWidgets/QWidget>
+#include <QWidget>
 
 namespace Ui
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SlicePushWidget.hxx
@@ -11,9 +11,9 @@
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 #if !defined(Q_MOC_RUN)
-#include <QtWidgets/QCheckBox>
-#include <QtWidgets/QWidget>
-#include <QtGui/QIcon>
+#include <QCheckBox>
+#include <QWidget>
+#include <QIcon>
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Slice/SliceComponent.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SliceRelationshipWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SliceRelationshipWidget.cpp
@@ -7,15 +7,15 @@
  */
 
 #include <AzCore/PlatformDef.h>
-#include <QtWidgets/QDialog>
-#include <QtWidgets/QDialogButtonBox>
+#include <QDialog>
+#include <QDialogButtonBox>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QTreeWidgetItemIterator::d_ptr': class 'QScopedPointer<QTreeWidgetItemIteratorPrivate,QScopedPointerDeleter<T>>' needs to have dll-interface to be used by clients of class 'QTreeWidgetItemIterator'
-#include <QtWidgets/QTreeWidget>
-#include <QtWidgets/QVBoxLayout>
+#include <QTreeWidget>
+#include <QVBoxLayout>
 AZ_POP_DISABLE_WARNING
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QHeaderView>
-#include <QtWidgets/QSplitter>
+#include <QPushButton>
+#include <QHeaderView>
+#include <QSplitter>
 
 #include "SliceRelationshipWidget.hxx"
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SliceRelationshipWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Slice/SliceRelationshipWidget.hxx
@@ -11,7 +11,7 @@
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 #if !defined(Q_MOC_RUN)
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <AzToolsFramework/Slice/SliceDependencyBrowserBus.h>
 #include <AzToolsFramework/UI/Slice/SliceRelationshipBus.h>
 #endif

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/QWidgetSavedState.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/QWidgetSavedState.cpp
@@ -9,8 +9,8 @@
 #include "QWidgetSavedState.h"
 
 #include <AzCore/Serialization/SerializeContext.h>
-#include <QtCore/QByteArray>
-#include <QtWidgets/QWidget>
+#include <QByteArray>
+#include <QWidget>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/TargetSelectorButton.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/TargetSelectorButton.hxx
@@ -14,8 +14,8 @@
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzFramework/Network/IRemoteTools.h>
-#include <QtWidgets/QPushButton>
-#include <qwidgetaction.h>
+#include <QPushButton>
+#include <QWidgetAction>
 #endif
 
 

--- a/Code/Framework/AzToolsFramework/Tests/EntityTestbed.h
+++ b/Code/Framework/AzToolsFramework/Tests/EntityTestbed.h
@@ -24,12 +24,12 @@
 #include <AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Application/ToolsApplication.h>
-#include <QtWidgets/QMainWindow>
-#include <QtWidgets/QApplication>
-#include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QPushButton>
-#include <QtWidgets/QFileDialog>
-#include <QtCore/QTimer>
+#include <QMainWindow>
+#include <QApplication>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QFileDialog>
+#include <QTimer>
 
 #pragma once
 

--- a/Code/Legacy/CryCommon/ILog.h
+++ b/Code/Legacy/CryCommon/ILog.h
@@ -6,11 +6,10 @@
  *
  */
 
-#ifndef CRYINCLUDE_CRYCOMMON_ILOG_H
-#define CRYINCLUDE_CRYCOMMON_ILOG_H
 #pragma once
 
 #include <IMiniLog.h> // <> required for Interfuscator
+#include <AzCore/std/string/string_view.h>
 
 // enable this define to support log scopes to provide more context information for log lines
 // this code is disable by default due it's runtime cost
@@ -251,9 +250,3 @@ public:
 
 #define CRY_DEFINE_ASSET_SCOPE(sAssetType, sAssetName) CLogAssetScopeName __asset_scope_name(gEnv->pLog, sAssetType, sAssetName);
 #endif
-
-
-#endif // CRYINCLUDE_CRYCOMMON_ILOG_H
-
-
-

--- a/Code/Legacy/CryCommon/IMiniLog.h
+++ b/Code/Legacy/CryCommon/IMiniLog.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <platform.h>
 #include <AzCore/std/function/function_fwd.h>
 namespace AZ::IO
 {

--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.h
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.h
@@ -14,8 +14,8 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h>
 
-#include <QtCore/QSet>
-#include <QtCore/QString>
+#include <QSet>
+#include <QString>
 
 #include "AzToolsFramework/API/EditorAssetSystemAPI.h"
 #include <native/AssetManager/SourceAssetReference.h>

--- a/Code/Tools/AssetProcessor/native/ui/BuilderInfoPatternsModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderInfoPatternsModel.cpp
@@ -6,7 +6,6 @@
  *
  */
 #include <ui/BuilderInfoPatternsModel.h>
-#include <AssetBuilderSDK/AssetBuilderSDK.h>
 
 namespace AssetProcessor
 {

--- a/Code/Tools/AssetProcessor/native/ui/BuilderInfoPatternsModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderInfoPatternsModel.h
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#if !defined(Q_MOC_RUN)
 #include <QAbstractItemModel>
 #include <AzCore/std/containers/vector.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
+#endif
 
 namespace AssetProcessor
 {

--- a/Code/Tools/AssetProcessor/native/ui/BuilderInfoPatternsModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderInfoPatternsModel.h
@@ -10,12 +10,7 @@
 
 #include <QAbstractItemModel>
 #include <AzCore/std/containers/vector.h>
-
-namespace AssetBuilderSDK
-{
-    struct AssetBuilderDesc;
-    struct AssetBuilderPattern;
-}
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
 
 namespace AssetProcessor
 {

--- a/Code/Tools/AssetProcessor/native/ui/GoToButtonDelegate.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/GoToButtonDelegate.cpp
@@ -7,8 +7,9 @@
  */
 
 #include "GoToButtonDelegate.h"
-#include <qpainter.h>
-#include <qevent.h>
+
+#include <QPainter>
+#include <QEvent>
 
 namespace AssetProcessor
 {

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -20,7 +20,6 @@
 #include <native/utilities/AssetUtilEBusHelper.h>
 #include <native/utilities/PlatformConfiguration.h>
 #include <native/ui/CacheServerData.h>
-#endif
 
 #include <QElapsedTimer>
 #include <QMainWindow>
@@ -28,6 +27,7 @@
 #include <QStringList>
 #include <QStringListModel>
 #include <ui/BuilderListModel.h>
+#endif
 
 namespace AzToolsFramework
 {

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -12,15 +12,22 @@
 #include <QStringList>
 #include <QStringListModel>
 #include "native/utilities/LogPanel.h"
-#include <QPointer>
-#include "native/assetprocessor.h"
+
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
+#include <AzCore/std/string/string_view.h>
 #include <AzQtComponents/Components/FilteredSearchWidget.h>
-#include <QElapsedTimer>
-#include <ui/BuilderListModel.h>
+#include <native/ui/CacheServerData.h>
 #include <native/utilities/AssetUtilEBusHelper.h>
 #include <native/utilities/PlatformConfiguration.h>
 #include <native/ui/CacheServerData.h>
 #endif
+
+#include <QElapsedTimer>
+#include <QMainWindow>
+#include <QPointer>
+#include <QStringList>
+#include <QStringListModel>
+#include <ui/BuilderListModel.h>
 
 namespace AzToolsFramework
 {

--- a/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
+++ b/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
@@ -10,7 +10,7 @@
 
 #include <AzQtComponents/Utilities/HandleDpiAwareness.h>
 
-#include <QtCore/QCoreApplication>
+#include <QCoreApplication>
 
 #if defined(EXTERNAL_CRASH_REPORTING)
 #include <ToolsCrashHandler.h>

--- a/Code/Tools/LuaIDE/Source/LUA/BreakpointPanel.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/BreakpointPanel.hxx
@@ -13,9 +13,9 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/base.h>
 
-#include <QtCore/QObject>
-#include <QtWidgets/QTableWidget>
-#include <QtWidgets/QWidget>
+#include <QObject>
+#include <QTableWidget>
+#include <QWidget>
 
 #include "LUABreakpointTrackerMessages.h"
 #endif

--- a/Code/Tools/LuaIDE/Source/LUA/ClassReferenceFilter.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/ClassReferenceFilter.hxx
@@ -12,9 +12,9 @@
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/Memory/SystemAllocator.h>
 
-#include <QtCore/QSortFilterProxyModel>
-#include <QtWidgets/QMainWindow>
-#include <QtCore/QSet>
+#include <QSortFilterProxyModel>
+#include <QMainWindow>
+#include <QSet>
 
 
 class ClassReferenceFilterModel : public QSortFilterProxyModel

--- a/Code/Tools/LuaIDE/Source/LUA/ClassReferencePanel.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/ClassReferencePanel.hxx
@@ -9,9 +9,9 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
 
-#include <QtCore/QObject>
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QTreeView>
+#include <QObject>
+#include <QWidget>
+#include <QTreeView>
 #endif
 
 #pragma once

--- a/Code/Tools/LuaIDE/Source/LUA/CodeCompletion/LUACompletionModel.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/CodeCompletion/LUACompletionModel.hxx
@@ -11,7 +11,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
-#include <QtCore/QStringListModel>
+#include <QStringListModel>
 #include <Source/LUA/LUAEditorStyleMessages.h>
 #include <QRegularExpression>
 #endif

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorBreakpointWidget.hxx
@@ -8,7 +8,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/base.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/std/functional.h>
 #include <AzCore/std/containers/unordered_set.h>

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFoldingWidget.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFoldingWidget.hxx
@@ -9,7 +9,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/base.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #include <Source/LUA/LUAEditorPlainTextEdit.hxx>
 #endif
 

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.hxx
@@ -57,7 +57,7 @@ namespace LUA
 }
 class ClassReferenceFilterModel;
 
-#include <QtWidgets/QMainWindow>
+#include <QMainWindow>
 #endif
 
 namespace LUAEditor

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorPlainTextEdit.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorPlainTextEdit.hxx
@@ -11,8 +11,8 @@
 #include <AzCore/base.h>
 #include <AzCore/std/functional.h>
 
-#include <QtWidgets/QCompleter>
-#include <QtWidgets/QPlainTextEdit>
+#include <QCompleter>
+#include <QPlainTextEdit>
 #endif
 
 #pragma once

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.cpp
@@ -11,7 +11,7 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 
-#include <QtWidgets/QVBoxLayout>
+#include <QVBoxLayout>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkAPI.h>

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSettingsDialog.hxx
@@ -13,7 +13,7 @@
 #include "LUAEditorView.hxx"
 #include "LUAEditorStyleMessages.h"
 
-#include <QtWidgets/QDialog>
+#include <QDialog>
 #endif
 
 #pragma once

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.hxx
@@ -14,7 +14,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
-#include <QtWidgets/QDockWidget>
+#include <QDockWidget>
 
 #include "LUAEditorContextInterface.h"
 #include "LUABreakpointTrackerMessages.h"

--- a/Code/Tools/LuaIDE/Source/LUA/StackPanel.hxx
+++ b/Code/Tools/LuaIDE/Source/LUA/StackPanel.hxx
@@ -13,9 +13,9 @@
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
 
-#include <QtCore/QObject>
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QTableWidget>
+#include <QObject>
+#include <QWidget>
+#include <QTableWidget>
 
 #include "LUAStackTrackerMessages.h"
 #endif

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemRequirementFilterProxyModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemRequirementFilterProxyModel.h
@@ -10,7 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzQtComponents/Utilities/SelectionProxyModel.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QItemSelectionModel)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemSortFilterProxyModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemSortFilterProxyModel.h
@@ -11,7 +11,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzQtComponents/Utilities/SelectionProxyModel.h>
 #include <GemCatalog/GemModel.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 #include <QSet>
 #endif
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
@@ -26,7 +26,7 @@ namespace ImageProcessingAtom
         ImageThumbnail::ImageThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey key)
             : Thumbnail(key)
         {
-            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.data());
+            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.get());
             if (sourceKey)
             {
                 bool foundIt = false;
@@ -41,7 +41,7 @@ namespace ImageProcessingAtom
                 }
             }
 
-            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.data());
+            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.get());
             if (productKey && productKey->GetAssetType() == AZ::RPI::StreamingImageAsset::RTTI_Type())
             {
                 m_assetIds.insert(productKey->GetAssetId());
@@ -110,7 +110,7 @@ namespace ImageProcessingAtom
 
         bool ImageThumbnailCache::IsSupportedThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey key) const
         {
-            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.data());
+            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.get());
             if (sourceKey)
             {
                 bool foundIt = false;
@@ -128,7 +128,7 @@ namespace ImageProcessingAtom
                 }
             }
 
-            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.data());
+            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.get());
             return productKey && productKey->GetAssetType() == AZ::RPI::StreamingImageAsset::RTTI_Type();
         }
     } // namespace Thumbnails

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
@@ -109,7 +109,7 @@ namespace ImageProcessingAtom
         void ImageThumbnailSystemComponent::RenderThumbnail(
             AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize)
         {
-            if (auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(thumbnailKey.data()))
+            if (auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(thumbnailKey.get()))
             {
                 bool foundIt = false;
                 AZ::Data::AssetInfo assetInfo;
@@ -127,7 +127,7 @@ namespace ImageProcessingAtom
                     );
                 }
             }
-            else if (auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(thumbnailKey.data()))
+            else if (auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(thumbnailKey.get()))
             {
                 m_imageAssetLoader->QueueAsset(
                     productKey->GetAssetId(),

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -192,7 +192,7 @@ namespace AtomToolsFramework
             m_thumbnailKeys[pathWithAlias] = thumbnailKey;
 
             connect(
-                thumbnailKey.data(), &AzToolsFramework::Thumbnailer::ThumbnailKey::ThumbnailUpdated, this,
+                thumbnailKey.get(), &AzToolsFramework::Thumbnailer::ThumbnailKey::ThumbnailUpdated, this,
                 [this, pathWithAlias]() { QueueUpdateThumbnail(pathWithAlias); });
 
             QueueUpdateThumbnail(pathWithAlias);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewUtils.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewUtils.cpp
@@ -42,7 +42,7 @@ namespace AZ
                 AZStd::vector<AZ::Data::AssetInfo> productsAssetInfo;
 
                 // if it's a source thumbnail key, find first product with a matching asset type
-                auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.data());
+                auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.get());
                 if (sourceKey)
                 {
                     bool foundIt = false;
@@ -52,7 +52,7 @@ namespace AZ
                 }
 
                 // if it's a product thumbnail key just return its assetInfo
-                auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.data());
+                auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.get());
                 if (productKey)
                 {
                     AZ::Data::AssetInfo assetInfo;

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportToolBar.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportToolBar.cpp
@@ -8,6 +8,7 @@
 
 #include <QToolButton>
 #include <QPushButton>
+#include <QActionGroup>
 #include <QMenu>
 #include <QSettings>
 #include <EMStudio/AtomRenderPlugin.h>

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/LoadActorSettingsWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/LoadActorSettingsWindow.h
@@ -10,6 +10,11 @@
 
 #if !defined(Q_MOC_RUN)
 #include "EMStudioConfig.h"
+
+#include <MCore/Source/MemoryCategoriesCore.h>
+#include <MCore/Source/MemoryManager.h>
+#include <AzCore/std/string/string.h>
+
 #include <QCheckBox>
 #include <QDialog>
 #endif

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RecoverFilesWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RecoverFilesWindow.h
@@ -10,6 +10,10 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+#include <MCore/Source/MemoryCategoriesCore.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/StandardPluginsConfig.h>
+
 #include "EMStudioConfig.h"
 #include <QDialog>
 #include <QTableWidget>

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphActionManager.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphActionManager.h
@@ -11,7 +11,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/std/containers/vector.h>
 #include <EMotionFX/Source/MotionSet.h>
-#include <QtCore/QObject>
+#include <QObject>
 #include <MCore/Source/StandardHeaders.h>
 #endif
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.cpp
@@ -20,9 +20,9 @@
 #include <EMotionFX/CommandSystem/Source/AnimGraphConnectionCommands.h>
 #include <EMotionFX/CommandSystem/Source/AnimGraphTriggerActionCommands.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h>
-#include <QtGui/QFont>
-#include <QtGui/QColor>
-#include <QtGui/QPixmap>
+#include <QFont>
+#include <QColor>
+#include <QPixmap>
 
 
 namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h
@@ -17,8 +17,8 @@
 #include <EMotionFX/Source/AnimGraphStateTransition.h>
 #include <EMotionFX/Source/BlendTreeConnection.h>
 #include <MCore/Source/Command.h>
-#include <QtCore/QAbstractItemModel>
-#include <QtCore/QItemSelectionModel>
+#include <QAbstractItemModel>
+#include <QItemSelectionModel>
 #include <Editor/QtMetaTypes.h>
 #endif
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.cpp
@@ -13,14 +13,20 @@
 namespace EMStudio
 {
 
-    SelectionProxyModel::SelectionProxyModel(QItemSelectionModel* sourceSelectionModel, QAbstractProxyModel* proxyModel, QObject* parent)
+    AnimGraphSelectionProxyModel::AnimGraphSelectionProxyModel(
+        QItemSelectionModel* sourceSelectionModel, QAbstractProxyModel* proxyModel, QObject* parent)
         : QItemSelectionModel(proxyModel, parent)
         , m_sourceSelectionModel(sourceSelectionModel)
     {
-        connect(sourceSelectionModel, &QItemSelectionModel::selectionChanged, this, &SelectionProxyModel::OnSourceSelectionChanged);
-        connect(sourceSelectionModel, &QItemSelectionModel::currentChanged, this, &SelectionProxyModel::OnSourceSelectionCurrentChanged);
+        connect(
+            sourceSelectionModel, &QItemSelectionModel::selectionChanged, this, &AnimGraphSelectionProxyModel::OnSourceSelectionChanged);
+        connect(
+            sourceSelectionModel,
+            &QItemSelectionModel::currentChanged,
+            this,
+            &AnimGraphSelectionProxyModel::OnSourceSelectionCurrentChanged);
         
-        connect(proxyModel, &QAbstractItemModel::rowsInserted, this, &SelectionProxyModel::OnProxyModelRowsInserted);
+        connect(proxyModel, &QAbstractItemModel::rowsInserted, this, &AnimGraphSelectionProxyModel::OnProxyModelRowsInserted);
 
         // Find the chain of proxy models
         QAbstractProxyModel* sourceProxyModel = proxyModel;
@@ -37,43 +43,43 @@ namespace EMStudio
         QItemSelectionModel::setCurrentIndex(currentModelIndex, QItemSelectionModel::Current | QItemSelectionModel::ClearAndSelect);
     }
 
-    SelectionProxyModel::~SelectionProxyModel()
+    AnimGraphSelectionProxyModel::~AnimGraphSelectionProxyModel()
     {}
 
-    void SelectionProxyModel::setCurrentIndex(const QModelIndex &index, QItemSelectionModel::SelectionFlags command)
+    void AnimGraphSelectionProxyModel::setCurrentIndex(const QModelIndex& index, QItemSelectionModel::SelectionFlags command)
     {
         const QModelIndex sourcetIndex = mapToSource(index);
         m_sourceSelectionModel->setCurrentIndex(sourcetIndex, command);
     }
 
-    void SelectionProxyModel::select(const QModelIndex &index, QItemSelectionModel::SelectionFlags command)
+    void AnimGraphSelectionProxyModel::select(const QModelIndex& index, QItemSelectionModel::SelectionFlags command)
     {
         const QModelIndex sourceIndex = mapToSource(index);
         m_sourceSelectionModel->select(sourceIndex, command);
     }
 
-    void SelectionProxyModel::select(const QItemSelection &selection, QItemSelectionModel::SelectionFlags command)
+    void AnimGraphSelectionProxyModel::select(const QItemSelection& selection, QItemSelectionModel::SelectionFlags command)
     {
         const QItemSelection sourceSelection = mapToSource(selection);
         m_sourceSelectionModel->select(sourceSelection, command);
     }
 
-    void SelectionProxyModel::clear()
+    void AnimGraphSelectionProxyModel::clear()
     {
         m_sourceSelectionModel->clear();
     }
 
-    void SelectionProxyModel::reset()
+    void AnimGraphSelectionProxyModel::reset()
     {
         m_sourceSelectionModel->reset();
     }
 
-    void SelectionProxyModel::clearCurrentIndex()
+    void AnimGraphSelectionProxyModel::clearCurrentIndex()
     {
         m_sourceSelectionModel->clearCurrentIndex();
     }
 
-    void SelectionProxyModel::OnSourceSelectionCurrentChanged(const QModelIndex& current, const QModelIndex& previous)
+    void AnimGraphSelectionProxyModel::OnSourceSelectionCurrentChanged(const QModelIndex& current, const QModelIndex& previous)
     {
         AZ_UNUSED(previous);
 
@@ -81,7 +87,7 @@ namespace EMStudio
         QItemSelectionModel::setCurrentIndex(targetCurrent, QItemSelectionModel::Current | QItemSelectionModel::NoUpdate);
     }
 
-    void SelectionProxyModel::OnSourceSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
+    void AnimGraphSelectionProxyModel::OnSourceSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
     {
         QItemSelection targetSelected = mapFromSource(selected);
         QItemSelection targetDeselected = mapFromSource(deselected);
@@ -90,7 +96,8 @@ namespace EMStudio
         QItemSelectionModel::select(targetDeselected, QItemSelectionModel::Current | QItemSelectionModel::Deselect | QItemSelectionModel::Rows);
     }
 
-    void SelectionProxyModel::OnProxyModelRowsInserted([[maybe_unused]] const QModelIndex& parent, [[maybe_unused]] int first, [[maybe_unused]] int last)
+    void AnimGraphSelectionProxyModel::OnProxyModelRowsInserted(
+        [[maybe_unused]] const QModelIndex& parent, [[maybe_unused]] int first, [[maybe_unused]] int last)
     {
         QModelIndex sourceIndex = m_sourceSelectionModel->currentIndex();
         QModelIndex targetIndex = mapFromSource(sourceIndex);
@@ -107,7 +114,7 @@ namespace EMStudio
         }
     }
 
-    QModelIndex SelectionProxyModel::mapFromSource(const QModelIndex& sourceIndex)
+    QModelIndex AnimGraphSelectionProxyModel::mapFromSource(const QModelIndex& sourceIndex)
     {
         QModelIndex mappedIndex = sourceIndex;
         for (AZStd::vector<QAbstractProxyModel*>::const_reverse_iterator itProxy = m_proxyModels.rbegin(); itProxy != m_proxyModels.rend(); ++itProxy) {
@@ -116,7 +123,7 @@ namespace EMStudio
         return mappedIndex;
     }
 
-    QItemSelection SelectionProxyModel::mapFromSource(const QItemSelection& sourceSelection)
+    QItemSelection AnimGraphSelectionProxyModel::mapFromSource(const QItemSelection& sourceSelection)
     {
         QItemSelection mappedSelection = sourceSelection;
         for (AZStd::vector<QAbstractProxyModel*>::const_reverse_iterator itProxy = m_proxyModels.rbegin(); itProxy != m_proxyModels.rend(); ++itProxy) {
@@ -125,7 +132,7 @@ namespace EMStudio
         return mappedSelection;
     }
 
-    QModelIndex SelectionProxyModel::mapToSource(const QModelIndex& targetIndex)
+    QModelIndex AnimGraphSelectionProxyModel::mapToSource(const QModelIndex& targetIndex)
     {
         QModelIndex mappedIndex = targetIndex;
         for (AZStd::vector<QAbstractProxyModel*>::const_iterator itProxy = m_proxyModels.begin(); itProxy != m_proxyModels.end(); ++itProxy) {
@@ -134,7 +141,7 @@ namespace EMStudio
         return mappedIndex;
     }
 
-    QItemSelection SelectionProxyModel::mapToSource(const QItemSelection& targetSelection)
+    QItemSelection AnimGraphSelectionProxyModel::mapToSource(const QItemSelection& targetSelection)
     {
         QItemSelection mappedSelection = targetSelection;
         for (AZStd::vector<QAbstractProxyModel*>::const_iterator itProxy = m_proxyModels.begin(); itProxy != m_proxyModels.end(); ++itProxy) {
@@ -145,4 +152,4 @@ namespace EMStudio
 
 } // namespace EMStudio
 
-#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/moc_SelectionProxyModel.cpp>
+#include <EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/moc_AnimGraphSelectionProxyModel.cpp>

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/SelectionProxyModel.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.h>
+#include <QSortFilterProxyModel>
 
 
 namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <QtCore/QItemSelectionModel>
+#include <QItemSelectionModel>
 #include <AzCore/std/containers/vector.h>
 #endif
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.h
@@ -24,14 +24,14 @@ namespace EMStudio
     // NOTE: this class does not support changing proxy models (anywhere in the chain). 
     // The class will have to be recreated with the new proxy model.
     //
-    class SelectionProxyModel
+    class AnimGraphSelectionProxyModel
         : public QItemSelectionModel
     {
         Q_OBJECT
 
     public:
-        SelectionProxyModel(QItemSelectionModel* sourceSelectionModel, QAbstractProxyModel* proxyModel, QObject* parent = nullptr);
-        ~SelectionProxyModel() override;
+        AnimGraphSelectionProxyModel(QItemSelectionModel* sourceSelectionModel, QAbstractProxyModel* proxyModel, QObject* parent = nullptr);
+        ~AnimGraphSelectionProxyModel() override;
 
         void setCurrentIndex(const QModelIndex &index, QItemSelectionModel::SelectionFlags command) override;
         void select(const QModelIndex &index, QItemSelectionModel::SelectionFlags command) override;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSortFilterProxyModel.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSortFilterProxyModel.h
@@ -11,7 +11,7 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/std/containers/unordered_set.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 #endif
 
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h
@@ -10,7 +10,9 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphActionManager.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraph.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/StandardPluginsConfig.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.h>

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigateWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigateWidget.cpp
@@ -14,7 +14,7 @@
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSortFilterProxyModel.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphWidget.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigateWidget.h>
-#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/SelectionProxyModel.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphSelectionProxyModel.h>
 #include <QHeaderView>
 #include <QKeyEvent>
 #include <QTreeView>
@@ -72,7 +72,7 @@ namespace EMStudio
         m_treeView->setItemDelegate(new AnimGraphItemDelegate(m_treeView));
 
         // tree's selection model
-        m_selectionProxyModel = new SelectionProxyModel(&plugin->GetAnimGraphModel().GetSelectionModel(), m_filterProxyModel, m_treeView);
+        m_selectionProxyModel = new AnimGraphSelectionProxyModel(&plugin->GetAnimGraphModel().GetSelectionModel(), m_filterProxyModel, m_treeView);
         m_treeView->setSelectionModel(m_selectionProxyModel);
         m_treeView->setSelectionMode(QAbstractItemView::ExtendedSelection);
         m_treeView->setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigateWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigateWidget.h
@@ -10,6 +10,8 @@
 
 #if !defined(Q_MOC_RUN)
 #include <MCore/Source/StandardHeaders.h>
+#include <MCore/Source/MemoryCategoriesCore.h>
+#include <EMotionStudio/Plugins/StandardPlugins/Source/StandardPluginsConfig.h>
 #include <QWidget>
 #endif
 
@@ -25,7 +27,7 @@ namespace EMStudio
     // forward declarations
     class AnimGraphPlugin;
     class AnimGraphSortFilterProxyModel;
-    class SelectionProxyModel;
+    class AnimGraphSelectionProxyModel;
 
     class NavigateWidget
         : public QWidget
@@ -52,7 +54,7 @@ namespace EMStudio
         AzQtComponents::FilteredSearchWidget* m_searchWidget;
         QTreeView* m_treeView;
         AnimGraphSortFilterProxyModel* m_filterProxyModel;
-        SelectionProxyModel* m_selectionProxyModel;
+        AnimGraphSelectionProxyModel* m_selectionProxyModel;
     };
 
 } // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.h
@@ -11,7 +11,7 @@
 #if !defined(Q_MOC_RUN)
 #include <EMotionStudio/Plugins/StandardPlugins/Source/StandardPluginsConfig.h>
 #include <AzQtComponents/Components/Widgets/BreadCrumbs.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QPixmap)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/RoleFilterProxyModel.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/RoleFilterProxyModel.h
@@ -10,7 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/std/containers/vector.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 #endif
 
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/standardplugins_files.cmake
@@ -81,7 +81,7 @@ set(FILES
     Source/AnimGraph/RoleFilterProxyModel.cpp
     Source/AnimGraph/RoleFilterProxyModel.h
     Source/AnimGraph/AnimGraphSelectionProxyModel.cpp
-    Source/AnimGraph/SelectionProxyModel.h
+    Source/AnimGraph/AnimGraphSelectionProxyModel.h
     Source/AnimGraph/StateFilterSelectionWindow.cpp
     Source/AnimGraph/StateFilterSelectionWindow.h
     Source/AnimGraph/StateGraphNode.cpp

--- a/Gems/EMotionFX/Code/MysticQt/Source/DialogStack.h
+++ b/Gems/EMotionFX/Code/MysticQt/Source/DialogStack.h
@@ -10,8 +10,8 @@
 
 #if !defined(Q_MOC_RUN)
 #include "MysticQtConfig.h"
-#include <QtWidgets/QWidget>
-#include <QtWidgets/QScrollArea>
+#include <QWidget>
+#include <QScrollArea>
 #include <AzCore/std/containers/vector.h>
 #endif
 

--- a/Gems/EMotionFX/Code/MysticQt/Source/KeyboardShortcutManager.cpp
+++ b/Gems/EMotionFX/Code/MysticQt/Source/KeyboardShortcutManager.cpp
@@ -14,9 +14,9 @@
 
 #include <MCore/Source/LogManager.h>
 #include <MCore/Source/IDGenerator.h>
-#include <QtCore/QStringList>
-#include <QtCore/QSettings>
-#include <QtGui/QKeyEvent>
+#include <QStringList>
+#include <QSettings>
+#include <QKeyEvent>
 
 namespace MysticQt
 {

--- a/Gems/EMotionFX/Code/MysticQt/Source/MysticQtConfig.h
+++ b/Gems/EMotionFX/Code/MysticQt/Source/MysticQtConfig.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <AzCore/std/string/string.h>
-#include <QtCore/QString>
+#include <QString>
 #include <MCore/Source/Config.h>
 
 // when we use DLL files, setup the EMFX_API macro

--- a/Gems/EMotionFX/Code/MysticQt/Source/MysticQtManager.cpp
+++ b/Gems/EMotionFX/Code/MysticQt/Source/MysticQtManager.cpp
@@ -9,7 +9,7 @@
 // include required files
 #include "MysticQtManager.h"
 #include <MCore/Source/StringConversions.h>
-#include <QtGui/QIcon>
+#include <QIcon>
 #include <QDir>
 
 namespace MysticQt

--- a/Gems/EMotionFX/Code/MysticQt/Source/RecentFiles.cpp
+++ b/Gems/EMotionFX/Code/MysticQt/Source/RecentFiles.cpp
@@ -13,10 +13,10 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <EMotionFX/Source/EMotionFXManager.h>
-#include <QtCore/QFileInfo>
-#include <QtCore/QSettings>
-#include <QtGui/QHelpEvent>
-#include <QtWidgets/QToolTip>
+#include <QFileInfo>
+#include <QSettings>
+#include <QHelpEvent>
+#include <QToolTip>
 
 namespace MysticQt
 {

--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/LODSceneGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/LODSceneGraphWidget.cpp
@@ -7,8 +7,8 @@
  */
 
 #include <QStandardItemModel>
-#include <QtWidgets/QCheckBox>
-#include <QtWidgets/QTreeView>
+#include <QCheckBox>
+#include <QTreeView>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/Views/PairIterator.h>
 #include <SceneAPI/SceneCore/Containers/Views/SceneGraphDownwardsIterator.h>

--- a/Gems/EMotionFX/Code/Source/Editor/SelectionProxyModel.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SelectionProxyModel.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <Source/Editor/SelectionProxyModel.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 
 
 namespace EMotionFX

--- a/Gems/EMotionFX/Code/Source/Editor/SelectionProxyModel.h
+++ b/Gems/EMotionFX/Code/Source/Editor/SelectionProxyModel.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <QtCore/QItemSelectionModel>
+#include <QItemSelectionModel>
 #include <AzCore/std/containers/vector.h>
 #endif
 

--- a/Gems/EMotionFX/Code/Source/Editor/SimulatedObjectModel.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/SimulatedObjectModel.cpp
@@ -13,7 +13,7 @@
 #include <EMotionFX/CommandSystem/Source/SimulatedObjectCommands.h>
 #include <EMotionFX/CommandSystem/Source/ColliderCommands.h>
 #include <Source/Editor/SimulatedObjectModel.h>
-#include <QtGui/QFont>
+#include <QFont>
 #include <Editor/QtMetaTypes.h>
 
 namespace EMotionFX

--- a/Gems/EMotionFX/Code/Source/Editor/SimulatedObjectModel.h
+++ b/Gems/EMotionFX/Code/Source/Editor/SimulatedObjectModel.h
@@ -13,8 +13,8 @@
 #include <EMotionFX/Source/Actor.h>
 #include <EMotionFX/Source/ActorInstance.h>
 #include <EMotionFX/Source/Node.h>
-#include <QtCore/QAbstractItemModel>
-#include <QtCore/QItemSelectionModel>
+#include <QAbstractItemModel>
+#include <QItemSelectionModel>
 #include <Editor/ActorEditorBus.h>
 #include <MCore/Source/Command.h>
 #include <EMotionFX/Source/SimulatedObjectSetup.h>

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.h
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonModel.h
@@ -12,8 +12,8 @@
 #include <EMotionFX/Source/Actor.h>
 #include <EMotionFX/Source/ActorInstance.h>
 #include <EMotionFX/Source/Node.h>
-#include <QtCore/QAbstractItemModel>
-#include <QtCore/QItemSelectionModel>
+#include <QAbstractItemModel>
+#include <QItemSelectionModel>
 #include <Editor/ActorEditorBus.h>
 #include <Editor/QtMetaTypes.h>
 #include <QIcon>

--- a/Gems/EMotionFX/Code/Source/Editor/SkeletonSortFilterProxyModel.h
+++ b/Gems/EMotionFX/Code/Source/Editor/SkeletonSortFilterProxyModel.h
@@ -10,7 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/std/containers/vector.h>
-#include <QtCore/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 #include <AzQtComponents/Components/FilteredSearchWidget.h>
 #endif
 

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -67,7 +67,7 @@
 
 #if defined(EMOTIONFXANIMATION_EDITOR) // EMFX tools / editor includes
 // Qt
-#include <QtGui/QSurfaceFormat>
+#include <QSurfaceFormat>
 // EMStudio tools and main window registration
 #include <LyViewPaneNames.h>
 #include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/AnimGraphActivateTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/AnimGraphActivateTests.cpp
@@ -10,7 +10,7 @@
 
 #include <QAction>
 #include <QtTest>
-#include <qtoolbar.h>
+#include <QToolBar>
 #include <QWidget>
 #include <QComboBox>
 

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/AnimGraphNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/AnimGraphNodeTests.cpp
@@ -9,11 +9,11 @@
 #include <gtest/gtest.h>
 
 #include <QtTest>
-#include <qtoolbar.h>
+#include <QToolBar>
 #include <QWidget>
 #include <QComboBox>
 #include <QModelIndex>
-#include <qrect.h>
+#include <QRect>
 
 #include <Tests/UI/UIFixture.h>
 #include <EMotionFX/Source/AnimGraphMotionNode.h>

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/StateMachine/EntryStateTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/StateMachine/EntryStateTests.cpp
@@ -10,10 +10,10 @@
 
 #include <QAction>
 #include <QtTest/QtTest>
-#include <qtoolbar.h>
+#include <QToolBar>
 #include <QWidget>
 #include <QComboBox>
-#include <qrect.h>
+#include <QRect>
 
 #include <Tests/UI/AnimGraphUIFixture.h>
 #include <EMotionFX/Source/AnimGraphMotionNode.h>

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Transitions/AddTransitionCondition.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/AnimGraph/Transitions/AddTransitionCondition.cpp
@@ -11,7 +11,7 @@
 #include <QAction>
 #include <QtTest>
 #include <QWidget>
-#include <qrect.h>
+#include <QRect>
 
 #include <EMotionFX/Source/AnimGraphMotionNode.h>
 #include <EMotionFX/Source/AnimGraphEntryNode.h>

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanAddMotions.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanAddMotions.cpp
@@ -12,7 +12,7 @@
 #include <QAction>
 #include <QtTest>
 #include <QTableWidget>
-#include <qtoolbar.h>
+#include <QToolBar>
 
 #include <Tests/UI/UIFixture.h>
 #include <EMotionFX/Source/MotionManager.h>

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanRemoveMotions.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Motions/CanRemoveMotions.cpp
@@ -12,7 +12,7 @@
 #include <QAction>
 #include <QtTest>
 #include <QTableWidget>
-#include <qtoolbar.h>
+#include <QToolBar>
 
 #include <Tests/UI/UIFixture.h>
 #include <Tests/UI/ModalPopupHandler.h>

--- a/Gems/EMotionFX/Code/Tests/SimulatedObjectModelTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/SimulatedObjectModelTests.cpp
@@ -14,7 +14,7 @@
 #include "EMotionFX/Source/Skeleton.h"
 #include "EMotionStudio/EMStudioSDK/Source/EMStudioManager.h"
 #include "Editor/Plugins/SimulatedObject/SimulatedObjectWidget.h"
-#include <QtWidgets/QApplication>
+#include <QApplication>
 
 #include <Editor/SimulatedObjectModel.h>
 #include <AzTest/AzTest.h>

--- a/Gems/EMotionFX/Code/Tests/UI/CanAddAnimGraph.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAddAnimGraph.cpp
@@ -11,7 +11,7 @@
 #include <QPushButton>
 #include <QAction>
 #include <QtTest>
-#include <qtoolbar.h>
+#include <QToolBar>
 
 #include <Tests/UI/UIFixture.h>
 #include <EMotionFX/Source/AnimGraphManager.h>

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Editor/PaintableImageAssetHelper.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Editor/PaintableImageAssetHelper.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#if !defined(Q_MOC_RUN)
 #include <AzCore/Component/ComponentBus.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/containers/vector.h>
@@ -17,6 +19,7 @@
 #include <GradientSignal/Util.h>
 #include <GradientSignal/Editor/EditorGradientImageCreatorRequestBus.h>
 #include <QDialog>
+#endif
 
 namespace AzQtComponents
 {

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Editor/PaintableImageAssetHelper.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Editor/PaintableImageAssetHelper.h
@@ -16,6 +16,12 @@
 
 #include <GradientSignal/Util.h>
 #include <GradientSignal/Editor/EditorGradientImageCreatorRequestBus.h>
+#include <QDialog>
+
+namespace AzQtComponents
+{
+    class SpinBox;
+}
 
 namespace GradientSignal::ImageCreatorUtils
 {
@@ -25,6 +31,29 @@ namespace GradientSignal::ImageCreatorUtils
         (AutoSave, 1),
         (AutoSaveWithIncrementalNames, 2)
     );
+
+    //! CreateImageDialog allows the user to specify a set of image creation parameters for use in creating a new image asset.
+    class CreateImageDialog : public QDialog
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(CreateImageDialog, AZ::SystemAllocator);
+
+        CreateImageDialog(QWidget* parent = nullptr);
+        ~CreateImageDialog() = default;
+
+        int GetWidth();
+        int GetHeight();
+
+    private:
+        // Min/max/default values for the image dimensions
+        static inline constexpr int MinPixels = 1;
+        static inline constexpr int MaxPixels = 8192;
+        static inline constexpr int DefaultPixels = 512;
+
+        AzQtComponents::SpinBox* m_width = nullptr;
+        AzQtComponents::SpinBox* m_height = nullptr;
+    };
 
     //! Helper class to manage all the common logic and UX for paintable image creation, editing, and saving.
     //! This is split out from PaintableImageAssetHelper so that we can minimize the amount of duplicated code caused

--- a/Gems/GradientSignal/Code/Source/Editor/PaintableImageAssetHelper.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/PaintableImageAssetHelper.cpp
@@ -38,84 +38,65 @@
 
 namespace GradientSignal::ImageCreatorUtils
 {
-    //! CreateImageDialog allows the user to specify a set of image creation parameters for use in creating a new image asset.
-    class CreateImageDialog : public QDialog
-    {
-        Q_OBJECT
-    public:
-        AZ_CLASS_ALLOCATOR(CreateImageDialog, AZ::SystemAllocator);
-
-        CreateImageDialog(QWidget* parent = nullptr)
-            : QDialog(parent)
-        {
-            setModal(true);
-            setMinimumWidth(300);
-            resize(300, 100);
-            setWindowTitle("Create New Image");
-
-            // Create the layout for all the widgets to be stacked vertically.
-            auto verticalLayout = new QVBoxLayout();
-
-            // Create the width and height widgets
-
-            m_width = new AzQtComponents::SpinBox();
-            m_width->setRange(MinPixels, MaxPixels);
-            m_width->setValue(DefaultPixels);
-
-            m_height = new AzQtComponents::SpinBox();
-            m_height->setRange(MinPixels, MaxPixels);
-            m_height->setValue(DefaultPixels);
-
-            QGridLayout* dimensionsLayout = new QGridLayout();
-            dimensionsLayout->addWidget(new QLabel("Width:"), 0, 0);
-            dimensionsLayout->addWidget(m_width, 0, 1);
-            dimensionsLayout->addWidget(new QLabel("Height:"), 0, 2);
-            dimensionsLayout->addWidget(m_height, 0, 3);
-
-            verticalLayout->addLayout(dimensionsLayout);
-
-            // Connect ok and cancel buttons and change "ok" to "next".
-            auto buttonBox = new QDialogButtonBox(this);
-            buttonBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
-            buttonBox->setOrientation(Qt::Horizontal);
-            buttonBox->setStandardButtons(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
-            QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
-            QObject::connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-            verticalLayout->addWidget(buttonBox);
-
-            // We set this to "Next" instead of "OK" because after the dialog box completes, a standard native file picker dialog
-            // will appear to select the save location for the created image, so the entire process appears as two steps to the end user.
-            buttonBox->button(QDialogButtonBox::Ok)->setText("Next");
-
-            auto gridLayout = new QGridLayout(this);
-            gridLayout->addLayout(verticalLayout, 0, 0, 1, 1);
-
-            adjustSize();
-        }
-
-        ~CreateImageDialog() = default;
-
-        int GetWidth()
-        {
-            return m_width->value();
-        }
-
-        int GetHeight()
-        {
-            return m_height->value();
-        }
-
-    private:
-        // Min/max/default values for the image dimensions
-        static inline constexpr int MinPixels = 1;
-        static inline constexpr int MaxPixels = 8192;
-        static inline constexpr int DefaultPixels = 512;
-
-        AzQtComponents::SpinBox* m_width = nullptr;
-        AzQtComponents::SpinBox* m_height = nullptr;
-    };
-
     AZ_ENUM_DEFINE_REFLECT_UTILITIES(PaintableImageAssetAutoSaveMode);
+
+    CreateImageDialog::CreateImageDialog(QWidget* parent)
+        : QDialog(parent)
+    {
+        setModal(true);
+        setMinimumWidth(300);
+        resize(300, 100);
+        setWindowTitle("Create New Image");
+
+        // Create the layout for all the widgets to be stacked vertically.
+        auto verticalLayout = new QVBoxLayout();
+
+        // Create the width and height widgets
+
+        m_width = new AzQtComponents::SpinBox();
+        m_width->setRange(MinPixels, MaxPixels);
+        m_width->setValue(DefaultPixels);
+
+        m_height = new AzQtComponents::SpinBox();
+        m_height->setRange(MinPixels, MaxPixels);
+        m_height->setValue(DefaultPixels);
+
+        QGridLayout* dimensionsLayout = new QGridLayout();
+        dimensionsLayout->addWidget(new QLabel("Width:"), 0, 0);
+        dimensionsLayout->addWidget(m_width, 0, 1);
+        dimensionsLayout->addWidget(new QLabel("Height:"), 0, 2);
+        dimensionsLayout->addWidget(m_height, 0, 3);
+
+        verticalLayout->addLayout(dimensionsLayout);
+
+        // Connect ok and cancel buttons and change "ok" to "next".
+        auto buttonBox = new QDialogButtonBox(this);
+        buttonBox->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
+        buttonBox->setOrientation(Qt::Horizontal);
+        buttonBox->setStandardButtons(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
+        QObject::connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+        QObject::connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+        verticalLayout->addWidget(buttonBox);
+
+        // We set this to "Next" instead of "OK" because after the dialog box completes, a standard native file picker dialog
+        // will appear to select the save location for the created image, so the entire process appears as two steps to the end user.
+        buttonBox->button(QDialogButtonBox::Ok)->setText("Next");
+
+        auto gridLayout = new QGridLayout(this);
+        gridLayout->addLayout(verticalLayout, 0, 0, 1, 1);
+
+        adjustSize();
+    }
+
+    int CreateImageDialog::GetWidth()
+    {
+        return m_width->value();
+    }
+
+    int CreateImageDialog::GetHeight()
+    {
+        return m_height->value();
+    }
 
     void PaintableImageAssetHelperBase::Reflect(AZ::ReflectContext* context)
     {
@@ -610,5 +591,3 @@ namespace GradientSignal::ImageCreatorUtils
         return createdAsset;
     }
 } // namespace GradientSignal::ImageCreatorUtils
-
-#include "PaintableImageAssetHelper.moc"

--- a/Gems/GraphCanvas/Code/Source/Components/BookmarkAnchor/BookmarkAnchorComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/BookmarkAnchor/BookmarkAnchorComponent.h
@@ -8,8 +8,8 @@
  */
 #pragma once
 
-#include <qgraphicswidget.h>
-#include <qcolor.h>
+#include <QGraphicsWidget>
+#include <QColor>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Math/Color.h>

--- a/Gems/GraphCanvas/Code/Source/Components/BookmarkAnchor/BookmarkAnchorVisualComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/BookmarkAnchor/BookmarkAnchorVisualComponent.h
@@ -7,8 +7,8 @@
  */
 #pragma once
 
-#include <qgraphicswidget.h>
-#include <qcolor.h>
+#include <QGraphicsWidget>
+#include <QColor>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityBus.h>

--- a/Gems/GraphCanvas/Code/Source/Components/BookmarkManagerComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/BookmarkManagerComponent.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qgraphicsitem.h>
+#include <QGraphicsItem>
 
 #include <AzCore/Component/Entity.h>
 

--- a/Gems/GraphCanvas/Code/Source/Components/BookmarkManagerComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/BookmarkManagerComponent.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qrect.h>
+#include <QRect>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityId.h>

--- a/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionComponent.cpp
@@ -6,9 +6,9 @@
  *
  */
 
-#include <qcursor.h>
-#include <qgraphicsscene.h>
-#include <qgraphicsview.h>
+#include <QCursor>
+#include <QGraphicsScene>
+#include <QGraphicsView>
 #include <QToolTip>
 
 #include <AzCore/Serialization/EditContext.h>

--- a/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionComponent.h
@@ -10,8 +10,8 @@
 #include <AzCore/PlatformDef.h>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
-#include <qgraphicswidget.h>
-#include <qgraphicssceneevent.h>
+#include <QGraphicsWidget>
+#include <QGraphicsSceneEvent>
 #include <QTimer>
 AZ_POP_DISABLE_WARNING
 

--- a/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionVisualComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Connections/ConnectionVisualComponent.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qevent.h>
+#include <QEvent>
 #include <QtMath>
 #include <QPainter>
 #include <QGraphicsSceneContextMenuEvent>

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/Comment/CommentTextGraphicsWidget.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/Comment/CommentTextGraphicsWidget.cpp
@@ -14,7 +14,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800 4244, "-Wunknown-warning-option")
 #include <QGraphicsGridLayout>
 #include <QGraphicsLayoutItem>
 #include <QGraphicsScene>
-#include <qgraphicssceneevent.h>
+#include <QGraphicsSceneEvent>
 #include <QGraphicsWidget>
 #include <QPainter>
 AZ_POP_DISABLE_WARNING

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/Group/NodeGroupFrameComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/Group/NodeGroupFrameComponent.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <QGraphicsWidget>
-#include <qgraphicslinearlayout.h>
+#include <QGraphicsLinearLayout>
 
 #include <AzCore/Math/Color.h>
 

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/Wrapper/WrapperNodeLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/Wrapper/WrapperNodeLayoutComponent.cpp
@@ -11,7 +11,7 @@
 #include <QGraphicsLayoutItem>
 #include <QGraphicsGridLayout>
 #include <QGraphicsScene>
-#include <qgraphicssceneevent.h>
+#include <QGraphicsSceneEvent>
 
 #include <AzCore/RTTI/TypeInfo.h>
 

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/Wrapper/WrapperNodeLayoutComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/Wrapper/WrapperNodeLayoutComponent.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <QGraphicsLinearLayout>
-#include <qgraphicswidget.h>
+#include <QGraphicsWidget>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityBus.h>

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotLayoutComponent.cpp
@@ -7,9 +7,9 @@
  */
 
 #include <QCoreApplication>
-#include <qgraphicslayoutitem.h>
-#include <qgraphicsscene.h>
-#include <qsizepolicy.h>
+#include <QGraphicsLayoutItem>
+#include <QGraphicsScene>
+#include <QSizePolicy>
 #include <QGraphicsSceneDragDropEvent>
 
 #include <AzQtComponents/Components/ToastNotification.h>

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Property/PropertySlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Property/PropertySlotLayoutComponent.cpp
@@ -7,9 +7,9 @@
  */
 
 #include <QCoreApplication>
-#include <qgraphicslayoutitem.h>
-#include <qgraphicsscene.h>
-#include <qsizepolicy.h>
+#include <QGraphicsLayoutItem>
+#include <QGraphicsScene>
+#include <QSizePolicy>
 
 #include <Components/Slots/Property/PropertySlotLayoutComponent.h>
 

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/SlotLayoutComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/SlotLayoutComponent.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qgraphicswidget.h>
+#include <QGraphicsWidget>
 
 #include <AzCore/Component/Component.h>
 

--- a/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasCheckBox.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasCheckBox.cpp
@@ -9,7 +9,7 @@
 #include <QCoreApplication>
 #include <QFont>
 #include <QGraphicsItem>
-#include <qgraphicssceneevent.h>
+#include <QGraphicsSceneEvent>
 #include <QPainter>
 
 #include <AzCore/Serialization/EditContext.h>

--- a/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasLabel.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasLabel.cpp
@@ -11,7 +11,7 @@
 #include <QGraphicsItem>
 #include <QGraphicsSceneEvent>
 #include <QPainter>
-#include <qwidget.h>
+#include <QWidget>
 
 #include <AzCore/Serialization/EditContext.h>
 

--- a/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/NodePropertyDisplayWidget.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <qgraphicslinearlayout.h>
-#include <qgraphicsscene.h>
+#include <QGraphicsLinearLayout>
+#include <QGraphicsScene>
 
 #include <Widgets/NodePropertyDisplayWidget.h>
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/MimeDataHandlerBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/MimeDataHandlerBus.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <qglobal.h>
-#include <qpoint.h>
+#include <QPoint>
 
 #include <AzCore/EBus/EBus.h>
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Nodes/Comment/CommentBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Nodes/Comment/CommentBus.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qrect.h>
+#include <QRect>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityId.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Nodes/Wrapper/WrapperNodeBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Nodes/Wrapper/WrapperNodeBus.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qstring.h>
+#include <QString>
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/SceneBus.h
@@ -10,9 +10,9 @@
 
 #include <qglobal.h>
 
-#include <qrect.h>
-#include <qpoint.h>
-#include <qcolor.h>
+#include <QRect>
+#include <QPoint>
+#include <QColor>
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Vector2.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/SlotBus.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qpoint.h>
+#include <QPoint>
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/GraphCanvasGraphSerialization.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/GraphCanvasGraphSerialization.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qbytearray.h>
+#include <QByteArray>
 
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/std/containers/unordered_set.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/Types.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Types/Types.h
@@ -10,9 +10,9 @@
 #include <AzCore/PlatformDef.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800 4244, "-Wunknown-warning-option")
-#include <qcolor.h>
-#include <qfont.h>
-#include <qfontinfo.h>
+#include <QColor>
+#include <QFont>
+#include <QFontInfo>
 AZ_POP_DISABLE_WARNING
 
 #include <AzCore/Math/Color.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Utils/ConversionUtils.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Utils/ConversionUtils.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qcolor.h>
+#include <QColor>
 
 #include <AzCore/Math/Color.h>
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Utils/QtVectorMath.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Utils/QtVectorMath.h
@@ -10,7 +10,7 @@
 #include <cmath>
 #include <AzCore/Math/MathUtils.h>
 
-#include <qpoint.h>
+#include <QPoint>
 
 namespace GraphCanvas
 {

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/Bookmarks/BookmarkDockWidget.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/Bookmarks/BookmarkDockWidget.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <qapplication.h>
-#include <qheaderview.h>
-#include <qlineedit.h>
-#include <qmessagebox.h>
-#include <qmenu.h>
-#include <qtableview.h>
+#include <QApplication>
+#include <QHeaderView>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QMenu>
+#include <QTableView>
 
 #include <GraphCanvas/Widgets/Bookmarks/BookmarkDockWidget.h>
 #include <StaticLib/GraphCanvas/Widgets/Bookmarks/ui_BookmarkDockWidget.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasEditor/GraphCanvasEditorDockWidget.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasEditor/GraphCanvasEditorDockWidget.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qevent.h>
+#include <QEvent>
 
 #include <AzCore/Component/Entity.h>
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasMimeContainer.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasMimeContainer.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qstring.h>
+#include <QString>
 
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/Serialization/ObjectStream.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeItem.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeItem.h
@@ -10,7 +10,7 @@
 #include <AzCore/PlatformDef.h>
 // qvariant.h(457) : error C2220 : warning treated as error - no 'object' file generated
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
-#include <qabstractitemmodel.h>
+#include <QAbstractItemModel>
 AZ_POP_DISABLE_WARNING
 
 #include <AzCore/Memory/SystemAllocator.h>

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/GraphCanvasTreeModel.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <qobject.h>
+#include <QObject>
 
 #include <GraphCanvas/Widgets/GraphCanvasTreeModel.h>
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/DraggableNodePaletteTreeItem.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/DraggableNodePaletteTreeItem.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <qpixmap.h>
+#include <QPixmap>
 
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/DraggableNodePaletteTreeItem.h>
 

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/IconDecoratedNodePaletteTreeItem.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/IconDecoratedNodePaletteTreeItem.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <qpixmap.h>
+#include <QPixmap>
 
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/IconDecoratedNodePaletteTreeItem.h>
 #include <GraphCanvas/Components/StyleBus.h>

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewUndo.h
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewUndo.h
@@ -15,7 +15,7 @@
 #include "UiAnimUndoObject.h"
 #include "UiAnimUndo.h"
 
-#include <QtCore/QString>
+#include <QString>
 
 class QWidget;
 

--- a/Gems/LyShine/Code/Editor/Widgets/PropertiesWidget/PropertyHandlers/PropertyHandlerDirectory.h
+++ b/Gems/LyShine/Code/Editor/Widgets/PropertiesWidget/PropertyHandlers/PropertyHandlerDirectory.h
@@ -11,7 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/base.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 
 #include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx>

--- a/Gems/LyShine/Code/Editor/Widgets/ViewportWidget/ViewportWidget.cpp
+++ b/Gems/LyShine/Code/Editor/Widgets/ViewportWidget/ViewportWidget.cpp
@@ -41,7 +41,6 @@
 
 #include <QGridLayout>
 #include <QSettings>
-#include <QtGui/private/qhighdpiscaling_p.h>
 
 #define UICANVASEDITOR_SETTINGS_VIEWPORTWIDGET_DRAW_ELEMENT_BORDERS_KEY         "ViewportWidget::m_drawElementBordersFlags"
 #define UICANVASEDITOR_SETTINGS_VIEWPORTWIDGET_DRAW_ELEMENT_BORDERS_DEFAULT     ( ViewportWidget::DrawElementBorders_Unselected )

--- a/Gems/OpenParticleSystem/Code/Source/Editor/ParticleBrowserInteractions.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/ParticleBrowserInteractions.cpp
@@ -6,8 +6,9 @@
  *
  */
 
+#include "ParticleBrowserInteractions.h"
+
 #include <AzCore/std/string/wildcard.h>
-#include <Editor/ParticleBrowserInteractions.h>
 #include <OpenParticleSystem/EditorParticleSystemComponentRequestBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
 
@@ -21,6 +22,9 @@
 namespace OpenParticleSystemEditor {
     class ParticleDocument;
 }
+
+#include <QObject>
+#include <QIcon>
 
 namespace OpenParticle
 {

--- a/Gems/OpenParticleSystem/Code/Source/Thumbnail/ParticleMaterialThumbnail.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Thumbnail/ParticleMaterialThumbnail.cpp
@@ -83,7 +83,7 @@ namespace OpenParticleSystem
 
         bool ParticleMaterialThumbnailCache::IsSupportedThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey key) const
         {
-            if (auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.data()))
+            if (auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.get()))
             {
                 bool found = false;
                 AZStd::vector<AZ::Data::AssetInfo> productAssetInfos;
@@ -104,7 +104,7 @@ namespace OpenParticleSystem
                 }
             }
 
-            if (auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.data()))
+            if (auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.get()))
             {
                 if (productKey->GetAssetType() != AZ::RPI::MaterialAsset::RTTI_Type())
                 {

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Viewport/OpenParticleViewportWidget.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Viewport/OpenParticleViewportWidget.cpp
@@ -18,8 +18,8 @@
 #include <Viewport/InputController/OpenParticleEditorViewportInputControllerBus.h>
 #include <AzFramework/Viewport/ViewportControllerList.h>
 
-#include <QtWidgets/QHBoxLayout>
-#include <QtWidgets/QVBoxLayout>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
 
 
 namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
@@ -13,7 +13,7 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
-#include <QtWidgets/QComboBox>
+#include <QComboBox>
 #include <OpenParticleSystem/Serializer/ParticleSourceData.h>
 #include <ParticleCommonData.h>
 #include <QVBoxLayout>

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EmitterInspector.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EmitterInspector.h
@@ -13,12 +13,12 @@
 #include <Window/ui_EmitterInspector.h>
 #include <Window/ParticleGraphicsScence.h>
 #include <QtWidgets/qtwidgetsglobal.h>
-#include <QtCore/qcoreapplication.h>
+#include <QCoreApplication>
 #include <QtGui/qwindowdefs.h>
-#include <QtCore/qpoint.h>
-#include <QtCore/qsize.h>
-#include <QtGui/qcursor.h>
-#include <QtGui/qguiapplication.h>
+#include <QPoint>
+#include <QSize>
+#include <QCursor>
+#include <QGuiApplication>
 #include <QGraphicsItem>
 #include <QGraphicsProxyWidget>
 #include <EffectorInspector.h>

--- a/Gems/PhysX/Core/Code/Editor/ConfigurationWidget.h
+++ b/Gems/PhysX/Core/Code/Editor/ConfigurationWidget.h
@@ -14,6 +14,8 @@
 #include <AzFramework/Physics/Configuration/SceneConfiguration.h>
 #endif
 
+#include <QWidget>
+
 namespace AzQtComponents
 {
     class TabWidget;

--- a/Gems/PhysX/Core/Code/Editor/PvdWidget.h
+++ b/Gems/PhysX/Core/Code/Editor/PvdWidget.h
@@ -6,14 +6,15 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#pragma once
 
 #if !defined(Q_MOC_RUN)
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
-#include <QWidget>
+#include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 #include <PhysX/Configuration/PhysXConfiguration.h>
 #endif
 
-#pragma once
+#include <QWidget>
 
 namespace PhysX
 {

--- a/Gems/PhysX/Core/Code/Editor/SettingsWidget.h
+++ b/Gems/PhysX/Core/Code/Editor/SettingsWidget.h
@@ -10,10 +10,12 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
+#include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 #include <AzFramework/Physics/Configuration/SceneConfiguration.h>
-#include <QWidget>
 #include <PhysX/Configuration/PhysXConfiguration.h>
 #endif
+
+#include <QWidget>
 
 namespace PhysX
 {

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -12,7 +12,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800 4244, "-Wunknown-warning-option")
 #include <QScopedValueRollback>
 #include <QInputDialog>
 #include <QFile>
-#include <qmimedata.h>
+#include <QMimeData>
 #include <QMessageBox>
 AZ_POP_DISABLE_WARNING
 

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraphVariableManagerComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraphVariableManagerComponent.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qstring.h>
+#include <QString>
 
 #include <ScriptCanvas/Components/EditorGraphVariableManagerComponent.h>
 

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerNodeDescriptorComponent.cpp
@@ -9,7 +9,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 
-#include <qstring.h>
+#include <QString>
 
 #include <GraphCanvas/Components/SceneBus.h>
 #include <GraphCanvas/Components/Slots/Data/DataSlotBus.h>

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraphVariableManagerComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraphVariableManagerComponent.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <qabstractitemmodel.h>
+#include <QAbstractItemModel>
 
 #include <ScriptCanvas/Variable/GraphVariableManagerComponent.h>
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Dialogs/ContainerWizard/ContainerTypeLineEdit.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Dialogs/ContainerWizard/ContainerTypeLineEdit.cpp
@@ -6,9 +6,8 @@
  *
  */
 
-#include <qtoolbutton.h>
-#include <qscopedvaluerollback.h>
-
+#include <QToolButton>
+#include <QScopedValueRollback>
 #include <QFocusEvent>
 #include <QHeaderView>
 #include <QWidgetAction>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.cpp
@@ -6,11 +6,11 @@
  *
  */
 
-#include <qaction.h>
-#include <qevent.h>
-#include <qheaderview.h>
-#include <qitemselectionmodel.h>
-#include <qscrollbar.h>
+#include <QAction>
+#include <QEvent>
+#include <QHeaderView>
+#include <QItemSelectionModel>
+#include <QScrollBar>
 
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/Utils.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.cpp
@@ -11,7 +11,7 @@
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <EditorCoreAPI.h>
 #include <IEditor.h>
-#include <QtWidgets/QLabel>
+#include <QLabel>
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
 
 #include <Editor/View/Widgets/LoggingPanel/LiveWindowSession/LiveLoggingWindowSession.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/FunctionNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/FunctionNodePaletteTreeItemTypes.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qmenu.h>
+#include <QMenu>
 #include <QPixmap>
 
 #include <AzToolsFramework/AssetEditor/AssetEditorUtils.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/ScriptEventsNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/ScriptEventsNodePaletteTreeItemTypes.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qmenu.h>
+#include <QMenu>
 #include <QPixmap>
 
 #include <AzToolsFramework/AssetEditor/AssetEditorUtils.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/VariableNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/VariableNodePaletteTreeItemTypes.cpp
@@ -9,7 +9,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 
 #include <QCoreApplication>
-#include <qmenu.h>
+#include <QMenu>
 
 #include <GraphCanvas/Components/GridBus.h>
 #include <GraphCanvas/Components/SceneBus.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/UnitTestPanel/UnitTestDockWidget.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/UnitTestPanel/UnitTestDockWidget.h
@@ -47,6 +47,8 @@
 class QAction;
 class QLineEdit;
 class QPushButton;
+class QLabel;
+class QCheckBox;
 
 namespace Ui
 {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/UnitTestPanel/UnitTestTreeView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/UnitTestPanel/UnitTestTreeView.cpp
@@ -6,11 +6,11 @@
  *
  */
 
-#include <qaction.h>
-#include <qevent.h>
-#include <qheaderview.h>
-#include <qitemselectionmodel.h>
-#include <qscrollbar.h>
+#include <QAction>
+#include <QEvent>
+#include <QHeaderView>
+#include <QItemSelectionModel>
+#include <QScrollBar>
 
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/Utils.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -6,10 +6,10 @@
  *
  */
 
-#include <qaction.h>
-#include <qapplication.h>
-#include <qclipboard.h>
-#include <qheaderview.h>
+#include <QAction>
+#include <QApplication>
+#include <QClipBoard>
+#include <QHeaderView>
 
 #include <GraphCanvas/Components/SceneBus.h>
 #include <GraphCanvas/Components/Slots/Data/DataSlotBus.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -8,7 +8,7 @@
 
 #include <QAction>
 #include <QApplication>
-#include <QClipBoard>
+#include <QClipboard>
 #include <QHeaderView>
 
 #include <GraphCanvas/Components/SceneBus.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariableDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariableDockWidget.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <QAction>
+#include <QActionGroup>
 #include <QCompleter>
 #include <QEvent>
 #include <QGraphicsScene>

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariablePaletteTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/VariablePaletteTableView.cpp
@@ -6,11 +6,11 @@
  *
  */
 
-#include <qaction.h>
-#include <qevent.h>
-#include <qheaderview.h>
-#include <qitemselectionmodel.h>
-#include <qscrollbar.h>
+#include <QAction>
+#include <QEvent>
+#include <QHeaderView>
+#include <QItemSelectionModel>
+#include <QScrollBar>
 
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/Utils.h>

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptCanvasContextMenus.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptCanvasContextMenus.h
@@ -23,7 +23,13 @@
 #include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/SceneMenuActions/SceneContextMenuAction.h>
 #include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/SlotMenuActions/SlotContextMenuAction.h>
 #include <GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/NodeMenuActions/NodeContextMenuAction.h>
+#include <ScriptCanvas/Core/Slot.h>
 #endif
+
+namespace AzToolsFramework::AssetBrowser
+{
+    class AssetBrowserFilterModel;
+}
 
 namespace ScriptCanvasEditor
 {

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/InterpreterWidget/InterpreterWidget.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/InterpreterWidget/InterpreterWidget.h
@@ -14,7 +14,7 @@
 #include <AzQtComponents/Components/StyledDialog.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <Editor/Framework/Interpreter.h>
-#include <QtWidgets/QWidget>
+#include <QWidget>
 #endif
 
 namespace AzToolsFramework

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/GraphCreationTests.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/GraphCreationTests.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qpushbutton.h>
+#include <QPushButton>
 
 #include <GraphCanvas/Components/GridBus.h>
 #include <GraphCanvas/Components/Nodes/Group/NodeGroupBus.h>

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/GroupTests.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/GroupTests.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qpushbutton.h>
+#include <QPushButton>
 
 #include <GraphCanvas/Components/GridBus.h>
 #include <GraphCanvas/Components/Nodes/Group/NodeGroupBus.h>

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/InteractionTests.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/InteractionTests.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qpushbutton.h>
+#include <QPushButton>
 
 #include <GraphCanvas/Components/GridBus.h>
 #include <GraphCanvas/Components/Nodes/Group/NodeGroupBus.h>

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/NodeCreationTests.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/NodeCreationTests.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qpushbutton.h>
+#include <QPushButton>
 
 #include <GraphCanvas/Components/GridBus.h>
 #include <GraphCanvas/Components/Nodes/Group/NodeGroupBus.h>

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/VariableTests.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/EditorAutomationTests/VariableTests.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qpushbutton.h>
+#include <QPushButton>
 
 #include <GraphCanvas/Components/GridBus.h>
 #include <GraphCanvas/Components/Nodes/Group/NodeGroupBus.h>

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/WrapperMock.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/WrapperMock.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <qmenu.h>
+#include <QMenu>
 
 #include <Editor/Include/ScriptCanvas/Bus/EditorScriptCanvasBus.h>
 #include <Editor/Include/ScriptCanvas/Bus/RequestBus.h>

--- a/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.cpp
+++ b/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.cpp
@@ -26,10 +26,10 @@
 #include <Atom/ImageProcessing/PixelFormats.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 
-#include <qimage.h>
+#include <QImage>
 #include <QString>
 #include <QDir>
-#include <qfileinfo.h>
+#include <QFileInfo>
 
 namespace TextureAtlasBuilder
 {

--- a/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.h
+++ b/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.h
@@ -12,8 +12,9 @@
 #include <AzCore/Math/Color.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 #include <AssetBuilderSDK/AssetBuilderBusses.h>
-#include <qimage.h>
 #include <TextureAtlas/TextureAtlasBus.h>
+
+#include <QImage>
 
 namespace TextureAtlasBuilder
 {


### PR DESCRIPTION
What does this PR do?

Related to :

- https://github.com/o3de/o3de/issues/19081

Cherry pick changes from [QT6 branch](https://github.com/o3de/o3de/tree/qt6) to ease review when it will come in action :

- Clean QT includes (remove QWidgets/... not needed)
- In EMFX gem, rename a proxy model to prevent name clash with the one its derived from and fix includes
- Use AZStd shared ptr instead of QSharedPtr for asset browser thumbnail API (cause issues in qt6)
- Move a private Q_Object class from cpp to .h in PaintableImageAssetHelper (in qt6 branch, moc declaration won't work in .cpp)
- Fix some includes missings triggering build issues in Qt6 branch

## How was this PR tested?

Local windows build both unity and non-unity
