### PR TITLE
Fix crash when enabling ray tracing for Debug-OBB shapes

### DIFF
--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -1212,6 +1212,9 @@ namespace DebugDraw
             m_rayTracingFeatureProcessor =
                 AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::Render::RayTracingFeatureProcessorInterface>(element.m_targetEntityId);
 
+            m_meshFeatureProcessor =
+                AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::Render::MeshFeatureProcessorInterface>(element.m_targetEntityId);
+
             auto shaderAsset = AZ::RPI::FindShaderAsset("shaders/obbintersection.azshader");
             auto rayTracingShader = AZ::RPI::Shader::FindOrCreate(shaderAsset, AZ::RHI::GetDefaultSupervariantNameWithNoFloat16Fallback());
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a crash when enabling ray tracing for a debug-OBB shape. This was likely an oversight from #19123, which introduced new requirements for users of the ray tracing APIs, and added the same code for acquiring the MeshFeatureProcessor when generating debug-sphere ray tracing data, but not when generating debug-OBB data.

## How was this PR tested?

Create a new level, add an entity, and add a "Debug Draw Obb" component. Then activate ray tracing for the component with the "Use ray tracing" toggle. Without this change, the Editor crashes immediately.
