### PR TITLE
Fix potential crash in Qt by correctly registering s64 type

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -65,7 +65,7 @@ ApplicationManagerBase::ApplicationManagerBase(int* argc, char*** argv, QObject*
     : ApplicationManager(argc, argv, parent, AZStd::move(componentAppSettings))
 {
     qRegisterMetaType<AZ::u32>("AZ::u32");
-    qRegisterMetaType<AZ::u32>("AZ::s64");
+    qRegisterMetaType<AZ::s64>("AZ::s64");
     qRegisterMetaType<AZ::Uuid>("AZ::Uuid");
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes that `qRegisterMetaType` is called with mismatching arguments for the `s64` type, which leads to incorrect allocations which are made visible by AddressSanitizer (#19279).

## How was this PR tested?

First, run AssetProcessor (with no assets to be processed) without this change and AddressSanitizer enabled to reproduce the error. This crashes on my machine with the same error as mentioned in the issue. Then, run AssetProcessor with this change, and it no longer crashes.
