### PR TITLE
Cry_Matrix33 deprecation

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1406,8 +1406,8 @@ void EditorViewportWidget::CenterOnAABB(const AZ::Aabb& aabb)
     affineParts.SpectralDecompose(originalTM);
 
     // Forward vector is y component of rotation matrix
-    Matrix33 rotationMatrix = AZMatrix3x3ToLYMatrix3x3(AZ::Matrix3x3(affineParts.rot));
-    const Vec3 viewDirection = rotationMatrix.GetColumn1().GetNormalized();
+    AZ::Matrix3x3 rotationMatrix(affineParts.rot);
+    const Vec3 viewDirection = AZVec3ToLYVec3(rotationMatrix.GetColumn(1).GetNormalized());
 
     // Compute adjustment required by FOV != 90 degrees
     const float fov = GetFOV();
@@ -1416,7 +1416,7 @@ void EditorViewportWidget::CenterOnAABB(const AZ::Aabb& aabb)
     // Compute new transform matrix
     const float distanceToTarget = selectionSize * fovScale * centerScale;
     const Vec3 newPosition = AZVec3ToLYVec3(selectionCenter) - (viewDirection * distanceToTarget);
-    AZ::Matrix3x4 newTM = AZ::Matrix3x4::CreateFromMatrix3x3AndTranslation(LyMatrix3x3ToAzMatrix3x3(rotationMatrix), LYVec3ToAZVec3(newPosition));
+    AZ::Matrix3x4 newTM = AZ::Matrix3x4::CreateFromMatrix3x3AndTranslation(rotationMatrix, LYVec3ToAZVec3(newPosition));
 
     // Set new orbit distance
     float orbitDistance = distanceToTarget;

--- a/Code/Legacy/CryCommon/Cry_Matrix33.h
+++ b/Code/Legacy/CryCommon/Cry_Matrix33.h
@@ -973,6 +973,8 @@ struct Matrix33_tpl
 // Typedefs                                                                  //
 ///////////////////////////////////////////////////////////////////////////////
 
+// O3DE_DEPRECATION_NOTICE(GHI-19495) - Use AZ::Matrix3x3
+AZ_DEPRECATED_MESSAGE("Matrix33 is deprecated, use AZ::Matrix3x3 instead.")
 typedef Matrix33_tpl<f32>  Matrix33;  //always 32 bit
 
 //----------------------------------------------------------------------------------

--- a/Code/Legacy/CryCommon/Cry_Matrix34.h
+++ b/Code/Legacy/CryCommon/Cry_Matrix34.h
@@ -737,7 +737,7 @@ struct Matrix34_tpl
     */
     ILINE void SetScale(const Vec3_tpl<F>& s, const Vec3_tpl<F>& t = Vec3(ZERO))
     {
-        *this = Matrix33::CreateScale(s);
+        *this = Matrix33_tpl<F>::CreateScale(s);
         this->SetTranslation(t);
     }
 

--- a/Code/Legacy/CryCommon/MathConversion.h
+++ b/Code/Legacy/CryCommon/MathConversion.h
@@ -95,6 +95,8 @@ inline AZ::Color LYColorBToAZColor(const ColorB& source)
     return AZ::Color(source.r, source.g, source.b, source.a);
 }
 
+// Disable the deprecated-declarations warning for all conversion operators of Matrix33
+AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations");
 inline Matrix33 AZMatrix3x3ToLYMatrix3x3(const AZ::Matrix3x3& source)
 {
     return Matrix33::CreateFromVectors(
@@ -110,6 +112,7 @@ inline AZ::Matrix3x3 LyMatrix3x3ToAzMatrix3x3(const Matrix33& source)
         LYVec3ToAZVec3(source.GetColumn(1)),
         LYVec3ToAZVec3(source.GetColumn(2)));
 }
+AZ_POP_DISABLE_WARNING
 
 // Disable the deprecated-declarations warning for all conversion operators of Matrix34
 AZ_PUSH_DISABLE_WARNING(4996, "-Wdeprecated-declarations");

--- a/Gems/LyShine/Code/Source/UiImageComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiImageComponent.cpp
@@ -29,6 +29,7 @@
 #include <LyShine/ISprite.h>
 #include <LyShine/IRenderGraph.h>
 
+#include "MathConversion.h"
 #include "UiSerialize.h"
 #include "UiLayoutHelpers.h"
 #include "Sprite.h"
@@ -2056,16 +2057,15 @@ void UiImageComponent::ClipAndRenderForSlicedRadialFill(uint32 numVertsPerSide, 
         firstHalfFixedLineEnd = firstHalfFixedLineEnd * -1.0f;
         secondHalfFixedLineEnd = secondHalfFixedLineEnd * -1.0f;
     }
-    Matrix33 lineRotationMatrix;
 
-    lineRotationMatrix.SetRotationZ(startAngle - fillOffset);
-    firstHalfFixedLineEnd = firstHalfFixedLineEnd * lineRotationMatrix;
+    AZ::Matrix3x3 lineRotationMatrix = AZ::Matrix3x3::CreateRotationZ(startAngle - fillOffset);
+    firstHalfFixedLineEnd = AZVec2ToLYVec2(AZ::Vector2(AZ::Vector3(LYVec2ToAZVec2(firstHalfFixedLineEnd), 0.f) * lineRotationMatrix));
     firstHalfFixedLineEnd = lineOrigin + firstHalfFixedLineEnd;
-    secondHalfFixedLineEnd = secondHalfFixedLineEnd * lineRotationMatrix;
+    secondHalfFixedLineEnd = AZVec2ToLYVec2(AZ::Vector2(AZ::Vector3(LYVec2ToAZVec2(secondHalfFixedLineEnd), 0.f) * lineRotationMatrix));
     secondHalfFixedLineEnd = lineOrigin + secondHalfFixedLineEnd;
 
-    lineRotationMatrix.SetRotationZ(startAngle - fillOffset + (endAngle - startAngle) * m_fillAmount);
-    rotatingLineEnd = rotatingLineEnd * lineRotationMatrix;
+    lineRotationMatrix = AZ::Matrix3x3::CreateRotationZ(startAngle - fillOffset + (endAngle - startAngle) * m_fillAmount);
+    rotatingLineEnd = AZVec2ToLYVec2(AZ::Vector2(AZ::Vector3(LYVec2ToAZVec2(rotatingLineEnd), 0.f) * lineRotationMatrix));
     rotatingLineEnd = lineOrigin + rotatingLineEnd;
 
     int numIndicesToRender = 0;
@@ -2168,9 +2168,8 @@ void UiImageComponent::ClipAndRenderForSlicedRadialCornerOrEdgeFill(uint32 numVe
         endAngle = temp;
         lineEnd = lineEnd * -1.0f;
     }
-    Matrix33 lineRotationMatrix;
-    lineRotationMatrix.SetRotationZ(startAngle + (endAngle - startAngle) * m_fillAmount);
-    lineEnd = lineEnd * lineRotationMatrix;
+    AZ::Matrix3x3 lineRotationMatrix = AZ::Matrix3x3::CreateRotationZ(startAngle + (endAngle - startAngle) * m_fillAmount);
+    lineEnd = AZVec2ToLYVec2(AZ::Vector2(AZ::Vector3(LYVec2ToAZVec2(lineEnd), 0.f) * lineRotationMatrix));
     lineEnd = lineOrigin + lineEnd;
 
     int numIndicesToRender = 0;


### PR DESCRIPTION
## What does this PR do?

Deprecation of Cry_Matrix33 (`Matrix33`):
* Update all usages of `Matrix33`
* Mark `Matrix33` as deprecated in favor of `AZ::Matrix3x3`

Fixes #19468

## How was this PR tested?

* Run the editor and do some editor interaction
* Control the camera in Gamemode with FlyCamera component
* Create a camera path in the TrackView and replay the path
