### PR TITLE
Fix compile warning on MeshOptimizerComponentTests

### DIFF
--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
@@ -92,12 +92,10 @@ namespace SceneProcessing
 
             auto mesh = AZStd::make_unique<AZ::SceneData::GraphData::MeshData>();
 
-            int i = 0;
             for (const AZ::Vector3& position : planeVertexPositions)
             {
                 mesh->AddPosition(position);
                 mesh->AddNormal(AZ::Vector3::CreateAxisY());
-                ++i;
             }
 
             mesh->AddFace({0, 1, 2}, 0);


### PR DESCRIPTION
## What does this PR do?

When compiling development, I got an error from an warning, caused by the no usage of a variable.

With this fix, the compilation works again.

Closes #19322 

Testing: 

Compiling `development` in the same environment of the issue. Now it compiles and the editor opens.