### PR TITLE
Add imgui.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _savebackup/
 .command_settings
 CrashDB/
 *.DotSettings.user
+imgui.ini


### PR DESCRIPTION
Different folders are now generating imgui files.
e.g., 
Code/Framework/AzCore/AzCore/Asset/imgui.ini
Gems/Atom/RHI/Vulkan/Code/Source/RHI/imgui.ini
Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/imgui.ini

Basic stuff. It was starting to bother me
