### PR TITLE
Update bundled CMake to 4.2.3 and build configurations (#19592)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,32 @@ include(cmake/FileUtil.cmake)
 include(cmake/Version.cmake)
 include(cmake/OutputDirectory.cmake)
 
+# The desired CMake version to ship with installers and recommend to users.
+set(CPACK_DESIRED_CMAKE_VERSION 4.2.3)
+
+# Visual Studio 2026 (VS 18.x) requires CMake 4.2 or later.
+if(CMAKE_GENERATOR MATCHES "Visual Studio 18" AND CMAKE_VERSION VERSION_LESS "4.2")
+    message(WARNING
+        "Visual Studio 2026 detected with CMake ${CMAKE_VERSION}. "
+        "CMake 4.2 or later is required for Visual Studio 2026 support. "
+        "We test with CMake ${CPACK_DESIRED_CMAKE_VERSION}. If you experience issues, consider upgrading to this version or later."
+    )
+endif()
+
 if(NOT PROJECT_NAME)
     include(cmake/CompilerSettings.cmake)
     project(O3DE
         LANGUAGES C CXX
         VERSION ${O3DE_INSTALL_VERSION_STRING}
+    )
+endif()
+
+# Xcode 26.x requires CMake 4.2 or later. XCODE_VERSION is only available after project().
+if(CMAKE_GENERATOR STREQUAL "Xcode" AND XCODE_VERSION VERSION_GREATER_EQUAL "26.0" AND CMAKE_VERSION VERSION_LESS "4.2")
+    message(WARNING
+        "Xcode ${XCODE_VERSION} detected with CMake ${CMAKE_VERSION}. "
+        "CMake 4.2 or later is required for Xcode 26.x support. "
+        "We test with CMake ${CPACK_DESIRED_CMAKE_VERSION}. If you experience issues, consider upgrading to this version or later."
     )
 endif()
 

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -39,7 +39,7 @@ set(CPACK_SNAP_DISTRO "" CACHE STRING
 )
 
 set(CPACK_THREADS 0)
-set(CPACK_DESIRED_CMAKE_VERSION 3.24.0)
+# CPACK_DESIRED_CMAKE_VERSION is defined in the root CMakeLists.txt
 if(${CPACK_DESIRED_CMAKE_VERSION} VERSION_LESS ${CMAKE_MINIMUM_REQUIRED_VERSION})
     message(FATAL_ERROR
         "The desired version of CMake to be included in the package is "
@@ -146,7 +146,7 @@ set(CPACK_PACKAGE_CHECKSUM SHA256) # Generate checksum file
 set(CPACK_PRE_BUILD_SCRIPTS ${pal_dir}/PackagingPreBuild_${PAL_HOST_PLATFORM_NAME_LOWERCASE}.cmake)
 set(CPACK_POST_BUILD_SCRIPTS ${pal_dir}/PackagingPostBuild_${PAL_HOST_PLATFORM_NAME_LOWERCASE}.cmake)
 set(CPACK_CODESIGN_SCRIPT ${pal_dir}/PackagingCodeSign_${PAL_HOST_PLATFORM_NAME_LOWERCASE}.cmake)
-set(CPACK_LY_PYTHON_CMD ${LY_PYTHON_CMD})
+set(CPACK_LY_PYTHON_CMD "${PYTHON_VENV_PATH}/${LY_PYTHON_VENV_PYTHON}" "-s")
 
 # IMPORTANT: required to be included AFTER setting all property overrides
 include(CPack REQUIRED)

--- a/cmake/Platform/Common/PackagingPostBuild_common.cmake
+++ b/cmake/Platform/Common/PackagingPostBuild_common.cmake
@@ -39,10 +39,10 @@ function(ly_upload_to_url in_url in_local_path in_file_regex)
     file(TO_NATIVE_PATH "${LY_ROOT_FOLDER}/scripts/build/tools/upload_to_s3.py" _upload_script)
 
     set(_upload_command
-        ${CPACK_LY_PYTHON_CMD} -s
+        ${CPACK_LY_PYTHON_CMD}
         -u ${_upload_script}
         --base_dir ${in_local_path}
-        --file_regex="${in_file_regex}"
+        --file_regex ${in_file_regex}
         --bucket ${_bucket}
         --key_prefix ${_prefix}
         --extra_args ${_extra_args}

--- a/cmake/Platform/Linux/Packaging_linux.cmake
+++ b/cmake/Platform/Linux/Packaging_linux.cmake
@@ -8,7 +8,7 @@
 
 set(_cmake_package_name "cmake-${CPACK_DESIRED_CMAKE_VERSION}-linux-x86_64")
 set(CPACK_CMAKE_PACKAGE_FILE "${_cmake_package_name}.tar.gz")
-set(CPACK_CMAKE_PACKAGE_HASH "726f88e6598523911e4bce9b059dc20b851aa77f97e4cc5573f4e42775a5c16f")
+set(CPACK_CMAKE_PACKAGE_HASH "5bb505d5e0cca0480a330f7f27ccf52c2b8b5214c5bba97df08899f5ef650c23")
 
 set(O3DE_INCLUDE_INSTALL_IN_PACKAGE FALSE CACHE BOOL "Option to copy the contents of the most recent install from CMAKE_INSTALL_PREFIX into CPACK_PACKAGING_INSTALL_PREFIX.  Useful for including a release build in a profile SDK.")
 

--- a/cmake/Platform/Windows/Packaging_windows.cmake
+++ b/cmake/Platform/Windows/Packaging_windows.cmake
@@ -25,7 +25,7 @@ set(CPACK_GENERATOR WIX)
 
 set(_cmake_package_name "cmake-${CPACK_DESIRED_CMAKE_VERSION}-windows-x86_64")
 set(CPACK_CMAKE_PACKAGE_FILE "${_cmake_package_name}.zip")
-set(CPACK_CMAKE_PACKAGE_HASH "b1ad8c2dbf0778e3efcc9fd61cd4a962e5c1af40aabdebee3d5074bcff2e103c")
+set(CPACK_CMAKE_PACKAGE_HASH "eb4ebf5155dbb05436d675706b2a08189430df58904257ae5e91bcba4c86933c")
 
 # workaround for shortening the path cpack installs to by stripping the platform directory
 set(CPACK_TOPLEVEL_TAG "")


### PR DESCRIPTION
## What does this PR do?

Cherry pick of https://github.com/o3de/o3de/pull/19592 to bring bundled CMake in parity in development

## How was this PR tested?

Tested on my fork
