### PR TITLE
Made the ScriptCanvasApplication toggleable with a cmake setting

### DIFF
--- a/Code/Editor/LyViewPaneNames.h
+++ b/Code/Editor/LyViewPaneNames.h
@@ -32,6 +32,7 @@ namespace LyViewPane
     static const char* const ConsoleMenuName = "&Console";
     static const char* const ConsoleVariables = "Console Variables";
     static const char* const TrackView = "Track View";
+    static const char* const ScriptCanvas = "Script Canvas";
     static const char* const UiEditor = "UI Editor";
 
     static const char* const EditorSettingsManager = "Editor Settings Manager";

--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -6,11 +6,22 @@
 #
 #
 
+# Script Canvas may be built and executed as a standalone tool, it is disabled
+# by default due to quality and performance issues that need to be fixed
+# before making this change
+option(SCRIPTCANVAS_BUILD_STANDALONE_APPLICATION "Build ScriptCanvas as a standalone tool" OFF)
 
 set(SCRIPT_CANVAS_COMMON_DEFINES 
     SCRIPTCANVAS
     ENABLE_EXTENDED_MATH_SUPPORT=0
 )
+
+if (SCRIPTCANVAS_BUILD_STANDALONE_APPLICATION)
+    message(STATUS "Building ScriptCanvas Standalone...")
+    set(SCRIPTCANVAS_STANDALONE_APPLICATION_DEFINE SCRIPTCANVAS_STANDALONE_APPLICATION=1)
+else()
+    set(SCRIPTCANVAS_STANDALONE_APPLICATION_DEFINE SCRIPTCANVAS_STANDALONE_APPLICATION=0)
+endif()
 
 set(SCRIPT_CANVAS_EXECUTION_NOTIFICATION_DEFINES
     $<$<NOT:$<CONFIG:Release>>:SC_EXECUTION_TRACE_ENABLED> # this is REQUIRED for debugging/execution logging
@@ -175,6 +186,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 SCRIPTCANVAS_ERRORS_ENABLED
             PRIVATE
                 ${SCRIPT_CANVAS_COMMON_DEFINES}
+                ${SCRIPTCANVAS_STANDALONE_APPLICATION_DEFINE}
         INCLUDE_DIRECTORIES
             PUBLIC
                 Editor/Include
@@ -233,6 +245,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             Gem::ExpressionEvaluation
     )
 
+if(SCRIPTCANVAS_BUILD_STANDALONE_APPLICATION)
+
     o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Application/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
     ly_add_target(
@@ -278,6 +292,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         ly_target_link_libraries(${gem_name}Application PRIVATE AZ::ToolsCrashHandler)
     endif()
 
+endif()
+
     # Inject the gem name into the Module source file
     ly_add_source_properties(
         SOURCES
@@ -291,6 +307,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
     ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 
+if(SCRIPTCANVAS_BUILD_STANDALONE_APPLICATION)
+    
     ly_set_gem_variant_to_load(TARGETS ${gem_name}Application VARIANTS Tools)
     
     # Add build dependency to Editor for the ScriptCanvas application since
@@ -302,6 +320,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     if(NOT PROJECT_NAME STREQUAL "O3DE")
         set_property(TARGET ${gem_name}Application APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${CMAKE_SOURCE_DIR}\"")
     endif()
+
+endif()
 
 endif()
 

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -32,7 +32,6 @@
 #include <Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h>
 #include <Editor/View/Windows/MainWindow.h>
 #include <GraphCanvas/GraphCanvasBus.h>
-#include <LyViewPaneNames.h>
 #include <QDir>
 #include <QFileInfo>
 #include <QMenu>
@@ -48,6 +47,10 @@
 #include <ScriptCanvas/Variable/VariableCore.h>
 #include <ScriptCanvasContextIdentifiers.h>
 
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
+#include <LyViewPaneNames.h>
+#endif
+
 namespace ScriptCanvasEditor
 {
     constexpr AZStd::string_view ScriptCanvasApplicationActionIdentifier = "o3de.action.tools.script_canvas";
@@ -56,6 +59,10 @@ namespace ScriptCanvasEditor
 
     SystemComponent::SystemComponent()
     {
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
+        AzToolsFramework::UnregisterViewPane(LyViewPane::ScriptCanvas);
+        AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
+#endif
         AzToolsFramework::AssetSeedManagerRequests::Bus::Handler::BusConnect();
         AZ::SystemTickBus::Handler::BusConnect();
         m_versionExplorer = AZStd::make_unique<VersionExplorer::Model>();
@@ -112,6 +119,10 @@ namespace ScriptCanvasEditor
 
     void SystemComponent::Init()
     {
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
+        AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+#endif
+
         m_viewportDragDropHandler = AZStd::make_unique<ScriptCanvasAssetDragDropHandler>();
     }
 
@@ -135,6 +146,9 @@ namespace ScriptCanvasEditor
 
         SystemRequestBus::Handler::BusConnect();
         ScriptCanvasExecutionBus::Handler::BusConnect();
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
+        AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+#endif
         AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusConnect();
@@ -153,6 +167,20 @@ namespace ScriptCanvasEditor
 
         m_nodeReplacementSystem.LoadReplacementMetadata();
     }
+
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
+    void SystemComponent::NotifyRegisterViews()
+    {
+        QtViewOptions options;
+        options.canHaveMultipleInstances = false;
+        options.isPreview = false;
+        options.showInMenu = true;
+        options.showOnToolsToolbar = true;
+        options.toolbarIcon = ":/Menu/script_canvas_editor.svg";
+
+        AzToolsFramework::RegisterViewPane<ScriptCanvasEditor::MainWindow>(LyViewPane::ScriptCanvas, LyViewPane::CategoryTools, options);
+    }
+#endif
 
     void SystemComponent::Deactivate()
     {
@@ -281,7 +309,7 @@ namespace ScriptCanvasEditor
     }
 
     void SystemComponent::AddSourceFileOpeners
-        ( [[maybe_unused]] const char* fullSourceFileName
+    ([[maybe_unused]] const char* fullSourceFileName
         , [[maybe_unused]] const AZ::Uuid& sourceUUID
         , [[maybe_unused]] AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
     {
@@ -290,17 +318,52 @@ namespace ScriptCanvasEditor
 
         if (AZ::IO::Path(fullSourceFileName).Extension() == ScriptCanvasEditor::SourceDescription::GetFileExtension())
         {
+#if SCRIPTCANVAS_STANDALONE_APPLICATION
             auto scriptCanvasOpenInEditorCallback =
                 [this](const char* fullSourceFileNameInCall, [[maybe_unused]] const AZ::Uuid& sourceUUIDInCall)
-            {
-                OpenScriptCanvasEditor(fullSourceFileNameInCall);
-            };
+                {
+                    OpenScriptCanvasEditor(fullSourceFileNameInCall);
+                };
+
+#else
+            auto scriptCanvasOpenInEditorCallback = []([[maybe_unused]] const char* fullSourceFileNameInCall, const AZ::Uuid& sourceUUIDInCall)
+                {
+                    AZ::Outcome<int, AZStd::string> openOutcome = AZ::Failure(AZStd::string());
+
+                    auto sourceHandle = CompleteDescription(SourceHandle(nullptr, sourceUUIDInCall));
+                    if (sourceHandle)
+                    {
+                        AzToolsFramework::EditorRequests::Bus::Broadcast(&AzToolsFramework::EditorRequests::OpenViewPane, "Script Canvas");
+
+                        GeneralRequestBus::BroadcastResult(openOutcome
+                            , &GeneralRequests::OpenScriptCanvasAsset
+                            , *sourceHandle
+                            , Tracker::ScriptCanvasFileState::UNMODIFIED
+                            , -1);
+
+                        if (!openOutcome.IsSuccess())
+                        {
+                            AZ_Error("ScriptCanvas", false, openOutcome.GetError().data());
+                        }
+                        else
+                        {
+                            AZ_Warning("ScriptCanvas", false, "Unable to find full path for Source UUID %s", sourceUUIDInCall.ToString<AZStd::string>().c_str());
+                        }
+
+                    }
+                };
+#endif
 
             openers.push_back({ "O3DE_ScriptCanvasEditor"
                 , "Open In Script Canvas Editor..."
                 , QIcon(ScriptCanvasEditor::SourceDescription::GetIconPath())
                 , scriptCanvasOpenInEditorCallback });
+
         }
+
+
+
+
     }
 
     void SystemComponent::OnStartPlayInEditor()
@@ -401,6 +464,7 @@ namespace ScriptCanvasEditor
         if (!actionManagerInterface)
             return;
 
+#if SCRIPTCANVAS_STANDALONE_APPLICATION
         {
             AzToolsFramework::ActionProperties actionProperties;
             actionProperties.m_name = "Script Canvas";
@@ -416,10 +480,21 @@ namespace ScriptCanvasEditor
                 });
             AZ_Assert(outcome.IsSuccess(), "Failed to RegisterAction %s", ScriptCanvasApplicationActionIdentifier.data());
         }
+#else
+        {
+            AzToolsFramework::ActionContextProperties contextProperties;
+            contextProperties.m_name = "O3DE Script Canvas";
+
+            // Register custom action contexts to allow duplicated shortcut hotkeys to work
+            actionManagerInterface->RegisterActionContext(ScriptCanvasIdentifiers::ScriptCanvasActionContextIdentifier, contextProperties);
+            actionManagerInterface->RegisterActionContext(ScriptCanvasIdentifiers::ScriptCanvasVariablesActionContextIdentifier, contextProperties);
+        }
+#endif
     }
 
     void SystemComponent::OnMenuBindingHook()
     {
+#if SCRIPTCANVAS_STANDALONE_APPLICATION
         auto* actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
         AZ_Assert(actionManagerInterface, "ScriptCanvas System Component - could not get ActionManagerInterface");
 
@@ -441,6 +516,7 @@ namespace ScriptCanvasEditor
                 ScriptCanvasApplicationActionIdentifier.data(),
                 EditorIdentifiers::ToolsMenuIdentifier.data());
         }
+#endif
     }
 
 }

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -309,7 +309,7 @@ namespace ScriptCanvasEditor
     }
 
     void SystemComponent::AddSourceFileOpeners
-    ([[maybe_unused]] const char* fullSourceFileName
+        ( [[maybe_unused]] const char* fullSourceFileName
         , [[maybe_unused]] const AZ::Uuid& sourceUUID
         , [[maybe_unused]] AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
     {
@@ -358,12 +358,7 @@ namespace ScriptCanvasEditor
                 , "Open In Script Canvas Editor..."
                 , QIcon(ScriptCanvasEditor::SourceDescription::GetIconPath())
                 , scriptCanvasOpenInEditorCallback });
-
         }
-
-
-
-
     }
 
     void SystemComponent::OnStartPlayInEditor()

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -53,7 +53,9 @@
 
 namespace ScriptCanvasEditor
 {
+#if SCRIPTCANVAS_STANDALONE_APPLICATION
     constexpr AZStd::string_view ScriptCanvasApplicationActionIdentifier = "o3de.action.tools.script_canvas";
+#endif
 
     static const size_t cs_jobThreads = 1;
 

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
@@ -35,6 +35,9 @@ namespace ScriptCanvasEditor
     class SystemComponent
         : public AZ::Component
         , private SystemRequestBus::Handler
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
+        , private AzToolsFramework::EditorEvents::Bus::Handler
+#endif
         , private AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
         , private ScriptCanvasExecutionBus::Handler
         , private AZ::UserSettingsNotificationBus::Handler
@@ -71,6 +74,13 @@ namespace ScriptCanvasEditor
         void CreateEditorComponentsOnEntity(AZ::Entity* entity, const AZ::Data::AssetType& assetType) override;
         void OpenScriptCanvasEditor(const AZStd::string& sourcePath) override;
         ////////////////////////////////////////////////////////////////////////
+
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
+        ////////////////////////////////////////////////////////////////////////
+        // AztoolsFramework::EditorEvents::Bus::Handler...
+        void NotifyRegisterViews() override;
+        ////////////////////////////////////////////////////////////////////////
+#endif
 
         ////////////////////////////////////////////////////////////////////////
         // ScriptCanvasExecutionBus::Handler...

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -361,6 +361,11 @@ namespace ScriptCanvasEditor
     // MainWindow
     ////////////////
 
+    MainWindow::MainWindow(QWidget* parent)
+        : MainWindow(AZ::Crc32("ScriptCanvas"), parent)
+    {
+    }
+
     MainWindow::MainWindow(const AZ::Crc32& toolId, QWidget* parent)
         : QMainWindow(parent, Qt::Widget | Qt::WindowMinMaxButtonsHint)
         , ui(new Ui::MainWindow)
@@ -397,14 +402,16 @@ namespace ScriptCanvasEditor
     {
         AZ_PROFILE_FUNCTION(ScriptCanvas);
 
+#if SCRIPTCANVAS_STANDALONE_APPLICATION
         static bool alreadyInit = false;
         if (alreadyInit)
         {
-            assert(false && "ScriptCanvas InitMainWindow() called twice, this shouldn't happen");
+            AZ_Assert(false, "ScriptCanvas InitMainWindow() called twice, this shouldn't happen");
             return;
         }
 
         alreadyInit = true;
+#endif
 
         AZStd::array<char, AZ::IO::MaxPathLength> unresolvedPath;
         AZ::IO::FileIOBase::GetInstance()->ResolvePath("@products@/translation/scriptcanvas_en_us.qm", unresolvedPath.data(), unresolvedPath.size());
@@ -968,8 +975,9 @@ namespace ScriptCanvasEditor
         m_workspace->Save();
         event->accept();
 
+#if SCRIPTCANVAS_STANDALONE_APPLICATION
         AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
-
+#endif
 
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -361,10 +361,14 @@ namespace ScriptCanvasEditor
     // MainWindow
     ////////////////
 
+if !SCRIPTCANVAS_STANDALONE_APPLICATION
+
     MainWindow::MainWindow(QWidget* parent)
         : MainWindow(AZ::Crc32("ScriptCanvas"), parent)
     {
     }
+
+#endif
 
     MainWindow::MainWindow(const AZ::Crc32& toolId, QWidget* parent)
         : QMainWindow(parent, Qt::Widget | Qt::WindowMinMaxButtonsHint)

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -361,7 +361,7 @@ namespace ScriptCanvasEditor
     // MainWindow
     ////////////////
 
-if !SCRIPTCANVAS_STANDALONE_APPLICATION
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
 
     MainWindow::MainWindow(QWidget* parent)
         : MainWindow(AZ::Crc32("ScriptCanvas"), parent)

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
@@ -262,6 +262,7 @@ namespace ScriptCanvasEditor
 
     public:
 
+        MainWindow(QWidget* parent = nullptr);
         MainWindow(const AZ::Crc32& toolId, QWidget* parent = nullptr);
         ~MainWindow() override;
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
@@ -262,7 +262,10 @@ namespace ScriptCanvasEditor
 
     public:
 
+if !SCRIPTCANVAS_STANDALONE_APPLICATION
         MainWindow(QWidget* parent = nullptr);
+#endif
+
         MainWindow(const AZ::Crc32& toolId, QWidget* parent = nullptr);
         ~MainWindow() override;
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.h
@@ -262,7 +262,7 @@ namespace ScriptCanvasEditor
 
     public:
 
-if !SCRIPTCANVAS_STANDALONE_APPLICATION
+#if !SCRIPTCANVAS_STANDALONE_APPLICATION
         MainWindow(QWidget* parent = nullptr);
 #endif
 


### PR DESCRIPTION
## What does this PR do?

The ScriptCanvas standalone application change had some quality, stability, and performance issues that need to be addressed before the change can be permanently enabled, these are being tracked in this project: github.com/orgs/o3de/projects/77

Closes #19347

To toggle the ScriptCanvas standalone application the CMake option `SCRIPTCANVAS_BUILD_STANDALONE_APPLICATION` needs to be enabled and rebuild.

## How was this PR tested?

Built with and without the `SCRIPTCANVAS_BUILD_STANDALONE_APPLICATION` option and verified that the ScriptCanvas editor worked as expected in each configuration
