### PR TITLE
Suppress the following cmake warning for 3P Library open-mesh

### DIFF
--- a/Gems/WhiteBox/3rdParty/FindOpenMesh.cmake
+++ b/Gems/WhiteBox/3rdParty/FindOpenMesh.cmake
@@ -74,6 +74,9 @@ function(GetOpenMesh)
     set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL}) # save the old CMAKE_MESSAGE_LOG_LEVEL
     set(CMAKE_MESSAGE_LOG_LEVEL ${O3DE_FETCHCONTENT_MESSAGE_LEVEL})
     set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
+
+    # Backup and set the developer warning suppression for OpenMesh to suppress a expected warning
+    set(ORIGINAL_CMAKE_SUPPRESS_DEVELOPER_WARNINGS ${CMAKE_SUPPRESS_DEVELOPER_WARNINGS})
     set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS ON CACHE BOOL "" FORCE)
 
     # The rest of these are all specific settings that come from OpenMesh's CMakeLists.txt files.
@@ -142,6 +145,9 @@ function(GetOpenMesh)
     # signal that find_package(OpenMesh) has succeeded.
     # we have to set it on the PARENT_SCOPE since we're in a function 
     set(OpenMesh_FOUND TRUE PARENT_SCOPE)
+
+    # Restore the original suppression flags that were forced as part of OpenMesh
+    set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS ${ORIGINAL_CMAKE_SUPPRESS_DEVELOPER_WARNINGS} CACHE BOOL "" FORCE)
 
 endfunction()
 

--- a/Gems/WhiteBox/3rdParty/FindOpenMesh.cmake
+++ b/Gems/WhiteBox/3rdParty/FindOpenMesh.cmake
@@ -74,6 +74,7 @@ function(GetOpenMesh)
     set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL}) # save the old CMAKE_MESSAGE_LOG_LEVEL
     set(CMAKE_MESSAGE_LOG_LEVEL ${O3DE_FETCHCONTENT_MESSAGE_LEVEL})
     set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
+    set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS ON CACHE BOOL "" FORCE)
 
     # The rest of these are all specific settings that come from OpenMesh's CMakeLists.txt files.
     set(OPENMESH_BUILD_SHARED OFF)


### PR DESCRIPTION
## What does this PR do?
Suppresses  the following cmake warning for 3P Library open-mesh:

```
CMake Warning (dev) at build/linux/_deps/openmesh-src/cmake-library/VCI/VCICompiler.cmake:98 (set):
  implicitly converting 'STRINGLIST' to 'STRING' type.
Call Stack (most recent call first):
  build/linux/_deps/openmesh-src/cmake-library/VCI/VCICommon.cmake:103 (include)
  build/linux/_deps/openmesh-src/CMakeLists.txt:44 (include)
This warning is for project developers.  Use -Wno-dev to suppress it
```

## How was this PR tested?
ran `cmake -B build/linux` on project from the default template on Linux
