### PR TITLE
Fix deviceIndex for DiffuseProbeGridVisualizationPreparePass

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -269,9 +269,14 @@ namespace AZ
             }
 
             // the pass may potentially migrate between devices dynamically at runtime so the deviceIndex is updated every frame.
-            if (GetScopeId().IsEmpty() || (ScopeProducer::GetDeviceIndex() != Pass::GetDeviceIndex()))
+            auto passDeviceIndex = Pass::GetDeviceIndex();
+            if (passDeviceIndex == RHI::MultiDevice::InvalidDeviceIndex)
             {
-                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, Pass::GetDeviceIndex());
+                passDeviceIndex = RHI::MultiDevice::DefaultDeviceIndex;
+            }
+            if (GetScopeId().IsEmpty() || (ScopeProducer::GetDeviceIndex() != passDeviceIndex))
+            {
+                InitScope(RHI::ScopeId(GetPathName()), m_hardwareQueueClass, passDeviceIndex);
             }
 
             params.m_frameGraphBuilder->ImportScopeProducer(*this);

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -102,6 +102,8 @@ namespace AZ
 
         void DiffuseProbeGridVisualizationPreparePass::FrameBeginInternal(FramePrepareParams params)
         {
+            RenderPass::FrameBeginInternal(params);
+
             RPI::Scene* scene = m_pipeline->GetScene();
             DiffuseProbeGridFeatureProcessor* diffuseProbeGridFeatureProcessor = scene->GetFeatureProcessor<DiffuseProbeGridFeatureProcessor>();
 
@@ -138,8 +140,6 @@ namespace AZ
                 visualizationTlas->CreateBuffers(
                     deviceMask, tlasDescriptor, diffuseProbeGridFeatureProcessor->GetVisualizationBufferPools());
             }
-
-            RenderPass::FrameBeginInternal(params);
         }
 
         void DiffuseProbeGridVisualizationPreparePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)


### PR DESCRIPTION
## What does this PR do?

Fixes a multi-device problem in DiffuseProbeGrid:

Most passes have an invalid device index by default. This is correct behaviour and important for supporting e.g. alternate frame rendering (see `AFRFeatureProcessor`).
Unfortunately the invalid device index cannot be used to get device objects from multi device objects. The `DiffuseProbeGridVisualizationPreparePass` accesses some device objects through the device index from the `ScopeProducer`. This leads to a problem because the device index of the `ScopeProducer` is `InvalidDeviceIndex`.

This PR fixes this problem by assigning the `DefaultDeviceIndex` to the `ScopeProducer` of a pass if the pass has an `InvalidDeviceIndex`

## How was this PR tested?

I tested this this in the `main` branch instead of development because I get this error when running this in current development:
```
(CommandList::Submit) - SRGs slots requested by shader       provided by render item  
(CommandList::Submit) -  Slot [0]: RayTracingGlobalSrg       RayTracingGlobalSrg      
(CommandList::Submit) -  Slot [1]: RayTracingSceneSrg        RayTracingSceneSrg       
(CommandList::Submit) -  Slot [2]: RayTracingMaterialSrg     None                     
(CommandList::Submit) -  Slot [3]: None                      None                     
(CommandList::Submit) -  Slot [4]: None                      None                     
(CommandList::Submit) -  Slot [5]: None                      None                     
(CommandList::Submit) -  Slot [6]: None                      None                     
(CommandList::Submit) -  Slot [7]: Bindless                  Bindless                 
(CommandList::Submit) - Notes:
(CommandList::Submit) -  - This may be inaccurate for merged SRGs.
(CommandList::Submit) -  - This does not track SRGs occupying the same slot.

The provided SRGs don't match the SRGs requested by the shader.
```
I think the Diffuse Probe Grid shaders need to be adapted for this PR: https://github.com/o3de/o3de/pull/19123
And probably also for PR: https://github.com/o3de/o3de/pull/19218 (This adds strides to the MeshInfo struct)

I also found a another problem when testing this is the main branch: PR https://github.com/o3de/o3de/pull/19175 is needed, otherwise an assert in `DeviceResource::SetFrameAttachment` is triggered.

With these fixes the Diffuse Probe Grid doesn't crash the engine anymore, but there is still a problem where the probes don't get any radiance as described here: https://discordapp.com/channels/805939474655346758/816043793576886273/1433136399992750281
I assume the DDGI shaders need to be adapted due to some other changes in shader includes as well.