### PR TITLE
[LUA Editor] Prevent crash when opening lua files.

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorSyntaxHighlighter.cpp
@@ -746,7 +746,7 @@ namespace LUAEditor
 
                 // Special case to allow to lint methods via regex
                 const int nextCharPos = position + length;
-                const bool nextCharNeededForRegEx = text.at(nextCharPos) == '(' || text.at(nextCharPos) == ':';
+                const bool nextCharNeededForRegEx = (nextCharPos < text.size()) && (text.at(nextCharPos) == '(' || text.at(nextCharPos) == ':');
 
                 const QString dhText = nextCharNeededForRegEx ? text.mid(position, length + 1) : text.mid(position, length);
                 for (const HighlightingRule& rule : m_highlightingRules)


### PR DESCRIPTION
## What does this PR do?

I noticed sometimes when opening lua files that the lua editor is just crashing. As the patch itself shows trying to access the element in 'text' at nextCharPos was the issue when we reached the end of the file.

## How was this PR tested?

Tested on my computer.
