### PR TITLE
Alternative fix for the failing test - run serially rather than parallel

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME APTests.Batch_2_Main
         PATH  ${CMAKE_CURRENT_LIST_DIR}/asset_processor_batch_tests_2.py
         TEST_SUITE main
+        TEST_SERIAL
         PYTEST_MARKS "not SUITE_sandbox" # don't run sandbox tests in this file
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessorBatch
@@ -26,6 +27,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME APTests.ap_builder_test
         PATH  ${CMAKE_CURRENT_LIST_DIR}/ap_builder_test.py
         TEST_SUITE main
+        TEST_SERIAL
         PYTEST_MARKS "not SUITE_sandbox" # don't run sandbox tests in this file
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessorBatch
@@ -36,6 +38,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME APTests.ScriptCanvas_Main
         PATH ${CMAKE_CURRENT_LIST_DIR}/ScriptCanvasAssetProcessorTests.py
         TEST_SUITE main
+        TEST_SERIAL
         PYTEST_MARKS "not SUITE_sandbox" # don't run sandbox tests in this file
         RUNTIME_DEPENDENCIES       
             AZ::AssetProcessorBatch


### PR DESCRIPTION
## What does this PR do?

Moves the test that is failing on linux only to serial execution, so multiple AP are not launched at the same time, as an altenative to disabling the test. (https://github.com/o3de/o3de/pull/19619)

## How was this PR tested?

I was able to repro the slow test run on linux.  Then, after adding this tag, the test no longer took 90 seconds, but rather, 5 seconds.

We can test it using AR, since its a 100% failure.

