### PR TITLE
Fail shader build job if azsl preprocessing fails

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -451,7 +451,12 @@ namespace AZ
                     PreprocessorData output;
                     auto preprocessorArguments = AppendIncludePathsToArgumentList(buildArgsManager.GetCurrentArguments().m_preprocessorArguments, projectIncludePaths);
                     const bool preprocessorSuccess = PreprocessFile(prependedAzslFilePath, output, preprocessorArguments,  true);
-                    RHI::ReportMessages(ShaderAssetBuilderName, output.diagnostics, !preprocessorSuccess);
+                    if (RHI::ReportMessages(ShaderAssetBuilderName, output.diagnostics, !preprocessorSuccess))
+                    {
+                        response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+                        return;
+                    }
+
                     // Dump the preprocessed string as a flat AZSL file with extension .azslin, which will be given to AZSLc to generate the HLSL file.
                     AZStd::string superVariantAzslinStemName = shaderFileName;
                     if (!supervariantInfo.m_name.IsEmpty())


### PR DESCRIPTION
## What does this PR do?

This PR changes the AssetProcessor behavior such that missing includes are treated as job failure. Before that, a missing include lead to an error in the event log, but shader processing continued, and only failed if the missing include leads to further compile errors. This behavior does not seem reasonable, and can lead to errors when an azsl file also works without a specific include but the behavior is changed by the include (eg. by using `#if defined(...)` or overwriting a macro definition).

## How was this PR tested?

Run the AssetProcessor with clean cache for a small test project, the AutomatedTesting project, and the AtomSampleViewer, all projects processed without showing an error. Adding an invalid `#include` to an azsl or azsli file marks the affected shader assets as failed in the job list.