### PR TITLE
Fix OpenParticleSystem module not found when running packaged (none Editor) builds.

### DIFF
--- a/Gems/OpenParticleSystem/Code/CMakeLists.txt
+++ b/Gems/OpenParticleSystem/Code/CMakeLists.txt
@@ -56,6 +56,7 @@ ly_add_target(
         NAMESPACE Gem
         FILES_CMAKE
             openparticlesystem_files.cmake
+            openparticlesystem_shared_files.cmake
         INCLUDE_DIRECTORIES
             PUBLIC
                 Source
@@ -84,8 +85,8 @@ ly_add_target(
             Gem::Atom_Utils.Static
 )
 
-ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name}.API)
-ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name}.API)
+ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name})
 
 # If we are on a host platform, we want to add the host tools targets like the OpenParticleSystem.Editor target which
 # will also depend on OpenParticleSystem.Private.Static

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponent.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponent.cpp
@@ -47,7 +47,6 @@ namespace OpenParticle
                     ->Attribute(AZ::Script::Attributes::Deprecated, true)
                     ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List)
                     ->Attribute(AZ::Script::Attributes::ToolTip, "Visibility modification no longer needed in game mode")
-                ->VirtualProperty("Particle", "GetParticle", "SetParticle")
                 ->VirtualProperty("Visible", "GetVisible", "SetVisible");
 
             behaviorContext->Class<ParticleComponent>()->RequestBus("ParticleRequestBus");


### PR DESCRIPTION
## What does this PR do?

Fixes so that the module can be found also client and server builds.

## How was this PR tested?

Locally on my Kubuntu 24.04