### PR TITLE
Migrate Android Automated Review to Linux

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -32,6 +32,9 @@ on:
       last_artifact:
         required: false
         type: boolean
+      clang_version:
+        required: false
+        type: string
       ndk_version:
         required: false
         type: string
@@ -41,22 +44,13 @@ on:
       gradle_version:
         required: false
         type: string
-      msvc_toolset_version:
-        required: false
-        type: string
-      msvc_platform_toolset:
-        required: false
-        type: string
 
 run-name: ${{ inputs.platform }} - ${{ inputs.type }}
 
-# Activate compiler cache
 env:
-  CMAKE_C_COMPILER_LAUNCHER: C:\ProgramData\Chocolatey\bin\ccache.exe
-  CMAKE_CXX_COMPILER_LAUNCHER: C:\ProgramData\Chocolatey\bin\ccache.exe
   NDK_VERSION: ${{ inputs.ndk_version }}
 
-# Note: All 3P Github Actions use the commit hash for security reasons 
+# Note: All 3P Github Actions use the commit hash for security reasons
 # Avoid using the tag version, which is vulnerable to supply chain attacks
 
 jobs:
@@ -64,6 +58,34 @@ jobs:
     runs-on: ${{ inputs.image }}
 
     steps:
+      - name: Check disk space
+        # Check if the workspace has enough free space, otherwise flag the disk for resizing
+        env:
+          MIN_FREE_DISK: 70 # in GB
+        id: check-disk
+        run: |
+          AVAIL_GB=$(df ${{ github.workspace }} --output=avail --block-size=1G | tail -1 | tr -d ' ')
+          echo "Workspace has ${AVAIL_GB}GB available"
+          if [ "$AVAIL_GB" -lt ${{ env.MIN_FREE_DISK }} ]; then
+            echo "needs_resize=true" >> $GITHUB_OUTPUT
+            echo "Workspace has less than ${{ env.MIN_FREE_DISK }}GB available, resizing disk"
+          else
+            echo "needs_resize=false" >> $GITHUB_OUTPUT
+            echo "Workspace has enough free space, skipping disk resize"
+          fi
+
+      - name: Maximize build space
+        # Resize and combine disks as LVM to maximize space for builds, if below the minimum free space
+        if: steps.check-disk.outputs.needs_resize == 'true'
+        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
+        with:
+          root-reserve-mb: 8000
+          swap-size-mb: 200
+          remove-dotnet: true
+          remove-haskell: true
+          remove-codeql: true
+          remove-docker-images: true
+
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -73,63 +95,36 @@ jobs:
         # Minimal pull for profile builds, otherwise pull all
         run: |
           git lfs install
-          if ("${{ inputs.type }}" -eq "profile") { git lfs pull --include "*.ico,*.bmp" } else { git lfs pull }
-
-      - name: Setup DevDrive
-        uses: samypr100/setup-dev-drive@b9079d2711b01ed39de859c79c96484bfd80e078 # v3.4.1
-        with:
-          drive-size: 130GB
-          drive-format: NTFS
-          drive-path: "D:/dev_drive.vhdx"
-          workspace-copy: true
-          trusted-dev-drive: true
+          [[ "${{ inputs.type }}" == "profile" ]] && git lfs pull --include "*.ico,*.bmp" || git lfs pull
 
       - name: Setup 3p, user, and build folders
-        # Symlink the .o3de folder to the github workspace to avoid permission issues
         run: |
-          "3rdParty", "build", ".o3de" | % {New-Item "${{ env.DEV_DRIVE_WORKSPACE }}\$_" -ItemType 'Directory' -Force}
-          "temp" | % {New-Item "${{ env.DEV_DRIVE }}\$_" -ItemType 'Directory' -Force}
-          ".o3de" | % {New-Item -Path $env:USERPROFILE\$_ -ItemType SymbolicLink -Target ${{ env.DEV_DRIVE_WORKSPACE }}\$_ -Force}
-          "AutomatedTesting\Cache", "AutomatedTesting\user" | % {New-Item "${{ env.DEV_DRIVE_WORKSPACE }}\$_" -ItemType 'Directory' -Force}
-
-      - name: Move Page File to Workspace drive
-        # Configure the page file to the workspace drive for the duration of the run
-        run: |
-          Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" `
-            -Name "PagingFiles" -Value "${{ env.DEV_DRIVE }}\temp\pagefile.sys 8192 8192"
-          echo "Page file moved to ${{ env.DEV_DRIVE }}\temp\pagefile.sys"
-
-      - name: Get drive info
-        run: |
-          Get-PSDrive
+          mkdir -p .o3de build 3rdParty && ln -sf "$(pwd)/.o3de" ~/.o3de
 
       - name: Setup ccache
         uses: chocobo1/setup-ccache-action@37c3347f8a7738e82aab7a06f276f7a12e3008fb # v1.5.3
         continue-on-error: true
         if: always()
         with:
-          windows_compile_environment: msvc
           prepend_symlinks_to_path: false
           store_cache: false
           restore_cache: false
           ccache_options: |
-            cache_dir=${{ env.DEV_DRIVE_WORKSPACE }}\.ccache
+            cache_dir=${{ github.workspace }}/.ccache
             hash_dir=false
-            inode_cache=true
             max_size=10G
-            temporary_dir=${{ env.DEV_DRIVE }}\temp
 
       - name: Check for rerun
         id: check-rerun
         run: |
           # GitHub sets GITHUB_RUN_ATTEMPT to track reruns
-          if ($env:GITHUB_RUN_ATTEMPT -gt 1) {
-            echo "is_rerun=true" >> $env:GITHUB_OUTPUT
-            echo "This is rerun attempt #$env:GITHUB_RUN_ATTEMPT"
-          } else {
-            echo "is_rerun=false" >> $env:GITHUB_OUTPUT
+          if [ "$GITHUB_RUN_ATTEMPT" -gt 1 ]; then
+            echo "is_rerun=true" >> $GITHUB_OUTPUT
+            echo "This is rerun attempt #$GITHUB_RUN_ATTEMPT"
+          else
+            echo "is_rerun=false" >> $GITHUB_OUTPUT
             echo "This is the first run attempt"
-          }
+          fi
 
       - name: Get last run
         # Get the last runid of the target branch of a PR or the current branch
@@ -152,19 +147,18 @@ jobs:
         id: set-artifact-run-id
         if: steps.last-run-id.outcome == 'success' && inputs.last_artifact == true
         run: |
-          $runId = ${{ fromJSON(steps.last-run-id.outputs.artifacts)[0].workflow_run.id }}
-          echo "artifact_run_id=$runId" >> $env:GITHUB_OUTPUT
+          runId=${{ fromJSON(steps.last-run-id.outputs.artifacts)[0].workflow_run.id }}
+          echo "artifact_run_id=$runId" >> $GITHUB_OUTPUT
           echo "Using artifacts from previous run: $runId"
 
       - name: Restore artifact cache
         # Restore the artifact from the "Get last run" step or from the current run
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         id: restore-artifact-cache
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         continue-on-error: true
         with:
           name: O3DE-${{ inputs.platform }}-${{ inputs.config }}-build
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ${{ env.DEV_DRIVE_WORKSPACE }}
           run-id: ${{ steps.set-artifact-run-id.outputs.artifact_run_id || github.run_id }}
 
       - name: Extract artifact
@@ -172,56 +166,34 @@ jobs:
         id: extract-artifact
         continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
-        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
-          if (Test-Path ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar) {          
-            tar -xvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
-            rm ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
+          if [ -f ${{ github.workspace }}/cache.tar ]; then
+            tar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
+            rm ${{ github.workspace }}/cache.tar
             ccache --zero-stats --cleanup
-          }
+          fi
 
       - name: Setup cmake
-        # Pin the version of cmake  
+        # Pin the version of cmake
         if: ${{ inputs.cmake_version }}
         uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # v4.2.3
         with:
           cmakeVersion: "${{ inputs.cmake_version }}"
+          ninjaVersion: "1.13.2"
 
-      - name: Configure generator/toolset env for CMake
-        # Set the environment variables for the CMake generator and toolset depending on CMake version
-        run: |
-          $cap = cmake -E capabilities | ConvertFrom-Json
-          $maj = [int]$cap.version.major
-          $min = [int]$cap.version.minor
-
-          echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV 
-
-          if ($maj -gt 3 -or ($maj -eq 3 -and $min -ge 25)) {
-            # CMake >= 3.25: support 'version='
-            echo "CMAKE_GENERATOR_TOOLSET=${{ inputs.msvc_platform_toolset }},version=${{ inputs.msvc_toolset_version }}" >> $env:GITHUB_ENV
-          } else {
-            # CMake 3.24: omit 'version='; MSBuild toolset is selected by msvc-dev-cmd
-            echo "CMAKE_GENERATOR_TOOLSET=${{ inputs.msvc_platform_toolset }}" >> $env:GITHUB_ENV
-          }
-
-      - name: Install specific MSVC toolset
-        # Install a specific MSVC toolset into VS2022 (for MSVC-based Android asset builds)
-        if: ${{ inputs.msvc_toolset_version && inputs.msvc_platform_toolset }}
-        run: |
-          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe" modify `
-          --installPath "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise" `
-          --add "Microsoft.VisualStudio.Component.VC.${{ inputs.msvc_toolset_version }}.x86.x64" --quiet --wait
-
-      - name: Set MSBuild options
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+      - name: Setup java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          toolset: ${{ inputs.msvc_toolset_version }}
+          distribution: zulu
+          java-version: 17
 
-      - name: Set MSBuild options
-        # Configuire VS environment variables through the developer command prompt for MSVC
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-        with:
-          toolset: ${{ inputs.msvc_toolset_version }}
+      - name: Setup clang
+        if: ${{ inputs.clang_version }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y clang-${{ inputs.clang_version }} lld-${{ inputs.clang_version }}
+          echo "CC=$(which clang-${{ inputs.clang_version }})" >> $GITHUB_ENV
+          echo "CXX=$(which clang++-${{ inputs.clang_version }})" >> $GITHUB_ENV
 
       - name: Setup gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
@@ -233,39 +205,45 @@ jobs:
       - name: Configure environment
         # Install dependencies for gradle and clang builds from the NDK
         continue-on-error: true
-        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
           echo "Installing dependencies"
+          pushd ./scripts/build/build_node/Platform/Linux
+          sudo ./install-ubuntu.sh
+          popd
           echo "Getting python..."
-          python\get_python.bat
+          ./python/get_python.sh
+          echo "Installing additional python dependencies..."
+          ./python/pip.sh install tempfile2 PyGithub
 
-          if ("${{ inputs.ndk_version }}") {
+          if [[ -n "${{ inputs.ndk_version }}" ]]; then
             echo "Installing NDK ${{ env.NDK_VERSION }}..."
-            & "$env:ANDROID_HOME\cmdline-tools\latest\bin\sdkmanager.bat" --install 'ndk;${{ env.NDK_VERSION }}' --sdk_root=$env:ANDROID_HOME
-          } else {
-            echo "Using preinstalled NDK" 
-          }
+            yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "ndk;${{ env.NDK_VERSION }}" --sdk_root="$ANDROID_HOME"
+          else
+            echo "Using preinstalled NDK"
+          fi
 
           echo "Accepting Android SDK licenses..."
-          "y`ny" | & "$env:ANDROID_HOME\cmdline-tools\latest\bin\sdkmanager.bat" --licenses --sdk_root=$env:ANDROID_HOME
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses --sdk_root="$ANDROID_HOME" || true
 
-          if ("${{ inputs.ndk_version }}") { echo "LY_NDK_DIR=$env:ANDROID_HOME\ndk\${{ env.NDK_VERSION }}" >> $env:GITHUB_ENV }
-          echo "JDK_HOME=$env:JAVA_HOME_17_X64" >> $env:GITHUB_ENV
-          echo "JAVA_HOME=$env:JAVA_HOME_17_X64" >> $env:GITHUB_ENV
-          echo "USE_GRADLE_FROM_PATH=1" >> $env:GITHUB_ENV
+          if [[ -n "${{ inputs.ndk_version }}" ]]; then
+            echo "LY_NDK_DIR=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
+          fi
+          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
+          echo "JDK_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+          echo "USE_GRADLE_FROM_PATH=1" >> $GITHUB_ENV
 
       - name: Build ${{ inputs.type }}
         # Builds with presets in ../scripts/build/Platform/Android/build_config.json
-        # Set temp folders to the workspace drive as the boot drive is slow
-        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         timeout-minutes: 330
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          LY_3RDPARTY_PATH: ${{ github.workspace }}/3rdParty
+          LY_PACKAGE_SERVER_URLS: "https://d1gg6ket0m44ly.cloudfront.net;https://d3t6xeg4fgfoum.cloudfront.net"
         run: |
-          $env:LY_3RDPARTY_PATH = "${{ env.DEV_DRIVE_WORKSPACE }}\3rdParty"
-          $env:LY_PACKAGE_SERVER_URLS = "https://d1gg6ket0m44ly.cloudfront.net;https://d3t6xeg4fgfoum.cloudfront.net"
-          $env:TEMP = "${{ env.DEV_DRIVE }}\temp" 
-          $env:TMP = "${{ env.DEV_DRIVE }}\temp"
-          scripts\o3de.bat register --this-engine # Resolves registration issue with gradle build
-          python\python.cmd -u scripts\build\ci_build.py --platform ${{ inputs.platform }} --type ${{ inputs.type }} 
+          scripts/o3de.sh register --this-engine
+          python/python.sh -u scripts/build/ci_build.py --platform ${{ inputs.platform }} --type ${{ inputs.type }}
 
       - name: Compress artifacts
         # Compress with posix format to preserve permissions and timestamps at nanosecond precision
@@ -273,17 +251,12 @@ jobs:
         id: compress-artifacts
         if: ${{ (steps.extract-artifact.outcome == 'success' || steps.extract-artifact.outcome == 'skipped') && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
-        working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
-          try {
-            tar --format=posix -cvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar `
-              .ccache `
-              .o3de\python\downloaded_packages `
-              3rdParty\downloaded_packages `
-              AutomatedTesting\Cache
-          } catch {
-            echo "Warning: Error during tar compression"
-          }
+          tar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+            .ccache \
+            .o3de/python/downloaded_packages \
+            3rdParty/downloaded_packages \
+            AutomatedTesting/Cache
 
       - name: Save artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -294,4 +267,4 @@ jobs:
           compression-level: 1
           overwrite: true
           path: |
-            ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
+            ${{ github.workspace }}/cache.tar

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -73,7 +73,7 @@ jobs:
     with:
       compiler: clang
       config: profile
-      image: windows-2022
+      image: ubuntu-22.04
       platform: Android
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
@@ -83,30 +83,29 @@ jobs:
 
   Android-Asset:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    needs: Android-Profile
     uses: ./.github/workflows/android-build.yml
     with:
-      compiler: msvc
-      config: asset_profile
-      image: windows-2022
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
       platform: Android
       type: asset_profile
-      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
-      msvc_toolset_version: "14.29"
-      msvc_platform_toolset: "v142"
+      clang_version: "14"
       ndk_version: "25.1.8937393"
       gradle_version: "8.12"
       cmake_version: *cmake_version
 
   Android-Gradle:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    needs: Android-Asset
     uses: ./.github/workflows/android-build.yml
     with:
       compiler: clang
-      config: gradle
-      image: windows-2022
+      config: profile
+      image: ubuntu-22.04
       platform: Android
       type: gradle
-      last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
       ndk_version: "25.1.8937393"
       gradle_version: "8.12"
       cmake_version: *cmake_version

--- a/scripts/build/Platform/Android/build_and_run_unit_tests.sh
+++ b/scripts/build/Platform/Android/build_and_run_unit_tests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set -o errexit # exit on the first failure encountered
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the gradle build first
+source "$SCRIPT_DIR/gradle_linux.sh"
+
+if [[ ! -d "$LY_3RDPARTY_PATH" ]]; then
+    echo "[ci_build] LY_3RDPARTY_PATH is invalid or not set"
+    exit 1
+fi
+
+if [[ -z "$ANDROID_SDK_ROOT" ]] && [[ -n "$ANDROID_HOME" ]]; then
+    export ANDROID_SDK_ROOT="$ANDROID_HOME"
+fi
+
+if [[ ! -d "$ANDROID_SDK_ROOT" ]]; then
+    echo "[ci_build] FAIL: ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+    exit 1
+fi
+echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+
+PYTHON=python/python.sh
+echo "[ci_build] $PYTHON scripts/build/Platform/Android/run_test_on_android_simulator.py --android-sdk-path $ANDROID_SDK_ROOT --build-path $OUTPUT_DIRECTORY --build-config $CONFIGURATION"
+$PYTHON scripts/build/Platform/Android/run_test_on_android_simulator.py --android-sdk-path "$ANDROID_SDK_ROOT" --build-path "$OUTPUT_DIRECTORY" --build-config "$CONFIGURATION"
+
+exit 0

--- a/scripts/build/Platform/Android/build_config.json
+++ b/scripts/build/Platform/Android/build_config.json
@@ -36,7 +36,7 @@
     "PARAMETERS": {
       "CONFIGURATION":"debug",
       "OUTPUT_DIRECTORY":"build/android",
-      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
+      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
       "CMAKE_TARGET":"all"
     }
@@ -50,7 +50,7 @@
     "PARAMETERS": {
       "CONFIGURATION":"profile",
       "OUTPUT_DIRECTORY":"build/android",
-      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
+      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
       "CMAKE_TARGET":"all"
     }
@@ -65,7 +65,7 @@
     "PARAMETERS": {
       "CONFIGURATION":"profile",
       "OUTPUT_DIRECTORY":"build/android",
-      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\" -DLY_UNITY_BUILD=FALSE",
+      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\" -DLY_UNITY_BUILD=FALSE",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
       "CMAKE_TARGET":"all"
     }
@@ -80,7 +80,7 @@
     "PARAMETERS": {
         "CONFIGURATION":"profile",
         "OUTPUT_DIRECTORY":"build/linux",
-        "CMAKE_OPTIONS":"-G Ninja",
+        "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\"",
         "CMAKE_LY_PROJECTS":"AutomatedTesting",
         "CMAKE_TARGET":"AssetProcessorBatch",
         "ASSET_PROCESSOR_BINARY": "bin/profile/AssetProcessorBatch",
@@ -98,7 +98,7 @@
     "PARAMETERS": {
       "CONFIGURATION":"release",
       "OUTPUT_DIRECTORY":"build/android",
-      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
+      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
       "CMAKE_TARGET":"all"
     }
@@ -113,7 +113,7 @@
     "PARAMETERS": {
       "CONFIGURATION":"release",
       "OUTPUT_DIRECTORY":"build/mono_android",
-      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\" -DLY_MONOLITHIC_GAME=TRUE",
+      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\" -DLY_MONOLITHIC_GAME=TRUE",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
       "CMAKE_TARGET":"all"
     }

--- a/scripts/build/Platform/Android/build_config.json
+++ b/scripts/build/Platform/Android/build_config.json
@@ -1,7 +1,7 @@
 {
   "clean": {
     "TAGS": [],
-    "COMMAND": "../Windows/clean_windows.cmd",
+    "COMMAND": "../Linux/clean_linux.sh",
     "PARAMETERS": {
       "OUTPUT_DIRECTORY": "build",
       "CMAKE_LY_PROJECTS": "AutomatedTesting"
@@ -20,10 +20,10 @@
     "TAGS":[
         "weekly"
     ],
-    "COMMAND":"../Windows/python_windows.cmd",
+    "COMMAND":"../Linux/python_linux.sh",
     "PARAMETERS": {
         "SCRIPT_PATH":"scripts/build/ci_build_metrics.py",
-        "SCRIPT_PARAMETERS":"--platform=Android --repository=!REPOSITORY_NAME! --jobname=!JOB_NAME! --jobnumber=!BUILD_NUMBER! --jobnode=!NODE_LABEL! --changelist=!CHANGE_ID!"
+        "SCRIPT_PARAMETERS":"--platform=Android --repository=${REPOSITORY_NAME} --jobname=${JOB_NAME} --jobnumber=${BUILD_NUMBER} --jobnode=${NODE_LABEL} --changelist=${CHANGE_ID}"
     }
   },
   "debug": {
@@ -32,14 +32,13 @@
         "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
-    "COMMAND":"../Windows/build_ninja_windows.cmd",
+    "COMMAND":"../Linux/build_linux.sh",
     "PARAMETERS": {
       "CONFIGURATION":"debug",
-      "OUTPUT_DIRECTORY":"build\\android",
-      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"!LY_NDK_DIR!\"",
+      "OUTPUT_DIRECTORY":"build/android",
+      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
-      "CMAKE_TARGET":"all",
-      "CMAKE_BUILD_ARGS":"-j!NUMBER_OF_PROCESSORS!"
+      "CMAKE_TARGET":"all"
     }
   },
   "profile": {
@@ -47,14 +46,13 @@
         "weekly-build-metrics",
         "daily-pipeline-metrics"
     ],
-    "COMMAND":"../Windows/build_ninja_windows.cmd",
+    "COMMAND":"../Linux/build_linux.sh",
     "PARAMETERS": {
       "CONFIGURATION":"profile",
-      "OUTPUT_DIRECTORY":"build\\android",
-      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"!LY_NDK_DIR!\"",
+      "OUTPUT_DIRECTORY":"build/android",
+      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
-      "CMAKE_TARGET":"all",
-      "CMAKE_BUILD_ARGS":"-j!NUMBER_OF_PROCESSORS!"
+      "CMAKE_TARGET":"all"
     }
   },
   "profile_nounity": {
@@ -63,14 +61,13 @@
         "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
-    "COMMAND":"../Windows/build_ninja_windows.cmd",
+    "COMMAND":"../Linux/build_linux.sh",
     "PARAMETERS": {
       "CONFIGURATION":"profile",
-      "OUTPUT_DIRECTORY":"build\\android",
-      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"!LY_NDK_DIR!\" -DLY_UNITY_BUILD=FALSE",
+      "OUTPUT_DIRECTORY":"build/android",
+      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\" -DLY_UNITY_BUILD=FALSE",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
-      "CMAKE_TARGET":"all",
-      "CMAKE_BUILD_ARGS":"-j!NUMBER_OF_PROCESSORS!"
+      "CMAKE_TARGET":"all"
     }
   },
   "asset_profile": {
@@ -79,15 +76,14 @@
         "weekly-build-metrics",
         "snapshot"
     ],
-    "COMMAND":"../Windows/build_asset_windows.cmd",
+    "COMMAND":"../Linux/build_asset_linux.sh",
     "PARAMETERS": {
         "CONFIGURATION":"profile",
-        "OUTPUT_DIRECTORY":"build\\windows",
-        "CMAKE_OPTIONS":"-DCMAKE_SYSTEM_VERSION=10.0",
+        "OUTPUT_DIRECTORY":"build/linux",
+        "CMAKE_OPTIONS":"-G Ninja",
         "CMAKE_LY_PROJECTS":"AutomatedTesting",
         "CMAKE_TARGET":"AssetProcessorBatch",
-        "CMAKE_NATIVE_BUILD_ARGS": "/m /nologo",
-        "ASSET_PROCESSOR_BINARY": "bin\\profile\\AssetProcessorBatch.exe",
+        "ASSET_PROCESSOR_BINARY": "bin/profile/AssetProcessorBatch",
         "ASSET_PROCESSOR_OPTIONS": "--zeroAnalysisMode --ignoreFutureAssetDatabaseVersionError --regset=\"/Amazon/AssetProcessor/Settings/Exclude Android/pattern=.*/DiffuseGlobalIllumination/.*precompiledshader\"",
         "ASSET_PROCESSOR_PLATFORMS":"android"
     }
@@ -98,14 +94,13 @@
         "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
-    "COMMAND":"../Windows/build_ninja_windows.cmd",
+    "COMMAND":"../Linux/build_linux.sh",
     "PARAMETERS": {
       "CONFIGURATION":"release",
-      "OUTPUT_DIRECTORY":"build\\android",
-      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"!LY_NDK_DIR!\"",
+      "OUTPUT_DIRECTORY":"build/android",
+      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\"",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
-      "CMAKE_TARGET":"all",
-      "CMAKE_BUILD_ARGS":"-j!NUMBER_OF_PROCESSORS!"
+      "CMAKE_TARGET":"all"
     }
   },
   "monolithic_release": {
@@ -114,14 +109,13 @@
         "periodic-clean-weekly-internal",
         "weekly-build-metrics"
     ],
-    "COMMAND":"../Windows/build_ninja_windows.cmd",
+    "COMMAND":"../Linux/build_linux.sh",
     "PARAMETERS": {
       "CONFIGURATION":"release",
-      "OUTPUT_DIRECTORY":"build\\mono_android",
-      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"!LY_NDK_DIR!\" -DLY_MONOLITHIC_GAME=TRUE",
+      "OUTPUT_DIRECTORY":"build/mono_android",
+      "CMAKE_OPTIONS":"-G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/Platform/Android/Toolchain_android.cmake -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"${LY_NDK_DIR}\" -DLY_MONOLITHIC_GAME=TRUE",
       "CMAKE_LY_PROJECTS":"AutomatedTesting",
-      "CMAKE_TARGET":"all",
-      "CMAKE_BUILD_ARGS":"-j!NUMBER_OF_PROCESSORS!"
+      "CMAKE_TARGET":"all"
     }
   },
   "gradle": {
@@ -130,10 +124,10 @@
         "weekly-build-metrics",
         "snapshot"
     ],
-    "COMMAND":"gradle_windows.cmd",
+    "COMMAND":"gradle_linux.sh",
     "PARAMETERS": {
       "CONFIGURATION":"profile",
-      "OUTPUT_DIRECTORY":"build\\ad_grd",
+      "OUTPUT_DIRECTORY":"build/ad_grd",
       "SIGN_APK": "false",
       "GRADLE_BUILD_CMD": "build",
       "ADDITIONAL_GENERATE_ARGS": ""
@@ -142,10 +136,10 @@
   "periodic_test_profile": {
     "TAGS":[
     ],
-    "COMMAND":"build_and_run_unit_tests.cmd",
+    "COMMAND":"build_and_run_unit_tests.sh",
     "PARAMETERS": {
       "CONFIGURATION":"profile",
-      "OUTPUT_DIRECTORY":"build\\android_unittest",
+      "OUTPUT_DIRECTORY":"build/android_unittest",
       "GAME_PROJECT": "AutomatedTesting",
       "SIGN_APK": "true",
       "GRADLE_BUILD_CMD": "assemble",

--- a/scripts/build/Platform/Android/gradle_linux.sh
+++ b/scripts/build/Platform/Android/gradle_linux.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set -o errexit # exit on the first failure encountered
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+O3DE_PATH="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+echo "Using O3DE Engine at '$O3DE_PATH'"
+
+# Validate the Android SDK is set
+if [[ -z "$ANDROID_SDK_ROOT" ]] && [[ -n "$ANDROID_HOME" ]]; then
+    export ANDROID_SDK_ROOT="$ANDROID_HOME"
+fi
+if [[ -z "$ANDROID_SDK_ROOT" ]]; then
+    echo "ANDROID_SDK_ROOT is not set"
+    exit 1
+fi
+if [[ ! -d "$ANDROID_SDK_ROOT" ]]; then
+    echo "ANDROID_SDK_ROOT '$ANDROID_SDK_ROOT' does not exist"
+    exit 1
+fi
+echo "Using Android SDK at '$ANDROID_SDK_ROOT'"
+"$O3DE_PATH/scripts/o3de.sh" android-configure --set-value sdk.root="$ANDROID_SDK_ROOT" --global
+
+# Configure gradle
+if [[ -n "$USE_GRADLE_FROM_PATH" ]]; then
+    GRADLE_LOCATION=$(which gradle 2>/dev/null || true)
+    if [[ -z "$GRADLE_LOCATION" ]]; then
+        echo "USE_GRADLE_FROM_PATH is set but gradle was not found on PATH"
+        exit 1
+    fi
+    GRADLE_HOME="$(dirname "$(dirname "$GRADLE_LOCATION")")"
+    GRADLE_BUILD_HOME="$GRADLE_HOME"
+else
+    if [[ -z "$GRADLE_BUILD_HOME" ]]; then
+        echo "GRADLE_BUILD_HOME is not set"
+        exit 1
+    fi
+    if [[ ! -d "$GRADLE_BUILD_HOME" ]]; then
+        echo "GRADLE_BUILD_HOME '$GRADLE_BUILD_HOME' does not exist"
+        exit 1
+    fi
+fi
+
+echo "Using Gradle Build at '$GRADLE_BUILD_HOME'"
+"$O3DE_PATH/scripts/o3de.sh" android-configure --set-value gradle.home="$GRADLE_BUILD_HOME" --global
+
+# Optionally override the gradle plugin version, otherwise default to 8.1.4
+ANDROID_GRADLE_PLUGIN="${ANDROID_GRADLE_PLUGIN:-8.1.4}"
+echo "Using Android gradle plugin version $ANDROID_GRADLE_PLUGIN"
+"$O3DE_PATH/scripts/o3de.sh" android-configure --set-value android.gradle.plugin="$ANDROID_GRADLE_PLUGIN" --global
+
+# Optionally override the version of the android NDK to use, otherwise default to 25
+ANDROID_NDK_VERSION="${ANDROID_NDK_VERSION:-25}"
+echo "Using Android NDK Version $ANDROID_NDK_VERSION"
+"$O3DE_PATH/scripts/o3de.sh" android-configure --set-value ndk.version="$ANDROID_NDK_VERSION.*"
+
+# Create/clean output directory
+if [[ -d "$OUTPUT_DIRECTORY" ]]; then
+    echo "Clearing and resetting existing build folder"
+    rm -rf "$OUTPUT_DIRECTORY"
+fi
+mkdir -p "$OUTPUT_DIRECTORY"
+
+# Set temp directory
+if [[ -z "$TMP" ]]; then
+    TMP="${WORKSPACE:-/tmp}/o3de_tmp"
+    export TMP
+    export TEMP="$TMP"
+    mkdir -p "$TMP"
+fi
+
+# Create a minimal project for the native build process
+GRADLE_PROJECT_DIR="$TMP/o3de_gradle_ar"
+rm -rf "$GRADLE_PROJECT_DIR"
+echo "Creating a minimal project for the native build process"
+echo "$O3DE_PATH/scripts/o3de.sh create-project -pp $GRADLE_PROJECT_DIR -pn GradleTest -tn MinimalProject"
+"$O3DE_PATH/scripts/o3de.sh" create-project -pp "$GRADLE_PROJECT_DIR" -pn GradleTest -tn MinimalProject
+
+# Optionally sign the APK if we are generating an APK
+GENERATE_SIGNED_APK=false
+if [[ "$SIGN_APK" == "true" ]] && [[ "$GRADLE_BUILD_CMD" == "assemble" ]]; then
+    GENERATE_SIGNED_APK=true
+fi
+
+if [[ "$GENERATE_SIGNED_APK" == "true" ]]; then
+    # Setup signing with JDK keytool
+    JAVA_BIN="$JAVA_HOME/bin"
+    KEYTOOL_PATH="$JAVA_BIN/keytool"
+
+    if [[ ! -x "$KEYTOOL_PATH" ]]; then
+        echo "keytool not found at '$KEYTOOL_PATH'. Ensure JAVA_HOME is set to a valid JDK installation."
+        exit 1
+    fi
+
+    CI_ANDROID_KEYSTORE_FILE="ly-android-dev.keystore"
+    CI_ANDROID_KEYSTORE_ALIAS="ly-android"
+    CI_ANDROID_KEYSTORE_PASSWORD="lumberyard"
+    CI_KEYSTORE_VALIDITY_DAYS=10000
+    CI_KEYSTORE_CERT_DN="cn=LY Developer, ou=Lumberyard, o=Amazon, c=US"
+    CI_ANDROID_KEYSTORE_FILE_ABS="$(pwd)/$OUTPUT_DIRECTORY/$CI_ANDROID_KEYSTORE_FILE"
+
+    # Generate the keystore file if needed
+    if [[ ! -f "$CI_ANDROID_KEYSTORE_FILE_ABS" ]]; then
+        echo "[ci_build] Generating keystore file $CI_ANDROID_KEYSTORE_FILE"
+        "$KEYTOOL_PATH" -genkeypair -v \
+            -keystore "$CI_ANDROID_KEYSTORE_FILE_ABS" \
+            -storepass "$CI_ANDROID_KEYSTORE_PASSWORD" \
+            -alias "$CI_ANDROID_KEYSTORE_ALIAS" \
+            -keypass "$CI_ANDROID_KEYSTORE_PASSWORD" \
+            -keyalg RSA -keysize 2048 \
+            -validity "$CI_KEYSTORE_VALIDITY_DAYS" \
+            -dname "$CI_KEYSTORE_CERT_DN"
+    else
+        echo "Using keystore file at $CI_ANDROID_KEYSTORE_FILE_ABS"
+    fi
+
+    "$O3DE_PATH/scripts/o3de.sh" android-configure --set-value signconfig.store.file="$CI_ANDROID_KEYSTORE_FILE_ABS"
+    "$O3DE_PATH/scripts/o3de.sh" android-configure --set-value signconfig.key.alias="$CI_ANDROID_KEYSTORE_ALIAS"
+    "$O3DE_PATH/scripts/o3de.sh" android-configure --set-value signconfig.key.password="$CI_ANDROID_KEYSTORE_PASSWORD"
+    "$O3DE_PATH/scripts/o3de.sh" android-configure --set-value signconfig.store.password="$CI_ANDROID_KEYSTORE_PASSWORD"
+fi
+
+"$O3DE_PATH/scripts/o3de.sh" android-configure --set-value asset.mode=NONE
+
+cd "$GRADLE_PROJECT_DIR"
+
+echo "$O3DE_PATH/scripts/o3de.sh android-generate -p $GRADLE_PROJECT_DIR -B $OUTPUT_DIRECTORY $ADDITIONAL_GENERATE_ARGS"
+"$O3DE_PATH/scripts/o3de.sh" android-generate -p "$GRADLE_PROJECT_DIR" -B "$OUTPUT_DIRECTORY" $ADDITIONAL_GENERATE_ARGS
+
+export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+
+# Run the gradle build from the output directory
+pushd "$OUTPUT_DIRECTORY"
+
+# Stop any running or orphaned gradle daemon
+echo "[ci_build] gradlew --stop"
+./gradlew --stop || true
+
+echo "[ci_build] gradlew --info --no-daemon ${GRADLE_BUILD_CMD}${CONFIGURATION}"
+./gradlew --info --no-daemon "${GRADLE_BUILD_CMD}${CONFIGURATION}"
+
+echo "[ci_build] gradlew --stop"
+./gradlew --stop
+
+popd
+
+exit 0

--- a/scripts/build/build_node/Platform/Linux/install-ubuntu-android-tools.sh
+++ b/scripts/build/build_node/Platform/Linux/install-ubuntu-android-tools.sh
@@ -26,7 +26,7 @@ fi
 #
 # Install the necessary tools to download, install, and run the android tools
 #
-apt install -y openjdk-11-jdk unzip wget
+apt install -y openjdk-17-jdk unzip wget
 
 mkdir /opt/android-sdk-linux
 wget -q https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip -O /tmp/commandlinetools-linux.zip


### PR DESCRIPTION
## What does this PR do?

Migrates the Android Build workflow from Windows runners to Linux runners and restructures the jobs to run sequentially (Profile => Asset => Gradle), aligning with the other platform workflows.

### Key changes:

- Runner: windows-2022 => ubuntu-22.04 for all Android jobs
- Compiler: All jobs now use clang (the Asset job previously used MSVC to build AssetProcessorBatch on Windows; it now builds natively and runs on Linux)
- Sequential pipeline: Jobs now chain and share a single artifact cache, instead of running concurrently with separate caches
- Build scripts: All `build_config.json` entries updated from Windows .cmd scripts to Linux .sh equivalents (reusing existing `build_linux.sh`, `build_asset_linux.sh`, etc.)
- New scripts: Added `gradle_linux.sh` and `build_and_run_unit_tests.sh` as Linux ports of the corresponding Windows .cmd scripts
- `android-build.yml`: Rewritten from scratch based on the Linux workflow template. Bash steps, Linux disk management, NDK/SDK setup via sdkmanager, ninja-build package installation

The previous Windows-based setup prevented the Asset job (MSVC) from sharing a cache with the Profile/Gradle jobs (Clang). Also, from what I observed, Linux runners are faster.

## How was this PR tested?

I tested that the new GHA workflow succeeded for all three jobs (Android-Profile, Android-Asset, Android-Gradle), with sequential artifact sharing working as expected