### PR TITLE
CMake will use policy CMP0168 if it is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ if(NOT ${CMAKE_VERSION} VERSION_LESS "3.24")
     cmake_policy(SET CMP0135 NEW) 
 endif()
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.30")
+    # CMP0168 - Controls whether fetchcontent uses sub builds (<3.30) or just does the fetch during
+    # configure, which is much faster, especially for subsequent configure.
+    # (OLD) Use a sub build
+    # (NEW) Do the fetch during configure
+    cmake_policy(SET CMP0168 NEW)
+endif()
+
 include(cmake/LySet.cmake)
 include(cmake/GeneralSettings.cmake)
 include(cmake/FileUtil.cmake)
@@ -36,11 +44,13 @@ get_property(O3DE_SCRIPT_ONLY GLOBAL PROPERTY "O3DE_SCRIPT_ONLY")
 if (O3DE_SCRIPT_ONLY)
     message(STATUS  "Basic Configuration Information (Script-only mode):\n" 
                     "   CMAKE_VERSION: ${CMAKE_VERSION}\n"
+                    "   CMAKE_COMMAND: ${CMAKE_COMMAND}\n"
                     "   CMAKE_GENERATOR: ${CMAKE_GENERATOR}"
             )
 else()
     message(STATUS  "Basic Configuration Information:\n" 
                     "   CMAKE_VERSION: ${CMAKE_VERSION}\n"
+                    "   CMAKE_COMMAND: ${CMAKE_COMMAND}\n"
                     "   CMAKE_GENERATOR: ${CMAKE_GENERATOR}\n"
                     "   CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}\n"
                     "   CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,14 @@
 # Cmake version 3.24 is the minimum version needed for all of Open 3D Engine's supported platforms
 cmake_minimum_required(VERSION 3.24)
 
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.24") 
+if(POLICY CMP0135)
     # CMP0135 - controls whether, when unpacking an archive file, it should:
     # (OLD) set the file timestamps to what they are in the archive (not recommended)
     # (NEW) set the file timestamps to the time of extraction (recommended)
     cmake_policy(SET CMP0135 NEW) 
 endif()
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.30")
+if(POLICY CMP0168)
     # CMP0168 - Controls whether fetchcontent uses sub builds (<3.30) or just does the fetch during
     # configure, which is much faster, especially for subsequent configure.
     # (OLD) Use a sub build

--- a/Gems/Atom/RPI/3rdParty/Findmeshoptimizer.cmake
+++ b/Gems/Atom/RPI/3rdParty/Findmeshoptimizer.cmake
@@ -12,13 +12,14 @@ if (TARGET 3rdParty::${MESHOPTIMIZER_TARGET})
 endif()
 
 set(MESHOPTIMIZER_GIT_REPO "https://github.com/zeux/meshoptimizer.git")
-set(MESHOPTIMIZER_GIT_TAG "v0.25")
+set(MESHOPTIMIZER_GIT_TAG "6daea4695c48338363b08022d2fb15deaef6ac09")   # v0.25
 
 include(FetchContent)
 FetchContent_Declare(
         ${MESHOPTIMIZER_TARGET}
         GIT_REPOSITORY ${MESHOPTIMIZER_GIT_REPO}
         GIT_TAG ${MESHOPTIMIZER_GIT_TAG}
+        GIT_SHALLOW TRUE
 )
 set(MESHOPT_INSTALL OFF)
 FetchContent_MakeAvailable(meshoptimizer)


### PR DESCRIPTION
## What does this PR do?

This does NOT update the min requirement to 3.30, but takes advantage of the fetchcontent changes if it IS available.

CMP0168 NEW makes CMake download FetchContent libraries during configure, directly from CMake's main executable, (ie, cmake.exe will execute git.exe), rather than making a sub-build to do it.

Also adds an output displaying the path to the cmake executable, since this actually mattered for at least one user diagnosing their troubles.

This has at least two benefits:
* It allows the download of FetchContent Libraries to be immediately present the moment FetchContent_MakeAvailable is called, and without generating a sub build and then executing the sub build to do it.
* It makes subsequent calls to cmake configure much faster, because it does not have to execute a sub build (ie, ninja or msbuild) to check if the FetchContent libraries are already downloaded.

The OLD way of doing this still works, (although there is a bug in CMake 3.24 that causes it to miss FetchContent Libraries that are inside other FetchContent calls.).  But the OLD way worked by each time it encountered FetchContent, autogenerating a new cmake folder with a fresh cmakelists.txt that itself is a whole isolated project (unrelated to the outside proejct) with only one target, and that one target consisted of just one custom build command, and that one custom build command executes cmake, and that cmake executes a script, and that script executes the git fetch/clone.

This means that it had to execute msbuild, which executed cmake, for each configure.  This is why it was slow.

## How was this PR tested?

Local testing, the fetchcontent works. If it didn't its going to be instantly breaking everything during automated testing.
