### PR TITLE
Remove the windows shortcut link to the Editor.exe from the Windows Installer

### DIFF
--- a/cmake/Platform/Windows/Packaging/Shortcuts.wxs
+++ b/cmake/Platform/Windows/Packaging/Shortcuts.wxs
@@ -28,11 +28,6 @@
         <DirectoryRef Id="DesktopFolder">
             <Component Id="DesktopShortcuts" Guid="{2600B54A-65FB-4507-A7CD-3CE4817C7173}">
 
-                <Shortcut Id="DesktopShortcut_Editor"
-                    Target="[root.bin.Windows.profile.Default]Editor.exe"
-                    WorkingDirectory="root.bin.Windows.profile.Default"
-                    Name="$(var.CPACK_PACKAGE_NAME) Editor" />
-
                 <Shortcut Id="DesktopShortcut_ProjectManager"
                     Target="[root.bin.Windows.profile.Default]o3de.exe"
                     WorkingDirectory="root.bin.Windows.profile.Default"


### PR DESCRIPTION
## What does this PR do?
This removes the windows shortcut to the Editor.exe. Launching the editor itself without providing a project path will popup a window saying "No project path was provided". The shortcut for the Project Manager from where the Editor can be launched by project still remains.

Fixes https://github.com/o3de/o3de/issues/19536

## How was this PR tested?
Will test on an built windows installer