### PR TITLE
InterlockedIncrement and InterlockedDecrement signatures

### DIFF
--- a/Code/Legacy/CryCommon/LinuxSpecific.h
+++ b/Code/Legacy/CryCommon/LinuxSpecific.h
@@ -339,7 +339,7 @@ extern bool QueryPerformanceFrequency(LARGE_INTEGER* frequency);
 
 static pthread_mutex_t mutex_t;
 template<typename T>
-const volatile T InterlockedIncrement(volatile T* pT)
+volatile T InterlockedIncrement(volatile T* pT)
 {
     pthread_mutex_lock(&mutex_t);
     ++(*pT);
@@ -348,7 +348,7 @@ const volatile T InterlockedIncrement(volatile T* pT)
 }
 
 template<typename T>
-const volatile T InterlockedDecrement(volatile T* pT)
+volatile T InterlockedDecrement(volatile T* pT)
 {
     pthread_mutex_lock(&mutex_t);
     --(*pT);


### PR DESCRIPTION
## What does this PR do?

Arch-Linux, Clang 21.1.5, treats the return of "const volatile" as error/warning. 
const volatile is _deprecated

## How was this PR tested?

Builds and runs without it. Not sure if it breaks something else long term.
