### PR TITLE
[EMotionFx, JointSelectionWidget] Fix first column not expanding.

### DIFF
--- a/Gems/EMotionFX/Code/Source/Editor/JointSelectionWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/JointSelectionWidget.cpp
@@ -86,6 +86,10 @@ namespace EMotionFX
         m_treeView->hideColumn(SkeletonModel::COLUMN_RAGDOLL_LIMIT);
         m_treeView->hideColumn(SkeletonModel::COLUMN_RAGDOLL_COLLIDERS);
         m_treeView->hideColumn(SkeletonModel::COLUMN_HITDETECTION_COLLIDERS);
+        m_treeView->hideColumn(SkeletonModel::COLUMN_CLOTH_COLLIDERS);
+        m_treeView->hideColumn(SkeletonModel::COLUMN_SIMULATED_JOINTS);
+        m_treeView->hideColumn(SkeletonModel::COLUMN_SIMULATED_JOINTS);
+        m_treeView->hideColumn(SkeletonModel::COLUMN_SIMULATED_COLLIDERS);
     }
 
     void JointSelectionWidget::SelectByJointName(const AZStd::string& jointName, [[maybe_unused]] bool clearSelection)
@@ -135,6 +139,7 @@ namespace EMotionFX
         if (actorInstance)
         {
             m_treeView->setVisible(true);
+            m_treeView->header()->resizeSections(QHeaderView::Stretch);
             m_searchWidget->setVisible(true);
             m_noSelectionLabel->setVisible(false);
         }


### PR DESCRIPTION
## What does this PR do?

The JointSelection dialog seem not to expand correctly within the first column (using QTreeView)

<img width="630" height="527" alt="image" src="https://github.com/user-attachments/assets/2819aec3-ccf2-4d7d-9d8b-5b3706015214" />

Using this  fix or workaround it looks like this:

<img width="595" height="482" alt="image" src="https://github.com/user-attachments/assets/0648653e-f477-4bc8-bf32-2e341f336c2b" />


## How was this PR tested?

I tested on my local Kubuntu 24.04 computer.

**Notes**
After the JointSelectDialog is created the HideIcons is also called. The number of icons is different from the one that is hidden within the function compared to the one existing as enums. Maybe this needs clarification, however I added this for now (the missing 4). If they are not hidden there is still this non visible icons size which is not used by the first column.
I do not know if they are supposed to be hidden too or not. So, if someone has more in-depth info on this widget/dialog, please help :).
