### PR TITLE
Simplify SceneAPI graph data

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
@@ -202,7 +202,6 @@ namespace AZ
                             context.m_sourceSceneSystem.ConvertUnit(vertex);
 
                             blendShapeData->AddPosition(vertex);
-                            blendShapeData->SetVertexIndexToControlPointIndexMap(vertIdx + vertexOffset, vertIdx + vertexOffset);
 
                             // Add normals
                             if (aiAnimMesh->HasNormals())

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.cpp
@@ -151,30 +151,27 @@ namespace AZ
                     return false;
                 }
 
-                bool hasNormals = lhs.HasNormalData();
-                unsigned int vertexCount = lhs.GetVertexCount();
-                for (unsigned int vertexIndex = 0; vertexIndex < vertexCount; ++vertexIndex)
+                if (lhs.GetPositions() != rhs.GetPositions())
                 {
-                    if (lhs.GetPosition(vertexIndex) != rhs.GetPosition(vertexIndex))
-                    {
-                        return false;
-                    }
+                    return false;
+                }
 
-                    if (hasNormals && (lhs.GetNormal(vertexIndex) != rhs.GetNormal(vertexIndex)))
-                    {
-                        return false;
-                    }
+                bool hasNormals = lhs.HasNormalData();
+
+                if (hasNormals && (lhs.GetNormals() != rhs.GetNormals()))
+                {
+                    return false;
+                }
+
+                if (lhs.GetFaces() != rhs.GetFaces())
+                {
+                    return false;
                 }
 
                 unsigned int faceCount = lhs.GetFaceCount();
                 for (unsigned int faceIndex = 0; faceIndex < faceCount; ++faceIndex)
                 {
                     if (lhs.GetFaceMaterialId(faceIndex) != rhs.GetFaceMaterialId(faceIndex))
-                    {
-                        return false;
-                    }
-
-                    if (lhs.GetFaceInfo(faceIndex) != rhs.GetFaceInfo(faceIndex))
                     {
                         return false;
                     }
@@ -210,7 +207,7 @@ namespace AZ
                         const DataTypes::ISkinWeightData::Link lhsLink = lhs.GetLink(vertexIndex, linkIndex);
                         const DataTypes::ISkinWeightData::Link rhsLink = rhs.GetLink(vertexIndex, linkIndex);
 
-                        if (lhsLink.boneId != rhsLink.boneId || !IsClose(lhsLink.weight, rhsLink.weight, g_sceneUtilityEqualityEpsilon))
+                        if (!lhsLink.IsClose(rhsLink, g_sceneUtilityEqualityEpsilon))
                         {
                             return false;
                         }
@@ -231,39 +228,12 @@ namespace AZ
                 return (lhs.GetWorldTransform() == rhs.GetWorldTransform());
             }
 
-            bool operator==(const DataTypes::Color& lhs, const DataTypes::Color& rhs)
-            {
-                if (!IsClose(lhs.alpha, rhs.alpha, g_sceneUtilityEqualityEpsilon) ||
-                    !IsClose(lhs.blue, rhs.blue, g_sceneUtilityEqualityEpsilon) ||
-                    !IsClose(lhs.green, rhs.green, g_sceneUtilityEqualityEpsilon) ||
-                    !IsClose(lhs.red, rhs.red, g_sceneUtilityEqualityEpsilon))
-                {
-                    return false;
-                }
-
-                return true;
-            }
-
-            bool operator!=(const DataTypes::Color& lhs, const DataTypes::Color& rhs)
-            {
-                return !(lhs == rhs);
-            }
-
             bool operator==(const SceneData::GraphData::MeshVertexColorData& lhs,
                 const SceneData::GraphData::MeshVertexColorData& rhs)
             {
-                if (lhs.GetCount() != rhs.GetCount())
+                if (lhs.GetColors() != rhs.GetColors())
                 {
                     return false;
-                }
-
-                size_t colorCount = lhs.GetCount();
-                for (size_t colorIndex = 0; colorIndex < colorCount; ++colorIndex)
-                {
-                    if (lhs.GetColor(colorIndex) != rhs.GetColor(colorIndex))
-                    {
-                        return false;
-                    }
                 }
 
                 return true;
@@ -272,17 +242,9 @@ namespace AZ
             bool operator==(const SceneData::GraphData::MeshVertexUVData& lhs,
                 const SceneData::GraphData::MeshVertexUVData& rhs)
             {
-                if (lhs.GetCount() != rhs.GetCount())
+                if (lhs.GetUVs() != rhs.GetUVs())
                 {
                     return false;
-                }
-                size_t uvCount = lhs.GetCount();
-                for (size_t uvIndex = 0; uvIndex < uvCount; ++uvIndex)
-                {
-                    if (lhs.GetUV(uvIndex) != rhs.GetUV(uvIndex))
-                    {
-                        return false;
-                    }
                 }
 
                 return true;
@@ -326,19 +288,9 @@ namespace AZ
             bool operator==(const SceneData::GraphData::AnimationData& lhs,
                 const SceneData::GraphData::AnimationData& rhs)
             {
-                if (lhs.GetKeyFrameCount() != rhs.GetKeyFrameCount())
+                if (lhs.GetKeyFrames() != rhs.GetKeyFrames())
                 {
                     return false;
-                }
-
-                size_t keyFrameCount = lhs.GetKeyFrameCount();
-                
-                for (size_t keyFrameIndex = 0; keyFrameIndex < keyFrameCount; ++keyFrameIndex)
-                {
-                    if (lhs.GetKeyFrame(keyFrameIndex) != rhs.GetKeyFrame(keyFrameIndex))
-                    {
-                        return false;
-                    }
                 }
 
                 return true;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/Utilities/AssImpMeshImporterUtilities.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/Utilities/AssImpMeshImporterUtilities.cpp
@@ -57,7 +57,6 @@ namespace AZ::SceneAPI::SceneBuilder
                 sceneSystem.SwapVec3ForUpAxis(vertex);
                 sceneSystem.ConvertUnit(vertex);
                 newMesh->AddPosition(vertex);
-                newMesh->SetVertexIndexToControlPointIndexMap(vertIdx + vertOffset, vertIdx + vertOffset);
 
                 if (mesh->HasNormals())
                 {

--- a/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IBlendShapeData.h
+++ b/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IBlendShapeData.h
@@ -44,9 +44,7 @@ namespace AZ
 
                 void CloneAttributesFrom([[maybe_unused]] const IGraphObject* sourceObject) override {}
 
-                virtual size_t GetUsedControlPointCount() const = 0;
-                virtual int GetControlPointIndex(int vertexIndex) const = 0;
-                virtual int GetUsedPointIndexForControlPoint(int controlPointIndex) const = 0;
+                virtual size_t GetVertexIndexCount() const = 0;
 
                 virtual unsigned int GetVertexCount() const = 0;
                 virtual unsigned int GetFaceCount() const = 0;

--- a/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h
+++ b/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h
@@ -67,16 +67,7 @@ namespace AZ
                 virtual const Face& GetFaceInfo(unsigned int index) const = 0;
                 virtual unsigned int GetFaceMaterialId(unsigned int index) const = 0;
 
-                //  0 <= vertexIndex < GetVertexCount().
-                virtual int GetControlPointIndex(int vertexIndex) const = 0;
-
-                // Returns number of unique control points used in the mesh.  Here, "used"
-                // means it is actually referenced by some polygon in the mesh.
-                virtual size_t GetUsedControlPointCount() const = 0;
-
-                // If the control point index specified is indeed used by the mesh, returns a unique value
-                // in the range [0,  GetUsedControlPointCount()). Otherwise, returns -1.
-                virtual int GetUsedPointIndexForControlPoint(int controlPointIndex) const = 0;
+                virtual size_t GetVertexIndexCount() const = 0;
 
                 virtual unsigned int GetVertexIndex(int faceIndex, int vertexIndexInFace) const = 0;
                 static const int s_invalidMaterialId = 0;

--- a/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexColorData.h
+++ b/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexColorData.h
@@ -74,6 +74,17 @@ namespace AZ
                 {
                     return Color(red - rhs.red, green - rhs.green, blue - rhs.blue, alpha - rhs.alpha);
                 }
+
+                bool operator==(const Color& rhs) const
+                {
+                    const constexpr float g_sceneUtilityEqualityEpsilon = 0.001f;
+                    return IsClose(rhs, g_sceneUtilityEqualityEpsilon);
+                }
+
+                bool operator!=(const Color& rhs) const
+                {
+                    return !(*this == rhs);
+                }
             };
 
             class IMeshVertexColorData

--- a/Code/Tools/SceneAPI/SceneCore/Mocks/DataTypes/GraphData/MockIBlendShapeData.h
+++ b/Code/Tools/SceneAPI/SceneCore/Mocks/DataTypes/GraphData/MockIBlendShapeData.h
@@ -18,9 +18,7 @@ namespace AZ::SceneAPI::DataTypes
         : public IBlendShapeData
     {
     public:
-        MOCK_CONST_METHOD0(GetUsedControlPointCount, size_t());
-        MOCK_CONST_METHOD1(GetControlPointIndex, int(int));
-        MOCK_CONST_METHOD1(GetUsedPointIndexForControlPoint, int(int));
+        MOCK_CONST_METHOD0(GetVertexIndexCount, size_t());
         MOCK_CONST_METHOD0(GetVertexCount, unsigned int());
         MOCK_CONST_METHOD0(GetFaceCount, unsigned int());
         MOCK_CONST_METHOD1(GetFaceInfo, const Face&(unsigned int index));

--- a/Code/Tools/SceneAPI/SceneCore/Mocks/DataTypes/GraphData/MockIMeshData.h
+++ b/Code/Tools/SceneAPI/SceneCore/Mocks/DataTypes/GraphData/MockIMeshData.h
@@ -43,14 +43,10 @@ namespace AZ
                     const Face&(unsigned int index));
                 MOCK_CONST_METHOD1(GetFaceMaterialId,
                     unsigned int(unsigned int index));
-                MOCK_CONST_METHOD1(GetControlPointIndex,
-                     int(int index));
-                MOCK_CONST_METHOD0(GetUsedControlPointCount,
+                MOCK_CONST_METHOD0(GetVertexIndexCount,
                     size_t());
                 MOCK_CONST_METHOD2(GetVertexIndex,
                     unsigned int(int faceIndex, int vertexIndexInFace));
-                MOCK_CONST_METHOD1(GetUsedPointIndexForControlPoint,
-                    int(int controlPointIndex));
             };
         }  // namespace DataTypes
     }  //namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneData/GraphData/AnimationData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/AnimationData.cpp
@@ -9,6 +9,7 @@
 #include <SceneAPI/SceneData/GraphData/AnimationData.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include "AnimationData.h"
 
 namespace AZ
 {
@@ -84,6 +85,15 @@ namespace AZ
                 output.Write("TimeStepBetweenFrames", m_timeStepBetweenFrames);
             }
 
+            AZStd::vector<SceneAPI::DataTypes::MatrixType>& AnimationData::GetKeyFrames()
+            {
+                return m_keyFrames;
+            }
+
+            const AZStd::vector<SceneAPI::DataTypes::MatrixType>& AnimationData::GetKeyFrames() const
+            {
+                return m_keyFrames;
+            }
 
             void BlendShapeAnimationData::Reflect(ReflectContext* context)
             {
@@ -172,6 +182,16 @@ namespace AZ
                 output.Write("BlendShapeName", m_blendShapeName);
                 output.Write("KeyFrames", m_keyFrames);
                 output.Write("TimeStepBetweenFrames", m_timeStepBetweenFrames);
+            }
+
+            AZStd::vector<double>& BlendShapeAnimationData::GetKeyFrames()
+            {
+                return m_keyFrames;
+            }
+
+            const AZStd::vector<double>& BlendShapeAnimationData::GetKeyFrames() const
+            {
+                return m_keyFrames;
             }
         }
     }

--- a/Code/Tools/SceneAPI/SceneData/GraphData/AnimationData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/AnimationData.h
@@ -40,6 +40,9 @@ namespace AZ
                 SCENE_DATA_API double GetTimeStepBetweenFrames() const override;
 
                 SCENE_DATA_API void GetDebugOutput(SceneAPI::Utilities::DebugOutput& output) const override;
+
+                SCENE_DATA_API AZStd::vector<SceneAPI::DataTypes::MatrixType>& GetKeyFrames();
+                SCENE_DATA_API const AZStd::vector<SceneAPI::DataTypes::MatrixType>& GetKeyFrames() const;
             protected:
                 AZStd::vector<SceneAPI::DataTypes::MatrixType>    m_keyFrames;
                 double                                            m_timeStepBetweenFrames;
@@ -68,6 +71,9 @@ namespace AZ
                 SCENE_DATA_API double GetTimeStepBetweenFrames() const override;
 
                 SCENE_DATA_API void GetDebugOutput(SceneAPI::Utilities::DebugOutput& output) const override;
+
+                SCENE_DATA_API AZStd::vector<double>& GetKeyFrames();
+                SCENE_DATA_API const AZStd::vector<double>& GetKeyFrames() const;
             protected:
                 AZStd::string            m_blendShapeName;
                 AZStd::vector<double>    m_keyFrames;

--- a/Code/Tools/SceneAPI/SceneData/GraphData/BlendShapeData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/BlendShapeData.cpp
@@ -40,9 +40,7 @@ namespace AZ
                         ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::ListOnly)
                         ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                         ->Attribute(AZ::Script::Attributes::Module, "scene")
-                        ->Method("GetUsedControlPointCount", &SceneAPI::DataTypes::IBlendShapeData::GetUsedControlPointCount)
-                        ->Method("GetControlPointIndex", &SceneAPI::DataTypes::IBlendShapeData::GetControlPointIndex)
-                        ->Method("GetUsedPointIndexForControlPoint", &SceneAPI::DataTypes::IBlendShapeData::GetUsedPointIndexForControlPoint)
+                        ->Method("GetVertexIndexCount", &SceneAPI::DataTypes::IBlendShapeData::GetVertexIndexCount)
                         ->Method("GetVertexCount", &SceneAPI::DataTypes::IBlendShapeData::GetVertexCount)
                         ->Method("GetFaceCount", &SceneAPI::DataTypes::IBlendShapeData::GetFaceCount)
                         ->Method("GetFaceInfo", &SceneAPI::DataTypes::IBlendShapeData::GetFaceInfo)
@@ -171,39 +169,9 @@ namespace AZ
                 m_faces.push_back(face);
             }
 
-            void BlendShapeData::SetVertexIndexToControlPointIndexMap(int vertexIndex, int controlPointIndex)
+            size_t BlendShapeData::GetVertexIndexCount() const
             {
-                m_vertexIndexToControlPointIndexMap[vertexIndex] = controlPointIndex;
-
-                // The above hashmap stores the control point index (value) per vertex (key).
-                // We construct an unordered set and fill in the control point indices in order to get access to the number of unique control points indices.
-                m_controlPointToUsedVertexIndexMap.emplace(controlPointIndex, aznumeric_cast<unsigned int>(m_controlPointToUsedVertexIndexMap.size()));
-            }
-
-            int BlendShapeData::GetControlPointIndex(int vertexIndex) const
-            {
-                auto iter = m_vertexIndexToControlPointIndexMap.find(vertexIndex);
-                AZ_Assert(iter != m_vertexIndexToControlPointIndexMap.end(), "Vertex index %i doesn't exist.", vertexIndex);
-                // Note: AZStd::unordered_map's operator [] doesn't have const version... 
-                return iter->second;
-            }
-
-            size_t BlendShapeData::GetUsedControlPointCount() const
-            {
-                return m_controlPointToUsedVertexIndexMap.size();
-            }
-
-            int BlendShapeData::GetUsedPointIndexForControlPoint(int controlPointIndex) const
-            {
-                auto iter = m_controlPointToUsedVertexIndexMap.find(controlPointIndex);
-                if (iter != m_controlPointToUsedVertexIndexMap.end())
-                {
-                    return iter->second;
-                }
-                else
-                {
-                    return -1; // That control point is not used in this mesh
-                }
+                return m_faces.size() * 3;
             }
 
             unsigned int BlendShapeData::GetVertexCount() const
@@ -239,6 +207,35 @@ namespace AZ
                 AZ_Assert(uvSetIndex < MaxNumUVSets, "uvSet index out of range");
                 AZ_Assert(vertexIndex < m_uvs[uvSetIndex].size(), "uvSet index out of range");
                 return m_uvs[uvSetIndex][vertexIndex];
+            }
+
+            AZStd::vector<AZ::Vector3>& BlendShapeData::GetPositions()
+            {
+                return m_positions;
+            }
+
+            const AZStd::vector<AZ::Vector3>& BlendShapeData::GetPositions() const
+            {
+                return m_positions;
+            }
+
+            AZStd::vector<AZ::Vector3>& BlendShapeData::GetNormals()
+            {
+                return m_normals;
+            }
+
+            const AZStd::vector<AZ::Vector3>& BlendShapeData::GetNormals() const
+            {
+                return m_normals;
+            }
+
+            AZStd::vector<BlendShapeData::Face>& BlendShapeData::GetFaces()
+            {
+                return m_faces;
+            }
+            const AZStd::vector<BlendShapeData::Face>& BlendShapeData::GetFaces() const
+            {
+                return m_faces;
             }
 
             AZStd::vector<Vector4>& BlendShapeData::GetTangents()

--- a/Code/Tools/SceneAPI/SceneData/GraphData/BlendShapeData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/BlendShapeData.h
@@ -47,11 +47,7 @@ namespace AZ
                 //assume consistent winding - no stripping or fanning expected (3 index per face)
                 SCENE_DATA_API virtual void AddFace(const Face& face);
 
-                SCENE_DATA_API void SetVertexIndexToControlPointIndexMap(int vertexIndex, int controlPointIndex);
-
-                SCENE_DATA_API size_t GetUsedControlPointCount() const override;
-                SCENE_DATA_API int GetControlPointIndex(int vertexIndex) const override;
-                SCENE_DATA_API int GetUsedPointIndexForControlPoint(int controlPointIndex) const override;
+                SCENE_DATA_API size_t GetVertexIndexCount() const override;
 
                 //assume consistent winding - no stripping or fanning expected (3 index per face)
                 SCENE_DATA_API unsigned int GetVertexCount() const override;
@@ -62,6 +58,12 @@ namespace AZ
                 SCENE_DATA_API const Vector3& GetNormal(unsigned int index) const override;
                 SCENE_DATA_API const Vector2& GetUV(unsigned int vertexIndex, unsigned int uvSetIndex) const;
 
+                SCENE_DATA_API AZStd::vector<AZ::Vector3>& GetPositions();
+                SCENE_DATA_API const AZStd::vector<AZ::Vector3>& GetPositions() const;
+                SCENE_DATA_API AZStd::vector<AZ::Vector3>& GetNormals();
+                SCENE_DATA_API const AZStd::vector<AZ::Vector3>& GetNormals() const;
+                SCENE_DATA_API AZStd::vector<Face>& GetFaces();
+                SCENE_DATA_API const AZStd::vector<Face>& GetFaces() const;
                 SCENE_DATA_API AZStd::vector<Vector4>& GetTangents();
                 SCENE_DATA_API const AZStd::vector<Vector4>& GetTangents() const;
                 SCENE_DATA_API AZStd::vector<Vector3>& GetBitangents();
@@ -82,9 +84,6 @@ namespace AZ
                 AZStd::vector<SceneAPI::DataTypes::Color> m_colors[MaxNumColorSets];
 
                 AZStd::vector<Face>     m_faces;
-
-                AZStd::unordered_map<int, int>                          m_vertexIndexToControlPointIndexMap;
-                AZStd::unordered_map<int, int>                          m_controlPointToUsedVertexIndexMap;
             };
         } // GraphData
     } // SceneData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include "MeshData.h"
 
 namespace AZ
 {
@@ -42,9 +43,7 @@ namespace AZ
                     behaviorContext->Class<MeshData>()
                         ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                         ->Attribute(AZ::Script::Attributes::Module, "scene")
-                        ->Method("GetControlPointIndex", &MeshData::GetControlPointIndex)
-                        ->Method("GetUsedControlPointCount", &MeshData::GetUsedControlPointCount)
-                        ->Method("GetUsedPointIndexForControlPoint", &MeshData::GetUsedPointIndexForControlPoint)
+                        ->Method("GetVertexIndexCount", &MeshData::GetVertexIndexCount)
                         ->Method("GetVertexCount", &MeshData::GetVertexCount)
                         ->Method("HasNormalData", &MeshData::HasNormalData)
                         ->Method("GetPosition", &MeshData::GetPosition)
@@ -103,41 +102,9 @@ namespace AZ
                 m_faceMaterialIds.push_back(faceMaterialId);
             }
 
-            void MeshData::SetVertexIndexToControlPointIndexMap(int vertexIndex, int controlPointIndex)
+            size_t MeshData::GetVertexIndexCount() const
             {
-                m_vertexIndexToControlPointIndexMap[vertexIndex] = controlPointIndex;
-
-                // The above hashmap stores the control point index (value) per vertex (key).
-                // We construct an unordered set and fill in the control point indices in order to get access to the number of unique control points indices.
-                if (m_controlPointToUsedVertexIndexMap.find(controlPointIndex) == m_controlPointToUsedVertexIndexMap.end())
-                {
-                    m_controlPointToUsedVertexIndexMap[controlPointIndex] = aznumeric_cast<unsigned int>(m_controlPointToUsedVertexIndexMap.size());
-                }
-            }
-
-            int MeshData::GetControlPointIndex(int vertexIndex) const
-            {
-                AZ_Assert(m_vertexIndexToControlPointIndexMap.find(vertexIndex) != m_vertexIndexToControlPointIndexMap.end(), "Vertex index %i doesn't exist", vertexIndex);
-                // Note: AZStd::unordered_map's operator [] doesn't have const version... 
-                return m_vertexIndexToControlPointIndexMap.find(vertexIndex)->second;
-            }
-
-            size_t MeshData::GetUsedControlPointCount() const
-            {
-                return m_controlPointToUsedVertexIndexMap.size();
-            }
-
-            int MeshData::GetUsedPointIndexForControlPoint(int controlPointIndex) const
-            {
-                auto iter = m_controlPointToUsedVertexIndexMap.find(controlPointIndex);
-                if (iter != m_controlPointToUsedVertexIndexMap.end())
-                {
-                    return iter->second;
-                }
-                else
-                {
-                    return -1; // That control point is not used in this mesh
-                }
+                return m_faceList.size() * 3;
             }
 
             unsigned int MeshData::GetVertexCount() const
@@ -160,6 +127,36 @@ namespace AZ
             {
                 AZ_Assert(index < m_normals.size(), "GetNormal index not in range");
                 return m_normals[index];
+            }
+
+            AZStd::vector<AZ::Vector3>& MeshData::GetPositions()
+            {
+                return m_positions;
+            }
+
+            const AZStd::vector<AZ::Vector3>& MeshData::GetPositions() const
+            {
+                return m_positions;
+            }
+
+            AZStd::vector<AZ::Vector3>& MeshData::GetNormals()
+            {
+                return m_normals;
+            }
+
+            const AZStd::vector<AZ::Vector3>& MeshData::GetNormals() const
+            {
+                return m_normals;
+            }
+
+            AZStd::vector<AZ::SceneAPI::DataTypes::IMeshData::Face>& MeshData::GetFaces()
+            {
+                return m_faceList;
+            }
+
+            const AZStd::vector<AZ::SceneAPI::DataTypes::IMeshData::Face>& MeshData::GetFaces() const
+            {
+                return m_faceList;
             }
 
             unsigned int MeshData::GetFaceCount() const

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.h
@@ -45,11 +45,7 @@ namespace AZ
                 SCENE_DATA_API void AddFace(const AZ::SceneAPI::DataTypes::IMeshData::Face& face,
                     unsigned int faceMaterialId = AZ::SceneAPI::DataTypes::IMeshData::s_invalidMaterialId);
 
-                SCENE_DATA_API void SetVertexIndexToControlPointIndexMap(int vertexIndex, int controlPointIndex);
-                SCENE_DATA_API size_t GetUsedControlPointCount() const override;
-                SCENE_DATA_API int GetControlPointIndex(int vertexIndex) const override;
-                SCENE_DATA_API int GetUsedPointIndexForControlPoint(int controlPointIndex) const override;
-
+                SCENE_DATA_API size_t GetVertexIndexCount() const override;
                 SCENE_DATA_API unsigned int GetVertexCount() const override;
                 SCENE_DATA_API bool HasNormalData() const override;
 
@@ -63,6 +59,13 @@ namespace AZ
                 SCENE_DATA_API unsigned int GetVertexIndex(int faceIndex, int vertexIndexInFace) const override;
 
                 SCENE_DATA_API void GetDebugOutput(SceneAPI::Utilities::DebugOutput& output) const override;
+
+                SCENE_DATA_API AZStd::vector<AZ::Vector3>& GetPositions();
+                SCENE_DATA_API const AZStd::vector<AZ::Vector3>& GetPositions() const;
+                SCENE_DATA_API AZStd::vector<AZ::Vector3>& GetNormals();
+                SCENE_DATA_API const AZStd::vector<AZ::Vector3>& GetNormals() const;
+                SCENE_DATA_API AZStd::vector<AZ::SceneAPI::DataTypes::IMeshData::Face>& GetFaces();
+                SCENE_DATA_API const AZStd::vector<AZ::SceneAPI::DataTypes::IMeshData::Face>& GetFaces() const;
             protected:
                 AZStd::vector<AZ::Vector3>                              m_positions;
                 AZStd::vector<AZ::Vector3>                              m_normals;
@@ -70,9 +73,6 @@ namespace AZ
                 AZStd::vector<AZ::SceneAPI::DataTypes::IMeshData::Face> m_faceList;
 
                 AZStd::vector<unsigned int>                             m_faceMaterialIds;
-
-                AZStd::unordered_map<int, int>                          m_vertexIndexToControlPointIndexMap;
-                AZStd::unordered_map<int, int>                          m_controlPointToUsedVertexIndexMap;
             };
         }
     }

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.cpp
@@ -9,6 +9,7 @@
 #include <SceneAPI/SceneData/GraphData/MeshVertexBitangentData.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include "MeshVertexBitangentData.h"
 
 namespace AZ::SceneData::GraphData
 {
@@ -100,5 +101,15 @@ namespace AZ::SceneData::GraphData
     {
         output.Write("Bitangents", m_bitangents);
         output.Write("GenerationMethod", aznumeric_cast<int64_t>(m_generationMethod));
+    }
+
+    AZStd::vector<AZ::Vector3>& MeshVertexBitangentData::GetBitangents()
+    {
+        return m_bitangents;
+    }
+
+    const AZStd::vector<AZ::Vector3>& MeshVertexBitangentData::GetBitangents() const
+    {
+        return m_bitangents;
     }
 } // AZ::SceneData::GraphData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.h
@@ -42,6 +42,9 @@ namespace AZ::SceneData::GraphData
         SCENE_DATA_API void SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod method) override;
 
         SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
+
+        SCENE_DATA_API AZStd::vector<AZ::Vector3>& GetBitangents();
+        SCENE_DATA_API const AZStd::vector<AZ::Vector3>& GetBitangents() const;
     protected:
         AZStd::vector<AZ::Vector3> m_bitangents;
         AZ::SceneAPI::DataTypes::TangentGenerationMethod m_generationMethod = AZ::SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene;

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexColorData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexColorData.cpp
@@ -9,6 +9,7 @@
 #include <SceneAPI/SceneData/GraphData/MeshVertexColorData.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include "MeshVertexColorData.h"
 
 namespace AZ
 {
@@ -92,6 +93,16 @@ namespace AZ
             {
                 output.Write("Colors", m_colors);
                 output.Write("ColorsCustomName", m_customName.GetCStr());
+            }
+
+            AZStd::vector<AZ::SceneAPI::DataTypes::Color>& MeshVertexColorData::GetColors()
+            {
+                return m_colors;
+            }
+
+            const AZStd::vector<AZ::SceneAPI::DataTypes::Color>& MeshVertexColorData::GetColors() const
+            {
+                return m_colors;
             }
         } // GraphData
     } // SceneData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexColorData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexColorData.h
@@ -43,6 +43,9 @@ namespace AZ
                 SCENE_DATA_API void AppendColor(const AZ::SceneAPI::DataTypes::Color& color);
 
                 SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
+
+                SCENE_DATA_API AZStd::vector<AZ::SceneAPI::DataTypes::Color>& GetColors();
+                SCENE_DATA_API const AZStd::vector<AZ::SceneAPI::DataTypes::Color>& GetColors() const;
             protected:
                 AZStd::vector<AZ::SceneAPI::DataTypes::Color> m_colors;
                 AZ::Name m_customName;

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.cpp
@@ -9,6 +9,7 @@
 #include <SceneAPI/SceneData/GraphData/MeshVertexTangentData.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include "MeshVertexTangentData.h"
 
 namespace AZ::SceneData::GraphData
 {
@@ -76,6 +77,16 @@ namespace AZ::SceneData::GraphData
         output.Write("Tangents", m_tangents);
         output.Write("GenerationMethod", aznumeric_cast<int64_t>(m_generationMethod));
         output.Write("SetIndex", aznumeric_cast<uint64_t>(m_setIndex));
+    }
+
+    AZStd::vector<AZ::Vector4>& MeshVertexTangentData::GetTangents()
+    {
+        return m_tangents;
+    }
+
+    const AZStd::vector<AZ::Vector4>& MeshVertexTangentData::GetTangents() const
+    {
+        return m_tangents;
     }
 
     void MeshVertexTangentData::SetTangent(size_t vertexIndex, const AZ::Vector4& tangent)

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.h
@@ -44,6 +44,8 @@ namespace AZ::SceneData::GraphData
 
         SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
 
+        SCENE_DATA_API AZStd::vector<AZ::Vector4>& GetTangents();
+        SCENE_DATA_API const AZStd::vector<AZ::Vector4>& GetTangents() const;
     protected:
         AZStd::vector<AZ::Vector4> m_tangents;
         AZ::SceneAPI::DataTypes::TangentGenerationMethod m_generationMethod = AZ::SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene;

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexUVData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexUVData.cpp
@@ -9,6 +9,7 @@
 #include <SceneAPI/SceneData/GraphData/MeshVertexUVData.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include "MeshVertexUVData.h"
 
 namespace AZ
 {
@@ -89,6 +90,16 @@ namespace AZ
             {
                 output.Write("UVs", m_uvs);
                 output.Write("UVCustomName", m_customName.GetCStr());
+            }
+
+            AZStd::vector<AZ::Vector2>& MeshVertexUVData::GetUVs()
+            {
+                return m_uvs;
+            }
+
+            const AZStd::vector<AZ::Vector2>& MeshVertexUVData::GetUVs() const
+            {
+                return m_uvs;
             }
         } // GraphData
     } // SceneData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexUVData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexUVData.h
@@ -46,6 +46,9 @@ namespace AZ
                 SCENE_DATA_API void Clear();
 
                 SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
+
+                SCENE_DATA_API AZStd::vector<AZ::Vector2>& GetUVs();
+                SCENE_DATA_API const AZStd::vector<AZ::Vector2>& GetUVs() const;
             protected:
                 AZStd::vector<AZ::Vector2> m_uvs;
                 AZ::Name m_customName;

--- a/Code/Tools/SceneAPI/SceneData/GraphData/SkinWeightData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/SkinWeightData.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Casting/numeric_cast.h>
 #include <SceneAPI/SceneData/GraphData/SkinWeightData.h>
+#include "SkinWeightData.h"
 
 namespace AZ
 {
@@ -88,6 +89,15 @@ namespace AZ
             void SkinWeightData::GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const
             {
                 output.Write("VertexLinks", m_vertexLinks);
+            }
+
+            AZStd::vector<AZStd::vector<SceneAPI::DataTypes::ISkinWeightData::Link>>& SkinWeightData::GetLinks()
+            {
+                return m_vertexLinks;
+            }
+            const AZStd::vector<AZStd::vector<SceneAPI::DataTypes::ISkinWeightData::Link>>& SkinWeightData::GetLinks() const
+            {
+                return m_vertexLinks;
             }
         } // GraphData
     } // SceneData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/SkinWeightData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/SkinWeightData.h
@@ -42,6 +42,9 @@ namespace AZ
                 SCENE_DATA_API int GetBoneId(const AZStd::string& boneName);
 
                 SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
+
+                SCENE_DATA_API AZStd::vector<AZStd::vector<SceneAPI::DataTypes::ISkinWeightData::Link>>& GetLinks();
+                SCENE_DATA_API const AZStd::vector<AZStd::vector<SceneAPI::DataTypes::ISkinWeightData::Link>>& GetLinks() const;
             protected:
                 AZStd::vector<AZStd::vector<SceneAPI::DataTypes::ISkinWeightData::Link>> m_vertexLinks;
                 AZStd::unordered_map<AZStd::string, int> m_boneNameIdMap;

--- a/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
@@ -62,10 +62,6 @@ namespace AZ
                         meshData->AddNormal(Vector3{0.4f, 0.5f, 0.6f});
                         meshData->SetOriginalUnitSizeInMeters(10.0f);
                         meshData->SetUnitSizeInMeters(0.5f);
-                        meshData->SetVertexIndexToControlPointIndexMap(0, 10);
-                        meshData->SetVertexIndexToControlPointIndexMap(1, 11);
-                        meshData->SetVertexIndexToControlPointIndexMap(2, 12);
-                        meshData->SetVertexIndexToControlPointIndexMap(3, 13);
                         meshData->AddFace({0, 1, 2}, 1);
                         meshData->AddFace({3, 4, 5}, 2);
                         meshData->AddFace({6, 7, 8}, 3);
@@ -148,9 +144,6 @@ namespace AZ
                         blendShapeData->AddFace({ 0, 1, 2 });
                         blendShapeData->AddFace({ 1, 2, 0 });
                         blendShapeData->AddFace({ 2, 0, 1 });
-                        blendShapeData->SetVertexIndexToControlPointIndexMap(0, 1);
-                        blendShapeData->SetVertexIndexToControlPointIndexMap(1, 2);
-                        blendShapeData->SetVertexIndexToControlPointIndexMap(2, 0);
                         return true;
                     }
                     else if (data.get_type_info().m_id == azrtti_typeid<AZ::SceneData::GraphData::MaterialData>())
@@ -318,16 +311,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(meshData:GetNormal(1).z, 0.6)");
                 ExpectExecute("TestExpectFloatEquals(meshData:GetOriginalUnitSizeInMeters(), 10.0)");
                 ExpectExecute("TestExpectFloatEquals(meshData:GetUnitSizeInMeters(), 0.5)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetUsedControlPointCount(), 4)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetControlPointIndex(0), 10)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetControlPointIndex(1), 11)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetControlPointIndex(2), 12)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetControlPointIndex(3), 13)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetUsedPointIndexForControlPoint(10), 0)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetUsedPointIndexForControlPoint(11), 1)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetUsedPointIndexForControlPoint(12), 2)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetUsedPointIndexForControlPoint(13), 3)");
-                ExpectExecute("TestExpectIntegerEquals(meshData:GetUsedPointIndexForControlPoint(0), -1)");
+                ExpectExecute("TestExpectIntegerEquals(meshData:GetVertexIndexCount(), 9)");
                 ExpectExecute("TestExpectIntegerEquals(meshData:GetFaceCount(), 3)");
                 ExpectExecute("TestExpectIntegerEquals(meshData:GetVertexIndex(0, 0), 0)");
                 ExpectExecute("TestExpectIntegerEquals(meshData:GetVertexIndex(0, 1), 1)");
@@ -441,18 +425,12 @@ namespace AZ
                 ExpectExecute("blendShapeData = BlendShapeData()");
                 ExpectExecute("TestExpectTrue(blendShapeData ~= nil)");
                 ExpectExecute("MockGraphData.FillData(blendShapeData)");
-                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetUsedControlPointCount(), 3)");
+                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetVertexIndexCount(), 9)");
                 ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetVertexCount(), 3)");
                 ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetFaceCount(), 3)");
                 ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetFaceVertexIndex(0, 2), 2)");
                 ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetFaceVertexIndex(1, 0), 1)");
                 ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetFaceVertexIndex(2, 1), 0)");
-                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetControlPointIndex(0), 1)");
-                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetControlPointIndex(1), 2)");
-                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetControlPointIndex(2), 0)");
-                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetUsedPointIndexForControlPoint(0), 2)");
-                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetUsedPointIndexForControlPoint(1), 0)");
-                ExpectExecute("TestExpectIntegerEquals(blendShapeData:GetUsedPointIndexForControlPoint(2), 1)");
                 ExpectExecute("TestExpectFloatEquals(blendShapeData:GetPosition(0).x, 1.0)");
                 ExpectExecute("TestExpectFloatEquals(blendShapeData:GetPosition(0).y, 2.0)");
                 ExpectExecute("TestExpectFloatEquals(blendShapeData:GetPosition(0).z, 3.0)");

--- a/Gems/EMotionFX/Code/Tests/MorphTargetPipelineTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MorphTargetPipelineTests.cpp
@@ -84,9 +84,6 @@ namespace EMotionFX
             meshData->AddNormal(AZ::Vector3(0.0f, 0.0f, 1.0f));
             meshData->AddNormal(AZ::Vector3(0.0f, 0.0f, 1.0f));
             meshData->AddNormal(AZ::Vector3(0.0f, 0.0f, 1.0f));
-            meshData->SetVertexIndexToControlPointIndexMap(0, 0);
-            meshData->SetVertexIndexToControlPointIndexMap(1, 1);
-            meshData->SetVertexIndexToControlPointIndexMap(2, 2);
             meshData->AddFace(0, 1, 2);
             AZ::SceneAPI::Containers::SceneGraph::NodeIndex meshNodeIndex = graph.AddChild(graph.GetRoot(), "testMesh", meshData);
 
@@ -116,7 +113,6 @@ namespace EMotionFX
                 {
                     blendShapeData->AddPosition(verticesForThisMorph.at(vertexIndex));
                     blendShapeData->AddNormal(AZ::Vector3::CreateAxisZ());
-                    blendShapeData->SetVertexIndexToControlPointIndexMap(vertexIndex, vertexIndex);
                 }
                 blendShapeData->AddFace({{0, 1, 2}});
                 AZStd::string morphTargetName("testMorphTarget");
@@ -248,7 +244,7 @@ namespace EMotionFX
             numVertices = meshData->GetVertexCount();
             for (uint vertexNum = 0; vertexNum < numVertices; ++vertexNum)
             {
-                expectedUnmorphedVertices.emplace_back(meshData->GetPosition(meshData->GetControlPointIndex(vertexNum)));
+                expectedUnmorphedVertices.emplace_back(meshData->GetPosition(vertexNum));
             }
             EXPECT_EQ(gotUnmorphedVertices, expectedUnmorphedVertices);
 
@@ -279,7 +275,7 @@ namespace EMotionFX
             numVertices = morphTargetData->GetVertexCount();
             for (uint vertexNum = 0; vertexNum < numVertices; ++vertexNum)
             {
-                expectedMorphedVertices.emplace_back(morphTargetData->GetPosition(morphTargetData->GetControlPointIndex(vertexNum)));
+                expectedMorphedVertices.emplace_back(morphTargetData->GetPosition(vertexNum));
             }
             EXPECT_EQ(gotMorphedVertices, expectedMorphedVertices);
 

--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
@@ -97,10 +97,6 @@ namespace SceneProcessing
             {
                 mesh->AddPosition(position);
                 mesh->AddNormal(AZ::Vector3::CreateAxisY());
-
-                // This assumes that the data coming from the import process gives a unique control point
-                // index to every vertex. This follows the behavior of the AssImp library.
-                mesh->SetVertexIndexToControlPointIndexMap(i, i);
                 ++i;
             }
 


### PR DESCRIPTION
## What does this PR do?

The PR made two changes to the SceneAPI:
 * Expose the underlying data container for GraphData nodes.
 * Remove "control point" from MeshData/BlendShapeData as they unnecessarily complicate the API but has no actual use.

## How was this PR tested?

Tested on Windows 11, no issue found so far