### PR TITLE
Fix incorrect flag check in Assimp scene importing

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -218,7 +218,7 @@ namespace AZ
             }
 
             // for FBX, root transform is not converted where there are no meshes in the scene.
-            if ((m_assImpScene->mFlags | AI_SCENE_FLAGS_INCOMPLETE) && m_assImpScene->mMetaData->HasKey("UpAxis"))
+            if ((m_assImpScene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) && m_assImpScene->mMetaData->HasKey("UpAxis"))
             {
                 readRootTransform = false;
             }


### PR DESCRIPTION
## What does this PR do?

This PR fixes an erroneous check in Assimp scene importing. The expression `m_assImpScene->mFlags | AI_SCENE_FLAGS_INCOMPLETE` is always true, it should rather use the `&` operator to correctly check for the incomplete flag being set.
This was already fixed once in #19016, but was changed back to the wrong version in a subsequent PR.

## How was this PR tested?

No testing performed
