### PR TITLE
Automatic Generic Asset Builder

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ap_setup_fixture.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/ap_setup_fixture.py
@@ -44,6 +44,7 @@ def ap_setup_fixture(request, workspace) -> Dict:
         "project_dir": workspace.paths.project(),
         # Path to AP Batch file
         "ap_batch_file": workspace.paths.asset_processor_batch(),
+        "ap_builder_file": workspace.paths.asset_builder(),
         # Path to shared TestAssets folder
         "shared_TestAssets": os.path.join(workspace.paths.project(), "TestAssets"),
         # Path to the asset cache folder

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/CMakeLists.txt
@@ -21,6 +21,17 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
             AZ::AssetProcessor
     )
 
+    
+    ly_add_pytest(
+        NAME APTests.ap_builder_test
+        PATH  ${CMAKE_CURRENT_LIST_DIR}/ap_builder_test.py
+        TEST_SUITE main
+        PYTEST_MARKS "not SUITE_sandbox" # don't run sandbox tests in this file
+        RUNTIME_DEPENDENCIES
+            AZ::AssetProcessorBatch
+            AZ::AssetProcessor
+    )
+
     ly_add_pytest(
         NAME APTests.ScriptCanvas_Main
         PATH ${CMAKE_CURRENT_LIST_DIR}/ScriptCanvasAssetProcessorTests.py

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ap_builder_test.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ap_builder_test.py
@@ -1,0 +1,169 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+General Asset Processor GUI Tests
+"""
+
+# Import builtin libraries
+import pytest
+import logging
+import os
+import tempfile as TF
+
+# Import LyTestTools
+import ly_test_tools
+import ly_test_tools.builtin.helpers as helpers
+import ly_test_tools.environment.waiter as waiter
+import ly_test_tools.environment.file_system as fs
+import ly_test_tools.environment.process_utils as process_utils
+import ly_test_tools.launchers.launcher_helper as launcher_helper
+from ly_test_tools.o3de.asset_processor import ASSET_PROCESSOR_PLATFORM_MAP
+from ly_test_tools.o3de.asset_processor import StopReason
+
+# Import fixtures
+from ..ap_fixtures.asset_processor_fixture import asset_processor as asset_processor
+from ..ap_fixtures.ap_setup_fixture import ap_setup_fixture as ap_setup_fixture
+from ..ap_fixtures.ap_idle_fixture import TimestampChecker
+from ..ap_fixtures.ap_fast_scan_setting_backup_fixture import (
+    ap_fast_scan_setting_backup_fixture as fast_scan_backup,
+)
+
+# Use the following logging pattern to hook all test logging together:
+logger = logging.getLogger(__name__)
+# Configuring the logging is done in ly_test_tools at the following location:
+# ~/dev/Tools/LyTestTools/ly_test_tools/log/py_logging_util.py
+
+# Helper: variables we will use for parameter values in the test:
+targetProjects = ["AutomatedTesting"]
+
+@pytest.fixture
+def ap_idle(workspace, ap_setup_fixture):
+    gui_timeout_max = 30
+    return TimestampChecker(workspace.paths.asset_catalog(ASSET_PROCESSOR_PLATFORM_MAP[workspace.asset_processor_platform]), gui_timeout_max)
+
+def setup_temp_dir() -> str:
+    tempDir = os.path.join(TF.gettempdir(), "TempTest")
+    if os.path.exists(tempDir):
+        fs.delete([tempDir], True, True)
+    if not os.path.exists(tempDir):
+        os.mkdir(tempDir)
+    return tempDir
+
+@pytest.mark.usefixtures("asset_processor")
+@pytest.mark.usefixtures("ap_setup_fixture")
+@pytest.mark.parametrize("project", targetProjects)
+@pytest.mark.SUITE_main
+class TestsAssetProcessorGUI(object):
+    """
+    Specific Tests for Asset Processor GUI
+    """
+
+    def test_GenericAssetBuilder_OutputsDependencies(self, asset_processor, ap_setup_fixture, workspace):
+
+        """
+        Ensures the Generic Asset Builder actually picks up the dependencies of an asset automatically.
+        Test Steps:
+        1. Start Asset Processor without quitonidle
+        2. Execute AssetBuilder with a command line that makes it dump the actual job output
+           into a folder instead of the cache.
+        3. Inspect the job output and verify everything is as expected.
+        """
+        env = ap_setup_fixture
+
+        # Copy test assets to project folder and verify test assets folder exists
+
+        result, _ = asset_processor.gui_process(quitonidle=False,connect_to_ap=True)
+        assert result, "AP GUI failed"
+
+        # Wait for AP to have finished processing
+        asset_processor.wait_for_idle()
+
+        path_to_test_asset = os.path.join(workspace.paths.engine_root(), "Gems", "TestAssetBuilder", "Assets", "GenericAssetBuilderAssets", "asset_with_dependencies.auto_test_depasset")
+        path_to_output_dir = setup_temp_dir()
+        result, _ = asset_processor.run_builder(extra_params=
+                 ["-debug", path_to_test_asset,
+                  "-output", path_to_output_dir])
+        assert result, "AP Builder failed"
+
+        # examine results
+        output_processjobs_xml = os.path.join(path_to_output_dir, "Generic Asset Builder", "ProcessJobs", "0_ProcessJobResponse.xml")
+
+        import xml.etree.ElementTree as ET
+        tree = ET.parse(output_processjobs_xml)
+        root = tree.getroot()
+
+        # The entire output XML file looks something like this.
+        # set of "class" structures whihc looks something like this:
+        '''
+        <ObjectStream version="3">
+            <Class name="ProcessJobResponse" version="3"">
+                <Class name="AZStd::vector&lt;JobProduct, allocator&gt;" field="Output Products"">
+                    <Class name="JobProduct" field="element" version="7">
+                        <Class name="AZStd::string" field="Product File Name"/>
+                        <Class name="AZ::Uuid" field="Product Asset Type"/>
+                        <Class name="unsigned int" field="Product Sub Id" value="0"/>
+                        <Class name="AZStd::vector&lt;unsigned int, allocator&gt;" field="Legacy Sub Ids"/>
+                        <Class name="AZStd::vector&lt;ProductDependency, allocator&gt;" field="Dependencies">
+                            ( Repeated set of product dependencies here, see below)
+        '''
+       
+        # here is an example of a ProductDependency section in the output XML:
+        # it consists of an "AssetId" which is a pair of (guid, subid) and a set of flags.
+        '''
+        <Class name="ProductDependency" field="element" version="1">
+            <Class name="AssetId" field="Dependency Id" version="1">
+                <Class name="AZ::Uuid" field="guid" value="{4CACAE2C-C361-57BE-A8D5-647F07660A3F}"/>
+                <Class name="unsigned int" field="subId" value="0"/>
+            </Class>
+            <Class name="AZStd::bitset&lt;64&gt;" field="Flags" value="0200000000000000"/>
+        </Class>
+        '''
+
+        # given a treeElement that points at the tree element with <Class name="ProductDependency"> as above, extract the guid and flags.
+        def extractProductDependencyInfo(treeElement):
+            guid = None
+            flags = None
+            foundFields = 0
+            for elem in treeElement.iter():
+                if elem.tag == "Class" and elem.attrib.get("field") == "guid":
+                    guid = elem.attrib.get("value")
+                    foundFields += 1
+                elif elem.tag == "Class" and elem.attrib.get("field") == "Flags":
+                    flags = elem.attrib.get("value")
+                    foundFields += 1
+                if foundFields == 2:
+                    break
+            assert (foundFields == 2), f"Expected to find both guid and flags for a ProductDependency, but only found {foundFields} fields."
+            return guid, flags
+    
+        found_dependencies = []
+    
+        # find the dependencies section, by iterating over the tree until we find an object of type "Class"
+        # with a name field of "ProductDependency":
+        for elem in root.iter():
+            if elem.tag == "Class" and elem.attrib.get("name") == "ProductDependency":
+                # we found a ProductDependency.  It will have 2 child nodes, the first of which
+                # has 2 children of its own, "Class" node with "Uuid" being one of the uuids.
+                # The second child node will have a "Class" node with a "AZStd::bitset&lt;64&gt;" field that we care about.
+                guid, flags = extractProductDependencyInfo(elem)
+                found_dependencies.append((guid, flags))
+
+        num_expected = 2
+        num_found = 0
+        for found_dependency in found_dependencies:
+            guid, flags = found_dependency
+            if guid == "{4CACAE2C-C361-57BE-A8D5-647F07660A3F}":
+                num_found += 1
+                assert flags == "0000000000000000", f"Flags for dependency with guid {expected_guid} were expected to be 0000000000000000 but were {flags}" 
+            elif guid == "{6677FA47-391A-591A-BC9E-279A03F75974}":
+                num_found += 1
+                assert flags == "0200000000000000", f"Flags for dependency with guid {expected_guid} were expected to be 0200000000000000 but were {flags}" 
+            else:
+                pytest.fail(f"Found a dependency with guid {guid} which was not expected.")
+        expected_guid = "4CACAE2C-C361-57BE-A8D5-647F07660A3F"
+        
+        assert num_found == num_expected, f"Expected to find {num_expected} dependencies but found {num_found}."
+

--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ap_builder_test.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/ap_builder_test.py
@@ -151,19 +151,22 @@ class TestsAssetProcessorGUI(object):
                 guid, flags = extractProductDependencyInfo(elem)
                 found_dependencies.append((guid, flags))
 
-        num_expected = 2
+        # we expect to find 3 dependencies, two from the asset<t> fields, and one from the loose assetid field.
+        num_expected = 3
         num_found = 0
         for found_dependency in found_dependencies:
             guid, flags = found_dependency
             if guid == "{4CACAE2C-C361-57BE-A8D5-647F07660A3F}":
                 num_found += 1
-                assert flags == "0000000000000000", f"Flags for dependency with guid {expected_guid} were expected to be 0000000000000000 but were {flags}" 
+                assert flags == "0000000000000000", f"Flags for dependency with guid {guid} were expected to be 0000000000000000 but were {flags}"
             elif guid == "{6677FA47-391A-591A-BC9E-279A03F75974}":
                 num_found += 1
-                assert flags == "0200000000000000", f"Flags for dependency with guid {expected_guid} were expected to be 0200000000000000 but were {flags}" 
+                assert flags == "0200000000000000", f"Flags for dependency with guid {guid} were expected to be 0200000000000000 but were {flags}"
+            elif guid == "{4D07F6E7-3D4E-59FA-840D-2757B523650C}":
+                num_found += 1
+                assert flags == "0200000000000000", f"Flags for dependency with guid {guid} were expected to be 0200000000000000 but were {flags}"
             else:
                 pytest.fail(f"Found a dependency with guid {guid} which was not expected.")
-        expected_guid = "4CACAE2C-C361-57BE-A8D5-647F07660A3F"
         
         assert num_found == num_expected, f"Expected to find {num_expected} dependencies but found {num_found}."
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/GenericAssetHandler.h
@@ -41,7 +41,11 @@ namespace AzFramework
      *      if (serialize)
      *      {
      *          serialize->Class<MyAsset>()
-     *              ->Field("SomeField", &MyAsset::m_someField)
+     *              ->Version(0)
+     *              ->Attribute(AZ::Edit::Attributes::EnableForAssetEditor, true) // optional:  automatically show in "create new" menu in Asset Editor
+     *              ->Field("SomeField", &MyAsset::m_someField) // a plain old data field (example)
+     *              ->Field("myAsset", &MyAsset::m_myAsset)     // assignment of some other asset we depend on (example)
+     *              
      *              ;
      *
      *          AZ::EditContext* edit = serialize->GetEditContext();
@@ -49,18 +53,39 @@ namespace AzFramework
      *          {
      *              edit->Class<MyAsset>("My Asset", "Asset for representing X, Y, and Z")
      *                  ->DataElement(0, &MyAsset::m_someField, "Some data field", "It's a float")
+     *                  ->DataElement(0, &MyAsset::m_myAsset, "Some Asset To Use", "It's a reference to some other asset")
      *                  ;
      *          }
      *      }
      *  }
      *
      *  float m_someField;
+     *  Asset<SomeType> m_myAsset { AZ::Data::AssetLoadBehavior::PreLoad }; // example, can choose a different auto load behavior here if you want
      * };
      *
      *
      * using MyAssetHandler = GenericAssetHandler<MyAsset>;
      *
+     * // Note that you must still register the actual asset handler instance on startup and tear it down on shutdown, using a system component or other
+     * // singleton.
+     * // Alternatively you can set autoprocess later:
+     * s_myAssetHandler = new MyAssetHandler("My Asset Friendly Display Name", "My Asset Group (ie, Graphics, Audio ...)", "my_file_extension_without_dot");
+     * s_myAssetHandler->SetAutoProcessToCache(true); // if you want the system to register, build and copy it to cache and extract deps for you.
+     * s_myAssetHandler->Register();
+     *
+     * // Registration timing is important.  Your component must activate and register its type before the system component that auto builds
+     * // asset checks for registration.  You do this by making sure your singleton / system component providing the above registration emits
+     * // AzFramework::s_GenericAssetRegistrar as one of its Provided Services, which will cause it to activate before the system
+     * // that depends on that service.
+     *
+     * Example:
+     * 
+     * void MySystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided) override
+     * {
+     *     provided.push_back(AzFramework::s_GenericAssetRegistrar); // Activate me before things that need these registrations.
+     * }
      */
+
 
     /** 
     * Just a base class to assign concrete RTTI to these classes - Don't derive from this - use GenericAssetHandler<T> instead.
@@ -81,7 +106,17 @@ namespace AzFramework
         // compilation.  See the body of this function for more information.
         AZ::Data::AssetId AssetMissingInCatalog(const AZ::Data::Asset<AZ::Data::AssetData>& asset) override;
 
+        //! Overridden in GenericAssetHandler to return whether or not the asset should be auto processed into the cache.
+        //! This is based on what the constructor sets.
+        virtual bool AutoBuildAssetToCache() = 0;
     };
+
+    // Important:  If you want your generic asset to automatically be processed by asset processor, and dependencies auto extracted
+    // you must make the system component which registers your generic asset handler emit the following in its GetProvidedServices
+    // that it is is activated before the system component that checks all existing handlers and registers the auto builder for them:
+    constexpr const AZ::Crc32 s_GenericAssetRegistrar = AZ_CRC_CE("GenericAssetRegistrar");
+    // Remember to also add ->Attribute(AZ::Edit::Attributes::EnableForAssetEditor, true) // as an attribute in your asset's
+    // reflection if you want it to show up in the asset editor "create new" / "open existing" dialogs automatically.
 
     template <typename AssetType>
     class GenericAssetHandler
@@ -92,18 +127,31 @@ namespace AzFramework
         AZ_CLASS_ALLOCATOR(GenericAssetHandler<AssetType>, AZ::SystemAllocator);
         AZ_RTTI(GenericAssetHandler<AssetType>, "{8B36B3E8-8C0B-4297-BDA2-1648C155C78E}", GenericAssetHandlerBase);
 
+        //! Construct your generic asset handler.
+        //! @param displayName The name of the asset type to show in the user-facing guis and logs
+        //! @param extension The file extension to associate with this asset type.  JUST the extension without a dot.
+        //! @param componentTypeId If this asset type is meant to be automatically added as a component to entities
+        //!                        when dragged and dropped into the level, specify the component typeid here.
+        //!                        This should be the typeid of the component that should be added.
+        //! @param streamType The type of stream to use when saving this asset. (Default is ObjectStream XML)
+        //! @param autoProcessToCache If true, the asset system will automatically process this asset into the cache
+        //!                           using the asset processor, and automatically extract dependencies for it.
+        //!                           if False, you're expected to do that work yourself, by either making a RC COPY rule in the
+        //!                           asset processor setreg, or make your own Asset Builder (Custom) to handle extreme custom cases.
         GenericAssetHandler(const char* displayName,
             const char* group,
             const char* extension,
             const AZ::Uuid& componentTypeId = AZ::Uuid::CreateNull(),
             AZ::SerializeContext* serializeContext = nullptr,
-            const AZ::DataStream::StreamType streamType = AZ::ObjectStream::ST_XML)
+            const AZ::DataStream::StreamType streamType = AZ::ObjectStream::ST_XML,
+            const bool autoProcessToCache = false) 
             : m_displayName(displayName)
             , m_group(group)
             , m_extension(extension)
             , m_componentTypeId(componentTypeId)
             , m_serializeContext(serializeContext)
             , m_streamType(streamType)
+            , m_autoProcessAsset(autoProcessToCache)
         {
             AZ_Assert(extension, "Extension is required.");
             if (extension[0] == '.')
@@ -125,6 +173,16 @@ namespace AzFramework
         virtual ~GenericAssetHandler()
         {
             AZ::AssetTypeInfoBus::Handler::BusDisconnect();
+        }
+
+        bool AutoBuildAssetToCache() override
+        {
+            return m_autoProcessAsset;
+        }
+
+        void SetAutoBuildAssetToCache(bool autoBuild)
+        {
+            m_autoProcessAsset = autoBuild;
         }
 
         AZ::Data::AssetPtr CreateAsset(const AZ::Data::AssetId& /*id*/, const AZ::Data::AssetType& /*type*/) override
@@ -241,6 +299,7 @@ namespace AzFramework
         AZStd::string m_displayName;
         AZStd::string m_group;
         AZStd::string m_extension;
+        bool m_autoProcessAsset = false;
         AZ::Uuid m_componentTypeId = AZ::Uuid::CreateNull();
         AZ::SerializeContext* m_serializeContext;
         AZ::DataStream::StreamType m_streamType;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1667,14 +1667,19 @@ namespace AzToolsFramework
         (void)index;
         (void)node;
 
+        // Preserve the desired load behavior
+        AZ::Data::AssetLoadBehavior oldBehavior = instance.GetAutoLoadBehavior();
         if (!GUI->GetSelectedAssetID().IsValid())
         {
+            
             instance = property_t(AZ::Data::AssetId(), GUI->GetCurrentAssetType(), "");
         }
         else
         {
             instance = property_t(GUI->GetSelectedAssetID(), GUI->GetCurrentAssetType(), GUI->GetCurrentAssetHint());
         }
+        instance.SetAutoLoadBehavior(oldBehavior);
+
     }
 
     void AssetPropertyHandlerDefault::WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)

--- a/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderCommon.h
+++ b/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderCommon.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+
+namespace LmbrCentral::GenericAssetBuilder
+{
+    //! "Registration" represents a registered type for the Generic Asset Builder to build.
+    //! You can make any number of these in response to the callback.
+    struct GenericAssetBuilderRegistration
+    {
+        AZStd::string m_pattern; //! The pattern to use to identify it, like "*.myasset"
+        AZ::Uuid m_outputAssetTypeId; //! The typeid to assign it in the asset database.
+                                      //!  This should match the typeid (the guid) of the asset type, ie,
+                                      //!  the typeid of the template parameter T inside AZ::Data::Asset<T>
+    };
+} // namespace LmbrCentral::GenericAssetBuilderAPI

--- a/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderComponent.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Builders/GenericAssetBuilder/GenericAssetBuilderComponent.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Asset/AssetManager.h>
+#include <AzFramework/Asset/GenericAssetHandler.h>
+
+AZ::ComponentDescriptor* GenericAssetBuilderComponent_CreateDescriptor()
+{
+    return LmbrCentral::GenericAssetBuilder::GenericAssetBuilderComponent::CreateDescriptor();
+}
+
+namespace LmbrCentral::GenericAssetBuilder
+{
+    void GenericAssetBuilderComponent::Init()
+    {
+    }
+
+    void GenericAssetBuilderComponent::Activate()
+    {
+        AZStd::vector<GenericAssetBuilderRegistration> registrations;
+
+        AssetBuilderSDK::AssetBuilderDesc builderDescriptor;
+        builderDescriptor.m_name = "Generic Asset Builder";
+
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+        AZ_Assert(serializeContext, "Failed to acquire serialize context.");
+        if (!serializeContext)
+        {
+            return;
+        }
+
+        AZ::Data::AssetManager& manager = AZ::Data::AssetManager::Instance();
+
+        // find all of the asset types that are handled by GenericAssetHandlers, and then check which ones
+        // are opting into auto building.
+        
+        auto callback = 
+        [&manager, &registrations](const AZ::SerializeContext::ClassData* classData, const AZ::Uuid&) -> bool
+        {
+            AZ::Data::AssetHandler* handler = manager.GetHandler(classData->m_typeId);
+            if (!azrtti_istypeof<AzFramework::GenericAssetHandlerBase*>(handler))
+            {
+                // Not handled by the generic asset handler.
+                return true; // return true to continue iterating!
+            }
+
+            AZ::Uuid assetTypeId = classData->m_typeId;
+
+            AzFramework::GenericAssetHandlerBase* genericHandler = azrtti_cast<AzFramework::GenericAssetHandlerBase*>(handler);
+            if (!genericHandler)
+            {
+                return true;
+            }
+            // check if we support copying this automatically
+            if (genericHandler->AutoBuildAssetToCache())
+            {
+                AZStd::vector<AZStd::string> extensions;
+                AZ::AssetTypeInfoBus::Event(assetTypeId, &AZ::AssetTypeInfoBus::Events::GetAssetTypeExtensions, extensions);
+                for (const AZStd::string& extension : extensions)
+                {
+                    if (extension.empty())
+                    {
+                        AZ_Error("GenericAssetBuilder", false,
+                            "GenericAsset with type [%s] wants to Auto Build using the Generic Asset Builder but has not "
+                            "emitted exensions using AZ::AssetTypeInfoBus::Events::GetAssetTypeExtensions(), it will not process.",
+                            classData->m_name);
+                        continue;
+                    }
+                    registrations.emplace_back(
+                        GenericAssetBuilderRegistration{ AZStd::string::format("*.%s", extension.c_str()), assetTypeId });
+                }
+            }
+            return true;
+        };
+         
+        serializeContext->EnumerateDerived<AZ::Data::AssetData>(callback);
+
+        for (const GenericAssetBuilderRegistration& registration : registrations)
+        {
+                builderDescriptor.m_patterns.emplace_back(
+                    AssetBuilderSDK::AssetBuilderPattern(
+                     registration.m_pattern,
+                     AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+        }
+
+        builderDescriptor.m_busId = azrtti_typeid<GenericAssetBuilderWorker>();
+        builderDescriptor.m_version = 1; // if you change this, all assets will automatically rebuild
+        builderDescriptor.m_analysisFingerprint = ""; // if you change this, all assets will re-analyze but not necessarily rebuild.
+        builderDescriptor.m_createJobFunction = AZStd::bind(&GenericAssetBuilderWorker::CreateJobs, &m_genericAssetBuilder,
+                                                            AZStd::placeholders::_1, AZStd::placeholders::_2);
+        builderDescriptor.m_processJobFunction = AZStd::bind(&GenericAssetBuilderWorker::ProcessJob, &m_genericAssetBuilder,
+                                                             AZStd::placeholders::_1, AZStd::placeholders::_2);
+
+        // This builder specifically emits dependencies
+        builderDescriptor.m_flags = AssetBuilderSDK::AssetBuilderDesc::BF_None;
+
+        m_genericAssetBuilder.BusConnect(builderDescriptor.m_busId);
+        m_genericAssetBuilder.SetRegistrations(AZStd::move(registrations));
+
+        AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBusTraits::RegisterBuilderInformation,
+                                                    builderDescriptor);
+    }
+
+    // Disconnects from any EBuses we connected to in Activate()
+    // Unregisters from objects and systems we register with in Activate()
+    void GenericAssetBuilderComponent::Deactivate()
+    {
+        // We don't need to unregister the builder - the AP will handle this for us, because it is
+        // managing the lifecycle of this component. All we need to do is disconnect from the bus.
+        m_genericAssetBuilder.BusDisconnect();
+    }
+
+    void GenericAssetBuilderComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<GenericAssetBuilderComponent, AZ::Component>()
+                ->Version(0)
+                ->Attribute(AZ::Edit::Attributes::SystemComponentTags,
+                            AZStd::vector<AZ::Crc32>({ AssetBuilderSDK::ComponentTags::AssetBuilder }))
+            ;
+        }
+    }
+
+    void GenericAssetBuilderComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        // do not depend on this in your component, or it will create a loop
+        provided.push_back(AZ_CRC_CE("GenericAssetBuilderPluginService"));
+    }
+
+    void GenericAssetBuilderComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("GenericAssetBuilderPluginService"));
+    }
+
+    void GenericAssetBuilderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        AZ_UNUSED(required);
+    }
+
+    void GenericAssetBuilderComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        // causes all of the components that provide this registrar service to activate before we do,
+        // so that by the time we activate, we know they are all there.
+        dependent.push_back(AzFramework::s_GenericAssetRegistrar);
+    }
+} // namespace LmbrCentral::GenericAssetBuilder

--- a/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderComponent.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <Builders/GenericAssetBuilder/GenericAssetBuilderWorker.h>
+
+namespace LmbrCentral::GenericAssetBuilder
+{
+    //! This component manages the lifetime of the GenericAssetBuilder.
+    class GenericAssetBuilderComponent
+        : public AZ::Component
+    {
+    public:
+        AZ_COMPONENT(GenericAssetBuilderComponent, "{F54C592B-99CA-44BF-8060-B8182AE949F4}");
+
+        GenericAssetBuilderComponent() = default;
+        ~GenericAssetBuilderComponent() override = default;
+
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+    private:
+        GenericAssetBuilderWorker m_genericAssetBuilder;
+    };
+} // namespace LmbrCentral::GenericAssetBuilder

--- a/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.cpp
@@ -7,11 +7,14 @@
  */
 
 #include <Builders/GenericAssetBuilder/GenericAssetBuilderWorker.h>
-#include <AzCore/std/string/wildcard.h>
-#include <AzCore/StringFunc/StringFunc.h>
+
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Serialization/Utils.h>
-#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/std/string/wildcard.h>
+#include <AzCore/StringFunc/StringFunc.h>
+
+#include <AssetBuilderSDK/SerializationDependencies.h>
 
 namespace LmbrCentral::GenericAssetBuilder
 {
@@ -105,14 +108,6 @@ namespace LmbrCentral::GenericAssetBuilder
         }
 
         AssetBuilderSDK::JobProduct jobProduct;
-        jobProduct.m_dependenciesHandled = true;
-
-        // Note that emitting the entire full path to source file as a product file is an actual
-        // supported operation, and causes the AP to just copy the source file to the cache directly, without us having to
-        // compile anything.
-        jobProduct.m_productFileName = request.m_fullPath;
-        jobProduct.m_productSubID = 0;
-        jobProduct.m_productAssetType = whichReg->m_outputAssetTypeId;
 
         // populate dependencies:
         AZ::SerializeContext* serializeContext = nullptr;
@@ -125,6 +120,50 @@ namespace LmbrCentral::GenericAssetBuilder
             return;
         }
 
+        AZ::ObjectStream::FilterDescriptor dontLoadAnyAssets(&AZ::Data::AssetFilterNoAssetLoading, AZ::ObjectStream::FILTERFLAG_IGNORE_UNKNOWN_CLASSES);
+        // load and convert the object so we can extract dependencies from it.
+        void* resultData = AZ::Utils::LoadObjectFromFile(request.m_fullPath, whichReg->m_outputAssetTypeId, serializeContext, dontLoadAnyAssets);
+        if (!resultData)
+        {
+            AZ_Error(
+                "GenericAssetBuilderWorker",
+                false,
+                "Failed to load asset file [%s] during generic asset building. Make sure the file is a valid AZ serialized file and that the type is reflected.",
+                request.m_fullPath.c_str());
+            response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+            return;
+        }
+        AZStd::string destFileName;
+        AZStd::string destFullPath;
+        AZ::StringFunc::Path::GetFullFileName(request.m_fullPath.c_str(), destFileName);
+        AZ::StringFunc::Path::ConstructFull(request.m_tempDirPath.c_str(), destFileName.c_str(), destFullPath, true);
+
+        // Save the asset to binary format for production
+        if (!AZ::Utils::SaveObjectToFile(
+                destFullPath, AZ::DataStream::ST_BINARY, resultData, whichReg->m_outputAssetTypeId, serializeContext))
+        {
+			AZ_Error(
+				"GenericAssetBuilderWorker",
+				false,
+				"Failed to save asset file [%s] during generic asset building.",
+				destFullPath.c_str());
+			response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+			return;
+		}
+
+		if (!AssetBuilderSDK::OutputObject(resultData, whichReg->m_outputAssetTypeId, destFullPath, whichReg->m_outputAssetTypeId, 0, jobProduct))
+        {
+			AZ_Error(
+				"GenericAssetBuilderWorker",
+				false,
+				"Failed to output asset file [%s] during generic asset building.",
+				destFullPath.c_str());
+			response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+            return;
+        }
+
+		response.m_outputProducts.emplace_back(AZStd::move(jobProduct));
+
         const AZ::SerializeContext::ClassData* classData = serializeContext->FindClassData(whichReg->m_outputAssetTypeId);
 
         if (!classData)
@@ -136,33 +175,14 @@ namespace LmbrCentral::GenericAssetBuilder
                 "If you want this file to automatically emit dependencies, make sure you have a reflection function for it. "
                 "If you have a reflection function, make sure that the reflection function is actually being called, ie, it "
                 "is in a module that is loaded during asset processing.",
-                    request.m_fullPath.c_str(),
-                    whichReg->m_outputAssetTypeId.ToString<AZStd::string>().c_str());
+                request.m_fullPath.c_str(),
+                whichReg->m_outputAssetTypeId.ToString<AZStd::string>().c_str());
         }
         else
         {
-            // A filter function gets called by the serializer whenever it encounters an asset reference.
-            // it contains the details about the asset, and also allows you to return true or false,
-            // depending on whether you want it to go ahead and load the asset, or just leave it at 0 refcount unloaded.
-            auto filterFn = [&jobProduct](const AZ::Data::AssetFilterInfo& assetInfo) -> bool
-            {
-                jobProduct.m_dependencies.emplace_back(AssetBuilderSDK::ProductDependency(assetInfo.m_assetId, assetInfo.m_loadBehavior));
-                return false; // return false since we dont actually want to load this asset, just know about it.
-            };
-
-            AZ::ObjectStream::FilterDescriptor filterDesc(filterFn, AZ::ObjectStream::FILTERFLAG_IGNORE_UNKNOWN_CLASSES);
-
-            void* data = AZ::Utils::LoadObjectFromFile(request.m_fullPath, whichReg->m_outputAssetTypeId, serializeContext, filterDesc);
-            if (data)
-            {
-                // we need to delete the data using the serializer, too, since we can't cast to it here.
-                // it may seem strange that we create it and destroy it but the purpose is so that the serializer,
-                // during reading, will call the filter function whenever it encounters an asset reference.
-                classData->m_factory->Destroy(data);
-            }
+            classData->m_factory->Destroy(resultData);
         }
 
-        response.m_outputProducts.push_back(jobProduct);
         response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
     }
 

--- a/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Builders/GenericAssetBuilder/GenericAssetBuilderWorker.h>
+#include <AzCore/std/string/wildcard.h>
+#include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/Serialization/Utils.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
+
+namespace LmbrCentral::GenericAssetBuilder
+{
+    // Note - Shutdown will be called on a different thread than your process job thread
+    void GenericAssetBuilderWorker::ShutDown()
+    {
+        m_isShuttingDown = true;
+    }
+
+    void GenericAssetBuilderWorker::CreateJobs(
+        const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response)
+    {
+        if (m_isShuttingDown)
+        {
+            response.m_result = AssetBuilderSDK::CreateJobsResultCode::ShuttingDown;
+            return;
+        }
+
+        AZStd::string ext;
+        constexpr bool includeDot = false;
+        AZ::StringFunc::Path::GetExtension(request.m_sourceFile.c_str(), ext, includeDot);
+
+        // There is no need to actually load the file here, if we got here it means
+        // its one of the extensions we registered for so we should just go ahead and emit a job
+        // to process it.
+
+        for (const AssetBuilderSDK::PlatformInfo& info : request.m_enabledPlatforms)
+        {
+            AssetBuilderSDK::JobDescriptor descriptor;
+            descriptor.m_jobKey = "Generic Asset Processing";
+            descriptor.SetPlatformIdentifier(info.m_identifier.data());
+            descriptor.m_critical = false;
+            response.m_createJobOutputs.push_back(descriptor);
+        }
+
+        response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
+        return;
+    }
+
+    void GenericAssetBuilderWorker::ProcessJob(
+        const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response)
+    {
+        // Before we begin, let's make sure we are not meant to abort.
+        {
+            AssetBuilderSDK::JobCancelListener jobCancelListener(request.m_jobId);
+            if (jobCancelListener.IsCancelled())
+            {
+                AZ_Warning(
+                    AssetBuilderSDK::WarningWindow,
+                    false,
+                    "Cancel Request: Cancelled generic asset processing job for %s.\n",
+                    request.m_fullPath.data());
+                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Cancelled;
+                return;
+            }
+
+            if (m_isShuttingDown)
+            {
+                AZ_Warning(
+                    AssetBuilderSDK::WarningWindow,
+                    false,
+                    "Shutdown Request: Cancelled generic asset processing job for %s.\n",
+                    request.m_fullPath.data());
+                response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Cancelled;
+                return;
+            }
+        }
+
+        
+        // Strategy:  Figure out which registration this asset matches, then just copy the file to the cache and register it as a product.
+        // Extract dependencies as part of this processing.
+        GenericAssetBuilderRegistration* whichReg = nullptr;
+        for (GenericAssetBuilderRegistration& reg : m_registrations)
+        {
+            if (AZStd::wildcard_match(reg.m_pattern, request.m_fullPath.c_str()))
+            {
+                whichReg = &reg;
+                break;
+            }
+        }
+
+        if (!whichReg)
+        {
+            AZ_Error(
+                AssetBuilderSDK::ErrorWindow,
+                false,
+                "Source File %s did not match any registered generic asset patterns.",
+                request.m_fullPath.c_str());
+            response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+            return;
+        }
+
+        AssetBuilderSDK::JobProduct jobProduct;
+        jobProduct.m_dependenciesHandled = true;
+
+        // Note that emitting the entire full path to source file as a product file is an actual
+        // supported operation, and causes the AP to just copy the source file to the cache directly, without us having to
+        // compile anything.
+        jobProduct.m_productFileName = request.m_fullPath;
+        jobProduct.m_productSubID = 0;
+        jobProduct.m_productAssetType = whichReg->m_outputAssetTypeId;
+
+        // populate dependencies:
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+        
+        if (!serializeContext)
+        {
+            AZ_Error("GenericAssetBuilderWorker", false, "Failed to get serialize context.");
+            response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+            return;
+        }
+
+        const AZ::SerializeContext::ClassData* classData = serializeContext->FindClassData(whichReg->m_outputAssetTypeId);
+
+        if (!classData)
+        {
+            AZ_Warning(
+                "GenericAssetBuilderWorker",
+                false,
+                "Asset file [%s] (type %s) requested automatic Generic Asset Building but is not registered with the serializer. "
+                "If you want this file to automatically emit dependencies, make sure you have a reflection function for it. "
+                "If you have a reflection function, make sure that the reflection function is actually being called, ie, it "
+                "is in a module that is loaded during asset processing.",
+                    request.m_fullPath.c_str(),
+                    whichReg->m_outputAssetTypeId.ToString<AZStd::string>().c_str());
+        }
+        else
+        {
+            // A filter function gets called by the serializer whenever it encounters an asset reference.
+            // it contains the details about the asset, and also allows you to return true or false,
+            // depending on whether you want it to go ahead and load the asset, or just leave it at 0 refcount unloaded.
+            auto filterFn = [&jobProduct](const AZ::Data::AssetFilterInfo& assetInfo) -> bool
+            {
+                jobProduct.m_dependencies.emplace_back(AssetBuilderSDK::ProductDependency(assetInfo.m_assetId, assetInfo.m_loadBehavior));
+                return false; // return false since we dont actually want to load this asset, just know about it.
+            };
+
+            AZ::ObjectStream::FilterDescriptor filterDesc(filterFn, AZ::ObjectStream::FILTERFLAG_IGNORE_UNKNOWN_CLASSES);
+
+            void* data = AZ::Utils::LoadObjectFromFile(request.m_fullPath, whichReg->m_outputAssetTypeId, serializeContext, filterDesc);
+            if (data)
+            {
+                // we need to delete the data using the serializer, too, since we can't cast to it here.
+                // it may seem strange that we create it and destroy it but the purpose is so that the serializer,
+                // during reading, will call the filter function whenever it encounters an asset reference.
+                classData->m_factory->Destroy(data);
+            }
+        }
+
+        response.m_outputProducts.push_back(jobProduct);
+        response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
+    }
+
+    void GenericAssetBuilderWorker::SetRegistrations(AZStd::vector<GenericAssetBuilderRegistration>&& registrations)
+    {
+        m_registrations = AZStd::move(registrations);
+    }
+} // namespace LmbrCentral::GenericAssetBuilder

--- a/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.cpp
@@ -142,27 +142,27 @@ namespace LmbrCentral::GenericAssetBuilder
         if (!AZ::Utils::SaveObjectToFile(
                 destFullPath, AZ::DataStream::ST_BINARY, resultData, whichReg->m_outputAssetTypeId, serializeContext))
         {
-			AZ_Error(
-				"GenericAssetBuilderWorker",
-				false,
-				"Failed to save asset file [%s] during generic asset building.",
-				destFullPath.c_str());
-			response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
-			return;
-		}
-
-		if (!AssetBuilderSDK::OutputObject(resultData, whichReg->m_outputAssetTypeId, destFullPath, whichReg->m_outputAssetTypeId, 0, jobProduct))
-        {
-			AZ_Error(
-				"GenericAssetBuilderWorker",
-				false,
-				"Failed to output asset file [%s] during generic asset building.",
-				destFullPath.c_str());
-			response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+            AZ_Error(
+                "GenericAssetBuilderWorker",
+                false,
+                "Failed to save asset file [%s] during generic asset building.",
+                destFullPath.c_str());
+            response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
             return;
         }
 
-		response.m_outputProducts.emplace_back(AZStd::move(jobProduct));
+        if (!AssetBuilderSDK::OutputObject(resultData, whichReg->m_outputAssetTypeId, destFullPath, whichReg->m_outputAssetTypeId, 0, jobProduct))
+        {
+            AZ_Error(
+                "GenericAssetBuilderWorker",
+                false,
+                "Failed to output asset file [%s] during generic asset building.",
+                destFullPath.c_str());
+            response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
+            return;
+        }
+
+        response.m_outputProducts.emplace_back(AZStd::move(jobProduct));
 
         const AZ::SerializeContext::ClassData* classData = serializeContext->FindClassData(whichReg->m_outputAssetTypeId);
 

--- a/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.h
+++ b/Gems/LmbrCentral/Code/Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/containers/vector.h>
+
+#include <AssetBuilderSDK/AssetBuilderBusses.h>
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
+
+#include <Builders/GenericAssetBuilder/GenericAssetBuilderCommon.h>
+
+namespace LmbrCentral::GenericAssetBuilder
+{
+    // The generic Asset Builder Worker takes any registered generic asset types
+    // and converts them into data in the cache by copying there.
+    // It also extracts dependencies and registers them, if requested.
+    // It can also convert the generic asset into a more compact binary format if requested.
+    class GenericAssetBuilderWorker
+        : public AssetBuilderSDK::AssetBuilderCommandBus::Handler // this will deliver you the "shut down!" message on another thread.
+    {
+    public:
+        AZ_RTTI(GenericAssetBuilderWorker, "{37C1FD99-D693-40D5-B0A4-71D542268B21}");
+
+        GenericAssetBuilderWorker() = default;
+        ~GenericAssetBuilderWorker() = default;
+
+        //! Asset Builder Callback Functions
+        void CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response);
+        void ProcessJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response);
+
+        //////////////////////////////////////////////////////////////////////////
+        //!AssetBuilderSDK::AssetBuilderCommandBus interface
+        void ShutDown() override; // if you get this you must fail all existing jobs and return.
+        //////////////////////////////////////////////////////////////////////////
+
+        void SetRegistrations(AZStd::vector<GenericAssetBuilderRegistration>&& registrations);
+    private:
+        bool m_isShuttingDown = false;
+        AZStd::vector<GenericAssetBuilderRegistration> m_registrations;
+    };
+}

--- a/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
+++ b/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
@@ -47,6 +47,8 @@
 #include <Builders/TranslationBuilder/TranslationBuilderComponent.h>
 #include "Builders/CopyDependencyBuilder/CopyDependencyBuilderComponent.h"
 
+extern AZ::ComponentDescriptor* GenericAssetBuilderComponent_CreateDescriptor();
+
 namespace LmbrCentral
 {
     LmbrCentralEditorModule::LmbrCentralEditorModule()
@@ -80,6 +82,7 @@ namespace LmbrCentral
             SliceBuilder::BuilderPluginComponent::CreateDescriptor(),
             TranslationBuilder::BuilderPluginComponent::CreateDescriptor(),
             LuaBuilder::BuilderPluginComponent::CreateDescriptor(),
+            GenericAssetBuilderComponent_CreateDescriptor(),
 
             BenchmarkAssetBuilder::BenchmarkAssetBuilderComponent::CreateDescriptor(),
         });

--- a/Gems/LmbrCentral/Code/lmbrcentral_editor_files.cmake
+++ b/Gems/LmbrCentral/Code/lmbrcentral_editor_files.cmake
@@ -106,5 +106,10 @@ set(FILES
     Source/Builders/LuaBuilder/LuaBuilderWorker.h
     Source/Builders/LuaBuilder/LuaHelpers.cpp
     Source/Builders/LuaBuilder/LuaHelpers.h
+    Source/Builders/GenericAssetBuilder/GenericAssetBuilderComponent.cpp
+    Source/Builders/GenericAssetBuilder/GenericAssetBuilderComponent.h
+    Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.cpp
+    Source/Builders/GenericAssetBuilder/GenericAssetBuilderWorker.h
+    Source/Builders/GenericAssetBuilder/GenericAssetBuilderCommon.h
 
 )

--- a/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_to_refer_to.auto_test_refasset
+++ b/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_to_refer_to.auto_test_refasset
@@ -1,0 +1,7 @@
+<ObjectStream version="3">
+	<Class name="TestGenericAssetRef" version="1" type="{B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8}">
+		<Class name="AssetData" field="BaseClass1" version="1" type="{AF3F7D32-1536-422A-89F3-A11E1F5B5A9C}"/>
+		<Class name="int" field="m_someField" value="32" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
+	</Class>
+</ObjectStream>
+

--- a/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_to_refer_to_by_assetid.auto_test_refasset
+++ b/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_to_refer_to_by_assetid.auto_test_refasset
@@ -1,0 +1,7 @@
+<ObjectStream version="3">
+	<Class name="TestGenericAssetRef" version="1" type="{B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8}">
+		<Class name="AssetData" field="BaseClass1" version="1" type="{AF3F7D32-1536-422A-89F3-A11E1F5B5A9C}"/>
+		<Class name="int" field="m_someField" value="22" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
+	</Class>
+</ObjectStream>
+

--- a/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_to_refer_to_via_noload.refasset.auto_test_refasset
+++ b/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_to_refer_to_via_noload.refasset.auto_test_refasset
@@ -1,0 +1,7 @@
+<ObjectStream version="3">
+	<Class name="TestGenericAssetRef" version="1" type="{B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8}">
+		<Class name="AssetData" field="BaseClass1" version="1" type="{AF3F7D32-1536-422A-89F3-A11E1F5B5A9C}"/>
+		<Class name="int" field="m_someField" value="16" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
+	</Class>
+</ObjectStream>
+

--- a/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_with_dependencies.auto_test_depasset
+++ b/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_with_dependencies.auto_test_depasset
@@ -1,0 +1,8 @@
+<ObjectStream version="3">
+	<Class name="TestGenericAsset" version="1" type="{63B3EA1F-8AFC-4C40-8F59-0B2E6A9CA191}">
+		<Class name="AssetData" field="BaseClass1" version="1" type="{AF3F7D32-1536-422A-89F3-A11E1F5B5A9C}"/>
+		<Class name="Asset&lt;TestGenericAssetRef&gt;" field="ReferencedAssets_Preload" value="id={4CACAE2C-C361-57BE-A8D5-647F07660A3F}:0,type={B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8},hint={genericassetbuilderassets/asset_to_refer_to.auto_test_refasset},loadBehavior=0" version="3" type="{BEAAEFF2-2D9C-5BB5-BD50-BC99385BC17B}"/>
+		<Class name="Asset&lt;TestGenericAssetRef&gt;" field="ReferencedAssets_NoLoad" value="id={6677FA47-391A-591A-BC9E-279A03F75974}:0,type={B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8},hint={genericassetbuilderassets/asset_to_refer_to_via_noload.refasset.auto_test_refasset},loadBehavior=2" version="3" type="{BEAAEFF2-2D9C-5BB5-BD50-BC99385BC17B}"/>
+	</Class>
+</ObjectStream>
+

--- a/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_with_dependencies.auto_test_depasset
+++ b/Gems/TestAssetBuilder/Assets/GenericAssetBuilderAssets/asset_with_dependencies.auto_test_depasset
@@ -1,8 +1,12 @@
 <ObjectStream version="3">
-	<Class name="TestGenericAsset" version="1" type="{63B3EA1F-8AFC-4C40-8F59-0B2E6A9CA191}">
+	<Class name="TestGenericAsset" version="2" type="{63B3EA1F-8AFC-4C40-8F59-0B2E6A9CA191}">
 		<Class name="AssetData" field="BaseClass1" version="1" type="{AF3F7D32-1536-422A-89F3-A11E1F5B5A9C}"/>
 		<Class name="Asset&lt;TestGenericAssetRef&gt;" field="ReferencedAssets_Preload" value="id={4CACAE2C-C361-57BE-A8D5-647F07660A3F}:0,type={B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8},hint={genericassetbuilderassets/asset_to_refer_to.auto_test_refasset},loadBehavior=0" version="3" type="{BEAAEFF2-2D9C-5BB5-BD50-BC99385BC17B}"/>
 		<Class name="Asset&lt;TestGenericAssetRef&gt;" field="ReferencedAssets_NoLoad" value="id={6677FA47-391A-591A-BC9E-279A03F75974}:0,type={B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8},hint={genericassetbuilderassets/asset_to_refer_to_via_noload.refasset.auto_test_refasset},loadBehavior=2" version="3" type="{BEAAEFF2-2D9C-5BB5-BD50-BC99385BC17B}"/>
+		<Class name="AssetId" field="ReferencedAssetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+			<Class name="AZ::Uuid" field="guid" value="{4D07F6E7-3D4E-59FA-840D-2757B523650C}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+			<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
 	</Class>
 </ObjectStream>
 

--- a/Gems/TestAssetBuilder/Code/CMakeLists.txt
+++ b/Gems/TestAssetBuilder/Code/CMakeLists.txt
@@ -48,5 +48,6 @@ ly_add_source_properties(
             O3DE_GEM_NAME=${gem_name}
             O3DE_GEM_VERSION=${gem_version})
 
-# the above module is for use in builders only
+# the above module is for use in tools and builders
+ly_create_alias(NAME ${gem_name}.Tools NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.cpp
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Asset/GenericAssetHandler.h>
+#include <Builder/TestGenericAssetBuilderComponent.h>
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+
+AZ::ComponentDescriptor* TestGenericAssetBuilderComponent_CreateDescriptor()
+{
+    return TestAssetBuilder::TestGenericAssetBuilderComponent::CreateDescriptor();
+}
+
+namespace TestAssetBuilder
+{
+    namespace Details
+    {
+        AzFramework::GenericAssetHandler<TestGenericAsset>* s_testGenericAssetHandler = nullptr;
+        AzFramework::GenericAssetHandler<TestGenericAssetRef>* s_testGenericAssetHandler_Ref = nullptr;
+
+        void RegisterAssethandlersGeneric()
+        {
+            bool autoProcessToCache = true;
+            s_testGenericAssetHandler =
+                aznew AzFramework::GenericAssetHandler<TestGenericAsset>(
+                    "Automated Test Asset With Deps", 
+                    "Other", 
+                    "auto_test_depasset", 
+                    AZ::Uuid::CreateNull(), 
+                    nullptr, 
+                    AZ::ObjectStream::ST_XML, 
+                    autoProcessToCache);
+
+            s_testGenericAssetHandler_Ref = aznew AzFramework::GenericAssetHandler<TestGenericAssetRef>(
+                "Automated Test Asset To Refer To",
+                "Other",
+                "auto_test_refasset",
+                AZ::Uuid::CreateNull(),
+                nullptr,
+                AZ::ObjectStream::ST_XML,
+                autoProcessToCache);
+
+            s_testGenericAssetHandler->Register();
+            s_testGenericAssetHandler_Ref->Register();
+        }
+
+        void UnregisterAssethandlersGeneric()
+        {
+            if (s_testGenericAssetHandler)
+            {
+                s_testGenericAssetHandler->Unregister();
+                delete s_testGenericAssetHandler;
+                s_testGenericAssetHandler = nullptr;
+            }
+
+            if (s_testGenericAssetHandler_Ref)
+            {
+                s_testGenericAssetHandler_Ref->Unregister();
+                delete s_testGenericAssetHandler_Ref;
+                s_testGenericAssetHandler_Ref = nullptr;
+            }
+        }
+    } // namespace Details
+
+    void TestGenericAsset::Reflect(AZ::ReflectContext* context)
+    {
+        auto serialize = azrtti_cast<AZ::SerializeContext*>(context);
+
+        if (serialize)
+        {
+            serialize->Class<TestGenericAsset, AZ::Data::AssetData>()
+                ->Version(1)
+                ->Attribute(AZ::Edit::Attributes::EnableForAssetEditor, true)
+                ->Field("ReferencedAssets_Preload", &TestGenericAsset::m_referencedAsset_Preload)
+                ->Field("ReferencedAssets_NoLoad", &TestGenericAsset::m_referencedAsset_NoLoad);
+
+            serialize->Class<TestGenericAssetRef, AZ::Data::AssetData>()
+                ->Version(1)
+                ->Attribute(AZ::Edit::Attributes::EnableForAssetEditor, true)
+                ->Field("m_someField", &TestGenericAssetRef::m_someField);
+
+            if (auto edit = serialize->GetEditContext())
+            {
+                edit->Class<TestGenericAsset>("Test Generic Asset", "A generic asset used for testing asset references")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAsset::m_referencedAsset_Preload, "Preload Asset Reference", "This asset reference will be set to PreLoad")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAsset::m_referencedAsset_NoLoad, "NoLoad Asset Reference", "This asset reference will be set to NoLoad");
+                 edit->Class<TestGenericAssetRef>("Test Generic Asset Ref", "A generic asset used for testing asset references (The ref)")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAssetRef::m_someField, "Just some field", "This is just some field to make sure the asset isn't empty");
+            }
+        }
+    }
+
+    void TestGenericAssetBuilderComponent::Init()
+    {
+    }
+
+    void TestGenericAssetBuilderComponent::Activate()
+    {
+        Details::RegisterAssethandlersGeneric();
+    }
+
+    void TestGenericAssetBuilderComponent::Deactivate()
+    {
+        Details::UnregisterAssethandlersGeneric();
+    }
+
+    void TestGenericAssetBuilderComponent::Reflect(AZ::ReflectContext* context)
+    {
+        TestGenericAsset::Reflect(context);
+
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<TestGenericAssetBuilderComponent, AZ::Component>()
+                ->Version(0)
+                ->Attribute(AZ::Edit::Attributes::SystemComponentTags, AZStd::vector<AZ::Crc32>({ AssetBuilderSDK::ComponentTags::AssetBuilder }));
+        }
+    }
+
+    void TestGenericAssetBuilderComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AzFramework::s_GenericAssetRegistrar);
+    }
+
+    void TestGenericAssetBuilderComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        AZ_UNUSED(incompatible)
+    }
+
+    void TestGenericAssetBuilderComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        AZ_UNUSED(required);
+    }
+
+    void TestGenericAssetBuilderComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        AZ_UNUSED(dependent);
+    }
+} // namespace TestAssetBuilder
+

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.cpp
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.cpp
@@ -6,12 +6,14 @@
  *
  */
 
-#include <AzFramework/Asset/GenericAssetHandler.h>
 #include <Builder/TestGenericAssetBuilderComponent.h>
+
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
-#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Asset/AssetSerializer.h> // needed if you use field<T> on an asset.  The VCI linter lies.
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Asset/GenericAssetHandler.h>
 
 AZ::ComponentDescriptor* TestGenericAssetBuilderComponent_CreateDescriptor()
 {
@@ -76,10 +78,11 @@ namespace TestAssetBuilder
         if (serialize)
         {
             serialize->Class<TestGenericAsset, AZ::Data::AssetData>()
-                ->Version(1)
+                ->Version(2)
                 ->Attribute(AZ::Edit::Attributes::EnableForAssetEditor, true)
                 ->Field("ReferencedAssets_Preload", &TestGenericAsset::m_referencedAsset_Preload)
-                ->Field("ReferencedAssets_NoLoad", &TestGenericAsset::m_referencedAsset_NoLoad);
+                ->Field("ReferencedAssets_NoLoad", &TestGenericAsset::m_referencedAsset_NoLoad)
+                ->Field("ReferencedAssetId", &TestGenericAsset::m_referencedAssetId);
 
             serialize->Class<TestGenericAssetRef, AZ::Data::AssetData>()
                 ->Version(1)
@@ -90,8 +93,15 @@ namespace TestAssetBuilder
             {
                 edit->Class<TestGenericAsset>("Test Generic Asset", "A generic asset used for testing asset references")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAsset::m_referencedAsset_Preload, "Preload Asset Reference", "This asset reference will be set to PreLoad")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAsset::m_referencedAsset_NoLoad, "NoLoad Asset Reference", "This asset reference will be set to NoLoad");
-                 edit->Class<TestGenericAssetRef>("Test Generic Asset Ref", "A generic asset used for testing asset references (The ref)")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAsset::m_referencedAsset_NoLoad, "NoLoad Asset Reference", "This asset reference will be set to NoLoad")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAsset::m_referencedAssetId, "AssetIdRef", "This asset reference is purely by ID and will be set to NoLoad")
+                        ->Attribute(AZ_CRC_CE("SupportedAssetTypes"), []() {
+                                AZStd::vector<AZ::Data::AssetType> supportedAssetTypes;
+                                supportedAssetTypes.push_back(AZ::Data::AssetType(s_TestGenericAssetTypeId));
+                                return supportedAssetTypes;
+                            });
+
+                edit->Class<TestGenericAssetRef>("Test Generic Asset Ref", "A generic asset used for testing asset references (The ref)")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TestGenericAssetRef::m_someField, "Just some field", "This is just some field to make sure the asset isn't empty");
             }
         }

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.h
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+
+
+namespace TestAssetBuilder
+{
+    // An asset that has just an int as its data and is referenced by other assets.
+    class TestGenericAssetRef : public AZ::Data::AssetData
+    {
+    public:
+        AZ_RTTI(TestGenericAssetRef, "{B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8}", AZ::Data::AssetData);
+        AZ_CLASS_ALLOCATOR(TestGenericAssetRef, AZ::SystemAllocator);
+
+        TestGenericAssetRef() = default;
+        virtual ~TestGenericAssetRef() = default;
+
+        int m_someField = 0;
+    };
+    // A generic asset that references other assets.
+    class TestGenericAsset : public AZ::Data::AssetData
+    {
+    public:
+        AZ_RTTI(TestGenericAsset, "{63B3EA1F-8AFC-4C40-8F59-0B2E6A9CA191}", AZ::Data::AssetData);
+        AZ_CLASS_ALLOCATOR(TestGenericAsset, AZ::SystemAllocator);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        TestGenericAsset() = default;
+        virtual ~TestGenericAsset() = default;
+
+        AZ::Data::Asset<TestGenericAssetRef> m_referencedAsset_Preload{ AZ::Data::AssetLoadBehavior::PreLoad };
+        AZ::Data::Asset<TestGenericAssetRef> m_referencedAsset_NoLoad{ AZ::Data::AssetLoadBehavior::NoLoad };
+    };
+
+    //! TestGenericAssetBuilderComponent handles the lifecycle of the generic asset registration.
+    //! note that this is NOT a builder, but a system component whos ONLY job is to register the
+    //! asset type.
+    class TestGenericAssetBuilderComponent : public AZ::Component
+    {
+    public:
+        AZ_COMPONENT(TestGenericAssetBuilderComponent, "{C0B9177F-3701-445A-BEDE-3415738F0EA1}");
+
+        TestGenericAssetBuilderComponent() = default;
+        ~TestGenericAssetBuilderComponent() override = default;
+
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+    private:
+    };
+
+    
+} // namespace TestAssetBuilder

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.h
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestGenericAssetBuilderComponent.h
@@ -16,10 +16,11 @@
 namespace TestAssetBuilder
 {
     // An asset that has just an int as its data and is referenced by other assets.
+    constexpr const char* const s_TestGenericAssetTypeId = "{B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8}";
     class TestGenericAssetRef : public AZ::Data::AssetData
     {
     public:
-        AZ_RTTI(TestGenericAssetRef, "{B0CAA8CE-EEE0-4EEE-BAD5-AC88B2C8F3B8}", AZ::Data::AssetData);
+        AZ_RTTI(TestGenericAssetRef, s_TestGenericAssetTypeId, AZ::Data::AssetData);
         AZ_CLASS_ALLOCATOR(TestGenericAssetRef, AZ::SystemAllocator);
 
         TestGenericAssetRef() = default;
@@ -27,6 +28,7 @@ namespace TestAssetBuilder
 
         int m_someField = 0;
     };
+
     // A generic asset that references other assets.
     class TestGenericAsset : public AZ::Data::AssetData
     {
@@ -41,6 +43,7 @@ namespace TestAssetBuilder
 
         AZ::Data::Asset<TestGenericAssetRef> m_referencedAsset_Preload{ AZ::Data::AssetLoadBehavior::PreLoad };
         AZ::Data::Asset<TestGenericAssetRef> m_referencedAsset_NoLoad{ AZ::Data::AssetLoadBehavior::NoLoad };
+        AZ::Data::AssetId m_referencedAssetId; // an assetId that is used instead of an asset ref.
     };
 
     //! TestGenericAssetBuilderComponent handles the lifecycle of the generic asset registration.

--- a/Gems/TestAssetBuilder/Code/Source/TestAssetBuilderModule.cpp
+++ b/Gems/TestAssetBuilder/Code/Source/TestAssetBuilderModule.cpp
@@ -13,6 +13,8 @@
 #include <Builder/TestIntermediateAssetBuilderComponent.h>
 #include <Builder/TestDependencyBuilderComponent.h>
 
+extern AZ::ComponentDescriptor* TestGenericAssetBuilderComponent_CreateDescriptor();
+
 namespace TestAssetBuilder
 {
     class TestAssetBuilderModule
@@ -25,12 +27,23 @@ namespace TestAssetBuilder
         TestAssetBuilderModule()
             : AZ::Module()
         {
+            auto genericAssetBuilderComponentDescriptor = TestGenericAssetBuilderComponent_CreateDescriptor();
             m_descriptors.insert(m_descriptors.end(), {
                 TestAssetBuilderComponent::CreateDescriptor(),
                 TestIntermediateAssetBuilderComponent::CreateDescriptor(),
                 TestDependencyBuilderComponent::CreateDescriptor(),
+                genericAssetBuilderComponentDescriptor,
             });
+
+            m_reqComponents = { genericAssetBuilderComponentDescriptor->GetUuid() };
         }
+
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override
+        {
+            return m_reqComponents;
+        }
+
+        AZ::ComponentTypeList m_reqComponents;
     };
 }
 

--- a/Gems/TestAssetBuilder/Code/testassetbuilder_files.cmake
+++ b/Gems/TestAssetBuilder/Code/testassetbuilder_files.cmake
@@ -13,4 +13,6 @@ set(FILES
     Source/Builder/TestIntermediateAssetBuilderComponent.cpp
     Source/Builder/TestDependencyBuilderComponent.h
     Source/Builder/TestDependencyBuilderComponent.cpp
+    Source/Builder/TestGenericAssetBuilderComponent.h
+    Source/Builder/TestGenericAssetBuilderComponent.cpp
 )

--- a/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
+++ b/Tools/LyTestTools/ly_test_tools/_internal/managers/abstract_resource_locator.py
@@ -171,6 +171,15 @@ class AbstractResourceLocator(object):
         """
         return os.path.join(self.build_directory(), 'AssetProcessorBatch')
 
+    def asset_builder(self):
+        """
+        Return path for the AssetBuilder compatible with this build platform and configuration
+        ex. engine_root/dev/mac/bin/profile/AssetBuilder
+        :return: path to AssetBuilder
+        """
+        return os.path.join(self.build_directory(), 'AssetBuilder')
+
+
     def ap_job_logs(self):
         """
         Return path to the Asset Processor JobLogs directory.

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -470,6 +470,12 @@ class AssetProcessor(object):
         return self.run_ap_process_command(command, timeout=timeout, capture_output=capture_output, decode=decode,
                                            expect_failure=expect_failure)
 
+    # You can run the AssetBuilder executable standalone using this function
+    def run_builder(self, timeout=DEFAULT_TIMEOUT_SECONDS, extra_params=None, platforms=None):
+        builder_path = self._workspace.paths.asset_builder()
+        command = self.build_ap_command(ap_path=builder_path, platforms=platforms, extra_params=extra_params)
+        return self.run_ap_process_command(command, timeout=timeout, capture_output=False, decode=True, expect_failure=False)
+
     # Start AP gui and run until idle.  Useful for asset processing tests where the assets should be seen and processed
     # by AP on startup and in the test you do not wish to continue execution until you know AP has gone idle.
     def gui_process(self, timeout=DEFAULT_TIMEOUT_SECONDS, fastscan=True, capture_output=False, platforms=None,


### PR DESCRIPTION
## What does this PR do?

1. Fixes a bug where the "auto load behavior" is blown away when you assign an asset in the gui causing all GUI assigned assets to become QueueLoad.
2. Adds a "generic asset builder" to the Asset Processor.   We already had GenericAssets, this just adds a builder for them if the user opts in to do so.  Opting in is a single function call or a `true` to the constructor. 

This can automatically create product asset files in the cache from any registered "Generic Asset" (as in GenericAsset<T>), without having to write an asset copy rule in the regset, or builder.

This has an added benefit of automatically emitting dependencies which will be auto discovered from any field of type AssetId or from Asset<T>.  Asset<T> fields will retain their load type (QueueLoad, Don'tLoad, PreLoad)  and AssetId will be assumed NoLoad.

## How was this PR tested?

I added an auto test, it takes about 15 seconds to run for me.  It verifies that the dependencies are emitted, the job succeeds, and that the load flags are correctly preserved.
