### PR TITLE
Replace AZStd::move with std::move

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetContainer.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetContainer.cpp
@@ -166,7 +166,7 @@ namespace AZ::Data
 
         // Add waiting assets ahead of time to hear signals for any which may already be loading
         AddWaitingAssets(waitingList);
-        SetupPreloadLists(move(preloadDependencies), rootAssetId);
+        SetupPreloadLists(AZStd::move(preloadDependencies), rootAssetId);
 
         auto loadParamsCopyWithNoLoadingFilter = loadParams;
 
@@ -195,7 +195,7 @@ namespace AZ::Data
             AZ_UNUSED(handledAssetDependencyList); // Prevent unused warning in release builds
 
             // Note that when in tools builds, this could just be because the asset catalog is not up to date, we are still compiling
-            // assets, so it should not be an assert. 
+            // assets, so it should not be an assert.
             AZ_Warning("Asset", AZStd::find(handledAssetDependencyList.begin(), handledAssetDependencyList.end(), filterInfo.m_assetId) !=
                 handledAssetDependencyList.end(),
                 "Dependent Asset ID (%s) is expected to load, but the Asset Catalog has no dependency recorded. "
@@ -208,7 +208,7 @@ namespace AZ::Data
             if (!Data::AssetManager::Instance().FindAsset(filterInfo.m_assetId, AZ::Data::AssetLoadBehavior::Default))
             {
                 // Note that when in tools builds, this could just be because the asset catalog is not up to date, we are still compiling
-                // assets, so it should not be an assert. 
+                // assets, so it should not be an assert.
                 AZ_Warning("Asset", !Data::AssetManager::Instance().FindAsset(filterInfo.m_assetId, AZ::Data::AssetLoadBehavior::Default),
                     "Dependent Asset ID (%s) can't be found in the AssetManager, which means the asset referencing it has probably "
                     "started loading before the dependent asset has been queued to load.  Verify that the asset dependencies have "
@@ -447,7 +447,7 @@ namespace AZ::Data
             auto waitingList = m_preloadWaitList.find(thisId);
             if (waitingList != m_preloadWaitList.end())
             {
-                checkList = move(waitingList->second);
+                checkList = AZStd::move(waitingList->second);
                 m_preloadWaitList.erase(waitingList);
             }
         }

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -934,7 +934,7 @@ namespace AZ::Data
         if(!asset || (!loadParams.m_reloadMissingDependencies && asset.IsReady()))
         {
             // If the asset is already ready, just return it and skip the container
-            return AZStd::move(asset);
+            return asset;
         }
 
         auto container = GetAssetContainer(asset, loadParams);
@@ -1216,7 +1216,7 @@ namespace AZ::Data
     {
         if (!assetId.IsValid())
         {
-            // The null Asset has an invalid asset ID, but uses the asset type and asset load behavior supplied to this method 
+            // The null Asset has an invalid asset ID, but uses the asset type and asset load behavior supplied to this method
             Asset<AssetData> nullAsset(assetId, assetType);
             nullAsset.SetAutoLoadBehavior(assetReferenceLoadBehavior);
             return nullAsset;
@@ -1257,7 +1257,7 @@ namespace AZ::Data
         {
             AZ_Error("AssetDatabase", false, R"(Cannot create Asset with the InvalidAssetId: %s)", assetId.ToFixedString().c_str());
 
-            // The null Asset has an invalid asset ID, but uses the asset type and asset load behavior supplied to this method 
+            // The null Asset has an invalid asset ID, but uses the asset type and asset load behavior supplied to this method
             Asset<AssetData> nullAsset(assetId, assetType);
             nullAsset.SetAutoLoadBehavior(assetReferenceLoadBehavior);
             return nullAsset;
@@ -2411,7 +2411,7 @@ namespace AZ::Data
 
         AZStd::lock_guard<AZStd::recursive_mutex> assetLock(m_assetMutex);
 
-        // we need to cache the AssetStreamInfo since json objects are referencing the names in it. 
+        // we need to cache the AssetStreamInfo since json objects are referencing the names in it.
         AZStd::vector<AssetStreamInfo> cachedStreamInfos;
         cachedStreamInfos.reserve(m_assets.size());
 
@@ -2433,7 +2433,7 @@ namespace AZ::Data
             assetInfoObject.AddMember("RefCount", static_cast<uint64_t>(assetEntry.second->GetUseCount()), doc.GetAllocator());
             infoArray.PushBack(assetInfoObject, doc.GetAllocator());
         }
-                
+
         rapidjson::Value typeSizeArray(rapidjson::kArrayType);
         for (const auto& [typeName, typeInfo] : assetTypeInfos)
         {
@@ -2480,7 +2480,7 @@ namespace AZ::Data
             AZ_Error("AssetManager", false, AZStd::string::format("Failed to open file %s for writing", filename.c_str()).c_str());
             return;
         }
-        
+
         outputFile.Write(jsonStringBuffer.GetString(), jsonStringBuffer.GetSize());
         outputFile.Close();
 

--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
@@ -86,7 +86,7 @@ AZ_THREAD_LOCAL JobManagerWorkStealing::ThreadInfo* m_currentThreadInfo = nullpt
 
 JobManagerWorkStealing::JobManagerWorkStealing(const JobManagerDesc& desc)
     : m_isAsynchronous(!desc.m_workerThreads.empty())
-    , m_workerThreads(AZStd::move(CreateWorkerThreads(desc)))
+    , m_workerThreads(CreateWorkerThreads(desc))
 {
     //allow workers to begin processing after they have all been created, needed to wait since they may access each others queues
     m_initSemaphore.release(static_cast<unsigned int>(desc.m_workerThreads.size()));
@@ -614,7 +614,7 @@ JobManagerWorkStealing::ThreadInfo* JobManagerWorkStealing::FindCurrentThreadInf
             {
                 info = m_threads[i];
                 break;
-            }   
+            }
         }
     }
 
@@ -637,8 +637,8 @@ JobManagerWorkStealing::ThreadList JobManagerWorkStealing::CreateWorkerThreads(c
         info->m_workerId = iThread;
 
         AZStd::fixed_string<128> threadName = AZStd::fixed_string<128>::format(
-            "%s worker thread %d", 
-            jmDesc.m_jobManagerName[0] != '\0' ? jmDesc.m_jobManagerName : "AZ JobManager", 
+            "%s worker thread %d",
+            jmDesc.m_jobManagerName[0] != '\0' ? jmDesc.m_jobManagerName : "AZ JobManager",
             iThread);
         AZStd::thread_desc threadDesc;
         threadDesc.m_name = threadName.c_str();

--- a/Code/Framework/AzCore/AzCore/Name/NameDictionary.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/NameDictionary.cpp
@@ -93,7 +93,7 @@ namespace AZ
         // invalidating our list.
         m_deferredHead.m_linkedToDictionary = true;
     }
-    
+
     NameDictionary::~NameDictionary()
     {
         // Unload deferred names
@@ -226,13 +226,13 @@ namespace AZ
 
         Name::Hash hash = CalcHash(nameString);
 
-        // If we find the same name with the same hash, just return it. 
+        // If we find the same name with the same hash, just return it.
         // This path is faster than the loop below because FindName() takes a shared_lock whereas the
         // loop requires a unique_lock to modify the dictionary.
         Name name = FindName(hash);
         if (name.GetStringView() == nameString)
         {
-            return AZStd::move(name);
+            return name;
         }
 
         // The name doesn't exist in the dictionary, so we have to lock and add it

--- a/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflectionLuaFunctions.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflectionLuaFunctions.inl
@@ -140,7 +140,7 @@ namespace AZ
             }
 
             AZ_Assert(value.m_value, "Invalid call to FromLua! Either a stack allocator must be passed, or value.m_value must be a valid storage location.");
-            return value.StoreResult(AZStd::move(ScriptValue<AZStd::any>::StackRead(lua, stackIndex)));
+            return value.StoreResult(ScriptValue<AZStd::any>::StackRead(lua, stackIndex));
         }
 
         // Pushes an any onto the Lua stack

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -5484,7 +5484,7 @@ LUA_API const Node* lua_getDummyNode()
                 // Lua: ExposedEvent, lambda
                 lua_pushvalue(lua, -1);
                 // Lua: ExposedEvent, lambda, lambda
-                auto handlerAndType = AZStd::invoke(holder.m_function, userData->value, AZStd::move(ExposedLambda(lua)));
+                auto handlerAndType = AZStd::invoke(holder.m_function, userData->value, ExposedLambda(lua));
                 // Lua: ExposedEvent, lambda
                 Internal::RegisteredObjectToLua(lua, handlerAndType.m_address, handlerAndType.m_typeId, ObjectToLua::ByReference, AcquisitionOnPush::ScriptAcquire);
                 // Lua: ExposedEvent, lambda, handler

--- a/Code/Framework/AzCore/AzCore/std/createdestroy.h
+++ b/Code/Framework/AzCore/AzCore/std/createdestroy.h
@@ -554,12 +554,8 @@ namespace AZStd
     {
         return AZStd::Internal::uninitialized_move(first, last, result, {});
     }
-    // 25.3.2 Move
-    template<class InputIterator, class OutputIterator>
-    OutputIterator move(InputIterator first, InputIterator last, OutputIterator result)
-    {
-        return AZStd::Internal::move(first, last, result, {});
-    }
+
+    using std::move;
 
     template<class BidirectionalIterator1, class BidirectionalIterator2>
     BidirectionalIterator2 move_backward(BidirectionalIterator1 first, BidirectionalIterator1 last, BidirectionalIterator2 result)

--- a/Code/Framework/AzCore/AzCore/std/smart_ptr/intrusive_ptr.h
+++ b/Code/Framework/AzCore/AzCore/std/smart_ptr/intrusive_ptr.h
@@ -142,7 +142,7 @@ namespace AZStd
         template<class U>
         enable_if_t<is_convertible<U*, T*>::value, intrusive_ptr&> operator=(intrusive_ptr<U>&& rhs)
         {
-            this_type(move(rhs)).swap(*this);
+            this_type(AZStd::move(rhs)).swap(*this);
             return *this;
         }
         intrusive_ptr& operator=(intrusive_ptr&& rhs)

--- a/Code/Framework/AzCore/AzCore/std/utility/move.h
+++ b/Code/Framework/AzCore/AzCore/std/utility/move.h
@@ -5,15 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #pragma once
+
+#include <utility>
 
 namespace AZStd
 {
-    // rvalue
-    // rvalue move
-    template<class T>
-    constexpr AZStd::remove_reference_t<T>&& move(T&& t)
-    {
-        return static_cast<AZStd::remove_reference_t<T>&&>(t);
-    }
+    using std::move;
+    using std::move_if_noexcept;
 }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/condition_variable_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/condition_variable_UnixLike.h
@@ -97,7 +97,7 @@ namespace AZStd
     template <class Rep, class Period, class Predicate>
     AZ_FORCE_INLINE bool condition_variable::wait_for(unique_lock<mutex>& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred)
     {
-        return wait_until(lock, chrono::steady_clock::now() + rel_time, move(pred));
+        return wait_until(lock, chrono::steady_clock::now() + rel_time, AZStd::move(pred));
     }
     condition_variable::native_handle_type
     inline condition_variable::native_handle()
@@ -204,7 +204,7 @@ namespace AZStd
     template <class Lock, class Rep, class Period, class Predicate>
     AZ_FORCE_INLINE bool condition_variable_any::wait_for(Lock& lock, const chrono::duration<Rep, Period>& rel_time, Predicate pred)
     {
-        return wait_until(lock, chrono::steady_clock::now() + rel_time, move(pred));
+        return wait_until(lock, chrono::steady_clock::now() + rel_time, AZStd::move(pred));
     }
     condition_variable_any::native_handle_type
     inline condition_variable_any::native_handle()

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptMediator.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptMediator.cpp
@@ -221,7 +221,7 @@ namespace AzFramework::Scripts
                     {
                         SpawnableScriptNotificationsBus::Event(
                             command.m_spawnTicket.GetId(), &SpawnableScriptNotifications::OnSpawn, command.m_spawnTicket,
-                            move(command.m_entityList));
+                            AZStd::move(command.m_entityList));
                     }
                 }
                 if constexpr (AZStd::is_same_v<CommandType, DespawnResult>)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -841,7 +841,7 @@ namespace AzToolsFramework
                 actionContextIdentifier.c_str()));
         }
 
-        return AZ::Success(AZStd::move(actionContextIterator->second->GetActiveMode()));
+        return AZ::Success(actionContextIterator->second->GetActiveMode());
     }
 
     QAction* ActionManager::GetAction(const AZStd::string& actionIdentifier)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
@@ -547,7 +547,7 @@ namespace AzToolsFramework
 
     AssetFileInfoList AssetSeedManager::GetDependencyList(AzFramework::PlatformId platformIndex, const AZStd::unordered_set<AZ::Data::AssetId>& exclusionList, AssetFileDebugInfoList* optionalDebugList, const AZStd::vector<AZStd::string>& wildcardPatternExclusionList) const
     {
-        AssetSeedManager::AssetsInfoList  assetInfoList = AZStd::move(GetDependenciesInfo(platformIndex, exclusionList, optionalDebugList, wildcardPatternExclusionList));
+        AssetSeedManager::AssetsInfoList  assetInfoList = GetDependenciesInfo(platformIndex, exclusionList, optionalDebugList, wildcardPatternExclusionList);
 
         AssetFileInfoList assetFileInfoList;
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.cpp
@@ -101,7 +101,7 @@ namespace AzToolsFramework
                 this,
                 [this]()
                 {
-                    auto entries = AZStd::move(GetSelectedAssets());
+                    auto entries = GetSelectedAssets();
                     if (entries.empty() && m_assetTreeView)
                     {
                         // Tree has the current open folder selected if context is valid (not searching, etc)
@@ -110,7 +110,7 @@ namespace AzToolsFramework
                         {
                             m_thumbnailViewWidget->selectionModel()->select(
                                 treeSelection.first(), QItemSelectionModel::SelectionFlag::ClearAndSelect);
-                            entries = AZStd::move(GetSelectedAssets());
+                            entries = GetSelectedAssets();
                         }
                     }
 
@@ -399,7 +399,7 @@ namespace AzToolsFramework
                                                 .data(AssetBrowserModel::Roles::EntryRole)
                                                 .value<const AssetBrowserEntry*>();
             AZStd::string pathName = item->GetFullPath();
-            
+
 
             using namespace AzQtComponents;
             DragAndDropContextBase context;
@@ -540,7 +540,7 @@ namespace AzToolsFramework
         {
             return m_assetFilterModel->GetSortMode();
         }
-        
+
         void AssetBrowserThumbnailView::SelectEntry(QString assetName)
         {
             QModelIndex rootIndex = m_thumbnailViewProxyModel->GetRootIndex();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorTab.cpp
@@ -124,7 +124,7 @@ namespace AzToolsFramework
                         else
                         {
                             AZStd::string error =
-                                AZStd::move(AZStd::string::format("Could not check out asset file: %s.", assetFullPath.c_str()));
+                                AZStd::string::format("Could not check out asset file: %s.", assetFullPath.c_str());
                             assetCheckoutAndSaveCallback(false, error, assetFullPath);
                         }
                         opComplete = true;
@@ -153,7 +153,7 @@ namespace AzToolsFramework
             else
             {
                 AZStd::string error =
-                    AZStd::move(AZStd::string::format("Could not resolve path name for asset {%s}.", id.ToString<AZStd::string>().c_str()));
+                    AZStd::string::format("Could not resolve path name for asset {%s}.", id.ToString<AZStd::string>().c_str());
                 assetCheckoutAndSaveCallback(false, error, AZStd::string{});
             }
         }
@@ -349,7 +349,7 @@ namespace AzToolsFramework
 
                         if (checkoutSuccess)
                         {
-                            saveError = AZStd::move(AZStd::string::format("Could not write asset file: %s.", assetFullPath.c_str()));
+                            saveError = AZStd::string::format("Could not write asset file: %s.", assetFullPath.c_str());
                             if (!m_saveData.empty())
                             {
                                 if (AZ::Utils::SaveStreamToFile(assetFullPath, m_saveData))
@@ -363,7 +363,7 @@ namespace AzToolsFramework
                         if (saveSuccessful)
                         {
                             Q_EMIT OnAssetSavedSignal();
-                                            
+
                             m_parentEditorWidget->AddRecentPath(m_inMemoryAsset->GetType(), assetFullPath);
                             if (!m_useDPE)
                             {
@@ -404,7 +404,7 @@ namespace AzToolsFramework
             {
                 return;
             }
-            
+
             SaveAssetImpl(nullptr);
         }
 
@@ -572,7 +572,7 @@ namespace AzToolsFramework
 
 
         void AssetEditorTab::UpdatePropertyEditor(AZ::Data::Asset<AZ::Data::AssetData>& asset)
-        {           
+        {
             if (m_useDPE)
             {
                 m_adapter->SetValue(asset.Get(), asset.GetType());
@@ -678,7 +678,7 @@ namespace AzToolsFramework
             auto asset = AZ::Data::AssetManager::Instance().GetAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::Default);
 
             asset.BlockUntilLoadComplete();
-            
+
             if (asset.IsReady())
             {
                 OnAssetReady(asset);
@@ -755,7 +755,7 @@ namespace AzToolsFramework
                 // given a chance to fix the errors and try again.
                 m_sourceAssetId.SetInvalid();
                 m_currentAsset = "New Asset";
-                
+
                 if (!m_useDPE)
                 {
                     m_propertyEditor->setEnabled(true);
@@ -801,7 +801,7 @@ namespace AzToolsFramework
         {
             DirtyAsset();
         }
-        
+
         void AssetEditorTab::OnDocumentPropertyChanged(const AZ::DocumentPropertyEditor::ReflectionAdapter::PropertyChangeInfo& changeInfo)
         {
             if (changeInfo.changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityActionComponent.cpp
@@ -533,7 +533,7 @@ namespace AzToolsFramework
                     }
 
                     // Run the scrubber and store the result
-                    resultMap.emplace(entity->GetId(), AZStd::move(ScrubEntity(entity)));
+                    resultMap.emplace(entity->GetId(), ScrubEntity(entity));
 
                     // Attempt to re-activate if we were previously active
                     if (reactivate)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -104,7 +104,7 @@ namespace AzToolsFramework
 
         Instance::~Instance()
         {
-            // when destroying an instance in its destructor, do not re-create any 
+            // when destroying an instance in its destructor, do not re-create any
             // new entities or instances (Avoids a leak)
             Reset(false);
         }
@@ -141,7 +141,7 @@ namespace AzToolsFramework
 
             m_templateId = templateId;
 
-            // If this instance's templateId is valid, we should be able to register this instance to 
+            // If this instance's templateId is valid, we should be able to register this instance to
             // Template to Instance mapping successfully.
             if (m_templateId != InvalidTemplateId &&
                 !m_templateInstanceMapper->RegisterInstanceToTemplate(*this))
@@ -191,7 +191,7 @@ namespace AzToolsFramework
         bool Instance::AddEntity(AZ::Entity& entity, EntityAlias entityAlias)
         {
             return
-                RegisterEntity(entity.GetId(), entityAlias) && 
+                RegisterEntity(entity.GetId(), entityAlias) &&
                 m_entities.emplace(AZStd::move(entityAlias), &entity).second;
         }
 
@@ -250,7 +250,7 @@ namespace AzToolsFramework
 
         void Instance::DetachAllEntitiesInHierarchy(const AZStd::function<void(AZStd::unique_ptr<AZ::Entity>)>& callback)
         {
-            callback(AZStd::move(DetachContainerEntity()));
+            callback(DetachContainerEntity());
             DetachEntities(callback);
 
             for (const auto& [instanceAlias, instance] : m_nestedInstances)
@@ -407,7 +407,7 @@ namespace AzToolsFramework
 
         bool Instance::RegisterEntity(const AZ::EntityId& entityId, const EntityAlias& entityAlias)
         {
-            
+
             if ((m_entityIdInstanceRelationship ==
                     EntityIdInstanceRelationship::OneToOne) && !(m_instanceEntityMapper->RegisterEntityToInstance(entityId, *this)))
             {
@@ -809,7 +809,7 @@ namespace AzToolsFramework
             if (instance)
             {
                 AZStd::vector<const Instance*> instanceChain;
-                
+
                 while (instance && instance != this)
                 {
                     instanceChain.push_back(instance);
@@ -977,7 +977,7 @@ namespace AzToolsFramework
             // force a flush of memory by clearing first if cache isn't empty.
             if (!m_cachedInstanceDom.IsNull())
             {
-                m_cachedInstanceDom = PrefabDom(); 
+                m_cachedInstanceDom = PrefabDom();
             }
 
             if (m_isDomCachingEnabled)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.cpp
@@ -140,7 +140,7 @@ namespace AzToolsFramework
                 entityAliasPath += "/";
                 entityAliasPath += entityAliasRef->get();
             }
-            return AZStd::move(entityAliasPath);
+            return entityAliasPath;
         }
 
         AZ::Dom::Path InstanceToTemplatePropagator::GenerateEntityPathFromFocusedPrefab(AZ::EntityId entityId)
@@ -166,14 +166,14 @@ namespace AzToolsFramework
                 AZ_Error("Prefab", false, "Focused prefab instance is null.");
                 return AZ::Dom::Path();
             }
-            
+
             auto relativePathBetweenInstances =
                 PrefabInstanceUtils::GetRelativePathBetweenInstances(focusedInstance->get(), owningInstance->get());
 
             AZ::Dom::Path fullPathBetweenInstances(relativePathBetweenInstances);
             AZStd::string entityPath = GenerateEntityAliasPath(entityId);
             fullPathBetweenInstances = fullPathBetweenInstances / AZ::Dom::Path(entityPath);
-            return AZStd::move(fullPathBetweenInstances);
+            return fullPathBetweenInstances;
         }
 
         void InstanceToTemplatePropagator::PrependEntityAliasPathToPatchPaths(
@@ -219,7 +219,7 @@ namespace AzToolsFramework
             if (result.GetProcessing() != AZ::JsonSerializationResult::Processing::Completed)
             {
                 AZ_Error("Prefab", false, "Patch was not successfully applied.");
-                return false; 
+                return false;
             }
             else
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -171,7 +171,7 @@ namespace AzToolsFramework
                     {
                         // Only track the instance that was passed in
                         return (&instance == entityIdMapper.GetLoadingInstance());
-                    }; 
+                    };
 
                     if ((flags & LoadFlags::ReportDeprecatedComponents) == LoadFlags::ReportDeprecatedComponents)
                     {
@@ -444,7 +444,7 @@ namespace AzToolsFramework
                     {
                         continue;
                     }
-                
+
                     AZStd::string_view patchPath = patchEntryIterator->value.GetString();
 
                     // Entities
@@ -522,7 +522,7 @@ namespace AzToolsFramework
                     }
                 }
 
-                return AZStd::move(patchesMetadata);
+                return patchesMetadata;
             }
 
             void PrintPrefabDomValue(
@@ -661,7 +661,7 @@ namespace AzToolsFramework
                                 path.c_str(), entityAlias.c_str(), entityName.c_str());
                             continue;
                         }
-                        
+
                         AZStd::string componentAlias(componentsTypeIt->value.GetString());
 
 
@@ -685,7 +685,7 @@ namespace AzToolsFramework
                             // Re-link this entity under the ContainerEntity using its Alias
                             parentIt->value.SetString(rapidjson::StringRef(containerEntityAlias.c_str()), templateDomRef.GetAllocator());
 
-                            result = false; // report that changes were needed and made 
+                            result = false; // report that changes were needed and made
                             AZ_Error("Prefab", false,
                                 "'%s' lacks 'Parent Entity' value in TransformComponent of Entity (%s, '%s')"
                                 "\nEntity re-linked under the root container '%s'.",

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.cpp
@@ -19,7 +19,7 @@ namespace AzToolsFramework
             InstanceClimbUpResult ClimbUpToTargetOrRootInstance(const Instance& startInstance, const Instance* targetInstance)
             {
                 InstanceClimbUpResult result;
-                
+
                 // Climbs up the instance hierarchy from the start instance until it hits the target or the root instance.
                 const Instance* instancePtr = &startInstance;
 
@@ -89,7 +89,7 @@ namespace AzToolsFramework
                     relativePath.append((*instanceIter)->GetInstanceAlias());
                 }
 
-                return AZStd::move(relativePath);
+                return relativePath;
             }
 
             bool IsDescendantInstance(const Instance& childInstance, const Instance& parentInstance)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -200,12 +200,12 @@ namespace AzToolsFramework
 
                         commonRootEntityOwningInstance->get().DetachEntity(entityId).release();
                     }
-                    
+
                     PrefabUndoHelpers::RemoveEntityDoms(detachedEntityDomAndPathList, commonRootInstanceTemplateId, undoBatch.GetUndoBatch());
                 }
 
                 // Detach the retrieved nested instances.
-                // When we create a prefab with other prefab instances, we have to remove the existing links between the source and 
+                // When we create a prefab with other prefab instances, we have to remove the existing links between the source and
                 // target templates of the other instances.
                 for (auto& instance : detachedInstances)
                 {
@@ -433,7 +433,7 @@ namespace AzToolsFramework
                         AZ_STRING_ARG(filePathString)));
                 }
             }
-            
+
             return result;
         }
 
@@ -462,7 +462,7 @@ namespace AzToolsFramework
             m_instanceToTemplateInterface->GeneratePatch(patch, containerEntityDomBefore, containerEntityDomAfter);
             m_instanceToTemplateInterface->PrependEntityAliasPathToPatchPaths(patch, containerEntityId);
 
-            return AZStd::move(patch);
+            return patch;
         }
 
         InstantiatePrefabResult PrefabPublicHandler::InstantiatePrefab(
@@ -706,7 +706,7 @@ namespace AzToolsFramework
             LinkReference nestedInstanceLink = m_prefabSystemComponentInterface->FindLink(sourceInstance->GetLinkId());
             AZ_Assert(
                 nestedInstanceLink.has_value(),
-                "A valid link was not found for one of the instances provided as input for the CreatePrefab operation.");    
+                "A valid link was not found for one of the instances provided as input for the CreatePrefab operation.");
 
             PrefabDom patchesCopyForUndoSupport;
             PrefabDom nestedInstanceLinkDom;
@@ -785,7 +785,7 @@ namespace AzToolsFramework
             AZStd::string entityName = AZStd::string::format("Entity%llu", static_cast<AZ::u64>(m_newEntityCounter++));
 
             AZ::Entity* entity = aznew AZ::Entity(entityId, entityName.c_str());
-            
+
             Instance& entityOwningInstance = owningInstanceOfParentEntity->get();
 
             ScopedUndoBatch undoBatch("Add Entity");
@@ -1154,7 +1154,7 @@ namespace AzToolsFramework
                     "PrefabEditorEntityOwnershipInterface unavailable.");
             }
             InstanceOptionalReference levelInstance = prefabEditorEntityOwnershipInterface->GetRootPrefabInstance();
-            
+
             return owningInstance
                 && levelInstance
                 && (&owningInstance->get() == &levelInstance->get())
@@ -1453,7 +1453,7 @@ namespace AzToolsFramework
 
             if (!retrieveEntitiesAndInstancesOutcome.IsSuccess())
             {
-                return AZStd::move(retrieveEntitiesAndInstancesOutcome);
+                return retrieveEntitiesAndInstancesOutcome;
             }
 
             // Gets selected entities.
@@ -1516,7 +1516,7 @@ namespace AzToolsFramework
 
                 if (isOverrideEditing)
                 {
-                    detachedInstanceAliasPaths.push_back(AZStd::move(PrefabDomUtils::PathStartingWithInstances + instanceAlias));
+                    detachedInstanceAliasPaths.push_back(PrefabDomUtils::PathStartingWithInstances + instanceAlias);
                 }
                 else
                 {
@@ -1570,7 +1570,7 @@ namespace AzToolsFramework
 
             AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
                 &AzToolsFramework::ToolsApplicationRequestBus::Events::ClearDirtyEntities);
-            
+
             return AZ::Success();
         }
 
@@ -1583,7 +1583,7 @@ namespace AzToolsFramework
         {
             return DetachPrefabImpl(containerEntityId, false /* Discard Container Entity */);
         }
-        
+
         PrefabOperationResult PrefabPublicHandler::DetachPrefabImpl(const AZ::EntityId& containerEntityId, bool keepContainerEntity)
         {
             if (!containerEntityId.IsValid())
@@ -1720,7 +1720,7 @@ namespace AzToolsFramework
                                     AZ::TransformBus::Event(currentEntityId, &AZ::TransformBus::Events::SetParent, containerParentId);
                                 }
                             }
-                            
+
                             PrefabDom nestedInstanceDomUnderNewParent;
                             m_instanceToTemplateInterface->GenerateInstanceDomBySerializing(
                                 nestedInstanceDomUnderNewParent, nestedInstanceUnderNewParent);
@@ -1753,7 +1753,7 @@ namespace AzToolsFramework
                             {
                                 // get the absolute alias path of the parent instance (the parent of the container entity
                                 AliasPath aliasPath = resultInstance.first->GetAbsoluteInstanceAliasPath();
-                        
+
                                 aliasPath.Append(resultInstance.second);
                                 AZ::EntityId newId = InstanceEntityIdMapper::GenerateEntityIdForAliasPath(aliasPath);
                                 if (newId.IsValid())
@@ -1772,7 +1772,7 @@ namespace AzToolsFramework
                         {
                             // use erase-remove-if idiom:
                             vector.erase(
-                                
+
                                 AZStd::remove_if(vector.begin(), vector.end(), [&toRemove](const AZ::EntityId& entityId)
                                 {
                                     return AZStd::find(toRemove.begin(), toRemove.end(), entityId) != toRemove.end();
@@ -1805,21 +1805,21 @@ namespace AzToolsFramework
                     // before the current undo batch expires, clear any dirty entities.
                     ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::ClearDirtyEntities);
                 } // end of first "inner" undo batch
-                
+
                 // now that a complete undo batch is done for the operation which leaves the data intact, we can delete
                 // the leftover container entity in a normal "delete this thing" step.  We can behave as if the entity
                 // is always attached.
 
                 // note that this is still within the scope of the "outer" undo batch, so it still counts as one operation.
                 if (!keepContainerEntity)
-                {   
+                {
                     DeleteFromInstance({containerEntityId});
                 }
 
                 // before the current undo batch expires, clear any dirty entities.
                 ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::ClearDirtyEntities);
             } // end of the "outer" undo batch.
-            
+
             return AZ::Success();
         }
 
@@ -1978,7 +1978,7 @@ namespace AzToolsFramework
                 {
                     // If it's the same instance, we can add this entity to the new instance entities.
                     size_t priorEntitiesSize = entities.size();
-                    
+
                     entities.insert(entity);
 
                     // If the size of entities increased, then it wasn't added before.
@@ -2070,7 +2070,7 @@ namespace AzToolsFramework
             {
                 outEntityIds.erase(iter);
             }
-            
+
             return outEntityIds;
         }
 
@@ -2172,7 +2172,7 @@ namespace AzToolsFramework
             AzToolsFramework::EntityIdList selectedEntities;
             AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
                 selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
-            
+
             // Find the EditorEntitySortComponent DOM
             auto componentsIter = parentEntityValue->FindMember(PrefabDomUtils::ComponentsName);
             if (componentsIter == parentEntityValue->MemberEnd())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -177,7 +177,7 @@ namespace AzToolsFramework
                     AZ_Assert(false, "Template with id %llu is not found", templateId);
                     continue;
                 }
-                
+
                 const AZ::IO::Path& loadedTemplateFilePathName = loadedTemplate->get().GetFilePath();
                 AZ::IO::Path unchangedPathSegment(loadedTemplateFilePathName.Native().substr(fromRelativePath.Native().size()));
                 AZ::IO::Path updatedTemplateFilePathName(toRelativePath.Native(), AZ::IO::PosixPathSeparator);
@@ -352,7 +352,7 @@ namespace AzToolsFramework
             }
         }
 
-      
+
         void PrefabSystemComponent::UpdateLinkedInstance(const LinkId linkIdToUpdate,
             TargetTemplateIdToLinkIdMap& targetTemplateIdToLinkIdMap, AZStd::queue<LinkIds>& linkIdsQueue)
         {
@@ -361,7 +361,7 @@ namespace AzToolsFramework
             PrefabDomValue& linkedInstanceDom = linkToUpdate.GetLinkedInstanceDom();
 
             // create an empty Dom to hold the temp allocations so they are cleared when we leave this scope:
-            PrefabDom linkedDomBeforeUpdate; 
+            PrefabDom linkedDomBeforeUpdate;
             linkedDomBeforeUpdate.CopyFrom(linkedInstanceDom, linkedDomBeforeUpdate.GetAllocator());
 
             // the following call modifies the linkedInstanceDom to have the updated changes.
@@ -379,7 +379,7 @@ namespace AzToolsFramework
             // from before in targetTemplateIdToLinkIdMap[targetTemplateId].second.  This also means that if
             // targetTemplateIdToLinkIdMap[targetTemplateId].second is true, there is no need to compare it again, as it will have
             // already added its links to the queue.
-            
+
             bool isTemplateUpdated = targetTemplateIdToLinkIdMap[targetTemplateId].second;
             if (!isTemplateUpdated || AZ::JsonSerialization::Compare(linkedDomBeforeUpdate, linkedInstanceDom) != AZ::JsonSerializerCompareResult::Equal)
             {
@@ -559,7 +559,7 @@ namespace AzToolsFramework
         {
             TemplateId newTemplateId = CreateUniqueTemplateId();
             Template& newTemplate = m_templateIdMap.emplace(
-                AZStd::make_pair(newTemplateId, AZStd::move(Template(filePath, AZStd::move(prefabDom))))).first->second;
+                AZStd::make_pair(newTemplateId, Template(filePath, AZStd::move(prefabDom)))).first->second;
 
             if (!newTemplate.IsValid())
             {
@@ -1029,7 +1029,7 @@ namespace AzToolsFramework
             GetDirtyTemplatePathsHelper(rootTemplateId, dirtyTemplatePathVector);
             AZStd::set<AZ::IO::PathView> dirtyTemplatePaths;
             dirtyTemplatePaths.insert(dirtyTemplatePathVector.begin(), dirtyTemplatePathVector.end());
-            return AZStd::move(dirtyTemplatePaths);
+            return dirtyTemplatePaths;
         }
 
         void PrefabSystemComponent::GetDirtyTemplatePathsHelper(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoApplyOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoApplyOverrides.cpp
@@ -40,7 +40,7 @@ namespace AzToolsFramework
             LinkReference link = m_prefabSystemComponentInterface->FindLink(m_linkId);
             if (link.has_value())
             {
-                m_overrideSubTree = AZStd::move(link->get().RemoveOverrides(m_pathToSubTree));
+                m_overrideSubTree = link->get().RemoveOverrides(m_pathToSubTree);
                 link->get().UpdateTarget();
                 m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
                 m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyOverride.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoComponentPropertyOverride.cpp
@@ -125,7 +125,7 @@ namespace AzToolsFramework
 
                 // Remove the subtree and cache the subtree for undo.
                 // Note: Depending on the path, this would remove all existing patches to individual values (e.g. vector).
-                m_overriddenPropertySubTree = AZStd::move(link->get().RemoveOverrides(pathToPropertyFromTopPrefab));
+                m_overriddenPropertySubTree = link->get().RemoveOverrides(pathToPropertyFromTopPrefab);
 
                 m_overriddenPropertyPath = pathToPropertyFromTopPrefab;
 
@@ -169,7 +169,7 @@ namespace AzToolsFramework
                     // In undo, before-state subtrees in map will be moved to the link tree.
                     // The previous states of subtrees in link are moved back to the map for next undo/redo if any.
                     AZ_Assert(!m_overriddenPropertyPath.IsEmpty(), "PrefabUndoComponentPropertyOverride - Overriden property path is empty.");
-                    PrefabOverridePrefixTree subtreeInLink = AZStd::move(link->get().RemoveOverrides(m_overriddenPropertyPath));
+                    PrefabOverridePrefixTree subtreeInLink = link->get().RemoveOverrides(m_overriddenPropertyPath);
                     link->get().AddOverrides(m_overriddenPropertyPath, AZStd::move(m_overriddenPropertySubTree));
                     m_overriddenPropertySubTree = AZStd::move(subtreeInLink);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoEntityOverrides.cpp
@@ -116,7 +116,7 @@ namespace AzToolsFramework
 
                 // Remove the subtree and cache the subtree for undo.
                 AZ::Dom::Path entityDomPath(entityPathFromTopInstance.c_str());
-                m_subtreeStates[entityDomPath] = AZStd::move(link->get().RemoveOverrides(entityDomPath));
+                m_subtreeStates[entityDomPath] = link->get().RemoveOverrides(entityDomPath);
 
                 // Redo - Add the override patches to the tree.
                 link->get().AddOverrides(overridePatches);
@@ -135,7 +135,7 @@ namespace AzToolsFramework
                         link->get().GetInstanceName().c_str(),
                         entityPathFromTopInstance.c_str());
                     PrefabUndoUtils::UpdateEntityInPrefabDom(cachedFocusedInstanceDom, entityDomAfterUpdate, pathInsideFocusedInstance);
-                } 
+                }
             }
 
             // Redo - Update target template of the link.
@@ -171,7 +171,7 @@ namespace AzToolsFramework
                     // In redo, after-state subtrees in map will be moved to the link tree.
                     // In undo, before-state subtrees in map will be moved to the link tree.
                     // The previous states of subtrees in link are moved back to the map for next undo/redo if any.
-                    PrefabOverridePrefixTree subtreeInLink = AZStd::move(link->get().RemoveOverrides(pathToSubtree));
+                    PrefabOverridePrefixTree subtreeInLink = link->get().RemoveOverrides(pathToSubtree);
                     link->get().AddOverrides(pathToSubtree, AZStd::move(subtreeState));
                     subtreeState = AZStd::move(subtreeInLink);
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoRevertOverrides.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Undo/PrefabUndoRevertOverrides.cpp
@@ -53,7 +53,7 @@ namespace AzToolsFramework
             LinkReference link = m_prefabSystemComponentInterface->FindLink(m_linkId);
             if (link.has_value())
             {
-                m_overrideSubTree = AZStd::move(link->get().RemoveOverrides(m_pathToSubTree));
+                m_overrideSubTree = link->get().RemoveOverrides(m_pathToSubTree);
                 link->get().UpdateTarget();
                 m_prefabSystemComponentInterface->SetTemplateDirtyFlag(link->get().GetTargetTemplateId(), true);
                 m_prefabSystemComponentInterface->PropagateTemplateChanges(link->get().GetTargetTemplateId());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.cpp
@@ -738,7 +738,7 @@ namespace AzToolsFramework
                 // Create temporary one with the type id then we can get its type info to construct a new AZStd::any with new data
                 auto tempAny = m_serializeContext->CreateAny(data.value().m_valueElement->m_typeId);
                 AZStd::any::type_info typeInfo = tempAny.get_type_info();
-                return { PropertyAccessOutcome::ValueType(AZStd::move(AZStd::any(value, typeInfo))) };
+                return { PropertyAccessOutcome::ValueType(AZStd::any(value, typeInfo)) };
             }
         }
         else if (data.value().m_dataContainer->GetAssociativeContainerInterface())
@@ -756,7 +756,7 @@ namespace AzToolsFramework
                 auto tempAny = m_serializeContext->CreateAny(keyPairInfo.value().m_valueElement->m_typeId);
                 AZStd::any::type_info typeInfo = tempAny.get_type_info();
                 void* value = keyPairInfo.value().m_pairClass->m_container->GetElementByIndex(keyPairValue, keyPairInfo.value().m_valueElement, 1);
-                return { PropertyAccessOutcome::ValueType(AZStd::move(AZStd::any(value, typeInfo))) };
+                return { PropertyAccessOutcome::ValueType(AZStd::any(value, typeInfo)) };
             }
         }
         return PropertyAccessOutcome{ AZStd::unexpect, PropertyAccessOutcome::ErrorType("GetContainerItem - keyed value could not be returned") };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
@@ -1404,20 +1404,20 @@ namespace AzToolsFramework
         {
         case PerforceJobRequest::PJR_Stat:
         {
-            resp.m_fileInfo = AZStd::move(GetFileInfo(request.m_requestPath.c_str()));
+            resp.m_fileInfo = GetFileInfo(request.m_requestPath.c_str());
             resp.m_succeeded = resp.m_fileInfo.m_status == SCS_OpSuccess;
         }
         break;
         case PerforceJobRequest::PJR_StatBulk:
         {
-            resp.m_bulkFileInfo = AZStd::move(GetBulkFileInfo(request.m_bulkFilePaths));
+            resp.m_bulkFileInfo = GetBulkFileInfo(request.m_bulkFilePaths);
             resp.m_succeeded = !resp.m_bulkFileInfo.empty();
         }
         break;
         case PerforceJobRequest::PJR_Edit:
         {
             resp.m_succeeded = RequestEdit(request.m_requestPath.c_str(), request.m_allowMultiCheckout);
-            resp.m_fileInfo = AZStd::move(GetFileInfo(request.m_requestPath.c_str()));
+            resp.m_fileInfo = GetFileInfo(request.m_requestPath.c_str());
         }
         break;
         case PerforceJobRequest::PJR_EditBulk:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
@@ -102,7 +102,7 @@ namespace AzToolsFramework
                 AZ_Assert(false, "PrefabSaveHandler - could not get PrefabPublicInterface on construction.");
                 return;
             }
-           
+
             s_prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
             if (s_prefabSystemComponentInterface == nullptr)
             {
@@ -123,7 +123,7 @@ namespace AzToolsFramework
                 AZ_Assert(false, "PrefabSaveHandler - could not get TemplateInstanceMapperInterface on construction.");
                 return;
             }
-            
+
             // we care about both outliner and viewport.
             AzQtComponents::DragAndDropEventsBus::Handler::BusConnect(AzQtComponents::DragAndDropContexts::EditorViewport);
             AzQtComponents::DragAndDropItemViewEventsBus::Handler::BusConnect(AzQtComponents::DragAndDropContexts::EntityOutliner);
@@ -253,7 +253,7 @@ namespace AzToolsFramework
 
                     DoDragAndDropData(instantiateLocation, AZ::EntityId(), thingsToInstantiate, thingsToDetach);
 
-                    
+
                 }
             }
         }
@@ -273,7 +273,7 @@ namespace AzToolsFramework
             {
                 return false;
             }
-                        
+
             // helper lambda: given a product, evaluate whether it is a proc prefab.
             // if it is, add it to the list of things that should be instantiated.
             // if its not selected, add it to the list of things that should also be detached.
@@ -387,7 +387,7 @@ namespace AzToolsFramework
                 {
                     EditorRequestBus::BroadcastResult(instantiateLocation, &EditorRequestBus::Events::GetWorldPositionAtViewportCenter);
                 }
-               
+
                 if (CanDragAndDropData(outlinerContext->m_dataBeingDropped, &thingsToInstantiate, &thingsToDetach))
                 {
                     accepted = true;
@@ -781,12 +781,12 @@ namespace AzToolsFramework
                 }
 
                 // We also check if the prefab template already exists in the Prefabs Database.
-                // This happens if the prefab file having the same name was removed from the disk, 
+                // This happens if the prefab file having the same name was removed from the disk,
                 // but the prefab instance still exists in the Editor.
                 TemplateId templateId = s_prefabSystemComponentInterface->GetTemplateIdFromFilePath(prefabRelativeName.c_str());
                 if (templateId != Prefab::InvalidTemplateId)
                 {
-                    const AZStd::string message = AZStd::string::format(                        
+                    const AZStd::string message = AZStd::string::format(
                         "A prefab with the path '%s' already exists in the Asset Database. \r\n\r\n"
                         "Overriding it will damage instances or cascades of this prefab.",
                         prefabRelativeName.c_str());
@@ -947,7 +947,7 @@ namespace AzToolsFramework
             AzQtComponents::StyleManager::setStyleSheet(savePrefabDialog->parentWidget(), QStringLiteral("style:Editor.qss"));
 
             savePrefabDialog->setLayout(contentLayout);
-            return AZStd::move(savePrefabDialog);
+            return savePrefabDialog;
         }
 
         AZStd::shared_ptr<QDialog> PrefabSaveHandler::ConstructClosePrefabDialog(TemplateId templateId)
@@ -1034,7 +1034,7 @@ namespace AzToolsFramework
             unsavedPrefabsScrollArea->setWidgetResizable(true);
             unsavedPrefabsContainer->setContentWidget(unsavedPrefabsScrollArea);
 
-            return AZStd::move(unsavedPrefabsContainer);
+            return unsavedPrefabsContainer;
         }
 
         void PrefabSaveHandler::SourceFileRemoved(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -495,7 +495,7 @@ namespace AzToolsFramework
 
 
     private:
-        EntityPropertyEditor* m_editor;        
+        EntityPropertyEditor* m_editor;
         int m_dropIndicatorOffset;
         int m_dropIndicatorRowWidgetOffset;
     };
@@ -696,7 +696,7 @@ namespace AzToolsFramework
         EntityPropertyEditorNotificationBus::Handler::BusDisconnect();
         AZ::EntitySystemBus::Handler::BusDisconnect();
         ToolsApplicationEvents::Bus::Handler::BusDisconnect();
-        
+
         for (auto& entityId : m_overrideSelectedEntityIds)
         {
             DisconnectFromEntityBuses(entityId);
@@ -1299,7 +1299,7 @@ namespace AzToolsFramework
             if (!m_customFilterSet)
             {
                 // Don't call SetAddComponentMenuFilter because it will set the custom filter flag.
-                m_componentFilter = AZStd::move(GetDefaultComponentFilter());
+                m_componentFilter = GetDefaultComponentFilter();
             }
         }
         else if (selectionEntityTypeInfo == SelectionEntityTypeInfo::LevelEntity)
@@ -1360,7 +1360,7 @@ namespace AzToolsFramework
         m_gui->m_entitySearchBox->setVisible(displayComponentSearchBox);
 
         bool isEditingPrefabContainer = isContainerOfFocusedPrefabLayout;
-        
+
         m_gui->m_entityIdWidget->setVisible(!isEditingPrefabContainer);
         m_gui->m_prefabContainerWidget->setVisible(isPrefabLayout);
 
@@ -2298,7 +2298,7 @@ namespace AzToolsFramework
             fieldNode = fieldNode->GetParent();
             AZ_Assert(fieldNode && fieldNode->GetClassMetadata() && fieldNode->GetClassMetadata()->m_container, "New element should be a child of a container.");
         }
-        
+
         AZ::Component* componentInstance =
             m_serializeContext->Cast<AZ::Component*>(componentNode->FirstInstance(), componentClassData->m_typeId);
         AZ_Assert(componentInstance, "Failed to cast component instance.");
@@ -3832,7 +3832,7 @@ namespace AzToolsFramework
             return;
         }
         m_shouldScrollToNewComponents = false;
-        
+
         // force new components to be visible
         // if no component has been explicitly set at the most recently added,
         // assume new components are added to the end of the list and layout
@@ -5448,7 +5448,7 @@ namespace AzToolsFramework
             // note: ComponentModeCollectionInterface cannot be cached as it may change during the lifetime of the application
             const auto componentModeTypes = AZ::Interface<ComponentModeCollectionInterface>::Get()->GetComponentTypes();
 
-            
+
             if (!componentModeTypes.empty())
             {
                 m_componentEditorLastSelectedIndex = GetComponentEditorIndexFromType(componentModeTypes.front());

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.cpp
@@ -118,7 +118,7 @@ namespace Benchmark
             // Add a nested instance and update the template.
             AZStd::unique_ptr<Instance> nestedInstance = AZStd::make_unique<Instance>("Added nested instance");
             Instance& addedInstance =
-                m_instanceToModify->AddInstance(AZStd::move(m_prefabSystemComponent->InstantiatePrefab(nestedPrefabTemplateId)));
+                m_instanceToModify->AddInstance(m_prefabSystemComponent->InstantiatePrefab(nestedPrefabTemplateId));
             const InstanceAlias& instanceAlias = addedInstance.GetInstanceAlias();
             UpdateTemplate();
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleNestedInstancesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleNestedInstancesBenchmarks.cpp
@@ -52,7 +52,7 @@ namespace Benchmark
 
         for (unsigned int nestedInstanceCounter = 0; nestedInstanceCounter < nestedPrefabsCount; nestedInstanceCounter++)
         {
-            nestedInstances.emplace_back(AZStd::move(m_prefabSystemComponent->InstantiatePrefab(m_nestedPrefabTemplateId)));
+            nestedInstances.emplace_back(m_prefabSystemComponent->InstantiatePrefab(m_nestedPrefabTemplateId));
         }
 
         m_entityToModify = CreateEntity("Entity", AZ::EntityId());
@@ -80,7 +80,7 @@ namespace Benchmark
     }
     REGISTER_MULTIPLE_NESTED_INSTANCES_BENCHMARK(
         SingleInstanceMultipleNestedInstancesBenchmarks, PropagateUpdateComponentChange);
-        
+
 
     BENCHMARK_DEFINE_F(SingleInstanceMultipleNestedInstancesBenchmarks, PropagateAddComponentChange)(benchmark::State& state)
     {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.cpp
@@ -28,7 +28,7 @@ namespace Benchmark
     void SingleInstanceOverrideBenchmarks::SetupHarness(const benchmark::State& state)
     {
         BM_Prefab::SetupHarness(state);
-        
+
         const unsigned int depthOfNesting = static_cast<unsigned int>(state.range(0));
         const unsigned int entitiesCountInEachPrefab = static_cast<unsigned int>(state.range(1));
 
@@ -72,7 +72,7 @@ namespace Benchmark
         {
             entitiesInNestedInstance.emplace_back(CreateEntity("Entity"));
         }
-        return AZStd::move(entitiesInNestedInstance);
+        return entitiesInNestedInstance;
     }
 
     BENCHMARK_DEFINE_F(SingleInstanceOverrideBenchmarks, PropagateOverrideComponent)(benchmark::State& state)

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Instance/InstanceDeserializationTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Instance/InstanceDeserializationTests.cpp
@@ -62,7 +62,7 @@ namespace UnitTest
                 }
                 return true;
             });
-        EXPECT_TRUE(isEntityFound); 
+        EXPECT_TRUE(isEntityFound);
     }
 
     static void ValidateTransformComponentValue(const AZStd::unique_ptr<AZ::Entity>& entity, const float worldXValue)
@@ -278,7 +278,7 @@ namespace UnitTest
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
-        createdPrefab->AddEntity(AZStd::move(AZStd::make_unique<AZ::Entity>("Entity2")));
+        createdPrefab->AddEntity(AZStd::make_unique<AZ::Entity>("Entity2"));
         GenerateDomAndReloadInstantiatedPrefab(createdPrefab, instantiatedPrefab);
 
         bool isEntity1Found = false, isEntity2Found = false;
@@ -311,7 +311,7 @@ namespace UnitTest
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
-        createdPrefab->AddEntity(AZStd::move(AZStd::make_unique<AZ::Entity>("Entity1")));
+        createdPrefab->AddEntity(AZStd::make_unique<AZ::Entity>("Entity1"));
         GenerateDomAndReloadInstantiatedPrefab(createdPrefab, instantiatedPrefab);
 
         bool isEntity1Found = false;
@@ -424,7 +424,7 @@ namespace UnitTest
 
         AZStd::vector<InstanceUniquePointer> nestedInstances;
         nestedInstances.emplace_back(AZStd::move(nestedInstanceToUseForCreation));
-        
+
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances = SetupPrefabInstances(
             AzToolsFramework::EntityList{ entity1 }, AZStd::move(nestedInstances),
             m_prefabSystemComponent);
@@ -456,7 +456,7 @@ namespace UnitTest
                     // Entities under an existing nested instance should be in active state. This indicates that the instance is untouched.
                     ValidateEntityState(nestedInstance, "EntityUnderNestedPrefab", AZ::Entity::State::Active);
                 }
-                
+
         });
     }
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestUndoFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestUndoFixture.cpp
@@ -18,14 +18,14 @@ namespace UnitTest
     {
         //create two prefabs for test
         //create prefab 1
-        firstInstance = AZStd::move(m_prefabSystemComponent->CreatePrefab({}, {}, "test/path0"));
+        firstInstance = m_prefabSystemComponent->CreatePrefab({}, {}, "test/path0");
         ASSERT_TRUE(firstInstance);
 
         //get template id
         ownerId = firstInstance->GetTemplateId();
 
         //create prefab 2
-        secondInstance = AZStd::move(m_prefabSystemComponent->CreatePrefab({}, {}, "test/path1"));
+        secondInstance = m_prefabSystemComponent->CreatePrefab({}, {}, "test/path1");
         ASSERT_TRUE(secondInstance);
 
         //get template id

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoAddEntityTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUndoAddEntityTestFixture.cpp
@@ -74,13 +74,13 @@ namespace UnitTest
         const EntityAlias& parentEntityAlias)
     {
         AZ::Entity& parentEntity = parentEntityAlias.empty()?
-            focusedInstance.GetContainerEntity()->get() : 
+            focusedInstance.GetContainerEntity()->get() :
             GetEntityFromOwningInstance(parentEntityAlias, focusedInstance);
         AZ::Entity& newEntity = GetEntityFromOwningInstance(newEntityAlias, focusedInstance);
 
         PrefabUndoAddEntity undoAddEntityNode(undoAddEntityOperationName);
         undoAddEntityNode.Capture(parentEntity, newEntity, focusedInstance);
-        return AZStd::move(undoAddEntityNode);
+        return undoAddEntityNode;
     }
 
     PrefabUndoAddEntityAsOverride PrefabUndoAddEntityTestFixture::CreatePrefabUndoAddEntityAsOverrideNode(
@@ -97,7 +97,7 @@ namespace UnitTest
 
         PrefabUndoAddEntityAsOverride undoAddEntityNode(undoAddEntityOperationName);
         undoAddEntityNode.Capture(parentEntity, newEntity, owningInstance, focusedInstance);
-        return AZStd::move(undoAddEntityNode);
+        return undoAddEntityNode;
     }
 
     void PrefabUndoAddEntityTestFixture::ValidateNewEntityUnderInstance(

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -443,8 +443,8 @@ void CSystem::OpenPlatformPaks()
     const char* const assetsDir = "@products@";
     // Load Android Obb files if available
     const char* obbStorage = AZ::Android::Utils::GetObbStoragePath();
-    AZStd::string mainObbPath = AZStd::move(AZStd::string::format("%s/%s", obbStorage, AZ::Android::Utils::GetObbFileName(true)));
-    AZStd::string patchObbPath = AZStd::move(AZStd::string::format("%s/%s", obbStorage, AZ::Android::Utils::GetObbFileName(false)));
+    AZStd::string mainObbPath = AZStd::string::format("%s/%s", obbStorage, AZ::Android::Utils::GetObbFileName(true));
+    AZStd::string patchObbPath = AZStd::string::format("%s/%s", obbStorage, AZ::Android::Utils::GetObbFileName(false));
     m_env.pCryPak->OpenPack(assetsDir, mainObbPath.c_str());
     m_env.pCryPak->OpenPack(assetsDir, patchObbPath.c_str());
 #endif // AZ_PLATFORM_ANDROID
@@ -1101,7 +1101,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     InlineInitializationProcessing("CSystem::Init End");
 
     // All CVARs should now be registered, load and apply quality settings for the default quality group
-    // using device rules to auto-detected the correct quality level 
+    // using device rules to auto-detected the correct quality level
     AzFramework::QualitySystemEvents::Bus::Broadcast(
         &AzFramework::QualitySystemEvents::LoadDefaultQualityGroup,
         AzFramework::QualityLevel::LevelFromDeviceRules);

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -660,7 +660,7 @@ namespace AssetProcessor
         {
             QMutexLocker locker(&m_registriesMutex);
             m_registries[platform].RegisterAssetDependency(assetId, newDependency);
-            message.m_dependencies = AZStd::move(m_registries[platform].GetAssetDependencies(assetId));
+            message.m_dependencies = m_registries[platform].GetAssetDependencies(assetId);
         }
 
         if (m_registryBuiltOnce)
@@ -702,7 +702,7 @@ namespace AssetProcessor
 
                 message.m_assetId = assetInfo.second.m_assetId;
                 message.m_sizeBytes = assetInfo.second.m_sizeBytes;
-                message.m_dependencies = AZStd::move(currentRegistry.GetAssetDependencies(assetInfo.second.m_assetId));
+                message.m_dependencies = currentRegistry.GetAssetDependencies(assetInfo.second.m_assetId);
 
 
                 bulkMessage.m_messages.push_back(AZStd::move(message));

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
@@ -88,14 +88,14 @@ namespace
     }
 
     // generic version of BuildFailure, generally assumes that the failure type is a string.
-    template<typename T> 
+    template<typename T>
     void BuildFailure(const T& failure,  AZStd::vector<AZStd::string>& lines)
     {
        ParseToLines(lines, failure);
     }
 
     // specialized version of BuildFailure, for when the failure type is a MoveFailure, the string will be in m_reason
-    template<> 
+    template<>
     void BuildFailure(const MoveFailure& failure,  AZStd::vector<AZStd::string>& lines)
     {
         ParseToLines(lines, failure.m_reason);
@@ -302,7 +302,7 @@ namespace
             AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Could not acquire a list of scan folders from the database.");
         }
 
-        return GetScanFoldersResponse(move(scanFolders));
+        return GetScanFoldersResponse(AZStd::move(scanFolders));
     }
 
     GetAssetSafeFoldersResponse HandleGetAssetSafeFoldersRequest([[maybe_unused]] MessageData<GetAssetSafeFoldersRequest> messageData)
@@ -317,7 +317,7 @@ namespace
             AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Could not acquire a list of asset safe folders from the database.");
         }
 
-        return GetAssetSafeFoldersResponse(move(assetSafeFolders));
+        return GetAssetSafeFoldersResponse(AZStd::move(assetSafeFolders));
     }
 
     void HandleRegisterSourceAssetRequest(MessageData<RegisterSourceAssetRequest> messageData)
@@ -611,7 +611,7 @@ void AssetRequestHandler::DeleteFenceFile_Retry(unsigned int fenceId, QString fe
         // add an entry in map
         // We have successfully created and deleted the fence file, insert an entry for it in the pendingFenceRequest map
         // and return, we will only process this request once the APM indicates that it has detected the fence file
-        m_pendingFenceRequestMap[fenceId] = AZStd::move(RequestInfo(key, AZStd::move(message), platform));
+        m_pendingFenceRequestMap[fenceId] = RequestInfo(key, AZStd::move(message), platform);
         return;
     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -902,7 +902,7 @@ namespace AssetProcessor
             AZ_Error(AssetProcessor::ConsoleChannel, false, "Failed to retrieve the registered setting registry.");
         }
 
-        return AZStd::move(scanDirectories);
+        return scanDirectories;
     }
 
     AssetProcessorManager::ConflictResult AssetProcessorManager::CheckIntermediateProductConflict(const char* searchSourcePath)
@@ -1892,7 +1892,7 @@ namespace AssetProcessor
                     // its already been picked up by a file monitoring / scanning step.
                     continue;
                 }
-                
+
                 if (source.m_fromDependencyChain.contains(absolutePath))
                 {
                     AZ_Trace(AssetProcessor::DebugChannel, "Ignoring dependant file: " AZ_STRING_FORMAT " - cyclic dependency detected\n", AZ_STRING_ARG(absolutePath));

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -104,7 +104,7 @@ namespace AssetProcessorMessagesTests
             };
             NetworkRequestID key(connId, serial);
             int fenceFileId = 0;
-            m_pendingFenceRequestMap[fenceFileId] = AZStd::move(AssetRequestHandler::RequestInfo(key, AZStd::move(message), platform));
+            m_pendingFenceRequestMap[fenceFileId] = AssetRequestHandler::RequestInfo(key, AZStd::move(message), platform);
 
             OnFenceFileDetected(fenceFileId);
         }

--- a/Code/Tools/AssetProcessor/native/utilities/AssetServerHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/AssetServerHandler.cpp
@@ -79,7 +79,7 @@ namespace AssetProcessor
                 + CacheServerAddressKey))
             {
                 AZ_TracePrintf(AssetProcessor::DebugChannel, "Server Address: %s\n", address.c_str());
-                return AZStd::move(address);
+                return address;
             }
         }
         return {};

--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
@@ -287,7 +287,7 @@ namespace AZ
                 //       valueAddress = *reinterpret_cast<void**>(valueAddress); // pointer to a pointer
                 //    }
                 // Notice the it expects it to be a void** (double reference) and dereferences it to get the address of the object.
-                // 
+                //
                 // That means that when TR_POINTER is set, not only does the object pointed to have to survive until used
                 // but the memory storing that pointer also has to survive until used.
                 // for example, this would be a scope use-after-free bug:
@@ -295,7 +295,7 @@ namespace AZ
                 //    AZ::Entity entity;
                 //    AZ::BehaviorArgument arg;
                 //    arg.m_traits = BehaviorParameter::TR_POINTER;
-                // 
+                //
                 //    {
                 //       const void* objectPtr = &entity;   // this is a 64-bit object living in the stack, holding the addr of entity.
                 //       arg.m_value = const_cast<void*>(&objectPtr); // notice, we are referencing objectPtr again with & since its TR_POINTER
@@ -397,7 +397,7 @@ namespace AZ
 
                 // Create temporary any to get its type info to construct a new AZStd::any with new data
                 AZStd::any tempAny = serializeContext->CreateAny(returnBehaviorValue.m_typeId);
-                return AZStd::move(AZStd::any(returnBehaviorValue.m_value, tempAny.get_type_info()));
+                return AZStd::any(returnBehaviorValue.m_value, tempAny.get_type_info());
             }
 
             AZStd::any GraphObjectProxy::Invoke(AZStd::string_view method, AZStd::vector<AZStd::any> argList)

--- a/Code/Tools/SceneAPI/SceneCore/Containers/SceneManifest.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/SceneManifest.cpp
@@ -237,7 +237,7 @@ namespace AZ
                                 rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>> writer(sb);
                                 rapidjson::Document& document = outcome.GetValue();
                                 document.Accept(writer);
-                                return AZStd::move(AZStd::string(sb.GetString()));
+                                return AZStd::string(sb.GetString());
                             }
                             AZ_Warning(ErrorWindowName, false, "SaveToJsonDocument outcome failure (%s)", outcome.GetError().c_str());
                             return {};

--- a/Gems/Atom/Feature/Common/Code/Source/ColorGrading/LutGenerationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ColorGrading/LutGenerationPass.cpp
@@ -20,7 +20,7 @@ namespace AZ
         RPI::Ptr<LutGenerationPass> LutGenerationPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<LutGenerationPass> pass = aznew LutGenerationPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
          LutGenerationPass::LutGenerationPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -135,7 +135,7 @@ namespace AZ
         {
             AZ_Assert(m_materials.size() > 0, "GetImageDimensions() cannot be called until at least one material has been added");
             const int iter = m_materials.begin();
-            // All textures in a texture array must have the same size, so just pick the first 
+            // All textures in a texture array must have the same size, so just pick the first
             const MaterialData& firstMaterial = m_materials[iter];
             const auto& baseColorAsset = GetStreamingImageAsset(firstMaterial.m_materialAssetData, GetMapName(mapType));
             return baseColorAsset->GetImageDescriptor().m_size;
@@ -164,7 +164,7 @@ namespace AZ
                 assetCreator.BeginMip(layout);
 
                 for (int i = 0; i < m_materials.array_size(); ++i)
-                {                   
+                {
                     const auto imageData = GetRawImageData(GetMapName(mapType), i, mipLevel);
                     assetCreator.AddSubImage(imageData.data(), imageData.size());
                 }
@@ -175,7 +175,7 @@ namespace AZ
             Data::Asset<RPI::ImageMipChainAsset> asset;
             assetCreator.End(asset);
 
-            return AZStd::move(asset);
+            return asset;
         }
 
         RHI::ImageDescriptor DecalTextureArray::CreatePackedImageDescriptor(
@@ -252,7 +252,7 @@ namespace AZ
         uint16_t DecalTextureArray::GetNumMipLevels(const DecalMapType mapType) const
         {
             AZ_Assert(m_materials.size() > 0, "GetNumMipLevels() cannot be called until at least one material has been added");
-            // All decals in a texture array must have the same number of mips, so just pick the first 
+            // All decals in a texture array must have the same number of mips, so just pick the first
             const int iter = m_materials.begin();
             const MaterialData& firstMaterial = m_materials[iter];
             const auto& imageAsset = GetStreamingImageAsset(firstMaterial.m_materialAssetData, GetMapName(mapType));
@@ -329,7 +329,7 @@ namespace AZ
             while (iter != -1)
             {
                 if (!IsTextureMapPresentInMaterial(m_materials[iter], mapType))
-                {                    
+                {
                     return false;
                 }
                 iter = m_materials.next(iter);

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -283,7 +283,7 @@ namespace AZ
             Data::AssetId shaderAssetId = AZ::RPI::AssetUtils::GetAssetIdForProductPath(shaderFilePath, AZ::RPI::AssetUtils::TraceLevel::Assert, azrtti_typeid<RPI::ShaderAsset>());
             if (!shaderAssetId.IsValid())
             {
-                // The above GetAssetIdForProductPath will already have asserted if the asset was not found.  
+                // The above GetAssetIdForProductPath will already have asserted if the asset was not found.
                 return nullptr;
             }
 
@@ -313,7 +313,7 @@ namespace AZ
             const Name ldrGradingLutTemplateName = Name{ "LdrGradingLutTemplate" };
             const Name outputTransformTemplateName = Name{ "OutputTransformTemplate" };
 
-            // Pass classes 
+            // Pass classes
             const Name acesOutputTransformPassClassName = Name{ "AcesOutputTransformPass" };
             const Name acesOutputTransformLutPassClassName = Name{ "AcesOutputTransformLutPass" };
             const Name bakeAcesOutputTransformLutPassClassName = Name{ "BakeAcesOutputTransformLutPass" };
@@ -403,7 +403,7 @@ namespace AZ
             }
 
             RPI::Ptr<PassType> returnPass = static_cast<PassType*>(pass.get());
-            return AZStd::move(returnPass);
+            return returnPass;
         }
 
         void DisplayMapperPass::CreateGradingAndAcesPasses()

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/OutputTransformPass.cpp
@@ -24,7 +24,7 @@ namespace AZ
         RPI::Ptr<OutputTransformPass> OutputTransformPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<OutputTransformPass> pass = aznew OutputTransformPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         OutputTransformPass::OutputTransformPass(const RPI::PassDescriptor& descriptor)
@@ -245,7 +245,7 @@ namespace AZ
                 break;
             }
 
-            shaderOption.SetValue(m_ldrGradingLutShaderVariantOptionName, GetLutAssetId().IsValid() ? AZ::Name("true") : AZ::Name("false")); 
+            shaderOption.SetValue(m_ldrGradingLutShaderVariantOptionName, GetLutAssetId().IsValid() ? AZ::Name("true") : AZ::Name("false"));
 
             UpdateShaderVariant(shaderOption);
             m_needToUpdateShaderVariant = false;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -21,11 +21,11 @@ namespace AZ
     namespace Render
     {
         static const char* const NumSourceLutsShaderVariantOptionName{ "o_numSourceLuts" };
-        
+
         RPI::Ptr<BlendColorGradingLutsPass> BlendColorGradingLutsPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<BlendColorGradingLutsPass> pass = aznew BlendColorGradingLutsPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         BlendColorGradingLutsPass::BlendColorGradingLutsPass(const RPI::PassDescriptor& descriptor)
@@ -247,7 +247,7 @@ namespace AZ
             m_blendedLutShaperParams = shaperParams;
         }
 
-        
+
         AZStd::optional<ShaperParams> BlendColorGradingLutsPass::GetCommonShaperParams() const
         {
             LookModificationSettings* settings = GetLookModificationSettings();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
@@ -52,7 +52,7 @@ namespace AZ
         RPI::Ptr<BloomBlurPass> BloomBlurPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<BloomBlurPass> pass = aznew BloomBlurPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         BloomBlurPass::BloomBlurPass(const RPI::PassDescriptor& descriptor)
@@ -324,7 +324,7 @@ namespace AZ
             // Gaussian kernel is radially symmetric, so we only store one wing of the 1d kernel
             AZStd::vector<float> weights;
             AZStd::vector<float> offsets;
-            
+
             // Center pixel
             weight = Gaussian1D(0, sigma);
             weights.push_back(weight);
@@ -410,7 +410,7 @@ namespace AZ
         RPI::Ptr<BloomBlurChildPass> BloomBlurChildPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<BloomBlurChildPass> pass = aznew BloomBlurChildPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         BloomBlurChildPass::BloomBlurChildPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
@@ -34,7 +34,7 @@ namespace AZ
         RPI::Ptr<BloomCompositePass> BloomCompositePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<BloomCompositePass> pass = aznew BloomCompositePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         BloomCompositePass::BloomCompositePass(const RPI::PassDescriptor& descriptor)
@@ -91,7 +91,7 @@ namespace AZ
 
         void BloomCompositePass::UpdateParameters()
         {
- 
+
             RPI::Scene* scene = GetScene();
             PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
             RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
@@ -183,7 +183,7 @@ namespace AZ
                 outBinding.m_unifiedScopeDesc.SetAsImage(outViewDesc);
                 outBinding.SetAttachment(parentInAttachment);
             }
-            
+
             pass->AddAttachmentBinding(outBinding);
         }
 
@@ -256,7 +256,7 @@ namespace AZ
         RPI::Ptr<BloomCompositeChildPass> BloomCompositeChildPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<BloomCompositeChildPass> pass = aznew BloomCompositeChildPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         BloomCompositeChildPass::BloomCompositeChildPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
@@ -36,7 +36,7 @@ namespace AZ
         RPI::Ptr<BloomDownsamplePass> BloomDownsamplePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<BloomDownsamplePass> pass = aznew BloomDownsamplePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         BloomDownsamplePass::BloomDownsamplePass(const RPI::PassDescriptor& descriptor)
@@ -69,7 +69,7 @@ namespace AZ
                 outBinding.m_shaderInputName = Name{ AZStd::string::format("m_targetMipLevel%d", i) };
                 outBinding.m_slotType = RPI::PassSlotType::Output;
                 outBinding.m_scopeAttachmentUsage = RHI::ScopeAttachmentUsage::Shader;
-                
+
                 // Set image view descriptor
                 RHI::ImageViewDescriptor outViewDesc;
                 outViewDesc.m_mipSliceMin = i;
@@ -90,7 +90,7 @@ namespace AZ
 
         AZ::Vector4 BloomDownsamplePass::CalThresholdConstants()
         {
-            // These constants will be used in shader to compute a soft knee based threshold 
+            // These constants will be used in shader to compute a soft knee based threshold
             float x = m_threshold;
             float y = x * m_knee;
             float z = 2.0f * y;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/ChromaticAberrationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/ChromaticAberrationPass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<ChromaticAberrationPass> ChromaticAberrationPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ChromaticAberrationPass> pass = aznew ChromaticAberrationPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ChromaticAberrationPass::ChromaticAberrationPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthUpsamplePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthUpsamplePass.cpp
@@ -20,13 +20,13 @@ namespace AZ
         RPI::Ptr<DepthUpsamplePass> DepthUpsamplePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DepthUpsamplePass> pass = aznew DepthUpsamplePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
-        
+
         DepthUpsamplePass::DepthUpsamplePass(const RPI::PassDescriptor& descriptor)
             : RPI::ComputePass(descriptor)
         { }
-        
+
         void DepthUpsamplePass::FrameBeginInternal(FramePrepareParams params)
         {
             // Must match the struct in DepthUpsample.azsl
@@ -75,7 +75,7 @@ namespace AZ
             SetTargetThreadCounts(targetThreadCountX, targetThreadCountY, 1);
 
             m_shaderResourceGroup->SetConstant(m_constantsIndex, upsampleConstants);
-        
+
             RPI::ComputePass::FrameBeginInternal(params);
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FastDepthAwareBlurPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FastDepthAwareBlurPasses.cpp
@@ -42,7 +42,7 @@ namespace AZ
         RPI::Ptr<FastDepthAwareBlurHorPass> FastDepthAwareBlurHorPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<FastDepthAwareBlurHorPass> pass = aznew FastDepthAwareBlurHorPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         FastDepthAwareBlurHorPass::FastDepthAwareBlurHorPass(const RPI::PassDescriptor& descriptor)
@@ -84,7 +84,7 @@ namespace AZ
         RPI::Ptr<FastDepthAwareBlurVerPass> FastDepthAwareBlurVerPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<FastDepthAwareBlurVerPass> pass = aznew FastDepthAwareBlurVerPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         FastDepthAwareBlurVerPass::FastDepthAwareBlurVerPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FilmGrainPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FilmGrainPass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<FilmGrainPass> FilmGrainPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<FilmGrainPass> pass = aznew FilmGrainPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         FilmGrainPass::FilmGrainPass(const RPI::PassDescriptor& descriptor)
@@ -100,7 +100,7 @@ namespace AZ
 
             constants.m_grainTextureSize[0] = grainTextureSize.m_width;
             constants.m_grainTextureSize[1] = grainTextureSize.m_height;
-            
+
             AZ_Assert(GetOutputCount() > 0, "FilmGrainPass: No output bindings!");
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/HDRColorGradingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/HDRColorGradingPass.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
 #include <PostProcessing/HDRColorGradingPass.h>
 #include <PostProcess/PostProcessFeatureProcessor.h>
 
@@ -20,14 +20,14 @@
         RPI::Ptr<HDRColorGradingPass> HDRColorGradingPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<HDRColorGradingPass> pass = aznew HDRColorGradingPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
-        
+
         HDRColorGradingPass::HDRColorGradingPass(const RPI::PassDescriptor& descriptor)
             : AZ::RPI::FullscreenTrianglePass(descriptor)
         {
         }
-        
+
         void HDRColorGradingPass::InitializeInternal()
         {
             FullscreenTrianglePass::InitializeInternal();
@@ -67,7 +67,7 @@
             m_colorGradingPostSaturationIndex.Reset();
             m_colorGradingHueShiftIndex.Reset();
         }
-        
+
         void HDRColorGradingPass::FrameBeginInternal(FramePrepareParams params)
         {
             SetSrgConstants();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationCompositePass.cpp
@@ -43,11 +43,11 @@ namespace AZ
             ConsoleFunctorFlags::Null,
             "This can be increased to deal with particularly tricky luts. Range (0-2). 0 (default) - Standard linear sampling. 1 - 7 tap b-spline sampling. 2 - 19 tap b-spline sampling."
         );
-        
+
         RPI::Ptr<LookModificationCompositePass> LookModificationCompositePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<LookModificationCompositePass> pass = aznew LookModificationCompositePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         LookModificationCompositePass::LookModificationCompositePass(const RPI::PassDescriptor& descriptor)
@@ -232,7 +232,7 @@ namespace AZ
             shaderOption.SetValue(m_exposureShaderVariantOptionName, m_exposureControlEnabled ? AZ::Name("true") : AZ::Name("false"));
             shaderOption.SetValue(m_colorGradingShaderVariantOptionName, m_colorGradingLutEnabled ? AZ::Name("true") : AZ::Name("false"));
             shaderOption.SetValue(m_lutSampleQualityShaderVariantOptionName, RPI::ShaderOptionValue(m_sampleQuality));
-            
+
             UpdateShaderVariant(shaderOption);
 
             m_needToUpdateShaderVariant = false;
@@ -258,7 +258,7 @@ namespace AZ
         {
             m_colorGradingShaperParams = shaperParams;
         }
-        
+
         void LookModificationCompositePass::SetSampleQuality(SampleQuality sampleQuality)
         {
             m_sampleQuality = sampleQuality;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
@@ -36,7 +36,7 @@ namespace AZ
         RPI::Ptr<LuminanceHistogramGeneratorPass> LuminanceHistogramGeneratorPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<LuminanceHistogramGeneratorPass> pass = aznew LuminanceHistogramGeneratorPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         LuminanceHistogramGeneratorPass::LuminanceHistogramGeneratorPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/MotionBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/MotionBlurPass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<MotionBlurPass> MotionBlurPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<MotionBlurPass> pass = aznew MotionBlurPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         MotionBlurPass::MotionBlurPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
@@ -39,7 +39,7 @@ namespace AZ
         RPI::Ptr<NewDepthOfFieldParentPass> NewDepthOfFieldParentPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<NewDepthOfFieldParentPass> pass = aznew NewDepthOfFieldParentPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         NewDepthOfFieldParentPass::NewDepthOfFieldParentPass(const RPI::PassDescriptor& descriptor)
@@ -102,7 +102,7 @@ namespace AZ
         RPI::Ptr<NewDepthOfFieldTileReducePass> NewDepthOfFieldTileReducePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<NewDepthOfFieldTileReducePass> pass = aznew NewDepthOfFieldTileReducePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         NewDepthOfFieldTileReducePass::NewDepthOfFieldTileReducePass(const RPI::PassDescriptor& descriptor)
@@ -134,7 +134,7 @@ namespace AZ
         RPI::Ptr<NewDepthOfFieldFilterPass> NewDepthOfFieldFilterPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<NewDepthOfFieldFilterPass> pass = aznew NewDepthOfFieldFilterPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         NewDepthOfFieldFilterPass::NewDepthOfFieldFilterPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/PaniniProjectionPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/PaniniProjectionPass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<PaniniProjectionPass> PaniniProjectionPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<PaniniProjectionPass> pass = aznew PaniniProjectionPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         PaniniProjectionPass::PaniniProjectionPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SsaoPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SsaoPasses.cpp
@@ -25,7 +25,7 @@ namespace AZ
         RPI::Ptr<SsaoParentPass> SsaoParentPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<SsaoParentPass> pass = aznew SsaoParentPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         SsaoParentPass::SsaoParentPass(const RPI::PassDescriptor& descriptor)
@@ -122,7 +122,7 @@ namespace AZ
         RPI::Ptr<SsaoComputePass> SsaoComputePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<SsaoComputePass> pass = aznew SsaoComputePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         SsaoComputePass::SsaoComputePass(const RPI::PassDescriptor& descriptor)
@@ -147,7 +147,7 @@ namespace AZ
                 // The strength of the SSAO effect
                 float m_strength = Ssao::DefaultStrength;
 
-                // The sampling radius calculated in screen UV space 
+                // The sampling radius calculated in screen UV space
                 float m_samplingRadius = Ssao::DefaultSamplingRadius;
 
             } ssaoConstants{};

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/VignettePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/VignettePass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<VignettePass> VignettePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<VignettePass> pass = aznew VignettePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         VignettePass::VignettePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/WhiteBalancePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/WhiteBalancePass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<WhiteBalancePass> WhiteBalancePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<WhiteBalancePass> pass = aznew WhiteBalancePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         WhiteBalancePass::WhiteBalancePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingAccelerationStructurePass.cpp
@@ -29,7 +29,7 @@ namespace AZ
         {
             RPI::Ptr<RayTracingAccelerationStructurePass> rayTracingAccelerationStructurePass =
                 aznew RayTracingAccelerationStructurePass(descriptor);
-            return AZStd::move(rayTracingAccelerationStructurePass);
+            return rayTracingAccelerationStructurePass;
         }
 
         RayTracingAccelerationStructurePass::RayTracingAccelerationStructurePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionCopyFrameBufferPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionCopyFrameBufferPass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<ReflectionCopyFrameBufferPass> ReflectionCopyFrameBufferPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionCopyFrameBufferPass> pass = aznew ReflectionCopyFrameBufferPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionCopyFrameBufferPass::ReflectionCopyFrameBufferPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurChildPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurChildPass.cpp
@@ -15,7 +15,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpaceBlurChildPass> ReflectionScreenSpaceBlurChildPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpaceBlurChildPass> pass = aznew ReflectionScreenSpaceBlurChildPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpaceBlurChildPass::ReflectionScreenSpaceBlurChildPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
@@ -31,7 +31,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpaceBlurPass> ReflectionScreenSpaceBlurPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpaceBlurPass> pass = aznew ReflectionScreenSpaceBlurPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpaceBlurPass::ReflectionScreenSpaceBlurPass(const RPI::PassDescriptor& descriptor)
@@ -161,7 +161,7 @@ namespace AZ
 
                 attachmentIndex++;
             }
- 
+
             // setup attachment bindings on horizontal blur child passes
             attachmentIndex = 0;
             for (auto& horizontalBlurChildPass : m_horizontalBlurChildPasses)
@@ -189,12 +189,12 @@ namespace AZ
             // get input attachment size
             RPI::PassAttachment* inputAttachment = GetInputOutputBinding(0).GetAttachment().get();
             AZ_Assert(inputAttachment, "ReflectionScreenSpaceBlurChildPass: Input binding has no attachment!");
-        
+
             RHI::Size size = inputAttachment->m_descriptor.m_image.m_size;
             if (m_imageSize != size)
             {
                 m_imageSize = size;
-        
+
                 uint32_t mip = 1;
                 for (auto& ownedAttachment : m_ownedAttachments)
                 {
@@ -203,7 +203,7 @@ namespace AZ
                     mip++;
                 }
             }
-        
+
             ParentPass::FrameBeginInternal(params);
         }
     }   // namespace RPI

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.cpp
@@ -21,7 +21,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpaceCompositePass> ReflectionScreenSpaceCompositePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpaceCompositePass> pass = aznew ReflectionScreenSpaceCompositePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpaceCompositePass::ReflectionScreenSpaceCompositePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearChildPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearChildPass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpaceDownsampleDepthLinearChildPass> ReflectionScreenSpaceDownsampleDepthLinearChildPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpaceDownsampleDepthLinearChildPass> pass = aznew ReflectionScreenSpaceDownsampleDepthLinearChildPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpaceDownsampleDepthLinearChildPass::ReflectionScreenSpaceDownsampleDepthLinearChildPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearPass.cpp
@@ -17,7 +17,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpaceDownsampleDepthLinearPass> ReflectionScreenSpaceDownsampleDepthLinearPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpaceDownsampleDepthLinearPass> pass = aznew ReflectionScreenSpaceDownsampleDepthLinearPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpaceDownsampleDepthLinearPass::ReflectionScreenSpaceDownsampleDepthLinearPass(const RPI::PassDescriptor& descriptor)
@@ -85,7 +85,7 @@ namespace AZ
                 // passes read from the previous mip level of DownsampledDepthLinear and write to the current mip level
                 uint32_t currentMipLevel = attachmentIndex;
                 uint32_t previousMipLevel = AZStd::max(0, aznumeric_cast<int32_t>(currentMipLevel) - 1);
-                
+
                 RPI::PassAttachmentBinding& inputAttachmentBinding = childPass->GetInputBinding(0);
                 RPI::PassAttachment* inputAttachment = nullptr;
 
@@ -104,7 +104,7 @@ namespace AZ
 
                 inputAttachmentBinding.m_unifiedScopeDesc.SetAsImage(inputViewDesc);
                 inputAttachmentBinding.SetAttachment(inputAttachment);
-                
+
                 // downsampled linear depth output (writing to current mip)
                 RHI::ImageViewDescriptor outputViewDesc;
                 RPI::PassAttachmentBinding& downsampledDepthOutputAttachmentBinding = childPass->GetOutputBinding(0);
@@ -112,9 +112,9 @@ namespace AZ
                 outputViewDesc.m_mipSliceMax = static_cast<int16_t>(currentMipLevel);
                 downsampledDepthOutputAttachmentBinding.m_unifiedScopeDesc.SetAsImage(outputViewDesc);
                 downsampledDepthOutputAttachmentBinding.SetAttachment(downsampledDepthLinearImageAttachment);
-                
+
                 childPass->UpdateConnectedBindings();
-                
+
                 attachmentIndex++;
             }
         }

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.cpp
@@ -22,7 +22,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpaceFilterPass> ReflectionScreenSpaceFilterPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpaceFilterPass> pass = aznew ReflectionScreenSpaceFilterPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpaceFilterPass::ReflectionScreenSpaceFilterPass(const RPI::PassDescriptor& descriptor)
@@ -47,11 +47,11 @@ namespace AZ
         {
             // retrieve the input reflection image descriptor to get the size
             RHI::ImageDescriptor reflectionImageDesc = m_ownedAttachments[0]->m_descriptor.m_image;
-            
+
             // create the history attachment
             RHI::ImageBindFlags imageBindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
             RHI::ImageDescriptor historyImageDesc = RHI::ImageDescriptor::Create2D(imageBindFlags, reflectionImageDesc.m_size.m_width, reflectionImageDesc.m_size.m_height, RHI::Format::R16G16B16A16_FLOAT);
-            
+
             RPI::Ptr<RPI::PassAttachment> historyAttachment = aznew RPI::PassAttachment();
             AZStd::string historyAttachmentName = AZStd::string::format("%s.ReflectionScreenSpace_HistoryImage", GetPathName().GetCStr());
             historyAttachment->m_name = historyAttachmentName;
@@ -122,7 +122,7 @@ namespace AZ
             RHI::Size& reflectionImageSize = m_ownedAttachments[0]->m_descriptor.m_image.m_size;
 
             if (historyImageSize != reflectionImageSize)
-            {              
+            {
                 historyImageSize = reflectionImageSize;
 
                 CreateHistoryAttachmentImage(historyAttachment);

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpacePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpacePass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpacePass> ReflectionScreenSpacePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpacePass> pass = aznew ReflectionScreenSpacePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpacePass::ReflectionScreenSpacePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
@@ -22,7 +22,7 @@ namespace AZ
         RPI::Ptr<ReflectionScreenSpaceTracePass> ReflectionScreenSpaceTracePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<ReflectionScreenSpaceTracePass> pass = aznew ReflectionScreenSpaceTracePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         ReflectionScreenSpaceTracePass::ReflectionScreenSpaceTracePass(const RPI::PassDescriptor& descriptor)
@@ -37,17 +37,17 @@ namespace AZ
             // retrieve the previous frame image attachment from the pass
             AZ_Assert(m_ownedAttachments.size() == 3, "ReflectionScreenSpaceTracePass must have the following attachment images defined: ReflectionImage, TraceCoordsImage, and PreviousFrameImage");
             RPI::Ptr<RPI::PassAttachment> previousFrameImageAttachment = m_ownedAttachments[2];
-            
+
             // update the image attachment descriptor to sync up size and format
             previousFrameImageAttachment->Update();
-            
+
             // change the lifetime since we want it to live between frames
             previousFrameImageAttachment->m_lifetime = RHI::AttachmentLifetimeType::Imported;
-            
+
             // set the bind flags
             RHI::ImageDescriptor& imageDesc = previousFrameImageAttachment->m_descriptor.m_image;
             imageDesc.m_bindFlags |= RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
-            
+
             // create the image attachment
             RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(0, 0, 0, 0);
             m_previousFrameImageAttachment = RPI::AttachmentImage::Create(*pool.get(), imageDesc, Name(previousFrameImageAttachment->m_path.GetCStr()), &clearValue, nullptr);

--- a/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ScreenSpace/DeferredFogPass.cpp
@@ -53,7 +53,7 @@ namespace AZ
             bool isEnabled = pass->Pass::IsEnabled(); // retrieves the state from the data driven pass
             fogSettings->SetEnabled(isEnabled); // Set it and mark for update
 
-            return AZStd::move(pass);
+            return pass;
         }
 
 
@@ -98,7 +98,7 @@ namespace AZ
         {
             DeferredFogSettings* fogSettings = GetPassFogSettings();
             Data::Instance<RPI::ShaderResourceGroup> srg = m_shaderResourceGroup.get();
-            
+
             // match and set all SRG constants' indices
 #define AZ_GFX_COMMON_PARAM(ValueType, FunctionName, MemberName, DefaultValue)                          \
             fogSettings->MemberName##SrgIndex = srg->FindShaderInputConstantIndex(Name(#MemberName));   \
@@ -131,7 +131,7 @@ namespace AZ
 
             if (fogSettings->GetSettingsNeedUpdate())
             {   // SRG constants are up to date and will be bound as they are.
-                // First time around they will be dirty to ensure properly set. 
+                // First time around they will be dirty to ensure properly set.
 
                 // Load all texture resources:
                 //  first set all macros to be empty, but override the texture for setting images.
@@ -175,14 +175,14 @@ namespace AZ
                         fogSettings->MemberName.c_str());                                                                                          \
                 }   \
             }   \
-       
+
 
 #include <Atom/Feature/ScreenSpace/DeferredFogParams.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 
             if (m_depthTextureDimensionsIndex.IsValid())
             {
-                
+
                 auto attachment = GetInputOutputBinding(0).GetAttachment();
                 if (attachment)
                 {
@@ -214,7 +214,7 @@ namespace AZ
             SetEnabled( fogSettings->GetEnabled() );
         }
 
-        bool DeferredFogPass::IsEnabled() const 
+        bool DeferredFogPass::IsEnabled() const
         {
             if (!r_enableFog)
             {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandListPool.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandListPool.cpp
@@ -23,7 +23,7 @@ namespace AZ
         {
             RHI::Ptr<CommandList> commandList = CommandList::Create();
             commandList->Init(m_descriptor.m_hardwareQueueClass, m_descriptor.m_device);
-            return AZStd::move(commandList);
+            return commandList;
         }
 
         void CommandListFactory::ShutdownObject(CommandList& commandList, bool isPoolShutdown)
@@ -41,19 +41,19 @@ namespace AZ
         {
             Reset();
         }
-        
+
         void CommandListSubAllocator::Init(CommandListPool& commandListPool)
         {
             m_commandListPool = &commandListPool;
         }
-        
+
         CommandList* CommandListSubAllocator::Allocate()
         {
             CommandList* commandList = m_commandListPool->Allocate();
             m_activeLists.push_back(commandList);
             return commandList;
         }
-        
+
         void CommandListSubAllocator::Reset()
         {
             m_commandListPool->DeAllocate(m_activeLists.data(), static_cast<uint32_t>(m_activeLists.size()));
@@ -65,7 +65,7 @@ namespace AZ
             for (uint32_t queueIdx = 0; queueIdx < RHI::HardwareQueueClassCount; ++queueIdx)
             {
                 CommandListPool& commandListPool = m_commandListPools[queueIdx];
-                
+
                 CommandListPool::Descriptor commandListPoolDescriptor;
                 commandListPoolDescriptor.m_hardwareQueueClass = static_cast<RHI::HardwareQueueClass>(queueIdx);
                 commandListPoolDescriptor.m_device = device;
@@ -78,7 +78,7 @@ namespace AZ
                                                                          subAllocator.Init(commandListPool);
                                                                      });
             }
-            
+
             m_isInitialized = true;
         }
 
@@ -94,13 +94,13 @@ namespace AZ
                 m_isInitialized = false;
             }
         }
-        
+
         CommandList* CommandListAllocator::Allocate(RHI::HardwareQueueClass hardwareQueueClass)
         {
             AZ_Assert(m_isInitialized, "CommandListAllocator is not initialized!");
             return m_commandListSubAllocators[static_cast<uint32_t>(hardwareQueueClass)].GetStorage().Allocate();
         }
-        
+
         void CommandListAllocator::Collect()
         {
             for (uint32_t queueIdx = 0; queueIdx < RHI::HardwareQueueClassCount; ++queueIdx)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/MSAAResolveFullScreenPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/MSAAResolveFullScreenPass.cpp
@@ -17,7 +17,7 @@ namespace AZ
         RPI::Ptr<MSAAResolveFullScreenPass> MSAAResolveFullScreenPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<MSAAResolveFullScreenPass> pass = aznew MSAAResolveFullScreenPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         MSAAResolveFullScreenPass::MSAAResolveFullScreenPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -165,7 +165,7 @@ namespace MaterialEditor
 
         for (const auto& group : m_groups)
         {
-            objects.push_back(AZStd::move(GetObjectInfoFromDynamicPropertyGroup(group.get())));
+            objects.push_back(GetObjectInfoFromDynamicPropertyGroup(group.get()));
         }
 
         return objects;
@@ -388,7 +388,7 @@ namespace MaterialEditor
                         addPropertiesResult = false;
                         return false;
                     }
-                    
+
                     sourceData.SetPropertyValue(propertyId, propertyValue);
                 }
             }
@@ -447,7 +447,7 @@ namespace MaterialEditor
             AZ_Error("MaterialDocument", false, "Document extension not supported: '%s'.", m_absolutePath.c_str());
             return OpenFailed();
         }
-        
+
         const bool elevateWarnings = false;
 
         // In order to support automation, general usability, and 'save as' functionality, the user must not have to wait
@@ -601,7 +601,7 @@ namespace MaterialEditor
                 using namespace AZ::RPI;
 
                 const MaterialTypeSourceData::PropertyGroup* propertyGroup = propertyGroupStack.back();
-                
+
                 MaterialNameContext groupNameContext = MaterialTypeSourceData::MakeMaterialNameContext(propertyGroupStack);
 
                 if (!AddEditorMaterialFunctors(propertyGroup->GetFunctors(), groupNameContext))
@@ -1031,7 +1031,7 @@ namespace MaterialEditor
 
     AtomToolsFramework::DynamicProperty* MaterialDocument::FindProperty(const AZ::Name& propertyId)
     {
-        AtomToolsFramework::DynamicProperty* result = nullptr; 
+        AtomToolsFramework::DynamicProperty* result = nullptr;
         TraverseGroups(m_groups, [&](auto& group) {
             for (auto& property : group->m_properties)
             {
@@ -1048,7 +1048,7 @@ namespace MaterialEditor
 
     const AtomToolsFramework::DynamicProperty* MaterialDocument::FindProperty(const AZ::Name& propertyId) const
     {
-        AtomToolsFramework::DynamicProperty* result = nullptr; 
+        AtomToolsFramework::DynamicProperty* result = nullptr;
         TraverseGroups(m_groups, [&](auto& group) {
             for (auto& property : group->m_properties)
             {

--- a/Gems/Atom/Utils/Code/Tests/StableDynamicArrayTests.cpp
+++ b/Gems/Atom/Utils/Code/Tests/StableDynamicArrayTests.cpp
@@ -29,7 +29,7 @@ namespace UnitTest
         void TearDown() override
         {
             handles = AZStd::vector<AZ::StableDynamicArray<TestItem>::Handle>(); // force memory deallocation.
-            
+
             LeakDetectionFixture::TearDown();
         }
 
@@ -657,8 +657,8 @@ namespace UnitTest
         using SourceHandle = AZ::StableDynamicArrayHandle<SourceTestItemType>;
         using DestinationHandle = AZ::StableDynamicArrayHandle<DestinationTestItemType>;
     public:
-        MoveTests() 
-        { 
+        MoveTests()
+        {
             AZ_Assert(SourceTestItemType::RTTI_IsContainType(DestinationTestItemType::RTTI_Type()) || DestinationTestItemType::RTTI_IsContainType(SourceTestItemType::RTTI_Type()), "These tests expect the transfer of ownership from one handle to the other will succeed, and should only be called with compatible types.");
         }
 
@@ -725,7 +725,7 @@ namespace UnitTest
         {
             {
                 StableDynamicArrayOwner owner;
-                
+
                 SourceHandle source;
                 DestinationHandle destination = owner.AcquireItem(456);
                 destination = AZStd::move(source);
@@ -803,7 +803,7 @@ namespace UnitTest
                         SourceHandle source = owner.AcquireItem(123);
                         destination = AZStd::move(source);
                     }
-                    // Letting the invalid source item go out of scope should be a no-op 
+                    // Letting the invalid source item go out of scope should be a no-op
                     EXPECT_EQ(StableDynamicArrayHandleTests::s_testItemsConstructed, 2);
                     EXPECT_EQ(StableDynamicArrayHandleTests::s_testItemsDestructed, 1);
                     EXPECT_EQ(StableDynamicArrayHandleTests::s_testItemsModified, 0);
@@ -974,7 +974,8 @@ namespace UnitTest
         handle->SetValue(testValue);
 
         // Self assignment should not invalidate the handle
-        handle = AZStd::move(handle);
+        TestItemHandle& handleAlias = handle;
+        handle = AZStd::move(handleAlias);
         EXPECT_TRUE(handle.IsValid());
         EXPECT_FALSE(handle.IsNull());
         EXPECT_EQ(handle->GetValue(), testValue);

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeBlurPass.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeBlurPass.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
 #include <Pass/Child/EditorModeBlurPass.h>
 
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -23,20 +23,20 @@ namespace AZ
         RPI::Ptr<EditorModeBlurPass> EditorModeBlurPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<EditorModeBlurPass> pass = aznew EditorModeBlurPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
-        
+
         EditorModeBlurPass::EditorModeBlurPass(const RPI::PassDescriptor& descriptor)
             : EditorModeFeedbackChildPassBase(descriptor, { 0.0f, 0.0f, 20.0f }, 1.0f)
         {
         }
-        
+
         void EditorModeBlurPass::InitializeInternal()
         {
             EditorModeFeedbackChildPassBase::InitializeInternal();
             m_kernelHalfWidthIndex.Reset();
         }
-        
+
         void EditorModeBlurPass::FrameBeginInternal(FramePrepareParams params)
         {
             SetSrgConstants();

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeDesaturationPass.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeDesaturationPass.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
 #include <Pass/Child/EditorModeDesaturationPass.h>
 
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -23,26 +23,26 @@ namespace AZ
         RPI::Ptr<EditorModeDesaturationPass> EditorModeDesaturationPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<EditorModeDesaturationPass> pass = aznew EditorModeDesaturationPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
-        
+
         EditorModeDesaturationPass::EditorModeDesaturationPass(const RPI::PassDescriptor& descriptor)
             : EditorModeFeedbackChildPassBase(descriptor, { 0.75f, 0.0f, 20.0f }, 1.0f)
         {
         }
-        
+
         void EditorModeDesaturationPass::InitializeInternal()
         {
             EditorModeFeedbackChildPassBase::InitializeInternal();
             m_desaturationAmountIndex.Reset();
         }
-        
+
         void EditorModeDesaturationPass::FrameBeginInternal(FramePrepareParams params)
         {
             SetSrgConstants();
             EditorModeFeedbackChildPassBase::FrameBeginInternal(params);
         }
-        
+
         void EditorModeDesaturationPass::SetDesaturationAmount(const float amount)
         {
             m_desaturationAmount = amount;

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeFeedbackChildPassBase.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeFeedbackChildPassBase.cpp
@@ -15,7 +15,7 @@ namespace AZ
         RPI::Ptr<EditorModeFeedbackChildPassBase> EditorModeFeedbackChildPassBase::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<EditorModeFeedbackChildPassBase> pass = aznew EditorModeFeedbackChildPassBase(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         EditorModeFeedbackChildPassBase::EditorModeFeedbackChildPassBase(

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeOutlinePass.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeOutlinePass.cpp
@@ -25,14 +25,14 @@ namespace AZ
         RPI::Ptr<EditorModeOutlinePass> EditorModeOutlinePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<EditorModeOutlinePass> pass = aznew EditorModeOutlinePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
-        
+
         EditorModeOutlinePass::EditorModeOutlinePass(const RPI::PassDescriptor& descriptor)
             : EditorModeFeedbackChildPassBase(descriptor, { 0.0f, 0.0f, 0.0f }, 1.0f)
         {
         }
-        
+
         void EditorModeOutlinePass::InitializeInternal()
         {
             EditorModeFeedbackChildPassBase::InitializeInternal();
@@ -40,7 +40,7 @@ namespace AZ
             m_lineColorIndex.Reset();
             m_outlineStyleIndex.Reset();
         }
-        
+
         void EditorModeOutlinePass::FrameBeginInternal(FramePrepareParams params)
         {
             SetSrgConstants();

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeTintPass.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/Child/EditorModeTintPass.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
 #include <Pass/Child/EditorModeTintPass.h>
 
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -24,20 +24,20 @@ namespace AZ
         RPI::Ptr<EditorModeTintPass> EditorModeTintPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<EditorModeTintPass> pass = aznew EditorModeTintPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
-        
+
         EditorModeTintPass::EditorModeTintPass(const RPI::PassDescriptor& descriptor)
             : EditorModeFeedbackChildPassBase(descriptor)
         {
         }
-        
+
         void EditorModeTintPass::InitializeInternal()
         {
             EditorModeFeedbackChildPassBase::InitializeInternal();
             m_tintAmountIndex.Reset();
         }
-        
+
         void EditorModeTintPass::FrameBeginInternal(FramePrepareParams params)
         {
             SetSrgConstants();

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorModeFeedbackParentPass.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/EditorModeFeedbackParentPass.cpp
@@ -17,7 +17,7 @@ namespace AZ
         RPI::Ptr<EditorModeFeedbackParentPass> EditorModeFeedbackParentPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<EditorModeFeedbackParentPass> pass = aznew EditorModeFeedbackParentPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         EditorModeFeedbackParentPass::EditorModeFeedbackParentPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/EditorStateBufferCopyPass.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/EditorStateBufferCopyPass.cpp
@@ -16,9 +16,9 @@ namespace AZ::Render
     RPI::Ptr<EditorStateBufferCopyPass> EditorStateBufferCopyPass::Create(const RPI::PassDescriptor& descriptor)
     {
         RPI::Ptr<EditorStateBufferCopyPass> pass = aznew EditorStateBufferCopyPass(descriptor);
-        return AZStd::move(pass);
+        return pass;
     }
-    
+
     EditorStateBufferCopyPass::EditorStateBufferCopyPass(const RPI::PassDescriptor& descriptor)
         : AZ::RPI::FullscreenTrianglePass(descriptor)
         , m_passDescriptor(descriptor)
@@ -29,7 +29,7 @@ namespace AZ::Render
     {
         const RPI::EditorStateBufferCopyPassData* passData =
             RPI::PassUtils::GetPassData<RPI::EditorStateBufferCopyPassData>(m_passDescriptor);
-            
+
         if (passData == nullptr)
         {
             AZ_Error(

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/EditorStateParentPass.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Pass/State/EditorStateParentPass.cpp
@@ -16,7 +16,7 @@ namespace AZ::Render
     RPI::Ptr<EditorStateParentPass> EditorStateParentPass::Create(const RPI::PassDescriptor& descriptor)
     {
         RPI::Ptr<EditorStateParentPass> pass = aznew EditorStateParentPass(descriptor);
-        return AZStd::move(pass);
+        return pass;
     }
 
     EditorStateParentPass::EditorStateParentPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/AtomTressFX/Code/Passes/HairPPLLResolvePass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairPPLLResolvePass.cpp
@@ -72,7 +72,7 @@ namespace AZ
             {
                 RPI::Ptr<HairPPLLResolvePass> pass = aznew HairPPLLResolvePass(descriptor);
 
-                return AZStd::move(pass);
+                return pass;
             }
 
             void HairPPLLResolvePass::InitializeInternal()

--- a/Gems/AudioSystem/Code/Include/Engine/AudioFileUtils.h
+++ b/Gems/AudioSystem/Code/Include/Engine/AudioFileUtils.h
@@ -36,7 +36,7 @@ namespace Audio
             AZ::IO::Result result = fileIO->FindFiles(folderPath.data(), filter, findFilesCallback);
             if (result == AZ::IO::ResultCode::Success)
             {
-                return AZStd::move(foundFiles);
+                return foundFiles;
             }
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendDistancePass.cpp
@@ -24,7 +24,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridBlendDistancePass> DiffuseProbeGridBlendDistancePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridBlendDistancePass> pass = aznew DiffuseProbeGridBlendDistancePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridBlendDistancePass::DiffuseProbeGridBlendDistancePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBlendIrradiancePass.cpp
@@ -24,7 +24,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridBlendIrradiancePass> DiffuseProbeGridBlendIrradiancePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridBlendIrradiancePass> pass = aznew DiffuseProbeGridBlendIrradiancePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridBlendIrradiancePass::DiffuseProbeGridBlendIrradiancePass(const RPI::PassDescriptor& descriptor)
@@ -142,7 +142,7 @@ namespace AZ
                     desc.m_attachmentId = diffuseProbeGrid->GetProbeDataImageAttachmentId();
                     desc.m_imageViewDescriptor = diffuseProbeGrid->GetRenderData()->m_probeDataImageViewDescriptor;
                     desc.m_loadStoreAction.m_loadAction = AZ::RHI::AttachmentLoadAction::Load;
-                
+
                     frameGraph.UseShaderAttachment(desc, RHI::ScopeAttachmentAccess::ReadWrite, RHI::ScopeAttachmentStage::ComputeShader);
                 }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridBorderUpdatePass.cpp
@@ -25,7 +25,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridBorderUpdatePass> DiffuseProbeGridBorderUpdatePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridBorderUpdatePass> pass = aznew DiffuseProbeGridBorderUpdatePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridBorderUpdatePass::DiffuseProbeGridBorderUpdatePass(const RPI::PassDescriptor& descriptor)
@@ -228,7 +228,7 @@ namespace AZ
                     submitItem.m_dispatchItem.SetPipelineState(m_columnPipelineState);
                     submitItem.m_dispatchItem.SetArguments(arguments);
                 }
-            }     
+            }
         }
 
         void DiffuseProbeGridBorderUpdatePass::BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridClassificationPass.cpp
@@ -28,7 +28,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridClassificationPass> DiffuseProbeGridClassificationPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridClassificationPass> pass = aznew DiffuseProbeGridClassificationPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridClassificationPass::DiffuseProbeGridClassificationPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridDownsamplePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridDownsamplePass.cpp
@@ -17,7 +17,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridDownsamplePass> DiffuseProbeGridDownsamplePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridDownsamplePass> pass = aznew DiffuseProbeGridDownsamplePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridDownsamplePass::DiffuseProbeGridDownsamplePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridPreparePass.cpp
@@ -26,7 +26,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridPreparePass> DiffuseProbeGridPreparePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridPreparePass> pass = aznew DiffuseProbeGridPreparePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridPreparePass::DiffuseProbeGridPreparePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
@@ -26,7 +26,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridQueryFullscreenPass> DiffuseProbeGridQueryFullscreenPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridQueryFullscreenPass> pass = aznew DiffuseProbeGridQueryFullscreenPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridQueryFullscreenPass::DiffuseProbeGridQueryFullscreenPass(const RPI::PassDescriptor& descriptor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryPass.cpp
@@ -24,7 +24,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridQueryPass> DiffuseProbeGridQueryPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridQueryPass> pass = aznew DiffuseProbeGridQueryPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridQueryPass::DiffuseProbeGridQueryPass(const RPI::PassDescriptor& descriptor)
@@ -161,7 +161,7 @@ namespace AZ
             }
 
             // output buffer
-            {                      
+            {
                 RHI::BufferScopeAttachmentDescriptor desc;
                 desc.m_attachmentId = m_outputBufferAttachmentId;
                 desc.m_bufferViewDescriptor = m_outputBufferViewDesc;
@@ -270,7 +270,7 @@ namespace AZ
             DiffuseProbeGridFeatureProcessor* diffuseProbeGridFeatureProcessor = scene->GetFeatureProcessor<DiffuseProbeGridFeatureProcessor>();
 
             diffuseProbeGridFeatureProcessor->ClearIrradianceQueries();
-                
+
             RenderPass::FrameEndInternal();
         }
     }   // namespace Render

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRayTracingPass.cpp
@@ -32,7 +32,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridRayTracingPass> DiffuseProbeGridRayTracingPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridRayTracingPass> pass = aznew DiffuseProbeGridRayTracingPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridRayTracingPass::DiffuseProbeGridRayTracingPass(const RPI::PassDescriptor& descriptor)
@@ -304,7 +304,7 @@ namespace AZ
                 m_rayTracingShaderTable->Build(descriptor);
             }
         }
-    
+
         void DiffuseProbeGridRayTracingPass::BuildCommandListInternal([[maybe_unused]] const RHI::FrameGraphExecuteContext& context)
         {
             RPI::Scene* scene = m_pipeline->GetScene();

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRelocationPass.cpp
@@ -29,7 +29,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridRelocationPass> DiffuseProbeGridRelocationPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridRelocationPass> pass = aznew DiffuseProbeGridRelocationPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridRelocationPass::DiffuseProbeGridRelocationPass(const RPI::PassDescriptor& descriptor)
@@ -108,7 +108,7 @@ namespace AZ
                 return true;
             }
 
-            // check to see if any grids need relocation           
+            // check to see if any grids need relocation
             for (auto& diffuseProbeGrid : diffuseProbeGridFeatureProcessor->GetVisibleRealTimeProbeGrids())
             {
                 if (diffuseProbeGrid->GetRemainingRelocationIterations() > 0)
@@ -116,7 +116,7 @@ namespace AZ
                     return true;
                 }
             }
-           
+
             return false;
         }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationAccelerationStructurePass.cpp
@@ -23,7 +23,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridVisualizationAccelerationStructurePass> DiffuseProbeGridVisualizationAccelerationStructurePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridVisualizationAccelerationStructurePass> diffuseProbeGridVisualizationAccelerationStructurePass = aznew DiffuseProbeGridVisualizationAccelerationStructurePass(descriptor);
-            return AZStd::move(diffuseProbeGridVisualizationAccelerationStructurePass);
+            return diffuseProbeGridVisualizationAccelerationStructurePass;
         }
 
         DiffuseProbeGridVisualizationAccelerationStructurePass::DiffuseProbeGridVisualizationAccelerationStructurePass(const RPI::PassDescriptor& descriptor)
@@ -77,7 +77,7 @@ namespace AZ
         void DiffuseProbeGridVisualizationAccelerationStructurePass::FrameBeginInternal(FramePrepareParams params)
         {
             params.m_frameGraphBuilder->ImportScopeProducer(*this);
-        }       
+        }
 
         void DiffuseProbeGridVisualizationAccelerationStructurePass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
         {
@@ -183,14 +183,14 @@ namespace AZ
         {
             RPI::Scene* scene = m_pipeline->GetScene();
             DiffuseProbeGridFeatureProcessor* diffuseProbeGridFeatureProcessor = scene->GetFeatureProcessor<DiffuseProbeGridFeatureProcessor>();
-            
+
             for (auto& diffuseProbeGrid : diffuseProbeGridFeatureProcessor->GetVisibleProbeGrids())
             {
                 if (!ShouldUpdate(diffuseProbeGrid))
                 {
                     continue;
                 }
-            
+
                 // TLAS is now updated
                 diffuseProbeGrid->ResetVisualizationTlasUpdateRequired();
             }

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationCompositePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationCompositePass.cpp
@@ -18,7 +18,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridVisualizationCompositePass> DiffuseProbeGridVisualizationCompositePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridVisualizationCompositePass> pass = aznew DiffuseProbeGridVisualizationCompositePass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridVisualizationCompositePass::DiffuseProbeGridVisualizationCompositePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationPreparePass.cpp
@@ -23,7 +23,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridVisualizationPreparePass> DiffuseProbeGridVisualizationPreparePass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridVisualizationPreparePass> diffuseProbeGridVisualizationPreparePass = aznew DiffuseProbeGridVisualizationPreparePass(descriptor);
-            return AZStd::move(diffuseProbeGridVisualizationPreparePass);
+            return diffuseProbeGridVisualizationPreparePass;
         }
 
         DiffuseProbeGridVisualizationPreparePass::DiffuseProbeGridVisualizationPreparePass(const RPI::PassDescriptor& descriptor)

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridVisualizationRayTracingPass.cpp
@@ -26,7 +26,7 @@ namespace AZ
         RPI::Ptr<DiffuseProbeGridVisualizationRayTracingPass> DiffuseProbeGridVisualizationRayTracingPass::Create(const RPI::PassDescriptor& descriptor)
         {
             RPI::Ptr<DiffuseProbeGridVisualizationRayTracingPass> pass = aznew DiffuseProbeGridVisualizationRayTracingPass(descriptor);
-            return AZStd::move(pass);
+            return pass;
         }
 
         DiffuseProbeGridVisualizationRayTracingPass::DiffuseProbeGridVisualizationRayTracingPass(const RPI::PassDescriptor& descriptor)
@@ -272,7 +272,7 @@ namespace AZ
                 BindSrg(viewSRG->GetRHIShaderResourceGroup());
             }
         }
-    
+
         void DiffuseProbeGridVisualizationRayTracingPass::BuildCommandListInternal([[maybe_unused]] const RHI::FrameGraphExecuteContext& context)
         {
             RPI::Scene* scene = m_pipeline->GetScene();

--- a/Gems/EMotionFX/Code/Tests/TestAssetCode/TestActorAssets.h
+++ b/Gems/EMotionFX/Code/Tests/TestAssetCode/TestActorAssets.h
@@ -28,7 +28,7 @@ namespace EMotionFX
             AZStd::unique_ptr<ActorT> actor = ActorFactory::CreateAndInit<ActorT>(AZStd::forward<Args>(args)...);
             AZ::Data::Asset<Integration::ActorAsset> actorAsset = TestActorAssets::GetAssetFromActor(assetId, AZStd::move(actor));
             GetEMotionFX().GetActorManager()->RegisterActor(actorAsset);
-            return AZStd::move(actorAsset);
+            return actorAsset;
         }
     };
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/UI/LODSkinnedMeshTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/LODSkinnedMeshTests.cpp
@@ -80,14 +80,14 @@ namespace EMotionFX
         // Modify the actor to have numLODs LOD levels.
         Actor* actor = actorAsset->GetActor();
         Mesh* lodMesh = actor->GetMesh(0, 0);
-        
+
         for (int i = 1; i < numLODs; ++i)
         {
             actor->InsertLODLevel(i);
             actor->SetMesh(i, 0, lodMesh->Clone());
         }
 
-        return AZStd::move(actorAsset);
+        return actorAsset;
     }
 
     class LODPropertyRowWidget

--- a/Gems/Multiplayer/Code/Source/Components/MultiplayerComponentRegistry.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/MultiplayerComponentRegistry.cpp
@@ -30,7 +30,7 @@ namespace Multiplayer
         const ComponentData& componentData = GetMultiplayerComponentData(netComponentId);
         if (componentData.m_allocComponentInputFunction)
         {
-            return AZStd::move(componentData.m_allocComponentInputFunction());
+            return componentData.m_allocComponentInputFunction();
         }
         return nullptr;
     }

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -464,7 +464,7 @@ namespace Multiplayer
         for (size_t i = 0; i < multiplayerComponentSize; ++i)
         {
             const NetComponentId netComponentId = m_multiplayerInputComponentVector[i]->GetNetComponentId();
-            AZStd::unique_ptr<IMultiplayerComponentInput> componentInput = AZStd::move(GetMultiplayerComponentRegistry()->AllocateComponentInput(netComponentId));
+            AZStd::unique_ptr<IMultiplayerComponentInput> componentInput = GetMultiplayerComponentRegistry()->AllocateComponentInput(netComponentId);
 
             if (componentInput != nullptr)
             {

--- a/Gems/Multiplayer/Code/Source/NetworkInput/NetworkInput.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkInput/NetworkInput.cpp
@@ -150,7 +150,7 @@ namespace Multiplayer
                 // Create a new input if we don't have one or the types do not match
                 if ((m_componentInputs[i] == nullptr) || (componentId != m_componentInputs[i]->GetNetComponentId()))
                 {
-                    m_componentInputs[i] = AZStd::move(GetMultiplayerComponentRegistry()->AllocateComponentInput(componentId));
+                    m_componentInputs[i] = GetMultiplayerComponentRegistry()->AllocateComponentInput(componentId);
                 }
                 if (!m_componentInputs[i])
                 {
@@ -207,7 +207,7 @@ namespace Multiplayer
             const NetComponentId rhsComponentId = rhs.m_componentInputs[i]->GetNetComponentId();
             if (m_componentInputs[i] == nullptr || m_componentInputs[i]->GetNetComponentId() != rhsComponentId)
             {
-                m_componentInputs[i] = AZStd::move(GetMultiplayerComponentRegistry()->AllocateComponentInput(rhsComponentId));
+                m_componentInputs[i] = GetMultiplayerComponentRegistry()->AllocateComponentInput(rhsComponentId);
             }
             *(m_componentInputs[i]) = *(rhs.m_componentInputs[i]);
         }

--- a/Gems/PhysX/Core/Code/Tests/Benchmarks/PhysXJointBenchmarks.cpp
+++ b/Gems/PhysX/Core/Code/Tests/Benchmarks/PhysXJointBenchmarks.cpp
@@ -174,7 +174,7 @@ namespace PhysX::Benchmarks
                 joints.emplace_back(AZStd::move(newJoint));
             }
 
-            return AZStd::move(joints);
+            return joints;
         }
     } // namespace Utils
 

--- a/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
@@ -33,7 +33,7 @@ namespace PhysX
         const AZStd::string RightCollider = "RightCollider";
         const int FramesToUpdate = 25;
 
-        void SetUp() override 
+        void SetUp() override
         {
             PhysXDefaultWorldTest::SetUp();
 
@@ -88,7 +88,7 @@ namespace PhysX
         auto leftColliderConfig = AZStd::make_shared<Physics::ColliderConfiguration>();
         leftColliderConfig->m_position = AZ::Vector3(-1.0f, 0.0f, 0.0f);
         leftColliderConfig->m_tag = leftColliderTag;
-        
+
         auto rightBoxConfig = AZStd::make_shared<Physics::BoxShapeConfiguration>();
         auto rightColliderConfig = AZStd::make_shared<Physics::ColliderConfiguration>();
         rightColliderConfig->m_position = AZ::Vector3(1.0f, 0.0f, 0.0f);
@@ -104,7 +104,7 @@ namespace PhysX
 
         entityPtr->Init();
         entityPtr->Activate();
-        return AZStd::move(entityPtr);
+        return entityPtr;
     }
 
     TEST_F(PhysXCollisionFilteringTest, TestSetColliderLayerOnStaticObject)

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/tests/PrefabBehaviorTestMocks.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/tests/PrefabBehaviorTestMocks.cpp
@@ -23,7 +23,7 @@ namespace AZ::Render
         {
             serializeContext->Class<AZ::Render::EditorMeshComponent>();
         }
-        
+
         if (BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
             behaviorContext->Class<EditorMeshComponent>("AZ::Render::EditorMeshComponent");
@@ -63,7 +63,7 @@ namespace UnitTest
         auto root = scene->GetGraph().GetRoot();
         scene->GetGraph().SetContent(root, AZStd::make_shared<DataTypes::MockIGraphObject>(0));
 
-        return AZStd::move(scene);
+        return scene;
     }
 
     void BuildMockScene(AZ::SceneAPI::Containers::Scene& scene)

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerEventNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/EBusHandlerEventNodeDescriptorComponent.cpp
@@ -48,7 +48,7 @@ namespace ScriptCanvasEditor
 
         return true;
     }
-    
+
     void EBusHandlerEventNodeDescriptorComponent::Reflect(AZ::ReflectContext* context)
     {
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
@@ -67,7 +67,7 @@ namespace ScriptCanvasEditor
         : NodeDescriptorComponent(NodeDescriptorType::EBusHandlerEvent)
     {
     }
-    
+
     EBusHandlerEventNodeDescriptorComponent::EBusHandlerEventNodeDescriptorComponent(const AZStd::string& busName, const AZStd::string& eventName, ScriptCanvas::EBusEventId eventId)
         : NodeDescriptorComponent(NodeDescriptorType::EBusHandlerEvent)
         , m_busName(busName)
@@ -80,7 +80,7 @@ namespace ScriptCanvasEditor
     {
         NodeDescriptorComponent::Activate();
 
-        EBusHandlerEventNodeDescriptorRequestBus::Handler::BusConnect(GetEntityId());        
+        EBusHandlerEventNodeDescriptorRequestBus::Handler::BusConnect(GetEntityId());
         GraphCanvas::ForcedWrappedNodeRequestBus::Handler::BusConnect(GetEntityId());
         GraphCanvas::SceneMemberNotificationBus::Handler::BusConnect(GetEntityId());
     }
@@ -117,12 +117,12 @@ namespace ScriptCanvasEditor
             GraphCanvas::SceneMemberRequestBus::EventResult(graphId, GetEntityId(), &GraphCanvas::SceneMemberRequests::GetScene);
 
             ScriptCanvas::ScriptCanvasId canvasId;
-            GeneralRequestBus::BroadcastResult(canvasId, &GeneralRequests::GetScriptCanvasId, graphId);            
+            GeneralRequestBus::BroadcastResult(canvasId, &GeneralRequests::GetScriptCanvasId, graphId);
 
             ScriptCanvas::GraphScopedNodeId scopedNodeId(canvasId, m_ebusWrapper.m_scriptCanvasId);
             ScriptCanvas::EBusHandlerNodeRequestBus::Event(scopedNodeId, &ScriptCanvas::EBusHandlerNodeRequests::SetAddressId, AZStd::move(idDatum));
 
-            m_queuedId = AZStd::move(ScriptCanvas::Datum());
+            m_queuedId = ScriptCanvas::Datum();
         }
         else
         {
@@ -258,7 +258,7 @@ namespace ScriptCanvasEditor
                                 Nodes::DisplayScriptCanvasSlot(GetEntityId(), (*scriptCanvasSlot), 0);
                             }
                         }
-                        
+
                         GraphCanvas::NodeRequestBus::EventResult(graphCanvasSlotIds, GetEntityId(), &GraphCanvas::NodeRequests::GetSlotIds);
                     }
 
@@ -267,7 +267,7 @@ namespace ScriptCanvasEditor
 
                 if (m_queuedId.GetType().IsValid())
                 {
-                    SetHandlerAddress(m_queuedId);                    
+                    SetHandlerAddress(m_queuedId);
                 }
             }
         }

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverEventNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverEventNodeDescriptorComponent.cpp
@@ -119,7 +119,7 @@ namespace ScriptCanvasEditor
             ScriptCanvas::GraphScopedNodeId scopedNodeId(canvasId, m_ebusWrapper.m_scriptCanvasId);
             ScriptCanvas::EBusHandlerNodeRequestBus::Event(scopedNodeId, &ScriptCanvas::EBusHandlerNodeRequests::SetAddressId, AZStd::move(idDatum));
 
-            m_queuedId = AZStd::move(ScriptCanvas::Datum());
+            m_queuedId = ScriptCanvas::Datum();
         }
         else
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
@@ -1824,7 +1824,7 @@ namespace ScriptCanvas
             }
             else
             {
-                (*this) = AZStd::move(Datum());
+                (*this) = Datum();
                 m_isDefaultConstructed = true;
             }
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
@@ -213,7 +213,7 @@ namespace ScriptCanvas
 
                     if (datumView.IsValid() && Data::IsValueType(datumView.GetDataType()))
                     {
-                        datumView.AssignToDatum(AZStd::move(Datum(defaultValue->m_value)));
+                        datumView.AssignToDatum(Datum(defaultValue->m_value));
                     }
                 }
             }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -54,7 +54,7 @@ namespace NodeCpp
 
         // add your named version above
         Current,
-    }; 
+    };
 }
 
 namespace ScriptCanvas
@@ -285,7 +285,7 @@ namespace ScriptCanvas
             // Create a variable mapping to the previous datum iterators for easier lookup
             AZStd::unordered_map<VariableId, typename AZStd::list<Deprecated::VariableDatumBase>::iterator> variableIdMap;
 
-            for (auto varIter = varDatums.begin(); varIter != varDatums.end(); ++varIter)            
+            for (auto varIter = varDatums.begin(); varIter != varDatums.end(); ++varIter)
             {
                 variableIdMap[varIter->GetId()] = varIter;
             }
@@ -325,7 +325,7 @@ namespace ScriptCanvas
                 Slot& slotReference = (*slotIter->second);
 
                 Deprecated::VariableInfo variableInfo = mapPair.second;
-                
+
                 // If the slot reference is an output. We don't want to register a datum for it, we just want to set the display
                 // type of the slot to the correct element.
                 if (slotReference.IsOutput())
@@ -422,7 +422,7 @@ namespace ScriptCanvas
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)
         {
-            // Needed to serialize in the AZStd::vector<Slot> from the old SlotContainer class 
+            // Needed to serialize in the AZStd::vector<Slot> from the old SlotContainer class
             serializeContext->RegisterGenericType<AZStd::vector<Slot>>();
 
             // Needed to serialize in the AZStd::vector<Datum> from this class
@@ -432,7 +432,7 @@ namespace ScriptCanvas
             serializeContext->RegisterGenericType<AZStd::vector<Data::Type>>();
 
             // Needed to serialize in the AZStd::unordered<int, int> from version 5 and below
-            serializeContext->RegisterGenericType<AZStd::unordered_map<int, int>>();            
+            serializeContext->RegisterGenericType<AZStd::unordered_map<int, int>>();
 
             // Needed to serialize in the AZStd::list<Deprecated::VariableDatumBase> from version 6 and below
             serializeContext->RegisterGenericType<AZStd::list<Deprecated::VariableDatum>>();
@@ -656,7 +656,7 @@ namespace ScriptCanvas
         {
             IteratorCache cache;
 
-            cache.m_slotIterator = slotIter;            
+            cache.m_slotIterator = slotIter;
 
             // Manage the datum iterator here as well
             if (slotIter->IsData() && slotIter->IsInput())
@@ -747,7 +747,7 @@ namespace ScriptCanvas
                 // for each output slot...
                 // for each connected node...
                 // remove the ability to default it...
-                
+
                 EndpointsResolved connections = GetConnectedNodes(inputSlot);
                 if (!connections.empty())
                 {
@@ -866,7 +866,7 @@ namespace ScriptCanvas
 
     GraphVariable* Node::FindGraphVariable(const VariableId& variableId) const
     {
-        return m_graphRequestBus->FindVariableById(variableId);      
+        return m_graphRequestBus->FindVariableById(variableId);
     }
 
     void Node::OnSlotConvertedToValue(const SlotId& slotId)
@@ -957,7 +957,7 @@ namespace ScriptCanvas
 
                 if (datumView.IsValid())
                 {
-                    cache.m_slotDatum = AZStd::move(datumView.CloneDatum());
+                    cache.m_slotDatum = datumView.CloneDatum();
                 }
             }
 
@@ -1229,7 +1229,7 @@ namespace ScriptCanvas
     bool Node::CanDeleteSlot([[maybe_unused]] const SlotId& slotId) const
     {
         return false;
-    }    
+    }
 
     SlotId Node::HandleExtension(AZ::Crc32 extensionId)
     {
@@ -1280,8 +1280,8 @@ namespace ScriptCanvas
 
     void Node::SignalReconfigurationEnd()
     {
-        
-        OnReconfigurationEnd();        
+
+        OnReconfigurationEnd();
     }
 
     void Node::ClearDisplayType(const AZ::Crc32& dynamicGroup, ExploredDynamicGroupCache& exploredGroupCache)
@@ -1678,7 +1678,7 @@ namespace ScriptCanvas
             else
             {
                 AZ_Error("ScriptCanvas", slot->CanConvertToReference(), "Could not convert Slot into a reference. Aborting SetVariableId attempt.");
-            }            
+            }
         }
     }
 
@@ -1762,7 +1762,7 @@ namespace ScriptCanvas
             for (const auto& updatePair : m_queuedDisplayUpdates)
             {
                 SetDisplayType(updatePair.first, updatePair.second);
-            }            
+            }
         }
     }
 
@@ -1860,7 +1860,7 @@ namespace ScriptCanvas
 
         if (slotIter != m_slotIdIteratorCache.end())
         {
-            
+
             if (slotIter->second.HasDatum())
             {
                 datumView.ConfigureView((*slotIter->second.GetDatum()));
@@ -1979,7 +1979,7 @@ namespace ScriptCanvas
                 return &(*slotNameIter->second);
             }
         }
-        
+
         return nullptr;
     }
 
@@ -2082,10 +2082,10 @@ namespace ScriptCanvas
 
                     storageDatum.SetLabel(slotConfig.m_name);
                     storageDatum.SetNotificationsTarget(GetEntityId());
-                    
+
                     DatumIterator insertionPoint = m_slotDatums.end();
 
-                    if (index >= 0)                    
+                    if (index >= 0)
                     {
                         insertionPoint = m_slotDatums.begin();
 
@@ -2173,7 +2173,7 @@ namespace ScriptCanvas
             {
                 m_slotDatums.erase(iteratorCache.GetDatumIter());
                 iteratorCache.ClearIterator();
-            }            
+            }
 
             m_slotIdIteratorCache.erase(slotIter);
 
@@ -2417,7 +2417,7 @@ namespace ScriptCanvas
         }
 
         return true;
-    }    
+    }
 
     Graph* Node::GetGraph() const
     {
@@ -2440,7 +2440,7 @@ namespace ScriptCanvas
         for (const auto& endpoint : GetAllEndpointsByDescriptor(slotDescriptor, followLatentConnections))
         {
             Node* connectedNode = m_graphRequestBus->FindNode(endpoint.GetNodeId());
-            
+
             if (connectedNode)
             {
                 connectedNodes.emplace_back(connectedNode);
@@ -2459,7 +2459,7 @@ namespace ScriptCanvas
         for (const auto& endpoint : GetAllEndpointsByDescriptor(slotDescriptor, followLatentConnections))
         {
             Node* connectedNode = m_graphRequestBus->FindNode(endpoint.GetNodeId());
-            
+
             if (connectedNode)
             {
                 connectedNodes.emplace_back(AZStd::make_pair(connectedNode, endpoint.GetSlotId()));
@@ -2638,7 +2638,7 @@ namespace ScriptCanvas
         if (slotId.IsValid())
         {
             NodeNotificationsBus::Event((GetEntity() != nullptr) ? GetEntityId() : AZ::EntityId(), &NodeNotifications::OnSlotInputChanged, slotId);
-        }        
+        }
     }
 
     void Node::OnDeserialize()
@@ -2860,9 +2860,9 @@ namespace ScriptCanvas
         const Slot* slot = GetSlot(slotId);
         return slot && IsConnected((*slot));
     }
-    
+
     bool Node::HasConnectionForDescriptor(const SlotDescriptor& slotDescriptor) const
-    {        
+    {
         for (const auto& slot : m_slots)
         {
             if (slot.GetDescriptor() == slotDescriptor)
@@ -2876,7 +2876,7 @@ namespace ScriptCanvas
 
         return false;
     }
-    
+
     bool Node::IsPureData() const
     {
         for (const auto& slot : m_slots)
@@ -2894,7 +2894,7 @@ namespace ScriptCanvas
     {
         return m_graphRequestBus;
     }
-    
+
     EndpointsResolved Node::GetConnectedNodes(const Slot& slot) const
     {
         AZ_PROFILE_SCOPE(ScriptCanvas, "ScriptCanvas::Node::GetConnectedNodes");
@@ -2909,7 +2909,7 @@ namespace ScriptCanvas
             auto node = m_graphRequestBus->FindNode(endpoint.GetNodeId());
 
             if (node == nullptr)
-            {                
+            {
                 AZStd::string assetName = m_graphRequestBus->GetAssetName();
                 [[maybe_unused]] AZ::EntityId assetNodeId = m_graphRequestBus->FindAssetNodeIdByRuntimeNodeId(endpoint.GetNodeId());
                 AZ_Warning("Script Canvas", false, "Unable to find node with id (id: %s) in the graph '%s'. Most likely the node was serialized with a type that is no longer reflected",
@@ -3152,7 +3152,7 @@ namespace ScriptCanvas
     {
         return AZ::Failure();
     }
-    
+
     AZ::Outcome<AZStd::string, void> Node::GetFunctionCallName(const Slot* /*slot*/) const
     {
         return AZ::Failure();

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -77,7 +77,7 @@ namespace ScriptCanvas
 
             classElement.RemoveElementByName(AZ_CRC_CE("dataTypeOverride"));
         }
-        
+
         // DisplayDataType
         if (classElement.GetVersion() < 12)
         {
@@ -114,9 +114,9 @@ namespace ScriptCanvas
 
             SlotDescriptor slotDescriptor;
             if (subElement && subElement->GetData(slotDescriptor))
-            {                
+            {
                 if (slotDescriptor.IsData() && dataType == Slot::DataType::NoData)
-                {                    
+                {
                     dataType = Slot::DataType::Data;
                 }
             }
@@ -125,7 +125,7 @@ namespace ScriptCanvas
         }
         // This data field wasn't actually being initalized correctly So need to re-version convert.
         else if (classElement.GetVersion() <= 17)
-        {            
+        {
             AZ::SerializeContext::DataElementNode* subElement = classElement.FindSubElement(AZ_CRC_CE("Descriptor"));
 
             Slot::DataType dataType = Slot::DataType::NoData;
@@ -196,7 +196,7 @@ namespace ScriptCanvas
                 ->Version(SlotVersion::Current, &SlotVersionConverter)
                 ->Field("IsOverload", &Slot::m_isOverload)
                 ->Field("isVisibile", &Slot::m_isVisible)
-                ->Field("id", &Slot::m_id)                
+                ->Field("id", &Slot::m_id)
                 ->Field("DynamicTypeOverride", &Slot::m_dynamicDataType)
                 ->Field("contracts", &Slot::m_contracts)
                 ->Field("slotName", &Slot::m_name)
@@ -316,11 +316,11 @@ namespace ScriptCanvas
         m_descriptor = slot.m_descriptor;
         m_isVariableReference = slot.m_isVariableReference;
         m_dataType = slot.m_dataType;
-        m_variableReference = slot.m_variableReference;        
+        m_variableReference = slot.m_variableReference;
         m_dynamicDataType = slot.m_dynamicDataType;
         m_displayDataType = slot.m_displayDataType;
         m_id = slot.m_id;
-        m_node = slot.m_node;        
+        m_node = slot.m_node;
 
         for (auto& otherContract : slot.m_contracts)
         {
@@ -331,7 +331,7 @@ namespace ScriptCanvas
 
         return *this;
     }
-    
+
     void Slot::AddContract(const ContractDescriptor& contractDesc)
     {
         if (contractDesc.m_createFunc)
@@ -342,7 +342,7 @@ namespace ScriptCanvas
                 m_contracts.emplace_back(newContract);
             }
         }
-    }    
+    }
 
     void Slot::ClearDynamicGroup()
     {
@@ -384,7 +384,7 @@ namespace ScriptCanvas
     }
 
     void Slot::InitializeVariables()
-    {        
+    {
         if (IsVariableReference())
         {
             m_variable = m_node->FindGraphVariable(m_variableReference);
@@ -403,7 +403,7 @@ namespace ScriptCanvas
     }
 
     Endpoint Slot::GetEndpoint() const
-    { 
+    {
         return Endpoint(GetNode()->GetEntityId(), GetId());
     }
 
@@ -582,7 +582,7 @@ namespace ScriptCanvas
     {
         return m_isUserAdded;
     }
-    
+
     bool Slot::IsInput() const
     {
         return m_descriptor.IsInput();
@@ -668,7 +668,7 @@ namespace ScriptCanvas
                         }
                         else
                         {
-                            datumView.ReconfigureDatumTo(AZStd::move(Datum()));
+                            datumView.ReconfigureDatumTo(Datum());
                         }
 
                         datumView.SetLabel(label);
@@ -694,7 +694,7 @@ namespace ScriptCanvas
     ScriptCanvas::Data::Type Slot::GetDisplayType() const
     {
         return m_displayDataType;
-    }    
+    }
 
     bool Slot::HasDisplayType() const
     {
@@ -836,7 +836,7 @@ namespace ScriptCanvas
         {
             return AZ::Success();
         }
-        
+
         return AZ::Failure(AZStd::string::format("%s is not a type match for %s", ScriptCanvas::Data::GetName(myType).c_str(), ScriptCanvas::Data::GetName(otherType).c_str()));
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -1194,7 +1194,7 @@ namespace ScriptCanvas
             }
             else
             {
-                output->m_datum = AZStd::move(Datum(outputSlot.GetDataType(), Datum::eOriginality::Copy));
+                output->m_datum = Datum(outputSlot.GetDataType(), Datum::eOriginality::Copy);
             }
             output->m_sourceSlotId = outputSlot.GetId();
             output->m_name = execution->ModScope()->AddVariableName(slotNameOverride.empty() ? outputSlot.GetName().c_str() : slotNameOverride.data(), suffix);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/ParsingMetaData.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/ParsingMetaData.cpp
@@ -50,7 +50,7 @@ namespace ParsingMetaDataCPP
     {
         size_t startPosition = 0;
         size_t foundPosition;
-        
+
         while ((foundPosition = replaced.find(from, startPosition)) != AZStd::string::npos)
         {
             replaced.replace(foundPosition, from.length(), to);
@@ -95,7 +95,7 @@ namespace ParsingMetaDataCPP
 
         const auto& slotIdsByName = formatted->GetNamedSlotIdMap();
         AZStd::vector<AZStd::pair<size_t, SlotId>> positionsAndSlotIds = ParsePositionsAndSlotIds(slotIdsByName, rawString);
-        
+
         // translate the formatted string to C++ / Lua friendly printf format
         AZStd::string formattedString(rawString);
 
@@ -206,7 +206,7 @@ namespace ScriptCanvas
 
         // turn the print node into a separate string format node and then a print node
         void PrintMetaData::PostParseExecutionTreeBody(AbstractCodeModel& model, ExecutionTreePtr print)
-        {            
+        {
             // set function call names
             print->SetNameLexicalScope(LexicalScope(Grammar::LexicalScopeType::Namespace, { k_printLexicalScopeName }));
             print->SetName(k_printName);
@@ -234,7 +234,7 @@ namespace ScriptCanvas
             }
 
             const auto indexAndChild = removeOutcome.TakeValue();
-            
+
             parent->InsertChild(indexAndChild.first, {indexAndChild.second.m_slot, indexAndChild.second.m_output, format });
             print->SetParent(format);
             format->AddChild({ nullptr, {}, print });
@@ -242,14 +242,14 @@ namespace ScriptCanvas
             // move input to format
             format->CopyInput(print, ExecutionTree::RemapVariableSource::Yes);
             print->ClearInput();
-            
+
             // add output to format
             auto output = AZStd::make_shared<Variable>();
             output->m_source = format;
-            output->m_datum = AZStd::move(Datum(Data::Type::String(), Datum::eOriginality::Copy));
+            output->m_datum = Datum(Data::Type::String(), Datum::eOriginality::Copy);
             output->m_name = print->ModScope()->AddVariableName("format", "output");
             format->ModChild(0).m_output.push_back({ nullptr, model.CreateOutputAssignment(output) });
-            
+
             // make format output the print input
             print->AddInput({ nullptr, output, DebugDataSource::FromInternal(output->m_datum.GetType()) });
 
@@ -284,7 +284,7 @@ namespace ScriptCanvas
                 oldInput.emplace(input.m_slot->GetId(), input);
             }
 
-            // rewrite the input so that it can appear with repeats and in usage order 
+            // rewrite the input so that it can appear with repeats and in usage order
             expression->ClearInput();
 
             for (auto andSlotId : positionsAndSlotIds)
@@ -295,6 +295,6 @@ namespace ScriptCanvas
             m_expressionString = expressionString;
         }
 
-    } 
+    }
 
-} 
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.cpp
@@ -54,7 +54,7 @@ namespace ScriptCanvas
 
             void EBusEventHandler::OnActivate()
             {
-                // Set the auto connect value to the serialized value to give the setter 
+                // Set the auto connect value to the serialized value to give the setter
                 // the chance to overrule it if the node's Connect slot is manually connected.
                 SetAutoConnectToGraphOwner(m_autoConnectToGraphOwner);
             }
@@ -78,7 +78,7 @@ namespace ScriptCanvas
                         variableIds.insert(scopedVariableId->m_identifier);
                     }
                 }
-                
+
                 Node::CollectVariableReferences(variableIds);
             }
 
@@ -466,7 +466,7 @@ namespace ScriptCanvas
                         {
                             Data::Type busIdType(AZ::BehaviorContextHelper::IsStringParameter(m_ebus->m_idParam) ? Data::Type::String() : Data::FromAZType(busId));
 
-                            config.ConfigureDatum(AZStd::move(Datum(busIdType, Datum::eOriginality::Original)));
+                            config.ConfigureDatum(Datum(busIdType, Datum::eOriginality::Original));
                         }
 
                         AddSlot(config);
@@ -527,7 +527,7 @@ namespace ScriptCanvas
                     resultConfiguration.SetConnectionType(ConnectionType::Input);
                     resultConfiguration.m_addUniqueSlotByNameAndType = false;
 
-                    resultConfiguration.ConfigureDatum(AZStd::move(Datum(inputType, Datum::eOriginality::Original)));
+                    resultConfiguration.ConfigureDatum(Datum(inputType, Datum::eOriginality::Original));
 
                     ebusEventEntry.m_resultSlotId = AddSlot(resultConfiguration);
                 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.cpp
@@ -36,7 +36,7 @@ namespace ScriptCanvas
             // FunctionCallNode
             /////////////////
 
-            FunctionCallNode::FunctionCallNode() 
+            FunctionCallNode::FunctionCallNode()
                 : m_asset(AZ::Data::AssetLoadBehavior::NoLoad)
             {}
 
@@ -296,7 +296,7 @@ namespace ScriptCanvas
                     SlotExecution::Ins slotMapIns;
                     slotMapIns.push_back(in);
                     SlotExecution::Outs slotMapLatents;
-                    m_slotExecutionMap = AZStd::move(SlotExecution::Map(AZStd::move(slotMapIns), AZStd::move(slotMapLatents)));
+                    m_slotExecutionMap = SlotExecution::Map(AZStd::move(slotMapIns), AZStd::move(slotMapLatents));
                 }
                 else
                 {
@@ -326,7 +326,7 @@ namespace ScriptCanvas
                 }
 
                 // when returning variables: sort variables by source slot id, they are sorted in the slot map, so just take them from the slot map
-                m_slotExecutionMap = AZStd::move(SlotExecution::Map(AZStd::move(slotMapIns), AZStd::move(slotMapLatents)));
+                m_slotExecutionMap = SlotExecution::Map(AZStd::move(slotMapIns), AZStd::move(slotMapLatents));
             }
 
             AZ::Outcome<Grammar::LexicalScope, void> FunctionCallNode::GetFunctionCallLexicalScope(const Slot* slot) const
@@ -381,7 +381,7 @@ namespace ScriptCanvas
             bool FunctionCallNode::IsEntryPoint() const
             {
                 return m_slotExecutionMapSourceInterface.IsActiveDefaultObject()
-                    || m_slotExecutionMapSourceInterface.IsLatent(); 
+                    || m_slotExecutionMapSourceInterface.IsLatent();
             }
 
             bool FunctionCallNode::IsNodeableNode() const
@@ -451,7 +451,7 @@ namespace ScriptCanvas
                 AZ::Data::AssetId interfaceAssetId(assetId.m_guid, AZ_CRC_CE("SubgraphInterface"));
                 auto asset = AZ::Data::AssetManager::Instance().GetAsset<SubgraphInterfaceAsset>(interfaceAssetId, AZ::Data::AssetLoadBehavior::PreLoad);
                 asset.BlockUntilLoadComplete();
-                
+
                 if (asset)
                 {
                     // do not nuke the assetId in case an update will be attempted immediately after this call

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Method.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Method.cpp
@@ -10,7 +10,7 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/Utils.h>
-#include <Core/SlotConfigurationDefaults.h> 
+#include <Core/SlotConfigurationDefaults.h>
 #include <Core/SlotExecutionMap.h>
 #include <ScriptCanvas/Utils/BehaviorContextUtils.h>
 #include <AzCore/StringFunc/StringFunc.h>
@@ -66,7 +66,7 @@ namespace ScriptCanvas
                     ? *argumentNamePtr
                     : (AZStd::string::format("%s:%2zu", argumentTypeName.data(), argIndex));
 
-                signature.m_inputs.emplace_back(AZStd::make_shared<Grammar::Variable>(AZStd::move(Datum(*argument, Datum::eOriginality::Original, nullptr)), AZStd::move(argName), Grammar::TraitsFlags()));
+                signature.m_inputs.emplace_back(AZStd::make_shared<Grammar::Variable>(Datum(*argument, Datum::eOriginality::Original, nullptr), AZStd::move(argName), Grammar::TraitsFlags()));
             }
         }
 
@@ -78,7 +78,7 @@ namespace ScriptCanvas
 
                 for (auto& type : unpackedTypes)
                 {
-                    signature.m_outputs.push_back(AZStd::make_shared<Grammar::Variable>(AZStd::move(Datum(Data::FromAZType(type), Datum::eOriginality::Original))));
+                    signature.m_outputs.push_back(AZStd::make_shared<Grammar::Variable>(Datum(Data::FromAZType(type), Datum::eOriginality::Original)));
                 }
             }
         }
@@ -138,7 +138,7 @@ namespace ScriptCanvas
                             }
                         }
                     }
-                }                    
+                }
 
                 return true;
             }
@@ -689,7 +689,7 @@ namespace ScriptCanvas
                             outType = eventType;
                             return true;
                         }
-                        
+
                         AZ_Warning("Script Canvas"
                             , !m_warnOnMissingFunction
                             , "Could not find event: %s, in bus: %s, anywhere in BehaviorContext"
@@ -740,7 +740,7 @@ namespace ScriptCanvas
                     }
                     break;
 
-                    default:    
+                    default:
                         break;
                     }
                 }
@@ -757,7 +757,7 @@ namespace ScriptCanvas
             AZStd::tuple<const AZ::BehaviorMethod*, MethodType, EventType, const AZ::BehaviorClass*> Method::LookupMethod() const
             {
                 using TupleType = AZStd::tuple<const AZ::BehaviorMethod*, MethodType, EventType, const AZ::BehaviorClass*>;
-                
+
                 AZStd::string prettyClassName;
 
                 const AZ::BehaviorClass* bcClass{};

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.cpp
@@ -119,7 +119,7 @@ namespace ScriptCanvas
                             {
                                 Data::Type busIdType(AZ::BehaviorContextHelper::IsStringParameter(m_ebus->m_idParam) ? Data::Type::String() : Data::FromAZType(busId));
 
-                                config.ConfigureDatum(AZStd::move(Datum(busIdType, Datum::eOriginality::Original)));
+                                config.ConfigureDatum(Datum(busIdType, Datum::eOriginality::Original));
                                 config.m_contractDescs = { { [busIdType]() { return aznew RestrictedTypeContract({ busIdType }); } } };
                             }
 
@@ -207,7 +207,7 @@ namespace ScriptCanvas
                     slotConfiguration.m_name = argumentTypeName;
 
                     slotConfiguration.SetConnectionType(ConnectionType::Input);
-                    slotConfiguration.ConfigureDatum(AZStd::move(Datum(inputType, Datum::eOriginality::Copy, nullptr, AZ::Uuid::CreateNull())));
+                    slotConfiguration.ConfigureDatum(Datum(inputType, Datum::eOriginality::Copy, nullptr, AZ::Uuid::CreateNull()));
                     slotConfiguration.m_addUniqueSlotByNameAndType = false;
 
                     auto remappingIdIter = m_eventSlotMapping.find(resultIdentifier);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SendScriptEvent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SendScriptEvent.cpp
@@ -146,7 +146,7 @@ namespace ScriptCanvas
                 }
                 else
                 {
-                    slotConfiguration.ConfigureDatum(AZStd::move(Datum(*argument, Datum::eOriginality::Copy, nullptr)));
+                    slotConfiguration.ConfigureDatum(Datum(*argument, Datum::eOriginality::Copy, nullptr));
                     slotId = InsertSlot(aznumeric_cast<AZ::s64>(slotIndex), slotConfiguration, isNewSlot);
 
                     if (auto defaultValue = method->GetDefaultValue(argIndex))
@@ -156,7 +156,7 @@ namespace ScriptCanvas
 
                         if (datumView.IsValid() && Data::IsValueType(datumView.GetDataType()))
                         {
-                            datumView.AssignToDatum(AZStd::move(Datum(defaultValue->m_value)));
+                            datumView.AssignToDatum(Datum(defaultValue->m_value));
                         }
                     }
                 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SetVariable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SetVariable.cpp
@@ -103,7 +103,7 @@ namespace ScriptCanvas
 
             bool SetVariableNode::RemoveVariableReferences(const AZStd::unordered_set< ScriptCanvas::VariableId >& variableIds)
             {
-                // These nodes should just be deleted when the variable they reference is removed. Don't try to 
+                // These nodes should just be deleted when the variable they reference is removed. Don't try to
                 // update the variable they reference.
                 if (m_variableId.IsValid() && variableIds.count(m_variableId) > 0)
                 {
@@ -190,7 +190,7 @@ namespace ScriptCanvas
 
                         slotConfiguration.m_name = Data::GetName(varType);
                         slotConfiguration.SetConnectionType(ConnectionType::Input);
-                        slotConfiguration.ConfigureDatum(AZStd::move(Datum(varType, Datum::eOriginality::Copy)));
+                        slotConfiguration.ConfigureDatum(Datum(varType, Datum::eOriginality::Copy));
 
                         m_variableDataInSlotId = AddSlot(slotConfiguration);
                     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Cycle.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Cycle.cpp
@@ -107,7 +107,7 @@ namespace ScriptCanvas
             AZStd::string Cycle::GenerateOutputName(int counter)
             {
                 AZStd::string slotName = AZStd::string::format("Out %i", counter);
-                return AZStd::move(slotName);
+                return slotName;
             }
 
             void Cycle::FixupStateNames()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.cpp
@@ -106,7 +106,7 @@ namespace ScriptCanvas
             AZStd::string OrderedSequencer::GenerateOutputName(int counter) const
             {
                 AZStd::string slotName = AZStd::string::format("Out %i", counter);
-                return AZStd::move(slotName);
+                return slotName;
             }
 
             void OrderedSequencer::FixupStateNames()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.cpp
@@ -75,7 +75,7 @@ namespace ScriptCanvas
             AZStd::string TargetedSequencer::GenerateOutputName(int counter)
             {
                 AZStd::string slotName = AZStd::string::format("Out %i", counter);
-                return AZStd::move(slotName);
+                return slotName;
             }
 
             void TargetedSequencer::FixupStateNames()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.cpp
@@ -71,7 +71,7 @@ namespace ScriptCanvas
 
             void OperatorArithmetic::OnInit()
             {
-                // Version conversion for previous elements                
+                // Version conversion for previous elements
                 for (Slot& currentSlot : ModSlots())
                 {
                     if (currentSlot.IsData())
@@ -114,7 +114,7 @@ namespace ScriptCanvas
                     m_scrapedInputs = false;
                     m_applicableInputs.clear();
 
-                    m_result.ReconfigureDatumTo(AZStd::move(ScriptCanvas::Datum()));
+                    m_result.ReconfigureDatumTo(ScriptCanvas::Datum());
                 }
             }
 
@@ -272,7 +272,7 @@ namespace ScriptCanvas
                 }
 
                 auto inputs = GetAllSlotsByDescriptor(SlotDescriptors::DataIn());
-                
+
                 for (size_t i = 0; i < inputs.size(); ++i)
                 {
                     Slot* slot = GetSlot(inputs[i]->GetId());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorLerpNodeableNode.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorLerpNodeableNode.cpp
@@ -230,7 +230,7 @@ namespace ScriptCanvas
                 }
             }
 
-            SetSlotExecutionMap(AZStd::move(SlotExecution::Map(AZStd::move(ins), AZStd::move(latentOuts))));
+            SetSlotExecutionMap(SlotExecution::Map(AZStd::move(ins), AZStd::move(latentOuts)));
         }
 
         AZStd::vector<AZStd::unique_ptr<Nodeable>> NodeableNodeOverloadedLerp::GetInitializationNodeables() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.cpp
@@ -22,7 +22,7 @@ namespace ScriptCanvas::Nodeables::Spawning
         // this method is required by Script Canvas, left intentionally blank to avoid copying m_SpawnableScriptMediator
         return *this;
     }
-    
+
     void SpawnNodeable::OnDeactivate()
     {
         m_spawnableScriptMediator.Clear();
@@ -32,9 +32,9 @@ namespace ScriptCanvas::Nodeables::Spawning
     void SpawnNodeable::OnSpawn(AzFramework::EntitySpawnTicket spawnTicket, AZStd::vector<AZ::EntityId> entityList)
     {
         AzFramework::Scripts::SpawnableScriptNotificationsBus::MultiHandler::BusDisconnect(spawnTicket.GetId());
-        CallOnSpawnCompleted(spawnTicket, move(entityList));
+        CallOnSpawnCompleted(spawnTicket, AZStd::move(entityList));
     }
-    
+
     void SpawnNodeable::RequestSpawn(
         AzFramework::EntitySpawnTicket spawnTicket,
         AZ::EntityId parentId,

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariable.cpp
@@ -283,7 +283,7 @@ namespace ScriptCanvas
     GraphVariable::GraphVariable(Deprecated::VariableNameValuePair&& valuePair)
         : GraphVariable(AZStd::move(valuePair.m_varDatum.GetData()))
     {
-        SetVariableName(AZStd::move(valuePair.GetVariableName()));
+        SetVariableName(valuePair.GetVariableName());
         m_variableId = valuePair.m_varDatum.GetId();
 
         if (valuePair.m_varDatum.ExposeAsComponentInput())

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestNodes.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestNodes.cpp
@@ -19,7 +19,7 @@ namespace TestNodes
 {
     //////////////////////////////////////////////////////////////////////////////
     void TestResult::OnInit()
-    {        
+    {
         Node::AddSlot(ScriptCanvas::CommonSlots::GeneralInSlot());
         Node::AddSlot(ScriptCanvas::CommonSlots::GeneralOutSlot());
 
@@ -210,7 +210,7 @@ namespace TestNodes
 
             slotConfiguration.m_name = "View";
             slotConfiguration.m_toolTip = "Input string_view object";
-            slotConfiguration.ConfigureDatum(AZStd::move(ScriptCanvas::Datum(ScriptCanvas::Data::Type::String(), ScriptCanvas::Datum::eOriginality::Copy)));
+            slotConfiguration.ConfigureDatum(ScriptCanvas::Datum(ScriptCanvas::Data::Type::String(), ScriptCanvas::Datum::eOriginality::Copy));
             slotConfiguration.SetConnectionType(ScriptCanvas::ConnectionType::Input);
 
             AddSlot(slotConfiguration);
@@ -277,7 +277,7 @@ namespace TestNodes
         Node::AddSlot(ScriptCanvas::CommonSlots::GeneralOutSlot());
         Node::AddSlot(ScriptCanvas::DataSlotConfiguration(ScriptCanvas::Data::Type::String(), "Result", ScriptCanvas::ConnectionType::Output));
     }
-    
+
     /////////////////////////////
     // ConfigurableUnitTestNode
     /////////////////////////////

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_MethodOverload.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_MethodOverload.cpp
@@ -208,7 +208,7 @@ public:
             }
         }
 
-        SetSlotExecutionMap(AZStd::move(ScriptCanvas::SlotExecution::Map(AZStd::move(ins), {})));
+        SetSlotExecutionMap(ScriptCanvas::SlotExecution::Map(AZStd::move(ins), {}));
     }
 
     AZStd::vector<AZStd::unique_ptr<ScriptCanvas::Nodeable>> GetInitializationNodeables() const override
@@ -419,7 +419,7 @@ TEST_F(ScriptCanvasTestFixture, Overload_NodeableNode_NumberConnection)
     ScriptCanvas::Endpoint validStartEndpoint = validSlot->GetEndpoint();
 
     ScriptCanvas::Endpoint paramEndpoint = { nodeableNode->GetEntityId(), paramId };
-    TestConnectionBetween(validStartEndpoint, paramEndpoint);    
+    TestConnectionBetween(validStartEndpoint, paramEndpoint);
 
     EXPECT_TRUE(paramOneSlot->HasDisplayType());
     EXPECT_EQ(paramOneSlot->GetDisplayType(), ScriptCanvas::Data::Type::Number());

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
@@ -156,7 +156,7 @@ namespace Terrain
             tagsInUse.insert(mapping.m_surfaceTag);
         }
 
-        return AZStd::move(tagsInUse);
+        return tagsInUse;
     }
 
     AZ::u32 EditorTerrainPhysicsColliderComponent::ConfigurationChanged()
@@ -176,7 +176,7 @@ namespace Terrain
 
     AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> TerrainPhysicsSurfaceMaterialMapping::BuildSelectableTagList() const
     {
-        return AZStd::move(Terrain::BuildSelectableTagList(m_tagListProvider, m_surfaceTag));
+        return Terrain::BuildSelectableTagList(m_tagListProvider, m_surfaceTag);
     }
 
     void TerrainPhysicsSurfaceMaterialMapping::SetTagListProvider(const EditorSurfaceTagListProvider* tagListProvider)

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainSurfaceGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainSurfaceGradientListComponent.cpp
@@ -85,12 +85,12 @@ namespace Terrain
             tagsInUse.insert(mapping.m_surfaceTag);
         }
 
-        return AZStd::move(tagsInUse);
+        return tagsInUse;
     }
 
     AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> TerrainSurfaceGradientMapping::BuildSelectableTagList() const
     {
-        return AZStd::move(Terrain::BuildSelectableTagList(m_tagListProvider, m_surfaceTag));
+        return Terrain::BuildSelectableTagList(m_tagListProvider, m_surfaceTag);
     }
 
     void TerrainSurfaceGradientMapping::SetTagListProvider(const EditorSurfaceTagListProvider* tagListProvider)

--- a/Gems/Terrain/Code/Source/EditorSurfaceTagListProvider.cpp
+++ b/Gems/Terrain/Code/Source/EditorSurfaceTagListProvider.cpp
@@ -21,7 +21,7 @@ namespace Terrain
 
         if (tagListProvider)
         {
-            tagsInUse = AZStd::move(tagListProvider->GetSurfaceTagsInUse());
+            tagsInUse = tagListProvider->GetSurfaceTagsInUse();
 
             // Filter out all tags in use from the list of registered tags
             AZStd::erase_if(availableTags, [&tagsInUse](const auto& tag)-> bool
@@ -36,6 +36,6 @@ namespace Terrain
         // Sorting for consistency
         AZStd::sort(availableTags.begin(), availableTags.end(), [](const auto& lhs, const auto& rhs) {return lhs.second < rhs.second; });
 
-        return AZStd::move(availableTags);
+        return availableTags;
     }
 }

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorViews.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxManipulatorViews.cpp
@@ -195,7 +195,7 @@ namespace WhiteBox
         AZStd::unique_ptr<ManipulatorViewPolygon> viewPolygon = AZStd::make_unique<ManipulatorViewPolygon>();
         viewPolygon->m_triangles = triangles;
         viewPolygon->m_outlines = outlines;
-        return AZStd::move(viewPolygon);
+        return viewPolygon;
     }
 
     AZStd::unique_ptr<ManipulatorViewEdge> CreateManipulatorViewEdge(const AZ::Vector3& start, const AZ::Vector3& end)
@@ -203,6 +203,6 @@ namespace WhiteBox
         AZStd::unique_ptr<ManipulatorViewEdge> viewEdge = AZStd::make_unique<ManipulatorViewEdge>();
         viewEdge->m_start = start;
         viewEdge->m_end = end;
-        return AZStd::move(viewEdge);
+        return viewEdge;
     }
 } // namespace WhiteBox


### PR DESCRIPTION
## What does this PR do?

This PR migrates uses of `AZStd::move` to `std::move` (by importing move from the std into AZStd) and cleans up the issues that surfaced.

`AZStd::move` and `std::move` have always had essentially the same signature and behavior. They're both just unconditional casts to an rvalue reference. The difference is that the compiler and its built-in diagnostics understand `std::move` intimately, but treat `AZStd::move` as an opaque function call. By switching to `std::move`, we unlock a whole category of compiler warnings and static analysis checks that were previously invisible to us.

And sure enough, once those checks kicked in, they found real problems!

The most common issue was pessimizing moves--places where `std::move` (or `AZStd::move`) was applied to a local variable being returned from a function. This sounds like it should help (thinking, "I'm done with this object, move it out!"), but it actually makes things worse. Without the move, the compiler is free to apply [Named Return Value Optimization (NRVO)](https://en.cppreference.com/w/cpp/language/copy_elision.html), which elides the copy/move entirely and constructs the object directly in the caller's memory. By wrapping the return value in a move, we force the compiler to treat it as an rvalue reference, a different type from the return type, which disqualifies NRVO. The result is that we *guarantee* a move happens where *zero* copies or moves would have happened otherwise. In some cases, especially with types that have non-trivial move constructors, this is a measurable pessimization.

There were also cases where `std::move` was applied to objects that were still used afterward, moves on trivially-copyable types where it has no effect but adds confusion, and a handful of other patterns the compiler now flags.

## How was this PR tested?

- Full clean rebuild from a cleared build directory.
- All unit tests pass.
- Editor launches and functions normally.