### PR TITLE
Fix #19348 Script Canvas Application: Keyboard shortcuts do not work

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
@@ -699,6 +699,7 @@ namespace ScriptCanvasEditor
                     m_nextCycleAction->setText(tr("Next Instance in Graph"));
 
                     m_nextCycleAction->setShortcut(QKeySequence(Qt::Key_F8));
+                    m_nextCycleAction->setShortcutContext(Qt::WidgetShortcut);
                     treeView->addAction(m_nextCycleAction);
 
                     QObject::connect(m_nextCycleAction, &QAction::triggered, this, &NodePaletteDockWidget::CycleToNextNode);
@@ -709,6 +710,7 @@ namespace ScriptCanvasEditor
                     m_previousCycleAction->setText(tr("Previous Instance in Graph"));
 
                     m_previousCycleAction->setShortcut(QKeySequence(Qt::Key_F7));
+                    m_previousCycleAction->setShortcutContext(Qt::WidgetShortcut);
                     treeView->addAction(m_previousCycleAction);
 
                     QObject::connect(m_previousCycleAction, &QAction::triggered, this, &NodePaletteDockWidget::CycleToPreviousNode);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/VariablePanel/GraphVariablesTableView.cpp
@@ -1112,8 +1112,8 @@ namespace ScriptCanvasEditor
 
         {
             QAction* deleteAction = new QAction(this);
-            deleteAction->setShortcut(QKeySequence(Qt::Key_Delete));
-
+            deleteAction->setShortcut(QKeySequence::Delete);
+            deleteAction->setShortcutContext(Qt::WidgetShortcut);
             QObject::connect(deleteAction, &QAction::triggered, this, &GraphVariablesTableView::OnDeleteSelected);
 
             addAction(deleteAction);
@@ -1122,7 +1122,7 @@ namespace ScriptCanvasEditor
         {
             QAction* copyAction = new QAction(this);
             copyAction->setShortcut(QKeySequence::Copy);
-
+            copyAction->setShortcutContext(Qt::WidgetShortcut);
             QObject::connect(copyAction, &QAction::triggered, this, &GraphVariablesTableView::OnCopySelected);
 
             addAction(copyAction);
@@ -1131,7 +1131,7 @@ namespace ScriptCanvasEditor
         {
             QAction* pasteAction = new QAction(this);
             pasteAction->setShortcut(QKeySequence::Paste);
-
+            pasteAction->setShortcutContext(Qt::WidgetShortcut);
             QObject::connect(pasteAction, &QAction::triggered, this, &GraphVariablesTableView::OnPaste);
 
             addAction(pasteAction);
@@ -1140,7 +1140,7 @@ namespace ScriptCanvasEditor
         {
             QAction* duplicateAction = new QAction(this);
             duplicateAction->setShortcut(QKeySequence(0x0 | Qt::CTRL | Qt::Key_D));
-
+            duplicateAction->setShortcutContext(Qt::WidgetShortcut);
             QObject::connect(duplicateAction, &QAction::triggered, this, &GraphVariablesTableView::OnDuplicate);
 
             addAction(duplicateAction);
@@ -1149,7 +1149,7 @@ namespace ScriptCanvasEditor
         {
             m_nextInstanceAction = new QAction(this);
             m_nextInstanceAction->setShortcut(QKeySequence(Qt::Key_F8));
-
+            m_nextInstanceAction->setShortcutContext(Qt::WidgetShortcut);
             QObject::connect(m_nextInstanceAction, &QAction::triggered, this, &GraphVariablesTableView::CycleToNextVariableReference);
 
             addAction(m_nextInstanceAction);
@@ -1158,7 +1158,7 @@ namespace ScriptCanvasEditor
         {
             m_previousInstanceAction = new QAction(this);
             m_previousInstanceAction->setShortcut(QKeySequence(Qt::Key_F7));
-
+            m_previousInstanceAction->setShortcutContext(Qt::WidgetShortcut);
             QObject::connect(m_previousInstanceAction, &QAction::triggered, this, &GraphVariablesTableView::CycleToPreviousVariableReference);
 
             addAction(m_previousInstanceAction);

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -2092,7 +2092,7 @@ namespace ScriptCanvasEditor
         GraphCanvas::SceneRequestBus::EventResult(copyMimeType, GetActiveGraphCanvasGraphId(), &GraphCanvas::SceneRequests::GetCopyMimeType);
 
         const bool pasteableClipboard = (!copyMimeType.empty() && QApplication::clipboard()->mimeData()->hasFormat(copyMimeType.c_str()))
-                                        || GraphVariablesTableView::HasCopyVariableData();
+                                        || !GraphVariablesTableView::HasCopyVariableData();
 
         ui->action_Paste->setEnabled(pasteableClipboard);
     }
@@ -2960,9 +2960,7 @@ namespace ScriptCanvasEditor
         ui->action_Cut->setEnabled(hasCopiableSelection);
         ui->action_Copy->setEnabled(hasCopiableSelection);
         ui->action_Duplicate->setEnabled(hasCopiableSelection);
-
-        // Delete will work for anything that is selectable
-        ui->action_Delete->setEnabled(hasSelection);
+        ui->action_Delete->setEnabled(m_selectedVariableIds.empty() && hasSelection);
     }
 
     void MainWindow::OnViewNodePalette()


### PR DESCRIPTION
## What does this PR do?

Fix #19348 so that the shortcuts for the Script Canvas works with the standard and the standalone version.

https://github.com/user-attachments/assets/93d7582a-408b-42fc-aa0f-ffbc5dc01d09

_Captured from the standalone version_

I just added context for the Qt shortcuts and prevented the paste and delete shortcut to fire from the MainWindow when something is selected in the Variable Manager.

## How was this PR tested?

Local Windows build.

Tested the following with both the standalone and the standard version.

- Start project build
- Opened Script Canvas
- Opened a script
- Added some nodes
- Try all shortcuts inside the main viewport, i.e : `CTRL+C -  CTRL+V` to copy-paste,  `DEL` to delete a node, `CTRL+X - CTRL+V` to cut-paste => It is working fine
- Try all shortcurts inside the Variable Manager, i.e : `CTRL+C -  CTRL+V` to copy-paste,  `DEL` to delete a node, `CTRL+X - CTRL+V` to cut-paste, `F7` and `F8` to switch to the node => It is working fine
- Try all shortcurts inside the Node Palette, i.e :  `F7` and `F8` to switch to the node => It is working fine