### PR TITLE
Editor: Fix fullscreen viewport.

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -900,12 +900,12 @@ void EditorActionsHandler::OnActionRegistrationHook()
         m_hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "Ctrl+G");
     }
 
-    // Play Game (Maximized)
+    // Play Game (Fullscreen)
     {
-        constexpr AZStd::string_view actionIdentifier = "o3de.action.game.playMaximized";
+        constexpr AZStd::string_view actionIdentifier = "o3de.action.game.playFullscreen";
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_name = "Play Game (Maximized)";
-        actionProperties.m_description = "Activate the game input mode (maximized).";
+        actionProperties.m_name = "Play Game (Fullscreen)";
+        actionProperties.m_description = "Activate the game input mode (fullscreen).";
         actionProperties.m_category = "Game";
         actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
 
@@ -1848,7 +1848,7 @@ void EditorActionsHandler::OnMenuBindingHook()
         m_menuManagerInterface->AddSubMenuToMenu(EditorIdentifiers::GameMenuIdentifier, EditorIdentifiers::PlayGameMenuIdentifier, 100);
         {
             m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::PlayGameMenuIdentifier, "o3de.action.game.play", 100);
-            m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::PlayGameMenuIdentifier, "o3de.action.game.playMaximized", 200);
+            m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::PlayGameMenuIdentifier, "o3de.action.game.playFullscreen", 200);
         }
         m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::GameMenuIdentifier, "o3de.action.game.simulate", 200);
         m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::GameMenuIdentifier, 300);

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2166,7 +2166,7 @@ void EditorViewportWidget::StartFullscreenPreview()
     setWindowFlag(Qt::MSWindowsFixedSizeDialogHint, true);
     setFixedSize(screenGeometry.size());
     move(QPoint(screenGeometry.x(), screenGeometry.y()));
-    showMaximized();
+    showFullScreen();
 
     // This must be done after unparenting this widget above
     MainWindow::instance()->hide();

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2163,7 +2163,6 @@ void EditorViewportWidget::StartFullscreenPreview()
     // Also set style to frameless and disable resizing by user
     setParent(nullptr);
     setWindowFlag(Qt::FramelessWindowHint, true);
-    setWindowFlag(Qt::MSWindowsFixedSizeDialogHint, true);
     setFixedSize(screenGeometry.size());
     move(QPoint(screenGeometry.x(), screenGeometry.y()));
     showFullScreen();
@@ -2179,7 +2178,6 @@ void EditorViewportWidget::StopFullscreenPreview()
 
     // Unset frameless window flags
     setWindowFlag(Qt::FramelessWindowHint, false);
-    setWindowFlag(Qt::MSWindowsFixedSizeDialogHint, false);
 
     // Unset fixed size (note that 50x50 is the minimum set in the constructor)
     setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);


### PR DESCRIPTION
## What does this PR do?
This fixes the Editor fullscreen behavior for preview, before in a Linux X11 environment the window wouldn't properly fullscreen and instead avoid panels on the desktop, with this fix it now properly fullscreens.

https://github.com/o3de/o3de/issues/19308

## How was this PR tested?

Ran the editor on KDE (Wayland with XWayland) and moved the editor to each monitor testing if `Play Game (Maximized)` button properly goes into fullscreen on the monitor that the editor is on.

I'm not sure if this works on Windows but I dont see why it would break there.
