### PR TITLE
Fix detection of ninja on Script-Only (Quick Start) mode

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -127,8 +127,11 @@ namespace O3DE::ProjectManager
             {
                 if (auto ninjaVersionQueryResult = FindSupportedNinja(); !ninjaVersionQueryResult.IsSuccess())
                 {
+                    // if we FAIL to find ninja, we need to fail here and advise the user to install it.
                     return ninjaVersionQueryResult;
                 }
+                // if we ARE able to find ninja, and in script only mode, we dont need to verify anything else
+                return AZ::Success(QString());
             }
 
             // we want to help the user here, by showing a helpful error message depending on their situation


### PR DESCRIPTION
## What does this PR do?

The Quick Start mode of O3DE should not require Visual Studio or any compiler to be installed, only Ninja.  However, there was a programming error in the code which verified that ninja was present.  The code would correctly verify the presence of ninja, but instead of returning and allowing the build to proceed it would instead continue on, to verify that Visual Studio was also present, which is not required for Quick Start mode.

This change makes it so that ONLY ninja is verified for quick start mode, and if all is ok, it returns success immediately from the verification function, allowing the build to proceed.

## How was this PR tested?
I renamed C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe to another name, so that it could not be found.
This causes visual studio to be unable to be detected.

Then I tested this with a script only project.  Before, it would complain about visual studio, after, it worked with just ninja.
