### PR TITLE
Add patch file for assimp to fix tinyusd missing includes

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/3rdParty/Findassimp.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/3rdParty/Findassimp.cmake
@@ -25,11 +25,13 @@ function(GetAssimp)
 
     set(ASSIMP_GIT_REPO "https://github.com/assimp/assimp.git")
     set(ASSIMP_GIT_TAG "fb375dd8c0a032106a2122815fb18dffe0283721")
+    set(ASSIMP_GIT_PATCH "${CMAKE_CURRENT_LIST_DIR}/tinyusd-include.patch")
 
     FetchContent_Declare(
             assimp
             GIT_REPOSITORY ${ASSIMP_GIT_REPO}
             GIT_TAG ${ASSIMP_GIT_TAG}
+            PATCH_COMMAND cmake -P "${LY_ROOT_FOLDER}/cmake/PatchIfNotAlreadyPatched.cmake" ${ASSIMP_GIT_PATCH}
             GIT_SHALLOW
             EXCLUDE_FROM_ALL # Prevent it from executing 'install' ops, it doesn't need to be included in installer
     )

--- a/Code/Tools/SceneAPI/SDKWrapper/3rdParty/tinyusd-include.patch
+++ b/Code/Tools/SceneAPI/SDKWrapper/3rdParty/tinyusd-include.patch
@@ -1,0 +1,33 @@
+diff --git a/contrib/tinyusdz/patches/tinyusdz.patch b/contrib/tinyusdz/patches/tinyusdz.patch
+index 2a883d16a..5645004d5 100644
+--- a/contrib/tinyusdz/patches/tinyusdz.patch
++++ b/contrib/tinyusdz/patches/tinyusdz.patch
+@@ -1,7 +1,8 @@
+-diff -rupN -x .git autoclone/tinyusdz_repo-src/src/external/stb_image_resize2.h tinyusdz_repo_patch/src/external/stb_image_resize2.h
+---- autoclone/tinyusdz_repo-src/src/external/stb_image_resize2.h	2024-10-27 03:26:45.457163600 -0700
+-+++ tinyusdz_repo_patch/src/external/stb_image_resize2.h	2024-10-27 03:31:09.255211100 -0700
+-@@ -2500,6 +2500,38 @@ static stbir__inline stbir_uint8 stbir__
++diff --git a/src/external/stb_image_resize2.h b/src/external/stb_image_resize2.h
++index b982eb1f..6b4d3582 100644
++--- a/src/external/stb_image_resize2.h
+++++ b/src/external/stb_image_resize2.h
++@@ -2500,6 +2500,38 @@ static stbir__inline stbir_uint8 stbir__linear_to_srgb_uchar(float in)
+      }
+    }
+  
+@@ -40,3 +41,15 @@ diff -rupN -x .git autoclone/tinyusdz_repo-src/src/external/stb_image_resize2.h
+  #endif
+  
+  
++diff --git a/src/value-types.hh b/src/value-types.hh
++index 5b6be1d2..0f15f7c3 100644
++--- a/src/value-types.hh
+++++ b/src/value-types.hh
++@@ -13,6 +13,7 @@
++ #include <algorithm>
++ #include <array>
++ #include <cmath>
+++#include <cstdint>
++ #include <cstring>
++ #include <functional>
++ #include <iostream>


### PR DESCRIPTION
## What does this PR do?

Close https://github.com/o3de/o3de/issues/19623 by patching Assimp.
I wasn't able to repro the issue on clang 18, 20 and 22, but since two users ran into it while building it must be tackled.

This might not be the approach we choose in the end, but I leave it up so that it makes the decision easier to take as it shows an alternative.

## How was this PR tested?

Local build on linux mint with clang 20
