### PR TITLE
Add "-xobjective-c" compile flag to miniaudio.c for Apple platforms

### DIFF
--- a/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
+++ b/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
@@ -90,15 +90,14 @@ ly_install(FILES ${CMAKE_CURRENT_LIST_DIR}/Installer/Findminiaudio.cmake DESTINA
 ly_install(FILES ${miniaudio_source_dir}/miniaudio.h DESTINATION include/miniaudio COMPONENT CORE)
 ly_install(FILES ${miniaudio_source_dir}/LICENSE DESTINATION include/miniaudio COMPONENT CORE)
 
-# On Apple platforms, miniaudio.c uses Objective-C API like CoreAudio and AVFoundation.
-# Because the file has a .c extension, it by default compiles as plain C.
-# Enable the OBJC language and force miniaudio.c to compile as Objective-C.
+# On Apple platforms, miniaudio.c uses Objective-C APIs like CoreAudio and AVFoundation.
+# Because the file has a .c extension, it compiles as plain C by default.
+# So we explicitly set the compile option to treat it as an Objective-C source.
 if(APPLE)
-    enable_language(OBJC)
     set_source_files_properties(
         "${miniaudio_source_dir}/miniaudio.c"
         TARGET_DIRECTORY miniaudio
-        PROPERTIES LANGUAGE OBJC
+        PROPERTIES COMPILE_OPTIONS -xobjective-c
     )
 endif()
 


### PR DESCRIPTION
## What does this PR do?

Fixes Apple builds for the MiniAudio (again).

`miniaudio.c` needs to compile as Objective-C on Apple platforms.  
The earlier approach used `LANGUAGE OBJC`, which worked for Xcode but broke Ninja unless `OBJC` was enabled globally. This change switches to a per-source flag (`-xobjective-c`) on `miniaudio.c`, matching existing project patterns and working with both Xcode and Ninja.

## How was this PR tested?

- Confirmed Xcode build still works.
- Confirmed Ninja configure/build works.
