### PR TITLE
Add point-release branch to AR merge triggers

### DIFF
--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -40,6 +40,7 @@ on:
       - development
       - stabilization/**
       - hotfix/**
+      - point-release/**
 
 jobs:
 


### PR DESCRIPTION
## What does this PR do?

Add an AR trigger based on any merge to the point-release/* branch

## How was this PR tested?

Tested in my fork: https://github.com/amzn-changml/o3de/actions/runs/21147895608
