### PR TITLE
Fix build error when building intermediate shader assets on Windows.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -712,7 +712,7 @@ namespace AZ
                 AZStd::to_upper(materialTypeNameUpper);
                 generatedAzsl += AZStd::string::format("#define MATERIAL_TYPE_%s 1 \n", materialTypeNameUpper.c_str());
 
-                generatedAzsl += AZStd::string::format("#include \"%s\" \n", shaderTemplate.m_azsli.c_str());
+                generatedAzsl += AZStd::string::format("#include \"%s\" \n", AZ::IO::PathView(shaderTemplate.m_azsli).StringAsPosix().c_str());
 
                 AZ::IO::Path shaderName = shaderTemplate.m_shader;
                 shaderName = shaderName.Filename(); // Removes the folder path


### PR DESCRIPTION
## What does this PR do?

Backslash (\\) is used by Windows as path separator but also used by unicode for escape sequences. Since #19315, shader include path expressed in Windows style causes error such as `error: Illegal UCN sequence`. This PR fixes the errors by converting the path to posix style.

## How was this PR tested?

Tested on Windows 11, previously failed shader asset are now compiled successfully.
