### PR TITLE
Fix clang-cl based Windows builds

### DIFF
--- a/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
@@ -98,18 +98,17 @@ foreach(targetname gtest gmock gtest_main gmock_main)
     set_target_properties(${targetname} PROPERTIES FOLDER "3rdParty Dependencies")
     # fast math is incompatible with google test / google mock / etc.
     target_compile_options(${targetname} ${O3DE_TARGET_COMPILE_OPTION_DISABLE_FAST_MATH})
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
+        # Workaround for a googletest bug with char conversions recognized by Clang 21+
+        # See https://github.com/google/googletest/issues/4762
+        # TODO: remove when googletest is updated
+        target_compile_options(${targetname} PUBLIC -Wno-character-conversion)
+    endif()
 endforeach()
 
 unset(CMAKE_POLICY_DEFAULT_CMP0148)
 set(CMAKE_WARN_DEPRECATED ${OLD_CMAKE_WARN_DEPRECATED} CACHE BOOL "" FORCE)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
-    # Workaround for a googletest bug with char conversions recognized by Clang 21+
-    # See https://github.com/google/googletest/issues/4762
-    # TODO: remove when googletest is updated
-    target_compile_options(gmock PUBLIC -Wno-character-conversion)
-    target_compile_options(gtest PUBLIC -Wno-character-conversion)
-endif()
 
 FetchContent_GetProperties(
     googletest

--- a/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
@@ -107,6 +107,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION
     # Workaround for a googletest bug with char conversions recognized by Clang 21+
     # See https://github.com/google/googletest/issues/4762
     # TODO: remove when googletest is updated
+    target_compile_options(gmock PUBLIC -Wno-character-conversion)
     target_compile_options(gtest PUBLIC -Wno-character-conversion)
 endif()
 

--- a/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
@@ -72,16 +72,6 @@ set(OLD_CMAKE_VISIBILITY_INLINES_HIDDEN "${CMAKE_VISIBILITY_INLINES_HIDDEN}")
 set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL}) # save the old CMAKE_MESSAGE_LOG_LEVEL
 set(CMAKE_MESSAGE_LOG_LEVEL ${O3DE_FETCHCONTENT_MESSAGE_LEVEL})
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
-    # Workaround for a googletest bug with char conversions recognized by Clang 21+
-    # See https://github.com/google/googletest/issues/4762
-    # TODO: remove when googletest is updated
-    ly_append_configurations_options(
-        COMPILATION
-            -Wno-character-conversion
-    )
-endif()
-
 FetchContent_MakeAvailable(googletest)
 
 set(CMAKE_MESSAGE_LOG_LEVEL ${OLD_LOG_LEVEL})
@@ -113,6 +103,12 @@ endforeach()
 unset(CMAKE_POLICY_DEFAULT_CMP0148)
 set(CMAKE_WARN_DEPRECATED ${OLD_CMAKE_WARN_DEPRECATED} CACHE BOOL "" FORCE)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
+    # Workaround for a googletest bug with char conversions recognized by Clang 21+
+    # See https://github.com/google/googletest/issues/4762
+    # TODO: remove when googletest is updated
+    target_compile_options(gtest PUBLIC -Wno-character-conversion)
+endif()
 
 FetchContent_GetProperties(
     googletest

--- a/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
@@ -72,6 +72,16 @@ set(OLD_CMAKE_VISIBILITY_INLINES_HIDDEN "${CMAKE_VISIBILITY_INLINES_HIDDEN}")
 set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL}) # save the old CMAKE_MESSAGE_LOG_LEVEL
 set(CMAKE_MESSAGE_LOG_LEVEL ${O3DE_FETCHCONTENT_MESSAGE_LEVEL})
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
+    # Workaround for a googletest bug with char conversions recognized by Clang 21+
+    # See https://github.com/google/googletest/issues/4762
+    # TODO: remove when googletest is updated
+    ly_append_configurations_options(
+        COMPILATION
+            -Wno-character-conversion
+    )
+endif()
+
 FetchContent_MakeAvailable(googletest)
 
 set(CMAKE_MESSAGE_LOG_LEVEL ${OLD_LOG_LEVEL})
@@ -157,5 +167,3 @@ add_library(3rdParty::googletest::GTest ALIAS gtest)
 add_library(3rdParty::googletest::GMock ALIAS gmock)
 
 set(googletest_FOUND TRUE)
-
-

--- a/cmake/Configurations.cmake
+++ b/cmake/Configurations.cmake
@@ -236,6 +236,7 @@ if (USE_FAST_MATH)
             # append our definition, even though __FAST_MATH__ is already defined
             # it gets undefined if any other flag that affects the fast math is used
             O3DE_USING_FAST_MATH 
+
         COMPILATION
             ${O3DE_COMPILE_OPTION_ENABLE_FAST_MATH}
     )
@@ -245,4 +246,3 @@ else()
             ${O3DE_COMPILE_OPTION_DISABLE_FAST_MATH}
     )
 endif()
-

--- a/cmake/LYWrappers.cmake
+++ b/cmake/LYWrappers.cmake
@@ -335,6 +335,13 @@ function(ly_add_target)
             set_property(TARGET ${ly_add_target_NAME} PROPERTY ${prop} ON)
         endif()
     endforeach()
+    if(${ly_add_target_AUTOMOC})
+        # Enable AUTOMOC_PATH_PREFIX so that moc generates shorter include paths (relative to the source directory)
+        # instead of deep relative paths from the moc output location back to the source tree.
+        # Without this, clang-cl's un-normalized /showIncludes paths can exceed Windows MAX_PATH (260 chars),
+        # causing ninja's MSVC dep parser to fail with "path too long".
+        set_property(TARGET ${ly_add_target_NAME} PROPERTY AUTOMOC_PATH_PREFIX ON)
+    endif()
     if(${ly_add_target_AUTOUIC})
         get_target_property(all_ui_sources ${ly_add_target_NAME} SOURCES)
         list(FILTER all_ui_sources INCLUDE REGEX "^.*\\.ui$")

--- a/cmake/Platform/Android/Configurations_android.cmake
+++ b/cmake/Platform/Android/Configurations_android.cmake
@@ -52,6 +52,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             -rdynamic            # add ALL symbols to the dynamic symbol table
             -Wl,--no-undefined   # tell the gcc linker to fail if it finds undefined references
             -Wl,--gc-sections    # discards unused sections
+            
+            # Guarantees that the native android activity entry point is present in the final binary
             -u ANativeActivity_onCreate
 
             -landroid            # Android Library

--- a/cmake/Platform/Android/Configurations_android.cmake
+++ b/cmake/Platform/Android/Configurations_android.cmake
@@ -42,10 +42,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         COMPILATION
             -femulated-tls           # All accesses to TLS variables are converted to calls to __emutls_get_address in the runtime library
             -fno-aligned-allocation  # Disable use of C++17 aligned_alloc for operator new/delete
-
         COMPILATION_DEBUG
             -gdwarf-2            # DWARF 2 debugging information
-
         COMPILATION_PROFILE
             -g                  # debugging information
             -gdwarf-2           # DWARF 2 debugging information
@@ -54,19 +52,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             -rdynamic            # add ALL symbols to the dynamic symbol table
             -Wl,--no-undefined   # tell the gcc linker to fail if it finds undefined references
             -Wl,--gc-sections    # discards unused sections
+            -u ANativeActivity_onCreate
 
             -landroid            # Android Library
             -llog                # log library for android
             -lc++_shared
             -ldl                 # Dynamic
             -stdlib=libc++
-
-            -u ANativeActivity_onCreate
-
         LINK_NON_STATIC_DEBUG
             -Wl,--build-id       # Android Studio needs the libraries to have an id in order to match them with what"s running on the device.
             -shared
-
         LINK_NON_STATIC_PROFILE
             -Wl,--build-id       # Android Studio needs the libraries to have an id in order to match them with what"s running on the device.
             -shared
@@ -84,4 +79,3 @@ else()
     message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} not supported in ${PAL_PLATFORM_NAME}")
 
 endif()
-

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -57,6 +57,7 @@ ly_append_configurations_options(
         _FORTIFY_SOURCE=2
     DEFINES_RELEASE
         _FORTIFY_SOURCE=2
+
     COMPILATION
         -fno-exceptions
         -fvisibility=hidden
@@ -72,32 +73,23 @@ ly_append_configurations_options(
             # was done to fix all hits. Leaving this disabled until there is a matching warning in MSVC.
 
         -Wrange-loop-analysis
-        -Wno-unknown-warning-option # used as a way to mark warnings that are MSVC only
+        -Wno-dllexport-explicit-instantiation-decl  # explicit instantiation declaration should not be 'dllexport'
         -Wno-parentheses
         -Wno-reorder
         -Wno-switch
         -Wno-undefined-var-template
-        -Wno-dllexport-explicit-instantiation-decl  # explicit instantiation declaration should not be 'dllexport'
-
-        ###################
-        # Enabled warnings (that are disabled by default)
-        ###################
-
+        -Wno-unknown-warning-option # used as a way to mark warnings that are MSVC only
     COMPILATION_DEBUG
         -O0                         # No optimization
         -g                          # debug symbols
         -fno-inline                 # don't inline functions
-
         -fstack-protector-all       # Enable stack protectors for all functions
         -fstack-check
-
     COMPILATION_PROFILE
         -O2
         -g                          # debug symbols
-
         -fstack-protector-all       # Enable stack protectors for all functions
         -fstack-check
-
     COMPILATION_RELEASE
         -O2
 )
@@ -107,10 +99,11 @@ if(LY_BUILD_WITH_ADDRESS_SANITIZER)
         COMPILATION_DEBUG
             -fsanitize=address
             -fno-omit-frame-pointer
+
         LINK_NON_STATIC_DEBUG
             -shared-libsan
             -fsanitize=address
     )
 endif()
-include(cmake/Platform/Common/TargetIncludeSystemDirectories_supported.cmake)
 
+include(cmake/Platform/Common/TargetIncludeSystemDirectories_supported.cmake)

--- a/cmake/Platform/Common/GCC/Configurations_gcc.cmake
+++ b/cmake/Platform/Common/GCC/Configurations_gcc.cmake
@@ -66,7 +66,6 @@ ly_append_configurations_options(
 
         ${LY_GCC_GCOV_FLAGS}
         ${LY_GCC_GPROF_FLAGS}
-
     COMPILATION_CXX
         -fno-exceptions
         -fvisibility=hidden
@@ -103,7 +102,6 @@ ly_append_configurations_options(
         -Wno-switch
         -Wno-uninitialized
         -Wno-unused-result
-
     COMPILATION_DEBUG
         -O0 # No optimization
         -g # debug symbols

--- a/cmake/Platform/Common/MSVC/Configurations_clang.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_clang.cmake
@@ -27,7 +27,7 @@ set(O3DE_COMPILE_OPTION_DISABLE_WARNINGS PRIVATE /W0)
 
 # C++20 no longer allows to implicitly convert between enum values of different types or enum values and integral types.
 # This is problematic if 3rd-party libraries use such operations in header files.
-set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE /Wv:18)
+set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE /Wv:18 -Wno-deprecated-enum-enum-conversion)
 
 # If (USE_FAST_MATH) is set, then enable fast math optimizations.
 # Some targets might need to disable fast math individually (likely 3rd Party libraries)
@@ -44,36 +44,34 @@ ly_append_configurations_options(
         _FORTIFY_SOURCE=2
     DEFINES_RELEASE
         _FORTIFY_SOURCE=2
+
     COMPILATION
-        -Wno-reorder-ctor
-        -Wno-logical-not-parentheses
-        -Wno-logical-op-parentheses
-        -Wno-switch
-        -Wno-undefined-var-template
-        -Wno-inconsistent-missing-override
-        -Wno-parentheses
-        -Wno-unused-parameter
-        -Wno-sign-compare
-        -Wno-ignored-qualifiers
-        -Wno-missing-field-initializers
-
-        # disable warning introduced by -fsized-deallocation, pybind11 used.
-        -Wno-unknown-argument
-
-        
-        /Gd             # Use _cdecl calling convention for all functions
-        /MP             # Multicore compilation in Visual Studio
         /nologo         # Suppress Copyright and version number message
+        /Gd             # Use _cdecl calling convention for all functions
         /W4             # Warning level 4
         /WX             # Warnings as errors
         /permissive-    # Conformance with standard
-        /Zc:preprocessor # Forces preprocessor into conformance mode:  https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170
-        /Zc:forScope    # Force Conformance in for Loop Scope
-        /diagnostics:caret # Compiler diagnostic options: includes the column where the issue was found and places a caret (^) under the location in the line of code where the issue was detected.
-        /Zc:__cplusplus       
-        /bigobj         # Increase number of sections in obj files. Profiling has shown no meaningful impact in memory nore build times
         /GS             # Enable Buffer security check
-        /sdl
+        /sdl            # Enable additional security checks
+
+        -Wno-cast-function-type-mismatch
+        -Wno-deprecated-copy
+        -Wno-dllexport-explicit-instantiation-decl
+        -Wno-ignored-qualifiers
+        -Wno-inconsistent-missing-override
+        -Wno-logical-not-parentheses
+        -Wno-logical-op-parentheses
+        -Wno-macro-redefined
+        -Wno-missing-field-initializers
+        -Wno-parentheses
+        -Wno-reorder-ctor
+        -Wno-sign-compare
+        -Wno-switch
+        -Wno-undefined-var-template
+        -Wno-unknown-argument # disable warning introduced by -fsized-deallocation, pybind11 used.
+        -Wno-unknown-warning-option
+        -Wno-unnecessary-virtual-specifier
+        -Wno-unused-parameter
     COMPILATION_DEBUG
         /MDd            # defines _DEBUG, _MT, and _DLL and causes the application to use the debug multithread-specific and DLL-specific version of the run-time library.
                         # It also causes the compiler to place the library name MSVCRTD.lib into the .obj file.
@@ -94,18 +92,19 @@ ly_append_configurations_options(
         /Ot             # Favor fast code over small code
         /Oi             # Use Intrinsic Functions
         /Oy             # Omit the frame pointer
+
     LINK
-        /NOLOGO             # Suppress Copyright and version number message
-        /IGNORE:4099        # 3rdParty linking produces noise with LNK4099
+        /nologo             # Suppress Copyright and version number message
+        /ignore:4099        # 3rdParty linking produces noise with LNK4099
     LINK_NON_STATIC_PROFILE
-        /OPT:REF            # Eliminates functions and data that are never referenced
-        /OPT:ICF            # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
-        /INCREMENTAL:NO
-        /DEBUG              # Generate pdbs
+        /opt:ref            # Eliminates functions and data that are never referenced
+        /opt:icf            # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
+        /incremental:no
+        /debug              # Generate pdbs
     LINK_NON_STATIC_RELEASE
-        /OPT:REF # Eliminates functions and data that are never referenced
-        /OPT:ICF # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
-        /INCREMENTAL:NO
+        /opt:ref            # Eliminates functions and data that are never referenced
+        /opt:icf            # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
+        /incremental:no
 )
 
 if(LY_BUILD_WITH_ADDRESS_SANITIZER)
@@ -113,10 +112,11 @@ if(LY_BUILD_WITH_ADDRESS_SANITIZER)
         COMPILATION_DEBUG
             -fsanitize=address
             -fno-omit-frame-pointer
+
         LINK_NON_STATIC_DEBUG
             -shared-libsan
             -fsanitize=address
     )
 endif()
-include(cmake/Platform/Common/TargetIncludeSystemDirectories_supported.cmake)
 
+include(cmake/Platform/Common/TargetIncludeSystemDirectories_supported.cmake)

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -62,6 +62,7 @@ ly_append_configurations_options(
     DEFINES
         _ENABLE_EXTENDED_ALIGNED_STORAGE # Enables support for extended alignment for the MSVC std::aligned_storage class
         _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING # Prevents triggering of STL4043 when checked iterators are used in 3rdParty libraries(QT and AWSNativeSDK)
+
     COMPILATION
         /Gd             # Use _cdecl calling convention for all functions
         /MP             # Multicore compilation in Visual Studio
@@ -99,7 +100,7 @@ ly_append_configurations_options(
         /we5032 # detected #pragma warning(push) with no corresponding #pragma warning(pop)
         /we5233 # explicit lambda capture 'identifier' is not used
 
-        /Zc:forScope    # Force Conformance in for Loop Scope
+        /Zc:forScope    # Force conformance in for loop scope
         /diagnostics:caret # Compiler diagnostic options: includes the column where the issue was found and places a caret (^) under the location in the line of code where the issue was detected.
         /Zc:__cplusplus
         /Zc:lambda      # Use the new lambda processor (See https://developercommunity.visualstudio.com/t/A-lambda-that-binds-the-this-pointer-w/1467873 for more details)
@@ -125,18 +126,19 @@ ly_append_configurations_options(
         /Ot             # Favor fast code over small code
         /Oi             # Use Intrinsic Functions
         /Oy             # Omit the frame pointer
+
     LINK
-        /NOLOGO             # Suppress Copyright and version number message
-        /IGNORE:4099        # 3rdParty linking produces noise with LNK4099
+        /nologo             # Suppress Copyright and version number message
+        /ignore:4099        # 3rdParty linking produces noise with LNK4099
     LINK_NON_STATIC_PROFILE
-        /OPT:REF            # Eliminates functions and data that are never referenced
-        /OPT:ICF            # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
-        /INCREMENTAL:NO
-        /DEBUG              # Generate pdbs
+        /opt:ref            # Eliminates functions and data that are never referenced
+        /opt:icf            # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
+        /incremental:no
+        /debug              # Generate pdbs
     LINK_NON_STATIC_RELEASE
-        /OPT:REF # Eliminates functions and data that are never referenced
-        /OPT:ICF # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
-        /INCREMENTAL:NO
+        /opt:ref            # Eliminates functions and data that are never referenced
+        /opt:icf            # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
+        /incremental:no
 )
 
 # Look for O3DE_ENABLE_COMPILER_CACHE as a CMake flag or environment variable, then sets the appropriate compatible flags for caching
@@ -201,6 +203,7 @@ else()
     ly_append_configurations_options(
         COMPILATION_DEBUG
             /Zi         # Generate debugging information (no Edit/Continue). Edit/Continue requires incremental linking
+
         LINK_NON_STATIC_DEBUG
             /DEBUG      # Despite the documentation states /Zi implies /DEBUG, without it, stack traces are not expanded
             /INCREMENTAL:NO
@@ -214,6 +217,7 @@ if(O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE)
         COMPILATION_RELEASE
             /Od             # Enable debug symbols
             /Zi             # Generate debugging information (no Edit/Continue)
+
         LINK_NON_STATIC_RELEASE
             /DEBUG          # Generate pdbs
     )
@@ -240,9 +244,9 @@ endif()
 include(cmake/Platform/Common/TargetIncludeSystemDirectories_unsupported.cmake)
 
 if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS_EQUAL "10.0.19041.0")
-  # Suppresses warning C5105 which triggers with Windows 10 SDK 10.0.19041 and below when using the /Zc:preprocessor option
-  # https://developercommunity.visualstudio.com/t/stdc17-generates-warning-compiling-windowsh/1249671
-  ly_append_configurations_options(
+    # Suppresses warning C5105 which triggers with Windows 10 SDK 10.0.19041 and below when using the /Zc:preprocessor option
+    # https://developercommunity.visualstudio.com/t/stdc17-generates-warning-compiling-windowsh/1249671
+    ly_append_configurations_options(
         COMPILATION
             /wd5104
             /wd5105

--- a/cmake/Platform/Linux/Configurations_linux_aarch64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_aarch64.cmake
@@ -15,8 +15,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             LINUX
             __linux__
             LINUX64
+
         COMPILATION
             -ffp-contract=off
+
         LINK_NON_STATIC
             -Wl,--no-undefined
             -fpie
@@ -46,8 +48,10 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             LINUX
             __linux__
             LINUX64
+
         COMPILATION
             -ffp-contract=off
+
         LINK_NON_STATIC
             ${LY_GCC_GCOV_LFLAGS}
             ${LY_GCC_GPROF_LFLAGS}

--- a/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
+++ b/cmake/Platform/Linux/Configurations_linux_x86_64.cmake
@@ -22,8 +22,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 LINUX
                 __linux__
                 LINUX64
+
             COMPILATION
                 -msse4.1
+
             LINK_NON_STATIC
                 ${SPECIFY_LINKER_FLAG}
                 -Wl,--no-undefined
@@ -47,8 +49,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                 LINUX
                 __linux__
                 LINUX64
+
             COMPILATION
                 -msse4.1
+
             LINK_NON_STATIC
                 ${SPECIFY_LINKER_FLAG}
                 -Wl,--no-undefined
@@ -81,8 +85,10 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             LINUX
             __linux__
             LINUX64
+
         COMPILATION
             -msse4.1
+
         LINK_NON_STATIC
             ${LY_GCC_GCOV_LFLAGS}
             ${LY_GCC_GPROF_LFLAGS}

--- a/cmake/Platform/Mac/Configurations_mac.cmake
+++ b/cmake/Platform/Mac/Configurations_mac.cmake
@@ -16,6 +16,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
             MAC
             __APPLE__
             DARWIN
+
         LINK_NON_STATIC
             -headerpad_max_install_names
             -lpthread

--- a/cmake/Platform/Windows/Configurations_windows.cmake
+++ b/cmake/Platform/Windows/Configurations_windows.cmake
@@ -18,6 +18,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
             _WIN64
             WIN64
             NOMINMAX
+
         LINK
             /MACHINE:X64
     )
@@ -38,6 +39,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             _WIN64
             WIN64
             NOMINMAX
+
         COMPILATION
             -msse3
             -mf16c

--- a/cmake/Platform/iOS/Configurations_ios.cmake
+++ b/cmake/Platform/iOS/Configurations_ios.cmake
@@ -17,15 +17,15 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
             IOS
             MOBILE
             APPLE_BUNDLE
+
         COMPILATION
             -miphoneos-version-min=${LY_IOS_DEPLOYMENT_TARGET}
             -Wno-shorten-64-to-32
             -fno-aligned-allocation
-        LINK_NON_STATIC
 
+        LINK_NON_STATIC
             -Wl,-dead_strip
             -miphoneos-version-min=${LY_IOS_DEPLOYMENT_TARGET}
-
             -lpthread
     )
     ly_set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
## What does this PR do?

### Configuration Changes

Fixes several issues encountered when building O3DE with Clang-CL (particularly Clang 18+) and Ninja on Windows, along with general CMake configuration cleanup.

Clang is sensitive to the order of warning flags. `/W4` and `/WX` must appear before any `-Wno-*` suppressions, otherwise the suppressions are silently ignored. The previous `MSVC/Configurations_clang.cmake` had the `-Wno-*` flags listed before `/W4` and `/WX`, causing all suppressed warnings to be treated as errors.

Additionally, the following warning suppressions were added for Clang 18+ compatibility:
- `-Wno-cast-function-type-mismatch`
- `-Wno-deprecated-copy` (a follow-up PR will address the underlying code issues so this can be removed)
- `-Wno-macro-redefined`
- `-Wno-unknown-warning-option`
- `-Wno-unnecessary-virtual-specifier`
- `-Wno-deprecated-enum-enum-conversion` (added to `O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION`)

Also removed flags that don't apply to Clang-CL (`/MP`, `/Zc:preprocessor`, `/Zc:forScope`, `/diagnostics:caret`, `/Zc:__cplusplus`, `/bigobj`).

A targeted workaround was added to `Findgoogletest.cmake` for a [known googletest bug](https://github.com/google/googletest/issues/4762) triggered by `-Wcharacter-conversion` in Clang 21+.

### MOC Fixes

When building with Ninja and Clang-CL, Qt's MOC generates deeply nested relative include paths (from the MOC output directory back to the source tree). These un-normalized paths, emitted via `/showIncludes` (which Ninja uses for MSVC-style dependency tracking), can exceed the 260-character Windows MAX_PATH limit. This caused Ninja's dep parser to fail with "path too long" errors, particularly in the EMotionFX gem.

### Formatting Changes

Standardized the formatting of all ly_append_configurations_options() calls across all platform configuration files to use a consistent style:

- No blank lines between closely related flag groups (e.g., COMPILATION_DEBUG / COMPILATION_PROFILE / COMPILATION_RELEASE)
- Blank line separators between major sections (e.g., between COMPILATION and LINK)
- Lowercased MSVC linker flags (`/opt:ref` instead of `/OPT:REF`) for consistency
- Fixed indentation in `Configurations_msvc.cmake` for the Windows SDK version workaround

## How was this PR tested?

Built successfully with Clang-CL included with VS, and Clang-CL 21 (the latest available) using both the Visual Studio Generator and Ninja.
