### PR TITLE
Adds a warning message if the Mesh Renderer is used

### DIFF
--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.cpp
@@ -241,10 +241,15 @@ namespace OpenParticleSystemEditor
         {
             m_materialAssetWidget->setVisible(true);
         }
-        else if (m_moduleName.c_str() == m_rendererClasses[MESH_RENDERER_INDEX].first)
+        else if (IsMeshRenderer())
         {
             m_materialAssetWidget->setVisible(true);
             m_modelAssetWidget->setVisible(true);
         }
     }
-}
+
+    bool ComboBoxWidget::IsMeshRenderer() const
+    {
+        return m_moduleName.c_str() == m_rendererClasses[MESH_RENDERER_INDEX].first;
+    }
+} // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
@@ -68,6 +68,8 @@ namespace OpenParticleSystemEditor
             AZ::Data::Asset<AZ::RPI::ModelAsset>* modelAsset,
             AZ::Data::Asset<AZ::RPI::ModelAsset>* skeletonModelAsset);
 
+        bool IsMeshRenderer() const;
+
     private slots:
         void OnIndexChanged(const QString& curString);
 

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
@@ -207,11 +207,23 @@ namespace OpenParticleSystemEditor
                 break;
             }
         }
+        CheckWarningText();
+    }
+
+    void EffectorInspector::CheckWarningText()
+    {
+        bool shouldBeVisible = false;
+        if (m_comboBoxWidget != nullptr)
+        {
+            shouldBeVisible = m_comboBoxWidget->IsMeshRenderer();
+        }
+
+        m_ui->meshWarningLabel->setVisible(shouldBeVisible);
     }
 
     void EffectorInspector::SetClassName(const QString& className, const QIcon& icon)
     {
-        m_ui->itemName->setText(className);
+        m_ui->itemName->setText(QCoreApplication::translate("OpenParticleSystem", qUtf8Printable(className)));
         m_ui->itemTitleIco->setIcon(icon);
     }
 
@@ -237,6 +249,7 @@ namespace OpenParticleSystemEditor
             m_comboBoxWidget->Refresh(m_detail->m_modules[className.data()][moduleName.data()].second);
         }
         EBUS_EVENT_ID(m_widgetName, OpenParticleSystemEditor::ParticleDocumentRequestBus, NotifyParticleSourceDataModified);
+        CheckWarningText();
     }
 
     void EffectorInspector::UpdatePropertyEditorWidget(const AZStd::string moduleName, const AZStd::string className, bool bCheck)
@@ -322,57 +335,58 @@ namespace OpenParticleSystemEditor
         case OpenParticleSystemEditor::WIDGET_LINE_TITLE:
         case OpenParticleSystemEditor::WIDGET_LINE_BLANK:
         case OpenParticleSystemEditor::WIDGET_LINE_EMITTER:
-            SetClassName(tr("Emitter"), QIcon(":/ColorPickerDialog/ColorGrid/toggle-normal-on.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Emitter"), QIcon(":/ColorPickerDialog/ColorGrid/toggle-normal-on.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_EMITTER]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_SPAWN:
-            SetClassName(tr("Spawn"), QIcon(":/Gallery/Grid-small.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Spawn"), QIcon(":/Gallery/Grid-small.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_SPAWN]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_PARTICLES:
-            SetClassName(tr("Particles"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Particles"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_PARTICLES]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_LOCATION:
-            SetClassName(tr("Shape"), QIcon(":/stylesheet/img/UI20/toolbar/SketchMode.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Shape"), QIcon(":/stylesheet/img/UI20/toolbar/SketchMode.svg"));
             ClickComboBoxWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_LOCATION]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_VELOCITY:
-            SetClassName(tr("Velocity"), QIcon(":/stylesheet/img/UI20/toolbar/joints/SwingLimits.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Velocity"), QIcon(":/stylesheet/img/UI20/toolbar/joints/SwingLimits.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_VELOCITY]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_COLOR:
-            SetClassName(tr("Color"), QIcon(":/ColorPickerDialog/ColorGrid/eyedropper-normal.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Color"), QIcon(":/ColorPickerDialog/ColorGrid/eyedropper-normal.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_COLOR]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_SIZE:
-            SetClassName(tr("Size"), QIcon(":/stylesheet/img/UI20/toolbar/Measure.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Size"), QIcon(":/stylesheet/img/UI20/toolbar/Measure.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_SIZE]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_FORCE:
-            SetClassName(tr("Force"), QIcon(":/stylesheet/img/UI20/toolbar/joints/MaxForce.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Force"), QIcon(":/stylesheet/img/UI20/toolbar/joints/MaxForce.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_FORCE]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_LIGHT:
-            SetClassName(tr("Light"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Light"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_LIGHT]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_SUBUV:
-            SetClassName(tr("SubUV"), QIcon(":/stylesheet/img/UI20/toolbar/XY2_copy.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "SubUV"), QIcon(":/stylesheet/img/UI20/toolbar/XY2_copy.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_SUBUV]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_EVENT:
-            SetClassName(tr("Event"), QIcon(":/stylesheet/img/logging/pending.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Event"), QIcon(":/stylesheet/img/logging/pending.svg"));
             ClickEventWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_EVENT]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_RENDERER:
-            SetClassName(tr("Renderer"), QIcon(":/stylesheet/img/UI20/toolbar/AutoFit.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Renderer"), QIcon(":/stylesheet/img/UI20/toolbar/AutoFit.svg"));
             ClickComboBoxWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_RENDERER]);
             break;
         default:
             break;
         }
         m_ui->particleName->setEnabled(true);
+        CheckWarningText();
     }
 
     // AzToolsFramework::IPropertyEditorNotify overrides...
@@ -476,6 +490,7 @@ namespace OpenParticleSystemEditor
             }
         }
         EBUS_EVENT_ID(m_widgetName, OpenParticleSystemEditor::ParticleDocumentRequestBus, NotifyParticleSourceDataModified);
+        CheckWarningText();
     }
     
     bool EffectorInspector::AfterVortexForceModified(AzToolsFramework::InstanceDataNode* pNode)
@@ -539,6 +554,8 @@ namespace OpenParticleSystemEditor
         m_ui->particleName->setText("");
         m_ui->itemTitleIco->setIcon(QIcon(""));
         m_ui->itemName->setText("");
+
+        CheckWarningText();
     }
 
     AZStd::vector<AZStd::string> EffectorInspector::GetEmitterNames()

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.h
@@ -90,6 +90,8 @@ namespace OpenParticleSystemEditor
         bool AfterSpawnRotationModified(AzToolsFramework::InstanceDataNode* pNode);
         bool AfterVector3Modifed(AzToolsFramework::InstanceDataNode* pNode, AZ::u8 classIndex, AZ::u8 moduleIndex);
 
+        void CheckWarningText();
+
     private:
         AZ::SerializeContext* m_serializeContext = nullptr;
         ComboBoxWidget* m_comboBoxWidget = nullptr;

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.ui
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.ui
@@ -124,7 +124,7 @@
        <item row="0" column="0">
         <layout class="QVBoxLayout" name="verticalLayout"/>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -136,6 +136,19 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="meshWarningLabel">
+         <property name="frameShape">
+          <enum>QFrame::Box</enum>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;⚠️Warning: The &amp;quot;Mesh&amp;quot; Renderer is still under development and may cause instability or other problems. Do not use it in production.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
## What does this PR do?

We do want to support Mesh Render, and once fixed, it will work in the same way as this UI already shows, and we don't want to actually delete all the data and classes related to it, but we want to make sure users know that it is not currently supported.

Also fixes a translation error in the same file.

<img width="604" height="642" alt="image" src="https://github.com/user-attachments/assets/76da0ec7-8b34-41af-86e2-66cb80504235" />

## How was this PR tested?

manual testing - having multiple particles open and clicking between them to ensure the warning ONLY appears if you have manually selected the "Mesh" render type.  Also changing the checkboxes and combo boxes selection to unselect/reselect the Mesh render type to make sure it dynamically disappears and appears.

Note that the reason we need this warning is that the mesh renderer currently uses a large chunk of duplicated custom shader and material code from the regular forward renderer, instead of using the normal forward renderer itself.  This causes problems as the forward renderer diverges, grows additional features, or changes the pipeline and is a lot of duplication.  the other problem this causes is that copying only the normal forward renderer means it doesn't work on the mobile, multi-view, or low end pipelines, either, without duplicating all of those, as well as maintaining them as they diverge.

This is untenable, so its going to get this warning until we can find a way to let people just choose a mesh and material like normal, and then use the normal renderer to do it (via instancing or whatever)