### PR TITLE
Fix issue #19579 - Transfer Queue not selected

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -153,15 +153,25 @@ namespace AZ
             {
                 const VkQueueFamilyProperties& familyProperties = m_queueFamilyProperties[familyIndex];
 
-                // There should be at least one queue family supporting both graphics and compute (as well as copying, but that might not be
-                // exposed)
+                VkQueueFlags effectiveFlags = familyProperties.queueFlags;
+                if (AZ::RHI::CheckBitsAny(effectiveFlags, static_cast<VkFlags>(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)))
+                {
+                    // according to the Vulkan spec, if a queue supports graphics or compute, transfer bit is implied and does not
+                    // need to actually be set.  See https://registry.khronos.org/VulkanSC/specs/1.0-extensions/man/html/VkQueueFlagBits.html
+                    effectiveFlags |= VK_QUEUE_TRANSFER_BIT;
+                }
+
+                // There should be at least one queue family supporting both graphics and compute. Quoting the above registry link:
+                // > If an implementation exposes any queue family that supports graphics operations, at least one queue family of at least
+                // > one physical device exposed by the implementation must support both graphics and compute operations.
                 if ((graphicsFamilyIndex == -1) &&
-                    AZ::RHI::CheckBitsAll(familyProperties.queueFlags, static_cast<VkFlags>(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)))
+                    AZ::RHI::CheckBitsAll(effectiveFlags, static_cast<VkFlags>(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)))
                 {
                     graphicsFamilyIndex = familyIndex;
                 }
 
-                if (AZ::RHI::CheckBitsAny(familyProperties.queueFlags, static_cast<VkFlags>(VK_QUEUE_COMPUTE_BIT)))
+                // if there is a compute queue that doesn't support graphics, we prefer it over one that supports both:
+                if (AZ::RHI::CheckBitsAny(effectiveFlags, static_cast<VkFlags>(VK_QUEUE_COMPUTE_BIT)))
                 {
                     if (computeFamilyIndex == -1)
                     {
@@ -171,15 +181,18 @@ namespace AZ
                     {
                         // We take the queue family that supports the least amount of features, but still supports compute. That way we
                         // likely get an async compute queue.
-                        if (AZ::RHI::CountBitsSet(familyProperties.queueFlags) <
-                            AZ::RHI::CountBitsSet(m_queueFamilyProperties[computeFamilyIndex].queueFlags))
+                        VkQueueFlags currentFlags = familyProperties.queueFlags;
+                        VkQueueFlags existingFlags = m_queueFamilyProperties[computeFamilyIndex].queueFlags;
+                        if (currentFlags < existingFlags)
                         {
                             computeFamilyIndex = familyIndex;
                         }
                     }
                 }
 
-                if (AZ::RHI::CheckBitsAny(familyProperties.queueFlags, static_cast<VkFlags>(VK_QUEUE_TRANSFER_BIT)))
+                // Look for a dedicated transfer queue, if one is availalble.  Same process as above, prefer queues that
+                // support less features, as they are more likely to be async.
+                if (AZ::RHI::CheckBitsAny(effectiveFlags, static_cast<VkFlags>(VK_QUEUE_TRANSFER_BIT)))
                 {
                     if (transferFamilyIndex == -1)
                     {
@@ -187,10 +200,9 @@ namespace AZ
                     }
                     else
                     {
-                        // We take the queue family that supports the least amount of features, but still supports copying. That way we
-                        // likely get an async copy queue.
-                        if (AZ::RHI::CountBitsSet(familyProperties.queueFlags) <
-                            AZ::RHI::CountBitsSet(m_queueFamilyProperties[transferFamilyIndex].queueFlags))
+                        VkQueueFlags currentFlags = familyProperties.queueFlags;
+                        VkQueueFlags existingFlags = m_queueFamilyProperties[transferFamilyIndex].queueFlags;
+                        if (currentFlags < existingFlags)
                         {
                             transferFamilyIndex = familyIndex;
                         }


### PR DESCRIPTION
## What does this PR do?
Fixes issue #19579 where atom could not initialize on some mobile devices.

Atom needs to select 3 queues during initialization in order to function properly:
* One for Graphics
* One for Compute
* One for Transfer

Each Queue available on the hardware is queried and indicates which operations it supports, via a bitset returned.  Commands are then submitted to the appropriate queue, based on what they need to do (for example, compute operations go to the one that supports compute).

Many queues support more than 1 type of operation, so multiple bits can be set.  We prefer to select the one with the least capability, since they are likely to be **dedicated** queues that can run asynchronously - for example, its preferrable to use a queue for transfer operations that ONLY supports transfer operations, as opposed to one which supports transfer and graphics.

However, it turns out that according to the specification, if a queue supports compute or graphics operations, it **implies** that it supports transfer operations, and does not need to actually set those bits in the bitset it returns when queried about capabilities.  Most desktop hardware, when queried, supplies those bits anyway (setting the `transfer` bit even though it doesn't technically have to), but some mobile hardware does not, since it is optional and that bit is "implied".

The bug is caused by Atom code only looking for queues which have the `transfer` bit set, without knowing about the fact that the transfer bit is implied by the compute and graphics bits.

This code changes it so that if a queue supports compute or graphics, `transfer` is implied, during selection.

Thanks to O3DE Discord users "Styx_Hc" and "JH Mueller [Huawei]" for additional help.

## How was this PR tested?

Tested on windows using Vulkan.  Transparent-box testing, that is, examining the flags and watching it select the right queue.

