### PR TITLE
Update AR CMake to 4.2.3

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Setup cmake
         # Pin the version of cmake  
         if: ${{ inputs.cmake_version }}
-        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6 # v3.31.6
+        uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # v4.2.3
         with:
           cmakeVersion: "${{ inputs.cmake_version }}"
 

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -73,7 +73,7 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }} # If CLEAN_ARTIFACTS is false, then this returns true
             msvc_toolset_version: '14.29'
             msvc_platform_toolset: 'v142'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
     
     Windows-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -87,7 +87,7 @@ jobs:
             type: asset_profile
             msvc_toolset_version: '14.29'
             msvc_platform_toolset: 'v142'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
 
     Windows-Test:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -101,7 +101,7 @@ jobs:
             type: test_cpu_profile
             msvc_toolset_version: '14.29'
             msvc_platform_toolset: 'v142'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
 
     Windows-Release:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
@@ -115,7 +115,7 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
             msvc_toolset_version: '14.29'
             msvc_platform_toolset: 'v142'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
 
 #### Linux Build ####
     Linux-Profile:
@@ -129,7 +129,7 @@ jobs:
             type: profile
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
             clang_version: '14'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
 
     Linux-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
@@ -142,7 +142,7 @@ jobs:
             platform: Linux
             type: asset_profile
             clang_version: '14'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
 
     Linux-Test:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
@@ -156,7 +156,7 @@ jobs:
             type: test_profile
             desktop: true
             clang_version: '14'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
 
 #### Android Build ####
     Android-Profile:
@@ -171,7 +171,7 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
             ndk_version: '25.1.8937393'
             gradle_version: '8.12'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
 
     Android-Asset:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
@@ -187,7 +187,7 @@ jobs:
             msvc_platform_toolset: 'v142'
             ndk_version: '25.1.8937393'
             gradle_version: '8.12'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'
             
     Android-Gradle:
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
@@ -201,4 +201,4 @@ jobs:
             last_artifact: ${{ inputs.CLEAN_ARTIFACTS == false }}
             ndk_version: '25.1.8937393'
             gradle_version: '8.12'
-            cmake_version: '~3.24'
+            cmake_version: '4.2.3'

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Setup cmake
         # Pin the version of cmake
         if: ${{ inputs.cmake_version }}
-        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6 # v3.31.6
+        uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # v4.2.3
         with:
           cmakeVersion: "${{ inputs.cmake_version }}"
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Setup cmake
         # Pin the version of cmake
         if: ${{ inputs.cmake_version }}
-        uses: lukka/get-cmake@56d043d188c3612951d8755da8f4b709ec951ad6 # v3.31.6
+        uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # v4.2.3
         with:
           cmakeVersion: "${{ inputs.cmake_version }}"
 


### PR DESCRIPTION
## What does this PR do?

Updates AR workflows to use CMake 4.2.3 to test against latest behavior as we move up the packaged CMake version described in https://github.com/o3de/o3de/issues/19574

## How was this PR tested?

Tested in my fork in AR. Example run here: https://github.com/amzn-changml/o3de/actions/runs/22211796600
