### PR TITLE
Fix Wignored-attributes warnings

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/PoolAllocator.h
+++ b/Code/Framework/AzCore/AzCore/Memory/PoolAllocator.h
@@ -188,9 +188,8 @@ namespace AZ::Internal
 
 namespace AZ
 {
-    // Extern the PoolAllocatorHelper<PoolSchema> AZ::AzTypeInfo template to
-    // to reduce instantations
-    extern template struct AZCORE_API AzTypeInfo<Internal::PoolAllocatorHelper<PoolSchema>>;
+    // Extern the PoolAllocatorHelper<PoolSchema> AZ::AzTypeInfo template to reduce instantiations
+    extern template struct AzTypeInfo<Internal::PoolAllocatorHelper<PoolSchema>>;
     /*!
      * Pool allocator
      * Specialized allocation for extremely fast small object memory allocations.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/EditorBaseComponentMode.cpp
@@ -11,8 +11,8 @@
 
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
-DECLARE_EBUS_INSTANTIATION(AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests);
-DECLARE_EBUS_INSTANTIATION_WITH_TRAITS(AzToolsFramework::ComponentModeFramework::ComponentModeDelegateRequests, AzToolsFramework::ComponentModeFramework::ComponentModeMouseViewportRequests)
+AZ_INSTANTIATE_EBUS_SINGLE_ADDRESS(AZTF_API, AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests);
+AZ_INSTANTIATE_EBUS_MULTI_ADDRESS_WITH_TRAITS(AZTF_API, AzToolsFramework::ComponentModeFramework::ComponentModeDelegateRequests, AzToolsFramework::ComponentModeFramework::ComponentModeMouseViewportRequests)
 
 namespace AzToolsFramework
 {


### PR DESCRIPTION
## What does this PR do?

`EditorBaseComponentMode.cpp` used `DECLARE_EBUS_INSTANTIATION` / `DECLARE_EBUS_INSTANTIATION_WITH_TRAITS` macros for explicit template instantiation, which do not apply `dllexport`. However, the corresponding extern declarations in `EditorComponentModeBus.h` use `AZ_DECLARE_EBUS_SINGLE_ADDRESS` / `AZ_DECLARE_EBUS_MULTI_ADDRESS_WITH_TRAITS` macros with `AZTF_API`, which apply `dllexport` to the extern declaration.

This attribute mismatch was previously silent, but LLVM/Clang 22 added a new `-Wignored-attributes` diagnostic that flags when an explicit template instantiation definition is missing an attribute (`dllexport`) that was present on the corresponding extern declaration. With `-Werror` enabled, this becomes a build failure.

The fix replaces the old macros with `AZ_INSTANTIATE_EBUS_SINGLE_ADDRESS` and `AZ_INSTANTIATE_EBUS_MULTI_ADDRESS_WITH_TRAITS`, which apply `AZ_DLL_EXPORT` to the definitions, matching the extern declarations.

## How was this PR tested?

Verified that the Clang 22 build completes with zero compilation errors and warnings. No runtime testing was performed outside of automated tests.