### PR TITLE
Updates the android project generator for latest (Gradle 8.13, AGP 8.13, JDK 17)

### DIFF
--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -10,43 +10,46 @@ apply plugin: "com.android.${TARGET_TYPE}"
 android {
     ${PROJECT_NAMESPACE_OPTION}
 ${SIGNING_CONFIGS}
-    compileSdkVersion sdkVer
-    buildToolsVersion buildToolsVer
-    ndkVersion ndkPlatformVer
+    compileSdkVersion = sdkVer
+    buildToolsVersion = buildToolsVer
+    ndkVersion =  ndkPlatformVer
     lintOptions {
-        abortOnError false
-        checkReleaseBuilds false
+        abortOnError = false
+        checkReleaseBuilds = false
     }
 
     defaultConfig {
-        minSdkVersion minSdkVer
-        targetSdkVersion sdkVer
+        minSdkVersion = minSdkVer
+        targetSdkVersion = sdkVer
+        aaptOptions {    // don't filter out files that start with underscore, as some assets do that.
+            ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!.scc:!CVS:!thumbs.db:!picasa.ini:!~'
+        }
 ${NATIVE_CMAKE_SECTION_DEFAULT_CONFIG}
     }
 
     buildTypes {
         debug {
-            debuggable true
+            debuggable = true
 ${NATIVE_CMAKE_SECTION_DEBUG_CONFIG}
             ${SIGNING_DEBUG_CONFIG}
         }
         profile {
             getIsDefault().set(true)
-            debuggable true
+            debuggable = true
 ${NATIVE_CMAKE_SECTION_PROFILE_CONFIG}
             ${SIGNING_PROFILE_CONFIG}
         }
         release {
-            debuggable false
-            minifyEnabled false
+            debuggable = false
+            minifyEnabled = false
 ${NATIVE_CMAKE_SECTION_RELEASE_CONFIG}
             ${SIGNING_RELEASE_CONFIG}
         }
     }
 
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
     }
 
 ${NATIVE_CMAKE_SECTION_ANDROID}
@@ -70,7 +73,7 @@ ${OVERRIDE_JAVA_SOURCESET}
     //   there is a bug causing the app to softlock when attempting to open the PAK. 
     // See https://github.com/o3de/o3de/issues/17625
     aaptOptions {
-        noCompress 'pak'
+        noCompress =  'pak'
     }
 }
 

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -296,8 +296,26 @@ class AndroidGradlePluginRequirements(object):
 
 # The ANDROID_GRADLE_PLUGIN_COMPATIBILITY_MAP manages the known android plugin known to O3DE and its compatibility requirements
 # Note: This map needs to be updated in conjunction with newer versions of the Android Gradle plugins.
-
+# see https://developer.android.com/build/releases/gradle-plugin for the actual table that this data comes from
+# each entry associates the key (version of the android gradle plugin)
+# to the minimum required version of gradle, android sdk build tools, and jdk version required for it to work.
 ANDROID_GRADLE_PLUGIN_COMPATIBILITY_MAP = {
+    '8.13': AndroidGradlePluginRequirements(agp_version='8.13',
+                                            gradle_version='8.13',
+                                            sdk_build_tools_version='35.0.0',
+                                            jdk_version='17',
+                                            release_note_url='https://developer.android.com/build/releases/gradle-plugin'),
+    '8.12': AndroidGradlePluginRequirements(agp_version='8.12',
+                                            gradle_version='8.13',
+                                            sdk_build_tools_version='35.0.0',
+                                            jdk_version='17',
+                                            release_note_url='https://developer.android.com/build/releases/gradle-plugin'),
+    '8.11': AndroidGradlePluginRequirements(agp_version='8.11',
+                                           gradle_version='8.13',
+                                           sdk_build_tools_version='35.0.0',
+                                           jdk_version='17',
+                                           release_note_url='https://developer.android.com/build/releases/gradle-plugin'),
+
     '8.10': AndroidGradlePluginRequirements(agp_version='8.10',
                                            gradle_version='8.11',
                                            sdk_build_tools_version='35.0.0',
@@ -781,10 +799,10 @@ class AndroidSigningConfig(object):
         :return:    The signing config string section to insert
         """
         tab_prefix = ' '* 4 * tabs  # 4 spaces per tab
-        return f"{tab_prefix}storeFile file('{self._store_file.as_posix()}')\n" \
-               f"{tab_prefix}storePassword '{self._store_password}'\n" \
-               f"{tab_prefix}keyPassword '{self._key_password}'\n" \
-               f"{tab_prefix}keyAlias '{self._key_alias}'"
+        return f"{tab_prefix}storeFile = file('{self._store_file.as_posix()}')\n" \
+               f"{tab_prefix}storePassword = '{self._store_password}'\n" \
+               f"{tab_prefix}keyPassword = '{self._key_password}'\n" \
+               f"{tab_prefix}keyAlias = '{self._key_alias}'"
 
 
 JAVA_VERSION_REGEX = re.compile(r'.*(\w)\s(version)\s*\"?(?P<version>[\d\_\.]+)', re.MULTILINE)
@@ -977,9 +995,9 @@ dependencies {{
 NATIVE_CMAKE_SECTION_ANDROID_FORMAT = """
     externalNativeBuild {{
         cmake {{
-            buildStagingDirectory "{native_build_path}"
-            version "{cmake_version}"
-            path "{absolute_cmakelist_path}"
+            buildStagingDirectory = "{native_build_path}"
+            version = "{cmake_version}"
+            path = "{absolute_cmakelist_path}"
         }}
     }}
 """
@@ -1679,7 +1697,7 @@ class AndroidProjectGenerator(object):
                                                                  full_command_line=sync_layout_command_line,
                                                                  config=native_config)
 
-            gradle_build_env[f'SIGNING_{native_config_upper}_CONFIG'] = f'signingConfig signingConfigs.{native_config_lower}' if self._signing_config else ''
+            gradle_build_env[f'SIGNING_{native_config_upper}_CONFIG'] = f'signingConfig = signingConfigs.{native_config_lower}' if self._signing_config else ''
 
         if self._signing_config:
             gradle_build_env['SIGNING_CONFIGS'] = f"""
@@ -1700,7 +1718,7 @@ class AndroidProjectGenerator(object):
 
         if self._gradle_plugin_version >= Version('7.0'):
             package_namespace = self._project_android_settings['package_name']
-            gradle_build_env['PROJECT_NAMESPACE_OPTION'] = f'namespace "{package_namespace}"'
+            gradle_build_env['PROJECT_NAMESPACE_OPTION'] = f'namespace = "{package_namespace}"'
         else:
             gradle_build_env['PROJECT_NAMESPACE_OPTION'] = ''
 
@@ -2155,7 +2173,7 @@ class AndroidProjectGenerator(object):
             }
 
             if self._gradle_plugin_version >= Version('7.0'):
-                build_gradle_env['PROJECT_NAMESPACE_OPTION'] = f'namespace "{name_space}"' if self._gradle_plugin_version >= Version('7.0') else ''
+                build_gradle_env['PROJECT_NAMESPACE_OPTION'] = f'namespace = "{name_space}"' if self._gradle_plugin_version >= Version('7.0') else ''
 
             build_gradle_content = utils.load_template_file(template_file_path=android_project_builder_path / 'build.gradle.in',
                                                              template_env=build_gradle_env)


### PR DESCRIPTION
## What does this PR do?

This updates the o3de `android-generate` and `androic-configure` commands to handle the latest versions of JDK, Gradle, NDK, and the Android Gradle Plugin.  It also corrects the assignment syntax of various settings in the gradle file, to use the `=` operator instead of a space, which is deprecated syntax.

The following versions are now supported (these are working combinations)
* Android Gradle Plugin v8.13, Gradle v8.13, JDK 17
* Android Gradle Plugin v8.12, Gradle v8.13, JDK 17
* Android Gradle Plugin v8.11, Gradle v8.13, JDK 17

This essentially means that if you install android studio, and just use the latest everything, it works.

Note also that gradle deprecated space assignment for properties, that is, 
```gradle
   somenamespace {
      blahproperty 5
  }
```
is not legal, it should be `blahproperty = 5`

Note that function calls still use spaces.  I fixed these up too, where I could find them, and this results in the "generate project" function not emitting any errors or warnings anymore.  Actually building it still generates some warnings, but those warnings are from libraries provided by google (ie, the android play store stuff), so its kind of up to them to fix those.

## How was this PR tested?

Building, testing and running on actual android hardware (pixel 8) with the above NDKs, JDKs, Gradle, AGP.

Following the O3DE https://www.docs.o3de.org/docs/user-guide/platforms/android/generating_android_project_windows guide, and setting the versions in the config as specified.


