### PR TITLE
Fixes the TODO in qt6 for the EmotionFX ParameterWindow

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/ParameterWindow.cpp
@@ -1584,56 +1584,95 @@ namespace EMStudio
         emit DragEnded();
     }
 
-    void ParameterWindowTreeWidget::dropEvent(QDropEvent* )
+    void ParameterWindowTreeWidget::dropEvent(QDropEvent* event)
     {
-        //QModelIndex topIndex;
-        //int col = -1;
-        //int row = -1;
-
-        // Getting the target drop index from the private implementation
-        // of QAbstractItemView
-        //
-        // Documentation from QAbstractItemViewPrivate::dropOn
-        // if (row == -1 && col == -1)
-        //     // append to this drop index
-        // else
-        //     // place at row, col in drop index
-
-        // #QT6_TODO
-        /*
-        if (dropOn(event, &row, &col, &topIndex))
+        if (event->isAccepted())
         {
-            QTreeWidgetItem* item = itemFromIndex(topIndex);
-            item = item ? item : invisibleRootItem();
+            return;
+        }
 
-            const QString& dragParamName = m_draggedParam->data(0, Qt::UserRole).toString();
-            const QString& dropTopParamName = item->data(0, Qt::UserRole).toString();
+        Qt::DropActions supportedDropActions = model() ? model()->supportedDropActions() : Qt::DropActions();
+        if (supportedDropActions & event->dropAction() == 0)
+        {
+            return;
+        }
 
-            // Attempting to group an element inside another element, need to check if
-            // the drop is being made on a group
-            if (row == -1 && col == -1)
+        // what index are we hovering over?
+        QModelIndex insertIndex = indexAt(event->position().toPoint());
+        if (!insertIndex.isValid())
+        {
+            insertIndex = rootIndex();
+        }
+
+        QAbstractItemView::DropIndicatorPosition dropPos = QAbstractItemView::OnViewport;
+        int col = -1;
+        int row = -1;
+
+        if (insertIndex != rootIndex())
+        {
+            dropPos = dropIndicatorPosition();
+            switch (dropPos)
             {
-                const EMotionFX::Parameter* parameter = m_animGraph->FindParameterByName(dropTopParamName.toUtf8().data());
-                if (azrtti_typeid(parameter) == azrtti_typeid<EMotionFX::GroupParameter>())
-                {
-                    QTreeWidget::dropEvent(event);
-                    // row will be -1 if a parameter is dragged on a group, we need
-                    // to place the parameter as the last child of the group
-                    emit ParameterMoved(item->childCount() - 1, dragParamName.toUtf8().data(), dropTopParamName);
-                    return;
-                }
+                case QAbstractItemView::AboveItem:
+                    // the mouse is hovering towards the top of the item, and the insertion
+                    // point should thus be at the index (since the index is where we insert it before)
+                    row = insertIndex.row();
+                    col = insertIndex.column();
+                    insertIndex = insertIndex.parent();
+                break;
+                case QAbstractItemView::BelowItem:
+                    // the mouse is hovering towards the bottom of the item, and the insertion
+                    // point should thus be after the index, the next row.  (Since insertion
+                    // specifies the index to insert before)
+                    row = insertIndex.row() + 1;
+                    col = insertIndex.column();
+                    insertIndex = insertIndex.parent();
+                    break;
+                case QAbstractItemView::OnItem:
+                    [[fallthrough]];
+                case QAbstractItemView::OnViewport:
+                    break;
             }
-            // Placing at col, row in as a child of topIndex, this is always allowed
-            else
+        }
+
+        // make sure we're not dropping on ourself.
+        if (event->dropAction() & Qt::MoveAction)
+        {
+            if (selectedIndexes().contains(insertIndex))
             {
-                const QString& dragParentName = m_draggedParentParam ? m_draggedParentParam->data(0, Qt::UserRole).toString() : QStringLiteral("");
-                QTreeWidget::dropEvent(event);
-                emit ParameterMoved(row - ((dragParentName == dropTopParamName) ? 1 : 0), dragParamName.toUtf8().data(), dropTopParamName);
-                // emit ParameterMoved(row, dragParamName.toUtf8().data(), dropTopParamName);
                 return;
             }
         }
-        */
+
+        QTreeWidgetItem* item = itemFromIndex(insertIndex);
+        item = item ? item : invisibleRootItem();
+
+        const QString& dragParamName = m_draggedParam->data(0, Qt::UserRole).toString();
+        const QString& dropTopParamName = item->data(0, Qt::UserRole).toString();
+
+        // Attempting to group an element inside another element, need to check if
+        // the drop is being made on a group
+        if (row == -1 && col == -1)
+        {
+            const EMotionFX::Parameter* parameter = m_animGraph->FindParameterByName(dropTopParamName.toUtf8().data());
+            if (azrtti_typeid(parameter) == azrtti_typeid<EMotionFX::GroupParameter>())
+            {
+                QTreeWidget::dropEvent(event);
+                // row will be -1 if a parameter is dragged on a group, we need
+                // to place the parameter as the last child of the group
+                emit ParameterMoved(item->childCount() - 1, dragParamName.toUtf8().data(), dropTopParamName);
+                return;
+            }
+        }
+        // Placing at col, row in as a child of topIndex, this is always allowed
+        else
+        {
+            const QString& dragParentName = m_draggedParentParam ? m_draggedParentParam->data(0, Qt::UserRole).toString() : QStringLiteral("");
+            QTreeWidget::dropEvent(event);
+            emit ParameterMoved(row - ((dragParentName == dropTopParamName) ? 1 : 0), dragParamName.toUtf8().data(), dropTopParamName);
+            // emit ParameterMoved(row, dragParamName.toUtf8().data(), dropTopParamName);
+            return;
+        }
     }
 
 } // namespace EMStudio


### PR DESCRIPTION
## What does this PR do?

This code was commented out with a TODO because it was incompatible with QT6.

I have implemented the code without a TODO and without calling or needing any private APIs.

The code was trying to figure out the index to drop the item being dragged onto - since Qt6 lets you drag an item over another item, and sometimes, the mouse cursor is closer to the top of the item, it draws a vertical line meaning "insert this before" and if the mouse cursor is closer to the bottom of the item, it draws a vertical line below meaning "insert this after". 

The internal function that was being called was a private internal function, but it does pretty much what this new code does anyway:

* determines what index you're hovering over
* determines whether you're hovering "above it" (insert before) or "below it" (insert after) and adjusts the index bumping it up by one if you're inserting after.
* makes sure you're not moving self onto self.

## How was this PR tested?

Opened the param view and dragged params around, behaved as expected.
