### PR TITLE
Cry_Matrix34 deprecation

### DIFF
--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -368,13 +368,13 @@ void CCryEditDoc::SerializeViewSettings(CXmlArchive& xmlAr)
                 view->getAttr(viewerAnglesName.toUtf8().constData(), va);
             }
 
-            Matrix34 tm = Matrix34::CreateRotationXYZ(va);
-            tm.SetTranslation(vp);
+            AZ::Transform tm = AZ::Transform::CreateFromQuaternionAndTranslation(
+                AZ::Quaternion::CreateFromEulerRadiansZYX(LYAng3ToAZVec3(va)), LYVec3ToAZVec3(vp));
 
             auto viewportContextManager = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
             if (auto viewportContext = viewportContextManager->GetViewportContextById(i))
             {
-                viewportContext->SetCameraTransform(LYTransformToAZTransform(tm));
+                viewportContext->SetCameraTransform(tm);
             }
         }
     }
@@ -394,8 +394,8 @@ void CCryEditDoc::SerializeViewSettings(CXmlArchive& xmlAr)
 
             if (pVP)
             {
-                Vec3 pos = pVP->GetViewTM().GetTranslation();
-                Ang3 angles = Ang3::GetAnglesXYZ(Matrix33(pVP->GetViewTM()));
+                Vec3 pos = AZVec3ToLYVec3(pVP->GetViewTM().GetTranslation());
+                Ang3 angles = AZVec3ToLYAng3(AZ::Quaternion::CreateFromMatrix3x4(pVP->GetViewTM()).GetEulerRadiansZYX());
                 auto viewerPosName = QString("ViewerPos%1").arg(i);
                 view->setAttr(viewerPosName.toUtf8().constData(), pos);
                 auto viewerAnglesName = QString("ViewerAngles%1").arg(i);

--- a/Code/Editor/CryEditPy.cpp
+++ b/Code/Editor/CryEditPy.cpp
@@ -87,7 +87,7 @@ namespace
                 CViewport* pGameViewport = pViewManager ? pViewManager->GetGameViewport() : nullptr;
                 if (pGameViewport)
                 {
-                    pGameViewport->SetViewTM(Matrix34::CreateIdentity());
+                    pGameViewport->SetViewTM(AZ::Matrix3x4::CreateIdentity());
                 }
             }
         }

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -183,8 +183,8 @@ private:
     bool IsBoundsVisible(const AZ::Aabb& box) const override;
     void CenterOnAABB(const AZ::Aabb& aabb) override;
     void OnTitleMenu(QMenu* menu) override;
-    void SetViewTM(const Matrix34& tm) override;
-    const Matrix34& GetViewTM() const override;
+    void SetViewTM(const AZ::Matrix3x4& tm) override;
+    const AZ::Matrix3x4& GetViewTM() const override;
     void Update() override;
     void UpdateContent(int flags) override;
 
@@ -316,7 +316,7 @@ private:
     AZ::EntityId m_viewEntityIdCachedForEditMode;
 
     // The editor camera TM before switching to game mode
-    Matrix34 m_preGameModeViewTM;
+    AZ::Matrix3x4 m_preGameModeViewTM;
 
     // Disables rendering during some periods of time, e.g. undo/redo, resize events
     uint m_disableRenderingCount = 0;
@@ -381,5 +381,5 @@ private:
     EditorViewportSettings m_editorViewportSettings;
 
     // DO NOT USE THIS! It exists only to satisfy the signature of the base class method GetViewTm
-    mutable Matrix34 m_viewTmStorage;
+    mutable AZ::Matrix3x4 m_viewTmStorage;
 };

--- a/Code/Editor/ErrorReportDialog.cpp
+++ b/Code/Editor/ErrorReportDialog.cpp
@@ -492,8 +492,8 @@ void CErrorReportDialog::OnReportItemDblClick(const QModelIndex& index)
         if (GetPositionFromString(pError->error, &x, &y, &z))
         {
             CViewport* vp = GetIEditor()->GetActiveView();
-            Matrix34 tm = vp->GetViewTM();
-            tm.SetTranslation(Vec3(x, y, z));
+            AZ::Matrix3x4 tm = vp->GetViewTM();
+            tm.SetTranslation(x, y, z);
             vp->SetViewTM(tm);
         }
     }
@@ -522,8 +522,8 @@ void CErrorReportDialog::OnReportHyperlink(const QModelIndex& index)
         if (GetPositionFromString(pError->error, &x, &y, &z))
         {
             CViewport* vp = GetIEditor()->GetActiveView();
-            Matrix34 tm = vp->GetViewTM();
-            tm.SetTranslation(Vec3(x, y, z));
+            AZ::Matrix3x4 tm = vp->GetViewTM();
+            tm.SetTranslation(x, y, z);
             vp->SetViewTM(tm);
         }
     }

--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -233,7 +233,7 @@ AZ_POP_DISABLE_WARNING
     m_bJustCreated = false;
     m_levelName = "Untitled";
     m_levelExtension = EditorUtils::LevelFile::GetDefaultFileExtension();
-    m_playerViewTM.SetIdentity();
+    m_playerViewTM = AZ::Matrix3x4::CreateIdentity();
     GetIEditor()->RegisterNotifyListener(this);
 }
 
@@ -307,10 +307,10 @@ static void CmdGotoEditor(IConsoleCmdArgs* pArgs)
         && azsscanf(pArgs->GetArg(5), "%f", &wy) == 1
         && azsscanf(pArgs->GetArg(6), "%f", &wz) == 1)
     {
-        Matrix34 tm = pRenderViewport->GetViewTM();
+        AZ::Matrix3x4 tm = pRenderViewport->GetViewTM();
 
-        tm.SetTranslation(Vec3(x, y, z));
-        tm.SetRotation33(Matrix33::CreateRotationXYZ(DEG2RAD(Ang3(wx, wy, wz))));
+        tm.SetTranslation(x, y, z);
+        tm.SetRotationPartFromQuaternion(AZ::Quaternion::CreateFromEulerDegreesZYX(AZ::Vector3(wx, wy, wz)));
         pRenderViewport->SetViewTM(tm);
     }
 }
@@ -696,7 +696,7 @@ void CGameEngine::SetSimulationMode(bool enabled, bool bOnlyPhysics)
     AzFramework::InputChannelRequestBus::Broadcast(&AzFramework::InputChannelRequests::ResetState);
 }
 
-void CGameEngine::SetPlayerViewMatrix(const Matrix34& tm, [[maybe_unused]] bool bEyePos)
+void CGameEngine::SetPlayerViewMatrix(const AZ::Matrix3x4& tm, [[maybe_unused]] bool bEyePos)
 {
     m_playerViewTM = tm;
 }

--- a/Code/Editor/GameEngine.h
+++ b/Code/Editor/GameEngine.h
@@ -20,6 +20,7 @@ class CStartupLogoDialog;
 struct IInitializeUIInfo;
 
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Vector3.h>
 
 #include <AzCore/Module/DynamicModuleHandle.h>
@@ -92,7 +93,7 @@ public:
     ISystem* GetSystem() { return m_pISystem; };
     //! Set player position in game.
     //! @param bEyePos If set then given position is position of player eyes.
-    void SetPlayerViewMatrix(const Matrix34& tm, bool bEyePos = true);
+    void SetPlayerViewMatrix(const AZ::Matrix3x4& tm, bool bEyePos = true);
     //! When set, player in game will be every frame synchronized with editor camera.
     void SyncPlayerPosition(bool bEnable);
     bool IsSyncPlayerPosition() const { return m_bSyncPlayerPosition; };
@@ -135,7 +136,7 @@ private:
     bool m_bJustCreated;
     bool m_bIgnoreUpdates;
     ISystem* m_pISystem;
-    Matrix34 m_playerViewTM;
+    AZ::Matrix3x4 m_playerViewTM;
     struct SSystemUserCallback* m_pSystemUserCallback;
     AZStd::unique_ptr<AZ::DynamicModuleHandle> m_hSystemHandle;
     enum EPendingGameMode

--- a/Code/Editor/Include/IDisplayViewport.h
+++ b/Code/Editor/Include/IDisplayViewport.h
@@ -38,8 +38,8 @@ struct IDisplayViewport
     };
     virtual void GetPerpendicularAxis(EAxis* axis, bool* is2D) const = 0;
 
-    virtual const Matrix34& GetViewTM() const = 0;
-    virtual const Matrix34& GetScreenTM() const = 0;
+    virtual const AZ::Matrix3x4& GetViewTM() const = 0;
+    virtual const AZ::Matrix3x4& GetScreenTM() const = 0;
     virtual QPoint WorldToView(const Vec3& worldPoint) const = 0;
     virtual Vec3 WorldToView3D(const Vec3& worldPoint, int flags = 0) const = 0;
     virtual Vec3 ViewToWorld(const QPoint& vp, bool* collideWithTerrain = nullptr, bool onlyTerrain = false, bool bSkipVegetation = false, bool bTestRenderMesh = false, bool* collideWithObject = nullptr) const = 0;

--- a/Code/Editor/Lib/Tests/test_CryLegacyDeprecation.cpp
+++ b/Code/Editor/Lib/Tests/test_CryLegacyDeprecation.cpp
@@ -24,7 +24,7 @@ namespace EditorUtilsTest
 
     typedef float HMatrix[4][4]; /* Right-handed, for column vectors */
 
-   TEST_F(LegacryDeprecationHelper, TestLegacyMaxtrix44_HMatrixConversion)
+   TEST_F(LegacryDeprecationHelper, TestLegacyMatrix44_HMatrixConversion)
     {
        AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations");
 
@@ -52,4 +52,45 @@ namespace EditorUtilsTest
         AZ_POP_DISABLE_WARNING;
     }
 
+    TEST_F(LegacryDeprecationHelper, TestLegacyMatrix33_CreateFromEulerAngles)
+    {
+        AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations");
+
+        // The legacy function Matrix33::CreateRotationXYZ is equivalent to the AZ::Matrix3x3 constructur with Quaternion argument created
+        // by AZ::Quaternion::CreateFromEulerRadiansZYX
+        Matrix33 legacyMatrix = Matrix33::CreateRotationXYZ(Ang3(1.f, 2.f, 3.f));
+        AZ::Matrix3x3 newMatrix(AZ::Quaternion::CreateFromEulerRadiansZYX(AZ::Vector3(1.f, 2.f, 3.f)));
+
+        // Validation
+        for (int r = 0; r < 3; ++r)
+        {
+            for (int c = 0; c < 3; ++c)
+            {
+                ASSERT_NEAR(legacyMatrix(r, c), newMatrix(r, c), 1e-6f);
+            }
+        }
+
+        AZ_POP_DISABLE_WARNING;
+    }
+
+    TEST_F(LegacryDeprecationHelper, TestLegacyMatrix33_GetEulerAngles)
+    {
+        AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations");
+
+        Matrix33 legacyMatrix = Matrix33::CreateRotationXYZ(Ang3(1.f, 2.f, 3.f));
+        AZ::Matrix3x3 newMatrix = AZ::Matrix3x3::CreateFromRowMajorFloat9(legacyMatrix.GetData());
+
+        // The legacy function Ang3::GetAnglesXYZ(Matrix33) is equivalent to
+        // AZ::Quaternion::CreateFromMatrix3x3(AZ::Matrix3x3).GetEulerRadiansZYX()
+        Ang3 legacyAngles = Ang3::GetAnglesXYZ(legacyMatrix);
+        AZ::Vector3 newAngles = AZ::Quaternion::CreateFromMatrix3x3(newMatrix).GetEulerRadiansZYX();
+
+        // Validation
+        for (int r = 0; r < 3; ++r)
+        {
+            ASSERT_NEAR(legacyAngles[r], newAngles[r], 1e-6f);
+        }
+
+        AZ_POP_DISABLE_WARNING;
+    }
 } // namespace EditorUtilsTest

--- a/Code/Editor/TrackView/TrackViewSequenceManager.h
+++ b/Code/Editor/TrackView/TrackViewSequenceManager.h
@@ -77,5 +77,5 @@ private:
     bool m_bUnloadingLevel;
 
     // Used to handle object attach/detach
-    AZStd::unordered_map<CTrackViewNode*, Matrix34> m_prevTransforms;
+    AZStd::unordered_map<CTrackViewNode*, AZ::Matrix3x4> m_prevTransforms;
 };

--- a/Code/Editor/Util/AffineParts.cpp
+++ b/Code/Editor/Util/AffineParts.cpp
@@ -823,11 +823,10 @@ static  void spectral_decomp_affine(HMatrix A, SAffineParts* parts)
 }
 
 // Decompose matrix to affine parts.
-void AffineParts::Decompose(const Matrix34& tm)
+void AffineParts::Decompose(const AZ::Matrix3x4& tm34)
 {
     SAffineParts parts;
 
-    AZ::Matrix3x4 tm34 = LYTransformToAZMatrix3x4(tm);
     AZ::Matrix4x4 tm44 = AZ::Matrix4x4::CreateFromMatrix3x4(tm34);
     HMatrix H;
     tm44.StoreToRowMajorFloat16((float*)&H);
@@ -842,11 +841,10 @@ void AffineParts::Decompose(const Matrix34& tm)
 }
 
 // Spectral matrix decompostion to affine parts.
-void AffineParts::SpectralDecompose(const Matrix34& tm)
+void AffineParts::SpectralDecompose(const AZ::Matrix3x4& tm34)
 {
     SAffineParts parts;
 
-    AZ::Matrix3x4 tm34 = LYTransformToAZMatrix3x4(tm);
     AZ::Matrix4x4 tm44 = AZ::Matrix4x4::CreateFromMatrix3x4(tm34);
     HMatrix H;
     tm44.StoreToRowMajorFloat16((float*)&H);

--- a/Code/Editor/Util/AffineParts.h
+++ b/Code/Editor/Util/AffineParts.h
@@ -22,12 +22,12 @@ struct AffineParts
 
     /** Decompose matrix to its affine parts.
     */
-    void Decompose(const Matrix34& mat);
+    void Decompose(const AZ::Matrix3x4& mat);
 
     /** Decompose matrix to its affine parts.
             Assume there`s no stretch rotation.
     */
-    void SpectralDecompose(const Matrix34& mat);
+    void SpectralDecompose(const AZ::Matrix3x4& mat);
 };
 
 #endif // CRYINCLUDE_EDITOR_UTIL_AFFINEPARTS_H

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -25,6 +25,7 @@
 #include <QtWinExtras/qwinfunctions.h>
 #endif
 
+#include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Uuid.h>
 #include <IEditor.h>
 #endif
@@ -152,24 +153,24 @@ public:
     //////////////////////////////////////////////////////////////////////////
     //! Set current view matrix,
     //! This is a matrix that transforms from world to view space.
-    virtual void SetViewTM([[maybe_unused]] const Matrix34& tm)
+    virtual void SetViewTM([[maybe_unused]] const AZ::Matrix3x4& tm)
     {
         AZ_Error("CryLegacy", false, "QtViewport::SetViewTM not implemented");
     }
 
     //! Get current view matrix.
     //! This is a matrix that transforms from world space to view space.
-    const Matrix34& GetViewTM() const override
+    const AZ::Matrix3x4& GetViewTM() const override
     {
         AZ_Error("CryLegacy", false, "QtViewport::GetViewTM not implemented");
-        static const Matrix34 m;
+        static const AZ::Matrix3x4 m = AZ::Matrix3x4::CreateZero();
         return m;
     };
 
     //////////////////////////////////////////////////////////////////////////
     //! Get current screen matrix.
     //! Screen matrix transform from World space to Screen space.
-    const Matrix34& GetScreenTM() const override
+    const AZ::Matrix3x4& GetScreenTM() const override
     {
         return m_screenTM;
     }
@@ -203,7 +204,7 @@ public:
     virtual int GetViewportId() const { return m_nCurViewportID; };
 
     // Store final Game Matrix ready for editor
-    void SetGameTM(const Matrix34& tm) { m_gameTM = tm; };
+    void SetGameTM(const AZ::Matrix3x4& tm) { m_gameTM = tm; };
 
     //////////////////////////////////////////////////////////////////////////
     // Drag and drop support on viewports.
@@ -253,10 +254,10 @@ protected:
     CLayoutViewPane* m_viewPane = nullptr;
     CViewManager* m_viewManager;
     // Screen Matrix
-    Matrix34 m_screenTM;
+    AZ::Matrix3x4 m_screenTM;
     int m_nCurViewportID;
     // Final game view matrix before dropping back to editor
-    Matrix34 m_gameTM;
+    AZ::Matrix3x4 m_gameTM;
 
     // Custom drop callback (Leroy@Conffx)
     DropCallback m_dropCallback;

--- a/Code/Legacy/CryCommon/Cry_Matrix34.h
+++ b/Code/Legacy/CryCommon/Cry_Matrix34.h
@@ -798,6 +798,8 @@ struct Matrix34_tpl
 // Typedefs                                                                  //
 ///////////////////////////////////////////////////////////////////////////////
 
+// O3DE_DEPRECATION_NOTICE(GHI-19491) - Use AZ::Matrix3x4
+AZ_DEPRECATED_MESSAGE("Matrix34 is deprecated, use AZ::Matrix3x4 instead.")
 typedef Matrix34_tpl<f32>  Matrix34; //always 32 bit
 
 //----------------------------------------------------------------------------------

--- a/Code/Legacy/CryCommon/IFont.h
+++ b/Code/Legacy/CryCommon/IFont.h
@@ -23,6 +23,7 @@
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Matrix3x4.h>
 
 struct ISystem;
 
@@ -155,7 +156,7 @@ struct STextDrawContext
 
     ColorB m_colorOverride;
 
-    Matrix34 m_transform;
+    AZ::Matrix3x4 m_transform;
 
     int m_baseState;
     bool m_overrideViewProjMatrices;
@@ -181,7 +182,7 @@ struct STextDrawContext
         , m_framed(false)
         , m_colorOverride(0, 0, 0, 0)
         , m_drawTextFlags(0)
-        , m_transform(IDENTITY)
+        , m_transform(AZ::Matrix3x4::CreateIdentity())
         , m_baseState(-1) // indicates not set, would like to set to GS_DEPTHFUNC_LEQUAL but header dependencies preclude that
         , m_overrideViewProjMatrices(true) // the old behavior that overrides the currently set view and projection matrices
         , m_kerningEnabled(true)
@@ -202,7 +203,7 @@ struct STextDrawContext
     void EnableFrame(bool enable) { m_framed = enable; }
     void SetColor(const ColorF& col) { m_colorOverride = col; }
     void SetFlags(int flags) { m_drawTextFlags = flags; }
-    void SetTransform(const Matrix34& transform) { m_transform = transform; }
+    void SetTransform(const AZ::Matrix3x4& transform) { m_transform = transform; }
     void SetBaseState(int baseState) { m_baseState = baseState; }
     void SetOverrideViewProjMatrices(bool overrideViewProjMatrices) { m_overrideViewProjMatrices = overrideViewProjMatrices; }
     void SetLineSpacing(float lineSpacing) { m_lineSpacing = lineSpacing; }

--- a/Code/Legacy/CryCommon/MathConversion.h
+++ b/Code/Legacy/CryCommon/MathConversion.h
@@ -95,15 +95,6 @@ inline AZ::Color LYColorBToAZColor(const ColorB& source)
     return AZ::Color(source.r, source.g, source.b, source.a);
 }
 
-inline Matrix34 AZTransformToLYTransform(const AZ::Transform& source)
-{
-    return Matrix34::CreateFromVectors(
-        AZVec3ToLYVec3(source.GetBasisX()),
-        AZVec3ToLYVec3(source.GetBasisY()),
-        AZVec3ToLYVec3(source.GetBasisZ()),
-        AZVec3ToLYVec3(source.GetTranslation()));
-}
-
 inline Matrix33 AZMatrix3x3ToLYMatrix3x3(const AZ::Matrix3x3& source)
 {
     return Matrix33::CreateFromVectors(
@@ -118,6 +109,17 @@ inline AZ::Matrix3x3 LyMatrix3x3ToAzMatrix3x3(const Matrix33& source)
         LYVec3ToAZVec3(source.GetColumn(0)),
         LYVec3ToAZVec3(source.GetColumn(1)),
         LYVec3ToAZVec3(source.GetColumn(2)));
+}
+
+// Disable the deprecated-declarations warning for all conversion operators of Matrix34
+AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations");
+inline Matrix34 AZTransformToLYTransform(const AZ::Transform& source)
+{
+    return Matrix34::CreateFromVectors(
+        AZVec3ToLYVec3(source.GetBasisX()),
+        AZVec3ToLYVec3(source.GetBasisY()),
+        AZVec3ToLYVec3(source.GetBasisZ()),
+        AZVec3ToLYVec3(source.GetTranslation()));
 }
 
 inline Matrix34 AZMatrix3x4ToLYMatrix3x4(const AZ::Matrix3x4& source)
@@ -144,6 +146,7 @@ inline AZ::Matrix3x4 LYTransformToAZMatrix3x4(const Matrix34& source)
 {
     return AZ::Matrix3x4::CreateFromRowMajorFloat12(source.GetData());
 }
+AZ_POP_DISABLE_WARNING
 
 inline AZ::Plane LyPlaneToAZPlane(const ::Plane& source)
 {

--- a/Code/Legacy/CryCommon/MathConversion.h
+++ b/Code/Legacy/CryCommon/MathConversion.h
@@ -40,6 +40,16 @@ inline Vec3 AZVec3ToLYVec3(const AZ::Vector3& source)
     return Vec3(source.GetX(), source.GetY(), source.GetZ());
 }
 
+inline AZ::Vector3 LYAng3ToAZVec3(const Ang3& source)
+{
+    return AZ::Vector3(source.x, source.y, source.z);
+}
+
+inline Ang3 AZVec3ToLYAng3(const AZ::Vector3& source)
+{
+    return Ang3(source.GetX(), source.GetY(), source.GetZ());
+}
+
 inline AZ::Vector4 LYVec4ToAZVec4(const Vec4& source)
 {
     return AZ::Vector4(source.x, source.y, source.z, source.w);

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -831,10 +831,10 @@ int AZ::FFont::CreateQuadsForText(const RHI::Viewport& viewport, float x, float 
 
                 if (ctx.m_drawTextFlags & eDrawText_UseTransform)
                 {
-                    v0 = ctx.m_transform * v0;
-                    v2 = ctx.m_transform * v2;
-                    v1 = ctx.m_transform * v1;
-                    v3 = ctx.m_transform * v3;
+                    v0 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v0));
+                    v2 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v2));
+                    v1 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v1));
+                    v3 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v3));
                 }
 
                 Vec2 gradientUvMin, gradientUvMax;
@@ -1060,10 +1060,10 @@ int AZ::FFont::CreateQuadsForText(const RHI::Viewport& viewport, float x, float 
 
             if (ctx.m_drawTextFlags & eDrawText_UseTransform)
             {
-                v0 = ctx.m_transform * v0;
-                v2 = ctx.m_transform * v2;
-                v1 = ctx.m_transform * v1;
-                v3 = ctx.m_transform * v3;
+                v0 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v0));
+                v2 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v2));
+                v1 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v1));
+                v3 = AZVec3ToLYVec3(ctx.m_transform * LYVec3ToAZVec3(v3));
             }
 
             if (AddQuad(v0, v1, v2, v3, tc0, tc1, tc2, tc3, packedColor))
@@ -1593,7 +1593,7 @@ static void SetCommonContextFlags(AZ::TextDrawContext& ctx, const AzFramework::T
         if (params.m_useTransform)
         {
             ctx.m_drawTextFlags |= eDrawText_UseTransform;
-            ctx.SetTransform(AZMatrix3x4ToLYMatrix3x4(params.m_transform));
+            ctx.SetTransform(params.m_transform);
         }
 }
 

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewSequenceManager.h
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewSequenceManager.h
@@ -78,7 +78,7 @@ private:
     uint32 m_nextSequenceId;
 
     // Used to handle object attach/detach
-    std::unordered_map<CUiAnimViewNode*, Matrix34> m_prevTransforms;
+    std::unordered_map<CUiAnimViewNode*, AZ::Matrix3x4> m_prevTransforms;
 
     static CUiAnimViewSequenceManager* s_instance;
     IUiAnimationSystem* m_animationSystem;

--- a/Gems/LyShine/Code/Source/Animation/AnimNode.cpp
+++ b/Gems/LyShine/Code/Source/Animation/AnimNode.cpp
@@ -682,9 +682,9 @@ void CUiAnimNode::PostLoad()
 }
 
 //////////////////////////////////////////////////////////////////////////
-Matrix34 CUiAnimNode::GetReferenceMatrix() const
+AZ::Matrix3x4 CUiAnimNode::GetReferenceMatrix() const
 {
-    static Matrix34 tm(IDENTITY);
+    static AZ::Matrix3x4 tm = AZ::Matrix3x4::CreateIdentity();
     return tm;
 }
 

--- a/Gems/LyShine/Code/Source/Animation/AnimNode.h
+++ b/Gems/LyShine/Code/Source/Animation/AnimNode.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <AzCore/Math/Matrix3x4.h>
 #include <LyShine/Animation/IUiAnimation.h>
 #include "UiAnimationSystem.h"
 
@@ -77,7 +78,7 @@ public:
     virtual void OnStop() {}
     virtual void OnLoop() {}
 
-    virtual Matrix34 GetReferenceMatrix() const;
+    virtual AZ::Matrix3x4 GetReferenceMatrix() const;
 
     //////////////////////////////////////////////////////////////////////////
     bool IsParamValid(const CUiAnimParamType& paramType) const override;

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -1874,8 +1874,6 @@ void UiTextComponent::Render(LyShine::IRenderGraph* renderGraph)
 
     // Render the text batches
 
-    STextDrawContext fontContext(m_renderCache.m_fontContext);
-
     for (RenderCacheBatch* batch : m_renderCache.m_batches)
     {
         AZ::FFont* font = static_cast<AZ::FFont*>(batch->m_font); // LYSHINE_ATOM_TODO - move IFont.h out of CryCommon/engine code
@@ -4009,11 +4007,7 @@ void UiTextComponent::RenderToCache(float alpha)
     AZ::Matrix4x4 transform;
     UiTransformBus::Event(GetEntityId(), &UiTransformBus::Events::GetTransformToViewport, transform);
 
-    float transFloats[16];
-    transform.StoreToRowMajorFloat16(transFloats);
-    Matrix34 transform34(transFloats[0], transFloats[1], transFloats[2], transFloats[3],
-        transFloats[4], transFloats[5], transFloats[6], transFloats[7],
-        transFloats[8], transFloats[9], transFloats[10], transFloats[11]);
+    AZ::Matrix3x4 transform34 = AZ::Matrix3x4::UnsafeCreateFromMatrix4x4(transform);
     fontContext.SetTransform(transform34);
 
     // Get the rect that positions the text prior to scale and rotate. The scale and rotate transform

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
@@ -918,9 +918,9 @@ namespace Maestro
         }
     }
 
-    Matrix34 CAnimNode::GetReferenceMatrix() const
+    AZ::Matrix3x4 CAnimNode::GetReferenceMatrix() const
     {
-        static Matrix34 tm(IDENTITY);
+        static AZ::Matrix3x4 tm = AZ::Matrix3x4::CreateIdentity();
         return tm;
     }
 

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.h
@@ -144,7 +144,7 @@ namespace Maestro
             return Vec3(0, 0, 0);
         }
 
-        virtual Matrix34 GetReferenceMatrix() const;
+        virtual AZ::Matrix3x4 GetReferenceMatrix() const;
 
         //////////////////////////////////////////////////////////////////////////
         bool IsParamValid(const CAnimParamType& paramType) const override;


### PR DESCRIPTION
## What does this PR do?

Deprecation of Cry_Matrix34 (`Matrix34`):
* Update all usages of `Matrix34`
* Mark `Matrix34`as deprecated in favor of `AZ::Matrix3x4`
* Add test to verify equality of functions `Matrix33::CreateRotationXYZ` and `AZ::Matrix3x3(AZ::Quaternion::CreateFromEulerRadiansZYX)`: I did not look into the implementation of these functions, but based on the newly added test these two functions lead to the same result (`CreateFromEulerRadiansXYZ` does not)
* Add test to verify equality of functions `Ang3::GetAnglesXYZ(Matrix33)` and `AZ::Quaternion::CreateFromMatrix3x3(AZ::Matrix3x3).GetEulerRadiansZYX()`: Same as before, not sure why the function `GetEulerRadiansXYZ` is the wrong one

Fixes #19455

## How was this PR tested?

* Run the editor and do some editor interaction
* Control the camera in Gamemode with FlyCamera component
* Create a camera path in the TrackView and replay the path
* Add an automated test to verify that the creation from/conversion to euler angles is equivalent
