### PR TITLE
Meshlets: fix 64->32 narrowing when building IndexBufferView size

### DIFF
--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsRenderObject.cpp
@@ -411,7 +411,7 @@ namespace AZ
                         meshRenderData.IndexBufferView = RHI::IndexBufferView(
                             *meshRenderData.ComputeBuffersViews[mappedIdx]->GetBuffer(),
                             bufferDesc.m_viewOffsetInBytes,
-                            (uint64_t)bufferDesc.m_elementCount * bufferDesc.m_elementSize,
+                            aznumeric_cast<uint32_t>(static_cast<uint64_t>(bufferDesc.m_elementCount) * bufferDesc.m_elementSize),
                             (bufferDesc.m_elementFormat == RHI::Format::R32_UINT) ? RHI::IndexFormat::Uint32 : RHI::IndexFormat::Uint16);
                     }
                 }


### PR DESCRIPTION
## What does this PR do?

Fixes a build break on macOS with Xcode 26.1.1 when compiling the Meshlets gem with Xcode.

Before: Meshlets.Static failed to compile because we were passing a 64-bit
byte-size expression into RHI::IndexBufferView, which expects a 32-bit size.
With -Werror, clang treats the implicit 64->32 narrowing as a hard error.

After: Compute the byte size in 64-bit, assert it fits in 32-bit, and pass it
to IndexBufferView via an explicit cast. This keeps the intent clear and avoids
silent truncation.

## How was this PR tested?

- macOS (Xcode generator), Profile config:
  - cmake --build build/macos --config profile --target Meshlets.Static
- Also built the SDK launcher target to ensure nothing else regressed:
  - cmake --build build/macos --config profile --target O3DE_SDK