### PR TITLE
Bugfix: Fix the arguments passed into startDetached for ffmpeg

### DIFF
--- a/Code/Editor/Plugins/FFMPEGPlugin/FFMPEGPlugin.cpp
+++ b/Code/Editor/Plugins/FFMPEGPlugin/FFMPEGPlugin.cpp
@@ -120,7 +120,9 @@ QString CFFMPEGPlugin::GetFFMPEGExectablePath()
 bool CFFMPEGPlugin::RuntimeTest()
 {
     QString ffmpegExectablePath = CFFMPEGPlugin::GetFFMPEGExectablePath();
-    return QProcess::startDetached(QStringLiteral("\"%1\" -version").arg(ffmpegExectablePath), {});
+    QStringList arguments;
+    arguments << "-version";
+    return QProcess::startDetached(ffmpegExectablePath, arguments);
 }
 
 void CFFMPEGPlugin::RegisterTheCommand()


### PR DESCRIPTION
## What does this PR do?

The arguments to QProcess::startDetached were being passed in incorrectly via string interpolation which can cause some string escape issues and cause it to fail to find ffmpeg. The idiomatic way of passing in the arguments list is used elsewhere in the engine so this fix brings it in line.

## How was this PR tested?

<23:45:51> FFMPEG plugin: Failed to execute FFmpeg. Please install FFmpeg.
This failed on my system prior to this change.
