### PR TITLE
Fixes VS Version detection in project manager

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -73,7 +73,7 @@ namespace O3DE::ProjectManager
                     ProjectUtils::ExecuteCommandResult("which", QStringList{ QString("clang++%1").arg(supportClangVersion) });
                 if (whichClangResult.IsSuccess() && whichClangPPResult.IsSuccess())
                 {
-                    return AZ::Success(QString("clang%1").arg(supportClangVersion));
+                    return AZ::Success(QString());
                 }
             }
 
@@ -82,7 +82,7 @@ namespace O3DE::ProjectManager
             auto whichGPlusPlusNoVersionResult = ProjectUtils::ExecuteCommandResult("which", QStringList{ QString("g++") });
             if (whichGccNoVersionResult.IsSuccess() && whichGPlusPlusNoVersionResult.IsSuccess())
             {
-                return AZ::Success(QString("gcc"));
+                return AZ::Success(QString());
             }
 
             return AZ::Failure(QObject::tr("Neither clang nor gcc not found. <br><br>"

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -89,7 +89,7 @@ namespace O3DE::ProjectManager
             QString xcodeBuilderVersionNumber = queryXcodeBuildVersion.GetValue().split("\n")[0];
             AZ_TracePrintf("Project Manager", "XcodeBuilder version %s detected.", xcodeBuilderVersionNumber.toUtf8().constData());
 
-            return AZ::Success(xcodeBuilderVersionNumber);
+            return AZ::Success(QString());
         }
 
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -139,9 +139,11 @@ namespace O3DE::ProjectManager
             QFileInfo vsWhereFile(vsWherePath);
             if (vsWhereFile.exists() && vsWhereFile.isFile())
             {
-                QStringList vsWhereBaseArguments =
-                    QStringList{ "-version", "[16.11,18)", "-latest", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" };
+                // note that the following version ranges are INCLUSIVE of 17.14 (Vs2022), but EXCLUSIVE of 19.0
+                // This covers the range ov VS2022 (v17.x) and VS2026 (v18.x), but not next VS202x (v19.x)
 
+                QStringList vsWhereBaseArguments =
+                   QStringList{ "-version", "[17.14, 19)", "-latest", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" };
                 QProcess vsWhereIsCompleteProcess;
                 vsWhereIsCompleteProcess.setProcessChannelMode(QProcess::MergedChannels);
 
@@ -152,22 +154,44 @@ namespace O3DE::ProjectManager
                     QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());
                     if (vsWhereIsCompleteOutput.startsWith("1"))
                     {
+                        return AZ::Success(QString()); // No notes!
+                    }
+                }
+
+                // if we fail to find a supported compiler here, we allow it to use some future unknown verson of vs, as long as its
+                // above 17.14 (Visual Studio 2022), instead of blocking compilation.
+                // note the open ended range here, indicating at least 17.14 but possibly a future version way ahead.
+                vsWhereBaseArguments =
+                    QStringList{ "-version", "[17.14, )", "-latest", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" };
+                
+                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "isComplete" });
+
+                if (vsWhereIsCompleteProcess.waitForStarted() && vsWhereIsCompleteProcess.waitForFinished())
+                {
+                    QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());
+                    if (vsWhereIsCompleteOutput.startsWith("1"))
+                    {
                         QProcess vsWhereCompilerVersionProcess;
                         vsWhereCompilerVersionProcess.setProcessChannelMode(QProcess::MergedChannels);
                         vsWhereCompilerVersionProcess.start(
-                            vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "catalog_productDisplayVersion" });
+                            vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "displayName" });
 
                         if (vsWhereCompilerVersionProcess.waitForStarted() && vsWhereCompilerVersionProcess.waitForFinished())
                         {
                             QString vsWhereCompilerVersionOutput(vsWhereCompilerVersionProcess.readAllStandardOutput());
-                            return AZ::Success(vsWhereCompilerVersionOutput);
+                            return AZ::Success(
+                                QObject::tr("A version of Visual Studio was found that isn't supported: %1<br><br>"
+                                        "O3DE will attempt to build the project with it, but there may be issues."
+                                        "  O3DE officially supports Visual Studio 2022 v17.14 or higher, and 2026 v18.0 or higher."
+                                        "<br><br>Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual "
+                                        "Studio requirements</a> for more information.")).arg(vsWhereCompilerVersionOutput.trimmed());
                         }
                     }
                 }
             }
 
             return AZ::Failure(
-                QObject::tr("Visual Studio 2019 version 16.11 or higher or Visual Studio 2022 version 17.0 or higher not found.<br><br>"
+                QObject::tr("Visual Studio 2022 v17.14 or higher, or Visual Studio 2026 v18.0 or higher not found.<br><br>"
                             "A compatible version of Visual Studio is required to build this project.<br>"
                             "Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual "
                             "Studio requirements</a> for more information."));

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -142,6 +142,17 @@ namespace O3DE::ProjectManager
             QString programFilesPath = environment.value("ProgramFiles(x86)");
             QString vsWherePath = QDir(programFilesPath).filePath("Microsoft Visual Studio/Installer/vswhere.exe");
 
+            // Range which represents an ideal supported version of Visual Studio
+            QStringList versionArgumentsIdeal{ "-version", "[17.14, 19)" }; // 17.14 is VS2022, 18.xxxx is VS2026
+
+            // Range which represents a deprecated, but still functional version of Visual Studio
+            QStringList versionArgumentsDeprecated{ "-version", "[16.11, 19)" }; // 16.11 is last of VS2019.
+
+            // Range which represents a future version of Visual Studio which we don't know about and was released
+            // as a surprise.
+            QStringList versionArgumentsFutureVS{ "-version", "[16.11, )" };
+
+
             QFileInfo vsWhereFile(vsWherePath);
             if (vsWhereFile.exists() && vsWhereFile.isFile())
             {
@@ -149,11 +160,10 @@ namespace O3DE::ProjectManager
                 QStringList isCompleteArguments{ "-property", "isComplete" }; // returns a 1 if all components are available.
 
                 // Check 1: are we in a perfect situation, where we are exactly on the supported versions?
-                QStringList versionArguments{ "-version", "[17.14, 19)" }; // 17.14 is VS2022, 18.xxxx is VS2026
-
+                
                 QProcess vsWhereIsCompleteProcess;
                 vsWhereIsCompleteProcess.setProcessChannelMode(QProcess::MergedChannels);
-                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArguments + isCompleteArguments);
+                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArgumentsIdeal + isCompleteArguments);
                 if (vsWhereIsCompleteProcess.waitForStarted() && vsWhereIsCompleteProcess.waitForFinished())
                 {
                     QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());
@@ -164,9 +174,7 @@ namespace O3DE::ProjectManager
                 }
 
                 // If we get here, we are not in the perfect supported version range, but might still be in the deprecated range.
-                versionArguments = QStringList{ "-version", "[16.11, 19)" }; // 16.11 is last of VS2019.
-
-                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArguments + isCompleteArguments);
+                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArgumentsDeprecated + isCompleteArguments);
                 if (vsWhereIsCompleteProcess.waitForStarted() && vsWhereIsCompleteProcess.waitForFinished())
                 {
                     QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());
@@ -175,13 +183,13 @@ namespace O3DE::ProjectManager
                         QProcess vsWhereCompilerVersionProcess;
                         vsWhereCompilerVersionProcess.setProcessChannelMode(QProcess::MergedChannels);
                         vsWhereCompilerVersionProcess.start(vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "displayName" });
-
+                        // note that displayname includes product so will be something like "Visual Studio 2019"
                         if (vsWhereCompilerVersionProcess.waitForStarted() && vsWhereCompilerVersionProcess.waitForFinished())
                         {
                             QString vsWhereCompilerVersionOutput(vsWhereCompilerVersionProcess.readAllStandardOutput());
                             return AZ::Success(
                                        QObject::tr(
-                                           "Visual studio 2019 (version %1) used, this will be deprecated in future releases.<br><br>"
+                                           "%1 is being used - this will be deprecated in future releases.<br><br>"
                                            "Please consider upgrading soon.<br><br>"
                                            "<br><br>Refer to the <a "
                                            "href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual "
@@ -193,8 +201,7 @@ namespace O3DE::ProjectManager
 
                 // if we get here, we might be on an unknown, perhaps supported future version, denoted with
                 // the open range with no parameter `, )` at the end:
-                versionArguments = QStringList{ "-version", "[16.11, )" };
-                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArguments + isCompleteArguments);
+                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArgumentsFutureVS + isCompleteArguments);
                 if (vsWhereIsCompleteProcess.waitForStarted() && vsWhereIsCompleteProcess.waitForFinished())
                 {
                     QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -131,6 +131,12 @@ namespace O3DE::ProjectManager
                 }
             }
 
+            // we want to help the user here, by showing a helpful error message depending on their situation
+            // 1. Known, supported version of the compiler installed:  No message
+            // 2. Known, deprecated version of the compiler installed:  Warning message
+            // 3. Future unsupported version of the compiler installed:  Warning message
+            // 4. No supported version of the compiler installed:  Error message
+
             // Validate that the minimal version of visual studio is installed
             QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
             QString programFilesPath = environment.value("ProgramFiles(x86)");
@@ -139,33 +145,28 @@ namespace O3DE::ProjectManager
             QFileInfo vsWhereFile(vsWherePath);
             if (vsWhereFile.exists() && vsWhereFile.isFile())
             {
-                // note that the following version ranges are INCLUSIVE of 17.14 (Vs2022), but EXCLUSIVE of 19.0
-                // This covers the range ov VS2022 (v17.x) and VS2026 (v18.x), but not next VS202x (v19.x)
+                QStringList vsWhereBaseArguments { "-latest", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" };
+                QStringList isCompleteArguments{ "-property", "isComplete" }; // returns a 1 if all components are available.
 
-                QStringList vsWhereBaseArguments =
-                   QStringList{ "-version", "[17.14, 19)", "-latest", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" };
+                // Check 1: are we in a perfect situation, where we are exactly on the supported versions?
+                QStringList versionArguments{ "-version", "[17.14, 19)" }; // 17.14 is VS2022, 18.xxxx is VS2026
+
                 QProcess vsWhereIsCompleteProcess;
                 vsWhereIsCompleteProcess.setProcessChannelMode(QProcess::MergedChannels);
-
-                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "isComplete" });
-
+                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArguments + isCompleteArguments);
                 if (vsWhereIsCompleteProcess.waitForStarted() && vsWhereIsCompleteProcess.waitForFinished())
                 {
                     QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());
                     if (vsWhereIsCompleteOutput.startsWith("1"))
                     {
-                        return AZ::Success(QString()); // No notes!
+                        return AZ::Success(QString()); // No issues, we are in the golden range.
                     }
                 }
 
-                // if we fail to find a supported compiler here, we allow it to use some future unknown verson of vs, as long as its
-                // above 17.14 (Visual Studio 2022), instead of blocking compilation.
-                // note the open ended range here, indicating at least 17.14 but possibly a future version way ahead.
-                vsWhereBaseArguments =
-                    QStringList{ "-version", "[17.14, )", "-latest", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" };
-                
-                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "isComplete" });
+                // If we get here, we are not in the perfect supported version range, but might still be in the deprecated range.
+                versionArguments = QStringList{ "-version", "[16.11, 19)" }; // 16.11 is last of VS2019.
 
+                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArguments + isCompleteArguments);
                 if (vsWhereIsCompleteProcess.waitForStarted() && vsWhereIsCompleteProcess.waitForFinished())
                 {
                     QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());
@@ -173,26 +174,58 @@ namespace O3DE::ProjectManager
                     {
                         QProcess vsWhereCompilerVersionProcess;
                         vsWhereCompilerVersionProcess.setProcessChannelMode(QProcess::MergedChannels);
-                        vsWhereCompilerVersionProcess.start(
-                            vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "displayName" });
+                        vsWhereCompilerVersionProcess.start(vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "displayName" });
 
                         if (vsWhereCompilerVersionProcess.waitForStarted() && vsWhereCompilerVersionProcess.waitForFinished())
                         {
                             QString vsWhereCompilerVersionOutput(vsWhereCompilerVersionProcess.readAllStandardOutput());
                             return AZ::Success(
-                                QObject::tr("A version of Visual Studio was found that isn't supported: %1<br><br>"
-                                        "O3DE will attempt to build the project with it, but there may be issues."
-                                        "  O3DE officially supports Visual Studio 2022 v17.14 or higher, and 2026 v18.0 or higher."
-                                        "<br><br>Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual "
-                                        "Studio requirements</a> for more information.")).arg(vsWhereCompilerVersionOutput.trimmed());
+                                       QObject::tr(
+                                           "Visual studio 2019 (version %1) used, this will be deprecated in future releases.<br><br>"
+                                           "Please consider upgrading soon.<br><br>"
+                                           "<br><br>Refer to the <a "
+                                           "href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual "
+                                           "Studio requirements</a> for more information."))
+                                .arg(vsWhereCompilerVersionOutput.trimmed());
+                        }
+                    }
+                }
+
+                // if we get here, we might be on an unknown, perhaps supported future version, denoted with
+                // the open range with no parameter `, )` at the end:
+                versionArguments = QStringList{ "-version", "[16.11, )" };
+                vsWhereIsCompleteProcess.start(vsWherePath, vsWhereBaseArguments + versionArguments + isCompleteArguments);
+                if (vsWhereIsCompleteProcess.waitForStarted() && vsWhereIsCompleteProcess.waitForFinished())
+                {
+                    QString vsWhereIsCompleteOutput(vsWhereIsCompleteProcess.readAllStandardOutput());
+                    if (vsWhereIsCompleteOutput.startsWith("1"))
+                    {
+                        QProcess vsWhereCompilerVersionProcess;
+                        vsWhereCompilerVersionProcess.setProcessChannelMode(QProcess::MergedChannels);
+                        vsWhereCompilerVersionProcess.start(vsWherePath, vsWhereBaseArguments + QStringList{ "-property", "displayName" });
+
+                        if (vsWhereCompilerVersionProcess.waitForStarted() && vsWhereCompilerVersionProcess.waitForFinished())
+                        {
+                            QString vsWhereCompilerVersionOutput(vsWhereCompilerVersionProcess.readAllStandardOutput());
+                            return AZ::Success(
+                                       QObject::tr(
+                                           "A version of Visual Studio was found that isn't supported: %1<br><br>"
+                                           "O3DE will attempt to build the project with it, but there may be issues."
+                                           "  O3DE officially supports Visual Studio 2022 v17.14 or higher, and 2026 v18.1 or higher."
+                                           "<br><br>Refer to the <a "
+                                           "href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual "
+                                           "Studio requirements</a> for more information."))
+                                .arg(vsWhereCompilerVersionOutput.trimmed());
                         }
                     }
                 }
             }
 
             return AZ::Failure(
-                QObject::tr("Visual Studio 2022 v17.14 or higher, or Visual Studio 2026 v18.0 or higher not found.<br><br>"
-                            "A compatible version of Visual Studio is required to build this project.<br>"
+                QObject::tr("No compatible C++ Compiler found.<br><br>"
+                            "O3DE officially supports Visual Studio 2022 v17.14 or higher, and 2026 v18.1 or higher.<br>"
+                            "Visual Studio does not automatically include the C++ compiler by default, so please ensure that "
+                            "the 'Desktop development with C++' workload is installed in the Visual Studio Installer.<br><br>"
                             "Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual "
                             "Studio requirements</a> for more information."));
         }

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -575,14 +575,15 @@ namespace O3DE::ProjectManager
         {
             auto findCompilerResult = FindSupportedCompilerForPlatform(projectInfo);
 
-            if (!findCompilerResult.IsSuccess())
+            QString messageNotes = findCompilerResult.IsSuccess() ? findCompilerResult.GetValue() : findCompilerResult.GetError();
+            if (!messageNotes.isEmpty())
             {
                 QMessageBox vsWarningMessage(parent);
                 vsWarningMessage.setIcon(QMessageBox::Warning);
                 vsWarningMessage.setWindowTitle(QObject::tr("Create Project"));
                 // Makes link clickable
                 vsWarningMessage.setTextFormat(Qt::RichText);
-                vsWarningMessage.setText(findCompilerResult.GetError());
+                vsWarningMessage.setText(messageNotes);
                 vsWarningMessage.setStandardButtons(QMessageBox::Close);
 
                 QSpacerItem* horizontalSpacer = new QSpacerItem(600, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -39,6 +39,10 @@ namespace O3DE::ProjectManager
         bool ReplaceProjectFile(const QString& origFile, const QString& newFile, QWidget* parent = nullptr, bool interactive = true);
 
         bool FindSupportedCompiler(const ProjectInfo& projectInfo, QWidget* parent = nullptr);
+
+        // Returns a failure string, or a success with message notes.
+        // If there are no notes, return an empty string on success.
+        // Any notes returned will be showend as a message box or output log, regardless of success or failure.
         AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform(const ProjectInfo& projectInfo);
 
         //! Detect if cmake is installed


### PR DESCRIPTION
## What does this PR do?
Visual studio was previously being disallowed in the project manager if the version was greater than the known
working version.   

This changes it so that it only blocks building if the version is less than the original known working version (vs17, aka vs2022+) and issues a warning, but does not block, if the version is greater than the last known version (VS2026).

## How was this PR tested?

Tested by running the project manager with modified code to block various versions and made sure the warning does NOT appear on vs2022 or vs2026, but if I change the required version to 2019-2022 the warning appears for 2026 but still does not block proceeding.

