### PR TITLE
Feature: Additional Tonemapping Operators

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -22,7 +22,7 @@ float3 TonemapReinhard(const float3 inputColor)
     // White point luminance - chosen for good balance in most scenes
     // Higher values compress highlights less, lower values compress more
     // This is something we could expose as a parameter in the future
-    const float maxWhiteLuminance = 4.0f;
+    const float maxWhiteLuminance = 6.0f;
     
     // Calculate input luminance and ensure it's positive
     float inputLuminance = max(dot(inputColor, luminanceWeights), 1e-10f);
@@ -71,20 +71,20 @@ float3 TonemapFilmic(const float3 inputColor)
 }
 
 // AGX tone mapping implementation with CDL (Color Decision List) support
-// Reference: https://github.com/sobotka/AgX
+// Reference: https://github.com/sobotka/AgX and https://github.com/google/filament
 // Adapted for O3DE's ACEScg -> Linear sRGB pipeline
 
 // Internal AGX function that applies the core transform and CDL parameters
 float3 TonemapAgxInternal(const float3 inputColor, const float3 slope, const float3 offset, const float3 power, const float saturation)
 {
-    // AGX Inset Matrix (input transform) - converted to column major
+    // AGX Inset Matrix (input transform) - column major
     const float3x3 agxInsetMatrix = float3x3(
         0.856627153315983f, 0.0951212405381588f, 0.0482516061458583f,
         0.137318972929847f, 0.761241990602591f, 0.101439036467562f,
         0.11189821299995f, 0.0767994186031903f, 0.811302368396859f
     );
     
-    // AGX Outset Matrix (output transform) - converted to column major and inverted
+    // AGX Outset Matrix (output transform) - column major
     const float3x3 agxOutsetMatrix = float3x3(
         1.1271005818144368f, -0.11060664309660323f, -0.016493938717834573f,
         -0.1413297634984383f, 1.157823702216272f, -0.016493938717834257f,
@@ -95,36 +95,40 @@ float3 TonemapAgxInternal(const float3 inputColor, const float3 slope, const flo
     const float agxMinEv = -12.47393f;
     const float agxMaxEv = 4.026069f;
     
+    // Ensure no negative values
+    float3 color = max(inputColor, 0.0f);
+    
     // 1. AGX Transform
     // Input transform (inset)
-    float3 color = mul(agxInsetMatrix, inputColor);
+    color = mul(agxInsetMatrix, color);
     
     // Avoid 0 or negative numbers for log2
     color = max(color, 1e-10f);
     
     // Log2 space encoding
-    color = clamp(log2(color), agxMinEv, agxMaxEv);
+    color = log2(color);
     color = (color - agxMinEv) / (agxMaxEv - agxMinEv);
     color = clamp(color, 0.0f, 1.0f);
     
-    // Apply sigmoid function approximation (6th order polynomial)
-    // Mean error^2: 3.6705141e-06
+    // Apply sigmoid function approximation (7th order polynomial from Filament)
     float3 x2 = color * color;
     float3 x4 = x2 * x2;
-    color = + 15.5f     * x4 * x2
-            - 40.14f    * x4 * color
-            + 31.96f    * x4
-            - 6.868f    * x2 * color
-            + 0.4298f   * x2
-            + 0.1191f   * color
-            - 0.00232f;
+    float3 x6 = x4 * x2;
+    color = - 17.86f    * x6 * color
+            + 78.01f    * x6
+            - 126.7f    * x4 * color
+            + 92.06f    * x4
+            - 28.72f    * x2 * color
+            + 4.361f    * x2
+            - 0.1718f   * color
+            + 0.002857f;
     
     // 2. AGX Look (CDL operations)
-    color = pow(color * slope + offset, power);
-    
-    // Apply saturation using luminance weights (Rec. 709)
     const float3 luminanceWeights = float3(0.2126f, 0.7152f, 0.0722f);
     float luma = dot(color, luminanceWeights);
+    
+    // ASC CDL
+    color = pow(color * slope + offset, power);
     color = luma + saturation * (color - luma);
     
     // 3. AGX EOTF
@@ -154,6 +158,12 @@ float3 TonemapAgxGolden(const float3 inputColor)
 float3 TonemapAgxPunchy(const float3 inputColor)
 {
     return TonemapAgxInternal(inputColor, float3(1.0f, 1.0f, 1.0f), float3(0.0f, 0.0f, 0.0f), float3(1.35f, 1.35f, 1.35f), 1.4f);
+}
+
+// AGX Warm - subtle warm cinematic look (less extreme than Golden)
+float3 TonemapAgxWarm(const float3 inputColor)
+{
+    return TonemapAgxInternal(inputColor, float3(1.0f, 0.95f, 0.85f), float3(0.0f, 0.0f, 0.0f), float3(0.95f, 0.95f, 0.95f), 1.1f);
 }
 
 // Khronos PBR Neutral Tone Mapping

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -10,10 +10,17 @@
 
 #include <Atom/Features/ColorManagement/TransformColor.azsli>
 
+// Simple reinhard tone mapping algorithm based on below paper.
+// http://www.cmap.polytechnique.fr/~peyre/cours/x2005signal/hdr_photographic.pdf
+float3 TonemapReinhard(const float3 inputColor)
+{
+    return inputColor / (1.0 + inputColor);
+}
+
 // Extended Reinhard tone mapping algorithm with white point
 // Luminance-based implementation that preserves hue while providing better highlight control
 // https://64.github.io/tonemapping/#extended-reinhard-luminance-tone-map
-float3 TonemapReinhard(const float3 inputColor)
+float3 TonemapReinhardExtended(const float3 inputColor)
 {
     // Rec. 709 luminance weights
     const float3 luminanceWeights = float3(0.2126f, 0.7152f, 0.0722f);
@@ -178,8 +185,9 @@ float3 TonemapPbrNeutral(const float3 inputColor)
     color -= offset;
     
     float peak = max(color.r, max(color.g, color.b));
-    if (peak < startCompression) 
+    if (peak < startCompression) {
         return color;
+    }
     
     const float d = 1.0f - startCompression;
     float newPeak = 1.0f - d * d / (peak + d - startCompression);

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -165,6 +165,7 @@ float3 TonemapAgxWarm(const float3 inputColor)
 // Khronos PBR Neutral Tone Mapping
 // Input color is non-negative and resides in the Linear Rec. 709 color space.
 // Output color is also Linear Rec. 709, but in the [0, 1] range.
+// https://github.com/KhronosGroup/ToneMapping
 float3 TonemapPbrNeutral(const float3 inputColor)
 {
     const float startCompression = 0.8f - 0.04f;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -136,6 +136,32 @@ float3 TonemapAgxPunchy(const float3 inputColor)
     return TonemapAgxInternal(inputColor, float3(1.0f, 1.0f, 1.0f), float3(0.0f, 0.0f, 0.0f), float3(1.35f, 1.35f, 1.35f), 1.4f);
 }
 
+// Khronos PBR Neutral Tone Mapping
+// Input color is non-negative and resides in the Linear Rec. 709 color space.
+// Output color is also Linear Rec. 709, but in the [0, 1] range.
+float3 TonemapPbrNeutral(const float3 inputColor)
+{
+    const float startCompression = 0.8f - 0.04f;
+    const float desaturation = 0.15f;
+    
+    float3 color = inputColor;
+    
+    float x = min(color.r, min(color.g, color.b));
+    float offset = x < 0.08f ? x - 6.25f * x * x : 0.04f;
+    color -= offset;
+    
+    float peak = max(color.r, max(color.g, color.b));
+    if (peak < startCompression) 
+        return color;
+    
+    const float d = 1.0f - startCompression;
+    float newPeak = 1.0f - d * d / (peak + d - startCompression);
+    color *= newPeak / peak;
+    
+    float g = 1.0f - 1.0f / (desaturation * (peak - newPeak) + 1.0f);
+    return lerp(color, newPeak * float3(1.0f, 1.0f, 1.0f), g);
+}
+
 float3 ApplyManualExposure(float3 color, float exposure)
 {
     // Apply Manual exposure

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -69,11 +69,8 @@ float3 TonemapFilmic(const float3 inputColor)
     return (color * (6.2 * color + 0.5)) / (color * (6.2 * color + 1.7) + 0.06);
 }
 
-// AGX tone mapping implementation with CDL (Color Decision List) support
+// AGX tone mapping implementation
 // Reference: https://github.com/sobotka/AgX and https://github.com/google/filament
-// Adapted for O3DE's ACEScg -> Linear sRGB pipeline
-
-// Internal AGX function that applies the core transform and CDL parameters
 float3 TonemapAgxInternal(const float3 inputColor, const float3 slope, const float3 offset, const float3 power, const float saturation)
 {
     // AGX Inset Matrix (input transform) - column major

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -15,7 +15,6 @@
 // https://64.github.io/tonemapping/#extended-reinhard-luminance-tone-map
 float3 TonemapReinhard(const float3 inputColor)
 {
-    // return inputColor / (1.0f + inputColor);
     // Rec. 709 luminance weights
     const float3 luminanceWeights = float3(0.2126f, 0.7152f, 0.0722f);
     

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -54,35 +54,55 @@ float3 TonemapFilmic(const float3 inputColor)
 // Reference: https://github.com/sobotka/AgX
 float3 TonemapAgx(const float3 inputColor)
 {
+    // AGX Inset Matrix (input transform) - converted to column major
+    const float3x3 agxInsetMatrix = float3x3(
+        0.856627153315983f, 0.0951212405381588f, 0.0482516061458583f,
+        0.137318972929847f, 0.761241990602591f, 0.101439036467562f,
+        0.11189821299995f, 0.0767994186031903f, 0.811302368396859f
+    );
+    
+    // AGX Outset Matrix (output transform) - converted to column major and inverted
+    const float3x3 agxOutsetMatrix = float3x3(
+        1.1271005818144368f, -0.11060664309660323f, -0.016493938717834573f,
+        -0.1413297634984383f, 1.157823702216272f, -0.016493938717834257f,
+        -0.14132976349843826f, -0.11060664309660294f, 1.2519364065950405f
+    );
+    
     // AGX constants
-    const float3x3 agxMat = float3x3(
-        0.842479062253094f, 0.0423282422610123f, 0.0423756549057051f,
-        0.0784335999999992f, 0.878468636469772f, 0.0784336f,
-        0.0792237451477643f, 0.0792237451477643f, 0.879142973793104f
-    );
+    const float agxMinEv = -12.47393f;
+    const float agxMaxEv = 4.026069f;
     
-    const float3x3 agxMatInv = float3x3(
-        1.19687900512017f, -0.0528968517574562f, -0.0529716355144438f,
-        -0.0980208811401368f, 1.15190312990417f, -0.0980434501171241f,
-        -0.0990297440797205f, -0.0990297440797205f, 1.15107367264116f
-    );
+    // Input transform (inset)
+    float3 color = mul(agxInsetMatrix, inputColor);
     
-    // Apply AgX input transform matrix
-    float3 color = mul(agxMat, inputColor);
+    // Avoid 0 or negative numbers for log2
+    color = max(color, 1e-10f);
     
-    // Apply the power function
-    color = pow(max(color, 0.0), 2.4f);
+    // Log2 space encoding
+    color = clamp(log2(color), agxMinEv, agxMaxEv);
+    color = (color - agxMinEv) / (agxMaxEv - agxMinEv);
+    color = clamp(color, 0.0f, 1.0f);
     
-    // Apply the sigmoid curve
-    color = (color * color + color) / (color * color + 2.0f * color + 1.0f);
+    // Apply sigmoid function approximation (6th order polynomial)
+    // Mean error^2: 3.6705141e-06
+    float3 x2 = color * color;
+    float3 x4 = x2 * x2;
+    color = + 15.5f     * x4 * x2
+            - 40.14f    * x4 * color
+            + 31.96f    * x4
+            - 6.868f    * x2 * color
+            + 0.4298f   * x2
+            + 0.1191f   * color
+            - 0.00232f;
     
-    // Apply inverse power function
-    color = pow(color, 1.0f / 2.4f);
+    // Inverse input transform (outset)
+    color = mul(agxOutsetMatrix, color);
     
-    // Apply AgX output transform matrix
-    color = mul(agxMatInv, color);
+    // sRGB IEC 61966-2-1 2.2 Exponent Reference EOTF Display
+    // We linearize the output since O3DE expects linear sRGB
+    color = pow(max(color, 0.0f), 2.2f);
     
-    return max(color, 0.0f);
+    return color;
 }
 
 float3 ApplyManualExposure(float3 color, float exposure)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -10,11 +10,31 @@
 
 #include <Atom/Features/ColorManagement/TransformColor.azsli>
 
-// Simple reinhard tone mapping algorithm based on below paper.
-// http://www.cmap.polytechnique.fr/~peyre/cours/x2005signal/hdr_photographic.pdf
+// Extended Reinhard tone mapping algorithm with white point
+// Luminance-based implementation that preserves hue while providing better highlight control
+// https://64.github.io/tonemapping/#extended-reinhard-luminance-tone-map
 float3 TonemapReinhard(const float3 inputColor)
 {
-    return inputColor / (1.0 + inputColor);
+    // return inputColor / (1.0f + inputColor);
+    // Rec. 709 luminance weights
+    const float3 luminanceWeights = float3(0.2126f, 0.7152f, 0.0722f);
+    
+    // White point luminance - chosen for good balance in most scenes
+    // Higher values compress highlights less, lower values compress more
+    // This is something we could expose as a parameter in the future
+    const float maxWhiteLuminance = 4.0f;
+    
+    // Calculate input luminance and ensure it's positive
+    float inputLuminance = max(dot(inputColor, luminanceWeights), 1e-10f);
+    
+    // Apply extended Reinhard tonemapping to luminance
+    // Formula: L_out = L_in * (1 + L_in / (maxWhite^2)) / (1 + L_in)
+    float numerator = inputLuminance * (1.0f + (inputLuminance / (maxWhiteLuminance * maxWhiteLuminance)));
+    float outputLuminance = numerator / (1.0f + inputLuminance);
+    
+    // Preserve chromaticity by scaling the original color
+    // This maintains hue relationships while applying the tone curve
+    return inputColor * (outputLuminance / inputLuminance);
 }
 
 // Originally written by Stephen Hill (@self_shadow)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -50,9 +50,12 @@ float3 TonemapFilmic(const float3 inputColor)
     return (color * (6.2 * color + 0.5)) / (color * (6.2 * color + 1.7) + 0.06);
 }
 
-// AGX tone mapping implementation
+// AGX tone mapping implementation with CDL (Color Decision List) support
 // Reference: https://github.com/sobotka/AgX
-float3 TonemapAgx(const float3 inputColor)
+// Adapted for O3DE's ACEScg -> Linear sRGB pipeline
+
+// Internal AGX function that applies the core transform and CDL parameters
+float3 TonemapAgxInternal(const float3 inputColor, const float3 slope, const float3 offset, const float3 power, const float saturation)
 {
     // AGX Inset Matrix (input transform) - converted to column major
     const float3x3 agxInsetMatrix = float3x3(
@@ -72,6 +75,7 @@ float3 TonemapAgx(const float3 inputColor)
     const float agxMinEv = -12.47393f;
     const float agxMaxEv = 4.026069f;
     
+    // 1. AGX Transform
     // Input transform (inset)
     float3 color = mul(agxInsetMatrix, inputColor);
     
@@ -95,6 +99,15 @@ float3 TonemapAgx(const float3 inputColor)
             + 0.1191f   * color
             - 0.00232f;
     
+    // 2. AGX Look (CDL operations)
+    color = pow(color * slope + offset, power);
+    
+    // Apply saturation using luminance weights (Rec. 709)
+    const float3 luminanceWeights = float3(0.2126f, 0.7152f, 0.0722f);
+    float luma = dot(color, luminanceWeights);
+    color = luma + saturation * (color - luma);
+    
+    // 3. AGX EOTF
     // Inverse input transform (outset)
     color = mul(agxOutsetMatrix, color);
     
@@ -103,6 +116,24 @@ float3 TonemapAgx(const float3 inputColor)
     color = pow(max(color, 0.0f), 2.2f);
     
     return color;
+}
+
+// Base AGX tonemapping
+float3 TonemapAgx(const float3 inputColor)
+{
+    return TonemapAgxInternal(inputColor, float3(1.0f, 1.0f, 1.0f), float3(0.0f, 0.0f, 0.0f), float3(1.0f, 1.0f, 1.0f), 1.0f);
+}
+
+// AGX Golden - warmer, more cinematic look
+float3 TonemapAgxGolden(const float3 inputColor)
+{
+    return TonemapAgxInternal(inputColor, float3(1.0f, 0.9f, 0.5f), float3(0.0f, 0.0f, 0.0f), float3(0.8f, 0.8f, 0.8f), 1.3f);
+}
+
+// AGX Punchy - higher contrast, more saturated
+float3 TonemapAgxPunchy(const float3 inputColor)
+{
+    return TonemapAgxInternal(inputColor, float3(1.0f, 1.0f, 1.0f), float3(0.0f, 0.0f, 0.0f), float3(1.35f, 1.35f, 1.35f), 1.4f);
 }
 
 float3 ApplyManualExposure(float3 color, float exposure)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -50,6 +50,41 @@ float3 TonemapFilmic(const float3 inputColor)
     return (color * (6.2 * color + 0.5)) / (color * (6.2 * color + 1.7) + 0.06);
 }
 
+// AGX tone mapping implementation
+// Reference: https://github.com/sobotka/AgX
+float3 TonemapAgx(const float3 inputColor)
+{
+    // AGX constants
+    const float3x3 agxMat = float3x3(
+        0.842479062253094f, 0.0423282422610123f, 0.0423756549057051f,
+        0.0784335999999992f, 0.878468636469772f, 0.0784336f,
+        0.0792237451477643f, 0.0792237451477643f, 0.879142973793104f
+    );
+    
+    const float3x3 agxMatInv = float3x3(
+        1.19687900512017f, -0.0528968517574562f, -0.0529716355144438f,
+        -0.0980208811401368f, 1.15190312990417f, -0.0980434501171241f,
+        -0.0990297440797205f, -0.0990297440797205f, 1.15107367264116f
+    );
+    
+    // Apply AgX input transform matrix
+    float3 color = mul(agxMat, inputColor);
+    
+    // Apply the power function
+    color = pow(max(color, 0.0), 2.4f);
+    
+    // Apply the sigmoid curve
+    color = (color * color + color) / (color * color + 2.0f * color + 1.0f);
+    
+    // Apply inverse power function
+    color = pow(color, 1.0f / 2.4f);
+    
+    // Apply AgX output transform matrix
+    color = mul(agxMatInv, color);
+    
+    return max(color, 0.0f);
+}
+
 float3 ApplyManualExposure(float3 color, float exposure)
 {
     // Apply Manual exposure

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
@@ -42,7 +42,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 }
 
 // Option shader variable to select tone mapper feature.
-option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx, AgxGolden, AgxPunchy, PbrNeutral} o_tonemapperType = ToneMapperType::None;
+option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx, AgxGolden, AgxPunchy, AgxWarm, PbrNeutral} o_tonemapperType = ToneMapperType::None;
 // Option shader variable to select transfer function.
 option enum class TransferFunctionType {None, Gamma22, PerceptualQuantizer} o_transferFunctionType = TransferFunctionType::None;
 // Option to enable color grading
@@ -95,6 +95,9 @@ PSOutput MainPS(VSOutput IN)
             break;
         case ToneMapperType::AgxPunchy:
             color = TonemapAgxPunchy(AcesCg_To_LinearSrgb(color));
+            break;
+        case ToneMapperType::AgxWarm:
+            color = TonemapAgxWarm(AcesCg_To_LinearSrgb(color));
             break;
         case ToneMapperType::PbrNeutral:
             color = TonemapPbrNeutral(AcesCg_To_LinearSrgb(color));

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
@@ -42,7 +42,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 }
 
 // Option shader variable to select tone mapper feature.
-option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic} o_tonemapperType = ToneMapperType::None;
+option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx} o_tonemapperType = ToneMapperType::None;
 // Option shader variable to select transfer function.
 option enum class TransferFunctionType {None, Gamma22, PerceptualQuantizer} o_transferFunctionType = TransferFunctionType::None;
 // Option to enable color grading
@@ -86,6 +86,9 @@ PSOutput MainPS(VSOutput IN)
             break;
         case ToneMapperType::Filmic:
             color = TonemapFilmic(AcesCg_To_LinearSrgb(color));
+            break;
+        case ToneMapperType::Agx:
+            color = TonemapAgx(AcesCg_To_LinearSrgb(color));
             break;
         default:
             break;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
@@ -42,7 +42,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 }
 
 // Option shader variable to select tone mapper feature.
-option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx} o_tonemapperType = ToneMapperType::None;
+option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx, AgxGolden, AgxPunchy} o_tonemapperType = ToneMapperType::None;
 // Option shader variable to select transfer function.
 option enum class TransferFunctionType {None, Gamma22, PerceptualQuantizer} o_transferFunctionType = TransferFunctionType::None;
 // Option to enable color grading
@@ -89,6 +89,12 @@ PSOutput MainPS(VSOutput IN)
             break;
         case ToneMapperType::Agx:
             color = TonemapAgx(AcesCg_To_LinearSrgb(color));
+            break;
+        case ToneMapperType::AgxGolden:
+            color = TonemapAgxGolden(AcesCg_To_LinearSrgb(color));
+            break;
+        case ToneMapperType::AgxPunchy:
+            color = TonemapAgxPunchy(AcesCg_To_LinearSrgb(color));
             break;
         default:
             break;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
@@ -42,7 +42,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 }
 
 // Option shader variable to select tone mapper feature.
-option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx, AgxGolden, AgxPunchy, AgxWarm, PbrNeutral} o_tonemapperType = ToneMapperType::None;
+option enum class ToneMapperType {None, Reinhard, ReinhardExtended, AcesFitted, AcesFilmic, Filmic, Agx, AgxGolden, AgxPunchy, AgxWarm, PbrNeutral} o_tonemapperType = ToneMapperType::None;
 // Option shader variable to select transfer function.
 option enum class TransferFunctionType {None, Gamma22, PerceptualQuantizer} o_transferFunctionType = TransferFunctionType::None;
 // Option to enable color grading
@@ -77,6 +77,9 @@ PSOutput MainPS(VSOutput IN)
     {
         case ToneMapperType::Reinhard:
             color = TonemapReinhard(AcesCg_To_LinearSrgb(color));
+            break;
+        case ToneMapperType::ReinhardExtended:
+            color = TonemapReinhardExtended(AcesCg_To_LinearSrgb(color));
             break;
         case ToneMapperType::AcesFitted:
             color = AcesCg_To_LinearSrgb(TonemapAcesFitted(color));

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.azsl
@@ -42,7 +42,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 }
 
 // Option shader variable to select tone mapper feature.
-option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx, AgxGolden, AgxPunchy} o_tonemapperType = ToneMapperType::None;
+option enum class ToneMapperType {None, Reinhard, AcesFitted, AcesFilmic, Filmic, Agx, AgxGolden, AgxPunchy, PbrNeutral} o_tonemapperType = ToneMapperType::None;
 // Option shader variable to select transfer function.
 option enum class TransferFunctionType {None, Gamma22, PerceptualQuantizer} o_transferFunctionType = TransferFunctionType::None;
 // Option to enable color grading
@@ -95,6 +95,9 @@ PSOutput MainPS(VSOutput IN)
             break;
         case ToneMapperType::AgxPunchy:
             color = TonemapAgxPunchy(AcesCg_To_LinearSrgb(color));
+            break;
+        case ToneMapperType::PbrNeutral:
+            color = TonemapPbrNeutral(AcesCg_To_LinearSrgb(color));
             break;
         default:
             break;

--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -148,6 +148,7 @@ namespace AZ
             Passthrough,
             GammaSRGB,
             Reinhard,
+            ReinhardExtended,
             AcesFitted,
             AcesFilmic,
             Filmic,
@@ -175,6 +176,7 @@ namespace AZ
         {
             None = 0,
             Reinhard,
+            ReinhardExtended,
             AcesFitted,
             AcesFilmic,
             Filmic,

--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -149,7 +149,8 @@ namespace AZ
             Reinhard,
             AcesFitted,
             AcesFilmic,
-            Filmic
+            Filmic,
+            Agx
         );
 
         enum class ShaperPresetType
@@ -171,7 +172,8 @@ namespace AZ
             Reinhard,
             AcesFitted,
             AcesFilmic,
-            Filmic
+            Filmic,
+            Agx
         };
 
         enum class TransferFunctionType

--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -153,7 +153,8 @@ namespace AZ
             Filmic,
             Agx,
             AgxGolden,
-            AgxPunchy
+            AgxPunchy,
+            PbrNeutral
         );
 
         enum class ShaperPresetType
@@ -178,7 +179,8 @@ namespace AZ
             Filmic,
             Agx,
             AgxGolden,
-            AgxPunchy
+            AgxPunchy,
+            PbrNeutral
         };
 
         enum class TransferFunctionType

--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -1,3 +1,4 @@
+
 // ACES code derived from the nVidia HDR Display Demo Project
 // (https://developer.nvidia.com/high-dynamic-range-display-development)
 // -----------------------------------------------------------------------------
@@ -150,7 +151,9 @@ namespace AZ
             AcesFitted,
             AcesFilmic,
             Filmic,
-            Agx
+            Agx,
+            AgxGolden,
+            AgxPunchy
         );
 
         enum class ShaperPresetType
@@ -173,7 +176,9 @@ namespace AZ
             AcesFitted,
             AcesFilmic,
             Filmic,
-            Agx
+            Agx,
+            AgxGolden,
+            AgxPunchy
         };
 
         enum class TransferFunctionType

--- a/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
+++ b/Gems/Atom/Feature/Common/Code/3rdParty/ACES/ACES/Aces.h
@@ -154,6 +154,7 @@ namespace AZ
             Agx,
             AgxGolden,
             AgxPunchy,
+            AgxWarm,
             PbrNeutral
         );
 
@@ -180,6 +181,7 @@ namespace AZ
             Agx,
             AgxGolden,
             AgxPunchy,
+            AgxWarm,
             PbrNeutral
         };
 

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -88,6 +88,7 @@ namespace AZ
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxGolden ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy ||
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxWarm ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::PbrNeutral)
                     {
                         // When using Reinhard tonemapper, a gamma of 2.2 for the transfer function is used for LDR display,
@@ -460,6 +461,9 @@ namespace AZ
                 case DisplayMapperOperationType::AgxPunchy:
                     type = ToneMapperType::AgxPunchy;
                     break;
+                case DisplayMapperOperationType::AgxWarm:
+                    type = ToneMapperType::AgxWarm;
+                    break;
                 case DisplayMapperOperationType::PbrNeutral:
                     type = ToneMapperType::PbrNeutral;
                     break;
@@ -584,6 +588,7 @@ namespace AZ
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxGolden ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy ||
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxWarm ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::PbrNeutral;
         }
     }   // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -85,7 +85,9 @@ namespace AZ
                     if (m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Reinhard ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFitted ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||
-                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx)
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx ||
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxGolden ||
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy)
                     {
                         // When using Reinhard tonemapper, a gamma of 2.2 for the transfer function is used for LDR display,
                         // and PQ is used for HDR.
@@ -451,6 +453,12 @@ namespace AZ
                 case DisplayMapperOperationType::Agx:
                     type = ToneMapperType::Agx;
                     break;
+                case DisplayMapperOperationType::AgxGolden:
+                    type = ToneMapperType::AgxGolden;
+                    break;
+                case DisplayMapperOperationType::AgxPunchy:
+                    type = ToneMapperType::AgxPunchy;
+                    break;
                 default:
                     AZ_Assert(false, "Invalid tonemapper type %d", m_displayMapperConfigurationDescriptor.m_operationType);
                     break;
@@ -569,7 +577,9 @@ namespace AZ
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFitted ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Filmic ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||
-                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx;
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx ||
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxGolden ||
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy;
         }
     }   // namespace Render
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -87,7 +87,8 @@ namespace AZ
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxGolden ||
-                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy)
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy ||
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::PbrNeutral)
                     {
                         // When using Reinhard tonemapper, a gamma of 2.2 for the transfer function is used for LDR display,
                         // and PQ is used for HDR.
@@ -459,6 +460,9 @@ namespace AZ
                 case DisplayMapperOperationType::AgxPunchy:
                     type = ToneMapperType::AgxPunchy;
                     break;
+                case DisplayMapperOperationType::PbrNeutral:
+                    type = ToneMapperType::PbrNeutral;
+                    break;
                 default:
                     AZ_Assert(false, "Invalid tonemapper type %d", m_displayMapperConfigurationDescriptor.m_operationType);
                     break;
@@ -579,7 +583,8 @@ namespace AZ
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxGolden ||
-                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy;
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AgxPunchy ||
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::PbrNeutral;
         }
     }   // namespace Render
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -83,6 +83,7 @@ namespace AZ
                 if (m_outputTransformPass)
                 {
                     if (m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Reinhard ||
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::ReinhardExtended ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFitted ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx ||
@@ -443,6 +444,9 @@ namespace AZ
                 case DisplayMapperOperationType::Reinhard:
                     type = ToneMapperType::Reinhard;
                     break;
+                case DisplayMapperOperationType::ReinhardExtended:
+                    type = ToneMapperType::ReinhardExtended;
+                    break;
                 case DisplayMapperOperationType::AcesFitted:
                     type = ToneMapperType::AcesFitted;
                     break;
@@ -582,6 +586,7 @@ namespace AZ
         bool DisplayMapperPass::UsesOutputTransformPass() const
         {
             return m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Reinhard ||
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::ReinhardExtended ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFitted ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Filmic ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -84,7 +84,8 @@ namespace AZ
                 {
                     if (m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Reinhard ||
                         m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFitted ||
-                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic)
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||
+                        m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx)
                     {
                         // When using Reinhard tonemapper, a gamma of 2.2 for the transfer function is used for LDR display,
                         // and PQ is used for HDR.
@@ -447,6 +448,9 @@ namespace AZ
                 case DisplayMapperOperationType::Filmic:
                     type = ToneMapperType::Filmic;
                     break;
+                case DisplayMapperOperationType::Agx:
+                    type = ToneMapperType::Agx;
+                    break;
                 default:
                     AZ_Assert(false, "Invalid tonemapper type %d", m_displayMapperConfigurationDescriptor.m_operationType);
                     break;
@@ -564,7 +568,8 @@ namespace AZ
             return m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Reinhard ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFitted ||
                 m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Filmic ||
-                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic;
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::AcesFilmic ||
+                m_displayMapperConfigurationDescriptor.m_operationType == DisplayMapperOperationType::Agx;
         }
     }   // namespace Render
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -154,7 +154,9 @@ namespace AZ
                                                                  AZ::Name("ToneMapperType::AcesFitted"),
                                                                  AZ::Name("ToneMapperType::AcesFilmic"),
                                                                  AZ::Name("ToneMapperType::Filmic"),
-                                                                 AZ::Name("ToneMapperType::Agx") };
+                                                                 AZ::Name("ToneMapperType::Agx"),
+                                                                 AZ::Name("ToneMapperType::AgxGolden"),
+                                                                 AZ::Name("ToneMapperType::AgxPunchy") };
             AZStd::vector<AZ::Name> transferFunctionVariationTypes = {
                 AZ::Name("TransferFunctionType::None"),
                 AZ::Name("TransferFunctionType::Gamma22"),
@@ -207,6 +209,12 @@ namespace AZ
                 break;
             case ToneMapperType::Agx:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::Agx"));
+                break;
+            case ToneMapperType::AgxGolden:
+                shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::AgxGolden"));
+                break;
+            case ToneMapperType::AgxPunchy:
+                shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::AgxPunchy"));
                 break;
             default:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::None"));

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -151,6 +151,7 @@ namespace AZ
 
             AZStd::vector<AZ::Name> toneMapperVariationTypes = { AZ::Name("ToneMapperType::None"),
                                                                  AZ::Name("ToneMapperType::Reinhard"),
+                                                                 AZ::Name("ToneMapperType::ReinhardExtended"),
                                                                  AZ::Name("ToneMapperType::AcesFitted"),
                                                                  AZ::Name("ToneMapperType::AcesFilmic"),
                                                                  AZ::Name("ToneMapperType::Filmic"),
@@ -199,6 +200,9 @@ namespace AZ
             {
             case ToneMapperType::Reinhard:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::Reinhard"));
+                break;
+            case ToneMapperType::ReinhardExtended:
+                shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::ReinhardExtended"));
                 break;
             case ToneMapperType::AcesFitted:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::AcesFitted"));

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -156,7 +156,8 @@ namespace AZ
                                                                  AZ::Name("ToneMapperType::Filmic"),
                                                                  AZ::Name("ToneMapperType::Agx"),
                                                                  AZ::Name("ToneMapperType::AgxGolden"),
-                                                                 AZ::Name("ToneMapperType::AgxPunchy") };
+                                                                 AZ::Name("ToneMapperType::AgxPunchy"),
+                                                                 AZ::Name("ToneMapperType::PbrNeutral") };
             AZStd::vector<AZ::Name> transferFunctionVariationTypes = {
                 AZ::Name("TransferFunctionType::None"),
                 AZ::Name("TransferFunctionType::Gamma22"),
@@ -215,6 +216,9 @@ namespace AZ
                 break;
             case ToneMapperType::AgxPunchy:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::AgxPunchy"));
+                break;
+            case ToneMapperType::PbrNeutral:
+                shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::PbrNeutral"));
                 break;
             default:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::None"));

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -153,7 +153,8 @@ namespace AZ
                                                                  AZ::Name("ToneMapperType::Reinhard"),
                                                                  AZ::Name("ToneMapperType::AcesFitted"),
                                                                  AZ::Name("ToneMapperType::AcesFilmic"),
-                                                                 AZ::Name("ToneMapperType::Filmic") };
+                                                                 AZ::Name("ToneMapperType::Filmic"),
+                                                                 AZ::Name("ToneMapperType::Agx") };
             AZStd::vector<AZ::Name> transferFunctionVariationTypes = {
                 AZ::Name("TransferFunctionType::None"),
                 AZ::Name("TransferFunctionType::Gamma22"),
@@ -203,6 +204,9 @@ namespace AZ
                 break;
             case ToneMapperType::AcesFilmic:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::AcesFilmic"));
+                break;
+            case ToneMapperType::Agx:
+                shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::Agx"));
                 break;
             default:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::None"));

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -157,6 +157,7 @@ namespace AZ
                                                                  AZ::Name("ToneMapperType::Agx"),
                                                                  AZ::Name("ToneMapperType::AgxGolden"),
                                                                  AZ::Name("ToneMapperType::AgxPunchy"),
+                                                                 AZ::Name("ToneMapperType::AgxWarm"),
                                                                  AZ::Name("ToneMapperType::PbrNeutral") };
             AZStd::vector<AZ::Name> transferFunctionVariationTypes = {
                 AZ::Name("TransferFunctionType::None"),
@@ -216,6 +217,9 @@ namespace AZ
                 break;
             case ToneMapperType::AgxPunchy:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::AgxPunchy"));
+                break;
+            case ToneMapperType::AgxWarm:
+                shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::AgxWarm"));
                 break;
             case ToneMapperType::PbrNeutral:
                 shaderOption.SetValue(m_toneMapperShaderVariantOptionName, AZ::Name("ToneMapperType::PbrNeutral"));


### PR DESCRIPTION
## What does this PR do?

Implements AgX tonemapping based on Google Filament's 7th order polynomial sigmoid approximation.
- Default AgX style is fairly low contrast compared to other tonemappers like ACES. Color grading should be adjusted.
- Punchy AgX style introduces some contrast and saturation into the tonemapper, bringing it closer to an "out of the box" look.
- Golden AgX style applies a very heavy golden tint to the scene. May have limited usefulness, but most implementations include this anyways.
- Warm AgX is my own tuned look with a small bump to contrast and a much more subtle warm tint.

Implements Khronos PBR Neutral tonemapping.
- [View this press release for an overview and motivations](https://www.khronos.org/news/press/khronos-pbr-neutral-tone-mapper-released-for-true-to-life-color-rendering-of-3d-products)
- Good for Archviz, product rendering etc, but generally looks pleasant in most scenes I've tested.

Improves basic Reinhard tonemapping with a luminance aware "extended" implementation.
- [View the reference and theory here](https://64.github.io/tonemapping/#extended-reinhard-luminance-tone-map)
- Should improve the general look of scenes using this tonemapper, regaining some lost saturation.

## How was this PR tested?

Only tested on Linux so far. Doesn't do anything drastic with the engine, mostly just introducing some enums and some new shader code.
