### PR TITLE
Refactor AZStd Allocators

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/Path/Path_fwd.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path_fwd.h
@@ -12,14 +12,14 @@
 
 namespace AZStd
 {
-    class allocator;
+    struct allocator;
 
     template <class Element>
     struct char_traits;
 
     template <class Element, class Traits, class Allocator>
     class basic_string;
-    
+
     template <class Element, size_t MaxElementCount, class Traits>
     class basic_fixed_string;
 

--- a/Code/Framework/AzCore/AzCore/Memory/AllocatorWrapper.h
+++ b/Code/Framework/AzCore/AzCore/Memory/AllocatorWrapper.h
@@ -18,7 +18,7 @@ namespace AZ
     * Safe wrapper for an instance of an allocator.
     *
     * Generally it is preferred to use AllocatorInstance<> for allocator singletons over this wrapper,
-    * but you may want to use this wrapper in particular when scoping a custom allocator to the lifetime 
+    * but you may want to use this wrapper in particular when scoping a custom allocator to the lifetime
     * of some other object.
     */
     template<class Allocator>
@@ -86,6 +86,6 @@ namespace AZ
 
     private:
         Allocator* m_allocator = nullptr;
-        typename AZStd::aligned_storage<sizeof(Allocator), AZStd::alignment_of<Allocator>::value>::type m_storage;
+        AZStd::aligned_storage_t<sizeof(Allocator), AZStd::alignment_of_v<Allocator>> m_storage;
     };
 }

--- a/Code/Framework/AzCore/AzCore/Memory/IAllocator.h
+++ b/Code/Framework/AzCore/AzCore/Memory/IAllocator.h
@@ -15,9 +15,7 @@
     using pointer = VALUETYPE*; \
     using size_type = AZStd::size_t; \
     using difference_type = AZStd::ptrdiff_t; \
-    using align_type = AZStd::size_t; \
-    using propagate_on_container_copy_assignment = AZStd::true_type; \
-    using propagate_on_container_move_assignment = AZStd::true_type;
+    using align_type = AZStd::size_t;
 
 #define AZ_ALLOCATOR_DEFAULT_TRAITS AZ_ALLOCATOR_TRAITS(void)
 

--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -26,7 +26,7 @@ namespace AZ
 
 namespace AZStd
 {
-    class allocator;
+    struct allocator;
     template <class T>
     struct less;
     template <class T>

--- a/Code/Framework/AzCore/AzCore/std/allocator.h
+++ b/Code/Framework/AzCore/AzCore/std/allocator.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZSTD_ALLOCATOR_H
-#define AZSTD_ALLOCATOR_H 1
+
+#pragma once
 
 #include <AzCore/std/base.h>
 #include <AzCore/std/typetraits/integral_constant.h>
@@ -17,42 +17,33 @@ namespace AZStd
     /**
      * \page Allocators
      *
-     * AZStd uses simple and fast allocator model, it does not follow the \ref CStd. It is not templated on any type, thus is doesn't care about
-     * construction or destruction. We do require
-     * name support, in most cases should be just a pointer to a literal.
+     * AZStd uses a simple, non-templated allocator model.
+     * Unlike std::allocator, AZStd allocators are not parameterized on a value type,
+     * they operate on raw bytes with explicit size and alignment parameters.
+     * This makes them lightweight and avoids per-type allocator instantiation.
      *
-     * This is the specification for an AZSTD allocator:
+     * AZStd allocators support alignment directly in allocate/deallocate,
+     * which differs from std::allocator where alignment is handled implicitly via operator new.
+     *
+     * Allocator type requirements for use with AZStd containers:
      * \code
-     * class allocator
+     * struct allocator
      * {
-     * public:
-     *  // Type of the returned pointer. Usually void*
-     *  typedef <impl defined>  pointer;
-     *  // Size type, any container using this allocator will use this size_type. Usually AZStd::size_t
-     *  typedef <impl defined>  size_type;
-     *  // Pointer difference type, usually AZStd::ptrdiff_t.
-     *  typedef <impl defined>  difference_type;
+     *     using value_type = void;
+     *     using size_type = size_t;
+     *     using difference_type = ptrdiff_t;
+     *     using align_type = size_t;
      *
-     *  allocator(const char* name = "AZSTD Allocator");
-     *  allocator(const allocator& rhs);
-     *  allocator(const allocator& rhs, const char* name);
-     *  allocator& operator=(const allocator& rhs;
+     *     [[nodiscard]] void* allocate(size_type byteSize, size_type alignment);
+     *     void deallocate(void* ptr, size_type byteSize, size_type alignment);
      *
-     *  pointer      allocate(size_type byteSize, size_type alignment);
-     *  void         deallocate(pointer ptr, size_type byteSize, size_type alignment);
-     *  /// Tries to resize an existing memory chunck. Returns the resized memory block or 0 if resize is not supported.
-     *  size_type    resize(pointer ptr, size_type newSize);
+     *     // Optional
+     *     [[nodiscard]] void* reallocate(void* ptr, size_type newSize, align_type alignment = 1);
+     *     size_type max_size() const;
+     *     size_type get_allocated_size() const;
      *
-     *  const char* get_name() const;
-     *  void        set_name(const char* name);
-     *
-     *  // Returns theoretical maximum size of a single contiguous allocation from this allocator.
-     *  size_type               max_size() const;
-     *  <optional> size_type    get_allocated_size() const;
+     *     friend bool operator==(const allocator&, const allocator&);
      * };
-     *
-     * bool operator==(const allocator& a, const allocator& b);
-     * bool operator!=(const allocator& a, const allocator& b);
      * \endcode
      *
      * \li \ref allocator "Default Allocator"
@@ -60,111 +51,81 @@ namespace AZStd
      * \li \ref static_buffer_allocator "Static Buffer Allocator"
      * \li \ref static_pool_allocator "Static Pool Allocator"
      * \li \ref allocator_ref "Allocator Reference"
-     *
      */
 
     /**
-     * All allocation will be piped to AZ::SystemAllocator, make sure it is created!
+     * Default allocator
+     *
+     * All allocations are forwarded to AZ::SystemAllocator.
+     * This is a stateless allocator; all instances compare equal.
      */
-    class AZCORE_API allocator
+    struct AZCORE_API allocator
     {
-    public:
         using value_type = void;
         using pointer = void*;
-        using size_type = AZStd::size_t;
-        using difference_type = AZStd::ptrdiff_t;
-        using align_type = AZStd::size_t;
-        using propagate_on_container_copy_assignment = AZStd::true_type;
-        using propagate_on_container_move_assignment = AZStd::true_type;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
+        using align_type = size_t;
 
-        AZ_FORCE_INLINE allocator() = default;
-        AZ_FORCE_INLINE allocator(const char*) {};
-        AZ_FORCE_INLINE allocator(const allocator& rhs) = default;
-        AZ_FORCE_INLINE allocator([[maybe_unused]] const allocator& rhs, [[maybe_unused]] const char* name) {}
-        AZ_FORCE_INLINE allocator& operator=(const allocator& rhs) = default;
+        allocator() = default;
+        allocator(const allocator&) = default;
+        allocator& operator=(const allocator&) = default;
 
-        pointer allocate(size_type byteSize, size_type alignment);
+        [[nodiscard]] pointer allocate(size_type byteSize, size_type alignment);
         void deallocate(pointer ptr, size_type byteSize, size_type alignment);
-        pointer reallocate(pointer ptr, size_type newSize, align_type alignment = 1);
+        [[nodiscard]] pointer reallocate(pointer ptr, size_type newSize, align_type alignment = 1);
 
-        size_type max_size() const
+        constexpr size_type max_size() const
         {
             return AZ_TRAIT_OS_MEMORY_MAX_ALLOCATOR_SIZE;
         }
 
-        size_type get_allocated_size() const
+        constexpr size_type get_allocated_size() const
         {
             return 0;
         }
 
-        AZ_FORCE_INLINE bool is_lock_free()
+        constexpr bool is_lock_free() const
         {
             return false;
         }
 
-        AZ_FORCE_INLINE bool is_stale_read_allowed()
+        constexpr bool is_stale_read_allowed() const
         {
             return false;
         }
 
-        AZ_FORCE_INLINE bool is_delayed_recycling()
+        constexpr bool is_delayed_recycling() const
         {
             return false;
         }
+
+        friend bool operator==(const allocator&, const allocator&) = default;
     };
-
-    AZ_FORCE_INLINE bool operator==(const AZStd::allocator& a, const AZStd::allocator& b)
-    {
-        (void)a;
-        (void)b;
-        return true;
-    }
-
-    AZ_FORCE_INLINE bool operator!=(const AZStd::allocator& a, const AZStd::allocator& b)
-    {
-        (void)a;
-        (void)b;
-        return false;
-    }
 
     /**
-    * No Default allocator implementation (invalid allocator).
-    * - If you want to make sure we don't use default allocator, define \ref AZStd::allocator to AZStd::no_default_allocator (this allocator)
-    *  the code which try to use it, will not compile.
-    *
-    * - If you have a compile error here, this means that
-    * you did not provide allocator to your container. This
-    * is intentional so you make sure where do you allocate from. If this is not
-    * the AZStd integration this means that you might have defined in your
-    * code a default allocator or even have predefined container types. Use them.
-    */
-    class AZCORE_API no_default_allocator
+     * Intentionally broken allocator used by fixed-size containers.
+     *
+     * If a container attempts to allocate through this,
+     * you get a compile-time error indicating that you must provide a real allocator.
+     */
+    struct AZCORE_API no_default_allocator final
     {
-    public:
         using pointer = void*;
-        using size_type = AZStd::size_t;
-        using difference_type = AZStd::ptrdiff_t;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
 
-        AZ_FORCE_INLINE no_default_allocator(const char* name = "Invalid allocator") { (void)name; }
-        AZ_FORCE_INLINE no_default_allocator(const allocator&) {}
-        AZ_FORCE_INLINE no_default_allocator(const allocator&, const char*) {}
+        no_default_allocator() = default;
+        no_default_allocator(const no_default_allocator&) = default;
+        no_default_allocator& operator=(const no_default_allocator&) = default;
 
-        // none of this functions are implemented we should get a link error if we use them!
-        AZ_FORCE_INLINE allocator& operator=(const allocator& rhs);
-        AZ_FORCE_INLINE pointer allocate(size_type byteSize, size_type alignment);
-        AZ_FORCE_INLINE void  deallocate(pointer ptr, size_type byteSize, size_type alignment);
-        AZ_FORCE_INLINE size_type    resize(pointer ptr, size_type newSize);
-
-        AZ_FORCE_INLINE const char*  get_name() const;
-        AZ_FORCE_INLINE void         set_name(const char* name);
-
-        AZ_FORCE_INLINE size_type   max_size() const;
-
-        AZ_FORCE_INLINE bool is_lock_free();
-        AZ_FORCE_INLINE bool is_stale_read_allowed();
-        AZ_FORCE_INLINE bool is_delayed_recycling();
+        // All operations are deleted to produce compile-time errors if used
+        pointer allocate(size_type byteSize, size_type alignment) = delete;
+        void deallocate(pointer ptr, size_type byteSize, size_type alignment) = delete;
+        size_type resize(pointer ptr, size_type newSize) = delete;
+        size_type max_size() const = delete;
+        bool is_lock_free() = delete;
+        bool is_stale_read_allowed() = delete;
+        bool is_delayed_recycling() = delete;
     };
 }
-
-#endif // AZSTD_ALLOCATOR_H
-#pragma once

--- a/Code/Framework/AzCore/AzCore/std/allocator_ref.h
+++ b/Code/Framework/AzCore/AzCore/std/allocator_ref.h
@@ -14,50 +14,56 @@
 namespace AZStd
 {
     /**
-    * This allocator allows us to share allocator instance between different containers.
-    */
+     * This allocator allows us to share allocator instance between different containers.
+     */
     template<class Allocator>
-    class allocator_ref
+    struct allocator_ref
     {
-        typedef allocator_ref<Allocator> this_type;
-    public:
         using pointer = typename Allocator::pointer;
         using size_type = typename Allocator::size_type;
         using difference_type = typename Allocator::difference_type;
-        using allocator_pointer = Allocator *;
-        using allocator_reference = Allocator &;
+        using allocator_pointer = Allocator*;
+        using allocator_reference = Allocator&;
 
         AZ_FORCE_INLINE allocator_ref(allocator_reference allocator)
             : m_allocator(&allocator) {}
-        AZ_FORCE_INLINE allocator_ref(const allocator_ref& rhs) = default;
-        AZ_FORCE_INLINE allocator_ref(allocator_ref&& rhs) = default;
-        AZ_FORCE_INLINE allocator_ref& operator=(const allocator_ref& rhs) = default;
-        AZ_FORCE_INLINE allocator_ref& operator=(allocator_ref&& rhs) = default;
 
-        constexpr size_type          max_size() const { return m_allocator->max_size(); }
+        constexpr size_type max_size() const
+        {
+            return m_allocator->max_size();
+        }
 
-        AZ_FORCE_INLINE size_type   get_allocated_size() const  { return m_allocator->get_allocated_size(); }
+        AZ_FORCE_INLINE size_type get_allocated_size() const
+        {
+            return m_allocator->get_allocated_size();
+        }
 
-        AZ_FORCE_INLINE pointer allocate(size_type byteSize, size_type alignment) { return m_allocator->allocate(byteSize, alignment); }
+        [[nodiscard]] AZ_FORCE_INLINE pointer allocate(size_type byteSize, size_type alignment)
+        {
+            return m_allocator->allocate(byteSize, alignment);
+        }
 
-        AZ_FORCE_INLINE void  deallocate(pointer ptr, size_type byteSize, size_type alignment) { m_allocator->deallocate(ptr, byteSize, alignment); }
+        AZ_FORCE_INLINE void deallocate(pointer ptr, size_type byteSize, size_type alignment)
+        {
+            m_allocator->deallocate(ptr, byteSize, alignment);
+        }
 
-        AZ_FORCE_INLINE size_type    resize(pointer ptr, size_type newSize)                    { return m_allocator->resize(ptr, newSize); }
+        AZ_FORCE_INLINE size_type resize(pointer ptr, size_type newSize)
+        {
+            return m_allocator->resize(ptr, newSize);
+        }
 
-        AZ_FORCE_INLINE allocator_reference get_allocator() const           { return *m_allocator; }
+        AZ_FORCE_INLINE allocator_reference get_allocator() const
+        {
+            return *m_allocator;
+        }
+
+        friend bool operator==(const allocator_ref& a, const allocator_ref& b)
+        {
+            return a.get_allocator() == b.get_allocator();
+        }
+
     private:
         allocator_pointer m_allocator;
     };
-
-    template<class Allocator>
-    AZ_FORCE_INLINE bool operator==(const AZStd::allocator_ref<Allocator>& a, const AZStd::allocator_ref<Allocator>& b)
-    {
-        return (a.get_allocator() == b.get_allocator());
-    }
-
-    template<class Allocator>
-    AZ_FORCE_INLINE bool operator!=(const AZStd::allocator_ref<Allocator>& a, const AZStd::allocator_ref<Allocator>& b)
-    {
-        return (a.get_allocator() != b.get_allocator());
-    }
 }

--- a/Code/Framework/AzCore/AzCore/std/allocator_stack.h
+++ b/Code/Framework/AzCore/AzCore/std/allocator_stack.h
@@ -5,34 +5,26 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZSTD_ALLOCATOR_STACK_H
-#define AZSTD_ALLOCATOR_STACK_H
+
+#pragma once
 
 #include <AzCore/std/base.h>
 #include <AzCore/std/typetraits/integral_constant.h>
 #include <AzCore/std/typetraits/aligned_storage.h>
 #include <AzCore/std/typetraits/alignment_of.h>
 
-#define AZ_STACK_ALLOCATOR(_Variable, _Size)     AZStd::stack_allocator _Variable(alloca(_Size), _Size);
+#define AZ_STACK_ALLOCATOR(_Variable, _Size) ::AZStd::stack_allocator _Variable(alloca(_Size), _Size);
 
-#define AZ_ALLOCA(_Size)    alloca(_Size)
-
-namespace AZ
-{
-    namespace Internal
-    {
-        struct AllocatorDummy;
-    }
-}
+#define AZ_ALLOCA(_Size) alloca(_Size)
 
 namespace AZStd
 {
     /**
      * Allocator that allocates memory from the stack (which you provide)
-     * The memory chunk is grabbed on construction, you CAN'T
-     * new this object. The memory will be alive only while the object
-     * exist. DON'T USE this allocator unless you are SURE you know what you are
-     * doing, it's dangerous and tricky to manage.
+     * The memory chunk is grabbed on construction, you CAN'T new this object.
+     * The memory will be alive only while the object exist.
+     * DON'T USE this allocator unless you are SURE you know what you are doing, it's dangerous and tricky to manage.
+     *
      * How to use:
      * void MyFunction()
      * {
@@ -41,92 +33,76 @@ namespace AZStd
      *     // NO reference to any memory after myAllocator goes out of scope.
      * }
      */
-    class stack_allocator
+    struct stack_allocator
     {
-        typedef stack_allocator this_type;
-    public:
         using pointer = void*;
-        using size_type = AZStd::size_t;
-        using difference_type = AZStd::ptrdiff_t;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
 
-        AZ_FORCE_INLINE stack_allocator(void* data, size_t size, const char* name = "AZStd::stack_allocator")
-            : m_name(name)
-            , m_data(reinterpret_cast<char*>(data))
-            , m_freeData(reinterpret_cast<char*>(data))
+        AZ_FORCE_INLINE stack_allocator(void* data, size_t size)
+            : m_data(static_cast<byte*>(data))
+            , m_freeData(static_cast<byte*>(data))
             , m_size(size)
         {}
 
-        AZ_FORCE_INLINE const char*  get_name() const            { return m_name; }
-        AZ_FORCE_INLINE void         set_name(const char* name)  { m_name = name; }
-        constexpr size_type          max_size() const            { return m_size; }
-        AZ_FORCE_INLINE size_type    get_allocated_size() const  { return m_freeData - m_data; }
-
-        pointer allocate(size_type byteSize, size_type alignment, int flags = 0)
+        [[nodiscard]] constexpr size_type max_size() const
         {
-            (void)flags;
-            char* address = AZ::PointerAlignUp(m_freeData, alignment);
+            return m_size;
+        }
+
+        AZ_FORCE_INLINE size_type get_allocated_size() const
+        {
+            return m_freeData - m_data;
+        }
+
+        [[nodiscard]] pointer allocate(
+            size_type byteSize,
+            size_type alignment,
+            [[maybe_unused]] int flags = 0)
+        {
+            byte* address = AZ::PointerAlignUp(m_freeData, alignment);
             m_freeData = address + byteSize;
             AZ_Assert(size_t(m_freeData - m_data) <= m_size, "AZStd::stack_allocator - run out of memory!");
             return address;
         }
 
-        AZ_FORCE_INLINE void  deallocate(pointer ptr, size_type byteSize, size_type alignment)
+        AZ_FORCE_INLINE void deallocate(
+            [[maybe_unused]] pointer ptr,
+            [[maybe_unused]] size_type byteSize,
+            [[maybe_unused]] size_type alignment)
         {
             // do nothing.
-            (void)ptr;
-            (void)byteSize;
-            (void)alignment;
         }
-        AZ_FORCE_INLINE size_type    resize(pointer ptr, size_type newSize)
+
+        AZ_FORCE_INLINE size_type resize(
+            [[maybe_unused]] pointer ptr,
+            [[maybe_unused]] size_type newSize)
         {
-            (void)ptr;
-            (void)newSize;
             return 0;
         }
 
-        AZ_FORCE_INLINE void  reset()
+        AZ_FORCE_INLINE void reset()
         {
             m_freeData = m_data;
         }
 
-    private:
         // Prevent heap allocation
-        void*  operator new(std::size_t size, const AZ::Internal::AllocatorDummy*);
-        void   operator delete(void* ptr, const AZ::Internal::AllocatorDummy*);
-        void*  operator new[](std::size_t size, const AZ::Internal::AllocatorDummy*);
-        void   operator delete[](void* ptr, const AZ::Internal::AllocatorDummy*);
-        void* operator new      (size_t);
-        void* operator new[]    (size_t);
-        void   operator delete   (void*);
-        void   operator delete[] (void*);
-        // no copy either
-        stack_allocator(const this_type& rhs);
-        this_type& operator=(const this_type& rhs);
+        void* operator new(std::size_t) = delete;
+        void* operator new[](std::size_t) = delete;
+        void operator delete(void*) = delete;
+        void operator delete[](void*) = delete;
 
-        const char*    m_name;
-        char*           m_data;
-        char*           m_freeData;
-        size_t          m_size;
+        stack_allocator(const stack_allocator&) = delete;
+        stack_allocator& operator=(const stack_allocator&) = delete;
+
+        friend AZ_FORCE_INLINE bool operator==(const stack_allocator& a, const stack_allocator& b)
+        {
+            return &a == &b;
+        }
+
+    private:
+        byte* m_data;
+        byte* m_freeData;
+        size_t m_size;
     };
-
-    AZ_FORCE_INLINE bool operator==(const stack_allocator& a, const stack_allocator& b)
-    {
-        if (&a == &b)
-        {
-            return true;
-        }
-        return false;
-    }
-
-    AZ_FORCE_INLINE bool operator!=(const stack_allocator& a, const stack_allocator& b)
-    {
-        if (&a != &b)
-        {
-            return true;
-        }
-        return false;
-    }
 }
-
-#endif // AZSTD_ALLOCATOR_STACK_H
-#pragma once

--- a/Code/Framework/AzCore/AzCore/std/allocator_stateless.cpp
+++ b/Code/Framework/AzCore/AzCore/std/allocator_stateless.cpp
@@ -25,35 +25,4 @@ namespace AZStd
     {
         return AZ_OS_REALLOC(ptr, newSize, alignment);
     }
-
-    auto stateless_allocator::resize(pointer, size_type) -> size_type
-    {
-        return 0;
-    }
-
-    bool stateless_allocator::is_lock_free()
-    {
-        return false;
-    }
-
-    bool stateless_allocator::is_stale_read_allowed()
-    {
-        return false;
-    }
-
-    bool stateless_allocator::is_delayed_recycling()
-    {
-        return false;
-    }
-
-    // comparison operators
-    bool operator==(const stateless_allocator&, const stateless_allocator&)
-    {
-        return true;
-    }
-
-    bool operator!=(const stateless_allocator&, const stateless_allocator&)
-    {
-        return false;
-    }
 }

--- a/Code/Framework/AzCore/AzCore/std/allocator_stateless.h
+++ b/Code/Framework/AzCore/AzCore/std/allocator_stateless.h
@@ -14,28 +14,43 @@
 
 namespace AZStd
 {
-    class AZCORE_API stateless_allocator
+    struct stateless_allocator
     {
-    public:
         AZ_TYPE_INFO(stateless_allocator, "{E4976C53-0B20-4F39-8D41-0A76F59A7D68}");
 
         AZ_ALLOCATOR_DEFAULT_TRAITS
 
-        pointer allocate(size_type byteSize, align_type alignment = 1);
-        void deallocate(pointer ptr, size_type byteSize = 0, align_type alignment = 0);
-        pointer reallocate(pointer ptr, size_type newSize, align_type alignment = 1);
-        size_type resize(pointer ptr, size_type newSize);
+        [[nodiscard]] AZCORE_API pointer allocate(size_type byteSize, align_type alignment = 1);
+        AZCORE_API void deallocate(pointer ptr, size_type byteSize = 0, align_type alignment = 0);
+        [[nodiscard]] AZCORE_API pointer reallocate(pointer ptr, size_type newSize, align_type alignment = 1);
 
-        size_type max_size() const
+        constexpr size_type resize(
+            [[maybe_unused]] pointer ptr,
+            [[maybe_unused]] size_type newSize) const
+        {
+            return 0;
+        }
+
+        constexpr size_type max_size() const
         {
             return AZ_TRAIT_OS_MEMORY_MAX_ALLOCATOR_SIZE;
         }
 
-        bool is_lock_free();
-        bool is_stale_read_allowed();
-        bool is_delayed_recycling();
-    };
+        constexpr bool is_lock_free() const
+        {
+            return false;
+        }
 
-    AZCORE_API bool operator==(const stateless_allocator& left, const stateless_allocator& right);
-    AZCORE_API bool operator!=(const stateless_allocator& left, const stateless_allocator& right);
+        constexpr bool is_stale_read_allowed() const
+        {
+            return false;
+        }
+
+        constexpr bool is_delayed_recycling() const
+        {
+            return false;
+        }
+
+        friend bool operator==(const stateless_allocator&, const stateless_allocator&) = default;
+    };
 }

--- a/Code/Framework/AzCore/AzCore/std/allocator_static.h
+++ b/Code/Framework/AzCore/AzCore/std/allocator_static.h
@@ -16,22 +16,20 @@
 namespace AZStd
 {
     /**
-     * This allocator uses aligned_storage to declare a static buffer, which
-     * is used for all allocations. This allocator is designed to be used as a temporary
-     * allocator on the stack. It just allocates from the buffer never frees anything, until
-     * you call reset. It does allow memory leaks, thus allowing containers never
-     * to call deallocate, which makes them faster.
+     * This allocator uses aligned_storage to declare a static buffer, which is used for all allocations.
+     * This allocator is designed to be used as a temporary allocator on the stack.
+     * It just allocates from the buffer never frees anything, until you call reset.
+     * It does allow memory leaks, thus allowing containers never to call deallocate, which makes them faster.
      */
-    template<AZStd::size_t Size, AZStd::size_t Alignment>
-    class static_buffer_allocator
+    template<size_t Size, size_t Alignment>
+    struct static_buffer_allocator
     {
         static_assert(Alignment > 0, "Alignment cannot be 0, the buffer must be aligned on some power of 2 greater than 0");
         static_assert(Size > 0, "Size of static buffer must be not be 0");
-        typedef static_buffer_allocator<Size, Alignment> this_type;
-    public:
+
         using pointer = void*;
-        using size_type = AZStd::size_t;
-        using difference_type = AZStd::ptrdiff_t;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
 
         AZ_FORCE_INLINE static_buffer_allocator()
             : m_lastAllocation(nullptr)
@@ -40,25 +38,36 @@ namespace AZStd
         }
 
         // When we copy the allocator we don't copy the allocated memory since it's the user responsibility.
-        AZ_FORCE_INLINE static_buffer_allocator(const this_type&)
+        AZ_FORCE_INLINE static_buffer_allocator(const static_buffer_allocator&)
             : m_freeData(reinterpret_cast<char*>(&m_data))
             , m_lastAllocation(nullptr)
-        {}
-        
-        AZ_FORCE_INLINE this_type& operator=(const this_type&)
+        {
+        }
+
+        AZ_FORCE_INLINE static_buffer_allocator& operator=(const static_buffer_allocator&)
         {
             return *this;
         }
-        
-        constexpr size_type         max_size() const { return Size; }
-        AZ_FORCE_INLINE size_type   get_allocated_size() const { return m_freeData - reinterpret_cast<const char*>(&m_data); }
-                
-        pointer allocate(size_type byteSize, size_type alignment, [[maybe_unused]] int flags = 0)
+
+        constexpr size_type max_size() const
+        {
+            return Size;
+        }
+
+        AZ_FORCE_INLINE size_type get_allocated_size() const
+        {
+            return m_freeData - reinterpret_cast<const char*>(&m_data);
+        }
+
+        [[nodiscard]] pointer allocate(
+            size_type byteSize,
+            size_type alignment,
+            [[maybe_unused]] int flags = 0)
         {
             AZ_Assert(alignment > 0 && (alignment & (alignment - 1)) == 0, "AZStd::static_buffer_allocator::allocate - alignment must be > 0 and power of 2");
             char* address = AZ::PointerAlignUp(m_freeData, alignment);
             m_freeData = address + byteSize;
-            if (size_t(m_freeData - reinterpret_cast<char*>(&m_data)) > Size)
+            if (static_cast<size_t>(m_freeData - reinterpret_cast<char*>(&m_data)) > Size)
             {
                 AZ_Assert(false, "AZStd::static_buffer_allocator - run out of memory!");
                 return nullptr;
@@ -68,27 +77,31 @@ namespace AZStd
             return address;
         }
 
-        AZ_FORCE_INLINE void  deallocate(pointer ptr, [[maybe_unused]] size_type byteSize = 0, [[maybe_unused]] size_type alignment = 0)
+        AZ_FORCE_INLINE void deallocate(
+            pointer ptr,
+            [[maybe_unused]] size_type byteSize = 0,
+            [[maybe_unused]] size_type alignment = 0)
         {
             // we can free only the last allocation
             if (ptr == m_lastAllocation)
             {
                 m_lastAllocation = nullptr;
-                m_freeData = reinterpret_cast<char*>(ptr);
+                m_freeData = static_cast<char*>(ptr);
             }
         }
-        AZ_FORCE_INLINE size_type    resize(pointer ptr, size_type newSize)
+
+        AZ_FORCE_INLINE size_type resize(pointer ptr, size_type newSize)
         {
             // We allow resize on last allocations only
-            if (ptr == m_lastAllocation && newSize <= (Size - size_t(reinterpret_cast<char*>(ptr) - reinterpret_cast<char*>(&m_data))))
+            if (ptr == m_lastAllocation && newSize <= (Size - static_cast<size_t>(static_cast<char*>(ptr) - reinterpret_cast<char*>(&m_data))))
             {
-                m_freeData = reinterpret_cast<char*>(m_lastAllocation) + newSize;
+                m_freeData = static_cast<char*>(m_lastAllocation) + newSize;
                 return newSize;
             }
             return 0;
         }
 
-        AZ_FORCE_INLINE void  reset()
+        AZ_FORCE_INLINE void reset()
         {
             m_freeData = reinterpret_cast<char*>(&m_data);
         }
@@ -98,49 +111,32 @@ namespace AZStd
             return address >= &m_data && address < reinterpret_cast<const char*>(&m_data) + Size;
         }
 
+        friend AZ_FORCE_INLINE bool operator==(const static_buffer_allocator& a, const static_buffer_allocator& b)
+        {
+            return &a == &b;
+        }
+
     private:
-        typename aligned_storage<Size, Alignment>::type  m_data;
-        char*           m_freeData;
-        void*           m_lastAllocation;
+        aligned_storage_t<Size, Alignment> m_data;
+        char* m_freeData;
+        void* m_lastAllocation;
     };
 
-    template<AZStd::size_t Size, AZStd::size_t Alignment>
-    AZ_FORCE_INLINE bool operator==(const static_buffer_allocator<Size, Alignment>& a, const static_buffer_allocator<Size, Alignment>& b)
-    {
-        return &a == &b;
-    }
-
-    template<AZStd::size_t Size, AZStd::size_t Alignment>
-    AZ_FORCE_INLINE bool operator!=(const static_buffer_allocator<Size, Alignment>& a, const static_buffer_allocator<Size, Alignment>& b)
-    {
-        return &a != &b;
-    }
-
     /**
-     *  Declares a static buffer of Node[NumNodes], and them pools them. This
-     *  is perfect allocator for pooling list or hash table nodes.
-     *  Internally the buffer is allocated using aligned_storage.
-     *  \note This is not thread safe allocator.
-     *  \note be careful if you use this on the stack, since many platforms
-     *  do NOT support alignment more than 16 bytes. In such cases you will need to do it manually.
+     * Declares a static buffer of Node[NumNodes], and them pools them.
+     * This is perfect allocator for pooling list or hash table nodes.
+     * Internally the buffer is allocated using aligned_storage.
+     *
+     * \note This is not thread safe allocator.
+     * \note be careful if you use this on the stack, since many platforms do NOT support alignment more than 16 bytes.
+     * In such cases you will need to do it manually.
      */
-    template< class Node, AZStd::size_t NumNodes >
-    class static_pool_allocator
+    template<class Node, size_t NumNodes>
+    struct static_pool_allocator
     {
-        typedef static_pool_allocator<Node, NumNodes> this_type;
-
-        typedef int32_t             index_type;
-
-        union  pool_node
-        {
-            typename aligned_storage<sizeof(Node), AZStd::alignment_of<Node>::value >::type m_node;
-            index_type  m_index;
-        };
-
-    public:
         using pointer = void*;
-        using size_type = AZStd::size_t;
-        using difference_type = AZStd::ptrdiff_t;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
 
         AZ_FORCE_INLINE static_pool_allocator()
         {
@@ -153,14 +149,36 @@ namespace AZStd
         }
 
         // When we copy the allocator we don't copy the allocated memory since it's the user responsibility.
-        AZ_FORCE_INLINE static_pool_allocator(const this_type&)
-            { reset(); }
-        AZ_FORCE_INLINE this_type& operator=(const this_type&)      { return *this; }
+        AZ_FORCE_INLINE static_pool_allocator(const static_pool_allocator&)
+        {
+            reset();
+        }
 
-        constexpr size_type          max_size() const           { return NumNodes * sizeof(Node); }
-        AZ_FORCE_INLINE size_type   get_allocated_size() const  { return m_numOfAllocatedNodes * sizeof(Node); }
+        AZ_FORCE_INLINE static_pool_allocator& operator=(const static_pool_allocator&)
+        {
+            return *this;
+        }
 
-        inline Node* allocate()
+        constexpr size_type max_size() const
+        {
+            return NumNodes * sizeof(Node);
+        }
+
+        AZ_FORCE_INLINE size_type get_allocated_size() const
+        {
+            return m_numOfAllocatedNodes * sizeof(Node);
+        }
+
+    private:
+        using index_type = int32_t;
+        union pool_node
+        {
+            aligned_storage_t<sizeof(Node), alignment_of_v<Node>> m_node;
+            index_type m_index;
+        };
+
+    public:
+        [[nodiscard]] AZ_FORCE_INLINE Node* allocate()
         {
             AZ_Assert(m_firstFreeNode != index_type(-1), "AZStd::static_pool_allocator - No more free nodes!");
             pool_node* poolNode = reinterpret_cast<pool_node*>(&m_data) + m_firstFreeNode;
@@ -169,12 +187,11 @@ namespace AZStd
             return reinterpret_cast<Node*>(poolNode);
         }
 
-        inline pointer allocate(size_type byteSize, size_type alignment, int flags = 0)
+        [[nodiscard]] AZ_FORCE_INLINE pointer allocate(
+            [[maybe_unused]] size_type byteSize,
+            [[maybe_unused]] size_type alignment,
+            [[maybe_unused]] int flags = 0)
         {
-            (void)alignment;
-            (void)byteSize;
-            (void)flags;
-
             AZ_Assert(alignment > 0 && (alignment & (alignment - 1)) == 0, "AZStd::static_pool_allocator::allocate - alignment must be > 0 and power of 2");
             AZ_Assert(byteSize == sizeof(Node), "AZStd::static_pool_allocator - We can allocate only node sizes from the pool!");
             AZ_Assert(alignment <= AZStd::alignment_of<Node>::value, "AZStd::static_pool_allocator - Invalid data alignment!");
@@ -182,72 +199,73 @@ namespace AZStd
             return allocate();
         }
 
-        void  deallocate(Node* ptr)
+        void deallocate(Node* ptr)
         {
             AZ_Assert(((char*)ptr >= (char*)&m_data) && ((char*)ptr < ((char*)&m_data + sizeof(Node) * NumNodes)), "AZStd::static_pool_allocator - Pointer is out of range!");
 
             pool_node* firstPoolNode = reinterpret_cast<pool_node*>(&m_data);
             pool_node* curPoolNode = reinterpret_cast<pool_node*>(ptr);
             curPoolNode->m_index = m_firstFreeNode;
-            m_firstFreeNode = (index_type)(curPoolNode - firstPoolNode);
+            m_firstFreeNode = static_cast<index_type>(curPoolNode - firstPoolNode);
             --m_numOfAllocatedNodes;
         }
 
-        inline void  deallocate(pointer ptr, size_type byteSize, size_type alignment)
+        AZ_FORCE_INLINE void deallocate(
+            pointer ptr,
+            [[maybe_unused]] size_type byteSize,
+            [[maybe_unused]] size_type alignment)
         {
-            (void)byteSize;
-            (void)alignment;
             AZ_Assert(alignment > 0 && (alignment & (alignment - 1)) == 0, "AZStd::static_pool_allocator::deallocate - alignment must be > 0 and power of 2");
             AZ_Assert(byteSize <= sizeof(Node), "AZStd::static_pool_allocator - We can allocate only node sizes from the pool!");
-            deallocate(reinterpret_cast<Node*>(ptr));
+            deallocate(static_cast<Node*>(ptr));
         }
 
-        AZ_FORCE_INLINE size_type    resize(pointer ptr, size_type newSize)
+        AZ_FORCE_INLINE size_type resize(
+            [[maybe_unused]] pointer ptr,
+            [[maybe_unused]] size_type newSize)
         {
-            (void)ptr;
-            (void)newSize;
             return sizeof(pool_node); // this is the max size we can have.
         }
 
-        void  reset()
+        void reset()
         {
             m_numOfAllocatedNodes = 0;
             m_firstFreeNode = 0;
             pool_node* poolNode = reinterpret_cast<pool_node*>(&m_data);
-            for (index_type iNode = 1; iNode < (index_type)NumNodes; ++iNode, ++poolNode)
+            for (index_type iNode = 1; iNode < static_cast<index_type>(NumNodes); ++iNode, ++poolNode)
             {
                 poolNode->m_index = iNode;
             }
 
-            poolNode->m_index = index_type(-1);
+            poolNode->m_index = -1;
         }
 
         void leak_before_destroy()
         {
-#ifdef AZ_Assert  // used only to confirm that it is ok for use to have allocated nodes
+#ifdef AZ_Assert // used only to confirm that it is ok for use to have allocated nodes
             m_numOfAllocatedNodes = 0;
-            m_firstFreeNode = index_type(-1); // We are not allowed to allocate after we call leak_before_destroy.
+            m_firstFreeNode = -1; // We are not allowed to allocate after we call leak_before_destroy.
 #endif
         }
 
-        AZ_FORCE_INLINE void*                 data()      const { return &m_data; }
-        AZ_FORCE_INLINE constexpr size_type   data_size() const { return sizeof(Node) * NumNodes; }
+        AZ_FORCE_INLINE void* data() const
+        {
+            return &m_data;
+        }
+
+        AZ_FORCE_INLINE constexpr size_type data_size() const
+        {
+            return sizeof(Node) * NumNodes;
+        }
+
+        friend AZ_FORCE_INLINE bool operator==(const static_pool_allocator& a, const static_pool_allocator& b)
+        {
+            return &a == &b;
+        }
 
     private:
-        typename aligned_storage<sizeof(Node) * NumNodes, AZStd::alignment_of<Node>::value>::type m_data;
-        index_type      m_firstFreeNode;
-        size_type       m_numOfAllocatedNodes;
+        aligned_storage_t<sizeof(Node) * NumNodes, alignment_of_v<Node>> m_data;
+        index_type m_firstFreeNode = 0;
+        size_type m_numOfAllocatedNodes = 0;
     };
-
-    template< class Node, AZStd::size_t NumNodes >
-    AZ_FORCE_INLINE bool operator==(const static_pool_allocator<Node, NumNodes>& a, const static_pool_allocator<Node, NumNodes>& b)
-    {
-        return &a == &b;
-    }
-
-    template< class Node, AZStd::size_t NumNodes >
-    AZ_FORCE_INLINE bool operator!=(const static_pool_allocator<Node, NumNodes>& a, const static_pool_allocator<Node, NumNodes>& b)
-    {
-        return &a != &b;
-    }
 }

--- a/Code/Framework/AzCore/AzCore/std/allocator_traits.h
+++ b/Code/Framework/AzCore/AzCore/std/allocator_traits.h
@@ -71,18 +71,6 @@ namespace AZStd
             using type = typename Allocator::const_pointer;
         };
 
-        //! void_pointer
-        template <typename Allocator, typename PointerType, typename = void>
-        struct get_void_pointer_type
-        {
-            using type = typename std::pointer_traits<PointerType>::template rebind<void>;
-        };
-        template <typename Allocator, typename PointerType>
-        struct get_void_pointer_type<Allocator, PointerType, void_t<typename Allocator::void_pointer>>
-        {
-            using type = typename Allocator::void_pointer;
-        };
-
         //! const_void_pointer
         template <typename Allocator, typename PointerType, typename = void>
         struct get_const_void_pointer_type
@@ -131,18 +119,6 @@ namespace AZStd
             using type = typename Allocator::size_type;
         };
 
-        //! propagate_on_container_copy_assignment
-        template <typename Allocator, typename = void>
-        struct get_propagate_on_container_copy_assignment_type
-        {
-            using type = AZStd::true_type;
-        };
-        template <typename Allocator>
-        struct get_propagate_on_container_copy_assignment_type<Allocator, void_t<typename Allocator::propagate_on_container_copy_assignment>>
-        {
-            using type = typename Allocator::propagate_on_container_copy_assignment;
-        };
-
         //! propagate_on_container_move_assignment
         template <typename Allocator, typename = void>
         struct get_propagate_on_container_move_assignment_type
@@ -165,18 +141,6 @@ namespace AZStd
         struct get_propagate_on_container_swap_type<Allocator, void_t<typename Allocator::propagate_on_container_swap>>
         {
             using type = typename Allocator::propagate_on_container_swap;
-        };
-
-        //! is_always_equal
-        template <typename Allocator, typename = void>
-        struct get_is_always_equal_type
-        {
-            using type = typename std::is_empty<Allocator>::type;
-        };
-        template <typename Allocator>
-        struct get_is_always_equal_type<Allocator, void_t<typename Allocator::is_always_equal>>
-        {
-            using type = typename Allocator::is_always_equal;
         };
 
         //! rebind
@@ -247,30 +211,6 @@ namespace AZStd
             }
         };
 
-        //! select_on_container_copy_construction
-        template <class Allocator>
-        static auto has_select_on_container_copy_construction_test(Allocator&& alloc) -> decltype(alloc.select_on_container_copy_construction(), true_type());
-        template <class Allocator>
-        static auto has_select_on_container_copy_construction_test(const volatile Allocator&) -> false_type;
-        template <typename Allocator, typename = void>
-        static constexpr bool has_select_on_container_copy_construction = integral_constant<bool, is_same<decltype(has_select_on_container_copy_construction_test(declval<Allocator&>())), true_type>::value>::value;
-
-        template <typename Allocator, bool select_on_container_copy_construction_callable>
-        struct call_select_on_container_copy_construction
-        {
-            static Allocator invoke(const Allocator& alloc)
-            {
-                return alloc;
-            }
-        };
-        template <typename Allocator>
-        struct call_select_on_container_copy_construction<Allocator, true>
-        {
-            static Allocator invoke(const Allocator& alloc)
-            {
-                return alloc.select_on_container_copy_construction();
-            }
-        };
     }
     /*
     The allocator_traits class template provides the standardized way to access various properties of AZStd allocators
@@ -282,18 +222,14 @@ namespace AZStd
         using value_type = typename get_value_type<allocator_type>::type;
         using pointer = typename get_pointer_type<allocator_type, value_type>::type;
         using const_pointer = typename get_const_pointer_type<allocator_type, pointer, value_type>::type;
-        using void_pointer = typename get_void_pointer_type<allocator_type, pointer>::type;
         using const_void_pointer = typename get_const_void_pointer_type<allocator_type, pointer>::type;
         using difference_type = typename get_difference_type<allocator_type, pointer>::type;
         using align_type = typename get_align_type<allocator_type, difference_type>::type;
         using size_type = typename get_size_type<allocator_type, difference_type>::type;
         using propagate_on_container_move_assignment = typename get_propagate_on_container_move_assignment_type<allocator_type>::type;
-        using propagate_on_container_copy_assignment = typename get_propagate_on_container_copy_assignment_type<allocator_type>::type;
         using propagate_on_container_swap = typename get_propagate_on_container_swap_type<allocator_type>::type;
-        using is_always_equal = typename get_is_always_equal_type<allocator_type>::type;
 
         template <class T> using rebind_alloc = typename get_rebind_type<allocator_type, T>::type;
-        template <class T> using rebind_traits = allocator_traits<rebind_alloc<T>>;
 
         // static allocator_trait functions
         static pointer allocate(allocator_type& alloc, size_type size)
@@ -338,9 +274,5 @@ namespace AZStd
             return call_max_size<allocator_type, value_type, size_type, has_max_size<allocator_type>, has_get_max_size<allocator_type>>::invoke(alloc);
         }
 
-        static allocator_type select_on_container_copy_construction(const allocator_type& alloc)
-        {
-            return call_select_on_container_copy_construction<allocator_type, has_select_on_container_copy_construction<allocator_type>>::invoke(alloc);
-        }
     };
 }

--- a/Code/Framework/AzCore/AzCore/std/any.h
+++ b/Code/Framework/AzCore/AzCore/std/any.h
@@ -94,7 +94,7 @@ namespace AZStd
         static constexpr auto get_action_handler_for_t();
 
         /// Constructs an empty object.
-        any(allocator alloc = allocator("AZStd::any"))
+        any(allocator alloc = allocator{})
             : m_allocator(alloc)
         {
             memset(m_buffer, 0, AZ_ARRAY_SIZE(m_buffer));
@@ -186,7 +186,7 @@ namespace AZStd
 
         /// Constructs an object with initial content an object of type decay_t<ValueType>, direct-initialized from forward<ValueType>(val)
         template <typename ValueType, typename = enable_if_t<!is_same<decay_t<ValueType>, any>::value>>
-        explicit any(ValueType&& val, allocator alloc = allocator("AZStd::any"))
+        explicit any(ValueType&& val, allocator alloc = allocator{})
             : any(alloc)
         {
             static_assert(std::is_copy_constructible<decay_t<ValueType>>::value
@@ -206,7 +206,7 @@ namespace AZStd
         /// Constructs an object with initial content of type decay_t<ValueType>, direct-non-list-initialized from forward<Args>(args)...
         template <typename ValueType, typename... Args>
         explicit any(in_place_type_t<ValueType>, Args&&... args)
-            : any(allocator("AZStd::any"))
+            : any(allocator{})
         {
             // Initialize typeinfo from the type given
             m_typeInfo = create_template_type_info<decay_t<ValueType>>();
@@ -221,7 +221,7 @@ namespace AZStd
         /// Constructs an object with initial content of type decay_t<ValueType>, direct-non-list-initialized from il, forward<Args>(args)...
         template <typename ValueType, typename U, typename... Args>
         explicit any(in_place_type_t<ValueType>, AZStd::initializer_list<U> il, Args&&... args)
-            : any(allocator("AZStd::any"))
+            : any(allocator{})
         {
             // Initialize typeinfo from the type given
             m_typeInfo = create_template_type_info<decay_t<ValueType>>();

--- a/Code/Framework/AzCore/AzCore/std/parallel/allocator_concurrent_static.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/allocator_concurrent_static.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZSTD_ALLOCATOR_CONCURRENT_STATIC_H
-#define AZSTD_ALLOCATOR_CONCURRENT_STATIC_H
+
+#pragma once
 
 #include <AzCore/std/base.h>
 #include <AzCore/std/parallel/atomic.h>
@@ -17,41 +17,41 @@
 namespace AZStd
 {
     /**
-     *  Declares a static buffer of Node[NumNodes], and them pools them. It provides concurrent
-     *  safe access. This is a perfect allocator for pooling lists or hash table nodes.
-     *  Internally the buffer is allocated using aligned_storage.
-     *  \note only allocate/deallocate are thread safe. 
-     *  reset, leak_before_destroy and comparison operators are not thread safe.
-     *  get_allocated_size is thread safe but the returned value is not perfectly in 
-     *  sync on the actual number of allocations (the number of allocations is incremented before the
-     *  allocation happens and decremented after the allocation happens, trying to give a conservative
-     *  number)
-     *  \note be careful if you use this on the stack, since many platforms
-     *  do NOT support alignment more than 16 bytes. In such cases you will need to do it manually.
+     * Declares a static buffer of Node[NumNodes], and them pools them.
+     * It provides concurrent safe access.
+     *
+     * This is a perfect allocator for pooling lists or hash table nodes.
+     * Internally the buffer is allocated using aligned_storage.
+     *
+     * \note only allocate/deallocate are thread safe.
+     * reset, leak_before_destroy and comparison operators are not thread safe.
+     * get_allocated_size is thread safe but the returned value is not perfectly in sync
+     * on the actual number of allocations (the number of allocations is incremented before the
+     * allocation happens and decremented after the allocation happens, trying to give a conservative number)
+     *
+     * \note be careful if you use this on the stack, since many platforms do NOT support alignment more than 16 bytes.
+     * In such cases you will need to do it manually.
      */
-    template< class Node, AZStd::size_t NumNodes >
+    template<class Node, size_t NumNodes>
     class static_pool_concurrent_allocator
     {
-        typedef static_pool_concurrent_allocator<Node, NumNodes> this_type;
+        using index_type = int32_t;
 
-        typedef int32_t            index_type;
-
-        union  pool_node
+        union pool_node
         {
-            typename aligned_storage<sizeof(Node), AZStd::alignment_of<Node>::value >::type m_node;
-            index_type  m_index;
+            aligned_storage_t<sizeof(Node), alignment_of_v<Node>> m_node;
+            index_type m_index;
         };
 
-        static constexpr index_type invalid_index = index_type(-1);
+        static constexpr index_type invalid_index = -1;
 
     public:
         using value_type = Node;
         using pointer = Node*;
-        using size_type = AZStd::size_t;
-        using difference_type = AZStd::ptrdiff_t;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
 
-        AZ_FORCE_INLINE static_pool_concurrent_allocator(const char* name = "AZStd::static_pool_concurrent_allocator")
-            : m_name(name)
+        AZ_FORCE_INLINE static_pool_concurrent_allocator()
         {
             reset();
         }
@@ -62,20 +62,29 @@ namespace AZStd
         }
 
         // When we copy the allocator we don't copy the allocated memory since it's the user responsibility.
-        AZ_FORCE_INLINE static_pool_concurrent_allocator(const this_type& rhs)
-            : m_name(rhs.m_name)    {  reset(); }
-        AZ_FORCE_INLINE static_pool_concurrent_allocator(const this_type& rhs, const char* name)
-            : m_name(name) { (void)rhs; reset(); }
-        AZ_FORCE_INLINE this_type& operator=(const this_type& rhs)      { m_name = rhs.m_name; return *this; }
-
-        AZ_FORCE_INLINE const char*  get_name() const           { return m_name; }
-        AZ_FORCE_INLINE void         set_name(const char* name) { m_name = name; }
-        constexpr size_type          max_size() const           { return NumNodes * sizeof(Node); }
-        AZ_FORCE_INLINE size_type   get_allocated_size() const  { return m_numOfAllocatedNodes.load(AZStd::memory_order_relaxed) * sizeof(Node); }
-
-        inline Node* allocate()
+        AZ_FORCE_INLINE static_pool_concurrent_allocator(const static_pool_concurrent_allocator& rhs)
         {
-            index_type firstFreeNode = m_firstFreeNode.load(AZStd::memory_order_relaxed);
+            reset();
+        }
+
+        AZ_FORCE_INLINE static_pool_concurrent_allocator& operator=(const static_pool_concurrent_allocator& rhs)
+        {
+            return *this;
+        }
+
+        constexpr size_type max_size() const
+        {
+            return NumNodes * sizeof(Node);
+        }
+
+        AZ_FORCE_INLINE size_type get_allocated_size() const
+        {
+            return m_numOfAllocatedNodes.load(memory_order_relaxed) * sizeof(Node);
+        }
+
+        [[nodiscard]] AZ_FORCE_INLINE Node* allocate()
+        {
+            index_type firstFreeNode = m_firstFreeNode.load(memory_order_relaxed);
             if (firstFreeNode != invalid_index)
             {
                 ++m_numOfAllocatedNodes;
@@ -85,8 +94,8 @@ namespace AZStd
                 while (!m_firstFreeNode.compare_exchange_weak(
                     firstFreeNode,
                     (reinterpret_cast<pool_node*>(&m_data) + firstFreeNode)->m_index,
-                    AZStd::memory_order_release,
-                    AZStd::memory_order_relaxed))
+                    memory_order_release,
+                    memory_order_relaxed))
                 {
                     if (firstFreeNode == invalid_index)
                     {
@@ -96,19 +105,16 @@ namespace AZStd
                 }
                 return reinterpret_cast<Node*>(reinterpret_cast<pool_node*>(&m_data) + firstFreeNode);
             }
-            else
-            {
-                AZ_Assert(false, "AZStd::static_pool_concurrent_allocator - No more free nodes!");
-                return nullptr;
-            }
+
+            AZ_Assert(false, "AZStd::static_pool_concurrent_allocator - No more free nodes!");
+            return nullptr;
         }
 
-        inline pointer allocate(size_type byteSize, size_type alignment, int flags = 0)
+        [[nodiscard]] AZ_FORCE_INLINE pointer allocate(
+            [[maybe_unused]] size_type byteSize,
+            [[maybe_unused]] size_type alignment,
+            [[maybe_unused]] int flags = 0)
         {
-            (void)alignment;
-            (void)byteSize;
-            (void)flags;
-
             AZ_Assert(alignment > 0 && (alignment & (alignment - 1)) == 0, "AZStd::static_pool_concurrent_allocator::allocate - alignment must be > 0 and power of 2");
             AZ_Assert(byteSize == sizeof(Node), "AZStd::static_pool_concurrent_allocator - We can allocate only node sizes from the pool!");
             AZ_Assert(alignment <= AZStd::alignment_of<Node>::value, "AZStd::static_pool_concurrent_allocator - Invalid data alignment!");
@@ -116,45 +122,46 @@ namespace AZStd
             return allocate();
         }
 
-        void  deallocate(Node* ptr)
+        void deallocate(Node* ptr)
         {
             AZ_Assert(((char*)ptr >= (char*)&m_data) && ((char*)ptr < ((char*)&m_data + sizeof(Node) * NumNodes)), "AZStd::static_pool_concurrent_allocator - Pointer is out of range!");
 
             pool_node* firstPoolNode = reinterpret_cast<pool_node*>(&m_data);
             pool_node* curPoolNode = reinterpret_cast<pool_node*>(ptr);
-            do 
+            do
             {
-                curPoolNode->m_index = m_firstFreeNode.load(AZStd::memory_order_relaxed);
+                curPoolNode->m_index = m_firstFreeNode.load(memory_order_relaxed);
             } while (!m_firstFreeNode.compare_exchange_weak(
                 curPoolNode->m_index,
-                (index_type)(curPoolNode - firstPoolNode),
-                AZStd::memory_order_release,
-                AZStd::memory_order_relaxed));
+                static_cast<index_type>(curPoolNode - firstPoolNode),
+                memory_order_release,
+                memory_order_relaxed));
             --m_numOfAllocatedNodes;
         }
 
-        inline void  deallocate(pointer ptr, size_type byteSize, size_type alignment)
-        { 
-            (void)byteSize;
-            (void)alignment;
+        AZ_FORCE_INLINE void deallocate(
+            pointer ptr,
+            [[maybe_unused]] size_type byteSize,
+            [[maybe_unused]] size_type alignment)
+        {
             AZ_Assert(alignment > 0 && (alignment & (alignment - 1)) == 0, "AZStd::static_pool_concurrent_allocator::deallocate - alignment must be > 0 and power of 2");
             AZ_Assert(byteSize <= sizeof(Node), "AZStd::static_pool_concurrent_allocator - We can allocate only node sizes from the pool!");
             deallocate(reinterpret_cast<Node*>(ptr));
         }
 
-        AZ_FORCE_INLINE size_type    resize(pointer ptr, size_type newSize)
+        AZ_FORCE_INLINE size_type resize(
+            [[maybe_unused]] pointer ptr,
+            [[maybe_unused]] size_type newSize) const
         {
-            (void)ptr;
-            (void)newSize;
             return sizeof(pool_node); // this is the max size we can have.
         }
 
-        void  reset()
+        void reset()
         {
             m_numOfAllocatedNodes = 0;
             m_firstFreeNode = 0;
             pool_node* poolNode = reinterpret_cast<pool_node*>(&m_data);
-            for (index_type iNode = 1; iNode < (index_type)NumNodes; ++iNode, ++poolNode)
+            for (index_type iNode = 1; iNode < static_cast<index_type>(NumNodes); ++iNode, ++poolNode)
             {
                 poolNode->m_index = iNode;
             }
@@ -164,34 +171,32 @@ namespace AZStd
 
         void leak_before_destroy()
         {
-#ifdef AZ_Assert  // used only to confirm that it is ok for use to have allocated nodes
+#ifdef AZ_Assert // used only to confirm that it is ok for use to have allocated nodes
             m_numOfAllocatedNodes = 0;
             m_firstFreeNode = invalid_index; // We are not allowed to allocate after we call leak_before_destroy.
 #endif
         }
 
-        AZ_FORCE_INLINE void*               data()      const { return &m_data; }
-        AZ_FORCE_INLINE constexpr size_type data_size() const { return sizeof(Node) * NumNodes; }
+        AZ_FORCE_INLINE void* data() const
+        {
+            return &m_data;
+        }
+
+        AZ_FORCE_INLINE constexpr size_type data_size() const
+        {
+            return sizeof(Node) * NumNodes;
+        }
+
+        friend AZ_FORCE_INLINE bool operator==(
+            const static_pool_concurrent_allocator& a,
+            const static_pool_concurrent_allocator& b)
+        {
+            return &a == &b;
+        }
 
     private:
-        typename aligned_storage<sizeof(Node)* NumNodes, AZStd::alignment_of<Node>::value>::type m_data;
-        const char*    m_name;
-        atomic<index_type>      m_firstFreeNode;
-        atomic<size_type>       m_numOfAllocatedNodes;
+        aligned_storage_t<sizeof(Node)* NumNodes, alignment_of_v<Node>> m_data;
+        atomic<index_type> m_firstFreeNode;
+        atomic<size_type> m_numOfAllocatedNodes;
     };
-
-    template< class Node, AZStd::size_t NumNodes >
-    AZ_FORCE_INLINE bool operator==(const static_pool_concurrent_allocator<Node, NumNodes>& a, const static_pool_concurrent_allocator<Node, NumNodes>& b)
-    {
-        return &a == &b;
-    }
-
-    template< class Node, AZStd::size_t NumNodes >
-    AZ_FORCE_INLINE bool operator!=(const static_pool_concurrent_allocator<Node, NumNodes>& a, const static_pool_concurrent_allocator<Node, NumNodes>& b)
-    {
-        return &a != &b;
-    }
 }
-
-#endif // AZSTD_ALLOCATOR_CONCURRENT_STATIC_H
-#pragma once

--- a/Code/Framework/AzCore/Tests/AZStd/Allocators.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Allocators.cpp
@@ -62,16 +62,12 @@ namespace UnitTest
         static_assert(AZStd::is_same<AZStdAllocatorTraits::value_type, void>::value, "Allocator trait value_type is not the same as void");
         static_assert(AZStd::is_same<AZStdAllocatorTraits::pointer, void*>::value, "Allocator trait pointer is not the same as void*");
         static_assert(AZStd::is_same<AZStdAllocatorTraits::const_pointer, const void*>::value, "Allocator trait const_pointer is not the same as const void*");
-        static_assert(AZStd::is_same<AZStdAllocatorTraits::void_pointer, void*>::value, "Allocator trait void_pointer is not the same as void*");
         static_assert(AZStd::is_same<AZStdAllocatorTraits::const_void_pointer, const void*>::value, "Allocator trait const_void_pointer is not the same as void*");
         static_assert(AZStd::is_same<AZStdAllocatorTraits::difference_type, ptrdiff_t>::value, "Allocator trait difference_type is not the same as ptrdiff_t");
         static_assert(AZStd::is_same<AZStdAllocatorTraits::size_type, size_t>::value, "Allocator trait size_type is not the same as size_t");
-        static_assert(AZStd::is_same<AZStdAllocatorTraits::propagate_on_container_copy_assignment, true_type>::value, "Allocator trait propagate_on_container_copy_assignment is not the same as true_type");
         static_assert(AZStd::is_same<AZStdAllocatorTraits::propagate_on_container_move_assignment, true_type>::value, "Allocator trait propagate_on_container_move_assignment is not the same as true_type");
         static_assert(AZStd::is_same<AZStdAllocatorTraits::propagate_on_container_swap, true_type>::value, "Allocator trait propagate_on_container_swap is not the same as true_type");
-        static_assert(AZStd::is_same<AZStdAllocatorTraits::is_always_equal, true_type>::value, "Allocator trait is_always_equal is not the same as true_type");
         static_assert(AZStd::is_same<typename AZStdAllocatorTraits::template rebind_alloc<int32_t>, AZStd::allocator>::value, "Rebind alloc for AZStd::allocator should return AZStd::allocator");
-        static_assert(AZStd::is_same<typename AZStdAllocatorTraits::template rebind_traits<int32_t>::allocator_type, AZStd::allocator>::value, "Rebind traits allocator_type should still be AZStd::allocator");
     }
 
     TEST_F(AllocatorDefaultTest, AllocatorTraitsAllocateAndDeallocateSucceeds)
@@ -127,14 +123,6 @@ namespace UnitTest
         AllocatorWithGetMaxSize testAllocator;
         typename AZStdAllocatorTraits::size_type maxSize = AZStdAllocatorTraits::max_size(testAllocator);
         EXPECT_EQ(testAllocator.get_max_size(), maxSize);
-    }
-
-    TEST_F(AllocatorDefaultTest, AllocatorTraitsSelectOnContainerCopyConstructionCompilesWithoutErrors)
-    {
-        using AZStdAllocatorTraits = AZStd::allocator_traits<AZStd::allocator>;
-        AZStd::allocator testAllocator;
-        AZStd::allocator copiedAllocator = AZStdAllocatorTraits::select_on_container_copy_construction(testAllocator);
-        EXPECT_EQ(testAllocator, copiedAllocator);
     }
 
     /// Static buffer allocator.

--- a/Code/Framework/AzCore/Tests/AZStd/Allocators.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Allocators.cpp
@@ -102,7 +102,7 @@ namespace UnitTest
         };
 
         using AZStdAllocatorTraits = AZStd::allocator_traits<AZStd::allocator>;
-        AZStd::allocator testAllocator("trait allocator");
+        AZStd::allocator testAllocator;
         typename AZStdAllocatorTraits::pointer data = AZStdAllocatorTraits::allocate(testAllocator, sizeof(TestAllocated), alignof(TestAllocated));
         EXPECT_NE(nullptr, data);
         auto testPtr = static_cast<TestAllocated*>(data);
@@ -124,7 +124,7 @@ namespace UnitTest
         };
 
         using AZStdAllocatorTraits = AZStd::allocator_traits<AllocatorWithGetMaxSize>;
-        AllocatorWithGetMaxSize testAllocator("trait allocator");
+        AllocatorWithGetMaxSize testAllocator;
         typename AZStdAllocatorTraits::size_type maxSize = AZStdAllocatorTraits::max_size(testAllocator);
         EXPECT_EQ(testAllocator.get_max_size(), maxSize);
     }
@@ -132,7 +132,7 @@ namespace UnitTest
     TEST_F(AllocatorDefaultTest, AllocatorTraitsSelectOnContainerCopyConstructionCompilesWithoutErrors)
     {
         using AZStdAllocatorTraits = AZStd::allocator_traits<AZStd::allocator>;
-        AZStd::allocator testAllocator("trait allocator");
+        AZStd::allocator testAllocator;
         AZStd::allocator copiedAllocator = AZStdAllocatorTraits::select_on_container_copy_construction(testAllocator);
         EXPECT_EQ(testAllocator, copiedAllocator);
     }
@@ -158,7 +158,7 @@ namespace UnitTest
         AZ_TEST_ASSERT(myalloc.get_allocated_size() == 0);
 
         data = myalloc.allocate(100, 1);
-        myalloc.allocate(3, 1);
+        AZ_UNUSED(myalloc.allocate(3, 1));
         myalloc.deallocate(data); // can't free allocation which is not the last.
         EXPECT_EQ(bufferSize - 103, myalloc.max_size() - myalloc.get_allocated_size());
         AZ_TEST_ASSERT(myalloc.get_allocated_size() == 103);
@@ -217,7 +217,7 @@ namespace UnitTest
         // Some platforms might fail. Which is ok, higher alignment should be handled by US. Or not on the stack.
         const int dataAlignment = 16;
 
-        typedef aligned_storage<sizeof(int), dataAlignment>::type aligned_int_type;
+        typedef aligned_storage_t<sizeof(int), dataAlignment> aligned_int_type;
         typedef static_pool_allocator<aligned_int_type, numNodes> aligned_int_node_pool_type;
         aligned_int_node_pool_type myaligned_pool;
         aligned_int_type* aligned_data = reinterpret_cast<aligned_int_type*>(myaligned_pool.allocate(sizeof(aligned_int_type), dataAlignment));
@@ -285,9 +285,6 @@ namespace UnitTest
         size_t bufferSize = 500;
 
         stack_allocator myalloc(alloca(bufferSize), bufferSize);
-        const char newName[] = "My new test allocator";
-        myalloc.set_name(newName);
-        AZ_TEST_ASSERT(strcmp(myalloc.get_name(), newName) == 0);
 
         EXPECT_EQ(bufferSize, myalloc.max_size());
         AZ_TEST_ASSERT(myalloc.get_allocated_size() == 0);

--- a/Code/Framework/AzCore/Tests/AZStd/ConcurrentAllocators.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/ConcurrentAllocators.cpp
@@ -40,19 +40,6 @@ namespace UnitTest
     >;
     TYPED_TEST_SUITE(ConcurrentAllocatorTestFixture, AllocatorTypes);
 
-    TYPED_TEST(ConcurrentAllocatorTestFixture, Name)
-    {
-        const char name[] = "My test allocator";
-        typename TestFixture::allocator_type myalloc(name);
-        EXPECT_EQ(0, strcmp(myalloc.get_name(), name));
-        {
-            const char newName[] = "My new test allocator";
-            myalloc.set_name(newName);
-            EXPECT_EQ(0, strcmp(myalloc.get_name(), newName));
-            EXPECT_EQ(sizeof(typename TestFixture::allocator_type::value_type) * s_allocatorCapacity, myalloc.max_size());
-        }
-    }
-
     TYPED_TEST(ConcurrentAllocatorTestFixture, AllocateDeallocate)
     {
         typename TestFixture::allocator_type myalloc;

--- a/Code/Framework/AzCore/Tests/AZStd/Variant.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Variant.cpp
@@ -260,7 +260,7 @@ namespace UnitTest
     {
         // Largest Element is string_view
         using TestVariant1 = AZStd::variant<int, float, bool, AZStd::string_view>;
-        
+
         static_assert(sizeof(AZStd::string_view) < sizeof(TestVariant1), "using the sizeof operator on a std::variant should return a size larger than all the alternatives");
         // Largest Element is MoveOnly
         using TestVariant2 = AZStd::variant<double, AZStd::string_view, VariantTestInternal::MoveConstructorOnly, bool, float>;
@@ -363,7 +363,7 @@ namespace UnitTest
 
         TEST_F(VariantTest, InPlaceTypeConstructorWithInitializerListSucceeds)
         {
-            AZStd::variant<int32_t, double, AZStd::vector<int32_t>, bool> inplaceIndexVariant(AZStd::in_place_type_t<AZStd::vector<int32_t>>{}, { 1, 2, 3 }, AZStd::allocator("Variant in_place_type allocator "));
+            AZStd::variant<int32_t, double, AZStd::vector<int32_t>, bool> inplaceIndexVariant(AZStd::in_place_type_t<AZStd::vector<int32_t>>{}, { 1, 2, 3 }, AZStd::allocator{});
             EXPECT_EQ(2, inplaceIndexVariant.index());
             auto& vectorAlt = AZStd::get<2>(inplaceIndexVariant);
             ASSERT_EQ(3, vectorAlt.size());
@@ -383,7 +383,7 @@ namespace UnitTest
 
         TEST_F(VariantTest, InPlaceIndexConstructorWithInitializerListSucceeds)
         {
-            AZStd::variant<float, AZStd::vector<int32_t>> inplaceIndexVariant(AZStd::in_place_index_t<1>{}, { 1, 2, 3 }, AZStd::allocator("Variant in_place_index allocator "));
+            AZStd::variant<float, AZStd::vector<int32_t>> inplaceIndexVariant(AZStd::in_place_index_t<1>{}, { 1, 2, 3 }, AZStd::allocator{});
             EXPECT_EQ(1, inplaceIndexVariant.index());
             auto& vectorAlt = AZStd::get<1>(inplaceIndexVariant);
             ASSERT_EQ(3, vectorAlt.size());
@@ -426,7 +426,7 @@ namespace UnitTest
             EXPECT_EQ(2, emplaceIndexVariant.index());
             EXPECT_TRUE(AZStd::get<2>(emplaceIndexVariant).empty());
             // Update current alternative
-            auto& updatedVector= emplaceIndexVariant.emplace<AZStd::vector<int32_t>>({ 2, 4, 6 }, AZStd::allocator("Variant emplace allocator"));
+            auto& updatedVector= emplaceIndexVariant.emplace<AZStd::vector<int32_t>>({ 2, 4, 6 }, AZStd::allocator{});
             EXPECT_EQ(2, emplaceIndexVariant.index());
 
             EXPECT_EQ(3, updatedVector.size());
@@ -441,7 +441,7 @@ namespace UnitTest
             EXPECT_EQ(0, emplaceIndexVariant.index());
             EXPECT_EQ(110, AZStd::get<0>(emplaceIndexVariant));
             // Update different alternative
-            auto& updatedVector = emplaceIndexVariant.emplace<AZStd::vector<int32_t>>({ 1, 2, 3 }, AZStd::allocator("Variant emplace allocator"));
+            auto& updatedVector = emplaceIndexVariant.emplace<AZStd::vector<int32_t>>({ 1, 2, 3 }, AZStd::allocator{});
             EXPECT_EQ(2, emplaceIndexVariant.index());
 
             ASSERT_EQ(3, updatedVector.size());
@@ -484,7 +484,7 @@ namespace UnitTest
             // Update current alternative
             auto& updatedVector = emplaceIndexVariant.emplace<2>({ 17, -54 });
             EXPECT_EQ(2, emplaceIndexVariant.index());
-            
+
             EXPECT_EQ(2, updatedVector.size());
             EXPECT_EQ(17, updatedVector[0]);
             EXPECT_EQ(-54, updatedVector[1]);
@@ -496,7 +496,7 @@ namespace UnitTest
             EXPECT_EQ(0, emplaceIndexVariant.index());
             EXPECT_EQ(110, AZStd::get<0>(emplaceIndexVariant));
             // Update different alternative
-            auto& updatedVector = emplaceIndexVariant.emplace<2>({ 1, 2, 3 }, AZStd::allocator("Variant emplace allocator"));
+            auto& updatedVector = emplaceIndexVariant.emplace<2>({ 1, 2, 3 }, AZStd::allocator{});
             EXPECT_EQ(2, emplaceIndexVariant.index());
 
             ASSERT_EQ(3, updatedVector.size());
@@ -668,7 +668,7 @@ namespace UnitTest
             // Set const alternative on construct
             AZStd::variant<int32_t, const int64_t> testVariant(static_cast<int64_t>(23LL));
             ASSERT_EQ(1, testVariant.index());
-            
+
             static_assert(AZStd::is_same<decltype(AZStd::get<1>(AZStd::move(testVariant))), const int64_t&&>::value,
                 "AZStd::get should return const rvalue reference to const alternative for non-const variant");
             EXPECT_EQ(23LL, AZStd::get<1>(AZStd::move(testVariant)));
@@ -678,7 +678,7 @@ namespace UnitTest
         {
             const AZStd::variant<int32_t, const int64_t> testVariant(6);
             ASSERT_EQ(0, testVariant.index());
-            
+
             static_assert(AZStd::is_same<decltype(AZStd::get<0>(AZStd::move(testVariant))), const int32_t&&>::value,
                 "AZStd::get should return const rvalue reference to non-const alternative for const variant");
             EXPECT_EQ(6, AZStd::get<0>(AZStd::move(testVariant)));
@@ -689,7 +689,7 @@ namespace UnitTest
             // Set const alternative on construct
             const AZStd::variant<int32_t, const int64_t> testVariant(static_cast<int64_t>(23LL));
             ASSERT_EQ(1, testVariant.index());
-            
+
             static_assert(AZStd::is_same<decltype(AZStd::get<1>(AZStd::move(testVariant))), const int64_t&&>::value,
                 "AZStd::get should return const rvalue reference to const alternative for const variant");
             EXPECT_EQ(23LL, AZStd::get<1>(AZStd::move(testVariant)));
@@ -878,7 +878,6 @@ namespace UnitTest
         {
             auto returnConstCharPtrVisitor = [](auto&& variantAlt) -> const char*
             {
-                (void)variantAlt;
                 return AZStd::is_same<AZStd::remove_cvref_t<decltype(variantAlt)>, const char*>::value ? "Boat" : "Willy";
             };
 

--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
@@ -121,7 +121,7 @@ namespace AzFramework
         FileIOStream outputStream;
         if (!outputStream.Open(request.m_destPath.c_str(), OpenMode::ModeWrite | OpenMode::ModeBinary))
         {
-            return AZ::Failure(AZStd::string("Failed to open output file %s", request.m_destPath.data()));
+            return AZ::Failure(AZStd::string::format("Failed to open output file %s", request.m_destPath.data()));
         }
 
         auto compileOutcome = CompileScript(request);

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -92,7 +92,7 @@ AZ_CVAR(bool, g_disableDeprecatedNodeUpdates, false, {}, AZ::ConsoleFunctorFlags
 
 namespace EditorGraphCpp
 {
-    enum Version 
+    enum Version
     {
         BeforeCovertedUnitTestNodes = 6,
         RemoveUnusedField,
@@ -201,7 +201,7 @@ namespace ScriptCanvasEditor
         delete m_graphCanvasSceneEntity;
         m_graphCanvasSceneEntity = nullptr;
     }
-    
+
     void EditorGraph::OnViewRegistered()
     {
         if (!m_saveFormatConverted)
@@ -272,7 +272,7 @@ namespace ScriptCanvasEditor
                                     }
                                 }
                             }
-                        }                        
+                        }
                     }
                     else
                     {
@@ -327,7 +327,7 @@ namespace ScriptCanvasEditor
         }
 
         ReplacementInfoByNode replacementInfoByNewNode;
-        
+
         AZStd::vector<ScriptCanvas::Node*> remainingNodes;
 
         {
@@ -602,7 +602,7 @@ namespace ScriptCanvasEditor
         {
             if (!nodeSlot)
             {
-                return AZ::Failure(AZStd::string("EditorGraph::GetSlotState null slot in Node %s list: ", node.GetNodeName().c_str()));
+                return AZ::Failure(AZStd::string::format("EditorGraph::GetSlotState null slot in Node %s list: ", node.GetNodeName().c_str()));
             }
 
             auto liveSlotInfoOutcome = ConvertToLiveStateInfo(node, *nodeSlot);
@@ -1028,7 +1028,7 @@ namespace ScriptCanvasEditor
                                             const ScriptCanvas::GraphVariable& variableConfiguration = variableIter->second;
 
                                             AZ::Outcome<ScriptCanvas::VariableId, AZStd::string> remapVariableOutcome = AZ::Failure(AZStd::string());
-                                            ScriptCanvas::GraphVariableManagerRequestBus::EventResult(remapVariableOutcome, GetScriptCanvasId(), &ScriptCanvas::GraphVariableManagerRequests::RemapVariable, variableConfiguration);                                            
+                                            ScriptCanvas::GraphVariableManagerRequestBus::EventResult(remapVariableOutcome, GetScriptCanvasId(), &ScriptCanvas::GraphVariableManagerRequests::RemapVariable, variableConfiguration);
 
                                             if (remapVariableOutcome)
                                             {
@@ -1138,7 +1138,7 @@ namespace ScriptCanvasEditor
         }
 
         UpdateCorrespondingImplicitConnection(scSourceEndpoint, scTargetEndpoint);
-        
+
         return scConnected;
     }
 
@@ -1667,7 +1667,7 @@ namespace ScriptCanvasEditor
         m_queuedConvertingNodes.clear();
 
         AZStd::unordered_set<AZ::EntityId> deletedNodes;
-        
+
         for (ScriptCanvas::Node* node : newUpdates)
         {
             ScriptCanvas::UpdateResult updateResult = node->UpdateNode();
@@ -1771,7 +1771,7 @@ namespace ScriptCanvasEditor
     }
 
     void EditorGraph::OnPreConnectionDeleted(const AZ::EntityId& connectionId)
-    {        
+    {
         AZStd::any* userData = nullptr;
         GraphCanvas::ConnectionRequestBus::EventResult(userData, connectionId, &GraphCanvas::ConnectionRequests::GetUserData);
 
@@ -1876,7 +1876,7 @@ namespace ScriptCanvasEditor
                     ScriptCanvas::NodeRequestBus::Event((*scNodeId), &ScriptCanvas::NodeRequests::RemoveNodeDisabledFlag, ScriptCanvas::NodeDisabledFlag::User);
                     enabledNodes = true;
                 }
-            }            
+            }
         }
 
         if (enabledNodes)
@@ -1964,7 +1964,7 @@ namespace ScriptCanvasEditor
                     AZStd::any* userData = nullptr;
                     GraphCanvas::NodeRequestBus::EventResult(userData, nodeId, &GraphCanvas::NodeRequests::GetUserData);
                     AZ::EntityId scSourceNodeId = (userData && userData->is<AZ::EntityId>()) ? *AZStd::any_cast<AZ::EntityId>(userData) : AZ::EntityId();
-                        
+
                         ScriptCanvas::Nodes::Core::FunctionDefinitionNode* nodeling = azrtti_cast<ScriptCanvas::Nodes::Core::FunctionDefinitionNode*>(FindNode(scSourceNodeId));
 
                     if (nodeling)
@@ -2103,7 +2103,7 @@ namespace ScriptCanvasEditor
             if (scSourceNodeId.IsValid())
             {
                 ScriptCanvas::Node* node = FindNode(scSourceNodeId);
-                
+
                 if (node)
                 {
                     node->SanityCheckDynamicDisplay(exploredCache);
@@ -2316,7 +2316,7 @@ namespace ScriptCanvasEditor
 
     bool EditorGraph::CanPromoteToVariable(const GraphCanvas::Endpoint& endpoint, [[maybe_unused]] bool isNewSlot) const
     {
-        ScriptCanvas::Endpoint scriptCanvasEndpoint = ConvertToScriptCanvasEndpoint(endpoint);        
+        ScriptCanvas::Endpoint scriptCanvasEndpoint = ConvertToScriptCanvasEndpoint(endpoint);
         auto activeSlot = FindSlot(scriptCanvasEndpoint);
 
         if (activeSlot && !activeSlot->IsVariableReference() && activeSlot->CanConvertToReference())
@@ -2360,8 +2360,8 @@ namespace ScriptCanvasEditor
         AZStd::string variableName = "";
 
         int variableCounter = 0;
-        AZStd::string defaultName; 
-        
+        AZStd::string defaultName;
+
         AZ::Outcome<void, ScriptCanvas::GraphVariableValidationErrorCode> hasValidDefault = AZ::Failure(ScriptCanvas::GraphVariableValidationErrorCode::Unknown);
 
         do
@@ -2515,7 +2515,7 @@ namespace ScriptCanvasEditor
         AZ_UNUSED(mimeData);
 
         AZ_Assert(false, "Unimplemented drag and drop flow");
-        
+
         return AZ::Failure(AZStd::string("Unimplemented drag and drop flow"));
     }
 
@@ -2691,7 +2691,7 @@ namespace ScriptCanvasEditor
         CreateCustomNodeMimeEvent mimeEvent(typeId);
 
         AZ::Vector2 dropPosition = position;
-        
+
         if (mimeEvent.ExecuteEvent(position, dropPosition, GetGraphCanvasGraphId()))
         {
             return mimeEvent.GetCreatedPair();
@@ -2732,7 +2732,7 @@ namespace ScriptCanvasEditor
     AZStd::string EditorGraph::DecodeCrc(const AZ::Crc32& crcValue)
     {
         auto mapIter = m_crcCacheMap.find(crcValue);
-        
+
         if (mapIter != m_crcCacheMap.end())
         {
             return mapIter->second.m_cacheValue;
@@ -2747,7 +2747,7 @@ namespace ScriptCanvasEditor
         {
             GraphCanvas::SceneRequestBus::Event(GetGraphCanvasGraphId(), &GraphCanvas::SceneRequests::CancelGraphicsEffect, effectId);
         }
-        
+
         m_highlights.clear();
     }
 
@@ -2800,7 +2800,7 @@ namespace ScriptCanvasEditor
         auto variableData = GetVariableData();
 
         auto variables = variableData->GetVariables();
-        
+
         AZStd::unordered_set<ScriptCanvas::VariableId> usedVariableIds;
 
         for (auto nodePair : GetNodeMapping())
@@ -2933,7 +2933,7 @@ namespace ScriptCanvasEditor
                     {
                         canDetachNode = false;
                     }
-                    
+
                     auto connectionIds = slotRequests->GetConnections();
 
                     for (auto connectionId : connectionIds)
@@ -3010,7 +3010,7 @@ namespace ScriptCanvasEditor
                 }
             }
         }
-        
+
         // Signal out on the graph that we did something to the node.
         GraphCanvas::AnimatedPulseConfiguration animatedPulseConfig;
 
@@ -3369,7 +3369,7 @@ namespace ScriptCanvasEditor
         }
 
         bool isNodeling = false;
-        NodeDescriptorRequestBus::EventResult(isNodeling, endpoint.GetNodeId(), &NodeDescriptorRequests::IsType, NodeDescriptorType::FunctionDefinitionNode);        
+        NodeDescriptorRequestBus::EventResult(isNodeling, endpoint.GetNodeId(), &NodeDescriptorRequests::IsType, NodeDescriptorType::FunctionDefinitionNode);
 
         return isEnabled && !isNodeling;
     }
@@ -3537,7 +3537,7 @@ namespace ScriptCanvasEditor
         {
             OnSaveDataDirtied(GetGraphCanvasGraphId());
         }
-        
+
         AZStd::vector< AZ::EntityId > graphCanvasNodes;
         GraphCanvas::SceneRequestBus::EventResult(graphCanvasNodes, GetGraphCanvasGraphId(), &GraphCanvas::SceneRequests::GetNodes);
 
@@ -3558,7 +3558,7 @@ namespace ScriptCanvasEditor
 
             UnregisterToast((*toastId));
 
-            SceneMemberMappingRequestBus::EventResult(pair.m_graphCanvasId, pair.m_scriptCanvasId, &SceneMemberMappingRequests::GetGraphCanvasEntityId);            
+            SceneMemberMappingRequestBus::EventResult(pair.m_graphCanvasId, pair.m_scriptCanvasId, &SceneMemberMappingRequests::GetGraphCanvasEntityId);
 
             AZStd::vector<AZ::EntityId> focusElements = { pair.m_graphCanvasId };
 
@@ -3598,7 +3598,7 @@ namespace ScriptCanvasEditor
         GraphCanvas::SceneRequestBus::EventResult(viewId, GetGraphCanvasGraphId(), &GraphCanvas::SceneRequests::GetViewId);
 
         AzToolsFramework::ToastId toastId;
-        GraphCanvas::ViewRequestBus::EventResult(toastId, viewId, &GraphCanvas::ViewRequests::ShowToastNotification, toastConfiguration);        
+        GraphCanvas::ViewRequestBus::EventResult(toastId, viewId, &GraphCanvas::ViewRequests::ShowToastNotification, toastConfiguration);
 
         AzToolsFramework::ToastNotificationBus::MultiHandler::BusConnect(toastId);
         m_toastNodeIds[toastId] = node.GetEntityId();
@@ -3766,7 +3766,7 @@ namespace ScriptCanvasEditor
             }
 
             ScriptCanvas::NodeIdList nodeList = GetNodes();
-            
+
             AZStd::unordered_set<ScriptCanvas::Node*> outOfDateNodes;
             AZStd::unordered_set<AZ::EntityId> deletedNodes;
             AZStd::unordered_set<AZ::EntityId> assetSanitizationSet;
@@ -4095,5 +4095,5 @@ namespace ScriptCanvasEditor
         GraphCanvas::SceneRequestBus::Event(graphCanvasGraphId, &GraphCanvas::SceneRequests::ClearScene);
 
         RequestPopPreventUndoStateUpdate();
-    }    
+    }
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EventHandlerTranslationUtility.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EventHandlerTranslationUtility.h
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #pragma once
+
 #include <Include/ScriptCanvas/Libraries/Core/EBusEventHandler.generated.h>
 #include <Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.generated.h>
 
@@ -25,7 +27,7 @@ namespace ScriptCanvas
             public:
                 // EbusEvent handler
                 static ConstSlotsOutcome  GetSlotsInExecutionThreadByType(const EBusEventHandler& handler, const Slot& executionSlot, CombinedSlotType targetSlotType);
-                
+
                 // ScriptEvent handler
                 static ConstSlotsOutcome  GetSlotsInExecutionThreadByType(const ReceiveScriptEvent& handler, const Slot& executionSlot, CombinedSlotType targetSlotType);
 
@@ -73,7 +75,7 @@ namespace ScriptCanvas
 
                 if (!eventEntry)
                 {
-                    return AZ::Failure(AZStd::string("Failure to find event with executionSlot, %s", executionSlot.GetName().data()));
+                    return AZ::Failure(AZStd::string::format("Failure to find event with executionSlot, %s", executionSlot.GetName().data()));
                 }
 
                 // some event slots are mis-labeled

--- a/Gems/SurfaceData/Code/Include/SurfaceData/MixedStackHeapAllocator.h
+++ b/Gems/SurfaceData/Code/Include/SurfaceData/MixedStackHeapAllocator.h
@@ -16,79 +16,57 @@
 
 namespace SurfaceData
 {
-    /* mixed_stack_heap_allocator
-    
-       This allocator is a hybrid between a stack-based allocator and a heap-based allocator.
-       It is intended for use with vector<> as a way to get the performance of fixed_vector<> when few nodes are needed, while still
-       retaining the flexibility of general-purpose resizing when a large number of nodes are needed.
-
-       In particular, this is useful for APIs that use a temporary vector<> during processing that is sized based on an input to the
-       API, and the APIs have different use cases that could significantly vary the size requirements.
-
-       Usage:
-       vector<T, mixed_stack_heap_allocator<T, N>> tempData;
-
-       This will create a vector<T> that pre-allocates space for N nodes on the stack. If the vector attempts to allocate
-       N entries or less, the allocation will come from the stack space. If more than N entries are allocated, or if the vector attempts
-       to grow beyond N entries, the memory will instead come from the heap.
-
-       Limitations:
-       - This currently only supports exactly one allocation from the stack, which works well for vector<>, but may not work as well for
-         other data types.
-       - Once the memory is allocated from the heap, shrinking the allocation won't cause it to use the stack unless the vector<> is fully
-         deallocated and reallocated.
-    */
-
-    template<class Node, AZStd::size_t NumNodes>
-    class mixed_stack_heap_allocator
+    /**
+     * mixed_stack_heap_allocator
+     *
+     * This allocator is a hybrid between a stack-based allocator and a heap-based allocator.
+     * It is intended for use with vector<> as a way to get the performance of fixed_vector<>
+     * when few nodes are needed, while still retaining the flexibility of
+     * general-purpose resizing when a large number of nodes are needed.
+     *
+     * In particular, this is useful for APIs that use a temporary vector<> during processing
+     * that is sized based on an input to the API, and the APIs have different use cases that
+     * could significantly vary the size requirements.
+     *
+     * Usage:
+     * vector<T, mixed_stack_heap_allocator<T, N>> tempData;
+     *
+     * This will create a vector<T> that pre-allocates space for N nodes on the stack.
+     * If the vector attempts to allocate N entries or less, the allocation will come from the stack space.
+     * If more than N entries are allocated, or if the vector attempts to grow beyond N entries,
+     * the memory will instead come from the heap.
+     *
+     * Limitations:
+     * - This currently only supports exactly one allocation from the stack,
+     *   which works well for vector<>, but may not work as well for other data types.
+     * - Once the memory is allocated from the heap, shrinking the allocation won't cause it to use the stack
+     *   unless the vector<> is fully deallocated and reallocated.
+     */
+    template<class Node, size_t NumNodes>
+    struct mixed_stack_heap_allocator
     {
         static_assert(NumNodes > 0, "Size of static buffer must be more than 0.");
-        typedef mixed_stack_heap_allocator<Node, NumNodes> this_type;
 
-    public:
         AZ_TYPE_INFO(mixed_stack_heap_allocator, "{49B6706B-716F-42F2-92CB-7FD1A57BE2F9}");
 
         AZ_ALLOCATOR_DEFAULT_TRAITS
 
-        mixed_stack_heap_allocator(const char* name = "AZStd::mixed_stack_heap_allocator")
-            : m_name(name)
-            , m_lastStaticAllocation(nullptr)
-        {
-        }
+        mixed_stack_heap_allocator() = default;
 
         mixed_stack_heap_allocator(const mixed_stack_heap_allocator& rhs)
-            : m_name(rhs.m_name)
-            , m_lastStaticAllocation(nullptr)
-        {
-        }
-
-        mixed_stack_heap_allocator([[maybe_unused]] const mixed_stack_heap_allocator& rhs, const char* name)
-            : m_name(name)
-            , m_lastStaticAllocation(nullptr)
         {
         }
 
         mixed_stack_heap_allocator& operator=(const mixed_stack_heap_allocator& rhs)
         {
-            m_name = rhs.m_name;
             return *this;
         }
 
-        const char* get_name() const
-        {
-            return m_name;
-        }
-
-        void set_name(const char* name)
-        {
-            m_name = name;
-        }
-
-        auto allocate(size_type byteSize, size_type alignment, int flags = 0) -> pointer
+        [[nodiscard]] pointer allocate(size_type byteSize, size_type alignment, int flags = 0)
         {
             // If the requested allocation will fit in our static buffer, and we aren't already using the static buffer,
             // then mark the static buffer as used and return a pointer to it.
-            if ((byteSize <= (sizeof(Node) * NumNodes)) && (alignment <= AZStd::alignment_of<Node>::value) &&
+            if ((byteSize <= (sizeof(Node) * NumNodes)) && (alignment <= AZStd::alignment_of_v<Node>) &&
                 (m_lastStaticAllocation == nullptr))
             {
                 m_lastStaticAllocation = &m_data;
@@ -96,7 +74,7 @@ namespace SurfaceData
             }
 
             // Otherwise, allocate from the heap.
-            return AZ::AllocatorInstance<AZ::SystemAllocator>::Get().Allocate(byteSize, alignment, flags, m_name, __FILE__, __LINE__, 1);
+            return AZ::AllocatorInstance<AZ::SystemAllocator>::Get().Allocate(byteSize, alignment, flags, nullptr, __FILE__, __LINE__, 1);
         }
 
         void deallocate(pointer ptr, size_type byteSize, size_type alignment)
@@ -112,7 +90,7 @@ namespace SurfaceData
             AZ::AllocatorInstance<AZ::SystemAllocator>::Get().DeAllocate(ptr, byteSize, alignment);
         }
 
-        auto reallocate(pointer ptr, size_type newSize, align_type newAlignment = 1) -> pointer
+        [[nodiscard]] pointer reallocate(pointer ptr, size_type newSize, align_type newAlignment = 1) const
         {
             // If we're trying to reallocate our static buffer, allow it to succeed as long as the new size is within the total size of the
             // static buffer. Otherwise, return 0 to fail the reallocate request.
@@ -129,13 +107,13 @@ namespace SurfaceData
             return AZ::AllocatorInstance<AZ::SystemAllocator>::Get().reallocate(ptr, newSize, newAlignment);
         }
 
-        auto max_size() const -> size_type
+        size_type max_size() const
         {
             // Since we allow both stack and heap allocations, the max allocation size for this container is the heap's maximum.
             return AZ::AllocatorInstance<AZ::SystemAllocator>::Get().GetMaxContiguousAllocationSize();
         }
 
-        auto NumAllocatedBytes() const -> size_type
+        size_type NumAllocatedBytes() const
         {
             // Always return the full size of our stack allocation, plus the total amount of heap allocations.
             // While this doesn't seem like an accurate result, it's consistent with how AZStd::allocator behaves.
@@ -144,48 +122,37 @@ namespace SurfaceData
             return (sizeof(Node) * NumNodes) + AZ::AllocatorInstance<AZ::SystemAllocator>::Get().NumAllocatedBytes();
         }
 
-        bool is_lock_free()
+        constexpr bool is_lock_free() const
         {
             return false;
         }
 
-        bool is_stale_read_allowed()
+        constexpr bool is_stale_read_allowed() const
         {
             return false;
         }
 
-        bool is_delayed_recycling()
+        constexpr bool is_delayed_recycling() const
         {
             return false;
+        }
+
+        friend bool operator==(
+            const mixed_stack_heap_allocator& a,
+            const mixed_stack_heap_allocator& b)
+        {
+            // Allocators should compare as equal if they can interchangeably handle each other's allocations.
+            // Since this allocator can allocate from a private static buffer, it can only process its own allocations.
+            return &a == &b;
         }
 
     private:
-        const char* m_name;
-
         // This will point to &m_data if the static allocation is currently in use, and nullptr if it isn't.
         // Eventually, this could also be used to support multiple static allocations from the same buffer.
-        void* m_lastStaticAllocation{ nullptr };
+        void* m_lastStaticAllocation{nullptr};
 
         // Stack-based storage that exists for the same lifetime as the data structure using this allocator.
-        typename AZStd::aligned_storage<sizeof(Node) * NumNodes, AZStd::alignment_of<Node>::value>::type m_data;
+        AZStd::aligned_storage_t<sizeof(Node) * NumNodes, AZStd::alignment_of_v<Node>> m_data;
     };
-
-    template<class Node, AZStd::size_t NumNodes>
-    bool operator==(
-        [[maybe_unused]] const mixed_stack_heap_allocator<Node, NumNodes>& a,
-        [[maybe_unused]] const mixed_stack_heap_allocator<Node, NumNodes>& b)
-    {
-        // Allocators should compare as equal if they can interchangeably handle each other's allocations.
-        // Since this allocator can allocate from a private static buffer, it can only process its own allocations.
-        return (&a == &b);
-    }
-
-    template<class Node, AZStd::size_t NumNodes>
-    bool operator!=(
-        [[maybe_unused]] const mixed_stack_heap_allocator<Node, NumNodes>& a,
-        [[maybe_unused]] const mixed_stack_heap_allocator<Node, NumNodes>& b)
-    {
-        return (&a != &b);
-    }
 
 } // namespace AZStd

--- a/Gems/SurfaceData/Code/Tests/MixedAllocatorTest.cpp
+++ b/Gems/SurfaceData/Code/Tests/MixedAllocatorTest.cpp
@@ -23,21 +23,6 @@ namespace UnitTest
         }
     };
 
-    TEST_F(MixedAllocatorTestFixture, MixedStackHeapAllocator_GetNameSetNameWorks)
-    {
-        const int StackElements = 4;
-
-        // Setting the name via construction should work.
-        const char name[] = "Mixed allocator";
-        SurfaceData::mixed_stack_heap_allocator<float, StackElements> allocator(name);
-        EXPECT_EQ(strcmp(allocator.get_name(), name), 0);
-
-        // Setting the name via set_name should work.
-        const char newName[] = "Renamed allocator";
-        allocator.set_name(newName);
-        EXPECT_EQ(strcmp(allocator.get_name(), newName), 0);
-    }
-
     TEST_F(MixedAllocatorTestFixture, MixedStackHeapAllocator_SingleStackAllocationWorks)
     {
         const int StackElements = 4;


### PR DESCRIPTION
## What does this PR do?

Removes the implicit `allocator(const char*)` constructor from `AZStd::allocator` and refactors all AZStd allocator classes to better match C++20 idioms.

### The Bug 🐛 

`AZStd::allocator` had a non-standard implicit constructor that accepted `const char*`:

```cpp
AZ_FORCE_INLINE allocator(const char*);
```

The original intent (I think) was to name allocators for debugging, but this was never actually leveraged. Instead, the implicit conversion created silent bugs. For example:

```cpp
AZStd::vector<AZ::Crc32>({ "AssetBuilder" })
```

This compiles but produces an **empty vector**. Because `Crc32`'s constructors are all `explicit`, the string literal `"AssetBuilder"` can't implicitly convert to `Crc32`. However, `AZStd::allocator(const char*)` is *implicit*, so the compiler interprets the single-argument brace-init as constructing an `allocator` from `"AssetBuilder"`, calling the allocator overload of vector's constructor rather than the initializer_list overload. The string is silently consumed as a discarded allocator name, and you get a default-constructed empty vector with no error or warning.

### The Fix 🔧 

The `allocator(const char*)` constructor is removed entirely. There was no code in the engine that intentionally created a named allocator. The few call sites that passed strings (in tests and `AZStd::any`) were dead patterns. If tagged/named allocators are needed in the future, that should be designed as a proper opt-in feature, not an implicit conversion from string literals.

Removing the implicit constructor revealed pre-existing bugs where `AZStd::string("format %s", arg)` was being used as if it were `printf`-style formatting. The `const char*` was silently consumed by the allocator constructor, so these calls compiled but produced garbage strings. Fixed with `AZStd::string::format(...)`.

### General Allocator Changes

While in these files, made updates to the existing AZStd allocator classes:

#### All Allocators:
- Added `[[nodiscard]]` on `allocate` and `reallocate` methods
- Removed `operator!=` (C++ auto-synthesizes it from `operator==`)

#### `allocator` (default):
- Removed `allocator(const char*)` and `allocator(const allocator&, const char*)` constructors
- Removed `propagate_on_container_copy/move_assignment` typedefs (allocator_traits defaults to `true_type`)
- Made `is_lock_free()`, `is_stale_read_allowed()`, `is_delayed_recycling()` `constexpr` and `const`
- Made `max_size()`, `get_allocated_size()` `constexpr`
- Replaced free `operator==`/`operator!=` with defaulted `friend operator==`
- Changed `class` to `struct` (updated forward declarations in `TypeInfo.h`, `Path_fwd.h`)
- Replaced `#ifndef` include guard with `#pragma once`
- Rewrote documentation

#### `no_default_allocator`:
- Replaced unimplemented-but-declared methods (link-time errors) with `= delete` (compile-time errors)
- Removed dead `get_name()`/`set_name()` API
- Fixed `operator=` (was returning `allocator&` instead of `no_default_allocator&`)
- Marked `final`

#### `stack_allocator`:
- Replaced private copy/new declarations with `= delete`
- Removed dead `AZ::Internal::AllocatorDummy` struct
- Replaced include guard with `#pragma once`

#### `stateless_allocator`:
- Made `is_lock_free()`, `is_stale_read_allowed()`, `is_delayed_recycling()` `const` and moved inline
- Removed stale `.cpp` implementations of `resize()`, `is_lock_free()`, `is_stale_read_allowed()`, `is_delayed_recycling()`

#### `allocator_concurrent_static`:
- Replaced include guard with `#pragma once`

#### `AllocatorWrapper`:
- Replaced `aligned_storage<...>::type` with `aligned_storage_t<...>` so typename can be removed.

## How was this PR tested?

- Full clean build on Windows with Clang and MSVC
- Editor builds and runs