### PR TITLE
[CMake][AutoGen] Improve CMake errors for failed AutoGen expansion.

### DIFF
--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -297,7 +297,7 @@ def ProcessExpansionRule(autogenConfig, sourceFiles, templateFiles, templateCach
                 templateFile = fullPathTemplate
                 break
         if templateFile is None:
-            print("No matching template file found for %s, template may be missing from your _files.cmake" % expansionRuleSet[1])
+            PrintError("No matching template file found for %s, template may be missing from your _files.cmake" % expansionRuleSet[1])
             return
         # We have a few potential modes of input to output mapping that we'll have to handle depending on how the user formatted their azdef expansion rule
         # if the data input file was explicit

--- a/cmake/LyAutoGen.cmake
+++ b/cmake/LyAutoGen.cmake
@@ -35,7 +35,16 @@ function(ly_add_autogen)
         execute_process(
             COMMAND ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py" "${ly_add_autogen_NAME}" "${CMAKE_BINARY_DIR}/Azcg/TemplateCache/" "${CMAKE_CURRENT_BINARY_DIR}/Azcg/Generated/${ly_add_autogen_NAME}/" "${CMAKE_CURRENT_SOURCE_DIR}" "${input_files_path}" "${ly_add_autogen_AUTOGEN_RULES}" "-n"
             OUTPUT_VARIABLE AUTOGEN_OUTPUTS
+            ERROR_VARIABLE AUTOGEN_ERROR
+            RESULT_VARIABLE AUTOGEN_RESULT
         )
+        # Print informative errors if the python script exited with error status.
+        if(NOT AUTOGEN_RESULT EQUAL 0)
+            message("AutoGen expansion rules failed for target: ${ly_add_autogen_NAME}")
+            message(${AUTOGEN_ERROR})
+        endif()
+        unset(AUTOGEN_RESULT)
+        unset(AUTOGEN_ERROR)
         string(STRIP "${AUTOGEN_OUTPUTS}" AUTOGEN_OUTPUTS)
         set(AZCG_DEPENDENCIES ${AZCG_INPUTFILES})
         list(APPEND AZCG_DEPENDENCIES "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py")

--- a/cmake/LyAutoGen.cmake
+++ b/cmake/LyAutoGen.cmake
@@ -40,8 +40,11 @@ function(ly_add_autogen)
         )
         # Print informative errors if the python script exited with error status.
         if(NOT AUTOGEN_RESULT EQUAL 0)
-            message("AutoGen expansion rules failed for target: ${ly_add_autogen_NAME}")
-            message(${AUTOGEN_ERROR})
+            message(FATAL_ERROR
+                "AutoGen expansion rules failed for target: ${ly_add_autogen_NAME}"
+                "\n"
+                "${AUTOGEN_ERROR}"
+            )
         endif()
         unset(AUTOGEN_RESULT)
         unset(AUTOGEN_ERROR)

--- a/cmake/LyAutoGen.cmake
+++ b/cmake/LyAutoGen.cmake
@@ -38,7 +38,7 @@ function(ly_add_autogen)
             ERROR_VARIABLE AUTOGEN_ERROR
             RESULT_VARIABLE AUTOGEN_RESULT
         )
-        # Print informative errors if the python script exited with error status.
+        # Make sure the script exited with success status before proceeding.
         if(NOT AUTOGEN_RESULT EQUAL 0)
             message(FATAL_ERROR
                 "AutoGen expansion rules failed for target: ${ly_add_autogen_NAME}"

--- a/cmake/LyAutoGen.cmake
+++ b/cmake/LyAutoGen.cmake
@@ -41,8 +41,7 @@ function(ly_add_autogen)
         # Make sure the script exited with success status before proceeding.
         if(NOT AUTOGEN_RESULT EQUAL 0)
             message(FATAL_ERROR
-                "AutoGen expansion rules failed for target: ${ly_add_autogen_NAME}"
-                "\n"
+                "AutoGen expansion rules failed for target: ${ly_add_autogen_NAME}" "\n"
                 "${AUTOGEN_ERROR}"
             )
         endif()


### PR DESCRIPTION

## What does this PR do?

This PR improves CMake configuration errors for cases where executing AutoGen expansion rules fails.

The goal of this PR is to save developer time with faster, more informative build errors and make the engine more approachable for newcomers.

### Old Behavior

The old behavior is that, despite the `AzAutoGen.py` script failing during cmake configuration (in `ly_add_autogen`), no errors were output, and the configuration step would actually finish successfully. Only during the cmake generation phase would we see the error that occurred.

Also, the errors used to be output in a confusing format:
- The python script's error output would get merged with errors from the `add_custom_command`.
    - E.g., for me it would say: `CUSTOMBUILD : CMake error : Could not create file: [` followed by the actual error message from the python script.
- There was also no indication of which target had the problematic AutoGen setup.

This was even more confusing if your IDE attempted to actually compile the code after the AutoGen errors (which is what would happen for me on Visual Studio). You would get additional build errors as a side effect of the original AutoGen configuration failure.

(See "How was this PR tested?" for real-world build output.)

### New Behavior

The new behavior outputs any errors from the `AzAutoGen.py` script (if it failed) *during* the cmake configuration phase - immediately after the script exits. This results in cmake configuration failing, and it outputs the error message nicely.
- The message first prints which target that the AutoGen rule expansion failed for.
- Then, it outputs the standard error output from the python script.
- CMake configuration ends because it is a `FATAL_ERROR` message.

This also prevents Visual Studio from attempting to build after the fact, so the output is much cleaner now.

(See "How was this PR tested?" for real-world build output.)

### Relevant links

I didn't find any existing issues, PRs, or RFCs related to improving AutoGen errors.

## How was this PR tested?

These changes have been tested with my [O3deUtils_Misc](https://github.com/ChristianHinkle/O3deUtils_Misc) gem, which is being used by my [BeatRun](https://github.com/b2hinkle/BeatRun) game project.

As I was developing my gem, I once had a moment where one of my `ly_add_target` invocations provided `AUTOGEN_RULES` but forgot to provide the AutoGen-related files via its `FILES_CMAKE`. I then got a slew of errors saying different things. These were all formatted weirdly and output after the CMake configuration phase, which made it confusing. Below, I have provided the before and after build output when attempting to build.

### Old Behavior Build Output (from Visual Studio)

```
1>  -- Executing CMake scripts...
1>  -- Finishing up configuration...
1>  --   Computing Runtime Dependencies (files to copy to the target's output directory)...
1>  -- Configuring done (20.0s)
1>CUSTOMBUILD : CMake error : Could not create file: [C:/O3DE/BeatRun/build/windows/CMakeFiles/cbc2b040a9da8886b2a0b17f0dafb5e1/No matching template file found for AutoComponent_Header.jinja, template may be missing from your _files.cmake
1>  No matching template file found for AutoComponent_Source.jinja, template may be missing from your _files.cmake
1>  No matching template file found for AutoComponentTypes_Header.jinja, template may be missing from your _files.cmake
1>  No matching template file found for AutoComponentTypes_Source.jinja, template may be missing from your _files.cmake.rule]  Invalid argument
1>  -- Generating done (33.0s)
1>  CMake Generate step failed.  Build files cannot be regenerated correctly.
1>  The system cannot find the batch label specified - VCEnd
1>C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Microsoft\VC\v180\Microsoft.CppCommon.targets(237,5): error MSB8066: Custom build for 'C:\O3DE\BeatRun\build\windows\CMakeFiles\c3b2501193ba275d559b86faa876a85a\generate.stamp.rule' exited with code 1.
21>------ Build started: Project: xXGameProjectNameXx.Tools, Configuration: debug x64 ------
22>------ Build started: Project: O3deUtils_Misc.Tools, Configuration: debug x64 ------
22>C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Microsoft\VC\v180\Microsoft.BuildSteps.Targets(168,5): error MSB4023: Cannot evaluate the item metadata "%(Extension)". The item metadata "%(Extension)" cannot be applied to the path "C:\O3DE\BeatRun\build\windows\CMakeFiles\cbc2b040a9da8886b2a0b17f0dafb5e1\No matching template file found for AutoComponent_Header.jinja, template may be missing from your _files.cmake
22>C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Microsoft\VC\v180\Microsoft.BuildSteps.Targets(168,5): error MSB4023: No matching template file found for AutoComponent_Source.jinja, template may be missing from your _files.cmake
22>C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Microsoft\VC\v180\Microsoft.BuildSteps.Targets(168,5): error MSB4023: No matching template file found for AutoComponentTypes_Header.jinja, template may be missing from your _files.cmake
22>C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Microsoft\VC\v180\Microsoft.BuildSteps.Targets(168,5): error MSB4023: No matching template file found for AutoComponentTypes_Source.jinja, template may be missing from your _files.cmake.rule". Illegal characters in path.
21>  Copying xXGameProjectNameXx.Tools runtime dependencies to output...
21>  -- Copying "C:/O3DE/o3de/install/bin/Windows/debug/Default/./EditorCore.dll" to "C:/O3DE/BeatRun/build/windows/bin/debug/"...
21>  Running AutoGen for xXGameProjectNameXx.Tools
21>  Total Time 0:00:00.00
21>  xXGameProjectNameXx.Tools.vcxproj -> C:\O3DE\BeatRun\build\windows\bin\debug\xXGameProjectNameXx.Tools.dll
25>------ Build started: Project: xXGameProjectNameXx.HeadlessServerLauncher, Configuration: debug x64 ------
25>  Copying xXGameProjectNameXx.HeadlessServerLauncher runtime dependencies to output...
25>  xXGameProjectNameXx.HeadlessServerLauncher.vcxproj -> C:\O3DE\BeatRun\build\windows\bin\debug\xXGameProjectNameXx.HeadlessServerLauncher.exe
```

Note: I removed unrelated lines from this output.

### New Behavior Build Output (from Visual Studio)

```
25>  -- Executing CMake scripts...
25>
25>  CMake Error at C:/O3DE/o3de/install/cmake/LyAutoGen.cmake:43 (message):
25>    AutoGen expansion rules failed for target: O3deUtils_Misc.Tools
25>
25>    No matching template file found for AutoComponent_Header.jinja, template
25>    may be missing from your _files.cmake
25>
25>    No matching template file found for AutoComponent_Source.jinja, template
25>    may be missing from your _files.cmake
25>
25>    No matching template file found for AutoComponentTypes_Header.jinja,
25>    template may be missing from your _files.cmake
25>
25>    No matching template file found for AutoComponentTypes_Source.jinja,
25>    template may be missing from your _files.cmake
25>
25>  Call Stack (most recent call first):
25>    C:/O3DE/o3de/install/cmake/LYWrappers.cmake:419 (ly_add_autogen)
25>    Dependencies/Gems/O3deUtils_Misc/Code/CMakeLists.txt:287 (ly_add_target)
25>
25>
25>  -- Configuring incomplete, errors occurred!
25>C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Microsoft\VC\v180\Microsoft.CppCommon.targets(254,5): error MSB8066: Custom build for 'C:\O3DE\BeatRun\build\windows\CMakeFiles\625169e3b6a4df7a0a4f4896ae9b74e2\xXGameProjectNameXx.HeadlessServerLauncher.stamp.rule;C:\O3DE\o3de\install\CMakeLists.txt' exited with code 1.
```

Note: I removed unrelated lines from this output.
