### PR TITLE
Alleviate moire pattern.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
@@ -261,6 +261,7 @@ namespace AZ::RPI
                     auto defaultSampler =
                         RHI::SamplerState::Create(RHI::FilterMode::Linear, RHI::FilterMode::Linear, RHI::AddressMode::Wrap);
                     defaultSampler.m_anisotropyMax = 16;
+                    defaultSampler.m_anisotropyEnable = true;
                     instanceData.m_textureSamplers = AZStd::make_unique<TextureSamplerRegistry>();
                     instanceData.m_textureSamplers->Init(desc.m_count, defaultSampler);
                 }
@@ -707,6 +708,7 @@ namespace AZ::RPI
         {
             auto defaultSampler = RHI::SamplerState::Create(RHI::FilterMode::Linear, RHI::FilterMode::Linear, RHI::AddressMode::Wrap);
             defaultSampler.m_anisotropyMax = 16;
+            defaultSampler.m_anisotropyEnable = true;
             m_sceneTextureSamplers.Init(AZ_TRAITS_SCENE_MATERIALS_MAX_SAMPLERS, defaultSampler);
         }
 


### PR DESCRIPTION
## What does this PR do?

This PR enable anisotropy in default samplers. It help alleviate moire pattern in render.

## How was this PR tested?

Before change:


<img width="692" height="326" alt="moire-before" src="https://github.com/user-attachments/assets/f6c53011-bc59-40be-b69f-557fecd121e6" />


After change:

<img width="770" height="356" alt="moire-after" src="https://github.com/user-attachments/assets/25132bd0-a9c2-48cc-936c-2fc0ed657e3c" />
