### PR TITLE
Add Unlit material type to Atom Gem

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit.materialtype
@@ -1,0 +1,64 @@
+{
+    "description": "Renders a model unlit with a single surface color value.",
+    "version": 0,
+    "versionUpdates": [],
+    "propertyLayout": {
+        "propertyGroups": [
+            {
+                "name": "settings",
+                "displayName": "Base Color",
+                "properties": [
+                    {
+                        "name": "color",
+                        "displayName": "Color",
+                        "type": "Color",
+                        "defaultValue": [ 1.0, 1.0, 1.0 ],
+                        "connection": {
+                            "type": "ShaderInput",
+                            "name": "m_unlitColor"
+                        }
+                    },
+                    {
+                        "name": "baseColorTexture",
+                        "displayName": "Texture",
+                        "description": "Base color texture map",
+                        "type": "Image",
+                        "defaultValue": "",
+                        "connection": {
+                            "type": "ShaderInput",
+                            "name": "m_baseColorTexture"
+                        }
+                    },
+                    {
+                        "name": "textureMapUv",
+                        "displayName": "UV",
+                        "description": "Base color map UV set",
+                        "type": "Enum",
+                        "enumIsUv": true,
+                        "defaultValue": "Tiled",
+                        "connection": {
+                            "type": "ShaderInput",
+                            "name": "m_baseColorMapUvIndex"
+                        }
+                    }
+                ]
+            },
+            {
+                "$import": "MaterialInputs/UvPropertyGroup.json"
+            }
+        ]
+    },
+    "functors": [],
+    "uvNameMap": {
+        "UV0": "Tiled",
+        "UV1": "Unwrapped"
+    },
+    "shaders": [
+        {
+            "file": "../../Shaders/Unlit/Unlit.shader"
+        },
+        {
+            "file": "../../Shaders/Depth/DepthPass.shader"
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/Unlit.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/Unlit.azsl
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
+#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
+#include <Atom/Features/InstancedTransforms.azsli>
+#include <Atom/Features/Pipeline/Forward/ForwardPassOutput.azsli>
+#include <Atom/Features/SrgSemantics.azsli>
+
+ShaderResourceGroup UnlitDrawSrg : SRG_PerDraw
+{
+}
+
+ShaderResourceGroup UnlitColorSrg : SRG_PerMaterial
+{
+    float3 m_unlitColor;
+    Texture2D m_baseColorTexture;
+    Sampler m_baseColorSampler
+    {
+        MaxAnisotropy = 1;
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        ReductionType = Filter;
+        AddressU = Wrap;
+        AddressV = Wrap;
+        AddressW = Wrap;
+        MinLOD = 0.000000;
+        MaxLOD = 15.000000;
+    };
+    float3x3 m_uvMatrix;
+    float2 m_uvMatrixPadding;
+    uint m_baseColorMapUvIndex;
+}
+
+struct VertexShaderInput
+{
+    float3 m_position : POSITION;
+    float2 m_uv0 : UV0;
+    float2 m_uv1 : UV1;
+};
+
+struct VertexShaderOutput
+{
+    float4 m_position : SV_Position;
+    float2 m_uvs[2] : TEXCOORD0;
+};
+
+VertexShaderOutput MainVS(VertexShaderInput IN, uint instanceId : SV_InstanceID)
+{
+    VertexShaderOutput OUT;
+    float4x4 objectToWorld = GetObjectToWorldMatrix(instanceId);
+    float4 worldPosition = mul(objectToWorld, float4(IN.m_position, 1.0));
+    OUT.m_position = mul(ViewSrg::m_viewProjectionMatrix, worldPosition);
+    
+    OUT.m_uvs[0] = mul(UnlitColorSrg::m_uvMatrix, float3(IN.m_uv0, 1.0)).xy;
+    OUT.m_uvs[1] = IN.m_uv1;
+   
+    return OUT;
+}
+
+ForwardPassOutput MainPS(VertexShaderOutput IN)
+{
+    ForwardPassOutput OUT;
+
+    float3 baseColor = UnlitColorSrg::m_unlitColor;
+    float2 baseColorUv = IN.m_uvs[UnlitColorSrg::m_baseColorMapUvIndex];
+    float4 tex = UnlitColorSrg::m_baseColorTexture.Sample(UnlitColorSrg::m_baseColorSampler, baseColorUv);
+    if (tex.a > 0.0)
+    {
+        baseColor = tex.rgb * UnlitColorSrg::m_unlitColor;
+    }
+
+    OUT.m_diffuseColor = float4(baseColor, -1.0); 
+    OUT.m_specularColor = float4(0.0, 0.0, 0.0, 0.0); 
+
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/Unlit.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/Unlit.shader
@@ -1,0 +1,25 @@
+{
+    "Source": "Unlit.azsl",
+
+    "DepthStencilState": {
+        "Depth": {
+            "Enable": true,
+            "CompareFunc": "GreaterEqual"
+        }
+    },
+
+    "ProgramSettings": {
+        "EntryPoints": [
+            {
+                "name": "MainVS",
+                "type": "Vertex"
+            },
+            {
+                "name": "MainPS",
+                "type": "Fragment"
+            }
+        ]
+    },
+
+    "DrawList": "forward"
+}


### PR DESCRIPTION
**What was added:**
- `Unlit.azsl` - AZSL shader implementation with unlit rendering support
- `Unlit.shader` - Shader configuration file for forward pass rendering
- `Unlit.materialtype` - Material type definition with standard O3DE material properties

**Features:**
- Base color support (RGB color value)
- Texture support with optional base color texture map
- UV set selection (Tiled/Unwrapped) - allows switching between UV0 and UV1 coordinate sets
- Compatible with standard O3DE material system and follows all material type conventions

**Design decisions:**
- Follows the same UV transformation behavior as PBR shaders (transformations apply only to UV0, UV1 remains untransformed by design)
- Integrates with existing `DepthPass.shader` for depth rendering

## How was this PR tested?

**Testing performed:**
- Tested on Windows with DX12 renderer
- Confirmed UV transformations (tile, offset, rotate, scale)
- Verified shader compiles without errors on DX12