### PR TITLE
Adds debug render for emissive and irradiance color

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHit.azsl
@@ -46,6 +46,29 @@ float3 GetFallbackPBRBaseColor(float2 barycentrics)
     return textureData.m_baseColor.rgb;
 }
 
+float3 GetEmissiveColor(float2 barycentrics)
+{
+    MaterialInfo materialInfo;
+    if(!GetMaterialInfoEntry(InstanceID(), materialInfo))
+    {
+        return float3(0, 0, 0);
+    }
+    VsInput vertexData = GetVertexData(barycentrics);
+
+    TextureData textureData = GetFallbackPBRMaterialTextureData(materialInfo, RayTracingGlobalSrg::LinearSampler, vertexData.uv0);
+    return textureData.m_emissiveColor.rgb;
+}
+
+float3 GetIrradianceColor()
+{
+    MaterialInfo materialInfo;
+    if(!GetMaterialInfoEntry(InstanceID(), materialInfo))
+    {
+        return float3(0, 0, 0);
+    }
+    return materialInfo.m_irradianceColor.rgb;
+}
+
 float3 GetClusterColor(inout bool noData)
 {
     if (GetClusterId() == -1)
@@ -61,14 +84,16 @@ void ClosestHit(inout PayloadData payload, BuiltInTriangleIntersectionAttributes
 {
     switch (GetRayTracingDebugViewMode())
     {
-    case RayTracingDebugViewMode::InstanceID:     payload.m_color = GetRandomColor(InstanceID());             break;
-    case RayTracingDebugViewMode::ClusterID:      payload.m_color = GetClusterColor(payload.m_noData);        break;
-    case RayTracingDebugViewMode::InstanceIndex:  payload.m_color = GetRandomColor(InstanceIndex());          break;
-    case RayTracingDebugViewMode::PrimitiveIndex: payload.m_color = GetRandomColor(PrimitiveIndex());         break;
-    case RayTracingDebugViewMode::Barycentrics:   payload.m_color = GetBarycentricColor(attrib.barycentrics); break;
-    case RayTracingDebugViewMode::Normals:        payload.m_color = GetNormalColor(attrib.barycentrics);      break;
-    case RayTracingDebugViewMode::UVs:            payload.m_color = GetUVColor(attrib.barycentrics);          break;
-    case RayTracingDebugViewMode::BaseColor:      payload.m_color = GetFallbackPBRBaseColor(attrib.barycentrics); break;
-    default:                                      payload.m_noData = true;                                    break;
+    case RayTracingDebugViewMode::InstanceID:       payload.m_color = GetRandomColor(InstanceID());                 break;
+    case RayTracingDebugViewMode::ClusterID:        payload.m_color = GetClusterColor(payload.m_noData);            break;
+    case RayTracingDebugViewMode::InstanceIndex:    payload.m_color = GetRandomColor(InstanceIndex());              break;
+    case RayTracingDebugViewMode::PrimitiveIndex:   payload.m_color = GetRandomColor(PrimitiveIndex());             break;
+    case RayTracingDebugViewMode::Barycentrics:     payload.m_color = GetBarycentricColor(attrib.barycentrics);     break;
+    case RayTracingDebugViewMode::Normals:          payload.m_color = GetNormalColor(attrib.barycentrics);          break;
+    case RayTracingDebugViewMode::UVs:              payload.m_color = GetUVColor(attrib.barycentrics);              break;
+    case RayTracingDebugViewMode::BaseColor:        payload.m_color = GetFallbackPBRBaseColor(attrib.barycentrics); break;
+    case RayTracingDebugViewMode::EmissiveColor:    payload.m_color = GetEmissiveColor(attrib.barycentrics);        break;
+    case RayTracingDebugViewMode::IrradianceColor:  payload.m_color = GetIrradianceColor();      break;
+    default:                                        payload.m_noData = true;                                        break;
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugClosestHitProcedural.azsl
@@ -29,7 +29,29 @@ float3 GetFallbackPBRBaseColor(float2 uv)
         return float3(0, 0, 0);
     }
     TextureData textureData = GetFallbackPBRMaterialTextureData(materialInfo, RayTracingGlobalSrg::LinearSampler, uv);
-    return textureData.m_baseColor;
+    return textureData.m_baseColor.rgb;
+}
+
+float3 GetEmissiveColor(float2 uv)
+{
+    MaterialInfo materialInfo;
+    if(!GetMaterialInfoEntry(InstanceID(), materialInfo))
+    {
+        return float3(0, 0, 0);
+    }
+
+    TextureData textureData = GetFallbackPBRMaterialTextureData(materialInfo, RayTracingGlobalSrg::LinearSampler, uv);
+    return textureData.m_emissiveColor.rgb;
+}
+
+float3 GetIrradianceColor()
+{
+    MaterialInfo materialInfo;
+    if(!GetMaterialInfoEntry(InstanceID(), materialInfo))
+    {
+        return float3(0, 0, 0);
+    }
+    return materialInfo.m_irradianceColor.rgb;
 }
 
 [shader("closesthit")]
@@ -37,12 +59,14 @@ void ClosestHitProcedural(inout PayloadData payload, ProceduralGeometryIntersect
 {
     switch (GetRayTracingDebugViewMode())
     {
-    case RayTracingDebugViewMode::InstanceID:     payload.m_color = GetRandomColor(InstanceID());       break;
-    case RayTracingDebugViewMode::InstanceIndex:  payload.m_color = GetRandomColor(InstanceIndex());    break;
-    case RayTracingDebugViewMode::PrimitiveIndex: payload.m_color = GetRandomColor(PrimitiveIndex());   break;
-    case RayTracingDebugViewMode::Normals:        payload.m_color = GetNormalColor(attrib.GetNormal()); break;
-    case RayTracingDebugViewMode::UVs:            payload.m_color = GetUVColor(attrib.GetUv());         break;
-    case RayTracingDebugViewMode::BaseColor:      payload.m_color = GetFallbackPBRBaseColor(attrib.GetUv()); break;
-    default:                                      payload.m_noData = true;                              break;
+    case RayTracingDebugViewMode::InstanceID:      payload.m_color = GetRandomColor(InstanceID());            break;
+    case RayTracingDebugViewMode::InstanceIndex:   payload.m_color = GetRandomColor(InstanceIndex());         break;
+    case RayTracingDebugViewMode::PrimitiveIndex:  payload.m_color = GetRandomColor(PrimitiveIndex());        break;
+    case RayTracingDebugViewMode::Normals:         payload.m_color = GetNormalColor(attrib.GetNormal());      break;
+    case RayTracingDebugViewMode::UVs:             payload.m_color = GetUVColor(attrib.GetUv());              break;
+    case RayTracingDebugViewMode::BaseColor:       payload.m_color = GetFallbackPBRBaseColor(attrib.GetUv()); break;
+    case RayTracingDebugViewMode::EmissiveColor:   payload.m_color = GetEmissiveColor(attrib.GetUv());   break;
+    case RayTracingDebugViewMode::IrradianceColor: payload.m_color = GetIrradianceColor(); break;
+    default:                                       payload.m_noData = true;                                   break;
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Debug/RayTracingDebugCommon.azsli
@@ -25,6 +25,8 @@ enum class RayTracingDebugViewMode
     Normals,
     UVs,
     BaseColor,
+    EmissiveColor,
+    IrradianceColor,
 };
 
 RayTracingDebugViewMode GetRayTracingDebugViewMode()

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Debug/RayTracingDebugConstants.h
@@ -23,6 +23,8 @@ namespace AZ::Render
         Barycentrics,
         Normals,
         UVs,
-        BaseColor
+        BaseColor,
+        EmissiveColor,
+        IrradianceColor
     };
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Debug/RayTracingDebugEditorComponent.cpp
@@ -56,6 +56,8 @@ namespace AZ::Render
                         ->EnumAttribute(RayTracingDebugViewMode::Normals, "Normals")
                         ->EnumAttribute(RayTracingDebugViewMode::UVs, "UV Coordinates")
                         ->EnumAttribute(RayTracingDebugViewMode::BaseColor, "Material Base Color")
+                        ->EnumAttribute(RayTracingDebugViewMode::EmissiveColor, "Material Emissive Color")
+                        ->EnumAttribute(RayTracingDebugViewMode::IrradianceColor, "Material Irradiance Color")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                         ->Attribute(Edit::Attributes::Visibility, &RayTracingDebugComponentConfig::GetEnabled)
                 ;


### PR DESCRIPTION
## What does this PR do?

This adds 2 new preview render modes to the existing ray trace debug component:  Emissive Color, irradiance color.

Emissive color is fetched from the material's emissive color property, with the texture being taken into account if present.

irradiance color is fetched from the materia's irradiance color property, and does not take any texture into account (since there is no texture for this property).

## How was this PR tested?

Running locally.  Ensuring no errors appear in the shader compiler.  Viewing them.

<img width="1200" height="523" alt="image" src="https://github.com/user-attachments/assets/5ed4f024-9422-4702-8adc-4f7a930ec6b9" />
