### PR TITLE
Adds a progress overlay when editor is processing critical assets.

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -39,6 +39,7 @@ AZ_POP_DISABLE_WARNING
 #include <QMessageBox>
 #include <QDialogButtonBox>
 #include <QUrlQuery>
+#include <QThread>
 
 // AzCore
 #include <AzCore/Casting/numeric_cast.h>
@@ -61,6 +62,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/ProjectManager/ProjectManager.h>
 #include <AzFramework/Spawnable/RootSpawnableInterface.h>
+#include <AzFramework/Network/SocketConnection.h>
 
 // AzToolsFramework
 #include <AzToolsFramework/ActionManager/ActionManagerSystemComponent.h>
@@ -153,6 +155,8 @@ static const char O3DEEditorClassName[] = "O3DEEditorClass";
 static const char O3DEApplicationName[] = "O3DEApplication";
 
 static AZ::EnvironmentVariable<bool> inEditorBatchMode = nullptr;
+
+AzToolsFramework::ProgressShield* CCryEditApp::s_progressShield = nullptr;
 
 namespace Platform
 {
@@ -1562,6 +1566,8 @@ bool CCryEditApp::InitInstance()
     // It will be launched if not running
     ConnectToAssetProcessor();
 
+    AzFramework::SocketConnection::SetKeepAliveCallback(SocketConnectionKeepAliveCallback);
+
     CCryEditApp::OutputStartupMessage(QString("Initializing Game System..."));
 
     auto initGameSystemOutcome = InitGameSystem(mainWindowWrapperHwnd);
@@ -1964,6 +1970,8 @@ bool CCryEditApp::FixDanglingSharedMemory(const QString& sharedMemName) const
 
 int CCryEditApp::ExitInstance(int exitCode)
 {
+    AzFramework::SocketConnection::SetKeepAliveCallback(nullptr);
+
     if (m_pEditor)
     {
         m_pEditor->OnBeginShutdownSequence();
@@ -3264,6 +3272,74 @@ void CCryEditApp::OnOpenProceduralMaterialEditor()
 {
     QtViewPaneManager::instance()->OpenPane(LyViewPane::SubstanceEditor);
 }
+
+// Now that we're connected, attach a hearbeat function
+void CCryEditApp::SocketConnectionKeepAliveCallback(bool operationIsComplete)
+{
+    if (QApplication::instance()->thread() != QThread::currentThread())
+    {
+        return; // only do anything if we're actually blocking the gui thread
+    }
+
+    // show a progress shield.
+    static bool s_isFirstCall = true;
+    static AZStd::chrono::steady_clock::time_point timeSinceFirstAppearing;
+
+    if (!operationIsComplete)
+    {
+        if (s_isFirstCall)
+        {
+            s_isFirstCall = false;
+            timeSinceFirstAppearing = AZStd::chrono::steady_clock::now();
+        }
+
+        // 2 seconds is most operating systems limit on how long a process can not respond before being considered unresponsive.
+        // Give it 1.5 seconds.
+        if (AZStd::chrono::steady_clock::now() < timeSinceFirstAppearing + AZStd::chrono::milliseconds(1500))
+        {
+            // we have not yet waited long enough to show the shield, this prevents flicker when
+            // a lot of assets are quickly processing.
+            return;
+        }
+
+        QWidget* target = QApplication::activeWindow();
+
+        if (!target)
+        {
+            target = g_splashScreen;
+            if (!target)
+            {
+                CCryEditApp::OutputStartupMessage(QString("First-time Asset Processing..."));
+                return; // no window to attach to.
+            }
+        }
+
+        if (!CCryEditApp::s_progressShield)
+        {
+            CCryEditApp::s_progressShield = new AzToolsFramework::ProgressShield(target);
+            CCryEditApp::s_progressShield->show();
+            CCryEditApp::s_progressShield->setProgress(0, 0, "Processing critical assets...");
+        }
+
+        if ((CCryEditApp::s_progressShield->parent() != target) && (target != s_progressShield))
+        {
+            CCryEditApp::s_progressShield->setParent(target);
+            CCryEditApp::s_progressShield->show();
+        }
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+    }
+    else
+    {
+        s_isFirstCall = true;
+        // op is complete, remove the shield
+        if (CCryEditApp::s_progressShield)
+        {
+            CCryEditApp::s_progressShield->hide();
+            CCryEditApp::s_progressShield->deleteLater();
+            CCryEditApp::s_progressShield = nullptr;
+        }
+    }
+};
 
 namespace Editor
 {

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -30,6 +30,11 @@ class QAction;
 class MainWindow;
 class QSharedMemory;
 
+namespace AzToolsFramework
+{
+    class ProgressShield;
+}
+
 class SANDBOX_API RecentFileList
 {
 public:
@@ -347,6 +352,10 @@ private:
 
     // @param files: A list of file paths, separated by '|';
     void OpenExternalLuaDebugger(AZStd::string_view luaDebuggerUri, AZStd::string_view enginePath, AZStd::string_view projectPath, const char * files);
+
+    // Generic progress indicator for socket connection blocks.
+    static AzToolsFramework::ProgressShield* s_progressShield;
+    static void SocketConnectionKeepAliveCallback(bool operationComplete);
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzCore/AzCore/Asset/AssetContainer.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetContainer.cpp
@@ -193,7 +193,10 @@ namespace AZ::Data
             // the loadParams.m_assetLoadFilterCB that was passed into the AddDependentAssets() methods to use as the dependent
             // asset filter instead of this lambda function.
             AZ_UNUSED(handledAssetDependencyList); // Prevent unused warning in release builds
-            AZ_Assert(AZStd::find(handledAssetDependencyList.begin(), handledAssetDependencyList.end(), filterInfo.m_assetId) !=
+
+            // Note that when in tools builds, this could just be because the asset catalog is not up to date, we are still compiling
+            // assets, so it should not be an assert. 
+            AZ_Warning("Asset", AZStd::find(handledAssetDependencyList.begin(), handledAssetDependencyList.end(), filterInfo.m_assetId) !=
                 handledAssetDependencyList.end(),
                 "Dependent Asset ID (%s) is expected to load, but the Asset Catalog has no dependency recorded. "
                 "Examine the asset builder for the asset relying on this to ensure it is generating the correct dependencies.",
@@ -204,7 +207,9 @@ namespace AZ::Data
             // to point to the asset data once it is loaded.
             if (!Data::AssetManager::Instance().FindAsset(filterInfo.m_assetId, AZ::Data::AssetLoadBehavior::Default))
             {
-                AZ_Assert(!Data::AssetManager::Instance().FindAsset(filterInfo.m_assetId, AZ::Data::AssetLoadBehavior::Default),
+                // Note that when in tools builds, this could just be because the asset catalog is not up to date, we are still compiling
+                // assets, so it should not be an assert. 
+                AZ_Warning("Asset", !Data::AssetManager::Instance().FindAsset(filterInfo.m_assetId, AZ::Data::AssetLoadBehavior::Default),
                     "Dependent Asset ID (%s) can't be found in the AssetManager, which means the asset referencing it has probably "
                     "started loading before the dependent asset has been queued to load.  Verify that the asset dependencies have "
                     "been created correctly for the parent asset.",

--- a/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Asset/GenericAssetHandler.h>
+
+#include <AzFramework/Asset/AssetSystemBus.h>
+
+namespace AzFramework
+{
+    AZ::Data::AssetId GenericAssetHandlerBase::AssetMissingInCatalog(const AZ::Data::Asset<AZ::Data::AssetData>& asset)
+    {
+        // GenericAssets are generally pure data, and should blockingly load unless you override this function
+        // to indicate you support async loading and reloading.
+
+        // If you override this function, consider calling this instead:
+        // AssetSystemRequestBus::Broadcast(AssetSystemRequestBus::Events::EscalateAssetByUuid(asset.GetId().m_guid));
+        // which will escalate your asset to the top of the list but without blocking the main thread on its loading.
+        // and then instead of returning an empty assetId, return a valid AssetId of some fallback asset that you can
+        // temporarily use until the real one is ready.  Once that real one is ready, you will recieve an OnAssetReloaded
+        // event from the asset system and can do what you need to do in order to swap it out.
+
+        // The default behavior, if you don't override this function, is to block the main thread until the asset has
+        // been compiled by the asset system (this will not affect release builds or builds where all the assets are already
+        // compiled).
+
+        using AzFramework::AssetSystemRequestBus;
+        using AzFramework::AssetSystem::AssetStatus;
+
+        // The following call blocks until the asset is compiled or fails to compile, or is not found.
+        AssetStatus status = AssetStatus::AssetStatus_Unknown;
+        AssetSystemRequestBus::BroadcastResult(status, &AssetSystemRequestBus::Events::CompileAssetSyncById, asset.GetId());
+        if (status == AssetStatus::AssetStatus_Compiled)
+        {
+            // If the asset was compiled, we can return the asset id to indicate that it is now available.
+            return asset.GetId();
+        }
+
+        // in all other cases, the asset is either never going to appear, or has failed to compile, etc.  so return an empty assetId.
+        // Implementors can also copy the above code and return some sort of "error asset" instead.
+        // Just remember to invoke CompileAssetSync on your fallback or error asset as well!
+
+        return AZ::Data::AssetId{};
+    }
+} // namespace AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.h
@@ -5,9 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZFRAMEWORK_ASSET_GENERICASSETHANDLER_H
-#define AZFRAMEWORK_ASSET_GENERICASSETHANDLER_H
-
 #pragma once
 
 #include <AzCore/Asset/AssetCommon.h>
@@ -15,7 +12,6 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
-#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/IO/GenericStreams.h>
 #include <AzCore/Asset/AssetTypeInfoBus.h>
 #include <AzCore/IO/FileIO.h>
@@ -71,11 +67,20 @@ namespace AzFramework
     * This being in the heirarchy allows you to easily ask whether a particular handler derives from this type and thus is a
     * GenericAssetHandler.
     */
-    class GenericAssetHandlerBase : public AZ::Data::AssetHandler
+    class AZF_API GenericAssetHandlerBase : public AZ::Data::AssetHandler
     {
     public:
         AZ_RTTI(GenericAssetHandlerBase, "{B153B8B5-25CC-4BB7-A2BD-9A47ECF4123C}", AZ::Data::AssetHandler);
         virtual ~GenericAssetHandlerBase() = default;
+
+        // This function is called when an asset is requested but not found in the catalog.
+        // This default implementation will block until the asset is compiled by the asset system (This has no
+        // effect in release builds or if the asset is already compiled).
+        // Overriding this function will allow you to do more complex things like returning a fallback or placeholder
+        // asset, or a different asset to indicate different kinds of problems with the data, or to allow async background
+        // compilation.  See the body of this function for more information.
+        AZ::Data::AssetId AssetMissingInCatalog(const AZ::Data::Asset<AZ::Data::AssetData>& asset) override;
+
     };
 
     template <typename AssetType>
@@ -117,7 +122,7 @@ namespace AzFramework
             AZ::AssetTypeInfoBus::Handler::BusConnect(AZ::AzTypeInfo<AssetType>::Uuid());
         }
 
-        ~GenericAssetHandler()
+        virtual ~GenericAssetHandler()
         {
             AZ::AssetTypeInfoBus::Handler::BusDisconnect();
         }
@@ -243,4 +248,3 @@ namespace AzFramework
     };
 } // namespace AzFramework
 
-#endif // AZFRAMEWORK_ASSET_GENERICASSETHANDLER_H

--- a/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
@@ -1017,13 +1017,13 @@ namespace AzFramework
                 });
 
             QueueMessageForSend(typeId, serial, dataBuffer, dataLength);
-            constexpr int KeepAliveDelayMS = 10;
+            constexpr AZStd::chrono::milliseconds KeepAliveDelayMS(10);
             SocketConnection::KeepAliveCallback callbackFn = SocketConnection::GetKeepAliveCallback();
             bool callbackAvailable = (callbackFn != nullptr);
 
             if (callbackAvailable)
             {
-                while (!wait.try_acquire_for(AZStd::chrono::milliseconds(KeepAliveDelayMS)))
+                while (!wait.try_acquire_for(KeepAliveDelayMS))
                 {
                     // emit a keep alive message.  It is crucial that this callback uses no locks, no mutexes, and no waits itself.
                      (callbackFn)(false); // signal operation in progress.

--- a/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
@@ -1017,7 +1017,24 @@ namespace AzFramework
                 });
 
             QueueMessageForSend(typeId, serial, dataBuffer, dataLength);
-            wait.acquire();
+            constexpr int KeepAliveDelayMS = 10;
+            SocketConnection::KeepAliveCallback callbackFn = SocketConnection::GetKeepAliveCallback();
+            bool callbackAvailable = (callbackFn != nullptr);
+
+            if (callbackAvailable)
+            {
+                while (!wait.try_acquire_for(AZStd::chrono::milliseconds(KeepAliveDelayMS)))
+                {
+                    // emit a keep alive message.  It is crucial that this callback uses no locks, no mutexes, and no waits itself.
+                     (callbackFn)(false); // signal operation in progress.
+                }
+                (callbackFn)(true); // signal end of operation
+            }
+            else
+            {
+                wait.acquire(); // wait for it to arrive, blocking
+            }
+
 
             return responseArrived;
         }

--- a/Code/Framework/AzFramework/AzFramework/Network/SocketConnection.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Network/SocketConnection.cpp
@@ -14,7 +14,9 @@ AZ_INSTANTIATE_EBUS_SINGLE_ADDRESS(AZF_API, AzFramework::EngineConnectionEvents)
 namespace AzFramework
 {
     static AZ::EnvironmentVariable<SocketConnection*> g_socketConnectionInstance;
+    static AZ::EnvironmentVariable<SocketConnection::KeepAliveCallback> g_keepAliveCallbackInstance;
     static const char* s_SocketConnectionName = "SocketConnection";
+    static const char* s_KeepAliveVariableName = "SocketConnectionKeepAliveCallback";
 
     SocketConnection* SocketConnection::GetInstance()
     {
@@ -40,5 +42,34 @@ namespace AzFramework
         }
 
         (*g_socketConnectionInstance) = instance;
+    }
+
+    SocketConnection::KeepAliveCallback SocketConnection::GetKeepAliveCallback()
+    {
+        if (!g_keepAliveCallbackInstance)
+        {
+            g_keepAliveCallbackInstance = AZ::Environment::FindVariable<SocketConnection::KeepAliveCallback>(s_KeepAliveVariableName);
+        }
+
+        return g_keepAliveCallbackInstance ? (*g_keepAliveCallbackInstance) : nullptr;
+    }
+
+    void SocketConnection::SetKeepAliveCallback(SocketConnection::KeepAliveCallback callbackFn)
+    {
+        if (!g_keepAliveCallbackInstance)
+        {
+            g_keepAliveCallbackInstance = AZ::Environment::CreateVariable<SocketConnection::KeepAliveCallback>(s_KeepAliveVariableName);
+            (*g_keepAliveCallbackInstance) = nullptr;
+        }
+
+        if ((callbackFn) && (g_keepAliveCallbackInstance) && (*g_keepAliveCallbackInstance))
+        {
+            AZ_Error(
+                "SocketConnection",
+                false,
+                "SocketConnection::SetKeepAliveCallback was called without first destroying the old instance and setting it to nullptr");
+        }
+
+        (*g_keepAliveCallbackInstance) = callbackFn;
     }
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Network/SocketConnection.h
+++ b/Code/Framework/AzFramework/AzFramework/Network/SocketConnection.h
@@ -23,12 +23,22 @@ namespace AzFramework
     class AZF_API SocketConnection
     {
     public:
+        // implementations may call this periodically when in long blocking waits.  One per application instance.
+        // It may be called on any thread.
+        using KeepAliveCallback = AZStd::function<void(bool /*operation is complete*/)>;
+
         AZ_RTTI(SocketConnection, "{CF95282C-B514-4AB8-8C72-6063AD03725B}");
         virtual ~SocketConnection() {};
 
         //! Utility functions to get or set the one global instance of a SocketConnection
         static SocketConnection* GetInstance();
         static void SetInstance(SocketConnection* instance);
+
+        //! Utility functions to get or set the one global keep-alive callback that will be periodically invoked
+        //! during SendMessage.  Non-blocking calls like SendMsg will not call it.
+        //! It is up to the application to manage the lifetime of the callback function.
+        static KeepAliveCallback GetKeepAliveCallback();
+        static void SetKeepAliveCallback(KeepAliveCallback callback);
 
         //! Connect to an address with this connection. Takes a null-terminated string address and a port
         //! Currently this blocks until connected
@@ -60,7 +70,8 @@ namespace AzFramework
         //! Callback parameters: Message ID, Serial, Data Buffer, Data Length
         //! Note that if the message is a request and it failed because of a protocol error (engine is shutting down for example)
         //! It is still guaranteed to be called, but will be called with 0, nullptr
-        typedef AZStd::function<void(AZ::u32, AZ::u32, const void*, AZ::u32)> TMessageCallback;
+        using TMessageCallback = AZStd::function<void(AZ::u32, AZ::u32, const void*, AZ::u32)>;
+
         typedef AZ::u32 TMessageCallbackHandle;
         static const TMessageCallbackHandle s_invalidCallbackHandle = 0;
 

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -63,6 +63,7 @@ set(FILES
     Asset/AssetSystemComponent.cpp
     Asset/AssetSystemComponent.h
     Asset/GenericAssetHandler.h
+    Asset/GenericAssetHandler.cpp
     Asset/AssetBundleManifest.cpp
     Asset/AssetBundleManifest.h
     Asset/AssetCatalogBus.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ProgressShield.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/UICore/ProgressShield.cpp
@@ -94,7 +94,7 @@ namespace AzToolsFramework
 
     bool ProgressShield::eventFilter(QObject* obj, QEvent* event)
     {
-        if (event->type() == QEvent::Resize)
+        if ((event->type() == QEvent::Resize) || (event->type() == QEvent::Move))
         {
             UpdateGeometry();
         }

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.cpp
@@ -262,7 +262,7 @@ namespace AZ
                 jobDescriptor.m_critical = false;
                 jobDescriptor.m_jobKey = JobKey;
                 jobDescriptor.SetPlatformIdentifier(AssetBuilderSDK::CommonPlatformName);
-                jobDescriptor.m_jobParameters.emplace(ShaderVariantLoadErrorParam, AZStd::string("Shader doesn't exist yet"));
+                jobDescriptor.m_jobParameters.emplace(ShaderNotReadyYetParam, AZStd::string::format("Shader doesn't exist yet: %s", shaderVariantList.m_shaderFilePath.c_str()));
                 response.m_createJobOutputs.push_back(jobDescriptor);
 
                 response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
@@ -401,10 +401,14 @@ namespace AZ
         {
             const auto& jobParameters = request.m_jobDescription.m_jobParameters;
 
-            if (jobParameters.contains(ShaderVariantLoadErrorParam))
+            if (jobParameters.contains(ShaderNotReadyYetParam))
             {
-                AZ_Error(ShaderVariantListBuilderName, false, "Error during CreateJobs: %s", jobParameters.at(ShaderVariantLoadErrorParam).c_str());
-                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+                // This is not an error, the shader variant list will try again later when its shader is ready.
+                // It has established a source dependency on the shader in all the places it may appear and its not an error
+                // to have a source dependency on a file that doesn't exist yet or even will never exis.  The file coming into existence
+                // will cause this job to be retriggered.
+                AZ_Info(ShaderVariantListBuilderName, "%s", jobParameters.at(ShaderNotReadyYetParam).c_str());
+                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
                 return;
             }
             

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantListBuilder.h
@@ -54,7 +54,7 @@ namespace AZ
             AZ_DISABLE_COPY_MOVE(ShaderVariantListBuilder);
 
             // Keys of job parameters that are shared between CreateJobs() and ProcessJob().
-            static constexpr uint32_t ShaderVariantLoadErrorParam = 0;
+            static constexpr uint32_t ShaderNotReadyYetParam = 0;
             static constexpr uint32_t ShouldExitEarlyFromProcessJobParam = 1;
             static constexpr uint32_t ShaderVariantListAbsolutePathJobParam = 2;
             static constexpr uint32_t ShaderAbsolutePathJobParam = 3;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -161,6 +161,8 @@ namespace AZ
             outputJobDescriptor.m_jobKey = PipelineStageJobKey;
             outputJobDescriptor.m_additionalFingerprintInfo = GetBuilderSettingsFingerprint();
             outputJobDescriptor.SetPlatformIdentifier(AssetBuilderSDK::CommonPlatformName);
+            outputJobDescriptor.m_critical = true;
+            outputJobDescriptor.m_priority = 3; // we'd like this job to process before other jobs that might depend on it's outputs.
 
             MaterialBuilderUtils::AddFingerprintForDependency(materialTypeSourcePath, outputJobDescriptor);
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -112,7 +112,6 @@ namespace AZ
             AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
             AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
             AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
-            AzFramework::AssetCatalogEventBus::Handler::BusConnect();
             AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusConnect();
 
             // All material previews use the same model and lighting preset assets
@@ -134,7 +133,6 @@ namespace AZ
             AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect(); 
             AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect(); 
             AZ::SystemTickBus::Handler::BusDisconnect();
-            AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
             AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
 
             m_materialBrowserInteractions.reset();
@@ -233,6 +231,18 @@ namespace AZ
 
         void EditorMaterialSystemComponent::OnSystemTick()
         {
+            if (m_materialPreviewModelAsset.GetStatus() == AZ::Data::AssetData::AssetStatus::NotLoaded)
+            {
+                m_materialPreviewModelAsset.QueueLoad();
+                return;
+            }
+
+            if (m_materialPreviewLightingPresetAsset.GetStatus() == AZ::Data::AssetData::AssetStatus::NotLoaded)
+            {
+                m_materialPreviewModelAsset.QueueLoad();
+                return;
+            }
+
             auto previewRenderer = AZ::Interface<AtomToolsFramework::PreviewRendererInterface>::Get();
             if (!previewRenderer || !m_materialPreviewModelAsset.IsReady() || !m_materialPreviewLightingPresetAsset.IsReady())
             {
@@ -299,12 +309,6 @@ namespace AZ
 
             m_materialPreviewRequests.clear();
             AZ::SystemTickBus::Handler::BusDisconnect();
-        }
-
-        void EditorMaterialSystemComponent::OnCatalogLoaded([[maybe_unused]] const char* catalogFile)
-        {
-            m_materialPreviewModelAsset.QueueLoad();
-            m_materialPreviewLightingPresetAsset.QueueLoad();
         }
 
         void EditorMaterialSystemComponent::OnRenderMaterialPreviewRendered(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.h
@@ -18,7 +18,6 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityBus.h>
 #include <AzCore/Component/TickBus.h>
-#include <AzFramework/Asset/AssetCatalogBus.h>
 #include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
@@ -42,7 +41,6 @@ namespace AZ
             , public AzToolsFramework::EditorEvents::Bus::Handler
             , public AzToolsFramework::ToolsApplicationNotificationBus::Handler
             , public AZ::SystemTickBus::Handler
-            , public AzFramework::AssetCatalogEventBus::Handler
             , private AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
         {
         public:
@@ -78,9 +76,6 @@ namespace AZ
 
             //! AZ::SystemTickBus::Handler interface overrides...
             void OnSystemTick() override;
-
-            // AzFramework::AssetCatalogEventBus::Handler overrides...
-            void OnCatalogLoaded(const char* catalogFile) override;
 
             //! EditorMaterialSystemComponentNotificationBus::Handler overrides...
             void OnRenderMaterialPreviewRendered(


### PR DESCRIPTION
## What does this PR do?

https://www.youtube.com/watch?v=y1szqBpXrFg

* Whenever something in the editor would query asset status and block to wait for it, the application would previously, freeze and "Become unresponsive". This change adds a progress bar loading animation thing that appears when the editor is waiting for the asset to compile, after about 1.5s, to prevent the "unresponsive" message from appearing from the OS and letting the user know its busy doing stuff.  

Note that this progress shield thing with the bar already existed and was already used in some cases, (for source control checkouts for example), so I'm not making a new GUI here, just using it for this purpose.

* Generic Asset Handler - Now automatically blocks and escalates when an asset is missing, preventing crashes on first startup when assets are not ready yet.

* ATOM assets that would not request escalation but which would crash if missing have been added to escalate and block.

* Editor Material System Component was asking for its assets way too early, and its assets are only required if a preview needs to be shown.  The load request has been moved to the point where it ticks and all systems are actually running.

* The Shader Variant List Builder was issuing failure/error when it meant to just delay a job for later.  This has been fixed to issue a normal message ("Shader is not ready yet") and then reprocess the job later when the shader is ready instead of issue a failure.

Note that this is kind of a "last resort" catchall.  Its better if individual systems manually escalate their critical assets so it does not come to this, but, this fills the gap meanwhile.

## How was this PR tested?

* manual Smoke testing
* Testing with a prepopulated cache
* Testing with a completely empty cache, to make sure it still makes it into the editor and I can load sponza and it looks fine

