### PR TITLE
Set ASSIMP_BUILD_USE_CCACHE=OFF

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/3rdParty/Findassimp.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/3rdParty/Findassimp.cmake
@@ -51,14 +51,16 @@ function(GetAssimp)
     set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 
     # The rest of these are all specific settings that come from Assimp's CMakeLists.txt files.
-    set(ASSIMP_BUILD_ZLIB OFF)  # Don't rebuild ZLIB. O3DE's comes with its own ZLIB 3rdParty package.
     set(ASSIMP_BUILD_ASSIMP_TOOLS OFF)
-    set(ASSIMP_BUILD_USD_IMPORTER ON)
-    set(ASSIMP_WARNINGS_AS_ERRORS OFF)  # Not sure why this doesn't work. Warnings are still treated as error; needed to add warning disabled commandline parameters to PAL_assimp_<compiler>.cmake
     set(ASSIMP_BUILD_TESTS OFF)
-    set(ASSIMP_INSTALL OFF)  # Disable since we're using Assimp as a sub module
-    set(ASSIMP_INJECT_DEBUG_POSTFIX OFF)  # Stop Assimp from adding 'd' to debug target outputs (mylibraryd.dll) https://github.com/assimp/assimp/blob/f63625256c4e6f18fca8e7dc857b47a02320e867/CMakeLists.txt#L411
+    set(ASSIMP_BUILD_USD_IMPORTER ON)
+    set(ASSIMP_BUILD_USE_CCACHE OFF)
+    set(ASSIMP_BUILD_ZLIB OFF)  # Don't rebuild ZLIB. O3DE's comes with its own ZLIB 3rdParty package.
     set(ASSIMP_HUNTER_ENABLED OFF)
+    set(ASSIMP_INJECT_DEBUG_POSTFIX OFF)  # Stop Assimp from adding 'd' to debug target outputs (mylibraryd.dll) https://github.com/assimp/assimp/blob/f63625256c4e6f18fca8e7dc857b47a02320e867/CMakeLists.txt#L411
+    set(ASSIMP_INSTALL OFF)  # Disable since we're using Assimp as a sub module
+    set(ASSIMP_WARNINGS_AS_ERRORS OFF)  # Not sure why this doesn't work. Warnings are still treated as error; needed to add warning disabled commandline parameters to PAL_assimp_<compiler>.cmake
+    set(TINYUSDZ_USE_CCACHE OFF)
 
     # Assimp requires ZLIB
     find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## What does this PR do?

Prevents Assimp from configuring ccache independently of the rest of the project. We already have a compiler launcher system in place that works with dependencies like Assimp. So this just introduces bugs on certain platforms.

I also sorted the cmake options, which is why the change looks larger than it is.

## How was this PR tested?

Tested on Windows, where ccache is installed in a path that contains whitespace.
