### PR TITLE
Fix MSVC Debug Symbols with Compiler Launchers

### DIFF
--- a/cmake/CompilerLauncher.cmake
+++ b/cmake/CompilerLauncher.cmake
@@ -29,6 +29,7 @@ include_guard(GLOBAL)
 
 function(_o3de_compiler_launcher)
     set(supported_languages C CXX)
+    set(caching_launchers ccache sccache)
 
     # Resolves Chocolatey shim executables to their real tool paths.
     # Chocolatey commonly places shims in <ChocolateyInstall>/bin. The real tool
@@ -130,6 +131,23 @@ function(_o3de_compiler_launcher)
         return()
     endif ()
 
+    # Signal to downstream platform configuration files that a compiler launcher is active.
+    set_property(GLOBAL PROPERTY O3DE_COMPILER_LAUNCHER_ENABLED TRUE)
+
+    # Detect whether the launcher is a known caching compiler (ccache, sccache).
+    # Caching compilers require embedded debug info (/Z7) instead of separate PDBs (/Zi)
+    # because they hash the .obj content and PDB writes are non-deterministic.
+    foreach (cl_lang IN ITEMS ${supported_languages})
+        if (cl_${cl_lang}_resolved)
+            get_filename_component(cl_launcher_name "${cl_${cl_lang}_resolved}" NAME_WE)
+            string(TOLOWER "${cl_launcher_name}" cl_launcher_name)
+            if (cl_launcher_name IN_LIST caching_launchers)
+                set_property(GLOBAL PROPERTY O3DE_CACHING_COMPILER_LAUNCHER_ENABLED TRUE)
+                break()
+            endif ()
+        endif ()
+    endforeach ()
+
     # == MAKEFILE / NINJA == #
     if (CMAKE_GENERATOR MATCHES "Makefiles|Ninja|Ninja Multi-Config")
         foreach (cl_lang IN ITEMS ${supported_languages})
@@ -209,9 +227,6 @@ function(_o3de_compiler_launcher)
             "UseMultiToolTask=true"
         )
         set(CMAKE_VS_GLOBALS "${CMAKE_VS_GLOBALS}" PARENT_SCOPE)
-
-        # Embedded debug info is required for compiler launcher compatibility
-        set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded" CACHE STRING "" FORCE)
 
         message(STATUS "CompilerLauncher: Configured for Visual Studio via cl.exe wrapper")
         return()

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -63,9 +63,9 @@ endif()
 # /ZI - Separate .pdb with Edit and Continue support (debug only, requires incremental linking)
 #
 # The correct flag depends on three factors:
-#   1. Caching compiler launcher active          => requires /Z7 (embedded debug info)
-#   2. Incremental linking enabled (debug only)  => requires /ZI (edit and continue)
-#   3. Debug symbols in Release (optional)       => uses same format as other configurations
+#   1. Caching compiler launcher active         => requires /Z7 (embedded debug info)
+#   2. Incremental linking enabled (debug only) => requires /ZI (edit and continue)
+#   3. Debug symbols in Release (optional)      => uses same format as other configurations
 #
 # Note: Incremental linking (/ZI) and caching compiler launchers (/Z7) are incompatible.
 # If both are requested, incremental linking takes priority for Debug builds.
@@ -187,8 +187,8 @@ set(LY_BUILD_WITH_INCREMENTAL_LINKING_DEBUG FALSE CACHE BOOL "Indicates if incre
 if(LY_BUILD_WITH_INCREMENTAL_LINKING_DEBUG)
     if(o3de_caching_compiler_launcher)
         message(WARNING
-            "Incremental linking and caching compiler launchers are incompatible for Debug builds. "
-            "Edit and Continue (/ZI) will be used; the compiler launcher may not cache Debug builds effectively."
+            "Incremental linking and caching compiler launchers are unsupported. "
+            "Edit and Continue (/ZI) may prevent the compiler launcher from caching effectively."
         )
     endif()
     
@@ -205,7 +205,6 @@ else()
         LINK_NON_STATIC_DEBUG
             /DEBUG      # Despite the documentation states /Zi implies /DEBUG, without it, stack traces are not expanded
             /INCREMENTAL:NO
-
     )
 endif()
 

--- a/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_msvc.cmake
@@ -57,6 +57,26 @@ if(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE AND NOT CMAKE_VS_PLATFORM_TOOLSET
     message(FATAL_ERROR "${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE} host toolset is not supported, it must be 'x64'")
 endif()
 
+# == DEBUG INFORMATION FORMAT == #
+# /Z7 - Embedded in .obj files (required when using caching compiler launchers like ccache/sccache)
+# /Zi - Separate .pdb files (default, better IDE integration)
+# /ZI - Separate .pdb with Edit and Continue support (debug only, requires incremental linking)
+#
+# The correct flag depends on three factors:
+#   1. Caching compiler launcher active          => requires /Z7 (embedded debug info)
+#   2. Incremental linking enabled (debug only)  => requires /ZI (edit and continue)
+#   3. Debug symbols in Release (optional)       => uses same format as other configurations
+#
+# Note: Incremental linking (/ZI) and caching compiler launchers (/Z7) are incompatible.
+# If both are requested, incremental linking takes priority for Debug builds.
+
+get_property(o3de_caching_compiler_launcher GLOBAL PROPERTY O3DE_CACHING_COMPILER_LAUNCHER_ENABLED)
+if(o3de_caching_compiler_launcher)
+    set(O3DE_MSVC_DEBUG_INFORMATION_FORMAT /Z7)
+else()
+    set(O3DE_MSVC_DEBUG_INFORMATION_FORMAT /Zi)
+endif()
+
 ly_append_configurations_options(
     DEFINES
         _ENABLE_EXTENDED_ALIGNED_STORAGE # Enables support for extended alignment for the MSVC std::aligned_storage class
@@ -119,6 +139,9 @@ ly_append_configurations_options(
         /O2             # Maximinize speed, equivalent to /Og /Oi /Ot /Oy /Ob2 /GF /Gy
         /Zc:inline      # Removes unreferenced functions or data that are COMDATs or only have internal linkage
         /Zc:wchar_t     # Use compiler native wchar_t
+        
+        # Profile always needs debug information 
+        ${O3DE_MSVC_DEBUG_INFORMATION_FORMAT}
     COMPILATION_RELEASE
         /Ox             # Full optimization
         /Ob2            # Inline any suitable function
@@ -162,6 +185,13 @@ endif()
 
 set(LY_BUILD_WITH_INCREMENTAL_LINKING_DEBUG FALSE CACHE BOOL "Indicates if incremental linking is used in debug configurations (default = FALSE)")
 if(LY_BUILD_WITH_INCREMENTAL_LINKING_DEBUG)
+    if(o3de_caching_compiler_launcher)
+        message(WARNING
+            "Incremental linking and caching compiler launchers are incompatible for Debug builds. "
+            "Edit and Continue (/ZI) will be used; the compiler launcher may not cache Debug builds effectively."
+        )
+    endif()
+    
     ly_append_configurations_options(
         COMPILATION_DEBUG
             /ZI         # Enable Edit/Continue
@@ -170,7 +200,7 @@ else()
     # Disable incremental linking
     ly_append_configurations_options(
         COMPILATION_DEBUG
-            /Zi         # Generate debugging information (no Edit/Continue). Edit/Continue requires incremental linking
+            ${O3DE_MSVC_DEBUG_INFORMATION_FORMAT}
 
         LINK_NON_STATIC_DEBUG
             /DEBUG      # Despite the documentation states /Zi implies /DEBUG, without it, stack traces are not expanded
@@ -183,8 +213,8 @@ set(O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE FALSE CACHE BOOL "Add debug symbols wh
 if(O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE)
     ly_append_configurations_options(
         COMPILATION_RELEASE
-            /Od             # Enable debug symbols
-            /Zi             # Generate debugging information (no Edit/Continue)
+            /Od             # Disable optimizations for debugging
+            ${O3DE_MSVC_DEBUG_INFORMATION_FORMAT}
 
         LINK_NON_STATIC_RELEASE
             /DEBUG          # Generate pdbs


### PR DESCRIPTION
## What does this PR do?

- Restore explicit MSVC debug-info flag handling for custom Profile config.
- Use `/Z7` only for known caching launchers (ccache, sccache), otherwise `/Zi`.
- Keep `/ZI` for Debug when incremental linking is enabled (with compatibility warning).
- Replace `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` reliance with 3.24-compatible logic.
- Add global properties to distinguish launcher presence vs caching launcher behavior.

## How was this PR tested?

Building now...
