### PR TITLE
(Stabilization/26050) Fix a crash when assigning actor instances to actor components

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -379,7 +379,7 @@ namespace AZ::Render
 
     void AtomActorInstance::SetRayTracingEnabled(bool enabled)
     {
-        if (m_meshHandle->IsValid() && m_meshFeatureProcessor)
+        if (m_meshHandle && m_meshHandle->IsValid() && m_meshFeatureProcessor)
         {
             m_rayTracingEnabled = enabled;
             m_meshFeatureProcessor->SetRayTracingEnabled(*m_meshHandle, m_rayTracingEnabled);
@@ -388,7 +388,7 @@ namespace AZ::Render
 
     bool AtomActorInstance::GetRayTracingEnabled() const
     {
-        if (m_meshHandle->IsValid() && m_meshFeatureProcessor)
+        if (m_meshHandle && m_meshHandle->IsValid() && m_meshFeatureProcessor)
         {
             return m_meshFeatureProcessor->GetRayTracingEnabled(*m_meshHandle);
         }
@@ -397,7 +397,7 @@ namespace AZ::Render
 
     void AtomActorInstance::SetExcludeFromReflectionCubeMaps(bool enabled)
     {
-        if (m_meshHandle->IsValid() && m_meshFeatureProcessor)
+        if (m_meshHandle && m_meshHandle->IsValid() && m_meshFeatureProcessor)
         {
             m_meshFeatureProcessor->SetExcludeFromReflectionCubeMaps(*m_meshHandle, enabled);
         }
@@ -405,7 +405,7 @@ namespace AZ::Render
 
     bool AtomActorInstance::GetExcludeFromReflectionCubeMaps() const
     {
-        if (m_meshHandle->IsValid() && m_meshFeatureProcessor)
+        if (m_meshHandle && m_meshHandle->IsValid() && m_meshFeatureProcessor)
         {
             return m_meshFeatureProcessor->GetExcludeFromReflectionCubeMaps(*m_meshHandle);
         }


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/19638

This was simply not checking for null.  I think the original implementer of the code thought that "IsValid" was a null check, but its a shared_ptr, so you must use operator bool on it, or get() if you want to check for null, before you dereference it.

## How was this PR tested?

I was able to easily cause a crash by assigning the actor Valena each time.

After this change, I can assign valena, and valena appears in the viewport, without a crash.

<img width="2180" height="868" alt="image" src="https://github.com/user-attachments/assets/182dd29d-ea93-4b25-a2c5-a34987d0e270" />
