### PR TITLE
BugFix PropertyHandlerDirectory didn't work in the game project

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -877,7 +877,7 @@ namespace AzToolsFramework
             }
             else if (entry->GetEntryType() == AssetBrowser::AssetBrowserEntry::AssetEntryType::Folder)
             {
-                SetFolderSelection(entry->GetRelativePath());
+                SetFolderSelection(entry->GetFullPath());
                 SetSelectedAssetID(AZ::Data::AssetId());
             }
         }

--- a/Gems/LyShine/Code/Editor/Widgets/PropertiesWidget/PropertyHandlers/PropertyHandlerDirectory.cpp
+++ b/Gems/LyShine/Code/Editor/Widgets/PropertiesWidget/PropertyHandlers/PropertyHandlerDirectory.cpp
@@ -98,23 +98,13 @@ void PropertyAssetDirectorySelectionCtrl::SetFolderSelection(const AZStd::string
     if (strFolderPath.empty())
     {
         m_folderPath.clear();
-    }    
-    // AssetBrowser will return relative paths for subdirectories of the game project,
-    // with the game project folder included in the path.
-    else if (AzFramework::StringFunc::Path::IsRelative(strFolderPath.c_str()))
-    {
-        // This assumes the asset picker will always a path relative to
-        // the project folder, which we need to omit since file IO routines
-        // seem to assume this anyways.
-        strFolderPath = strFolderPath.substr(strFolderPath.find('/') + 1);
-        m_folderPath = PathUtil::MakeGamePath(strFolderPath);
-        AZStd::to_lower(m_folderPath.begin(), m_folderPath.end());
     }
-    // For paths in gems, absolute paths are returned
+    // AssetBrowser will return absolute paths
     else
     {
+        strFolderPath = PathUtil::ToUnixPath(strFolderPath.c_str());
         m_folderPath = Path::FullPathToGamePath(strFolderPath.c_str());
-        AZStd::to_lower(m_folderPath.begin(), m_folderPath.end());
+        m_folderPath = PathUtil::ToLower(m_folderPath);
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

PropertyHandlerDirectory is only used in one place within O3DE: the LyShine Gem's UiImageSequenceComponent.h.

**The Problem:**
The issue was that if you used the UiImageSequenceComponent and referenced a sequence located within a Gem (e.g., Gems/LyShineExamples/Assets/UI/Textures/LyShineExamples/imagesequence), everything worked correctly. However, if you copied that same sequence into the game project's Assets folder, the component could no longer find it. This was because the relative directory path was being generated incorrectly.

**The Solution:**
To fix this, I modified PropertyAssetCtrl.cpp to return an absolute path to the folder. Then, within PropertyHandlerDirectory, this absolute path is converted to the correct relative path.
As a result, the component now works correctly with assets located in both Gems and the main game project.

## How was this PR tested?

1. To test everything, I copied the directory Gems/LyShineExamples/Assets/UI/Textures/LyShineExamples/imagesequence into my game project at <MyGame>/Assets/imagesequence.
2. I opened the UI Editor and added an entity with a UiImageSequenceComponent.
3. Next, I first assigned the image sequence from the Gem path (Gems/LyShineExamples/Assets/UI/Textures/LyShineExamples/imagesequence) and verified that the component correctly recognized the sequence.
4. Then, I loaded the sequence from the game project path (<MyGame>/Assets/imagesequence) and confirmed that the component also saw it and worked correctly.
