### PR TITLE
Extend Unlit material support

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit.materialtype
@@ -1,6 +1,6 @@
 {
     "description": "Renders a model unlit with a single surface color value.",
-    "version": 0,
+    "version": 1,
     "versionUpdates": [],
     "propertyLayout": {
         "propertyGroups": [
@@ -30,6 +30,13 @@
                         }
                     },
                     {
+                        "name": "useTexture",
+                        "displayName": "Use Texture",
+                        "description": "Whether to use the texture.",
+                        "type": "Bool",
+                        "defaultValue": true
+                    },
+                    {
                         "name": "textureMapUv",
                         "displayName": "UV",
                         "description": "Base color map UV set",
@@ -39,6 +46,144 @@
                         "connection": {
                             "type": "ShaderInput",
                             "name": "m_baseColorMapUvIndex"
+                        }
+                    }
+                ],
+                "functors": [
+                    {
+                        "type": "UseTexture",
+                        "args": {
+                            "textureProperty": "baseColorTexture",
+                            "useTextureProperty": "useTexture",
+                            "dependentProperties": ["textureMapUv"],
+                            "shaderOption": "o_baseColor_useTexture"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "opacity",
+                "displayName": "Opacity",
+                "description": "Properties for configuring alpha clipping and blending.",
+                "properties": [
+                    {
+                        "name": "mode",
+                        "displayName": "Opacity Mode",
+                        "description": "Indicates whether alpha clipping or alpha blending is enabled.",
+                        "type": "Enum",
+                        "enumValues": [ "Opaque", "Cutout", "Blended" ],
+                        "defaultValue": "Opaque",
+                        "connection": {
+                            "type": "ShaderOption",
+                            "name": "o_opacity_mode"
+                        }
+                    },
+                    {
+                        "name": "alphaSource",
+                        "displayName": "Alpha Source",
+                        "description": "Indicates whether to get the alpha from the base color map or from a separate greyscale texture.",
+                        "type": "Enum",
+                        "enumValues": [ "Packed", "Split", "None" ],
+                        "defaultValue": "Packed",
+                        "connection": {
+                            "type": "ShaderOption",
+                            "name": "o_opacity_source"
+                        }
+                    },
+                    {
+                        "name": "textureMap",
+                        "displayName": "Texture",
+                        "description": "Texture for defining opacity.",
+                        "type": "Image",
+                        "connection": {
+                            "type": "ShaderInput",
+                            "name": "m_opacityMap"
+                        }
+                    },
+                    {
+                        "name": "useTexture",
+                        "displayName": "Use Texture",
+                        "description": "Whether to use the opacity texture.",
+                        "type": "Bool",
+                        "defaultValue": true
+                    },
+                    {
+                        "name": "textureMapUv",
+                        "displayName": "UV",
+                        "description": "Opacity map UV set",
+                        "type": "Enum",
+                        "enumIsUv": true,
+                        "defaultValue": "Tiled",
+                        "connection": {
+                            "type": "ShaderInput",
+                            "name": "m_opacityMapUvIndex"
+                        }
+                    },
+                    {
+                        "name": "factor",
+                        "displayName": "Factor",
+                        "description": "Factor for cutout threshold and blended opacity.",
+                        "type": "Float",
+                        "min": 0.0,
+                        "max": 1.0,
+                        "defaultValue": 0.5,
+                        "connection": {
+                            "type": "ShaderInput",
+                            "name": "m_opacityFactor"
+                        }
+                    }
+                ],
+                "functors": [
+                    {
+                        "type": "Lua",
+                        "args": {
+                            "file": "Materials/Types/Unlit_OpacityState.lua"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "general",
+                "displayName": "General Settings",
+                "description": "General settings.",
+                "properties": [
+                    {
+                        "name": "doubleSided",
+                        "displayName": "Double-sided",
+                        "description": "Whether to render back-faces or just front-faces.",
+                        "type": "Bool",
+                        "defaultValue": false
+                    },
+                    {
+                        "name": "castShadows",
+                        "displayName": "Cast Shadows",
+                        "description": "Whether this material contributes to shadow maps.",
+                        "type": "Bool",
+                        "defaultValue": true
+                    },
+                    {
+                        "name": "billboard",
+                        "displayName": "Billboard",
+                        "description": "Whether the geometry should face the active camera.",
+                        "type": "Bool",
+                        "defaultValue": false,
+                        "connection": {
+                            "type": "ShaderOption",
+                            "name": "o_billboardEnabled"
+                        }
+                    }
+                ],
+                "functors": [
+                    {
+                        "type": "Lua",
+                        "args": {
+                            "file": "Materials/Pipelines/Common/DoubleSided.lua"
+                        }
+                    },
+                    {
+                        "type": "Lua",
+                        "args": {
+                            "file": "Materials/Types/Unlit_GeneralState.lua"
                         }
                     }
                 ]
@@ -55,10 +200,20 @@
     },
     "shaders": [
         {
-            "file": "../../Shaders/Unlit/Unlit.shader"
+            "file": "../../Shaders/Unlit/Unlit.shader",
+            "tag": "forward"
         },
         {
-            "file": "../../Shaders/Depth/DepthPass.shader"
+            "file": "../../Shaders/Unlit/UnlitTransparent.shader",
+            "tag": "transparent"
+        },
+        {
+            "file": "../../Shaders/Unlit/UnlitDepthPass.shader",
+            "tag": "depth"
+        },
+        {
+            "file": "../../Shaders/Unlit/UnlitShadowmap.shader",
+            "tag": "shadow"
         }
     ]
 }

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit_GeneralState.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit_GeneralState.lua
@@ -1,0 +1,23 @@
+--------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+----------------------------------------------------------------------------------------------------
+
+function GetMaterialPropertyDependencies()
+    return {"castShadows"}
+end
+
+function Process(context)
+    local castShadows = context:GetMaterialPropertyValue_bool("castShadows")
+
+    if context:HasShaderWithTag("shadow") then
+        local shadowShader = context:GetShaderByTag("shadow")
+        if shadowShader then
+            shadowShader:SetEnabled(castShadows)
+        end
+    end
+end

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit_OpacityState.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit_OpacityState.lua
@@ -1,0 +1,105 @@
+--------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+----------------------------------------------------------------------------------------------------
+
+function GetMaterialPropertyDependencies()
+    return {"mode", "alphaSource", "textureMap", "useTexture"}
+end
+
+OpacityMode_Opaque = 0
+OpacityMode_Cutout = 1
+OpacityMode_Blended = 2
+
+AlphaSource_Packed = 0
+AlphaSource_Split = 1
+AlphaSource_None = 2
+
+function GetShaderOptionDependencies()
+    return {"o_opacity_useTexture"}
+end
+
+function Process(context)
+    local opacityMode = context:GetMaterialPropertyValue_enum("mode")
+    local alphaSource = context:GetMaterialPropertyValue_enum("alphaSource")
+    local opacityTexture = context:GetMaterialPropertyValue_Image("textureMap")
+    local useOpacityTexture = context:GetMaterialPropertyValue_bool("useTexture")
+
+    local enableOpacityTexture = opacityMode ~= OpacityMode_Opaque
+        and alphaSource == AlphaSource_Split
+        and opacityTexture ~= nil
+        and useOpacityTexture
+
+    context:SetShaderOptionValue_bool("o_opacity_useTexture", enableOpacityTexture)
+
+    local isBlended = opacityMode == OpacityMode_Blended
+
+    if context:HasShaderWithTag("forward") then
+        local shader = context:GetShaderByTag("forward")
+        if shader then
+            shader:SetEnabled(not isBlended)
+        end
+    end
+
+    if context:HasShaderWithTag("depth") then
+        local shader = context:GetShaderByTag("depth")
+        if shader then
+            shader:SetEnabled(not isBlended)
+        end
+    end
+
+    if context:HasShaderWithTag("transparent") then
+        local shader = context:GetShaderByTag("transparent")
+        if shader then
+            shader:SetEnabled(isBlended)
+        end
+    end
+end
+
+function ProcessEditor(context)
+    local opacityMode = context:GetMaterialPropertyValue_enum("mode")
+    local alphaSource = context:GetMaterialPropertyValue_enum("alphaSource")
+    local opacityTexture = context:GetMaterialPropertyValue_Image("textureMap")
+    local useOpacityTexture = context:GetMaterialPropertyValue_bool("useTexture")
+
+    local showOpacitySettings = opacityMode ~= OpacityMode_Opaque
+    local mainVisibility = showOpacitySettings and MaterialPropertyVisibility_Enabled or MaterialPropertyVisibility_Hidden
+
+    context:SetMaterialPropertyVisibility("alphaSource", mainVisibility)
+    context:SetMaterialPropertyVisibility("textureMap", MaterialPropertyVisibility_Hidden)
+    context:SetMaterialPropertyVisibility("useTexture", MaterialPropertyVisibility_Hidden)
+    context:SetMaterialPropertyVisibility("textureMapUv", MaterialPropertyVisibility_Hidden)
+    context:SetMaterialPropertyVisibility("factor", MaterialPropertyVisibility_Hidden)
+
+    if not showOpacitySettings then
+        return
+    end
+
+    if opacityMode == OpacityMode_Cutout and alphaSource == AlphaSource_None then
+        return
+    end
+
+    context:SetMaterialPropertyVisibility("factor", MaterialPropertyVisibility_Enabled)
+
+    if alphaSource ~= AlphaSource_Split then
+        return
+    end
+
+    context:SetMaterialPropertyVisibility("textureMap", MaterialPropertyVisibility_Enabled)
+
+    if opacityTexture == nil then
+        return
+    end
+
+    context:SetMaterialPropertyVisibility("useTexture", MaterialPropertyVisibility_Enabled)
+
+    if useOpacityTexture then
+        context:SetMaterialPropertyVisibility("textureMapUv", MaterialPropertyVisibility_Enabled)
+    else
+        context:SetMaterialPropertyVisibility("textureMapUv", MaterialPropertyVisibility_Disabled)
+    end
+end

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitDepthPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitDepthPass.azsl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "UnlitShared.azsli"
+
+VertexShaderOutput DepthVS(VertexShaderInput IN, uint instanceId : SV_InstanceID)
+{
+    return TransformVertex(IN, instanceId);
+}
+
+struct DepthOutput
+{
+    precise float m_depth : SV_Depth;
+};
+
+DepthOutput DepthPS(VertexShaderOutput IN)
+{
+    float4 sampledBaseColor = SampleBaseColorTexture(IN);
+    ApplyAlphaClip(IN, sampledBaseColor.a);
+
+    DepthOutput OUT;
+    OUT.m_depth = IN.m_position.z;
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitDepthPass.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitDepthPass.shader
@@ -1,0 +1,25 @@
+{
+    "Source": "UnlitDepthPass.azsl",
+
+    "DepthStencilState": {
+        "Depth": {
+            "Enable": true,
+            "CompareFunc": "GreaterEqual"
+        }
+    },
+
+    "ProgramSettings": {
+        "EntryPoints": [
+            {
+                "name": "DepthVS",
+                "type": "Vertex"
+            },
+            {
+                "name": "DepthPS",
+                "type": "Fragment"
+            }
+        ]
+    },
+
+    "DrawList": "depth"
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitShadowmap.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitShadowmap.shader
@@ -1,0 +1,30 @@
+{
+    "Source": "UnlitDepthPass.azsl",
+
+    "DepthStencilState": {
+        "Depth": {
+            "Enable": true,
+            "CompareFunc": "LessEqual"
+        }
+    },
+
+    "RasterState": {
+        "depthBias": "10",
+        "depthBiasSlopeScale": "4"
+    },
+
+    "ProgramSettings": {
+        "EntryPoints": [
+            {
+                "name": "DepthVS",
+                "type": "Vertex"
+            },
+            {
+                "name": "DepthPS",
+                "type": "Fragment"
+            }
+        ]
+    },
+
+    "DrawList": "shadow"
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitShared.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitShared.azsli
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
+#include <Atom/Features/PBR/DefaultObjectSrg.azsli>
+#include <Atom/Features/InstancedTransforms.azsli>
+#include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/AlphaInput.azsli>
+
+option bool o_baseColor_useTexture = false;
+option bool o_opacity_useTexture = false;
+option bool o_billboardEnabled = false;
+
+ShaderResourceGroup UnlitDrawSrg : SRG_PerDraw
+{
+}
+
+ShaderResourceGroup UnlitColorSrg : SRG_PerMaterial
+{
+    float3 m_unlitColor;
+    float m_padding1;
+    Texture2D m_baseColorTexture;
+    Sampler m_textureSampler
+    {
+        AddressU = Wrap;
+        AddressV = Wrap;
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+    };
+    float3x3 m_uvMatrix;
+    float2 m_uvMatrixPadding;
+    uint m_baseColorMapUvIndex;
+    Texture2D m_opacityMap;
+    uint m_opacityMapUvIndex;
+    float m_opacityFactor;
+    float m_padding0;
+}
+
+struct VertexShaderInput
+{
+    float3 m_position : POSITION;
+    float2 m_uv0 : UV0;
+    float2 m_uv1 : UV1;
+};
+
+struct VertexShaderOutput
+{
+    float4 m_position : SV_Position;
+    float2 m_uvs[2] : TEXCOORD0;
+};
+
+float2 TransformUv(float2 uv, uint uvIndex)
+{
+    return uvIndex == 0 ? mul(UnlitColorSrg::m_uvMatrix, float3(uv, 1.0)).xy : uv;
+}
+
+float3 CalculateBillboardPosition(float4x4 objectToWorld, float3 localPosition)
+{
+    float3 worldCenter = mul(objectToWorld, float4(0.0, 0.0, 0.0, 1.0)).xyz;
+
+    float scaleX = length(mul(objectToWorld, float4(1.0, 0.0, 0.0, 0.0)).xyz);
+    float scaleY = length(mul(objectToWorld, float4(0.0, 1.0, 0.0, 0.0)).xyz);
+    float scaleZ = length(mul(objectToWorld, float4(0.0, 0.0, 1.0, 0.0)).xyz);
+
+    float3 cameraRight = normalize(mul(ViewSrg::m_viewMatrixInverse, float4(1.0, 0.0, 0.0, 0.0)).xyz);
+    float3 cameraUp = normalize(mul(ViewSrg::m_viewMatrixInverse, float4(0.0, 1.0, 0.0, 0.0)).xyz);
+    float3 cameraForward = normalize(mul(ViewSrg::m_viewMatrixInverse, float4(0.0, 0.0, 1.0, 0.0)).xyz);
+
+    return worldCenter
+        + cameraRight * (localPosition.x * scaleX)
+        + cameraUp * (localPosition.y * scaleY)
+        + cameraForward * (localPosition.z * scaleZ);
+}
+
+VertexShaderOutput TransformVertex(VertexShaderInput IN, uint instanceId)
+{
+    VertexShaderOutput OUT;
+    float4x4 objectToWorld = GetObjectToWorldMatrix(instanceId);
+
+    float3 worldPosition = o_billboardEnabled
+        ? CalculateBillboardPosition(objectToWorld, IN.m_position)
+        : mul(objectToWorld, float4(IN.m_position, 1.0)).xyz;
+
+    OUT.m_position = mul(ViewSrg::m_viewProjectionMatrix, float4(worldPosition, 1.0));
+
+    OUT.m_uvs[0] = TransformUv(IN.m_uv0, 0);
+    OUT.m_uvs[1] = TransformUv(IN.m_uv1, 1);
+
+    return OUT;
+}
+
+float4 SampleBaseColorTexture(VertexShaderOutput IN)
+{
+    if (!o_baseColor_useTexture)
+    {
+        return float4(1.0, 1.0, 1.0, 1.0);
+    }
+
+    const float2 baseColorUv = IN.m_uvs[UnlitColorSrg::m_baseColorMapUvIndex];
+    return UnlitColorSrg::m_baseColorTexture.Sample(UnlitColorSrg::m_textureSampler, baseColorUv);
+}
+
+real ResolveOpacityAlpha(VertexShaderOutput IN, real baseColorAlpha = 1.0)
+{
+    switch (o_opacity_source)
+    {
+    case OpacitySource::Packed:
+        return o_baseColor_useTexture ? baseColorAlpha : 1.0;
+    case OpacitySource::Split:
+        if (o_opacity_useTexture)
+        {
+            const float2 opacityUv = IN.m_uvs[UnlitColorSrg::m_opacityMapUvIndex];
+            return real(UnlitColorSrg::m_opacityMap.Sample(UnlitColorSrg::m_textureSampler, opacityUv).r);
+        }
+        return 1.0;
+    case OpacitySource::None:
+    default:
+        return 1.0;
+    }
+}
+
+void ApplyAlphaClip(VertexShaderOutput IN, real baseColorAlpha = 1.0)
+{
+    CheckClipping(ResolveOpacityAlpha(IN, baseColorAlpha), real(UnlitColorSrg::m_opacityFactor));
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitTransparent.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitTransparent.azsl
@@ -8,29 +8,31 @@
 #pragma once
 
 #include "UnlitShared.azsli"
-#include <Atom/Features/Pipeline/Forward/ForwardPassOutput.azsli>
+
+struct TransparentOutput
+{
+    float4 m_color : SV_Target0;
+};
 
 VertexShaderOutput MainVS(VertexShaderInput IN, uint instanceId : SV_InstanceID)
 {
     return TransformVertex(IN, instanceId);
 }
 
-ForwardPassOutput MainPS(VertexShaderOutput IN)
+TransparentOutput MainPS(VertexShaderOutput IN)
 {
-    ForwardPassOutput OUT = (ForwardPassOutput)0;
+    TransparentOutput OUT;
 
     float3 baseColor = UnlitColorSrg::m_unlitColor;
     float4 sampledBaseColor = SampleBaseColorTexture(IN);
-
-    ApplyAlphaClip(IN, sampledBaseColor.a);
 
     if (o_baseColor_useTexture)
     {
         baseColor *= sampledBaseColor.rgb;
     }
 
-    OUT.m_diffuseColor = float4(baseColor, -1.0);
-    OUT.m_specularColor = float4(0.0, 0.0, 0.0, 0.0);
+    float alpha = saturate(float(ResolveOpacityAlpha(IN, sampledBaseColor.a)) * UnlitColorSrg::m_opacityFactor);
 
+    OUT.m_color = float4(baseColor * alpha, alpha);
     return OUT;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitTransparent.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitTransparent.shader
@@ -1,0 +1,36 @@
+{
+    "Source": "UnlitTransparent.azsl",
+
+    "DepthStencilState": {
+        "Depth": {
+            "Enable": true,
+            "CompareFunc": "GreaterEqual",
+            "writeMask": "Zero"
+        }
+    },
+
+    "GlobalTargetBlendState": {
+        "Enable": true,
+        "BlendSource": "One",
+        "BlendAlphaSource": "One",
+        "BlendDest": "AlphaSourceInverse",
+        "BlendAlphaDest": "AlphaSourceInverse",
+        "BlendOp": "Add",
+        "BlendAlphaOp": "Add"
+    },
+
+    "ProgramSettings": {
+        "EntryPoints": [
+            {
+                "name": "MainVS",
+                "type": "Vertex"
+            },
+            {
+                "name": "MainPS",
+                "type": "Fragment"
+            }
+        ]
+    },
+
+    "DrawList": "transparent"
+}


### PR DESCRIPTION
## What does this PR do?

Adds missing material features:
- Cutout opacity mode
- Blended opacity mode
- Double-sided rendering
- optional Cast Shadows
- optional Billboard

This also adds the supporting shader/material plumbing required for opacity handling, transparent rendering, and alpha-clipped depth rendering.

This PR also removes the DXC warnings caused by partially written forward pass outputs in the Unlit shader.

## How was this PR tested?

Manual validation in Editor:
- created and applied Unlit materials using Opaque, Cutout, and Blended
- verified alpha clipping with packed alpha and separate opacity texture inputs
- verified opacity.factor
- verified Double-sided, Cast Shadows, and Billboard
- validated updated .materialtype and .shader JSON files




