### PR TITLE
Allows gems to be programmatically selected by cmake scripts

### DIFF
--- a/cmake/Subdirectories.cmake
+++ b/cmake/Subdirectories.cmake
@@ -349,6 +349,13 @@ function(get_all_external_subdirectories_for_o3de_object output_subdirs object_t
     o3de_read_json_array(initial_gem_names ${object_path}/${object_json_filename} "gem_names")
     set(gem_names "")
 
+    # allow additional gems to be specified for an object through the O3DE_${object_type}_${object_name}_GEMS GLOBAL property
+    # for example O3DE_PROJECT_MyProject_GEMS
+    get_property(additional_gems GLOBAL PROPERTY "O3DE_${object_type}_${object_name}_GEMS")
+    if (additional_gems)
+        list(APPEND initial_gem_names ${additional_gems})
+    endif()
+
     # Gem dependency resolution can be disabled to speed up configuration 
     # for projects where it is not needed
     if(initial_gem_names AND NOT O3DE_DISABLE_GEM_DEPENDENCY_RESOLUTION)


### PR DESCRIPTION
## What does this PR do?

This allows projects (for example MultiplayerSample) to have CMake options to select which gems to include, and then have those gems be included in the build, without having to modify the project.json file.

Note this variable needs to be set early on, before the inclusion of findO3DE.cmake or any other o3de cmake file (so it cannot be in a function), and it cannot be inside your Gem's cmake file (it must be in project root cmake), as that would be too late - by the time the project's gem's  CMake file is being executed, its already done all of the subdirectory calculations and is currently iterating over the subdirectories already.


## How was this PR tested?


Testing:  Multiplayer sample, switching between using PopcornFX and OpenParticleSystem without having to modify the project.json file.

Example of usage (o3de-multiplayersample root CMakelists.txt file)

```cmake

set(MULTIPLAYERSAMPLE_USE_POPCORNFX FALSE CACHE BOOL "Use PopcornFX 3rd Party particle library.")
set(MULTIPLAYERSAMPLE_USE_WWISE FALSE CACHE BOOL "Use Wwise 3rd Party audio library.  If enabled, you will have to download and install Wwise")

macro(MultiplayerSample_add_optional_gems)
    # programmatically enable gems based on options.  
    # This has to be done up-front because it controls what subdirectories are recursed into
    # when reading all the cmake files, which happens in o3de_initialize().
    # to do this we just have to append them to the global property
    # "O3DE_<ObjectType>_<ProjectName>_GEMS", and in this case, ObjectType is PROJECT

    # the following line is not strictly necessary as we are assuming nothing else besides the project
    # sets PROJECT gems.
    get_property(additional_project_gems GLOBAL PROPERTY "O3DE_PROJECT_MultiplayerSample_GEMS")
    # if we're using POPCORNFX, we don't use OpenParticle, and vice versa.
    if (MULTIPLAYERSAMPLE_USE_POPCORNFX)
        message(STATUS "Using PopcornFX as the particle engine for MultiplayerSample (option MULTIPLAYERSAMPLE_USE_POPCORNFX is set)")
        # Append to any existing active gems mapped using the ${object_type} key
        list(APPEND additional_project_gems PopcornFX)
    else()
        list(APPEND additional_project_gems OpenParticleSystem)
    endif()
    # if we're using WWISE, we don't use MiniAudio, and vice versa.
    if (MULTIPLAYERSAMPLE_USE_WWISE)
        message(STATUS "Using WWISE as the audio engine for MultiplayerSample (option MULTIPLAYERSAMPLE_USE_WWISE is set)")
        list(APPEND additional_project_gems AudioEngineWwise)
    else()
        list(APPEND additional_project_gems MiniAudio)
    endif()
    set_property(GLOBAL PROPERTY "O3DE_PROJECT_MultiplayerSample_GEMS" "${additional_project_gems}")
endmacro()
...
...
...
...
 MultiplayerSample_add_optional_gems()
 o3de_initialize()
end()
```