### PR TITLE
Adds backward compatibility to SkyAtmosphere gem.

### DIFF
--- a/Gems/SkyAtmosphere/Code/Source/Tools/Components/EditorSkyAtmosphereComponent.h
+++ b/Gems/SkyAtmosphere/Code/Source/Tools/Components/EditorSkyAtmosphereComponent.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/RTTI/TypeInfo.h>
 #include <Atom/Feature/Utils/EditorRenderComponentAdapter.h>
 #include <Components/SkyAtmosphereComponent.h>
 
@@ -25,6 +26,15 @@ namespace SkyAtmosphere
 
         EditorSkyAtmosphereComponent() = default;
         EditorSkyAtmosphereComponent(const SkyAtmosphereComponentConfig& config);
+
+        static void DeprecatedTypeNameVisitor(const AZ::DeprecatedTypeNameCallback& visitCallback)
+        {
+            constexpr AZStd::string_view deprecatedName = "AZ::Render::EditorSkyAtmosphereComponent";
+            if (visitCallback)
+            {
+                visitCallback(deprecatedName);
+            }
+        }
 
     private:
         //! EditorRenderComponentAdapter


### PR DESCRIPTION
## What does this PR do?

This makes it so that levels and prefabs that have previously been created with the SkyAtmosphere gem will continue to find the component in their prefab files and levels, despite it having changed its name.

This problem was caused by the change in location of the Sky Atmosphere component from atom to a gem instead.  This changed its namespace, and thus the "full official name" of the component.  Prefabs that contained that component were looking for it in its old name, and could not find it.

This adds a declaration that this used to be known as its previous name, so the serializer can find it.

## How was this PR tested?

Multiplayer sample gem uses Sky Atmosphere.  It was showing the error, until these lines were added.  No more error, and the component works with latest dev.
<img width="2394" height="1340" alt="image" src="https://github.com/user-attachments/assets/12c6dff5-890d-4e5a-bd76-b71fa5f5720f" />

