### PR TITLE
Add Physics::CollisionMeshAsset class as parent of PhysX::MeshAsset.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
@@ -18,6 +18,14 @@
 
 namespace Physics
 {
+    void CollisionMeshAsset::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<CollisionMeshAsset>();
+        }
+    }
+
     void ShapeConfiguration::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
@@ -55,6 +55,16 @@ namespace Physics
         static constexpr AZ::u8 DefaultCylinderSubdivisionCount = 16;
     } // namespace ShapeConstants
 
+    class AZF_API CollisionMeshAsset
+        : public AZ::Data::AssetData
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(CollisionMeshAsset, AZ::SystemAllocator);
+        AZ_RTTI(CollisionMeshAsset, "{B3308B0E-B925-43C5-8345-85B72385C36D}", AZ::Data::AssetData);
+
+        static void Reflect(AZ::ReflectContext* context);
+    };
+
     class AZF_API ShapeConfiguration
     {
     public:
@@ -196,7 +206,7 @@ namespace Physics
             return AZStd::make_shared<PhysicsAssetShapeConfiguration>(*this);
         }
 
-        AZ::Data::Asset<AZ::Data::AssetData> m_asset{ AZ::Data::AssetLoadBehavior::PreLoad };
+        AZ::Data::Asset<CollisionMeshAsset> m_asset{ AZ::Data::AssetLoadBehavior::PreLoad };
         AZ::Vector3 m_assetScale = AZ::Vector3::CreateOne();
         bool m_useMaterialsFromAsset = true;
         AZ::u8 m_subdivisionLevel = 4; ///< The level of subdivision if a primitive shape is replaced with a convex mesh due to scaling.

--- a/Code/Framework/AzFramework/AzFramework/Physics/Utils.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Utils.cpp
@@ -135,6 +135,7 @@ namespace Physics
             AzPhysics::SceneQuery::ReflectSceneQueryObjects(context);
             ReflectWindBus(context);
             ReflectCharacterBus(context);
+            CollisionMeshAsset::Reflect(context);
         }
     }
 

--- a/Gems/PhysX/Core/Code/Include/PhysX/MeshAsset.h
+++ b/Gems/PhysX/Core/Code/Include/PhysX/MeshAsset.h
@@ -70,11 +70,11 @@ namespace PhysX
 
         //! Represents a PhysX mesh asset. This is an AZ::Data::AssetData wrapper around MeshAssetData
         class MeshAsset
-            : public AZ::Data::AssetData
+            : public Physics::CollisionMeshAsset
         {
         public:
             AZ_CLASS_ALLOCATOR(MeshAsset, AZ::SystemAllocator);
-            AZ_RTTI(MeshAsset, "{7A2871B9-5EAB-4DE0-A901-B0D2C6920DDB}", AZ::Data::AssetData);
+            AZ_RTTI(MeshAsset, "{7A2871B9-5EAB-4DE0-A901-B0D2C6920DDB}", Physics::CollisionMeshAsset);
 
             static void Reflect(AZ::ReflectContext* context);
 


### PR DESCRIPTION
## What does this PR do?

Currently, collision mesh asset is specific to PhysX gem (PhysX::MeshAsset). This PR adds a generic Physics::CollisionMeshAsset that serves as a parent class of all physics gem-specific collision mesh asset. This enables third party gems to reference a collision mesh asset (or asset browser to filter out collision mesh) without linking with any specific physics gem.

## How was this PR tested?

N/A