### PR TITLE
Remove OpenGL widget usage in EMFX.

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.cpp
@@ -32,8 +32,7 @@ namespace EMStudio
 {
     //NodeGraphWidget::NodeGraphWidget(NodeGraph* activeGraph, QWidget* parent) : QGLWidget(QGLFormat(QGL::SampleBuffers), parent)
     NodeGraphWidget::NodeGraphWidget(AnimGraphPlugin* plugin, NodeGraph* activeGraph, QWidget* parent)
-        : QOpenGLWidget(parent)
-        , QOpenGLFunctions()
+        : QWidget(parent)
     {
         setObjectName("NodeGraphWidget");
 
@@ -84,18 +83,10 @@ namespace EMStudio
         delete m_fontMetrics;
     }
 
-
-    // initialize opengl
-    void NodeGraphWidget::initializeGL()
+    void NodeGraphWidget::resizeEvent(QResizeEvent* event)
     {
-        initializeOpenGLFunctions();
-        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    }
-
-
-    //
-    void NodeGraphWidget::resizeGL(int w, int h)
-    {
+        const int w = event->size().width();
+        const int h = event->size().height();
         static QPoint sizeDiff(0, 0);
 
         m_curWidth = w;
@@ -139,9 +130,7 @@ namespace EMStudio
             m_activeGraph->SetScrollOffset(QPoint(scrollOffsetX, scrollOffsetY));
             //MCore::LOG("%d, %d", scrollOffsetX, scrollOffsetY);
         }
-
-        QOpenGLWidget::resizeGL(w, h);
-
+        QWidget::resizeEvent(event);
         m_prevWidth = w;
         m_prevHeight = h;
     }
@@ -176,10 +165,9 @@ namespace EMStudio
         return m_activeGraph;
     }
 
-
-    // paint event
-    void NodeGraphWidget::paintGL()
+    void NodeGraphWidget::paintEvent(QPaintEvent* event)
     {
+        QWidget::paintEvent(event);
         if (visibleRegion().isEmpty())
         {
             return;
@@ -189,8 +177,6 @@ namespace EMStudio
         {
             return;
         }
-
-        glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
         // calculate the time passed since the last render
         const float timePassedInSeconds = m_renderTimer.StampAndGetDeltaTimeInSeconds();
@@ -1471,14 +1457,6 @@ namespace EMStudio
         setCursor(Qt::ArrowCursor);
         return node;
     }
-
-
-    // resize
-    void NodeGraphWidget::resizeEvent(QResizeEvent* event)
-    {
-        QOpenGLWidget::resizeEvent(event);
-    }
-
 
     // calculate the selection rect
     void NodeGraphWidget::CalcSelectRect(QRect& outRect)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NodeGraphWidget.h
@@ -8,19 +8,14 @@
 
 #pragma once
 
-#if !defined(Q_MOC_RUN)
 #include <AzCore/Debug/Timer.h>
 #include <AzCore/std/string/string.h>
 #include <EMotionStudio/Plugins/StandardPlugins/Source/StandardPluginsConfig.h>
-#include <QOpenGLFunctions>
-#include <QOpenGLWidget>
+#include <QWidget>
 #include <QPoint>
-#endif
 
 QT_FORWARD_DECLARE_CLASS(QLineEdit)
 QT_FORWARD_DECLARE_CLASS(QPainter)
-
-#define NODEGRAPHWIDGET_USE_OPENGL
 
 namespace EMotionFX
 {
@@ -36,23 +31,17 @@ namespace EMStudio
     class NodeConnection;
     class AnimGraphPlugin;
 
-
-    /**
-     *
-     *
-     */
     class NodeGraphWidget
-        : public QOpenGLWidget
-        , public QOpenGLFunctions
+        : public QWidget
     {
         Q_OBJECT
         MCORE_MEMORYOBJECTCATEGORY(NodeGraphWidget, EMFX_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS_ANIMGRAPH);
 
     public:
         NodeGraphWidget(AnimGraphPlugin* plugin, NodeGraph* activeGraph = nullptr, QWidget* parent = nullptr);
-        virtual ~NodeGraphWidget();
+        ~NodeGraphWidget() override;
 
-        AnimGraphPlugin* GetPlugin() { return m_plugin; }
+        AnimGraphPlugin* GetPlugin() const { return m_plugin; }
 
         void SetActiveGraph(NodeGraph* graph);
         NodeGraph* GetActiveGraph() const;
@@ -110,7 +99,7 @@ namespace EMStudio
         void ActiveGraphChanged();
 
     protected:
-        //virtual void paintEvent(QPaintEvent* event);
+        void paintEvent(QPaintEvent* event) override;
         void mouseMoveEvent(QMouseEvent* event) override;
         void mousePressEvent(QMouseEvent* event) override;
         void mouseDoubleClickEvent(QMouseEvent* event) override;
@@ -121,10 +110,6 @@ namespace EMStudio
         void keyReleaseEvent(QKeyEvent* event) override;
         void focusInEvent(QFocusEvent* event) override;
         void focusOutEvent(QFocusEvent* event) override;
-
-        void initializeGL() override;
-        void paintGL() override;
-        void resizeGL(int w, int h) override;
 
         GraphNode* UpdateMouseCursor(const QPoint& localMousePos, const QPoint& globalMousePos);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataHeaderWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataHeaderWidget.cpp
@@ -18,35 +18,22 @@
 #include <QPaintEvent>
 #include <QMenu>
 
-#include <MCore/Source/LogManager.h>
 #include <MCore/Source/Algorithms.h>
 
 #include <MysticQt/Source/MysticQtManager.h>
-
-#include <EMotionFX/Source/BlendTree.h>
-#include <EMotionFX/Source/AnimGraphMotionNode.h>
-#include <EMotionFX/Source/AnimGraphStateMachine.h>
-
 #include <EMotionFX/Source/EventManager.h>
 #include <EMotionFX/Source/Motion.h>
 #include <EMotionFX/Source/MotionManager.h>
 #include <EMotionFX/Source/MotionEvent.h>
-#include <EMotionFX/Source/MotionEventTrack.h>
 #include <EMotionFX/Source/Recorder.h>
-#include <EMotionFX/Source/MotionEventTable.h>
-#include <EMotionFX/Source/MotionManager.h>
-#include <EMotionFX/Source/AnimGraphManager.h>
-#include <EMotionFX/CommandSystem/Source/MotionEventCommands.h>
 #include "../../../../EMStudioSDK/Source/EMStudioManager.h"
-#include "../../../../EMStudioSDK/Source/MainWindow.h"
 
 
 namespace EMStudio
 {
     // the constructor
     TrackDataHeaderWidget::TrackDataHeaderWidget(TimeViewPlugin* plugin, QWidget* parent)
-        : QOpenGLWidget(parent)
-        , QOpenGLFunctions()
+        : QWidget(parent)
         , m_plugin(plugin)
         , m_lastMouseX(0)
         , m_lastMouseY(0)
@@ -101,31 +88,20 @@ namespace EMStudio
     {
     }
 
-
-    // init gl
-    void TrackDataHeaderWidget::initializeGL()
+    void TrackDataHeaderWidget::resizeEvent(QResizeEvent* event)
     {
-        initializeOpenGLFunctions();
-        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    }
-
-
-    // resize
-    void TrackDataHeaderWidget::resizeGL(int w, int h)
-    {
-        MCORE_UNUSED(w);
-        MCORE_UNUSED(h);
+        QWidget::resizeEvent(event);
         if (m_plugin)
         {
             m_plugin->SetRedrawFlag();
         }
     }
 
-    void TrackDataHeaderWidget::paintGL()
+    void TrackDataHeaderWidget::paintEvent(QPaintEvent* event)
     {
-        glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        QWidget::paintEvent(event);
 
-        // start painting
+        // start painting using standard Qt painter
         QPainter painter(this);
         painter.setRenderHint(QPainter::Antialiasing, false);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataHeaderWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataHeaderWidget.h
@@ -10,24 +10,24 @@
 
 #if !defined(Q_MOC_RUN)
 #include <MCore/Source/StandardHeaders.h>
-#include <AzCore/std/containers/vector.h>
 #include "../StandardPluginsConfig.h"
-#include <EMotionFX/CommandSystem/Source/MotionEventCommands.h>
-#include <EMotionFX/Source/Recorder.h>
-#include "TimeTrack.h"
-#include <QOpenGLWidget>
+#include <AzCore/std/string/string.h>
+
+#include <QWidget>
 #include <QPen>
 #include <QFont>
-#include <QOpenGLFunctions>
+#include <QBrush>
+#include <QPixmap>
 #endif
+
+
 
 namespace EMStudio
 {
     class TimeViewPlugin;
 
     class TrackDataHeaderWidget
-        : public QOpenGLWidget
-        , public QOpenGLFunctions
+        : public QWidget
     {
         MCORE_MEMORYOBJECTCATEGORY(TrackDataHeaderWidget, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
         Q_OBJECT
@@ -41,9 +41,8 @@ namespace EMStudio
         static void DoWheelEvent(QWheelEvent* event, TimeViewPlugin* plugin);
         static void DoMouseYMoveZoom(int32 deltaY, TimeViewPlugin* plugin);
 
-        void initializeGL() override;
-        void resizeGL(int w, int h) override;
-        void paintGL() override;
+        void paintEvent(QPaintEvent* event) override;
+        void resizeEvent(QResizeEvent* event) override;
 
     protected:
         void mouseDoubleClickEvent(QMouseEvent* event) override;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
@@ -19,6 +19,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QMenu>
+#include <QBrush>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPaintEvent>
@@ -26,13 +27,8 @@
 
 #include <MCore/Source/LogManager.h>
 #include <MCore/Source/Algorithms.h>
-
-#include <MysticQt/Source/MysticQtManager.h>
-
-#include <EMotionFX/Source/BlendTree.h>
 #include <EMotionFX/Source/AnimGraphMotionNode.h>
 #include <EMotionFX/Source/AnimGraphStateMachine.h>
-
 #include <EMotionFX/Source/EventManager.h>
 #include <EMotionFX/Source/Motion.h>
 #include <EMotionFX/Source/MotionData/MotionData.h>
@@ -41,18 +37,15 @@
 #include <EMotionFX/Source/MotionEventTrack.h>
 #include <EMotionFX/Source/Recorder.h>
 #include <EMotionFX/Source/MotionEventTable.h>
-#include <EMotionFX/Source/MotionManager.h>
 #include <EMotionFX/Source/AnimGraphManager.h>
 #include <EMotionFX/CommandSystem/Source/MotionEventCommands.h>
 #include "../../../../EMStudioSDK/Source/EMStudioManager.h"
-#include "../../../../EMStudioSDK/Source/MainWindow.h"
 
 namespace EMStudio
 {
     // the constructor
     TrackDataWidget::TrackDataWidget(TimeViewPlugin* plugin, QWidget* parent)
-        : QOpenGLWidget(parent)
-        , QOpenGLFunctions()
+        : QWidget(parent)
         , m_brushBackground(QColor(40, 45, 50), Qt::SolidPattern)
         , m_brushBackgroundClipped(QColor(40, 40, 40), Qt::SolidPattern)
         , m_brushBackgroundOutOfRange(QColor(35, 35, 35), Qt::SolidPattern)
@@ -101,26 +94,14 @@ namespace EMStudio
     {
     }
 
-
-    // init gl
-    void TrackDataWidget::initializeGL()
+    void TrackDataWidget::resizeEvent(QResizeEvent* event)
     {
-        initializeOpenGLFunctions();
-        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    }
-
-
-    // resize
-    void TrackDataWidget::resizeGL(int w, int h)
-    {
-        MCORE_UNUSED(w);
-        MCORE_UNUSED(h);
+        QWidget::resizeEvent(event);
         if (m_plugin)
         {
             m_plugin->SetRedrawFlag();
         }
     }
-
 
     // calculate the selection rect
     void TrackDataWidget::CalcSelectRect(QRect& outRect)
@@ -134,15 +115,14 @@ namespace EMStudio
     }
 
 
-    void TrackDataWidget::paintGL()
+    void TrackDataWidget::paintEvent(QPaintEvent* event)
     {
-        glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        QWidget::paintEvent(event);
 
-        // start painting
         QPainter painter(this);
         painter.setRenderHint(QPainter::Antialiasing, false);
 
-        QRect rect(0, 0, geometry().width(), geometry().height());
+        const QRect rect(0, 0, geometry().width(), geometry().height());
 
         // draw a background rect
         painter.setPen(Qt::NoPen);
@@ -2194,7 +2174,7 @@ namespace EMStudio
             // get the position
             if (localPos.y() < 0)
             {
-                return QOpenGLWidget::event(event);
+                return QWidget::event(event);
             }
 
             // if we have a recording
@@ -2228,7 +2208,7 @@ namespace EMStudio
                 TimeTrackElement*   element = m_plugin->GetElementAt(localPos.x(), localPos.y());
                 if (element == nullptr)
                 {
-                    return QOpenGLWidget::event(event);
+                    return QWidget::event(event);
                 }
 
                 QString toolTipString;
@@ -2242,7 +2222,7 @@ namespace EMStudio
             }
         }
 
-        return QOpenGLWidget::event(event);
+        return QWidget::event(event);
     }
 
     // update the rects

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.h
@@ -12,25 +12,24 @@
 #include <MCore/Source/StandardHeaders.h>
 #include <AzCore/std/containers/vector.h>
 #include "../StandardPluginsConfig.h"
-#include <EMotionFX/CommandSystem/Source/MotionEventCommands.h>
 #include <EMotionFX/Source/Recorder.h>
+#include <EMotionFX/Source/Event.h>
 #include "TimeTrack.h"
-#include <QOpenGLWidget>
-#include <QPen>
+
+#include <QWidget>
 #include <QFont>
-#include <QOpenGLFunctions>
+#include <QBrush>
+#include <QRect>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QBrush)
-
 
 namespace EMStudio
 {
     class TimeViewPlugin;
 
     class TrackDataWidget
-        : public QOpenGLWidget
-        , public QOpenGLFunctions
+        : public QWidget
     {
         MCORE_MEMORYOBJECTCATEGORY(TrackDataWidget, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_STANDARDPLUGINS);
         Q_OBJECT
@@ -43,14 +42,12 @@ namespace EMStudio
         TrackDataWidget(TimeViewPlugin* plugin, QWidget* parent = nullptr);
         ~TrackDataWidget();
 
-        void initializeGL() override;
-        void resizeGL(int w, int h) override;
-        void paintGL() override;
+        void paintEvent(QPaintEvent* event) override;
+        void resizeEvent(QResizeEvent* event) override;
 
         void RemoveTrack(size_t trackIndex);
         
     protected:
-        //void paintEvent(QPaintEvent* event);
         void mouseDoubleClickEvent(QMouseEvent* event) override;
         void mouseMoveEvent(QMouseEvent* event) override;
         void mousePressEvent(QMouseEvent* event) override;


### PR DESCRIPTION
## What does this PR do?

This is actually a fix for the Qt6 branch where the EMFX shows a black screen. I do not know why OpenGL was used for those widgets but this shouldn't be used and its not needed in my point of view. 
The reason I am targeting the 'development' branch is, that I think those OpenGL widgets shouldn't be used. If anyone knows why they shouldn't be removed, feel free to put some comments. We need more testers for this. 


## How was this PR tested?

I tested on my KUbuntu computer. Unfortunately I wasn't able to test it on Windows, so if someone can test that.
