### PR TITLE
Update version and copyright year in engine.json for 25.10.2

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -4,7 +4,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.2.1",
@@ -12,7 +12,7 @@
         "tools": "1.1.0"
     },
     "file_version": 2,
-    "copyright_year": 2025,
+    "copyright_year": 2026,
     "build": 0,
     "external_subdirectories": [
         "Gems/Achievements",


### PR DESCRIPTION
## What does this PR do?

Bumps the engine version and copyright year for the 25.10.2 point release

NOTE: Do not cherry pick this into the development branch, This is for mainline only

## How was this PR tested?

Will be testing in the installer build and fork branch
