### PR TITLE
Cry Common Cleanup Chores

### DIFF
--- a/Code/Editor/EditorDefs.h
+++ b/Code/Editor/EditorDefs.h
@@ -69,21 +69,6 @@
 #undef new
 #endif
 
-#ifndef SAFE_DELETE
-#define SAFE_DELETE(p)          { if (p) { delete (p);       (p) = nullptr; } \
-}
-#endif
-
-#ifndef SAFE_DELETE_ARRAY
-#define SAFE_DELETE_ARRAY(p)    { if (p) { delete[] (p);     (p) = nullptr; } \
-}
-#endif
-
-#ifndef SAFE_RELEASE
-#define SAFE_RELEASE(p)         { if (p) { (p)->Release();   (p) = nullptr; } \
-}
-#endif
-
 /////////////////////////////////////////////////////////////////////////////
 // CRY Stuff ////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzCore/AzCore/base.h
+++ b/Code/Framework/AzCore/AzCore/base.h
@@ -499,3 +499,23 @@ constexpr bool operator!=(EnumType lhs, EnumType rhs) \
         using UnderlyingType = AZStd::underlying_type_t<EnumType>; \
         return static_cast<UnderlyingType>(lhs) != static_cast<UnderlyingType>(rhs); \
     }
+
+// Macros to safely delete raw pointers and set them to nullptr afterwards
+
+#ifndef SAFE_DELETE
+// Delete a raw pointer and set it to nullptr to prevent dangling pointers
+#define SAFE_DELETE(p) { if (p) { delete (p); (p) = NULL; } \
+}
+#endif
+
+#ifndef SAFE_DELETE_ARRAY
+// Delete a raw pointer to an array and set it to nullptr to prevent dangling pointers
+#define SAFE_DELETE_ARRAY(p) { if (p) { delete [] (p); (p) = NULL; } \
+}
+#endif
+
+#ifndef SAFE_RELEASE
+// For object pointers that releases itself using a `Release()` call, call the release on the pointer and set it to nullptr
+#define SAFE_RELEASE(p) { if (p) { (p)->Release(); (p) = NULL; } \
+}
+#endif

--- a/Code/Legacy/CryCommon/AndroidSpecific.h
+++ b/Code/Legacy/CryCommon/AndroidSpecific.h
@@ -84,7 +84,6 @@ typedef long long                       LONGLONG;
 typedef ULONG_PTR                       SIZE_T;
 typedef unsigned char               byte;
 
-#define ILINE __forceinline
 
 #define _A_RDONLY (0x01)
 #define _A_SUBDIR (0x10)
@@ -143,7 +142,6 @@ extern char* stpcpy(char* dest, const char* str);
 
 #define S_IWRITE S_IWUSR
 
-#define ILINE __forceinline
 #define _A_RDONLY (0x01)
 #define _A_SUBDIR (0x10)
 #define _A_HIDDEN (0x02)

--- a/Code/Legacy/CryCommon/AppleSpecific.h
+++ b/Code/Legacy/CryCommon/AppleSpecific.h
@@ -103,7 +103,6 @@ typedef const char* LPCSTR, * PCSTR;
 typedef long long                       LONGLONG;
 typedef ULONG_PTR                       SIZE_T;
 typedef uint8                               byte;
-#define ILINE __forceinline
 
 #ifndef MAXUINT
 #define MAXUINT ((uint) ~((uint)0))
@@ -123,23 +122,6 @@ typedef uint8                               byte;
 #endif
 
 #define _PACK __attribute__ ((packed))
-
-// Safe memory freeing
-#ifndef SAFE_DELETE
-#define SAFE_DELETE(p)          { if (p) { delete (p);       (p) = NULL; } \
-}
-#endif
-
-#ifndef SAFE_DELETE_ARRAY
-#define SAFE_DELETE_ARRAY(p)    { if (p) { delete[] (p);     (p) = NULL; } \
-}
-#endif
-
-#ifndef SAFE_RELEASE
-#define SAFE_RELEASE(p)         { if (p) { (p)->Release();   (p) = NULL; } \
-}
-#endif
-
 
 #define MAKEWORD(a, b)      ((WORD)(((BYTE)((DWORD_PTR)(a) & 0xff)) | ((WORD)((BYTE)((DWORD_PTR)(b) & 0xff))) << 8))
 #define MAKELONG(a, b)      ((LONG)(((WORD)((DWORD_PTR)(a) & 0xffff)) | ((DWORD)((WORD)((DWORD_PTR)(b) & 0xffff))) << 16))

--- a/Code/Legacy/CryCommon/Cry_Vector3.h
+++ b/Code/Legacy/CryCommon/Cry_Vector3.h
@@ -761,9 +761,9 @@ struct Vec3_tpl
     }
 
     //f32* fptr=vec;
-    DEPRECATED operator F* ()                   { return (F*)this; }
+    operator F* ()                   { return (F*)this; }
     template <class T>
-    explicit DEPRECATED Vec3_tpl(const T* src) { x = F(src[0]); y = F(src[1]); z = F(src[2]); }
+    explicit Vec3_tpl(const T* src) { x = F(src[0]); y = F(src[1]); z = F(src[2]); }
 
     ILINE Vec3_tpl& zero() { x = y = z = 0; return *this; }
     ILINE F len() const

--- a/Code/Legacy/CryCommon/Linux32Specific.h
+++ b/Code/Legacy/CryCommon/Linux32Specific.h
@@ -66,8 +66,6 @@ typedef unsigned char       byte;
 
 #define __int64     long long
 
-#define ILINE __forceinline
-
 #define _A_RDONLY (0x01)
 #define _A_SUBDIR (0x10)
 

--- a/Code/Legacy/CryCommon/Linux64Specific.h
+++ b/Code/Legacy/CryCommon/Linux64Specific.h
@@ -74,7 +74,7 @@ typedef const char* LPCSTR, * PCSTR;
 typedef long long           LONGLONG;
 typedef ULONG_PTR           SIZE_T;
 typedef uint8               byte;
-#define ILINE __forceinline
+
 #define _A_RDONLY (0x01)
 #define _A_SUBDIR (0x10)
 #define _A_HIDDEN (0x02)

--- a/Code/Legacy/CryCommon/LinuxSpecific.h
+++ b/Code/Legacy/CryCommon/LinuxSpecific.h
@@ -85,23 +85,6 @@ typedef float FLOAT;
 
 #define _PACK __attribute__ ((packed))
 
-// Safe memory freeing
-#ifndef SAFE_DELETE
-#define SAFE_DELETE(p)          { if (p) { delete (p);       (p) = NULL; } \
-}
-#endif
-
-#ifndef SAFE_DELETE_ARRAY
-#define SAFE_DELETE_ARRAY(p)    { if (p) { delete[] (p);     (p) = NULL; } \
-}
-#endif
-
-#ifndef SAFE_RELEASE
-#define SAFE_RELEASE(p)         { if (p) { (p)->Release();   (p) = NULL; } \
-}
-#endif
-
-
 #define MAKEWORD(a, b)      ((WORD)(((BYTE)((DWORD_PTR)(a) & 0xff)) | ((WORD)((BYTE)((DWORD_PTR)(b) & 0xff))) << 8))
 #define MAKELONG(a, b)      ((LONG)(((WORD)((DWORD_PTR)(a) & 0xffff)) | ((DWORD)((WORD)((DWORD_PTR)(b) & 0xffff))) << 16))
 #define LOWORD(l)           ((WORD)((DWORD_PTR)(l) & 0xffff))

--- a/Code/Legacy/CryCommon/Win64specific.h
+++ b/Code/Legacy/CryCommon/Win64specific.h
@@ -17,9 +17,6 @@
 
 #define _CPU_AMD64
 #define _CPU_SSE
-#define ILINE __forceinline
-
-#define DEPRECATED __declspec(deprecated)
 
 #ifndef _WIN32_WINNT
 # define _WIN32_WINNT 0x501
@@ -67,21 +64,6 @@ typedef ULONG_PTR DWORD_PTR, * PDWORD_PTR;
 
 int64 CryGetTicks();
 int64 CryGetTicksPerSec();
-
-#ifndef SAFE_DELETE
-#define SAFE_DELETE(p) { if (p) { delete (p); (p) = NULL; } \
-}
-#endif
-
-#ifndef SAFE_DELETE_ARRAY
-#define SAFE_DELETE_ARRAY(p) { if (p) { delete [] (p); (p) = NULL; } \
-}
-#endif
-
-#ifndef SAFE_RELEASE
-#define SAFE_RELEASE(p) { if (p) { (p)->Release(); (p) = NULL; } \
-}
-#endif
 
 #ifndef FILE_ATTRIBUTE_NORMAL
     #define FILE_ATTRIBUTE_NORMAL 0x00000080

--- a/Code/Legacy/CryCommon/platform.h
+++ b/Code/Legacy/CryCommon/platform.h
@@ -27,6 +27,9 @@
 #define PLATFORM_H_SECTION_15 15
 #endif
 
+
+#define ILINE AZ_FORCE_INLINE
+
 #if (defined(LINUX) && !defined(ANDROID)) || defined(APPLE)
     #define _FILE_OFFSET_BITS 64 // define large file support > 2GB
 #endif
@@ -222,9 +225,6 @@ ILINE DestinationType alias_cast(SourceType pPtr)
 }
 
 //////////////////////////////////////////////////////////////////////////
-#ifndef DEPRECATED
-#define DEPRECATED
-#endif
 
 // Assert dialog box macros
 #include <AzCore/Debug/Trace.h>

--- a/Gems/Atom/Asset/ImageProcessingAtom/External/CubeMapGen/CImageSurface.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/External/CubeMapGen/CImageSurface.h
@@ -20,15 +20,6 @@
 #define WCHAR wchar_t
 #endif // WCHAR
 
-#ifndef SAFE_DELETE 
-#define SAFE_DELETE(p)       { if(p) { delete (p);   (p)=NULL; } }
-#endif
-
-#ifndef SAFE_DELETE_ARRAY 
-#define SAFE_DELETE_ARRAY(p) { if(p) { delete[] (p); (p)=NULL; } }
-#endif
-
-
 //Data types processed by cube map processor
 // note that UNORM data types use the full range 
 // of the unsigned integer to represent the range [0, 1] inclusive

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.inl
@@ -16,9 +16,6 @@
 #include <Atom/RHI/BufferScopeAttachment.h>
 namespace ImGui
 {
-    #ifndef SAFE_DELETE
-    #define SAFE_DELETE(p){if(p){delete p;p=nullptr;}}
-    #endif
     #ifndef ImGuiMouseButton_Left
         #define ImGuiMouseButton_Left 0
     #endif

--- a/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.cpp
+++ b/Gems/Meshlets/Code/Source/Meshlets/MeshletsFeatureProcessor.cpp
@@ -25,10 +25,6 @@
 #include <MeshletsRenderObject.h>
 #include <MeshletsFeatureProcessor.h>
 
-#ifndef SAFE_DELETE
-    #define SAFE_DELETE(p){if(p){delete p;p=nullptr;}}
-#endif
-
 namespace AZ
 {
     namespace Meshlets


### PR DESCRIPTION
## What does this PR do?

* SAFE_DELETE, SAFE_DELETE_ARRAY, and SAFE_RELEASE were defined in multiple places with the same definition. Consolidated to a common header, location
* Moved to AzCore (base.h) due to its use outside of legacy cry code
* `ILINE` was also defined in multiple places with the same definition. Consolidated to CryCommon/platform.h
* Removed the unused `DEPRECATED` macro defined in Cry Common. Remove its only 2 uses in Cry_Vector3 since this whole class will eventually be deprecated

## How was this PR tested?
TBD

