### PR TITLE
Added ClassWizard Directory to install output.

### DIFF
--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -8,3 +8,4 @@
 
 add_subdirectory(LyTestTools)
 add_subdirectory(RemoteConsole)
+add_subdirectory(ClassCreationWizard)

--- a/Tools/ClassCreationWizard/CMakeLists.txt
+++ b/Tools/ClassCreationWizard/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+ly_install_directory(DIRECTORIES .)

--- a/Tools/ClassCreationWizard/CMakeLists.txt
+++ b/Tools/ClassCreationWizard/CMakeLists.txt
@@ -6,4 +6,5 @@
 #
 #
 
+
 ly_install_directory(DIRECTORIES .)


### PR DESCRIPTION
Original ClassWizard is not appearing in `/Tools/` on "install" type build package output.

## What does this PR do?

Adds it as subdirectory to the Tools CMakeLists.

## How was this PR tested?

Built an internal install package, verified that the Wizard is now included in deployed folder.
