### PR TITLE
Improve some Atom error messages

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceShaderResourceGroupData.h
@@ -563,8 +563,14 @@ namespace AZ::RHI
             // For any other type the buffer view's element size should match the stride.
             if (shaderInputBuffer.m_strideSize != bufferViewDescriptor.m_elementSize)
             {
-                AZ_Error("DeviceShaderResourceGroupData", false, "Buffer Input '%s[%d]': Does not match expected stride size %d",
-                    shaderInputBuffer.m_name.GetCStr(), arrayIndex, bufferViewDescriptor.m_elementSize);
+                AZ_Error(
+                    "DeviceShaderResourceGroupData",
+                    false,
+                    "Buffer Input '%s[%d]': Does not match expected stride size. Buffer has stride size %d. SRG expects stride size %d",
+                    shaderInputBuffer.m_name.GetCStr(),
+                    arrayIndex,
+                    bufferViewDescriptor.m_elementSize,
+                    shaderInputBuffer.m_strideSize);
                 return false;
             }
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/DeviceBufferView.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/DeviceBufferView.cpp
@@ -20,9 +20,15 @@ namespace AZ::RHI
         if (Validation::IsEnabled())
         {
             // Check buffer view does not reach outside buffer's memory
-            if (buffer.GetDescriptor().m_byteCount < (viewDescriptor.m_elementOffset + viewDescriptor.m_elementCount) * viewDescriptor.m_elementSize)
+            auto endOfView = (viewDescriptor.m_elementOffset + viewDescriptor.m_elementCount) * viewDescriptor.m_elementSize;
+            if (buffer.GetDescriptor().m_byteCount < endOfView)
             {
-                AZ_Warning("DeviceBufferView", false, "Buffer view out of boundaries of buffer's memory.");
+                AZ_Warning(
+                    "DeviceBufferView",
+                    false,
+                    "Buffer view out of boundaries of buffer's memory. Buffer size %jd. End of view %d",
+                    buffer.GetDescriptor().m_byteCount,
+                    (viewDescriptor.m_elementOffset + viewDescriptor.m_elementCount) * viewDescriptor.m_elementSize);
                 return ResultCode::OutOfMemory;
             }
         }


### PR DESCRIPTION
## What does this PR do?

Improves two error messages in Atom:
- When a buffer view views memory outside the buffer bounds: Show both the buffer size and the end of the given view
- When the buffer stride side does not match the SRGs stride size: Show both the buffer stride size and the SRG input stride size

## How was this PR tested?

Tested on Windows with Clang
