### PR TITLE
3rdParty FetchContent: pybind11

### DIFF
--- a/cmake/3rdParty/Findpybind11.cmake
+++ b/cmake/3rdParty/Findpybind11.cmake
@@ -19,18 +19,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 if(INSTALLED_ENGINE)
-    ly_target_include_system_directories(TARGET 3rdParty::pybind11
+    ly_target_include_system_directories(
+        TARGET 3rdParty::pybind11
         INTERFACE "${LY_ROOT_FOLDER}/include/pybind11"
     )
     return()
 endif()
 
 block()
-    set(ADDITIONAL_FETCHCONTENT_FLAGS "")
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
-        list(APPEND ADDITIONAL_FETCHCONTENT_FLAGS "SYSTEM")
-    endif()
-
     o3de_fetch_content(pybind11
         VERSION "v2.10.0"
         LICENSE "BSD-3-Clause"
@@ -38,32 +34,24 @@ block()
         URL_HASH "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec"
         GIT "https://github.com/pybind/pybind11.git"
         GIT_HASH "aa304c9c7d725ffb9d10af08a3b34cb372307020"
-        EXCLUDE_FROM_ALL
-        ${ADDITIONAL_FETCHCONTENT_FLAGS}
+        SOURCE_SUBDIR "include"
     )
 
-    # FetchContent ignores CMAKE_ARGS, so configure pybind11 through the variables its option() calls consume.
-    # O3DE provides Python separately through 3rdParty::Python; only pybind11's headers are needed here.
-    set(PYBIND11_INSTALL OFF)
-    set(PYBIND11_NOPYTHON ON)
-    set(PYBIND11_TEST OFF)
-    set(CMAKE_POLICY_VERSION_MINIMUM "3.5")
-
-    set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL})
-    set(CMAKE_MESSAGE_LOG_LEVEL ${O3DE_FETCHCONTENT_MESSAGE_LEVEL})
-
     FetchContent_MakeAvailable(pybind11)
-
-    set(CMAKE_MESSAGE_LOG_LEVEL ${OLD_LOG_LEVEL})
-
-    target_link_libraries(3rdParty::pybind11 INTERFACE pybind11::pybind11)
-
     FetchContent_GetProperties(pybind11 SOURCE_DIR pybind11_source_dir)
-    ly_install(DIRECTORY "${pybind11_source_dir}/include/pybind11"
+
+    ly_target_include_system_directories(
+        TARGET 3rdParty::pybind11
+        INTERFACE "${pybind11_source_dir}/include"
+    )
+
+    ly_install(
+        DIRECTORY "${pybind11_source_dir}/include/pybind11"
         DESTINATION include/pybind11
         COMPONENT CORE
     )
-    ly_install(FILES "${pybind11_source_dir}/LICENSE"
+    ly_install(
+        FILES "${pybind11_source_dir}/LICENSE"
         DESTINATION include/pybind11
         COMPONENT CORE
     )

--- a/cmake/3rdParty/Findpybind11.cmake
+++ b/cmake/3rdParty/Findpybind11.cmake
@@ -1,0 +1,46 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+include_guard(GLOBAL)
+
+function(_pybind11_scope)
+    set(package_name "pybind11")
+    set(package_version "2.10.0")
+    set(package_hash "SHA256=eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec")
+
+    if(TARGET 3rdParty::${package_name})
+        return()
+    endif()
+
+    set(CMAKE_POLICY_VERSION_MINIMUM "3.5")
+    FetchContent_Declare(${package_name}
+        URL "https://github.com/pybind/pybind11/archive/refs/tags/v${package_version}.tar.gz"
+        URL_HASH ${package_hash}
+
+        DOWNLOAD_DIR "${LY_PACKAGE_DOWNLOAD_CACHE_LOCATION}/${package_name}"
+        DOWNLOAD_NO_PROGRESS TRUE
+
+        EXCLUDE_FROM_ALL
+
+        CMAKE_ARGS
+        -DPYBIND11_INSTALL=OFF
+        -DPYBIND11_TEST=OFF
+    )
+    FetchContent_MakeAvailable(${package_name})
+
+    add_library(3rdParty::${package_name} INTERFACE IMPORTED GLOBAL)
+    target_link_libraries(3rdParty::${package_name} INTERFACE pybind11::pybind11)
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        target_compile_options(3rdParty::${package_name} INTERFACE -fsized-deallocation)
+    endif()
+
+    message(STATUS "Using ${package_name}@${package_version} (BSD-3-Clause)")
+endfunction()
+
+_pybind11_scope()

--- a/cmake/3rdParty/Findpybind11.cmake
+++ b/cmake/3rdParty/Findpybind11.cmake
@@ -6,41 +6,65 @@
 #
 #
 
-include_guard(GLOBAL)
+set(pybind11_FOUND TRUE)
 
-function(_pybind11_scope)
-    set(package_name "pybind11")
-    set(package_version "2.10.0")
-    set(package_hash "SHA256=eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec")
+if(TARGET 3rdParty::pybind11)
+    return()
+endif()
 
-    if(TARGET 3rdParty::${package_name})
-        return()
-    endif()
+add_library(3rdParty::pybind11 INTERFACE IMPORTED GLOBAL)
 
-    set(CMAKE_POLICY_VERSION_MINIMUM "3.5")
-    FetchContent_Declare(${package_name}
-        URL "https://github.com/pybind/pybind11/archive/refs/tags/v${package_version}.tar.gz"
-        URL_HASH ${package_hash}
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(3rdParty::pybind11 INTERFACE -fsized-deallocation)
+endif()
 
-        DOWNLOAD_DIR "${LY_PACKAGE_DOWNLOAD_CACHE_LOCATION}/${package_name}"
-        DOWNLOAD_NO_PROGRESS TRUE
-
-        EXCLUDE_FROM_ALL
-
-        CMAKE_ARGS
-        -DPYBIND11_INSTALL=OFF
-        -DPYBIND11_TEST=OFF
+if(INSTALLED_ENGINE)
+    ly_target_include_system_directories(TARGET 3rdParty::pybind11
+        INTERFACE "${LY_ROOT_FOLDER}/include/pybind11"
     )
-    FetchContent_MakeAvailable(${package_name})
+    return()
+endif()
 
-    add_library(3rdParty::${package_name} INTERFACE IMPORTED GLOBAL)
-    target_link_libraries(3rdParty::${package_name} INTERFACE pybind11::pybind11)
-
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        target_compile_options(3rdParty::${package_name} INTERFACE -fsized-deallocation)
+block()
+    set(ADDITIONAL_FETCHCONTENT_FLAGS "")
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
+        list(APPEND ADDITIONAL_FETCHCONTENT_FLAGS "SYSTEM")
     endif()
 
-    message(STATUS "Using ${package_name}@${package_version} (BSD-3-Clause)")
-endfunction()
+    o3de_fetch_content(pybind11
+        VERSION "v2.10.0"
+        LICENSE "BSD-3-Clause"
+        URL "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.0.tar.gz"
+        URL_HASH "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec"
+        GIT "https://github.com/pybind/pybind11.git"
+        GIT_HASH "aa304c9c7d725ffb9d10af08a3b34cb372307020"
+        EXCLUDE_FROM_ALL
+        ${ADDITIONAL_FETCHCONTENT_FLAGS}
+    )
 
-_pybind11_scope()
+    # FetchContent ignores CMAKE_ARGS, so configure pybind11 through the variables its option() calls consume.
+    # O3DE provides Python separately through 3rdParty::Python; only pybind11's headers are needed here.
+    set(PYBIND11_INSTALL OFF)
+    set(PYBIND11_NOPYTHON ON)
+    set(PYBIND11_TEST OFF)
+    set(CMAKE_POLICY_VERSION_MINIMUM "3.5")
+
+    set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL})
+    set(CMAKE_MESSAGE_LOG_LEVEL ${O3DE_FETCHCONTENT_MESSAGE_LEVEL})
+
+    FetchContent_MakeAvailable(pybind11)
+
+    set(CMAKE_MESSAGE_LOG_LEVEL ${OLD_LOG_LEVEL})
+
+    target_link_libraries(3rdParty::pybind11 INTERFACE pybind11::pybind11)
+
+    FetchContent_GetProperties(pybind11 SOURCE_DIR pybind11_source_dir)
+    ly_install(DIRECTORY "${pybind11_source_dir}/include/pybind11"
+        DESTINATION include/pybind11
+        COMPONENT CORE
+    )
+    ly_install(FILES "${pybind11_source_dir}/LICENSE"
+        DESTINATION include/pybind11
+        COMPONENT CORE
+    )
+endblock()

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
@@ -11,7 +11,6 @@
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
-ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)
 ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)
 
 # platform-specific:

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
@@ -11,7 +11,6 @@
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
-ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)
 ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                        TARGETS cityhash                    PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)
 

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
@@ -11,7 +11,6 @@
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
-ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                        TARGETS cityhash                    PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)
 ly_associate_package(PACKAGE_NAME zstd-1.35-multiplatform                           TARGETS zstd                        PACKAGE_HASH 45d466c435f1095898578eedde85acf1fd27190e7ea99aeaa9acfd2f09e12665)
 ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac_arm64.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac_arm64.cmake
@@ -11,7 +11,6 @@
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
-ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-rev1-mac-arm64                       TARGETS cityhash                    PACKAGE_HASH c5844582b4fe819e74ca923dbb58405dd687a4b9acb82d7de04e3e766addb4ed)
 ly_associate_package(PACKAGE_NAME zstd-1.35-rev1-mac-arm64                          TARGETS zstd                        PACKAGE_HASH bb401d198d9fd2be2669acb6fe8dbe59fd7d33a66b5f2fd7d3e0221e5b72d1f4)
 ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -11,7 +11,6 @@
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                    TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                      TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
-ly_associate_package(PACKAGE_NAME pybind11-2.10.0-rev1-multiplatform                    TARGETS pybind11                    PACKAGE_HASH 6690acc531d4b8cd453c19b448e2fb8066b2362cbdd2af1ad5df6e0019e6c6c4)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                            TARGETS cityhash                    PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)
 ly_associate_package(PACKAGE_NAME zstd-1.35-multiplatform                               TARGETS zstd                        PACKAGE_HASH 45d466c435f1095898578eedde85acf1fd27190e7ea99aeaa9acfd2f09e12665)
 ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                       TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)


### PR DESCRIPTION
## What does this PR do?

This PR moves pybind11 from the 3p-package-source flow to a FetchContent-based integration.

### Changes
- pybind11 is fetched directly from upstream at configure time via FetchContent (version + hash pinned).
- The old pybind11 package associations were removed from Linux, macOS, and Windows BuiltInPackages entries.

### Why

pybind11 is header-only and platform-agnostic, so FetchContent is a better fit and significantly simplifies future version updates compared to 3p-package-source revision bumps.

## How was this PR tested?
- Verified on Windows (build works).
- Verified on macOS (build succeeds).