### PR TITLE
Implement Policy.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,24 +6,10 @@
 #
 #
 
-# Cmake version 3.24 is the minimum version needed for all of Open 3D Engine's supported platforms
+# CMake version 3.24 is the minimum version needed for all of Open 3D Engine's supported platforms
 cmake_minimum_required(VERSION 3.24)
 
-if(POLICY CMP0135)
-    # CMP0135 - controls whether, when unpacking an archive file, it should:
-    # (OLD) set the file timestamps to what they are in the archive (not recommended)
-    # (NEW) set the file timestamps to the time of extraction (recommended)
-    cmake_policy(SET CMP0135 NEW) 
-endif()
-
-if(POLICY CMP0168)
-    # CMP0168 - Controls whether fetchcontent uses sub builds (<3.30) or just does the fetch during
-    # configure, which is much faster, especially for subsequent configure.
-    # (OLD) Use a sub build
-    # (NEW) Do the fetch during configure
-    cmake_policy(SET CMP0168 NEW)
-endif()
-
+include(cmake/Policy.cmake NO_POLICY_SCOPE)
 include(cmake/LySet.cmake)
 include(cmake/GeneralSettings.cmake)
 include(cmake/FileUtil.cmake)

--- a/cmake/Policy.cmake
+++ b/cmake/Policy.cmake
@@ -1,0 +1,36 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# https://cmake.org/cmake/help/latest/policy/CMP0135.html
+if(POLICY CMP0135)
+    # Ensure extracted archive files use the extraction time as their timestamp.
+    # This avoids embedding historical or non-deterministic timestamps from the archive itself,
+    # which improves build reproducibility and prevents unnecessary rebuilds
+    # when timestamps differ but file contents do not.
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+# https://cmake.org/cmake/help/latest/policy/CMP0156.html
+if(POLICY CMP0156)
+    # Automatically remove redundant libraries from link lines when the linker supports it.
+    cmake_policy(SET CMP0156 NEW)
+endif()
+
+# https://cmake.org/cmake/help/latest/policy/CMP0168.html
+if(POLICY CMP0168)
+    # Perform FetchContent downloads directly during the configure step
+    # rather than using separate sub-builds.
+    cmake_policy(SET CMP0168 NEW)
+endif()
+
+# https://cmake.org/cmake/help/latest/policy/CMP0179.html
+if(POLICY CMP0179)
+    # When de-duplicating static libraries on the link line,
+    # keep the first occurrence and discard later duplicates.
+    cmake_policy(SET CMP0179 NEW)
+endif()

--- a/cmake/cmake_files.cmake
+++ b/cmake/cmake_files.cmake
@@ -13,6 +13,7 @@ set(FILES
     CalculateEnginePathId.cmake
     CMakeFiles.cmake
     CommandExecution.cmake
+    CompilerLauncher.cmake
     Configurations.cmake
     Dependencies.cmake
     Deployment.cmake
@@ -33,6 +34,7 @@ set(FILES
     Packaging.cmake
     PAL.cmake
     PALTools.cmake
+    Policy.cmake
     Projects.cmake
     RuntimeDependencies.cmake
     SettingsRegistry.cmake


### PR DESCRIPTION
## What does this PR do?

This is a small cleanup in our CMake setup.

I moved the `cmake_policy` settings out of the root CMakeLists and into a new `Policy.cmake` file, keeping the top-level file cleaner as we add more policies over time. The wording justifying each policy was updated to explain the policy's side effects, making it consistent.

The immediate reason for this was setting [CMP0156](https://cmake.org/cmake/help/latest/policy/CMP0156.html) and [CMP0179](https://cmake.org/cmake/help/latest/policy/CMP0179.html) to `NEW`. Those policies let CMake de-duplicate libraries on link lines. Most linkers handle duplicate libs fine anyway, but they still tend to spam warnings/noise in build output. That noise was annoying enough that I wanted to backport this policy behavior to the CMake version we currently use.

No intended runtime behavior changes--this is just build system cleanup and quieter link logs.

## How was this PR tested?

- Built and ran normally on Windows.
- Built and ran normally on macOS.
- No regressions observed in normal configure/build/run flow.
