### PR TITLE
Fix Builds on macOS

### DIFF
--- a/Code/Framework/AzCore/Tests/AZStd/Atomics.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Atomics.cpp
@@ -570,12 +570,6 @@ namespace UnitTest
         EXPECT_TRUE(vt == TypeParam(2));
     }
 
-    TEST_F(Atomics, AtomicVarInit)
-    {
-        AZStd::atomic<int> v = AZ_ATOMIC_VAR_INIT(5);
-        EXPECT_TRUE(v == 5);
-    }
-
     template <class Tp>
     void test_ctor() {
         typedef AZStd::atomic<Tp> Atomic;
@@ -589,7 +583,7 @@ namespace UnitTest
             EXPECT_TRUE(a == t);
         }
         {
-            Atomic a = AZ_ATOMIC_VAR_INIT(t);
+            Atomic a = t;
             EXPECT_TRUE(a == t);
         }
     }

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_Mac.mm
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_Mac.mm
@@ -704,7 +704,7 @@ namespace AzFramework
         {
             // Mac swaps these two key codes for keyboards that use an ISO mechanical layout,
             // so we have to swap them back.
-            keyCode = (kVK_ISO_Section + kVK_ANSI_Grave) - keyCode;
+            keyCode = (static_cast<AZ::u32>(kVK_ISO_Section) + static_cast<AZ::u32>(kVK_ANSI_Grave)) - keyCode;
         }
 
         const InputChannelId* channelId = (keyCode < InputChannelIdByKeyCodeTable.size()) ?

--- a/Code/LauncherUnified/Platform/Mac/launcher_project_mac.cmake
+++ b/Code/LauncherUnified/Platform/Mac/launcher_project_mac.cmake
@@ -10,6 +10,10 @@ set(LY_TARGET_PROPERTIES
     BUILD_RPATH @executable_path/
 )
 
+if(launcher_generator_BUILD_GENERIC)
+    return()
+endif()
+
 # Add resources and app icons to launchers
 list(APPEND candidate_paths ${project_real_path}/Resources/Platform/Mac)
 list(APPEND candidate_paths ${project_real_path}/Gem/Resources/Platform/Mac) # Legacy projects

--- a/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
+++ b/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
@@ -11,6 +11,10 @@ set(LY_LINK_OPTIONS
         -ObjC
 )
 
+if(launcher_generator_BUILD_GENERIC)
+    return()
+endif()
+
 # Add resources and app icons to launchers
 list(APPEND candidate_paths ${project_real_path}/Resources/Platform/iOS)
 list(APPEND candidate_paths ${project_real_path}/Gem/Resources/Platform/iOS) # Legacy projects

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -55,8 +55,9 @@ if (NOT launcher_generator_LY_PROJECTS AND NOT LY_MONOLITHIC_GAME)
     # they can use this in their code and logic to avoid doing things like loading the burned-in
     # registry keys.
     set(GENERIC_LAUNCHER_COMPILE_DEFINITION "O3DE_IS_GENERIC_LAUNCHER")
+else ()
+    set(launcher_generator_BUILD_GENERIC FALSE)
 endif()
-
 
 foreach(project_name project_path IN ZIP_LISTS O3DE_PROJECTS_NAME launcher_generator_LY_PROJECTS)
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ObjectCollector.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ObjectCollector.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI/Object.h>
 
 #include <AzCore/Debug/Profiler.h>

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/AsyncUploadQueue.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/AsyncUploadQueue.cpp
@@ -109,7 +109,7 @@ namespace AZ
                 fenceToSignal = &fence;
             }
 
-            m_copyQueue->QueueCommand([=](void* queue)
+            m_copyQueue->QueueCommand([=, this](void* queue)
             {
                 AZ_PROFILE_SCOPE(RHI, "Upload Buffer");
                 size_t pendingByteOffset = 0;
@@ -170,7 +170,7 @@ namespace AZ
 
             uint64_t queueValue = m_uploadFence.Increment();
             
-            CommandQueue::Command command = [=](void* queue)
+            CommandQueue::Command command = [=, this](void* queue)
             {
                 CommandQueue* commandQueue = static_cast<CommandQueue*>(queue);
                 FramePacket* framePacket = BeginFramePacket(commandQueue);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.cpp
@@ -938,7 +938,9 @@ namespace AZ
         }
 
         void CommandList::BuildTopLevelAccelerationStructure(
-            const RHI::DeviceRayTracingTlas& rayTracingTlas, const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList)
+            const RHI::DeviceRayTracingTlas& rayTracingTlas,
+            const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList,
+            const AZStd::vector<const RHI::DeviceRayTracingClusterBlas*>& changedClusterBlasList)
         {
             // [GFX TODO][ATOM-5268] Implement Metal Ray Tracing
             AZ_Assert(false, "Not implemented");

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
@@ -79,8 +79,9 @@ namespace AZ
                 const RHI::DeviceRayTracingBlas &sourceBlas,
                 const RHI::DeviceRayTracingBlas &compactBlas) override;
             void BuildTopLevelAccelerationStructure(
-                const RHI::DeviceRayTracingTlas &rayTracingTlas,
-                const AZStd::vector<const RHI::DeviceRayTracingBlas *> &changedBlasList) override;
+                const RHI::DeviceRayTracingTlas& rayTracingTlas,
+                const AZStd::vector<const RHI::DeviceRayTracingBlas*>& changedBlasList,
+                const AZStd::vector<const RHI::DeviceRayTracingClusterBlas*>& changedClusterBlasList) override;
             void SetFragmentShadingRate(
                 [[maybe_unused]] RHI::ShadingRate rate,
                 [[maybe_unused]] const RHI::ShadingRateCombinators& combinators = DefaultShadingRateCombinators) override {}

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueue.cpp
@@ -115,7 +115,7 @@ namespace AZ
             }
             
             //Queue the fence signals, swapchain presents and commit call for this command buffer
-            QueueCommand([=](void* unused)
+            QueueCommand([=, this](void* unused)
             {
                  //Autoreleasepool is to ensure that the driver is not leaking memory related to the command buffer and encoder
                  @autoreleasepool

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroup.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroup.h
@@ -9,6 +9,7 @@
 
 #include <Atom/RHI/FrameGraphExecuteGroup.h>
 #include <RHI/CommandQueue.h>
+#include <RHI/Scope.h>
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupHandler.cpp
@@ -55,7 +55,7 @@ namespace AZ
             if constexpr (RHI::ForceCpuGpuInSync)
             {
                 //Cache the name of the scope we just queued and wait for it to finish on the cpu
-                m_device->SetLastExecutingScope(m_workRequest.m_commandList->GetName().GetStringView());
+                m_device->SetLastExecutingScope(m_workRequest.m_commandLists.front()->GetName().GetStringView());
                 cmdQueue->FlushCommands();
                 cmdQueue->WaitForIdle();
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupHandler.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupHandler.h
@@ -24,6 +24,7 @@ namespace AZ
     {
         class Device;
         class FrameGraphExecuteGroup;
+        struct RenderPassContext;
     
         //! Base class for handler classes that manage frame graph execute groups.
         //! Contains common functionality for all types of handlers including

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -82,9 +82,10 @@ namespace AZ
                     }
                     else
                     {
-                        mergedScopes.push_back(static_cast<const Scope*>(scopeBase));
-                        FrameGraphExecuteGroupMerged* scopeContextGroup = AddGroup<FrameGraphExecuteGroupMerged>();
-                        scopeContextGroup->Init(static_cast<Device&>(scopeBase->GetDevice()), AZStd::move(mergedScopes), GetGroupCount());
+                        mergedScopes.clear();
+                        mergedScopes.push_back(&scope);
+                        FrameGraphExecuteGroupPrimary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupPrimary>();
+                        scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), AZStd::move(mergedScopes));
                     }
                 }
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/RenderPassBuilder.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/RenderPassBuilder.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
+#include <RHI/ImageView.h>
 #include <RHI/RenderPassBuilder.h>
 #include <RHI/Scope.h>
 

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Platform/Mac/platform_mac_files.cmake
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Platform/Mac/platform_mac_files.cmake
@@ -1,0 +1,7 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/LevelOfDetailInspector.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/LevelOfDetailInspector.cpp
@@ -161,7 +161,7 @@ namespace OpenParticleSystemEditor
         auto it = AZStd::find(m_levels.begin(), m_levels.end(), levelWidget);
         if (it != m_levels.end())
         {
-            index = it - m_levels.begin();
+            index = static_cast<AZ::u32>(it - m_levels.begin());
             m_levels.erase(it);
         }
         m_layout->removeWidget(levelWidget);
@@ -373,8 +373,8 @@ namespace OpenParticleSystemEditor
                 {
                     return;
                 }
-                AZ::u32 index = it - m_checkboxes.begin();
-                bool checked = state == Qt::Checked ? true : false;
+                AZ::u32 index = static_cast<AZ::u32>(it - m_checkboxes.begin());
+                bool checked = state == Qt::Checked;
                 emit OnEmitterChecked(index, checked);
             });
         m_layout->addWidget(checkbox);


### PR DESCRIPTION
## What does this PR do?

Addresses multiple macOS build issues, with a primary focus on restoring support for generic engine builds. (i.e., when the engine is built standalone, without an accompanying project.)

Previously, the macOS project launcher CMake assumed that project-specific image resources were always present. This assumption holds for non-generic builds, but causes configuration failures for generic builds where those resources do not exist. These changes fix this by early returning from the platform launcher PAL when `launcher_generator_BUILD_GENERIC` is enabled.

In addition to the build system fix, this PR fixes other areas of drift and compilation failures on macOS:

* Updates to Atom RHI Metal code to match recent interface changes, mirroring the Vulkan RHI where appropriate
* Signature updates for unimplemented Metal ray tracing entry points to match the current RHI interfaces
* Fixes for Clang compilation errors where implicit `this` capture is no longer allowed with `=` lambda captures
* Minor type safety fixes and missing includes uncovered during macOS builds
* Cleanup of deprecated atomic initialization usage in tests

The intent is to bring macOS builds back to a functional state without changing behavior on other platforms.

## How was this PR tested?

This PR was tested on macOS 26.2 using Apple Clang 17 and CMake 4.2.

The following configurations were verified:

* Generic engine build without a game project
* Non-generic build alongside a game project

Due to the lack of a previously working macOS build, RHI Metal changes were validated primarily through successful compilation and interface consistency with Vulkan. No exhaustive runtime validation of Metal RHI behavior was performed.
