### PR TITLE
Adjust PrefabDomUtils to distinguish TransformComponent and GradientEditorTransformComponent.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <AzCore/std/string/regex.h>
+#include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetJsonSerializer.h>
 #include <AzCore/JSON/prettywriter.h>
@@ -29,13 +29,10 @@ namespace AzToolsFramework
         {
             namespace Internal
             {
-                // regex to match  : optional uuid, optional space, TransformComponent
-                //   - `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} TransformComponent`
-                //   - `TransformComponent`
-                //  but do not match :
-                //   - `GradientEditorTransformComponent`
-                const AZStd::regex TransformComponentRegex(R"(^(\{........-....-....-....-............\})?\s?TransformComponent$)");
-
+                const AZStd::unordered_set<AZStd::string> TransformComponentNames= {
+                    "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "TransformComponent"
+                };
                 [[maybe_unused]] static constexpr const char* const ComponentRemovalNotice =
                     "[INFORMATION] %s data has been altered to remove component '%s'. "
                     "Please edit and save %s to persist the change.";
@@ -666,7 +663,7 @@ namespace AzToolsFramework
                         
                         AZStd::string componentAlias(componentsTypeIt->value.GetString());
 
-                        if (!AZStd::regex_match(componentAlias, Internal::TransformComponentRegex))
+                        if (!Internal::TransformComponentNames.contains(componentAlias))
                         {
                             continue; // not the component we are looking for
                         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
+#include <AzCore/std/string/regex.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetJsonSerializer.h>
 #include <AzCore/JSON/prettywriter.h>
@@ -29,6 +29,13 @@ namespace AzToolsFramework
         {
             namespace Internal
             {
+                // regex to match  : optional uuid, optional space, TransformComponent
+                //   - `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} TransformComponent`
+                //   - `TransformComponent`
+                //  but do not match :
+                //   - `GradientEditorTransformComponent`
+                const AZStd::regex TransformComponentRegex(R"(^(\{........-....-....-....-............\})?\s?TransformComponent$)");
+
                 [[maybe_unused]] static constexpr const char* const ComponentRemovalNotice =
                     "[INFORMATION] %s data has been altered to remove component '%s'. "
                     "Please edit and save %s to persist the change.";
@@ -658,11 +665,12 @@ namespace AzToolsFramework
                         }
                         
                         AZStd::string componentAlias(componentsTypeIt->value.GetString());
-                        if (!componentAlias.contains("TransformComponent"))
+
+                        if (!AZStd::regex_match(componentAlias, Internal::TransformComponentRegex))
                         {
-                            continue;
+                            continue; // not the component we are looking for
                         }
-                        
+
                         constexpr const auto parentObjectName = "Parent Entity";
                         auto parentIt = componentIt->value.FindMember(parentObjectName);
                         if (parentIt == componentIt->value.MemberEnd() || !parentIt->value.IsString())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -29,10 +29,6 @@ namespace AzToolsFramework
         {
             namespace Internal
             {
-                const AZStd::unordered_set<AZStd::string> TransformComponentNames= {
-                    "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "TransformComponent"
-                };
                 [[maybe_unused]] static constexpr const char* const ComponentRemovalNotice =
                     "[INFORMATION] %s data has been altered to remove component '%s'. "
                     "Please edit and save %s to persist the change.";
@@ -589,6 +585,11 @@ namespace AzToolsFramework
 
             bool SubstituteInvalidParentsInEntities(PrefabDom& templateDomRef)
             {
+                const AZStd::unordered_set<AZStd::string> TransformComponentNames = {
+                    "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "TransformComponent"
+                };
+
                 // Search for a TransformComponent and check the "Parent Entity" statement
                 auto sourceIt = templateDomRef.FindMember(PrefabDomUtils::SourceName);
                 if (sourceIt == templateDomRef.MemberEnd() || !sourceIt->value.IsString())
@@ -663,7 +664,8 @@ namespace AzToolsFramework
                         
                         AZStd::string componentAlias(componentsTypeIt->value.GetString());
 
-                        if (!Internal::TransformComponentNames.contains(componentAlias))
+
+                        if (!TransformComponentNames.contains(componentAlias))
                         {
                             continue; // not the component we are looking for
                         }


### PR DESCRIPTION
## What does this PR do?
Deals with warnings regarding missing Parent Entity.
The check which produce this warning was searching for TransformComponent in string type name that can be something like:
```
{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent
```
This too simple logic catch:
```
EditorGradientTransformComponent
```
but `EditorGradientTransformComponent` does not have parent entity. It was not spurious warning, it could alter logic of prefab system. 

I've handwrote  (I did not like AI generated clever regex) dummy regex to match:
```cpp
               // regex to match  : optional uuid, optional space, TransformComponent
                //   - `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} TransformComponent`
                //   - `TransformComponent`
                //  but do not match :
                //   - `GradientEditorTransformComponent`
                const AZStd::regex TransformComponentRegex(R"(^(\{........-....-....-....-............\})?\s?TransformComponent$)");
```
## How was this PR tested?
- Loaded some prefabs to see that warning is not present.
- Evaluate flow of the code with debugger
- Tested Regex with https://regex101.com/r/YXfYpv/1
