### PR TITLE
Make SkyAtmosphereParentPass available only if SkyAtmosphere Gem is enabled

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/OpaqueParent.pass
@@ -350,62 +350,20 @@
                     ]
                 },
                 {
-                    "Name": "SkyAtmosphereParentPass",
-                    "TemplateName": "SkyAtmosphereParentTemplate",
-                    "Enabled": true,
-                    "Connections": [
-                        {
-                            "LocalSlot": "SpecularInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "SkyBoxPass",
-                                "Attachment": "SpecularInputOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "ReflectionInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "SkyBoxPass",
-                                "Attachment": "ReflectionInputOutput"
-                            }
-                        },
-                        {
-                            "LocalSlot": "SkyBoxDepth",
-                            "AttachmentRef": {
-                                "Pass": "SkyBoxPass",
-                                "Attachment": "SkyBoxDepth"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DirectionalShadowmap",
-                            "AttachmentRef": {
-                                "Pass": "Parent",
-                                "Attachment": "DirectionalShadowmap"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DirectionalESM",
-                            "AttachmentRef": {
-                                "Pass": "Parent",
-                                "Attachment": "DirectionalESM"
-                            }
-                        }
-                    ]
-                },
-                {
                     "Name": "ReflectionCompositePass",
                     "TemplateName": "ReflectionCompositePassTemplate",
                     "Connections": [
                         {
                             "LocalSlot": "ReflectionInput",
                             "AttachmentRef": {
-                                "Pass": "SkyAtmosphereParentPass",
+                                "Pass": "SkyBoxPass",
                                 "Attachment": "ReflectionInputOutput"
                             }
                         },
                         {
                             "LocalSlot": "SpecularInputOutput",
                             "AttachmentRef": {
-                                "Pass": "SkyAtmosphereParentPass",
+                                "Pass": "SkyBoxPass",
                                 "Attachment": "SpecularInputOutput"
                             }
                         },

--- a/Gems/SkyAtmosphere/Assets/Passes/SkyAtmospherePassRequest.azasset
+++ b/Gems/SkyAtmosphere/Assets/Passes/SkyAtmospherePassRequest.azasset
@@ -1,0 +1,47 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassRequest",
+    "ClassData": {
+        "Name": "SkyAtmosphereParentPass",
+        "TemplateName": "SkyAtmosphereParentTemplate",
+        "Enabled": true,
+        "Connections": [
+            {
+                "LocalSlot": "SpecularInputOutput",
+                "AttachmentRef": {
+                    "Pass": "SkyBoxPass",
+                    "Attachment": "SpecularInputOutput"
+                }
+            },
+            {
+                "LocalSlot": "ReflectionInputOutput",
+                "AttachmentRef": {
+                    "Pass": "SkyBoxPass",
+                    "Attachment": "ReflectionInputOutput"
+                }
+            },
+            {
+                "LocalSlot": "SkyBoxDepth",
+                "AttachmentRef": {
+                    "Pass": "SkyBoxPass",
+                    "Attachment": "SkyBoxDepth"
+                }
+            },
+            {
+                "LocalSlot": "DirectionalShadowmap",
+                "AttachmentRef": {
+                    "Pass": "Parent",
+                    "Attachment": "DirectionalShadowmap"
+                }
+            },
+            {
+                "LocalSlot": "DirectionalESM",
+                "AttachmentRef": {
+                    "Pass": "Parent",
+                    "Attachment": "DirectionalESM"
+                }
+            }
+        ]
+    }
+}

--- a/Gems/SkyAtmosphere/Code/Source/Render/SkyAtmosphereFeatureProcessor.h
+++ b/Gems/SkyAtmosphere/Code/Source/Render/SkyAtmosphereFeatureProcessor.h
@@ -61,6 +61,6 @@ namespace SkyAtmosphere
         };
 
         AZ::Render::SparseVector<SkyAtmosphere> m_atmospheres;
-        AZStd::map<AZ::RPI::RenderPipeline*, AZStd::vector<SkyAtmosphereParentPass*>> m_renderPipelineToSkyAtmosphereParentPasses;
+        AZStd::map<AZ::RPI::RenderPipeline*, SkyAtmosphereParentPass*> m_renderPipelineToSkyAtmosphereParentPass;
     };
 }


### PR DESCRIPTION

## What does this PR do?

This PR is a follow up of https://github.com/o3de/o3de/pull/19479. It removes hard-coded SkyAtmosphereParentPass from Atom's OpaqueParent pass and inserts one after SkyBox pass only when SkyAtmosphere Gem is enabled.

## How was this PR tested?

Tested on Windows 11
