### PR TITLE
Fix depth image preview

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
@@ -109,6 +109,12 @@ namespace AZ
             copyImage.m_sourceImage = image;
             copyImage.m_sourceSize = image->GetDescriptor().m_size;
             copyImage.m_sourceSubresource.m_arraySlice = m_sourceArraySlice;
+            if ((image->GetAspectFlags() & RHI::ImageAspectFlags::Depth) != RHI::ImageAspectFlags::None)
+            {
+                // Only the depth is previewed, so no need to copy a potential stencil part as well
+                copyImage.m_sourceSubresource.m_aspect = RHI::ImageAspect::Depth;
+                copyImage.m_destinationSubresource.m_aspect = RHI::ImageAspect::Depth;
+            }
             copyImage.m_destinationImage = context.GetImage(m_destAttachmentId);
             
             m_copyItem = copyImage;


### PR DESCRIPTION
## What does this PR do?

Fixes the preview feature of the Atom pass viewer for depth images.

The `ImageAttachmentPreviewPass` previously always copied the color aspect of the image.
This led to a device lost error when previewing an image with Vulkan because neither the source nor destination image had a color aspect.
DX12 worked fine because the PlaneSlice of color and Depth are the same.

This PR fixes that by copying the Depth aspect if a given image has one.

## How was this PR tested?

Tested on Windows with DX12 and Vulkan