### PR TITLE
Fix non-unity build error caused by missing include

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/EntityActiveSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/EntityActiveSystemComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Component/EntityActiveSystemComponent.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?
Fixes the follow error from the update to [Entity Driven Startup and Hierarchical Activation Handling](https://github.com/o3de/o3de/pull/19319) due to a missing include.

```
In file included from /home/o3de/github/o3de/Code/Framework/AzCore/./AzCore/Memory/IAllocator.h:11:
In file included from /home/o3de/github/o3de/Code/Framework/AzCore/./AzCore/RTTI/RTTI.h:12:
In file included from /home/o3de/github/o3de/Code/Framework/AzCore/./AzCore/RTTI/TypeInfo.h:10:
/home/o3de/github/o3de/Code/Framework/AzCore/./AzCore/RTTI/TypeInfoSimple.h:338:31: error: static assertion failed due to requirement 'HasGetO3deTypeId_v<AZ::SerializeContext>': No unqualified or static member GetO3deTypeId method is available. AZ_TYPE_INFO or AZ_RTTI can be used in a class/struct, or use AZ_TYPE_INFO_SPECIALIZE() externally. Make sure to include the header containing this information (usually your class header).
  338 |                 static_assert(HasGetO3deTypeId_v<ValueTypeNoQualifiers>,
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/o3de/github/o3de/Code/Framework/AzCore/./AzCore/RTTI/TypeInfoSimple.h:288:24: note: in instantiation of member function 'AZ::AzTypeInfo<AZ::SerializeContext>::GetCanonicalTypeId' requested here
  288 |                 return GetCanonicalTypeId();
      |                        ^
/home/o3de/github/o3de/Code/Framework/AzCore/./AzCore/RTTI/RTTI.h:363:88: note: in instantiation of member function 'AZ::AzTypeInfo<AZ::SerializeContext>::Uuid' requested here
  363 |             return ptr ? reinterpret_cast<T>(ptr->RTTI_AddressOf(AzTypeInfo<CastType>::Uuid())) : nullptr;
      |                                                                                        ^
/home/o3de/github/o3de/Code/Framework/AzCore/./AzCore/RTTI/RTTI.h:634:30: note: in instantiation of function template specialization 'AZ::Internal::RttiCastHelper<AZ::SerializeContext *, AZ::ReflectContext *>' requested here
  634 |         return AZ::Internal::RttiCastHelper<T>(ptr, typename HasAZRtti<AZStd::remove_pointer_t<U>>::kind_type());
      |                              ^
/home/o3de/github/o3de/Code/Framework/AzCore/AzCore/Component/EntityActiveSystemComponent.cpp:15:54: note: in instantiation of function template specialization 'AZ::RttiCast<AZ::SerializeContext *, AZ::ReflectContext *>' requested here
   15 |         if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
   ```
 (This was caught when building in non unity build mode).

## How was this PR tested?
Built locally in non-unity builds
