### PR TITLE
Cry_Matrix44 Deprecation

### DIFF
--- a/Code/Editor/Lib/Tests/test_CryLegacyDeprecation.cpp
+++ b/Code/Editor/Lib/Tests/test_CryLegacyDeprecation.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "EditorDefs.h"
+#include <AzTest/AzTest.h>
+#include <AzCore/Math/Matrix4x4.h>
+#include <CryCommon/Cry_Matrix44.h>
+#include <CryCommon/MathConversion.h>
+
+namespace EditorUtilsTest
+{
+    class LegacryDeprecationHelper : public ::testing::Test
+    {
+    public:
+        LegacryDeprecationHelper()
+        {
+        }
+    };
+
+    typedef float HMatrix[4][4]; /* Right-handed, for column vectors */
+
+   TEST_F(LegacryDeprecationHelper, TestLegacyMaxtrix44_HMatrixConversion)
+    {
+       AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations");
+
+        // Validation for AffineParts::Decompose and AffineParts::SpectralDecompose
+        Matrix34 tm(0.0f, 1.0f, 2.0f, 3.0f, 10.0f, 11.0f, 12.0f, 13.0f, 20.0f, 21.0f, 22.0f, 23.0f);
+
+        // Legacy Base
+        Matrix44 cryTm44(tm);
+        HMatrix& legacyH = *((HMatrix*)&cryTm44); // Treat HMatrix as a Matrix44.
+
+        // Updated AZ::Matrix4x4
+        AZ::Matrix3x4 tm34 = LYTransformToAZMatrix3x4(tm);
+        AZ::Matrix4x4 azTm44 = AZ::Matrix4x4::CreateFromMatrix3x4(tm34);
+        HMatrix newH;
+        azTm44.StoreToRowMajorFloat16((float*)&newH);
+
+        // Validation
+        for (int r = 0; r < 4; ++r)
+        {
+            for (int c = 0; c < 4; ++c)
+            {
+                ASSERT_FLOAT_EQ(legacyH[r][c], newH[r][c]);
+            }
+        }
+        AZ_POP_DISABLE_WARNING;
+    }
+
+} // namespace EditorUtilsTest

--- a/Code/Editor/Util/AffineParts.cpp
+++ b/Code/Editor/Util/AffineParts.cpp
@@ -9,6 +9,8 @@
 
 #include "EditorDefs.h"
 
+#include <CryCommon/MathConversion.h>
+
 /**** Decompose.h - Basic declarations ****/
 typedef struct
 {
@@ -825,8 +827,10 @@ void AffineParts::Decompose(const Matrix34& tm)
 {
     SAffineParts parts;
 
-    Matrix44 tm44(tm);
-    HMatrix& H = *((HMatrix*)&tm44); // Treat HMatrix as a Matrix44.
+    AZ::Matrix3x4 tm34 = LYTransformToAZMatrix3x4(tm);
+    AZ::Matrix4x4 tm44 = AZ::Matrix4x4::CreateFromMatrix3x4(tm34);
+    HMatrix H;
+    tm44.StoreToRowMajorFloat16((float*)&H);
 
     decomp_affine(H, &parts);
 
@@ -842,8 +846,10 @@ void AffineParts::SpectralDecompose(const Matrix34& tm)
 {
     SAffineParts parts;
 
-    Matrix44 tm44(tm);
-    HMatrix& H = *((HMatrix*)&tm44); // Treat HMatrix as a Matrix44.
+    AZ::Matrix3x4 tm34 = LYTransformToAZMatrix3x4(tm);
+    AZ::Matrix4x4 tm44 = AZ::Matrix4x4::CreateFromMatrix3x4(tm34);
+    HMatrix H;
+    tm44.StoreToRowMajorFloat16((float*)&H);
 
     spectral_decomp_affine(H, &parts);
 

--- a/Code/Editor/editor_lib_test_files.cmake
+++ b/Code/Editor/editor_lib_test_files.cmake
@@ -22,6 +22,7 @@ set(FILES
     Lib/Tests/test_ModularViewportCameraController.cpp
     Lib/Tests/Camera/test_EditorCamera.cpp
     Lib/Tests/test_AzAssetBrowserRequestHandler.cpp
+    Lib/Tests/test_CryLegacyDeprecation.cpp
     DisplaySettingsPythonFuncs.cpp
     DisplaySettingsPythonFuncs.h
 )

--- a/Code/Legacy/CryCommon/Cry_Math.h
+++ b/Code/Legacy/CryCommon/Cry_Math.h
@@ -517,7 +517,6 @@ enum type_identity
 #include "Cry_Vector4.h"
 #include "Cry_Matrix33.h"
 #include "Cry_Matrix34.h"
-#include "Cry_Matrix44.h"
 #include "Cry_Quat.h"
 
 // function for safe comparsion of floating point  values

--- a/Code/Legacy/CryCommon/Cry_Matrix44.h
+++ b/Code/Legacy/CryCommon/Cry_Matrix44.h
@@ -637,6 +637,8 @@ struct Matrix44_tpl
 // Typedefs                                                                  //
 ///////////////////////////////////////////////////////////////////////////////
 
+// O3DE_DEPRECATION_NOTICE(GHI-19470) - Use AZ::Matrix4x4
+AZ_DEPRECATED_MESSAGE("Matrix44 is deprecated, use AZ::Matrix4x4 instead. ")
 typedef Matrix44_tpl<f32>  Matrix44;   //always 32 bit
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?
Deprecation of Cry_Matrix44 (`Matrix44`)

* Add Unit Test to validate mathematics of update to AZ::Matrix44
* Mark `Matrix44` as deprecated in favor of AZ::Matrix4x4
* Update usage of Matrix44
  - Code/Editor/AffineParts.cpp

Fixes https://github.com/o3de/o3de/issues/19454 

## How was this PR tested?

* Added Unit Test LegacryDeprecationHelper::TestLegacyMaxtrix44_HMatrixConversion)
