### PR TITLE
(Stabilization 26050) Fixes the inability to generate visual studio projects (issue #19636)

### DIFF
--- a/cmake/LYWrappers.cmake
+++ b/cmake/LYWrappers.cmake
@@ -349,6 +349,10 @@ function(ly_add_target)
             message(FATAL_ERROR "Target ${ly_add_target_NAME} contains AUTOUIC but doesnt have any .ui file")
         endif()
         ly_qt_uic_target(${ly_add_target_NAME})
+        # remove the UIC sources from the target since a custom build command will be applied for them:
+        get_target_property(all_ui_sources ${ly_add_target_NAME} SOURCES)
+        list(FILTER all_ui_sources EXCLUDE REGEX "^.*\\.ui$")
+        set_target_properties(${ly_add_target_NAME} PROPERTIES SOURCES "${all_ui_sources}")
     endif()
 
     # Add dependencies that were added before this target was available


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/19636

After updating to latest vs2026 and cmake, the project generator caused duplicate file errors to cause the visual studio IDE to be unable to open any project with a uic file in it.

The problem is that the UIC files were being added to a custom compile step (to run uic.exe on them)
and also still remained in the normal SOURCES list of the target, which caused the cmake generator to add a
`<none "filename.uic">` entry to the project file.

This strips the UIC files out of the normal compile list since they are being added via a custom compile command, avoiding the duplicate file error.

## How was this PR tested?

Compilation and running on VS2026 latest cmake latest on windows.

Note that the UI files still appear in visual studio, as custom build objects:
<img width="1362" height="604" alt="image" src="https://github.com/user-attachments/assets/d16a0202-6f77-4e9f-b8fd-457212ba88ba" />

