### PR TITLE
Fix FFont::DrawScreenAlignedText3d #18562

### DIFF
--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -1728,9 +1728,9 @@ void AZ::FFont::DrawScreenAlignedText3d(
     DrawStringUInternal(
         internalParams.m_viewport, 
         internalParams.m_viewportContext, 
-        positionNdc.GetX() * internalParams.m_viewport.GetWidth() + internalParams.m_position.GetX(), 
-        (1.0f - positionNdc.GetY()) * internalParams.m_viewport.GetHeight() + internalParams.m_position.GetY(), 
-        positionNdc.GetZ(), // Z
+        positionNdc.GetX() * internalParams.m_viewport.GetWidth(),
+        (1.0f - positionNdc.GetY()) * internalParams.m_viewport.GetHeight(),
+        positionNdc.GetZ(),
         text.data(),
         params.m_multiline,
         internalParams.m_ctx


### PR DESCRIPTION
## What does this PR do?

Closes #18562 

The coordinates of the debug text in 3D were calculated incorrectly. In particular, the `positionNdc` is the position projected from world space to screen space (normalized device coordinates for the given camera). The normalized position from the camera space needs to be multiplied by the size of the viewport to match the view space (note, that the direction of Y changes in the viewport as well). There is no need to add the world position to X and Y.

## How was this PR tested?

Used code in #18562  (changed color to red and X to value).

Before:
<img width="1969" height="907" alt="Screenshot from 2025-11-28 16-48-24" src="https://github.com/user-attachments/assets/77d4dd3d-f10e-4212-bd40-75046c657176" />

After:
<img width="1969" height="907" alt="Screenshot from 2025-11-28 16-49-28" src="https://github.com/user-attachments/assets/86fca1cd-f147-4a04-985f-3b1e4d2f8d04" />

