### PR TITLE
Automated Review Workflows for iOS and Mac

### DIFF
--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -14,191 +14,250 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-        CLEAN_ARTIFACTS:
-            type: boolean
-            description: Use no artifacts for next build (will be saved as clean artifacts)
-            required: false
-            default: false
-        windows_build:
-            description: 'Build Windows'
-            required: false
-            default: true
-            type: boolean
-        linux_build:
-            description: 'Build Linux'
-            required: false
-            default: true
-            type: boolean
-        android_build:
-            description: 'Build Android'
-            required: false
-            default: true
-            type: boolean
+      CLEAN_ARTIFACTS:
+        description: Use no artifacts for next build (will be saved as clean artifacts)
+        type: boolean
+        default: false
+      android_build:
+        description: Build Android
+        type: boolean
+        default: true
+      ios_build:
+        description: Build iOS
+        type: boolean
+        default: true
+      linux_build:
+        description: Build Linux
+        type: boolean
+        default: true
+      mac_build:
+        description: Build Mac
+        type: boolean
+        default: true
+      windows_build:
+        description: Build Windows
+        type: boolean
+        default: true
   push:
     branches:
       - main
       - development
-      - stabilization/**
       - hotfix/**
       - point-release/**
+      - stabilization/**
 
 jobs:
-
-# The following jobs are used to build the project for the different platforms.
-# The parameters are the following:
-# - compiler: The compiler to use (msvc, clang, gcc)
-# - config: The configuration to use (profile, release). This is defined by presets in ../scripts/build/Platform/<os>/build_config.json
-# - image: The image to use (windows-2022, ubuntu-22.04). The images are defined from runners images repo: https://github.com/actions/runner-images
-# - platform: The platform to use (Windows, Linux, Android)
-# - type: The type of build to use (profile, asset_profile, test_profile, test_cpu_profile, release)
-# - last_artifact: Whether to use the artifact from the last run, from the target branch if it's a pull request or its own branch if it's a push
-# - desktop: Whether to use the desktop environment for tests (Linux only)
-# - msvc_toolset_version: MSVC toolset version to install (Windows only)
-# - msvc_platform_toolset: MSVC platform toolset name, e.g. v143 (Windows only)
-# - clang_version: Clang major version to install (Linux only)
-# - ndk_version: Android NDK version to install (Android only)
-# - cmake_version: CMake version constraint to use (all platforms)
-# - gradle_version: Gradle version to use (Android only)
-
-#### Windows Build ####
-    Windows-Profile:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
-        uses: ./.github/workflows/windows-build.yml
-        with:
-            compiler: msvc
-            config: profile
-            image: windows-2022
-            platform: Windows
-            type: profile
-            last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }} # If CLEAN_ARTIFACTS is false, then this returns true
-            msvc_toolset_version: '14.29'
-            msvc_platform_toolset: 'v142'
-            cmake_version: '4.2.3'
-    
-    Windows-Asset:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
-        needs: Windows-Profile
-        uses: ./.github/workflows/windows-build.yml
-        with:
-            compiler: msvc
-            config: profile
-            image: windows-2022
-            platform: Windows
-            type: asset_profile
-            msvc_toolset_version: '14.29'
-            msvc_platform_toolset: 'v142'
-            cmake_version: '4.2.3'
-
-    Windows-Test:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
-        needs: Windows-Asset
-        uses: ./.github/workflows/windows-build.yml
-        with:
-            compiler: msvc
-            config: profile
-            image: windows-2022
-            platform: Windows
-            type: test_cpu_profile
-            msvc_toolset_version: '14.29'
-            msvc_platform_toolset: 'v142'
-            cmake_version: '4.2.3'
-
-    Windows-Release:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
-        uses: ./.github/workflows/windows-build.yml
-        with:
-            compiler: msvc
-            config: release
-            image: windows-2022
-            platform: Windows
-            type: release
-            last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            msvc_toolset_version: '14.29'
-            msvc_platform_toolset: 'v142'
-            cmake_version: '4.2.3'
-
-#### Linux Build ####
-    Linux-Profile:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
-        uses: ./.github/workflows/linux-build.yml
-        with:
-            compiler: clang
-            config: profile
-            image: ubuntu-22.04
-            platform: Linux
-            type: profile
-            last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            clang_version: '14'
-            cmake_version: '4.2.3'
-
-    Linux-Asset:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
-        needs: Linux-Profile
-        uses: ./.github/workflows/linux-build.yml
-        with:
-            compiler: clang
-            config: profile
-            image: ubuntu-22.04
-            platform: Linux
-            type: asset_profile
-            clang_version: '14'
-            cmake_version: '4.2.3'
-
-    Linux-Test:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
-        needs: Linux-Asset
-        uses: ./.github/workflows/linux-build.yml
-        with:
-            compiler: clang
-            config: profile
-            image: ubuntu-22.04
-            platform: Linux
-            type: test_profile
-            desktop: true
-            clang_version: '14'
-            cmake_version: '4.2.3'
+  # The following jobs are used to build the project for the different platforms.
+  # The parameters are the following:
+  # - compiler: The compiler to use (msvc, clang, gcc)
+  # - config: The configuration to use (profile, release). This is defined by presets in ../scripts/build/Platform/<os>/build_config.json
+  # - image: The image to use (windows-2022, ubuntu-22.04, macos-15, macos-15-intel). The images are defined from runners images repo: https://github.com/actions/runner-images
+  # - platform: The platform to use (Windows, Linux, Mac, Android, iOS)
+  # - type: The type of build to use (profile, asset_profile, test_profile, test_cpu_profile, release)
+  # - last_artifact: Whether to use the artifact from the last run, from the target branch if it's a pull request or its own branch if it's a push
+  # - desktop: Whether to use the desktop environment for tests (Linux only)
+  # - msvc_toolset_version: MSVC toolset version to install (Windows only)
+  # - msvc_platform_toolset: MSVC platform toolset name, e.g. v143 (Windows only)
+  # - clang_version: Clang major version to install (Linux only)
+  # - ndk_version: Android NDK version to install (Android only)
+  # - cmake_version: CMake version constraint to use (all platforms)
+  # - gradle_version: Gradle version to use (Android only)
 
 #### Android Build ####
-    Android-Profile:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
-        uses: ./.github/workflows/android-build.yml
-        with:
-            compiler: clang
-            config: profile
-            image: windows-2022
-            platform: Android
-            type: profile
-            last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            ndk_version: '25.1.8937393'
-            gradle_version: '8.12'
-            cmake_version: '4.2.3'
+  Android-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: windows-2022
+      platform: Android
+      type: profile
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
+      ndk_version: "25.1.8937393"
+      gradle_version: "8.12"
+      cmake_version: &cmake_version "4.2.3"
 
-    Android-Asset:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
-        uses: ./.github/workflows/android-build.yml
-        with:
-            compiler: msvc
-            config: asset_profile
-            image: windows-2022
-            platform: Android
-            type: asset_profile
-            last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            msvc_toolset_version: '14.29'
-            msvc_platform_toolset: 'v142'
-            ndk_version: '25.1.8937393'
-            gradle_version: '8.12'
-            cmake_version: '4.2.3'
-            
-    Android-Gradle:
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
-        uses: ./.github/workflows/android-build.yml
-        with:
-            compiler: clang
-            config: gradle
-            image: windows-2022
-            platform: Android
-            type: gradle
-            last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
-            ndk_version: '25.1.8937393'
-            gradle_version: '8.12'
-            cmake_version: '4.2.3'
+  Android-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: msvc
+      config: asset_profile
+      image: windows-2022
+      platform: Android
+      type: asset_profile
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
+      msvc_toolset_version: "14.29"
+      msvc_platform_toolset: "v142"
+      ndk_version: "25.1.8937393"
+      gradle_version: "8.12"
+      cmake_version: *cmake_version
+
+  Android-Gradle:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: gradle
+      image: windows-2022
+      platform: Android
+      type: gradle
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
+      ndk_version: "25.1.8937393"
+      gradle_version: "8.12"
+      cmake_version: *cmake_version
+
+#### iOS Build ####
+  iOS-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      type: profile
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
+      cmake_version: *cmake_version
+
+  iOS-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    needs: iOS-Profile
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      type: asset_profile
+      cmake_version: *cmake_version
+
+  iOS-Test:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.ios_build }}
+    needs: iOS-Asset
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      type: device_test_profile
+      cmake_version: *cmake_version
+
+#### Linux Build ####
+  Linux-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Linux
+      type: profile
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
+      clang_version: "14"
+      cmake_version: *cmake_version
+
+  Linux-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    needs: Linux-Profile
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Linux
+      type: asset_profile
+      clang_version: "14"
+      cmake_version: *cmake_version
+
+  Linux-Test:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    needs: Linux-Asset
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Linux
+      type: test_profile
+      desktop: true
+      clang_version: "14"
+      cmake_version: *cmake_version
+
+#### Mac Build ####
+  Mac-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
+    uses: ./.github/workflows/mac-build.yml
+    with:
+      config: profile
+      type: profile
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
+      cmake_version: *cmake_version
+
+  Mac-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
+    needs: Mac-Profile
+    uses: ./.github/workflows/mac-build.yml
+    with:
+      config: profile
+      type: asset_profile
+      cmake_version: *cmake_version
+
+  Mac-Test:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.mac_build }}
+    needs: Mac-Asset
+    uses: ./.github/workflows/mac-build.yml
+    with:
+      config: profile
+      type: test_profile
+      cmake_version: *cmake_version
+
+#### Windows Build ####
+  Windows-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2022
+      platform: Windows
+      type: profile
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }} # If CLEAN_ARTIFACTS is false, then this returns true
+      msvc_toolset_version: "14.29"
+      msvc_platform_toolset: "v142"
+      cmake_version: *cmake_version
+
+  Windows-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    needs: Windows-Profile
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2022
+      platform: Windows
+      type: asset_profile
+      msvc_toolset_version: "14.29"
+      msvc_platform_toolset: "v142"
+      cmake_version: *cmake_version
+
+  Windows-Test:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    needs: Windows-Asset
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2022
+      platform: Windows
+      type: test_cpu_profile
+      msvc_toolset_version: "14.29"
+      msvc_platform_toolset: "v142"
+      cmake_version: *cmake_version
+
+  Windows-Release:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: release
+      image: windows-2022
+      platform: Windows
+      type: release
+      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
+      msvc_toolset_version: "14.29"
+      msvc_platform_toolset: "v142"
+      cmake_version: *cmake_version

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -46,6 +46,9 @@ on:
       - point-release/**
       - stabilization/**
 
+env:
+  CMAKE_VERSION: &cmake_version "4.2.3"
+
 jobs:
   # The following jobs are used to build the project for the different platforms.
   # The parameters are the following:
@@ -76,7 +79,7 @@ jobs:
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
       ndk_version: "25.1.8937393"
       gradle_version: "8.12"
-      cmake_version: &cmake_version "4.2.3"
+      cmake_version: *cmake_version
 
   Android-Asset:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,179 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+name: iOS Build
+
+# These jobs are to be triggered by ar.yml
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        default: macos-15-intel
+      config:
+        type: string
+        required: true
+      type:
+        type: string
+        required: true
+      last_artifact:
+        type: boolean
+        required: false
+      cmake_version:
+        type: string
+        required: false
+
+run-name: iOS - ${{ inputs.type }}
+
+# Note: All 3P Github Actions use the commit hash for security reasons
+# Avoid using the tag version, which is vulnerable to supply chain attacks
+
+jobs:
+  Build:
+    runs-on: ${{ inputs.image }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          show-progress: false
+
+      - name: Git LFS pull
+        run: |
+          git lfs install
+          git lfs pull
+
+      - name: Setup 3p, user, and build folders
+        run: |
+          mkdir -p .o3de build 3rdParty && ln -sf "$(pwd)/.o3de" ~/.o3de
+
+      - name: Setup ccache
+        uses: chocobo1/setup-ccache-action@37c3347f8a7738e82aab7a06f276f7a12e3008fb # v1.5.3
+        continue-on-error: true
+        if: always()
+        with:
+          prepend_symlinks_to_path: false
+          store_cache: false
+          restore_cache: false
+          ccache_options: |
+            cache_dir=${{ github.workspace }}/.ccache
+            hash_dir=false
+            max_size=10G
+
+      - name: Check for rerun
+        id: check-rerun
+        run: |
+          # GitHub sets GITHUB_RUN_ATTEMPT to track reruns
+          if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "is_rerun=true" >> $GITHUB_OUTPUT
+            echo "This is rerun attempt #$GITHUB_RUN_ATTEMPT"
+          else
+            echo "is_rerun=false" >> $GITHUB_OUTPUT
+            echo "This is the first run attempt"
+          fi
+
+      - name: Get last run
+        # Get the last runid of the target branch of a PR or the current branch
+        # Skip if this is a rerun to either freshly build or get artifacts from existing run
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        id: last-run-id
+        if: ${{ inputs.last_artifact && steps.check-rerun.outputs.is_rerun != 'true' }}
+        continue-on-error: true
+        with:
+          workflow_search: true
+          workflow_conclusion: ""
+          branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+          search_artifacts: true
+          check_artifacts: true
+          name: O3DE-iOS-${{ inputs.config }}-build
+          dry_run: true
+
+      - name: Set artifact run ID
+        # Set the run ID of the artifact to be used for the download step
+        id: set-artifact-run-id
+        if: steps.last-run-id.outcome == 'success' && inputs.last_artifact == true
+        run: |
+          runId=${{ fromJSON(steps.last-run-id.outputs.artifacts)[0].workflow_run.id }}
+          echo "artifact_run_id=$runId" >> $GITHUB_OUTPUT
+          echo "Using artifacts from previous run: $runId"
+
+      - name: Restore artifact cache
+        # Restore the artifact from the "Get last run" step or from the current run
+        id: restore-artifact-cache
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        continue-on-error: true
+        with:
+          name: O3DE-iOS-${{ inputs.config }}-build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.set-artifact-run-id.outputs.artifact_run_id || github.run_id }}
+
+      - name: Extract artifact
+        # Extract the tar file from the artifact
+        id: extract-artifact
+        continue-on-error: true
+        if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
+        run: |
+          if [ -f ${{ github.workspace }}/cache.tar ]; then
+            gtar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
+            rm ${{ github.workspace }}/cache.tar
+            ccache --zero-stats --cleanup
+          fi
+
+      - name: Setup cmake
+        # Pin the version of cmake
+        if: ${{ inputs.cmake_version }}
+        uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # v4.2.3
+        with:
+          cmakeVersion: "${{ inputs.cmake_version }}"
+
+      - name: Configure environment
+        continue-on-error: true
+        run: |
+          echo "Installing dependencies"
+          brew install --quiet xcbeautify
+          echo "Getting python..."
+          ./python/get_python.sh
+          echo "Installing additional python dependencies..."
+          ./python/pip.sh install tempfile2 PyGithub
+          df -h
+
+      - name: Build ${{ inputs.type }}
+        # Builds with presets in ../scripts/build/Platform/iOS/build_config.json
+        timeout-minutes: 330
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          LY_3RDPARTY_PATH: ${{ github.workspace }}/3rdParty
+          LY_PACKAGE_SERVER_URLS: "https://d1gg6ket0m44ly.cloudfront.net;https://d3t6xeg4fgfoum.cloudfront.net"
+        run: python/python.sh -u scripts/build/ci_build.py --platform iOS --type ${{ inputs.type }}
+
+      - name: Compress artifacts
+        # Compress with posix format to preserve permissions and timestamps at nanosecond precision
+        # Skip compression and upload if the type is a test to reduce dirty build artifacts from previous runs
+        id: compress-artifacts
+        if: ${{ (steps.extract-artifact.outcome == 'success' || steps.extract-artifact.outcome == 'skipped') && !cancelled() && !contains(inputs.type, 'test') }}
+        continue-on-error: true
+        run: |
+          gtar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+            .ccache \
+            .o3de/python/downloaded_packages \
+            3rdParty/downloaded_packages \
+            AutomatedTesting/Cache
+
+      - name: Save artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
+        continue-on-error: true
+        with:
+          name: O3DE-iOS-${{ inputs.config }}-build
+          compression-level: 1
+          overwrite: true
+          path: |
+            ${{ github.workspace }}/cache.tar

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -1,0 +1,180 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+name: Mac Build
+
+# These jobs are to be triggered by ar.yml
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      image:
+        type: string
+        default: macos-15-intel
+      config:
+        type: string
+        required: true
+      type:
+        type: string
+        required: true
+      last_artifact:
+        type: boolean
+        required: false
+      cmake_version:
+        type: string
+        required: false
+
+run-name: Mac - ${{ inputs.type }}
+
+# Note: All 3P Github Actions use the commit hash for security reasons
+# Avoid using the tag version, which is vulnerable to supply chain attacks
+
+jobs:
+  Build:
+    runs-on: ${{ inputs.image }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          show-progress: false
+
+      - name: Git LFS pull
+        # Minimal pull for profile builds, otherwise pull all
+        run: |
+          git lfs install
+          [[ "${{ inputs.type }}" == "profile" ]] && git lfs pull --include "*.ico,*.bmp" || git lfs pull
+
+      - name: Setup 3p, user, and build folders
+        run: |
+          mkdir -p .o3de build 3rdParty && ln -sf "$(pwd)/.o3de" ~/.o3de
+
+      - name: Setup ccache
+        uses: chocobo1/setup-ccache-action@37c3347f8a7738e82aab7a06f276f7a12e3008fb # v1.5.3
+        continue-on-error: true
+        if: always()
+        with:
+          prepend_symlinks_to_path: false
+          store_cache: false
+          restore_cache: false
+          ccache_options: |
+            cache_dir=${{ github.workspace }}/.ccache
+            hash_dir=false
+            max_size=10G
+
+      - name: Check for rerun
+        id: check-rerun
+        run: |
+          # GitHub sets GITHUB_RUN_ATTEMPT to track reruns
+          if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "is_rerun=true" >> $GITHUB_OUTPUT
+            echo "This is rerun attempt #$GITHUB_RUN_ATTEMPT"
+          else
+            echo "is_rerun=false" >> $GITHUB_OUTPUT
+            echo "This is the first run attempt"
+          fi
+
+      - name: Get last run
+        # Get the last runid of the target branch of a PR or the current branch
+        # Skip if this is a rerun to either freshly build or get artifacts from existing run
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        id: last-run-id
+        if: ${{ inputs.last_artifact && steps.check-rerun.outputs.is_rerun != 'true' }}
+        continue-on-error: true
+        with:
+          workflow_search: true
+          workflow_conclusion: ""
+          branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+          search_artifacts: true
+          check_artifacts: true
+          name: O3DE-Mac-${{ inputs.config }}-build
+          dry_run: true
+
+      - name: Set artifact run ID
+        # Set the run ID of the artifact to be used for the download step
+        id: set-artifact-run-id
+        if: steps.last-run-id.outcome == 'success' && inputs.last_artifact == true
+        run: |
+          runId=${{ fromJSON(steps.last-run-id.outputs.artifacts)[0].workflow_run.id }}
+          echo "artifact_run_id=$runId" >> $GITHUB_OUTPUT
+          echo "Using artifacts from previous run: $runId"
+
+      - name: Restore artifact cache
+        # Restore the artifact from the "Get last run" step or from the current run
+        id: restore-artifact-cache
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        continue-on-error: true
+        with:
+          name: O3DE-Mac-${{ inputs.config }}-build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.set-artifact-run-id.outputs.artifact_run_id || github.run_id }}
+
+      - name: Extract artifact
+        # Extract the tar file from the artifact
+        id: extract-artifact
+        continue-on-error: true
+        if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
+        run: |
+          if [ -f ${{ github.workspace }}/cache.tar ]; then
+            gtar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
+            rm ${{ github.workspace }}/cache.tar
+            ccache --zero-stats --cleanup
+          fi
+
+      - name: Setup cmake
+        # Pin the version of cmake
+        if: ${{ inputs.cmake_version }}
+        uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # v4.2.3
+        with:
+          cmakeVersion: "${{ inputs.cmake_version }}"
+
+      - name: Configure environment
+        continue-on-error: true
+        run: |
+          echo "Installing dependencies"
+          brew install --quiet xcbeautify
+          echo "Getting python..."
+          ./python/get_python.sh
+          echo "Installing additional python dependencies..."
+          ./python/pip.sh install tempfile2 PyGithub
+          df -h
+
+      - name: Build ${{ inputs.type }}
+        # Builds with presets in ../scripts/build/Platform/Mac/build_config.json
+        timeout-minutes: 330
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          LY_3RDPARTY_PATH: ${{ github.workspace }}/3rdParty
+          LY_PACKAGE_SERVER_URLS: "https://d1gg6ket0m44ly.cloudfront.net;https://d3t6xeg4fgfoum.cloudfront.net"
+        run: python/python.sh -u scripts/build/ci_build.py --platform Mac --type ${{ inputs.type }}
+
+      - name: Compress artifacts
+        # Compress with posix format to preserve permissions and timestamps at nanosecond precision
+        # Skip compression and upload if the type is a test to reduce dirty build artifacts from previous runs
+        id: compress-artifacts
+        if: ${{ (steps.extract-artifact.outcome == 'success' || steps.extract-artifact.outcome == 'skipped') && !cancelled() && !contains(inputs.type, 'test') }}
+        continue-on-error: true
+        run: |
+          gtar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+            .ccache \
+            .o3de/python/downloaded_packages \
+            3rdParty/downloaded_packages \
+            AutomatedTesting/Cache
+
+      - name: Save artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
+        continue-on-error: true
+        with:
+          name: O3DE-Mac-${{ inputs.config }}-build
+          compression-level: 1
+          overwrite: true
+          path: |
+            ${{ github.workspace }}/cache.tar

--- a/cmake/CompilerLauncher.cmake
+++ b/cmake/CompilerLauncher.cmake
@@ -73,16 +73,6 @@ function(_o3de_compiler_launcher)
         set(${out_path} "${resolved}" PARENT_SCOPE)
     endfunction()
 
-    # CMake does not natively initialize CMAKE_<LANG>_COMPILER_LAUNCHER from
-    # environment variables, so we do it here as a convenience.
-    foreach (cl_lang IN ITEMS ${supported_languages})
-        if (NOT DEFINED CMAKE_${cl_lang}_COMPILER_LAUNCHER
-            AND DEFINED ENV{CMAKE_${cl_lang}_COMPILER_LAUNCHER}
-            AND NOT "$ENV{CMAKE_${cl_lang}_COMPILER_LAUNCHER}" STREQUAL "")
-            set(CMAKE_${cl_lang}_COMPILER_LAUNCHER "$ENV{CMAKE_${cl_lang}_COMPILER_LAUNCHER}" CACHE STRING "")
-        endif ()
-    endforeach ()
-
     # Early return if no launcher is configured
     if (NOT CMAKE_C_COMPILER_LAUNCHER AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
         message(VERBOSE "CompilerLauncher: Not configured")

--- a/scripts/build/Platform/Mac/build_mac.sh
+++ b/scripts/build/Platform/Mac/build_mac.sh
@@ -51,8 +51,20 @@ fi
 # Split the configuration on semi-colon and use the cmake --build wrapper to run the underlying build command for each
 for config in $(echo $CONFIGURATION | sed "s/;/ /g")
 do
-    echo [ci_build] cmake --build . --target ${CMAKE_TARGET} --config ${config} -j $(/usr/sbin/sysctl -n hw.ncpu) -- ${CMAKE_NATIVE_BUILD_ARGS}
-    cmake --build . --target ${CMAKE_TARGET} --config ${config} -j $(/usr/sbin/sysctl -n hw.ncpu) -- ${CMAKE_NATIVE_BUILD_ARGS}
+    build_cmd="cmake --build . --target ${CMAKE_TARGET} --config ${config} -j $(/usr/sbin/sysctl -n hw.ncpu) -- ${CMAKE_NATIVE_BUILD_ARGS}"
+
+    # Use xcbeautify to format the output if available
+    if command -v xcbeautify &> /dev/null; then
+        xcbeautify_args="--is-ci --disable-logging"
+
+        if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+            xcbeautify_args="${xcbeautify_args} --renderer github-actions"
+        fi
+
+        build_cmd="${build_cmd} | xcbeautify ${xcbeautify_args}"
+    fi
+
+    eval ${build_cmd}
 done
 
 popd


### PR DESCRIPTION
## What does this PR do?

### New Workflows:
- Added `ios-build.yml` workflow (disabled by default pending MiniAudio fixes; also includes a broken test job placeholder, which needs a simulator to be provisioned to work)
- Added `mac-build.yml` workflow for macOS builds

### Workflow Changes:
- Reformatted ar.yml workflow to use consistent 2-space indentation and alphabetically sorted jobs/inputs
- Updated actions/checkout to v6.0.2
- Updated chocobo1/setup-ccache-action to v1.5.3
- Added missing copyright headers to workflow files

## How was this PR tested?

AR completes successfully.
