### PR TITLE
(stabilization) Fixes CMake errors for external projects 

### DIFF
--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -912,7 +912,7 @@ function(ly_setup_assets)
     # this first loop real-path-izes all the paths to avoid doing so repeatedly.
     get_external_subdirectories_in_use(external_subdirs_non_realpath)
     foreach(gem_candidate_dir IN LISTS external_subdirs_non_realpath)
-        file(REAL_PATH ${gem_candidate_dir} gem_candidate_dir BASE_DIRECTORY ${LY_ROOT_FOLDER})
+        cmake_path(ABSOLUTE_PATH gem_candidate_dir OUTPUT_VARIABLE gem_candidate_dir NORMALIZE BASE_DIRECTORY ${LY_ROOT_FOLDER})
         list(APPEND external_subdirs ${gem_candidate_dir})
     endforeach()
 

--- a/cmake/Subdirectories.cmake
+++ b/cmake/Subdirectories.cmake
@@ -17,7 +17,7 @@ set(O3DE_DISABLE_GEM_DEPENDENCY_RESOLUTION FALSE CACHE BOOL "Option to forcibly 
 # Add a GLOBAL property which can be used to quickly determine if a directory is an external subdirectory
 get_property(cache_external_subdirs CACHE O3DE_EXTERNAL_SUBDIRS PROPERTY VALUE)
 foreach(cache_external_subdir IN LISTS cache_external_subdirs)
-    file(REAL_PATH ${cache_external_subdir} real_external_subdir)
+    cmake_path(ABSOLUTE_PATH cache_external_subdir OUTPUT_VARIABLE real_external_subdir NORMALIZE)
     set_property(GLOBAL PROPERTY "O3DE_SUBDIRECTORY_${real_external_subdir}" TRUE)
 endforeach()
 
@@ -47,7 +47,7 @@ function(add_o3de_object_gem_json_external_subdirectories object_type object_nam
         # Push the gem name onto the visited set
         list(APPEND ${visited_gem_name_set_ref} ${gem_name})
         foreach(gem_external_subdir IN LISTS gem_external_subdirs)
-            file(REAL_PATH ${gem_external_subdir} real_external_subdir BASE_DIRECTORY ${gem_path})
+            cmake_path(ABSOLUTE_PATH gem_external_subdir BASE_DIRECTORY ${gem_path} OUTPUT_VARIABLE real_external_subdir NORMALIZE)
 
             if(NOT object_name STREQUAL "")
                 # Append external subdirectory to the O3DE_EXTERNAL_SUBDIRS_${object_type}_${object_name} PROPERTY
@@ -83,7 +83,7 @@ function(add_o3de_object_json_external_subdirectories object_type object_name ob
     if(EXISTS ${object_json_path})
         o3de_read_json_external_subdirs(object_external_subdirs ${object_json_path})
         foreach(object_external_subdir IN LISTS object_external_subdirs)
-            file(REAL_PATH ${object_external_subdir} real_external_subdir BASE_DIRECTORY ${object_path})
+            cmake_path(ABSOLUTE_PATH object_external_subdir BASE_DIRECTORY ${object_path} OUTPUT_VARIABLE real_external_subdir NORMALIZE)
 
             # Append external subdirectory ONLY to O3DE_EXTERNAL_SUBDIRS_PROJECT_${project_name} PROPERTY
             if(NOT object_name STREQUAL "")
@@ -487,7 +487,7 @@ function(add_subdirectory_on_external_subdirs)
         # Hash the external_directory name and append it to the Binary Directory section of add_subdirectory
         # This is to deal with potential situations where multiple external directories has the same last directory name
         # For example if D:/Company1/RayTracingGem and F:/Company2/Path/RayTracingGem were both added as a subdirectory
-        file(REAL_PATH ${external_directory} full_directory_path)
+        cmake_path(ABSOLUTE_PATH external_directory OUTPUT_VARIABLE full_directory_path NORMALIZE)
         string(SHA256 full_directory_hash ${full_directory_path})
         # Truncate the full_directory_hash down to 8 characters to avoid hitting the Windows 260 character path limit
         # when the external subdirectory contains relative paths of significant length


### PR DESCRIPTION
## What does this PR do?
fixes https://github.com/o3de/o3de/issues/19633

I tried to get StarterGame-assets running with 26.05.0 and ran into a bunch of cmake errors, where the use of file(REAL_PATH) was causing problems, on windows.

It looks like given a relative path, `file(REAL_PATH)` will resolve it to the full path, but change the drive letter to always be uppercase, wheras `cmake_path(ABSOLUTE_PATH)` will resolve it to the full path but preserve the case of the drive letter if one is passed in.

What makes this worse, is that other path operations like `cmake_path(RELATIVE_PATH)` will fail on windows if the drive letter is not the same case, even if the rest of the path is the same since its doing a string compare.

This caused errors where, for example, cmake code would call `cmake_path(RELATIVE_PATH "D:/O3DE/SomeFolder" BASE_PATH "d:/O3DE" OUTPUT_VARIABLE result)` and it would expect a return value of `SomeFolder` but instead would fail and return a blank string due to the drive letter case mismatch.

This is possibly a CMake bug, but we can avoid it.


## How was this PR tested?
Simple case of "before and after" - before this fix, you could not configure the project.  After, you could, and it runs.
