### PR TITLE
BuxFix activate in gamemode SurfaceDataColliderComponent

### DIFF
--- a/Gems/SurfaceData/Code/Include/SurfaceData/Components/SurfaceDataColliderComponent.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Components/SurfaceDataColliderComponent.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <AzFramework/Physics/ColliderComponentBus.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
 
 #include <SurfaceData/SurfaceDataTypes.h>
 #include <SurfaceData/SurfaceDataProviderRequestBus.h>
@@ -45,6 +46,7 @@ namespace SurfaceData
         , public SurfaceDataProviderRequestBus::Handler
         , private SurfaceDataModifierRequestBus::Handler
         , public Physics::ColliderComponentEventBus::Handler
+        , private Physics::RigidBodyNotificationBus::Handler
     {
     public:
         template<typename, typename> friend class LmbrCentral::EditorWrappedComponentBase;
@@ -65,6 +67,10 @@ namespace SurfaceData
         void Deactivate() override;
         bool ReadInConfig(const AZ::ComponentConfig* baseConfig) override;
         bool WriteOutConfig(AZ::ComponentConfig* outBaseConfig) const override;
+
+        //////////////////////////////////////////////////////////////////////////
+        // RigidBodyNotificationBus
+        void OnPhysicsEnabled(const AZ::EntityId& entityId) override;        
 
         //////////////////////////////////////////////////////////////////////////
         // ColliderComponentEventBus

--- a/Gems/SurfaceData/Code/Include/SurfaceData/Components/SurfaceDataColliderComponent.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Components/SurfaceDataColliderComponent.h
@@ -14,7 +14,6 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <AzFramework/Physics/ColliderComponentBus.h>
-#include <AzFramework/Physics/RigidBodyBus.h>
 
 #include <SurfaceData/SurfaceDataTypes.h>
 #include <SurfaceData/SurfaceDataProviderRequestBus.h>
@@ -45,8 +44,7 @@ namespace SurfaceData
         , public AZ::TransformNotificationBus::Handler
         , public SurfaceDataProviderRequestBus::Handler
         , private SurfaceDataModifierRequestBus::Handler
-        , public Physics::ColliderComponentEventBus::Handler
-        , private Physics::RigidBodyNotificationBus::Handler
+        , public Physics::ColliderComponentEventBus::Handler        
     {
     public:
         template<typename, typename> friend class LmbrCentral::EditorWrappedComponentBase;
@@ -66,11 +64,7 @@ namespace SurfaceData
         void Activate() override;
         void Deactivate() override;
         bool ReadInConfig(const AZ::ComponentConfig* baseConfig) override;
-        bool WriteOutConfig(AZ::ComponentConfig* outBaseConfig) const override;
-
-        //////////////////////////////////////////////////////////////////////////
-        // RigidBodyNotificationBus
-        void OnPhysicsEnabled(const AZ::EntityId& entityId) override;        
+        bool WriteOutConfig(AZ::ComponentConfig* outBaseConfig) const override;                
 
         //////////////////////////////////////////////////////////////////////////
         // ColliderComponentEventBus

--- a/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
@@ -37,13 +37,6 @@ namespace UnitTest
 
             entity->Activate();
             EXPECT_EQ(AZ::Entity::State::Active, entity->GetState());
-
-            SurfaceData::SurfaceDataRegistryHandle providerHandle(AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfaceDataProviderHandle(entity->GetId()));
-            if (providerHandle == SurfaceData::InvalidSurfaceDataRegistryHandle)
-            {
-                // Sends out the message that will cause the entity to initialize its data
-                Physics::RigidBodyNotificationBus::Event(entity->GetId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, entity->GetId());
-            }
         }
 
         template <typename Component, typename Configuration>

--- a/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
@@ -38,8 +38,12 @@ namespace UnitTest
             entity->Activate();
             EXPECT_EQ(AZ::Entity::State::Active, entity->GetState());
 
-            // Sends out the message that will cause the entity to initialize its data
-            Physics::RigidBodyNotificationBus::Event(entity->GetId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, entity->GetId());
+            SurfaceData::SurfaceDataRegistryHandle providerHandle(AZ::Interface<SurfaceData::SurfaceDataSystem>::Get()->GetSurfaceDataProviderHandle(entity->GetId()));
+            if (providerHandle == SurfaceData::InvalidSurfaceDataRegistryHandle)
+            {
+                // Sends out the message that will cause the entity to initialize its data
+                Physics::RigidBodyNotificationBus::Event(entity->GetId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, entity->GetId());
+            }
         }
 
         template <typename Component, typename Configuration>

--- a/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/Tests/SurfaceDataTestMocks.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/hash.h>
 
 #include <LmbrCentral/Shape/ShapeComponentBus.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
 #include <SurfaceData/SurfaceDataSystemRequestBus.h>
 
 namespace UnitTest
@@ -36,6 +37,9 @@ namespace UnitTest
 
             entity->Activate();
             EXPECT_EQ(AZ::Entity::State::Active, entity->GetState());
+
+            // Sends out the message that will cause the entity to initialize its data
+            Physics::RigidBodyNotificationBus::Event(entity->GetId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, entity->GetId());
         }
 
         template <typename Component, typename Configuration>

--- a/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
@@ -129,11 +129,13 @@ namespace SurfaceData
         m_refresh = false;
 
         AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
-        Physics::ColliderComponentEventBus::Handler::BusConnect(GetEntityId());
-        Physics::RigidBodyNotificationBus::Handler::BusConnect(GetEntityId());
+        Physics::ColliderComponentEventBus::Handler::BusConnect(GetEntityId());        
 
         // Update the cached collider data and bounds, then register the surface data provider / modifier
         m_newPointWeights.AssignSurfaceTagWeights(m_configuration.m_providerTags, 1.0f);
+
+        UpdateColliderData();
+        OnCompositionChanged();
     }
 
     void SurfaceDataColliderComponent::Deactivate()
@@ -281,17 +283,7 @@ namespace SurfaceData
             m_refresh = true;
             AZ::TickBus::Handler::BusConnect();
         }
-    }
-
-    void SurfaceDataColliderComponent::OnPhysicsEnabled(const AZ::EntityId& entityId)
-    {
-        if (entityId == GetEntityId())
-        {
-            Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
-            UpdateColliderData();
-            m_refresh = false;
-        }
-    }
+    }    
 
     void SurfaceDataColliderComponent::OnColliderChanged()
     {

--- a/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
@@ -126,14 +126,14 @@ namespace SurfaceData
     {
         m_providerHandle = InvalidSurfaceDataRegistryHandle;
         m_modifierHandle = InvalidSurfaceDataRegistryHandle;
-        m_refresh = false;
 
         AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
         Physics::ColliderComponentEventBus::Handler::BusConnect(GetEntityId());
 
         // Update the cached collider data and bounds, then register the surface data provider / modifier
         m_newPointWeights.AssignSurfaceTagWeights(m_configuration.m_providerTags, 1.0f);
-        UpdateColliderData();
+        m_refresh = true;
+        AZ::TickBus::Handler::BusConnect();
     }
 
     void SurfaceDataColliderComponent::Deactivate()

--- a/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
+++ b/Gems/SurfaceData/Code/Source/Components/SurfaceDataColliderComponent.cpp
@@ -126,14 +126,14 @@ namespace SurfaceData
     {
         m_providerHandle = InvalidSurfaceDataRegistryHandle;
         m_modifierHandle = InvalidSurfaceDataRegistryHandle;
+        m_refresh = false;
 
         AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
         Physics::ColliderComponentEventBus::Handler::BusConnect(GetEntityId());
+        Physics::RigidBodyNotificationBus::Handler::BusConnect(GetEntityId());
 
         // Update the cached collider data and bounds, then register the surface data provider / modifier
         m_newPointWeights.AssignSurfaceTagWeights(m_configuration.m_providerTags, 1.0f);
-        m_refresh = true;
-        AZ::TickBus::Handler::BusConnect();
     }
 
     void SurfaceDataColliderComponent::Deactivate()
@@ -280,6 +280,16 @@ namespace SurfaceData
         {
             m_refresh = true;
             AZ::TickBus::Handler::BusConnect();
+        }
+    }
+
+    void SurfaceDataColliderComponent::OnPhysicsEnabled(const AZ::EntityId& entityId)
+    {
+        if (entityId == GetEntityId())
+        {
+            Physics::RigidBodyNotificationBus::Handler::BusDisconnect();
+            UpdateColliderData();
+            m_refresh = false;
         }
     }
 

--- a/Gems/SurfaceData/Code/Tests/SurfaceDataColliderComponentTest.cpp
+++ b/Gems/SurfaceData/Code/Tests/SurfaceDataColliderComponentTest.cpp
@@ -48,6 +48,9 @@ namespace UnitTest
                 // Just need to set this to a non-null value, it gets checked vs InvalidSimulatedBodyHandle but not otherwise used.
                 m_rayCastHit.m_bodyHandle = AzPhysics::SimulatedBodyHandle(AZ::Crc32(12345), 0);
             }
+
+            // Sends out the message that will cause the entity to initialize its data
+            Physics::RigidBodyNotificationBus::Event(id, &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, id);
         }
 
         virtual ~MockPhysicsWorldBusProvider()

--- a/Gems/SurfaceData/Code/Tests/SurfaceDataColliderComponentTest.cpp
+++ b/Gems/SurfaceData/Code/Tests/SurfaceDataColliderComponentTest.cpp
@@ -47,10 +47,7 @@ namespace UnitTest
                 m_rayCastHit.m_normal = hitResult.m_normal;
                 // Just need to set this to a non-null value, it gets checked vs InvalidSimulatedBodyHandle but not otherwise used.
                 m_rayCastHit.m_bodyHandle = AzPhysics::SimulatedBodyHandle(AZ::Crc32(12345), 0);
-            }
-
-            // Sends out the message that will cause the entity to initialize its data
-            Physics::RigidBodyNotificationBus::Event(id, &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, id);
+            }            
         }
 
         virtual ~MockPhysicsWorldBusProvider()

--- a/Gems/SurfaceData/Code/Tests/SurfaceDataColliderComponentTest.cpp
+++ b/Gems/SurfaceData/Code/Tests/SurfaceDataColliderComponentTest.cpp
@@ -47,7 +47,7 @@ namespace UnitTest
                 m_rayCastHit.m_normal = hitResult.m_normal;
                 // Just need to set this to a non-null value, it gets checked vs InvalidSimulatedBodyHandle but not otherwise used.
                 m_rayCastHit.m_bodyHandle = AzPhysics::SimulatedBodyHandle(AZ::Crc32(12345), 0);
-            }            
+            }
         }
 
         virtual ~MockPhysicsWorldBusProvider()


### PR DESCRIPTION
## What does this PR do?
This change correctly activates the SurfaceDataColliderComponent in the SurfaceDataGem.

When I was working with the Vegetation Gem, I noticed that if you use the "PhysX Collider Surface Tag Emitter Component" for vegetation, everything works correctly in Editor Mode. However, if you launch Game Mode, the vegetation disappears. The same thing happens in the compiled game. The problem was specifically with the SurfaceDataColliderComponent. Before the changes, it tried to update the collider immediately upon activation, but the collider wasn't ready yet. To fix this, I simply made the update use the component's internal mechanics via the TickBus. And everything started working.

## How was this PR tested?


The result was tested in both the editor's "Game Mode" and in the game. The following are test examples.


![EditorMode](https://github.com/user-attachments/assets/7f26413f-ac33-422d-9755-2593e4fde877)
**Editor, not in Game Mode.**

![GameMode_Before](https://github.com/user-attachments/assets/61aa661f-4d75-47fa-9ceb-0bd57126ae61)
**Game Mode (before fixing)**

![GameNode_After](https://github.com/user-attachments/assets/a9973a81-1606-46f8-9793-9c04648b90c5)
**Game Mode (after fixing)**
