### PR TITLE
Remove PRI_THREADID

### DIFF
--- a/Code/Legacy/CryCommon/platform.h
+++ b/Code/Legacy/CryCommon/platform.h
@@ -77,22 +77,6 @@
     #endif
 #endif
 
-#if !defined(PRI_THREADID)
-    #if defined(AZ_RESTRICTED_PLATFORM)
-        #define AZ_RESTRICTED_SECTION PLATFORM_H_SECTION_7
-        #include AZ_RESTRICTED_FILE(platform_h)
-    #endif
-    #if defined(AZ_RESTRICTED_SECTION_IMPLEMENTED)
-        #undef AZ_RESTRICTED_SECTION_IMPLEMENTED
-    #elif defined(MAC) || defined(IOS) && defined(__LP64__) && defined(__LP64__)
-        #define PRI_THREADID "lld"
-    #elif defined(LINUX64) || defined(ANDROID)
-        #define PRI_THREADID "ld"
-    #else
-        #define PRI_THREADID "d"
-    #endif
-#endif
-
 #include "ProjectDefines.h"                         // to get some defines available in every CryEngine project
 
 // Function attribute for printf/scanf-style parameters.

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -413,7 +413,7 @@ void CSystem::ShutDown()
 /////////////////////////////////////////////////////////////////////////////////
 void CSystem::Quit()
 {
-    CryLogAlways("CSystem::Quit invoked from thread %" PRI_THREADID " (main is %" PRI_THREADID ")", AZStd::this_thread::get_id().m_id, gEnv->mMainThreadId.m_id);
+    CryLogAlways("CSystem::Quit invoked from thread %p (main is %p)", AZStd::this_thread::get_id().m_id, gEnv->mMainThreadId.m_id);
 
     AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
 


### PR DESCRIPTION
## What does this PR do?

Now that `threadID` has been replaced with `std::thread:id`, printing should always use the void* printer.
`CSystem::Quit()` was the last consumer of `PRI_THREADID`, so with the switch to `%p`, which works on all platforms, this macro is no longer needed.

## How was this PR tested?

This fix was necessary to fix macOS builds, which is the only platform I have tested so far.
