### PR TITLE
Update to OpenParticleSystem to allow typeids to be in the API

### DIFF
--- a/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/ParticleTypeIDs.h
+++ b/Gems/OpenParticleSystem/Code/Include/OpenParticleSystem/ParticleTypeIDs.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace OpenParticle
+{
+    //! the typeid of ParticleAsset, which can be used to specify supported asset types for drag and drop
+    constexpr const char* ParticleAssetTypeID = "86cf03d6-d1b2-4a5c-a4b8-1d3bdeb5a507";
+};

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/Asset/ParticleAsset.h
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/Asset/ParticleAsset.h
@@ -12,6 +12,7 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/containers/vector.h>
 #include <OpenParticleSystem/ParticleConfig.h>
+#include <OpenParticleSystem/ParticleTypeIDs.h>
 
 namespace OpenParticle
 {
@@ -55,7 +56,7 @@ namespace OpenParticle
     public:
         friend class ParticleAssetData;
 
-        AZ_RTTI(OpenParticle::ParticleAsset, "{86cf03d6-d1b2-4a5c-a4b8-1d3bdeb5a507}", AZ::Data::AssetData);
+        AZ_RTTI(OpenParticle::ParticleAsset, ParticleAssetTypeID, AZ::Data::AssetData);
         AZ_CLASS_ALLOCATOR(ParticleAsset, AZ::SystemAllocator, 0);
 
         static const char* DisplayName;

--- a/Gems/OpenParticleSystem/Code/openparticlesystem_api_files.cmake
+++ b/Gems/OpenParticleSystem/Code/openparticlesystem_api_files.cmake
@@ -8,4 +8,5 @@
 
 set(FILES
     Include/OpenParticleSystem/ParticleRequestBus.h
+    Include/OpenParticleSystem/ParticleTypeIDs.h
 )


### PR DESCRIPTION
## What does this PR do?

This initially adds an typeids header to the OpenParticleSystem API gem, to allow other gems
that depend on `Gem::OpenParticleSystem.API` to know typeids without having to actually export
the full class headers. 

We will probably add more typeids to this later, as well as other APIs.  This is just the simplest, first one.

If we want to use fields of type `Asset<PaticleAsset>` we'll have to find ways to clean that up too.

## How was this PR tested?

I'm using it in my updates to the MultiplayerSample, ie
```cpp
#if AZ_TRAIT_CLIENT
#include <OpenParticleSystem/ParticleTypeIDs.h>
#endif
```

```cpp
editContext->Class<GameEffect>("GameEffect", "A single game effect, consisting of a particle effect and a sound trigger pair")
                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                    ->DataElement(AZ::Edit::UIHandlers::Default, &GameEffect::m_particleAssetId, "ParticleAsset", "The particle effect to play upon effect trigger")
                        ->Attribute(AZ_CRC_CE("SupportedAssetTypes"), []() { return AZStd::vector<AZ::Data::AssetType>({ OpenParticle::ParticleAssetTypeID }); }}
```
