### PR TITLE
Allows you to save default paths into assetbundler rules

### DIFF
--- a/Code/Tools/AssetBundler/source/ui/ComparisonDataWidget.cpp
+++ b/Code/Tools/AssetBundler/source/ui/ComparisonDataWidget.cpp
@@ -156,8 +156,33 @@ namespace AssetBundler
 
         // Inputs
         UpdateListOfTokenNames();
+        if (comparisonData.m_firstInput.empty())
+        {
+            m_ui->firstInputComboBox->setCurrentIndex(0);
+            SetFirstInputFileVisibility(true);
+        }
+        else
+        {
+            int firstInputIndex = m_inputTokenNameList.indexOf(RemoveTokenCharFromString(comparisonData.m_firstInput));
+            if (firstInputIndex != -1)
+            {
+                m_ui->firstInputComboBox->setCurrentIndex(firstInputIndex);
+                SetFirstInputFileVisibility(firstInputIndex == 0);
+            }
+        }
+
         m_ui->firstInputLineEdit->setText(QString(comparisonData.m_cachedFirstInputPath.c_str()));
         m_ui->secondInputLineEdit->setText(QString(comparisonData.m_cachedSecondInputPath.c_str()));
+
+        // override with hard set values
+        if (!comparisonData.m_firstInput.empty())
+        {
+            m_ui->firstInputLineEdit->setText(QString(comparisonData.m_firstInput.c_str()));
+        }
+        if (!comparisonData.m_secondInput.empty())
+        {
+            m_ui->secondInputLineEdit->setText(QString(comparisonData.m_secondInput.c_str()));
+        }
 
         // Update fields that are not always visible
         UpdateOnComparisonTypeChanged(comparisonData.m_filePatternType != AssetFileInfoListComparison::FilePatternType::Default);
@@ -343,7 +368,9 @@ namespace AssetBundler
         }
 
         m_ui->firstInputLineEdit->setText(absoluteFilePath);
+        m_comparisonList->SetFirstInput(m_comparisonDataIndex, absoluteFilePath.toUtf8().constData());
         m_comparisonList->SetCachedFirstInputPath(m_comparisonDataIndex, absoluteFilePath.toUtf8().data());
+        emit comparisonDataChanged();
     }
 
     void ComparisonDataWidget::OnSecondInputComboBoxChanged(int index)
@@ -392,6 +419,8 @@ namespace AssetBundler
 
         m_ui->secondInputLineEdit->setText(absoluteFilePath);
         m_comparisonList->SetCachedSecondInputPath(m_comparisonDataIndex, absoluteFilePath.toUtf8().data());
+        m_comparisonList->SetSecondInput(m_comparisonDataIndex, absoluteFilePath.toUtf8().constData());
+        emit comparisonDataChanged();
     }
 
     QString ComparisonDataWidget::BrowseButtonPressed()

--- a/Code/Tools/AssetBundler/source/ui/RulesTabWidget.cpp
+++ b/Code/Tools/AssetBundler/source/ui/RulesTabWidget.cpp
@@ -244,30 +244,25 @@ namespace AssetBundler
                 AssetFileInfoListComparison::ComparisonData comparisonStep = currentFileCopy.GetComparisonList()[comparisonStepIndex];
                 if (comparisonStep.m_firstInput.empty())
                 {
-                    if (comparisonStep.m_cachedFirstInputPath.empty())
-                    {
-                        AZ_Error("AssetBundler", false,
-                            "Unable to run Rule: Comparison Step #%u has no specified first input.", comparisonStepIndex);
-                        return;
-                    }
-
-                    FilePath firstInput = FilePath(comparisonStep.m_cachedFirstInputPath, platformName);
-                    currentFileCopy.SetFirstInput(comparisonStepIndex, firstInput.AbsolutePath());
+                    
+                    AZ_Error("AssetBundler", false,
+                        "Unable to run Rule: Comparison Step #%u has no specified first input.", comparisonStepIndex);
+                    return;
                 }
 
                 if (comparisonStep.m_comparisonType != AssetFileInfoListComparison::ComparisonType::FilePattern
                     && comparisonStep.m_secondInput.empty())
                 {
-                    if (comparisonStep.m_cachedSecondInputPath.empty())
-                    {
-                        AZ_Error("AssetBundler", false,
-                            "Unable to run Rule: Comparison Step #%u has no specified second input.", comparisonStepIndex);
-                        return;
-                    }
-
-                    FilePath secondInput = FilePath(comparisonStep.m_cachedSecondInputPath, platformName);
-                    currentFileCopy.SetSecondInput(comparisonStepIndex, secondInput.AbsolutePath());
+                    AZ_Error("AssetBundler", false,
+                        "Unable to run Rule: Comparison Step #%u has no specified second input.", comparisonStepIndex);
+                    return;
                 }
+
+                // update the paths to use
+                FilePath firstInput = FilePath(comparisonStep.m_firstInput, platformName);
+                currentFileCopy.SetFirstInput(comparisonStepIndex, firstInput.AbsolutePath());
+                FilePath secondInput = FilePath(comparisonStep.m_secondInput, platformName);
+                currentFileCopy.SetSecondInput(comparisonStepIndex, secondInput.AbsolutePath());
             }
 
             // Set the output location of the Asset List file that will be generated

--- a/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
+++ b/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
@@ -716,7 +716,10 @@ namespace AssetBundler
             return AZ::Failure(AZStd::string::format("Invalid command: \"--%s\" must have exactly one value.", IntersectionCountArg));
         }
 
-        params.m_intersectionCount = AZStd::stoi(parser->GetSwitchValue(IntersectionCountArg, 0));
+        if (parser->HasSwitch(IntersectionCountArg))
+        {
+            params.m_intersectionCount = AZStd::stoi(parser->GetSwitchValue(IntersectionCountArg, 0));
+        }
 
         size_t numTokenNames = parser->GetNumSwitchValues(ComparisonTokenNameArg);
 
@@ -1023,7 +1026,11 @@ namespace AssetBundler
                 FilePath path = FilePath(value);
                 value = path.AbsolutePath();
             }
-            params.m_printComparisons.emplace_back(AZStd::move(value));
+
+            if (!value.empty())
+            {
+                params.m_printComparisons.emplace_back(AZStd::move(value));
+            }
         }
 
         params.m_printLast = parser->HasSwitch(ComparePrintArg) && params.m_printComparisons.empty();
@@ -1929,6 +1936,12 @@ namespace AssetBundler
                     {
                         comparisonOperations.SetFirstInput(idx, params.m_firstCompareFile.at(idx));
                     }
+                    else
+                    {
+                        // if its not the "default token" then make sure to update the actual entry to have the `_platname` wart at the end
+                        FilePath updatedPath(comparisonOperations.GetComparisonList().at(idx).m_firstInput, platformName);
+                        comparisonOperations.SetFirstInput(idx, updatedPath.AbsolutePath());
+                    }
 
                     // Set the second input (if needed)
                     if (comparisonOperations.GetComparisonList().at(idx).m_comparisonType != AssetFileInfoListComparison::ComparisonType::FilePattern)
@@ -1944,6 +1957,12 @@ namespace AssetBundler
                         if (!IsDefaultToken(params.m_secondCompareFile.at(secondInputIdx)))
                         {
                             comparisonOperations.SetSecondInput(idx, params.m_secondCompareFile.at(secondInputIdx));
+                        }
+                        else
+                        {
+                            // if its not the "default token" then make sure to update the actual entry to have the `_platname` wart at the
+                            FilePath updatedPath(comparisonOperations.GetComparisonList().at(idx).m_secondInput, platformName);
+                            comparisonOperations.SetSecondInput(idx, updatedPath.AbsolutePath());
                         }
 
                         ++secondInputIdx;
@@ -1961,6 +1980,12 @@ namespace AssetBundler
                     if (!IsDefaultToken(params.m_outputs.at(idx)))
                     {
                         comparisonOperations.SetOutput(idx, params.m_outputs.at(idx));
+                    }
+                    else
+                    {
+                        // if its not the "default token" then make sure to update the actual entry to have the `_platname` wart at the
+                        FilePath updatedPath(comparisonOperations.GetComparisonList().at(idx).m_output, platformName);
+                        comparisonOperations.SetOutput(idx, updatedPath.AbsolutePath());
                     }
                 }
             }


### PR DESCRIPTION
## What does this PR do?

AssetBundler did not actually save paths you specify in the GUI, since the intention there was that the gui is for constructing rule files that have blanks for you to fill in later, from the command line.  So for example, if you made a rule that generated the delta between 2 different asset lists (by browsing for the 2 asset lists) it would not save the paths you chose. 

This change makes it so that the GUI actually saves those paths into the asset files, if you specify them.  You can still leave them blank if you want.  

This would allow a smaller (1 user) team to use the GUI to assemble bundles instead of the CLI, while still allowing power users to use the command line with custom paths to substitute if they want.   This does not change existing batch behavior.

This also fixes an invalid param access in assetbundler, and fixes an issue where it would not properly add the `_pc`, `_android` etc warts onto the file name before trying to open them.

## How was this PR tested?

Manual testing, and local CI tests (which do exercise these features).


Example rules in the gui
<img width="1186" height="435" alt="image" src="https://github.com/user-attachments/assets/ea072858-352b-4f3e-860e-fa8bd14f3a03" />

This is a delta rule, which is going to result in an asset list which only contains the difference between those two asset lists.  This is useful for example if you want to make an `engine.pak` (containing all baseline assets) and then a `level01.pak` and `level02.pak` and so on which just has the level assets.   you wouldn't want to include the engine assets in each level pack, so you'd create a rule to `delta(engine.assetlist, level01.assetlist)` which would result in a new list of assets in level01 but NOT the engine.  You'd then turn that delta assetlist into the final level01.pak.

With this change you can now do this by using the gui (click 'run rule') and it saves its state.

You can still use the command line options to run this rule too, just like before, except that you can use `$` for these params to mean `just use the default value already in the file.`

Note that the `$` operation was always available, the paths were just never saved into the file before.

example
```
build\windows\bin\debug\AssetBundlerBatch.exe --project-path=AutomatedTesting compare --comparisonRulesFile AutomatedTesting\AssetBundling\Rules\sep.rules --platform pc --firstAssetFile=$ --secondAssetFile=$ --output=test.assetlist --print
```

example using paths instead (you'd have to do this every time, before this change)

```
build\windows\bin\debug\AssetBundlerBatch.exe --project-path=AutomatedTesting compare --comparisonRulesFile AutomatedTesting\AssetBundling\Rules\sep.rules --platform pc --firstAssetFile=AutomatedTesting\AssetBundling\AssetLists\engine.assetlist --secondAssetFile=AutomatedTesting\AssetBundling\AssetLists\automatedtesting.assetlist --output=test.assetlist --print
```
