### PR TITLE
Support for linking against `AZ::Component` subclasses defined by shared libraries

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Component.h
+++ b/Code/Framework/AzCore/AzCore/Component/Component.h
@@ -395,6 +395,13 @@ namespace AZ
     AZ_COMPONENT_BASE_DECL() \
     AZ_CLASS_ALLOCATOR_DECL
 
+    #define AZ_COMPONENT_DECL_API(_Api, _ComponentClass) \
+    AZ_TYPE_INFO_WITH_NAME_DECL_API(_Api, _ComponentClass) \
+    AZ_RTTI_NO_TYPE_INFO_DECL() \
+    AZ_COMPONENT_INTRUSIVE_DESCRIPTOR_TYPE(AZ_USE_FIRST_ARG(AZ_UNWRAP(_ComponentClass))) \
+    AZ_COMPONENT_BASE_DECL() \
+    AZ_CLASS_ALLOCATOR_DECL
+
     // Helper macro for allowing expansion of macro parameters
     // in the second pass over the AZ_COMPONENT_IMPL when making a call
     // The reason these macros are needed, is to avoid recursively invoking


### PR DESCRIPTION

## What does this PR do?

This PR introduces a new macro `AZ_COMPONENT_DECL_API`, which is functionally identical to the existing `AZ_COMPONENT_DECL` macro but adds support for passing in an `_API` import/export macro.

This allows component classes that are defined in shared libraries to export the symbols introduced by the macro expansion, allowing other targets to directly link against those components and use them as they expect.

### Old behavior

The "old behavior" is that the shared library attempts to use `AZ_COMPONENT_DECL` (without the "_API" suffix) which does not export the component's type information symbols. When building it this way, I get linker errors related to `AzTypeInfo` saying there are missing implementations for `GetO3deTypeName` and `GetO3deTypeId`. Here is the actual output of the errors on MSVC (see "How was this PR tested?" below for full context of the code):

```
4>     Creating library C:/O3DE/o3de/build/windows/lib/debug/O3deUtils_Misc.Tools.lib and object C:/O3DE/o3de/build/windows/lib/debug/O3deUtils_Misc.Tools.exp
4>unity_0_cxx.obj : error LNK2019: unresolved external symbol "class AZStd::basic_fixed_string<char,512,struct AZStd::char_traits<char> > __cdecl O3deUtils_Misc::GetO3deTypeName(struct AZ::Adl,struct AZStd::type_identity<class O3deUtils_Misc::O3deUtils_MiscSystemComponent>)" (?GetO3deTypeName@O3deUtils_Misc@@YA?AV?$basic_fixed_string@D$0CAA@U?$char_traits@D@AZStd@@@AZStd@@UAdl@AZ@@U?$type_identity@VO3deUtils_MiscSystemComponent@O3deUtils_Misc@@@3@@Z) referenced in function "public: static char const * __cdecl AZ::AzTypeInfo<class O3deUtils_Misc::O3deUtils_MiscSystemComponent>::Name(void)" (?Name@?$AzTypeInfo@VO3deUtils_MiscSystemComponent@O3deUtils_Misc@@@AZ@@SAPEBDXZ)
4>unity_0_cxx.obj : error LNK2019: unresolved external symbol "struct AZ::Uuid __cdecl O3deUtils_Misc::GetO3deTypeId(struct AZ::Adl,struct AZStd::type_identity<class O3deUtils_Misc::O3deUtils_MiscSystemComponent>)" (?GetO3deTypeId@O3deUtils_Misc@@YA?AUUuid@AZ@@UAdl@3@U?$type_identity@VO3deUtils_MiscSystemComponent@O3deUtils_Misc@@@AZStd@@@Z) referenced in function "public: static struct AZ::Uuid __cdecl AZ::AzTypeInfo<class O3deUtils_Misc::O3deUtils_MiscSystemComponent>::GetCanonicalTypeId(void)" (?GetCanonicalTypeId@?$AzTypeInfo@VO3deUtils_MiscSystemComponent@O3deUtils_Misc@@@AZ@@SA?AUUuid@2@XZ)
4>C:\O3DE\o3de\build\windows\bin\debug\O3deUtils_Misc.Tools.dll : fatal error LNK1120: 2 unresolved externals
```

### New behavior

With the "new behavior", shared libraries can use `AZ_COMPONENT_DECL_API` and supply their `_API` macro to export the important type information symbols. This results in a successful build when attempting to link against the component class from another library.

### Relevant links

I couldn't find any existing issues or PRs related to cross-DLL linking of component classes. It might be a less common use case, but I see it as important to keep the engine flexible and support teams who may want to use shared libraries like this.

## How was this PR tested?

This engine change was tested by my [O3deUtils_Misc](https://github.com/ChristianHinkle/O3deUtils_Misc) gem, which is being used by my [BeatRun](https://github.com/b2hinkle/BeatRun) game project.
- `Gem::O3deUtils_Misc.Unified` is a shared library target that defines a system component using `AZ_COMPONENT_DECL_API`.
- `Gem::O3deUtils_Misc.Tools` is a module library target that links against the shared library and inherits from the exported component.

### Shared library component definition

```cpp
namespace O3deUtils_Misc
{
    class O3DEUTILS_MISC_API O3deUtils_MiscSystemComponent
        : public AZ::Component
        , protected O3deUtils_MiscRequestBus::Handler
        , public AZ::TickBus::Handler
    {
    public:
        AZ_COMPONENT_DECL_API(O3DEUTILS_MISC_API, O3deUtils_MiscSystemComponent);

// ...
```

### Downstream usage of the component (inheritance)

```cpp
namespace O3deUtils_Misc
{
    /// System component for O3deUtils_Misc editor
    class O3deUtils_MiscEditorSystemComponent
        : public O3deUtils_MiscSystemComponent
        , protected AzToolsFramework::EditorEvents::Bus::Handler
    {
        using BaseSystemComponent = O3deUtils_MiscSystemComponent;
    public:
        AZ_COMPONENT_DECL(O3deUtils_MiscEditorSystemComponent);

// ...
```
