### PR TITLE
Remove unused member variable m_pDefaultButton

### DIFF
--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/Controls/PropertyGradientColorCtrl.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/Controls/PropertyGradientColorCtrl.h
@@ -53,7 +53,6 @@ namespace OpenParticleSystemEditor
         size_t GetDistIndex(const OpenParticle::DistributionType& distType, int index) const;
         void SetDistIndex(const OpenParticle::DistributionType& distType, size_t value, int index) const;
 
-        QToolButton* m_pDefaultButton = nullptr;
         GradientColorDialog* m_gradientColorDialog = nullptr;
         GradientWidget* m_gradientWidget = nullptr;
         QGradientStops m_gradientStops;


### PR DESCRIPTION
## What does this PR do?

Removed m_pDefaultButton, not used, breaks build when warnings are treated as errors

## How was this PR tested?

Compiles and builds on Arch-Linux
