### PR TITLE
Fix unused variable warning in Clang release build

### DIFF
--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
@@ -168,7 +168,7 @@ namespace AZ
 
         bool MeshletsRenderObject::ProcessBuffersData(float* position, uint32_t vtxNum)
         {
-            uint32_t badVertices = 0;
+            [[maybe_unused]] uint32_t badVertices = 0;
             const float maxVertexSizeSqr = 99.9f * 99.9f;  // under 100 meters
             for (uint32_t vtx = 0; vtx < vtxNum; ++vtx, position += 3)
             {


### PR DESCRIPTION
## What does this PR do?

This PR fixes an unused variable warning which appears in a release build with Clang on Windows (The variable `badVertices` is written to unconditionally, but then only read from in `AZ_Error`, which is unused in a release build).
There is a corresponding MSVC warning (`4189 'identifier' : local variable is initialized but not referenced`), but this code piece does not trigger the warning, so there is no MSVC equivalent to the clang `Wunused-but-set-variable` flag.

## How was this PR tested?

Build the engine in release mode with Clang19 on Windows
