### PR TITLE
Fixes a compile error with assimp

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/MSVC/PAL_assimp_msvc.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/Platform/Common/MSVC/PAL_assimp_msvc.cmake
@@ -11,6 +11,7 @@ function(PAL_Assimp_Lift_CxxFlagsWarnings)
     string(REPLACE "/we5032" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # detected #pragma warning(push) with no corresponding #pragma warning(pop)
     string(REPLACE "/we4777" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # 'function' : format string 'string' requires an argument of type 'type1', but variadic argument number has type 'type2
     string(REPLACE "/we4437" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # dynamic_cast from virtual base 'class1' to 'class2' could fail in some contexts
+    string(REPLACE "/we4296" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") # expression is always true / expression is always false.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
## What does this PR do?

assimp contains an expression that always evaluates to true, which causes compiler error C4296.

O3DE auto enables this warning as well as warnings as errors, and MSVC completely ignores the "Disable All Warnings" option when it comes to specific warnings being enabled, so it has to be added specifically to the compile options for assimp

## How was this PR tested?

I was able to compile, when before I could not.  Note that this changed after an update to MSVC, so it might affect only the very latest MSVC compiler.
