### PR TITLE
Extend the Look At component's capabilities

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
@@ -223,7 +223,7 @@ namespace LmbrCentral
 
                 lookAtTransform.SetTranslation(sourceTM.GetTranslation());
 
-                // update the rotation and translation for sourceTM based on lookAtTransform, but leave scale unchanged
+                // When strength is maxed out, update the rotation and translation for sourceTM based on lookAtTransform, but leave scale unchanged
                 if (m_strength == 1.f)
                 {
                     sourceTM.SetRotation(lookAtTransform.GetRotation());

--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
@@ -28,6 +28,7 @@ namespace LmbrCentral
                 ->Field("FixateRoll", &EditorLookAtComponent::m_fixateRoll)
                 ->Field("FixateYaw", &EditorLookAtComponent::m_fixateYaw)
                 ->Field("Enabled", &EditorLookAtComponent::m_enabled)
+                ->Field("ApplyLookAtTransform", &EditorLookAtComponent::m_applyLookAtTransform)
                 ;
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -68,8 +69,10 @@ namespace LmbrCentral
                     ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_fixateYaw, "Fixate Yaw", "Whether the pitch is fixated towards the Look At entity / point")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::RecalculateTransform)
 
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_enabled, "Enabled", "Whether the Look At component is enabled or Disabled")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_enabled, "Enabled", "Whether the Look At component is enabled or disabled")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::OnEnabledChanged)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_applyLookAtTransform, "Apply Look At Transform", "Whether the Look At transform is applied when the component is enabled")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::RecalculateTransform)
                     ;
             }
         }
@@ -146,6 +149,7 @@ namespace LmbrCentral
             lookAtComponent->m_fixateRoll = m_fixateRoll;
             lookAtComponent->m_fixateYaw = m_fixateYaw;
             lookAtComponent->m_enabled = m_enabled;
+            lookAtComponent->m_applyLookAtTransform = m_applyLookAtTransform;
         }
     }
 
@@ -234,7 +238,7 @@ namespace LmbrCentral
                 lookAtTransform.SetTranslation(sourceTM.GetTranslation());
 
                 // When strength is maxed out, update the rotation and translation for sourceTM based on lookAtTransform, but leave scale unchanged
-                if (m_strength == 1.f)
+                if (m_strength == 1.f && m_applyLookAtTransform)
                 {
                     sourceTM.SetRotation(lookAtTransform.GetRotation());
                     sourceTM.SetTranslation(lookAtTransform.GetTranslation());

--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
@@ -182,7 +182,9 @@ namespace LmbrCentral
     void EditorLookAtComponent::OnEnabledChanged()
     {
         if (m_enabled)
+        {
             RecalculateTransform();
+        }
     }
 
     //=========================================================================
@@ -196,7 +198,9 @@ namespace LmbrCentral
     void EditorLookAtComponent::RecalculateTransform()
     {
         if (!m_enabled)
+        {
             return;
+        }
 
         if (m_targetId.IsValid())
         {
@@ -215,11 +219,17 @@ namespace LmbrCentral
                     );
 
                 if (!m_fixatePitch)
+                {
                     lookAtTransform.SetFromEulerRadians(AZ::Vector3(sourceTM.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+                }
                 if (!m_fixateRoll)
+                {
                     lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), sourceTM.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+                }
                 if (!m_fixateYaw)
+                {
                     lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), sourceTM.GetRotation().GetEulerRadians().GetZ()));
+                }
 
                 lookAtTransform.SetTranslation(sourceTM.GetTranslation());
 

--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.cpp
@@ -23,6 +23,11 @@ namespace LmbrCentral
                 ->Version(1)
                 ->Field("Target", &EditorLookAtComponent::m_targetId)
                 ->Field("ForwardAxis", &EditorLookAtComponent::m_forwardAxis)
+                ->Field("Strength", &EditorLookAtComponent::m_strength)
+                ->Field("FixatePitch", &EditorLookAtComponent::m_fixatePitch)
+                ->Field("FixateRoll", &EditorLookAtComponent::m_fixateRoll)
+                ->Field("FixateYaw", &EditorLookAtComponent::m_fixateYaw)
+                ->Field("Enabled", &EditorLookAtComponent::m_enabled)
                 ;
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -48,6 +53,23 @@ namespace LmbrCentral
                         ->EnumAttribute(AZ::Transform::Axis::ZPositive, "Z+")
                         ->EnumAttribute(AZ::Transform::Axis::ZNegative, "Z-")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::RecalculateTransform)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Slider, &EditorLookAtComponent::m_strength, "Strength", "Determines how quickly the rotation is performed and how much it resists changes in the rotation")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Step, 0.0001f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1.f)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_fixatePitch, "Fixate Pitch", "Whether the pitch is fixated towards the Look At entity / point")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::RecalculateTransform)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_fixateRoll, "Fixate Roll", "Whether the pitch is fixated towards the Look At entity / point")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::RecalculateTransform)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_fixateYaw, "Fixate Yaw", "Whether the pitch is fixated towards the Look At entity / point")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::RecalculateTransform)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorLookAtComponent::m_enabled, "Enabled", "Whether the Look At component is enabled or Disabled")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorLookAtComponent::OnEnabledChanged)
                     ;
             }
         }
@@ -119,6 +141,11 @@ namespace LmbrCentral
         {
             lookAtComponent->m_targetId = m_targetId;
             lookAtComponent->m_forwardAxis = m_forwardAxis;
+            lookAtComponent->m_strength = m_strength;
+            lookAtComponent->m_fixatePitch = m_fixatePitch;
+            lookAtComponent->m_fixateRoll = m_fixateRoll;
+            lookAtComponent->m_fixateYaw = m_fixateYaw;
+            lookAtComponent->m_enabled = m_enabled;
         }
     }
 
@@ -152,6 +179,13 @@ namespace LmbrCentral
     }
 
     //=========================================================================
+    void EditorLookAtComponent::OnEnabledChanged()
+    {
+        if (m_enabled)
+            RecalculateTransform();
+    }
+
+    //=========================================================================
     void EditorLookAtComponent::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
     {
         RecalculateTransform();
@@ -161,6 +195,9 @@ namespace LmbrCentral
     //=========================================================================
     void EditorLookAtComponent::RecalculateTransform()
     {
+        if (!m_enabled)
+            return;
+
         if (m_targetId.IsValid())
         {
             AZ::TransformNotificationBus::MultiHandler::BusDisconnect(GetEntityId());
@@ -177,12 +214,24 @@ namespace LmbrCentral
                     m_forwardAxis
                     );
 
-                // update the rotation and translation for sourceTM based on lookAtTransform, but leave scale unchanged
-                sourceTM.SetRotation(lookAtTransform.GetRotation());
-                sourceTM.SetTranslation(lookAtTransform.GetTranslation());
+                if (!m_fixatePitch)
+                    lookAtTransform.SetFromEulerRadians(AZ::Vector3(sourceTM.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+                if (!m_fixateRoll)
+                    lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), sourceTM.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+                if (!m_fixateYaw)
+                    lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), sourceTM.GetRotation().GetEulerRadians().GetZ()));
 
-                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, lookAtTransform);
-                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, sourceTM);
+                lookAtTransform.SetTranslation(sourceTM.GetTranslation());
+
+                // update the rotation and translation for sourceTM based on lookAtTransform, but leave scale unchanged
+                if (m_strength == 1.f)
+                {
+                    sourceTM.SetRotation(lookAtTransform.GetRotation());
+                    sourceTM.SetTranslation(lookAtTransform.GetTranslation());
+
+                    AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, lookAtTransform);
+                    AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, sourceTM);
+                }
             }
             AZ::TransformNotificationBus::MultiHandler::BusConnect(GetEntityId());
         }

--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.h
@@ -92,6 +92,7 @@ namespace LmbrCentral
         bool m_fixateRoll = true;
         bool m_fixateYaw = true;
         bool m_enabled = true;
+        bool m_applyLookAtTransform = true;
 
         // Transient data
         AZ::EntityId m_oldTargetId;

--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.h
@@ -81,11 +81,17 @@ namespace LmbrCentral
 
     private:
         void OnTargetChanged();
+        void OnEnabledChanged();
         void RecalculateTransform();
 
         // Serialized data
         AZ::EntityId m_targetId;
         AZ::Transform::Axis m_forwardAxis;
+        float m_strength = 1.f;
+        bool m_fixatePitch = true;
+        bool m_fixateRoll = true;
+        bool m_fixateYaw = true;
+        bool m_enabled = true;
 
         // Transient data
         AZ::EntityId m_oldTargetId;

--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorLookAtComponent.h
@@ -85,8 +85,8 @@ namespace LmbrCentral
         void RecalculateTransform();
 
         // Serialized data
-        AZ::EntityId m_targetId;
-        AZ::Transform::Axis m_forwardAxis;
+        AZ::EntityId m_targetId = AZ::EntityId();
+        AZ::Transform::Axis m_forwardAxis = AZ::Constants::Axis::YPositive;
         float m_strength = 1.f;
         bool m_fixatePitch = true;
         bool m_fixateRoll = true;

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -49,6 +49,7 @@ namespace LmbrCentral
                 ->Field("FixateRoll", &LookAtComponent::m_fixateRoll)
                 ->Field("FixateYaw", &LookAtComponent::m_fixateYaw)
                 ->Field("Enabled", &LookAtComponent::m_enabled)
+                ->Field("ApplyLookAtTransform", &LookAtComponent::m_applyLookAtTransform)
                 ;
         }
 
@@ -90,6 +91,10 @@ namespace LmbrCentral
                     ->Attribute(AZ::Script::Attributes::ToolTip, "Get whether the Look At component is enabled or disabled")
                 ->Event("SetEnabled", &LookAtComponentRequestBus::Events::SetEnabled, "Set Enabled", { { { "Enabled", "Whether the Look At component is enabled or disabled" } } })
                     ->Attribute(AZ::Script::Attributes::ToolTip, "Set whether the Look At component is enabled or disabled")
+                ->Event("GetApplyLookAtTransform", &LookAtComponentRequestBus::Events::GetApplyLookAtTransform, "Get Apply Look At Transform")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get whether the Look At transform is applied")
+                ->Event("SetApplyLookAtTransform", &LookAtComponentRequestBus::Events::SetApplyLookAtTransform, "Set Apply Look At Transform", { { { "Enabled", "Whether the Look At transform is applied when calculated" } } })
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set whether the Look At transform is applied when the component is enabled")
                 ;
                 ;
 
@@ -247,6 +252,24 @@ namespace LmbrCentral
         }
         m_enabled = enabled;
         AZ::TransformBus::EventResult(m_lastDiscreteTM, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
+        if (m_enabled)
+        {
+            RecalculateTransform(0.f);
+        }
+    }
+
+    bool LookAtComponent::GetApplyLookAtTransform() const
+    {
+        return m_applyLookAtTransform;
+    }
+
+    void LookAtComponent::SetApplyLookAtTransform(const bool applyLookAtTransform)
+    {
+        m_applyLookAtTransform = applyLookAtTransform;
+        if (m_applyLookAtTransform)
+        {
+            RecalculateTransform(0.f);
+        }
     }
 
     //=========================================================================
@@ -266,6 +289,11 @@ namespace LmbrCentral
     //=========================================================================
     void LookAtComponent::RecalculateTransform(const float deltaTime)
     {
+        if (!m_enabled)
+        {
+            return;
+        }
+
         AZ::Vector3 targetPosition = m_targetPosition;
 
         if (m_targetId.IsValid())
@@ -330,8 +358,8 @@ namespace LmbrCentral
 
             m_lookAtTransform.SetTranslation(currentTM.GetTranslation());
 
-            // Only set the transform when enabled
-            if (m_enabled)
+            // Only set the transform when set to do so
+            if (m_applyLookAtTransform)
             {
                 AZ::TransformBus::Event(GetEntityId(), &AZ::TransformInterface::SetWorldTM, m_lookAtTransform);
             }

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -241,12 +241,12 @@ namespace LmbrCentral
 
     void LookAtComponent::SetEnabled(const bool enabled)
     {
-        m_enabled = enabled;
-        AZ::TransformBus::EventResult(m_lastDiscreteTM, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
-        if (m_enabled)
+        if (m_enabled != enabled)
         {
             LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnEnabledChanged, m_enabled);
         }
+        m_enabled = enabled;
+        AZ::TransformBus::EventResult(m_lastDiscreteTM, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
     }
 
     //=========================================================================

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -19,12 +19,18 @@ namespace LmbrCentral
     {
     public:
         AZ_EBUS_BEHAVIOR_BINDER(BehaviorLookAtComponentNotificationBusHandler, "{2C171B89-CE6A-4C53-A286-0E1236A61FA0}", AZ::SystemAllocator,
-            OnTargetChanged);
+            OnTargetChanged, OnEnabledChanged);
 
-        // Sent when the light is turned on.
+        // Sent when the target entityId changes
         void OnTargetChanged(AZ::EntityId entityId) override
         {
             Call(FN_OnTargetChanged, entityId);
+        }
+
+        // Sent when Look At is enabled or disabled
+        void OnEnabledChanged(bool enabled) override
+        {
+            Call(FN_OnEnabledChanged, enabled);
         }
     };
 
@@ -38,6 +44,11 @@ namespace LmbrCentral
                 ->Version(1)
                 ->Field("Target", &LookAtComponent::m_targetId)
                 ->Field("ForwardAxis", &LookAtComponent::m_forwardAxis)
+                ->Field("Strength", &LookAtComponent::m_strength)
+                ->Field("FixatePitch", &LookAtComponent::m_fixatePitch)
+                ->Field("FixateRoll", &LookAtComponent::m_fixateRoll)
+                ->Field("FixateYaw", &LookAtComponent::m_fixateYaw)
+                ->Field("Enabled", &LookAtComponent::m_enabled)
                 ;
         }
 
@@ -45,12 +56,39 @@ namespace LmbrCentral
         {
             behaviorContext->EBus<LookAtComponentRequestBus>("LookAt", "LookAtRequestBus")
                 ->Attribute(AZ::Script::Attributes::Category, "Gameplay")
+                ->Event("GetTarget", &LookAtComponentRequestBus::Events::GetTarget, "Get Target")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get the entity being looked at")
                 ->Event("SetTarget", &LookAtComponentRequestBus::Events::SetTarget, "Set Target", { { { "Target", "The entity to look at" } } })
                     ->Attribute(AZ::Script::Attributes::ToolTip, "Set the entity to look at")
+                ->Event("GetTargetPosition", &LookAtComponentRequestBus::Events::GetTargetPosition, "Get Target Position")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get the target position being looked at.")
                 ->Event("SetTargetPosition", &LookAtComponentRequestBus::Events::SetTargetPosition, "Set Target Position", { { { "Position", "The position to look at" } } })
-                    ->Attribute(AZ::Script::Attributes::ToolTip, "Sets the target position to look at.")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set the target position to look at.")
+                ->Event("GetAxis", &LookAtComponentRequestBus::Events::GetAxis, "Get Axis")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get the forward axis being used as reference for the look at")
                 ->Event("SetAxis", &LookAtComponentRequestBus::Events::SetAxis, "Set Axis", { { { "Axis", "The forward axis to use as reference" } } })
-                ->Attribute(AZ::Script::Attributes::ToolTip, "Specify the forward axis to use as reference for the look at")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set the forward axis to use as reference for the look at")
+                ->Event("GetStrength", &LookAtComponentRequestBus::Events::GetStrength, "Get Strength")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get the strength / quickness of the look at rotation")
+                ->Event("SetStrength", &LookAtComponentRequestBus::Events::SetStrength, "Set Strength", { { { "Strength", "Determines how quickly the rotation is performed and how much it resists changes in the rotation" } } })
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set the strength / quickness of the look at rotation")
+                ->Event("GetFixatePitch", &LookAtComponentRequestBus::Events::GetFixatePitch, "Get Fixate Pitch")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get whether the pitch is fixated")
+                ->Event("SetFixatePitch", &LookAtComponentRequestBus::Events::SetFixatePitch, "Set Fixate Pitch", { { { "Fixate Pitch", "Whether the pitch is fixated towards the Look At entity / point" } } })
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set whether the pitch is fixated")
+                ->Event("GetFixateRoll", &LookAtComponentRequestBus::Events::GetFixateRoll, "Get Fixate Roll")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get whether the roll is fixated")
+                ->Event("SetFixateRoll", &LookAtComponentRequestBus::Events::SetFixateRoll, "Set Fixate Roll", { { { "Fixate Roll", "Whether the roll is fixated towards the Look At entity / point" } } })
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set whether the roll is fixated")
+                ->Event("GetFixateYaw", &LookAtComponentRequestBus::Events::GetFixateYaw, "Get Fixate Yaw")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get whether the yaw is fixated")
+                ->Event("SetFixateYaw", &LookAtComponentRequestBus::Events::SetFixateYaw, "Set Fixate Yaw", { { { "Fixate Yaw", "Whether the yaw is fixated towards the Look At entity / point" } } })
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set whether the yaw is fixated")
+                ->Event("GetEnabled", &LookAtComponentRequestBus::Events::GetEnabled, "Get Enabled")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get whether the Look At component is enabled or disabled")
+                ->Event("SetEnabled", &LookAtComponentRequestBus::Events::SetEnabled, "Set Enabled", { { { "Enabled", "Whether the Look At component is enabled or disabled" } } })
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Set whether the Look At component is enabled or disabled")
+                ;
                 ;
 
             behaviorContext->EBus<LookAtComponentNotificationBus>("LookAtNotification", "LookAtComponentNotificationBus", "Notifications for the Look At Component")
@@ -94,7 +132,12 @@ namespace LmbrCentral
         AZ::TransformNotificationBus::MultiHandler::BusDisconnect(m_targetId);
     }
 
-    void LookAtComponent::SetTarget(AZ::EntityId targetEntity)
+    AZ::EntityId LookAtComponent::GetTarget() const
+    {
+        return m_targetId;
+    }
+
+    void LookAtComponent::SetTarget(const AZ::EntityId& targetEntity)
     {
         if (m_targetId.IsValid())
         {
@@ -109,6 +152,11 @@ namespace LmbrCentral
         RecalculateTransform();
 
         LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnTargetChanged, m_targetId);
+    }
+
+    AZ::Vector3 LookAtComponent::GetTargetPosition() const
+    {
+        return m_targetPosition;
     }
 
     void LookAtComponent::SetTargetPosition(const AZ::Vector3& targetPosition)
@@ -127,11 +175,68 @@ namespace LmbrCentral
         LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnTargetChanged, m_targetId);
     }
 
-    void LookAtComponent::SetAxis(AZ::Transform::Axis axis)
+    AZ::Transform::Axis LookAtComponent::GetAxis() const
+    {
+        return m_forwardAxis;
+    }
+
+    void LookAtComponent::SetAxis(const AZ::Transform::Axis axis)
     {
         m_forwardAxis = axis;
 
         RecalculateTransform();
+    }
+
+    float LookAtComponent::GetStrength() const
+    {
+        return m_strength;
+    }
+
+    void LookAtComponent::SetStrength(const float strength)
+    {
+        m_strength = AZ::GetClamp(strength, 0.f, 1.f);
+    }
+
+    bool LookAtComponent::GetFixatePitch() const
+    {
+        return m_fixatePitch;
+    }
+
+    void LookAtComponent::SetFixatePitch(const bool fixatePitch)
+    {
+        m_fixatePitch = fixatePitch;
+    }
+
+    bool LookAtComponent::GetFixateRoll() const
+    {
+        return m_fixateRoll;
+    }
+
+    void LookAtComponent::SetFixateRoll(const bool fixateRoll)
+    {
+        m_fixateRoll = fixateRoll;
+    }
+
+    bool LookAtComponent::GetFixateYaw() const
+    {
+        return m_fixateYaw;
+    }
+
+    void LookAtComponent::SetFixateYaw(const bool fixateYaw)
+    {
+        m_fixateYaw = fixateYaw;
+    }
+
+    bool LookAtComponent::GetEnabled() const
+    {
+        return m_enabled;
+    }
+
+    void LookAtComponent::SetEnabled(const bool enabled)
+    {
+        m_enabled = enabled;
+        if (m_enabled)
+            LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnEnabledChanged, m_enabled);
     }
 
     //=========================================================================
@@ -151,6 +256,9 @@ namespace LmbrCentral
     //=========================================================================
     void LookAtComponent::RecalculateTransform()
     {
+        if (!m_enabled)
+            return;
+
         AZ::Vector3 targetPosition = m_targetPosition;
 
         if (m_targetId.IsValid())
@@ -172,6 +280,17 @@ namespace LmbrCentral
                 m_forwardAxis
                 );
             lookAtTransform.SetUniformScale(currentTM.GetUniformScale());
+
+            lookAtTransform.SetRotation(currentTM.GetRotation().Slerp(lookAtTransform.GetRotation(), m_strength));
+
+            if (!m_fixatePitch)
+                lookAtTransform.SetFromEulerRadians(AZ::Vector3(currentTM.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+            if (!m_fixateRoll)
+                lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), currentTM.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+            if (!m_fixateYaw)
+                lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), currentTM.GetRotation().GetEulerRadians().GetZ()));
+
+            lookAtTransform.SetTranslation(currentTM.GetTranslation());
 
             AZ::TransformBus::Event(GetEntityId(), &AZ::TransformInterface::SetWorldTM, lookAtTransform);
         }

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -332,7 +332,9 @@ namespace LmbrCentral
 
             // Only set the transform when enabled
             if (m_enabled)
+            {
                 AZ::TransformBus::Event(GetEntityId(), &AZ::TransformInterface::SetWorldTM, m_lookAtTransform);
+            }
         }
         AZ::TransformNotificationBus::MultiHandler::BusConnect(GetEntityId());
     }

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -64,6 +64,8 @@ namespace LmbrCentral
                     ->Attribute(AZ::Script::Attributes::ToolTip, "Get the target position being looked at.")
                 ->Event("SetTargetPosition", &LookAtComponentRequestBus::Events::SetTargetPosition, "Set Target Position", { { { "Position", "The position to look at" } } })
                     ->Attribute(AZ::Script::Attributes::ToolTip, "Set the target position to look at.")
+                ->Event("GetLookAtTransform", &LookAtComponentRequestBus::Events::GetLookAtTransform, "Get Look At Transform")
+                    ->Attribute(AZ::Script::Attributes::ToolTip, "Get the target Look At transform.")
                 ->Event("GetAxis", &LookAtComponentRequestBus::Events::GetAxis, "Get Axis")
                     ->Attribute(AZ::Script::Attributes::ToolTip, "Get the forward axis being used as reference for the look at")
                 ->Event("SetAxis", &LookAtComponentRequestBus::Events::SetAxis, "Set Axis", { { { "Axis", "The forward axis to use as reference" } } })
@@ -149,10 +151,7 @@ namespace LmbrCentral
 
         AZ::TransformNotificationBus::MultiHandler::BusConnect(m_targetId);
 
-        if (m_strength == 1.f)
-        {
-            RecalculateTransform(0.f);
-        }
+        RecalculateTransform(0.f);
 
         LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnTargetChanged, m_targetId);
     }
@@ -173,12 +172,14 @@ namespace LmbrCentral
 
         m_targetPosition = targetPosition;
 
-        if (m_strength == 1.f)
-        {
-            RecalculateTransform(0.f);
-        }
+        RecalculateTransform(0.f);
 
         LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnTargetChanged, m_targetId);
+    }
+
+    AZ::Transform LookAtComponent::GetLookAtTransform() const
+    {
+        return m_lookAtTransform;
     }
 
     AZ::Transform::Axis LookAtComponent::GetAxis() const
@@ -190,10 +191,7 @@ namespace LmbrCentral
     {
         m_forwardAxis = axis;
 
-        if (m_strength == 1.f)
-        {
-            RecalculateTransform(0.f);
-        }
+        RecalculateTransform(0.f);
     }
 
     float LookAtComponent::GetStrength() const
@@ -268,9 +266,6 @@ namespace LmbrCentral
     //=========================================================================
     void LookAtComponent::RecalculateTransform(const float deltaTime)
     {
-        if (!m_enabled)
-            return;
-
         AZ::Vector3 targetPosition = m_targetPosition;
 
         if (m_targetId.IsValid())
@@ -286,12 +281,12 @@ namespace LmbrCentral
             AZ::Transform currentTM = AZ::Transform::CreateIdentity();
             AZ::TransformBus::EventResult(currentTM, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
 
-            AZ::Transform lookAtTransform = AZ::Transform::CreateLookAt(
+            m_lookAtTransform = AZ::Transform::CreateLookAt(
                 currentTM.GetTranslation(),
                 targetPosition,
                 m_forwardAxis
                 );
-            lookAtTransform.SetUniformScale(currentTM.GetUniformScale());
+            m_lookAtTransform.SetUniformScale(currentTM.GetUniformScale());
 
             // Only apply the strength / slerp when it's not at it's not maxed out to 1
             if (m_strength < 1.f)
@@ -315,27 +310,29 @@ namespace LmbrCentral
                     m_accumulatedDeltaTime = deltaTime;
                 }
 
-                const AZ::Quaternion targetRotation = m_lastDiscreteTM.GetRotation().Slerp(lookAtTransform.GetRotation(), m_accumulatedDeltaTime * normalizedFrameRate * m_strength);
+                const AZ::Quaternion targetRotation = m_lastDiscreteTM.GetRotation().Slerp(m_lookAtTransform.GetRotation(), m_accumulatedDeltaTime * normalizedFrameRate * m_strength);
 
-                lookAtTransform.SetRotation(targetRotation);
+                m_lookAtTransform.SetRotation(targetRotation);
             }
 
             if (!m_fixatePitch)
             {
-                lookAtTransform.SetFromEulerRadians(AZ::Vector3(currentTM.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+                m_lookAtTransform.SetFromEulerRadians(AZ::Vector3(currentTM.GetRotation().GetEulerRadians().GetX(), m_lookAtTransform.GetRotation().GetEulerRadians().GetY(), m_lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
             }
             if (!m_fixateRoll)
             {
-                lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), currentTM.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+                m_lookAtTransform.SetFromEulerRadians(AZ::Vector3(m_lookAtTransform.GetRotation().GetEulerRadians().GetX(), currentTM.GetRotation().GetEulerRadians().GetY(), m_lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
             }
             if (!m_fixateYaw)
             {
-                lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), currentTM.GetRotation().GetEulerRadians().GetZ()));
+                m_lookAtTransform.SetFromEulerRadians(AZ::Vector3(m_lookAtTransform.GetRotation().GetEulerRadians().GetX(), m_lookAtTransform.GetRotation().GetEulerRadians().GetY(), currentTM.GetRotation().GetEulerRadians().GetZ()));
             }
 
-            lookAtTransform.SetTranslation(currentTM.GetTranslation());
+            m_lookAtTransform.SetTranslation(currentTM.GetTranslation());
 
-            AZ::TransformBus::Event(GetEntityId(), &AZ::TransformInterface::SetWorldTM, lookAtTransform);
+            // Only set the transform when enabled
+            if (m_enabled)
+                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformInterface::SetWorldTM, m_lookAtTransform);
         }
         AZ::TransformNotificationBus::MultiHandler::BusConnect(GetEntityId());
     }

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -149,7 +149,10 @@ namespace LmbrCentral
 
         AZ::TransformNotificationBus::MultiHandler::BusConnect(m_targetId);
 
-        RecalculateTransform();
+        if (m_strength == 1.f)
+        {
+            RecalculateTransform(0.f);
+        }
 
         LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnTargetChanged, m_targetId);
     }
@@ -170,7 +173,10 @@ namespace LmbrCentral
 
         m_targetPosition = targetPosition;
 
-        RecalculateTransform();
+        if (m_strength == 1.f)
+        {
+            RecalculateTransform(0.f);
+        }
 
         LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnTargetChanged, m_targetId);
     }
@@ -184,7 +190,10 @@ namespace LmbrCentral
     {
         m_forwardAxis = axis;
 
-        RecalculateTransform();
+        if (m_strength == 1.f)
+        {
+            RecalculateTransform(0.f);
+        }
     }
 
     float LookAtComponent::GetStrength() const
@@ -235,8 +244,11 @@ namespace LmbrCentral
     void LookAtComponent::SetEnabled(const bool enabled)
     {
         m_enabled = enabled;
+        AZ::TransformBus::EventResult(m_lastDiscreteTM, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
         if (m_enabled)
+        {
             LookAtComponentNotificationBus::Broadcast(&LookAtComponentNotifications::OnEnabledChanged, m_enabled);
+        }
     }
 
     //=========================================================================
@@ -247,14 +259,14 @@ namespace LmbrCentral
     }
 
     //=========================================================================
-    void LookAtComponent::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
+    void LookAtComponent::OnTick(float deltaTime, AZ::ScriptTimePoint /*time*/)
     {
-        RecalculateTransform();
+        RecalculateTransform(deltaTime);
         AZ::TickBus::Handler::BusDisconnect();
     }
 
     //=========================================================================
-    void LookAtComponent::RecalculateTransform()
+    void LookAtComponent::RecalculateTransform(const float deltaTime)
     {
         if (!m_enabled)
             return;
@@ -281,14 +293,45 @@ namespace LmbrCentral
                 );
             lookAtTransform.SetUniformScale(currentTM.GetUniformScale());
 
-            lookAtTransform.SetRotation(currentTM.GetRotation().Slerp(lookAtTransform.GetRotation(), m_strength));
+            // Only apply the strength / slerp when it's not at it's not maxed out to 1
+            if (m_strength < 1.f)
+            {
+                // Normalize the strength / slerp calculation to 30FPS
+                const float normalizedFrameRate = 30.f;
+
+                if (deltaTime < 1.f / normalizedFrameRate)
+                {
+                    m_accumulatedDeltaTime += deltaTime;
+                    if (m_accumulatedDeltaTime >= 1.f / normalizedFrameRate)
+                    {
+                        m_lastDiscreteTM = currentTM;
+                        m_accumulatedDeltaTime -= 1.f / normalizedFrameRate;
+                    }
+                }
+                else
+                {
+                    // When the frame rate is below 30FPS, simply use deltaTime
+                    m_lastDiscreteTM = currentTM;
+                    m_accumulatedDeltaTime = deltaTime;
+                }
+
+                const AZ::Quaternion targetRotation = m_lastDiscreteTM.GetRotation().Slerp(lookAtTransform.GetRotation(), m_accumulatedDeltaTime * normalizedFrameRate * m_strength);
+
+                lookAtTransform.SetRotation(targetRotation);
+            }
 
             if (!m_fixatePitch)
+            {
                 lookAtTransform.SetFromEulerRadians(AZ::Vector3(currentTM.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+            }
             if (!m_fixateRoll)
+            {
                 lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), currentTM.GetRotation().GetEulerRadians().GetY(), lookAtTransform.GetRotation().GetEulerRadians().GetZ()));
+            }
             if (!m_fixateYaw)
+            {
                 lookAtTransform.SetFromEulerRadians(AZ::Vector3(lookAtTransform.GetRotation().GetEulerRadians().GetX(), lookAtTransform.GetRotation().GetEulerRadians().GetY(), currentTM.GetRotation().GetEulerRadians().GetZ()));
+            }
 
             lookAtTransform.SetTranslation(currentTM.GetTranslation());
 

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.cpp
@@ -320,7 +320,7 @@ namespace LmbrCentral
             if (m_strength < 1.f)
             {
                 // Normalize the strength / slerp calculation to 30FPS
-                const float normalizedFrameRate = 30.f;
+                constexpr float normalizedFrameRate = 30.f;
 
                 if (deltaTime < 1.f / normalizedFrameRate)
                 {

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
@@ -161,17 +161,21 @@ namespace LmbrCentral
         }
 
     private:
-        void RecalculateTransform();
+        void RecalculateTransform(const float deltaTime);
 
         // Serialized data
-        AZ::EntityId m_targetId;
-        AZ::Vector3  m_targetPosition;
-        AZ::Transform::Axis m_forwardAxis;
-        float m_strength;
-        bool m_fixatePitch;
-        bool m_fixateRoll;
-        bool m_fixateYaw;
-        bool m_enabled;
+        AZ::EntityId m_targetId = AZ::EntityId();
+        AZ::Vector3  m_targetPosition = AZ::Vector3::CreateZero();
+        AZ::Transform::Axis m_forwardAxis = AZ::Constants::Axis::YPositive;
+        float m_strength = 1.f;
+        bool m_fixatePitch = true;
+        bool m_fixateRoll = true;
+        bool m_fixateYaw = true;
+        bool m_enabled = true;
+
+        // Framerate independence for strength application
+        float m_accumulatedDeltaTime = 0.f;
+        AZ::Transform m_lastDiscreteTM = AZ::Transform::Identity();
     };
 
 }//namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
@@ -34,6 +34,9 @@ namespace LmbrCentral
         //! Set the target position to look at
         virtual void SetTargetPosition([[maybe_unused]] const AZ::Vector3& position) {}
 
+        //! Get the target Look At transform
+        virtual AZ::Transform GetLookAtTransform() const = 0;
+
         //! Get the reference forward axis
         virtual AZ::Transform::Axis GetAxis() const = 0;
 
@@ -128,6 +131,7 @@ namespace LmbrCentral
         void SetTarget(const AZ::EntityId& targetEntity) override;
         AZ::Vector3 GetTargetPosition() const override;
         void SetTargetPosition(const AZ::Vector3& targetPosition) override;
+        AZ::Transform GetLookAtTransform() const override;
         AZ::Transform::Axis GetAxis() const override;
         void SetAxis(AZ::Transform::Axis axis) override;
         float GetStrength() const override;
@@ -165,7 +169,8 @@ namespace LmbrCentral
 
         // Serialized data
         AZ::EntityId m_targetId = AZ::EntityId();
-        AZ::Vector3  m_targetPosition = AZ::Vector3::CreateZero();
+        AZ::Vector3 m_targetPosition = AZ::Vector3::CreateZero();
+        AZ::Transform m_lookAtTransform = AZ::Transform::Identity();
         AZ::Transform::Axis m_forwardAxis = AZ::Constants::Axis::YPositive;
         float m_strength = 1.f;
         bool m_fixatePitch = true;

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
@@ -21,15 +21,54 @@ namespace LmbrCentral
         : public AZ::ComponentBus
     {
     public:
-        
+
+        //! Get the target entity being looked at
+        virtual AZ::EntityId GetTarget() const = 0;
+
         //! Set the target entity to look at
-        virtual void SetTarget([[maybe_unused]] AZ::EntityId targetEntity) {}
+        virtual void SetTarget([[maybe_unused]] const AZ::EntityId& targetEntity) {}
+
+        //! Get the target position being looked at
+        virtual AZ::Vector3 GetTargetPosition() const = 0;
 
         //! Set the target position to look at
         virtual void SetTargetPosition([[maybe_unused]] const AZ::Vector3& position) {}
 
+        //! Get the reference forward axis
+        virtual AZ::Transform::Axis GetAxis() const = 0;
+
         //! Set the reference forward axis
         virtual void SetAxis([[maybe_unused]] AZ::Transform::Axis axis = AZ::Transform::Axis::ZPositive) {}
+
+        //! Get the strength / quickness of the look at rotation
+        virtual float GetStrength() const = 0;
+
+        //! Set the strength / quickness of the look at rotation
+        virtual void SetStrength([[maybe_unused]] const float strength) {};
+
+        //! Get whether the pitch is fixated
+        virtual bool GetFixatePitch() const = 0;
+
+        //! Set whether the pitch is fixated
+        virtual void SetFixatePitch([[maybe_unused]] const bool fixatePitch) {};
+
+        //! Get whether the roll is fixated
+        virtual bool GetFixateRoll() const = 0;
+
+        //! Set whether the roll is fixated
+        virtual void SetFixateRoll([[maybe_unused]] const bool fixateRoll) {};
+
+        //! Get whether the yaw is fixated
+        virtual bool GetFixateYaw() const = 0;
+
+        //! Set whether the yaw is fixated
+        virtual void SetFixateYaw([[maybe_unused]] const bool fixateYaw) {};
+
+        //! Get whether the Look At component is enabled
+        virtual bool GetEnabled() const = 0;
+
+        //! Set whether the Look At component is enabled
+        virtual void SetEnabled([[maybe_unused]] bool enabled = true) {}
     };
 
     using LookAtComponentRequestBus = AZ::EBus<LookAtComponentRequests>;
@@ -41,6 +80,7 @@ namespace LmbrCentral
 
         //! Notifies you that the target has changed
         virtual void OnTargetChanged(AZ::EntityId) { }
+        virtual void OnEnabledChanged(bool) { }
     };
 
     using LookAtComponentNotificationBus = AZ::EBus<LookAtComponentNotifications>;
@@ -84,9 +124,22 @@ namespace LmbrCentral
 
         //=====================================================================
         // LookAtComponentRequestBus
-        void SetTarget(AZ::EntityId targetEntity) override;
+        AZ::EntityId GetTarget() const;
+        void SetTarget(const AZ::EntityId& targetEntity) override;
+        AZ::Vector3 GetTargetPosition() const override;
         void SetTargetPosition(const AZ::Vector3& targetPosition) override;
+        AZ::Transform::Axis GetAxis() const override;
         void SetAxis(AZ::Transform::Axis axis) override;
+        float GetStrength() const override;
+        void SetStrength(const float strength) override;
+        bool GetFixatePitch() const override;
+        void SetFixatePitch(const bool fixatePitch) override;
+        bool GetFixateRoll() const override;
+        void SetFixateRoll(const bool fixateRoll) override;
+        bool GetFixateYaw() const override;
+        void SetFixateYaw(const bool fixateYaw) override;
+        bool GetEnabled() const override;
+        void SetEnabled(const bool enabled) override;
         //=====================================================================
 
     protected:
@@ -113,8 +166,12 @@ namespace LmbrCentral
         // Serialized data
         AZ::EntityId m_targetId;
         AZ::Vector3  m_targetPosition;
-
         AZ::Transform::Axis m_forwardAxis;
+        float m_strength;
+        bool m_fixatePitch;
+        bool m_fixateRoll;
+        bool m_fixateYaw;
+        bool m_enabled;
     };
 
 }//namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/LookAtComponent.h
@@ -71,7 +71,13 @@ namespace LmbrCentral
         virtual bool GetEnabled() const = 0;
 
         //! Set whether the Look At component is enabled
-        virtual void SetEnabled([[maybe_unused]] bool enabled = true) {}
+        virtual void SetEnabled([[maybe_unused]] bool enabled) {}
+
+        //! Get whether the Look At transform is applied
+        virtual bool GetApplyLookAtTransform() const = 0;
+
+        //! Set whether the Look At transform is applied
+        virtual void SetApplyLookAtTransform([[maybe_unused]] bool applyLookAtTransform) {}
     };
 
     using LookAtComponentRequestBus = AZ::EBus<LookAtComponentRequests>;
@@ -144,6 +150,8 @@ namespace LmbrCentral
         void SetFixateYaw(const bool fixateYaw) override;
         bool GetEnabled() const override;
         void SetEnabled(const bool enabled) override;
+        bool GetApplyLookAtTransform() const override;
+        void SetApplyLookAtTransform(const bool applyLookAtTransform) override;
         //=====================================================================
 
     protected:
@@ -177,6 +185,7 @@ namespace LmbrCentral
         bool m_fixateRoll = true;
         bool m_fixateYaw = true;
         bool m_enabled = true;
+        bool m_applyLookAtTransform = true;
 
         // Framerate independence for strength application
         float m_accumulatedDeltaTime = 0.f;

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/LookAt.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/LookAt.names
@@ -5,10 +5,201 @@
             "context": "EBusSender",
             "variant": "",
             "details": {
-                "name": "Look At",
-                "category": "Gameplay"
+                "name": "Look At"
             },
             "methods": [
+                {
+                    "base": "SetFixatePitch",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Fixate Pitch"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Fixate Pitch is invoked"
+                    },
+                    "details": {
+                        "name": "Set Fixate Pitch",
+                        "tooltip": "Set whether the pitch is fixated"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Fixate Pitch",
+                                "tooltip": "Whether the pitch is fixated towards the Look At entity / point"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetFixateRoll",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Fixate Roll"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Fixate Roll is invoked"
+                    },
+                    "details": {
+                        "name": "Set Fixate Roll",
+                        "tooltip": "Set whether the roll is fixated"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Fixate Roll",
+                                "tooltip": "Whether the roll is fixated towards the Look At entity / point"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetFixateYaw",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Fixate Yaw"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Fixate Yaw is invoked"
+                    },
+                    "details": {
+                        "name": "Get Fixate Yaw",
+                        "tooltip": "Get whether the yaw is fixated"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Fixated Yaw",
+                                "tooltip": "Whether the yaw is fixated towards the Look At entity / point"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetTargetPosition",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Target Position"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Target Position is invoked"
+                    },
+                    "details": {
+                        "name": "Set Target Position",
+                        "tooltip": "Set the target position to look at."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Position",
+                                "tooltip": "The position to look at"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetAxis",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Axis"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Axis is invoked"
+                    },
+                    "details": {
+                        "name": "Get Axis",
+                        "tooltip": "Get the forward axis being used as reference for the look at"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}",
+                            "details": {
+                                "name": "Axis",
+                                "tooltip": "The forward axis being used as reference"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetStrength",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Strength"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Strength is invoked"
+                    },
+                    "details": {
+                        "name": "Get Strength",
+                        "tooltip": "Get the strength / quickness of the look at rotation"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Strength",
+                                "tooltip": "How quickly the rotation is performed and how much it resists changes in the rotation"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetTargetPosition",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Target Position"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Target Position is invoked"
+                    },
+                    "details": {
+                        "name": "Get Target Position",
+                        "tooltip": "Get the target position being looked at."
+                    },
+                    "results": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Position",
+                                "tooltip": "The position being looked at"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetAxis",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Axis"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Axis is invoked"
+                    },
+                    "details": {
+                        "name": "Set Axis",
+                        "tooltip": "Set the forward axis to use as reference for the look at"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}",
+                            "details": {
+                                "name": "Axis",
+                                "tooltip": "The forward axis to use as reference"
+                            }
+                        }
+                    ]
+                },
                 {
                     "base": "SetTarget",
                     "entry": {
@@ -34,49 +225,169 @@
                     ]
                 },
                 {
-                    "base": "SetTargetPosition",
+                    "base": "SetStrength",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Target Position"
+                        "tooltip": "When signaled, this will invoke Set Strength"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Target Position is invoked"
+                        "tooltip": "Signaled after Set Strength is invoked"
                     },
                     "details": {
-                        "name": "Set Target Position",
-                        "tooltip": "Sets the target position to look at."
+                        "name": "Set Strength",
+                        "tooltip": "Set the strength / quickness of the look at rotation"
                     },
                     "params": [
                         {
-                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
                             "details": {
-                                "name": "Position",
-                                "tooltip": "The position to look at"
+                                "name": "Strength",
+                                "tooltip": "Determines how quickly the rotation is performed and how much it resists changes in the rotation"
                             }
                         }
                     ]
                 },
                 {
-                    "base": "SetAxis",
+                    "base": "GetFixateRoll",
                     "entry": {
                         "name": "In",
-                        "tooltip": "When signaled, this will invoke Set Axis"
+                        "tooltip": "When signaled, this will invoke Get Fixate Roll"
                     },
                     "exit": {
                         "name": "Out",
-                        "tooltip": "Signaled after Set Axis is invoked"
+                        "tooltip": "Signaled after Get Fixate Roll is invoked"
                     },
                     "details": {
-                        "name": "Set Axis",
-                        "tooltip": "Specify the forward axis to use as reference for the look at"
+                        "name": "Get Fixate Roll",
+                        "tooltip": "Get whether the roll is fixated"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Fixated Roll",
+                                "tooltip": "Whether the roll is fixated towards the Look At entity / point"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetFixateYaw",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Fixate Yaw"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Fixate Yaw is invoked"
+                    },
+                    "details": {
+                        "name": "Set Fixate Yaw",
+                        "tooltip": "Set whether the yaw is fixated"
                     },
                     "params": [
                         {
-                            "typeid": "{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}",
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
                             "details": {
-                                "name": "Axis",
-                                "tooltip": "The forward axis to use as reference"
+                                "name": "Fixate Yaw",
+                                "tooltip": "Whether the yaw is fixated towards the Look At entity / point"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetTarget",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Target"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Target is invoked"
+                    },
+                    "details": {
+                        "name": "Get Target",
+                        "tooltip": "Get the entity being looked at"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{6383F1D3-BB27-4E6B-A49A-6409B2059EAA}",
+                            "details": {
+                                "name": "Target",
+                                "tooltip": "The entity being looked at"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetFixatePitch",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Fixate Pitch"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Fixate Pitch is invoked"
+                    },
+                    "details": {
+                        "name": "Get Fixate Pitch",
+                        "tooltip": "Get whether the pitch is fixated"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Fixated Pitch",
+                                "tooltip": "Whether the pitch is fixated towards the Look At entity / point"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetEnabled",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Enabled"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Enabled is invoked"
+                    },
+                    "details": {
+                        "name": "Get Enabled",
+                        "tooltip": "Get whether the Look At component is enabled or disabled"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Enabled",
+                                "tooltip": "Whether the Look At component is enabled or disabled"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetEnabled",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Enabled"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Enabled is invoked"
+                    },
+                    "details": {
+                        "name": "Set Enabled",
+                        "tooltip": "Set whether the Look At component is enabled or disabled"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Enabled",
+                                "tooltip": "Whether the Look At component is enabled or disabled"
                             }
                         }
                     ]

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/LookAt.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/LookAt.names
@@ -225,6 +225,30 @@
                     ]
                 },
                 {
+                    "base": "GetLookAtTransform",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Look At Transform"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Look At Transform is invoked"
+                    },
+                    "details": {
+                        "name": "Get Look At Transform",
+                        "tooltip": "Get the target Look At transform."
+                    },
+                    "results": [
+                        {
+                            "typeid": "{5D9958E9-9F1E-4985-B532-FFFDE75FEDFD}",
+                            "details": {
+                                "name": "Look At Transform",
+                                "tooltip": "The transform when looking at the target"
+                            }
+                        }
+                    ]
+                },
+                {
                     "base": "SetStrength",
                     "entry": {
                         "name": "In",

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/LookAt.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/LookAt.names
@@ -5,7 +5,8 @@
             "context": "EBusSender",
             "variant": "",
             "details": {
-                "name": "Look At"
+                "name": "Look At",
+                "category": "Gameplay"
             },
             "methods": [
                 {
@@ -148,6 +149,30 @@
                             "details": {
                                 "name": "Strength",
                                 "tooltip": "How quickly the rotation is performed and how much it resists changes in the rotation"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "SetApplyLookAtTransform",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Apply Look At Transform"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Apply Look At Transform is invoked"
+                    },
+                    "details": {
+                        "name": "Set Apply Look At Transform",
+                        "tooltip": "Set whether the Look At transform is applied when the component is enabled"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Enabled",
+                                "tooltip": "Whether the Look At transform is applied when calculated"
                             }
                         }
                     ]
@@ -316,6 +341,30 @@
                             "details": {
                                 "name": "Fixate Yaw",
                                 "tooltip": "Whether the yaw is fixated towards the Look At entity / point"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "GetApplyLookAtTransform",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Apply Look At Transform"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Apply Look At Transform is invoked"
+                    },
+                    "details": {
+                        "name": "Get Apply Look At Transform",
+                        "tooltip": "Get whether the Look At transform is applied"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{A0CA880C-AFE4-43CB-926C-59AC48496112}",
+                            "details": {
+                                "name": "Enabled",
+                                "tooltip": "Whether the Look At transform is applied when calculated"
                             }
                         }
                     ]


### PR DESCRIPTION
- Add a strength parameter that determines how quickly the rotation approaches the target, and therefore also how much it resists the change in rotation.
- Add options to disable rotating about X, Y, and/or Z (pitch, roll, and yaw).
- Add a bool that enables or disables the component.
- Add a bool that sets whether the Look At transform is applied (still calculated and retrievable when not applied).
- Add getters for each of the previously existing attributes and add both getters and setters for the new ones.

This was tested with the First Person Controller gem.

<img width="447" height="237" alt="image" src="https://github.com/user-attachments/assets/ec8d05a9-5ecd-4137-a22b-223b108e6863" />
<br>
<img width="248" height="526" alt="image" src="https://github.com/user-attachments/assets/6b8fecec-ead9-4486-a0a0-5725cff84705" />