### PR TITLE
Adds missing assets to the default seed lists for Asset Bundling / Release shipping

### DIFF
--- a/Gems/Atom/RPI/Assets/seedList.seed
+++ b/Gems/Atom/RPI/Assets/seedList.seed
@@ -39,7 +39,27 @@
             },
             "platformFlags": 255,
             "pathHint": "textures/defaults/missing.png.streamingimage"
+        },
+        {
+            "assetId": {
+                "guid": "{5AC35A99-540A-59D0-AB03-5D42DE9433D6}"
+            },
+            "platformFlags": 255,
+            "pathHint": "shaders/scenematerialsrg.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{3095BDDE-37CA-53A2-9C5A-AF42D9EE68BE}"
+            },
+            "platformFlags": 255,
+            "pathHint": "shaders/deferredpasssrg.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{B37F7B9E-C6D2-5098-99E1-1288FB4AD902}"
+            },
+            "platformFlags": 255,
+            "pathHint": "shaders/forwardpasssrg.azshader"
         }
     ]
 }
-

--- a/Gems/DiffuseProbeGrid/Assets/seedList.seed
+++ b/Gems/DiffuseProbeGrid/Assets/seedList.seed
@@ -142,6 +142,69 @@
             },
             "platformFlags": 255,
             "pathHint": "passes/diffuseprobegridpreparepassrequest.azasset"
+        },
+        {
+            "assetId": {
+                "guid": "{66A5858B-5FFB-5CCE-ACEC-C065470941F2}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffusecomposite.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{985FA532-05D5-532C-AAAB-7A38D99B249E}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffuseglobalfullscreen.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{C36E2078-9853-5548-A8E0-33F2607B7838}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffuseprobegriddownsample.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{59C6F544-3CFE-5F2B-A4A1-E1D14BAB6839}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridqueryfullscreen.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{55EBE62C-1FB4-5823-B66D-B03853006672}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridvisualizationcomposite.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{189103A6-6548-5B7E-A3AC-0F854D865B09}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridvisualizationraytracing.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{858724E9-B36D-5F36-8944-947224609995}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridvisualizationraytracingclosesthit.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{59981F35-8D89-5F2B-B3EB-C94F46A3A7FA}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/diffuseprobegridvisualizationraytracingmiss.azshader"
+        },
+        {
+            "assetId": {
+                "guid": "{5D846658-301B-548D-870A-B9F812D1586F}"
+            },
+            "platformFlags": 3,
+            "pathHint": "shaders/diffuseglobalillumination/sceneandviewsrgs.azshader"
         }
     ]
 }


### PR DESCRIPTION
## What does this PR do?

A few shaders had been added or changed, since last the seedlist was made, and the seedlist has not been updated to compensate.

This adds the missing assets to the seed lists and fixes a release-shipping issue where PAK files would end up missing these shaders.

Without this change:
Release games using only the generated paks will be missing all shading information (not just diffuse probe).
If you use the method where you pack up all your assets, it works of course.



## How was this PR tested?

Building PAK bundles and running in release monolithic PC PAK-Only-Mode with ONLY the generated PAK file (about 38mb), on a level with diffuse probes and some meshes.  


