### PR TITLE
Add missing override in AzCore/RTTI/BehaviorContext.h

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -606,7 +606,7 @@ namespace AZ::Internal
 #endif
 
         bool Call(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result) const override;
-        ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const;
+        ResultOutcome IsCallable(AZStd::span<BehaviorArgument> arguments, BehaviorArgument* result = nullptr) const override;
         bool HasResult() const override;
         bool IsMember() const override;
         bool HasBusId() const override;


### PR DESCRIPTION
## What does this PR do?

Adds a missing override in AzCore/RTTI/BehaviorContext.h.

## How was this PR tested?

Compiled with Clang, no warnings.
