### PR TITLE
Remove Interlocked functions and mutex from LinuxSpecific.h

### DIFF
--- a/Code/Legacy/CryCommon/LinuxSpecific.h
+++ b/Code/Legacy/CryCommon/LinuxSpecific.h
@@ -337,25 +337,6 @@ typedef struct _SECURITY_ATTRIBUTES
 extern bool QueryPerformanceCounter(LARGE_INTEGER*);
 extern bool QueryPerformanceFrequency(LARGE_INTEGER* frequency);
 
-static pthread_mutex_t mutex_t;
-template<typename T>
-volatile T InterlockedIncrement(volatile T* pT)
-{
-    pthread_mutex_lock(&mutex_t);
-    ++(*pT);
-    pthread_mutex_unlock(&mutex_t);
-    return *pT;
-}
-
-template<typename T>
-volatile T InterlockedDecrement(volatile T* pT)
-{
-    pthread_mutex_lock(&mutex_t);
-    --(*pT);
-    pthread_mutex_unlock(&mutex_t);
-    return *pT;
-}
-
 #if 0
 template<typename S, typename T>
 inline const S& min(const S& rS, const T& rT)


### PR DESCRIPTION
## What does this PR do?

Revisits const volatile that cannot be returned, volatile cannot be returned either.

Removed InterlockedIncrement and InterlockedDecrement functions and associated mutex. These functions are not used and can be removed. Compiles and builds without it.

Tried to remove Linux64Specific.h, but it breaks to many things, LinuxSpecific.h, Linux64Specific.h and consequently other platforms need to be rewritten! 

## How was this PR tested?

Compiles and builds on Arch-Linux
