### PR TITLE
Remove Gradle Job Summary from Workflow Summary

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -224,10 +224,12 @@ jobs:
           toolset: ${{ inputs.msvc_toolset_version }}
 
       - name: Setup gradle
-        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 #v4.4.2
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         if: ${{ inputs.gradle_version }}
         with:
           gradle-version: '${{ inputs.gradle_version }}'
+          add-job-summary: on-failure
+
       - name: Configure environment
         # Install dependencies for gradle and clang builds from the NDK
         continue-on-error: true


### PR DESCRIPTION
## What does this PR do?

The `gradle/actions/setup-gradle` action adds a number of reports to the AR workflow. There isn't much useful information here, and it just crowds a space that could be useful in the future for more detailed reports (like CMake profiles, ccache stats, test reports, etc.).

This change disables it (except when the step fails), and bumps the version of setup-gradle from v4.4.2 to v5.0.2

<img width="1028" height="1050" alt="image" src="https://github.com/user-attachments/assets/08e81126-19a2-4f48-94fd-acbb494fd036" />

## How was this PR tested?

Ensured Gradle is still installed like normal, and that the report is not appended to the workflow summary.
