### PR TITLE
No longer require `git` to build and run in installer

### DIFF
--- a/Gems/PhysX/Common/CMakeLists.txt
+++ b/Gems/PhysX/Common/CMakeLists.txt
@@ -8,6 +8,8 @@
 
 add_subdirectory(Code)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/3rdParty)
+
 o3de_gem_setup("PhysXCommon")
 
 if(PAL_TRAIT_BUILD_HOST_TOOLS)

--- a/Gems/PhysX/Core/PhysX4/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX4/CMakeLists.txt
@@ -7,11 +7,8 @@
 #
 
 o3de_gem_setup("PhysX")
-
-ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
-
 get_property(v_hacd_gem_root GLOBAL PROPERTY "@GEMROOT:PhysXCommon@")
-ly_add_external_target_path(${v_hacd_gem_root}/3rdParty)
+list(APPEND CMAKE_MODULE_PATH ${v_hacd_gem_root}/3rdParty)
 
 o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 

--- a/Gems/PhysX/Core/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX5/CMakeLists.txt
@@ -7,11 +7,8 @@
 #
 
 o3de_gem_setup("PhysX5")
-
-ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
-
 get_property(v_hacd_gem_root GLOBAL PROPERTY "@GEMROOT:PhysXCommon@")
-ly_add_external_target_path(${v_hacd_gem_root}/3rdParty)
+list(APPEND CMAKE_MODULE_PATH ${v_hacd_gem_root}/3rdParty)
 
 o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 


### PR DESCRIPTION
## What does this PR do?

Fixes the installer verison of O3DE so it no longer requires `git` to be installed in order to function.

The v-hacd library had 2 different files that were intended to be used, one for the code version of the engine which downloaded v-hacd from github, using git, and one for the installer version of the engine which noted the copyright information and the fact that it was being used, but didn't need to actually download it since its entire contents were subsumed inside the physx gem dlls and were not public api.

Its also only used by the tools (editor, etc) and not the standalone game runtime, so it isn't necessary to have it available in the installer build.

The original problem is caused by the use of the cmake `ly_add_external_target_path` function, which appears to make sure that the files in that location are copied to the installer.

Instead, in this case, we want different files in the installer than in the code version, so instead of using that macro, we add the directory to the module path directly, and then use `ly_install` to copy the other cmake file (that does not use git) to the installer.

## How was this PR tested?

Manual verification - making sure the correct file was copied into the installer by looking at the file that was copied.  Previously, the file that fetches v-hacd from git was included.  Now the file that just uses the existing one is included.

Manual verification - building a custom installer and using it on a project.

