### PR TITLE
Force ProjectManager to use the included ninja and cmake runtimes if available

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -24,6 +24,17 @@ namespace O3DE::ProjectManager
         // so a empty string entry is added to the end
         const QStringList SupportedClangVersions = {"-13", "-12", "-11", "-10", "-9", "-8", "-7", "-6.0", ""};
 
+        QChar GetPlatformPathEnvSeparator()
+        {
+            return QChar(':');
+        }
+
+        QString GetPlatformPathEnvVariableName()
+        {
+            // Qt: do not translate this string, it is the name of an environment variable not a user facing view
+            return QString("PATH"); 
+        }
+
         // this is currently the same implementation as windows, but this is not necessarily going to remain
         // the case.
         AZ::Outcome<void, QString> SetupCommandLineProcessEnvironment()
@@ -40,17 +51,17 @@ namespace O3DE::ProjectManager
             // with since its the one we know works.
             QDir cmakePath(engineInfo.m_path);
             cmakePath.cd("cmake/runtime/bin");
-            if (!PrependToPath(cmakePath.path()))
+            if (!AddPathToPathEnv(cmakePath.path(), /*prepend=*/true))
             {
-                return AZ::Failure(QObject::tr("Failed to append the path of the CMake binary to the PATH environment variable"));
+                return AZ::Failure(QObject::tr("Failed to add the path of the CMake binary to the PATH environment variable"));
             }
 
             // if we ship with a specific version of ninja, preppend ito the PATH as well,  we prefer to use it.
             QDir ninjaPath(engineInfo.m_path);
             ninjaPath.cd("ninja");
-            if (!PrependToPath(ninjaPath.path()))
+            if (!AddPathToPathEnv(ninjaPath.path(), /*prepend=*/true))
             {
-                return AZ::Failure(QObject::tr("Failed to append the path of the ninja binary to the PATH environment variable"));
+                return AZ::Failure(QObject::tr("Failed to add the path of the ninja binary to the PATH environment variable"));
             }
 
             return AZ::Success();

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -24,10 +24,38 @@ namespace O3DE::ProjectManager
         // so a empty string entry is added to the end
         const QStringList SupportedClangVersions = {"-13", "-12", "-11", "-10", "-9", "-8", "-7", "-6.0", ""};
 
+        // this is currently the same implementation as windows, but this is not necessarily going to remain
+        // the case.
         AZ::Outcome<void, QString> SetupCommandLineProcessEnvironment()
         {
+            // Use the engine path to insert a path for cmake
+            auto engineInfoResult = PythonBindingsInterface::Get()->GetEngineInfo();
+            if (!engineInfoResult.IsSuccess())
+            {
+                return AZ::Failure(QObject::tr("Failed to get engine info"));
+            }
+            auto engineInfo = engineInfoResult.GetValue();
+
+            // prepend cmake path to the current environment PATH - we prefer to use the one we ship O3DE
+            // with since its the one we know works.
+            QDir cmakePath(engineInfo.m_path);
+            cmakePath.cd("cmake/runtime/bin");
+            if (!PrependToPath(cmakePath.path()))
+            {
+                return AZ::Failure(QObject::tr("Failed to append the path of the CMake binary to the PATH environment variable"));
+            }
+
+            // if we ship with a specific version of ninja, preppend ito the PATH as well,  we prefer to use it.
+            QDir ninjaPath(engineInfo.m_path);
+            ninjaPath.cd("ninja");
+            if (!PrependToPath(ninjaPath.path()))
+            {
+                return AZ::Failure(QObject::tr("Failed to append the path of the ninja binary to the PATH environment variable"));
+            }
+
             return AZ::Success();
         }
+
 
         AZ::Outcome<QString, QString> FindSupportedCMake()
         {

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -20,22 +20,24 @@ namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
     {
+        QChar GetPlatformPathEnvSeparator()
+        {
+            return QChar(':');
+        }
+
+        QString GetPlatformPathEnvVariableName()
+        {
+            // Qt: do not translate this string, it is the name of an environment variable not a user facing view
+            return QString("PATH"); 
+        }
+
         AZ::Outcome<void, QString> SetupCommandLineProcessEnvironment()
         {
             // For CMake on Mac, if its installed through home-brew, then it will be installed
             // under /usr/local/bin, which may not be in the system PATH environment.
             // Add that path for the command line process so that it will be able to locate
             // a home-brew installed version of CMake
-            QString pathEnv = qEnvironmentVariable("PATH");
-            QStringList pathEnvList = pathEnv.split(":");
-            if (!pathEnvList.contains("/usr/local/bin"))
-            {
-                pathEnv += ":/usr/local/bin";
-                if (!qputenv("PATH", pathEnv.toStdString().c_str()))
-                {
-                    return AZ::Failure(QObject::tr("Failed to set PATH environment variable"));
-                }
-            }
+            AddPathToPathEnv("/usr/local/bin", false);
 
             return AZ::Success();
         }

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -22,20 +22,16 @@ namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
     {
-        bool AppendToPath(QString newPath)
+        QChar GetPlatformPathEnvSeparator()
         {
-            QString pathEnv = qEnvironmentVariable("Path");
-            QStringList pathEnvList = pathEnv.split(";");
-            if (!pathEnvList.contains(newPath, Qt::CaseInsensitive))
-            {
-                pathEnv += ";" + newPath;
-                if (!qputenv("Path", pathEnv.toStdString().c_str()))
-                {
-                    return false;
-                }
-            }
-            return true;
+            return QChar(';');
         }
+
+        QString GetPlatformPathEnvVariableName()
+        {
+            // Qt: do not translate this string, it is the name of an environment variable not a user facing view
+            return QString("Path"); 
+        }    
 
         AZ::Outcome<void, QString> SetupCommandLineProcessEnvironment()
         {
@@ -47,26 +43,21 @@ namespace O3DE::ProjectManager
             }
             auto engineInfo = engineInfoResult.GetValue();
 
-            // Append cmake path to the current environment PATH incase it is missing, since if
-            // we are starting CMake itself the current application needs to find it using Path
-            // This also takes affect for all child processes.
+            // prepend cmake path to the current environment PATH - we prefer to use the one we ship O3DE
+            // with since its the one we know works.
             QDir cmakePath(engineInfo.m_path);
             cmakePath.cd("cmake/runtime/bin");
-            if (!AppendToPath(cmakePath.path()))
+            if (!PrependToPath(cmakePath.path()))
             {
-                return AZ::Failure(QObject::tr("Failed to append the path to CMake to the PATH environment variable"));
+                return AZ::Failure(QObject::tr("Failed to append the path of the CMake binary to the PATH environment variable"));
             }
 
-            // if we don't have ninja, use one that might come with the installer
-            auto ninjaQueryResult = ExecuteCommandResult("ninja", QStringList{ "--version" });
-            if (!ninjaQueryResult.IsSuccess())
+            // if we ship with a specific version of ninja, preppend ito the PATH as well,  we prefer to use it.
+            QDir ninjaPath(engineInfo.m_path);
+            ninjaPath.cd("ninja");
+            if (!PrependToPath(ninjaPath.path()))
             {
-                QDir ninjaPath(engineInfo.m_path);
-                ninjaPath.cd("ninja");
-                if (!AppendToPath(ninjaPath.path()))
-                {
-                    return AZ::Failure(QObject::tr("Failed to append the path to ninja to the PATH environment variable"));
-                }
+                return AZ::Failure(QObject::tr("Failed to append the path of the ninja binary to the PATH environment variable"));
             }
 
             return AZ::Success();

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -47,17 +47,17 @@ namespace O3DE::ProjectManager
             // with since its the one we know works.
             QDir cmakePath(engineInfo.m_path);
             cmakePath.cd("cmake/runtime/bin");
-            if (!PrependToPath(cmakePath.path()))
+            if (!AddPathToPathEnv(cmakePath.path(), /*prepend=*/true))
             {
-                return AZ::Failure(QObject::tr("Failed to append the path of the CMake binary to the PATH environment variable"));
+                return AZ::Failure(QObject::tr("Failed to add the path of the CMake binary to the PATH environment variable"));
             }
 
             // if we ship with a specific version of ninja, preppend ito the PATH as well,  we prefer to use it.
             QDir ninjaPath(engineInfo.m_path);
             ninjaPath.cd("ninja");
-            if (!PrependToPath(ninjaPath.path()))
+            if (!AddPathToPathEnv(ninjaPath.path(), /*prepend=*/true))
             {
-                return AZ::Failure(QObject::tr("Failed to append the path of the ninja binary to the PATH environment variable"));
+                return AZ::Failure(QObject::tr("Failed to add the path of the ninja binary to the PATH environment variable"));
             }
 
             return AZ::Success();

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -37,6 +37,22 @@ namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
     {
+        bool PrependToPath(QString newPath)
+        {
+            QString pathEnvName = GetPlatformPathEnvVariableName();
+            QString pathEnv = qEnvironmentVariable(pathEnvName.toUtf8().constData());
+            QStringList pathEnvList = pathEnv.split(";");
+            if (!pathEnvList.contains(newPath, Qt::CaseInsensitive))
+            {
+                pathEnv = GetPlatformPathEnvSeparator() + newPath + pathEnv;
+                if (!qputenv(pathEnvName.toUtf8().constData(), pathEnv.toStdString().c_str()))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         static bool WarnDirectoryOverwrite(const QString& path, QWidget* parent)
         {
             if (!QDir(path).isEmpty())

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -37,15 +37,33 @@ namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
     {
-        bool PrependToPath(QString newPath)
+        bool AddPathToPathEnv(QString newPath, bool prepend)
         {
             QString pathEnvName = GetPlatformPathEnvVariableName();
             QString pathEnv = qEnvironmentVariable(pathEnvName.toUtf8().constData());
-            QStringList pathEnvList = pathEnv.split(";");
-            if (!pathEnvList.contains(newPath, Qt::CaseInsensitive))
+            QStringList pathEnvList = pathEnv.split(GetPlatformPathEnvSeparator());
+
+            // if we are prepending it means that the path must, absolutely contain the given
+            // path at the very front, we want it to take priority, so its not enough for the
+            // path to just contain it.  Thus, when prepending it, we check if it starts with the given one
+            // instead of just whether it contains it.
+
+            bool should_apply = false;
+            QString newCombinedPath;
+            if (prepend)
             {
-                pathEnv = GetPlatformPathEnvSeparator() + newPath + pathEnv;
-                if (!qputenv(pathEnvName.toUtf8().constData(), pathEnv.toStdString().c_str()))
+                should_apply = !pathEnvList.startsWith(newPath);
+                newCombinedPath = newPath + GetPlatformPathEnvSeparator() + pathEnv;
+            }
+            else
+            {
+                should_apply = !pathEnvList.contains(newPath);
+                newCombinedPath = pathEnv + GetPlatformPathEnvSeparator() + newPath;
+            }
+
+            if (should_apply)
+            {
+                if (!qputenv(pathEnvName.toUtf8().constData(), newCombinedPath.toStdString().c_str()))
                 {
                     return false;
                 }

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -45,6 +45,15 @@ namespace O3DE::ProjectManager
         // Any notes returned will be showend as a message box or output log, regardless of success or failure.
         AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform(const ProjectInfo& projectInfo);
 
+        //! Return the platform specific path separator for the PATH environment variable, e.g. ';' on windows and ':' on unix
+        QChar GetPlatformPathEnvSeparator();
+
+        //! Return the platform specific name of the PATH environment variable, e.g. 'Path' on windows and 'PATH' on unix
+        QString GetPlatformPathEnvVariableName();
+
+        //! modify the process environment to prepent the given path to the front of the system environment path
+        bool PrependToPath(QString newPath);
+
         //! Detect if cmake is installed
         //! Does NOT detect if the version of cmake required to run O3DE
         //! The cmake exeuctable is only tool suitable for detecting the minimum cmake version

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -52,7 +52,8 @@ namespace O3DE::ProjectManager
         QString GetPlatformPathEnvVariableName();
 
         //! modify the process environment to prepent the given path to the front of the system environment path
-        bool PrependToPath(QString newPath);
+        //! Prepend it, if prepend is true, otherwise append it.
+        bool AddPathToPathEnv(QString newPath, bool prepend = true);
 
         //! Detect if cmake is installed
         //! Does NOT detect if the version of cmake required to run O3DE


### PR DESCRIPTION
## What does this PR do?

This changes the behavior on linux and windows to *prepend* the path to the embedded ninja and cmake runtimes as opposed to append them.  This means that if present they will prefer to use them.  We will need to update the runtimes we use to be the ones we know are good.

## How was this PR tested?

Windows and linux did both the following tests

* Compiled and ran the Project Manager *WITHOUT* cmake in the cmake/runtime/bin folder and checked the version used (it used the one from my system)
* Compiled and ran the Project Manager *WITH* a cmake binary in cmake/runtime/bin folder, (a different version than was installed in my system) and checked the log for the version used when building a project.  It was the version in that folder.


