### PR TITLE
Fixes a bug where particles would discard mesh or skeleton mesh info

### DIFF
--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
@@ -697,12 +697,12 @@ namespace OpenParticle
         auto modelAssetType = azrtti_typeid<AZ::Data::Asset<AZ::RPI::ModelAsset>>();
         resultCode.Combine(ContinueStoringToJsonObjectField(outputValue, "material", &mat, nullptr, materialAssetType, context));
 
-        if (!info->m_model)
+        if (info->m_model.GetId().IsValid())
         {
             resultCode.Combine(ContinueStoringToJsonObjectField(outputValue, "model", &info->m_model, nullptr, modelAssetType, context));
         }
 
-        if (!info->m_skeletonModel)
+        if (info->m_skeletonModel.GetId().IsValid())
         {
             resultCode.Combine(ContinueStoringToJsonObjectField(outputValue, "skeleton model", &info->m_skeletonModel, nullptr, modelAssetType, context));
         }


### PR DESCRIPTION
## What does this PR do?

The code is simply wrong, it was only saving fields if empty, instead of if not empty.

It needs to save it if the assetId is valid, not if its *invalid*

## How was this PR tested?

Just saving the file and monitoring the changes to the file on disk.