### PR TITLE
Make SceneGraph::Find function const

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.h
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.h
@@ -174,7 +174,7 @@ namespace AZ
                 inline NodeIndex GetRoot() const;
                 SCENE_CORE_API NodeIndex Find(const char* path) const;
                 SCENE_CORE_API NodeIndex Find(NodeIndex root, const char* name) const;
-                inline NodeIndex Find(const Name& name);
+                inline NodeIndex Find(const Name& name) const;
                 inline NodeIndex Find(const AZStd::string& path) const;
                 inline NodeIndex Find(NodeIndex root, const AZStd::string& name) const;
 

--- a/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.inl
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.inl
@@ -176,7 +176,7 @@ namespace AZ
                 return Find(path.c_str());
             }
 
-            SceneGraph::NodeIndex SceneGraph::Find(const Name& name)
+            SceneGraph::NodeIndex SceneGraph::Find(const Name& name) const
             {
                 return Find(name.GetPath());
             }


### PR DESCRIPTION
## What does this PR do?

This PR adds the `const` modifier to the function `AZ::SceneAPI::Containers::SceneGraph::Find(const Name& name)`, since the modifier is also present in the other Find functions with different parameters and this functions does not modify the SceneGraph class.

## How was this PR tested?

Compiling the engine, no other testing performed
