### PR TITLE
Make the Multiplayer gem use PhysX5 instead of PhysX4

### DIFF
--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -83,7 +83,7 @@ ly_add_target(
             Gem::${gem_name}.Common.Static
         PRIVATE
             Gem::EMotionFXStaticLib
-            Gem::PhysX.Static
+            Gem::PhysX5.Static
     AUTOGEN_RULES
         *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
         *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp
@@ -113,7 +113,7 @@ ly_add_target(
             Gem::${gem_name}.Common.Static
         PRIVATE
             Gem::EMotionFXStaticLib
-            Gem::PhysX.Static
+            Gem::PhysX5.Static
     AUTOGEN_RULES
         *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
         *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp
@@ -143,7 +143,7 @@ ly_add_target(
             Gem::${gem_name}.Common.Static
         PRIVATE
             Gem::EMotionFXStaticLib
-            Gem::PhysX.Static
+            Gem::PhysX5.Static
     AUTOGEN_RULES
         *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
         *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp
@@ -355,7 +355,7 @@ if (PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             PRIVATE
                 AZ::AzTest
                 Gem::${gem_name}.Unified.Static
-                Gem::PhysX.Static
+                Gem::PhysX5.Static
         AUTOGEN_RULES
             *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
             *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp


### PR DESCRIPTION
Closes #19428

## What does this PR do?

The the Multiplayer gem's `Code/CMakeLists.txt` in depends on PhysX4 rather than PhysX5, which means that any gems that have PhysX5 as a dependency cannot make use the Multiplayer gem. This PR modifies `Code/CMakeLists.txt` to use PhysX5 instead. 

## How was this PR tested?

Using the [FirstPersonController gem](https://github.com/Porcupine-Factory/FirstPersonController) along with a fork of the [Multiplayer gem using PhysX5](https://github.com/Porcupine-Factory/MultiplayerPhysX5#).