### PR TITLE
Add check for adequate free space in linux AR workspace

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -44,7 +44,7 @@ on:
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
-# Note: All 3P Github Actions use the commit hash for security reasons 
+# Note: All 3P Github Actions use the commit hash for security reasons
 # Avoid using the tag version, which is vulnerable to supply chain attacks
 
 jobs:
@@ -55,8 +55,25 @@ jobs:
     runs-on: ${{ inputs.image }}
 
     steps:
+      - name: Check disk space
+        # Check if the workspace has enough free space, otherwise flag the disk for resizing
+        env:
+          MIN_FREE_DISK: 70 # in GB
+        id: check-disk
+        run: |
+          AVAIL_GB=$(df ${{ github.workspace }} --output=avail --block-size=1G | tail -1 | tr -d ' ')
+          echo "Workspace has ${AVAIL_GB}GB available"
+          if [ "$AVAIL_GB" -lt ${{ env.MIN_FREE_DISK }} ]; then
+            echo "needs_resize=true" >> $GITHUB_OUTPUT
+            echo "Workspace has less than ${{ env.MIN_FREE_DISK }}GB available, resizing disk"
+          else
+            echo "needs_resize=false" >> $GITHUB_OUTPUT
+            echo "Workspace has enough free space, skipping disk resize"
+          fi
+
       - name: Maximize build space
-        # Resize and combine disks as LVM in order to maximize the amount of space for builds
+        # Resize and combine disks as LVM to maximize space for builds, if below the minimum free space
+        if: steps.check-disk.outputs.needs_resize == 'true'
         uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
         with:
           root-reserve-mb: 8000
@@ -65,7 +82,7 @@ jobs:
           remove-haskell: true
           remove-codeql: true
           remove-docker-images: true
-            
+
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## What does this PR do?

Fixes a disk space reallocation issue due to changes in GHA disk layout for Debian Linux. GHA runners are now no longer using /mnt for temp folders and have resized the root disk for maximum space. This renders the resizing redundant and actually causes startup errors, as the resizing causes the root drive to be 100MB. 

To resolve this, we do two actions:

* Added a new step to check available disk space in the workspace and set an output flag (`needs_resize`) based on whether the space is less than 70GB (this is generally enough for a build)
* Modified the "Maximize build space" step to run only if the disk space check determines that resizing is needed, preventing redundant disk operations.

## How was this PR tested?

Tested in my fork. The build with these changes is here: https://github.com/amzn-changml/o3de/actions/runs/21553223519/job/62105123036
