### PR TITLE
Fix (again) assimp importer root transform when processing pure FBX animation.

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
@@ -54,6 +54,7 @@ namespace AZ
             aiAABB m_aabb;
             uint32_t m_vertices;
             bool m_extractEmbeddedTextures;
+            bool m_readRootTransform;
         };
 
     } // namespace AssImpSDKWrapper


### PR DESCRIPTION
## What does this PR do?

This PR fixed a coordinate system error when importing animation-only FBX files which was previously fixed by #19061 but was reintroduced by #18931.

## How was this PR tested?

Tested on windows 11.
