### PR TITLE
Fix MiniAudio iOS Build

### DIFF
--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -413,7 +413,11 @@ void CSystem::ShutDown()
 /////////////////////////////////////////////////////////////////////////////////
 void CSystem::Quit()
 {
-    CryLogAlways("CSystem::Quit invoked from thread %" PRI_THREADID " (main is %" PRI_THREADID ")", AZStd::this_thread::get_id().m_id, gEnv->mMainThreadId.m_id);
+    AZ_Printf(
+        "System",
+        "CSystem::Quit invoked from thread %p (main is %p)",
+        AZStd::this_thread::get_id().m_id,
+        gEnv->mMainThreadId.m_id);
 
     AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
 

--- a/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
+++ b/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
@@ -57,7 +57,7 @@ function(Getminiaudio)
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-    # the below line is what actualy runs its CMakeList.txt file, recurses into its subfolder, defines targets and so on:
+    # the below line is what actually runs its CMakeList.txt file, recurses into its subfolder, defines targets and so on:
     FetchContent_MakeAvailable(miniaudio)
 
     set(CMAKE_WARN_DEPRECATED ON CACHE BOOL "" FORCE)
@@ -89,6 +89,18 @@ FetchContent_GetProperties(miniaudio SOURCE_DIR miniaudio_source_dir)
 ly_install(FILES ${CMAKE_CURRENT_LIST_DIR}/Installer/Findminiaudio.cmake DESTINATION cmake/3rdParty)
 ly_install(FILES ${miniaudio_source_dir}/miniaudio.h DESTINATION include/miniaudio COMPONENT CORE)
 ly_install(FILES ${miniaudio_source_dir}/LICENSE DESTINATION include/miniaudio COMPONENT CORE)
+
+# On Apple platforms, miniaudio.c uses Objective-C API like CoreAudio and AVFoundation.
+# Because the file has a .c extension, it by default compiles as plain C.
+# Enable the OBJC language and force miniaudio.c to compile as Objective-C.
+if(APPLE)
+    enable_language(OBJC)
+    set_source_files_properties(
+        "${miniaudio_source_dir}/miniaudio.c"
+        TARGET_DIRECTORY miniaudio
+        PROPERTIES LANGUAGE OBJC
+    )
+endif()
 
 # plugin headers
 foreach(node_plugin ma_channel_combiner_node ma_channel_separator_node ma_ltrim_node ma_reverb_node ma_vocoder_node)


### PR DESCRIPTION
## What does this PR do?

Fixes an iOS build issue in the MiniAudio gem by forcing `miniaudio.c` to compile as Objective-C on Apple platforms.

Previously, `miniaudio.c` was compiled as plain C due to its `.c` extension, which caused build failures on iOS when Apple audio APIs were used. Now, on Apple platforms, CMake enables Objective-C and sets the source language for `miniaudio.c` to `OBJC`, allowing the MiniAudio third-party target to compile correctly.

## How was this PR tested?

- Configured with iOS preset (`cmake --preset ios-default`)
- Built iOS target successfully (`cmake --build build/ios_xcode --config profile`)
- Verified `miniaudio.c` is compiled with Objective-C (`-x objective-c`) and the build succeeds

Testing scope is currently limited to iOS build validation; broader Apple platform testing is still in a rough state. 😞 