### PR TITLE
Prevent annoying dialog upon opening material editor

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
@@ -128,6 +128,8 @@ namespace AtomToolsFramework
         for (size_t openDocumentIndex = 0; openDocumentIndex < openDocumentCount; ++openDocumentIndex)
         {
             const AZStd::string openDocumentPath = commandLine.GetMiscValue(openDocumentIndex);
+            if (openDocumentPath.empty())
+                continue;
 
             AZ_Printf(m_targetName.c_str(), "Opening document: %s", openDocumentPath.c_str());
             AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, openDocumentPath);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentApplication.cpp
@@ -129,7 +129,9 @@ namespace AtomToolsFramework
         {
             const AZStd::string openDocumentPath = commandLine.GetMiscValue(openDocumentIndex);
             if (openDocumentPath.empty())
+            {
                 continue;
+            }
 
             AZ_Printf(m_targetName.c_str(), "Opening document: %s", openDocumentPath.c_str());
             AtomToolsDocumentSystemRequestBus::Event(m_toolId, &AtomToolsDocumentSystemRequestBus::Events::OpenDocument, openDocumentPath);


### PR DESCRIPTION
## What does this PR do?

Close https://github.com/o3de/o3de/issues/19612.
Not yet sure on what caused the regression (will have a quick look at the history), likely something in CommandLine::GetNumMiscValues(), but either way its still important to have this safe-guard.

## How was this PR tested?

Local windows build.
- Open material editor, opens as expected
- Double click on a material to open material editor, opens as expected with the material in edit
- Double click on a material from content browser with material editor opened, new tab opens
