### PR TITLE
fix: replace sqlite3.version with sqlite3.sqlite_version for Python 3.14 (Fixes #19644)

### DIFF
--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/general_utils.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/general_utils.py
@@ -137,7 +137,7 @@ def set_json_data(target_path: Path, json_data: Box):
 def get_database(database_path: str) -> sqlite3.Connection:
     try:
         db = sqlite3.connect(database_path)
-        _LOGGER.info(f'DB Connection Made: {sqlite3.version}')
+        _LOGGER.info(f'DB Connection Made: {sqlite3.sqlite_version}')
         return db
     except Error as e:
         _LOGGER.info(f'Database connection failed. Error: {e}')
@@ -185,5 +185,3 @@ def get_database_values(cursor: sqlite3.Cursor, tables: list) -> dict:
         table_values = cursor.fetchall()
         database_values[table] = table_values
     return database_values
-
-


### PR DESCRIPTION
## Summary

`sqlite3.version` was deprecated in Python 3.12 and **removed in Python 3.14**. This breaks the `get_database()` function with an `AttributeError`.

## Fix

Replace `sqlite3.version` with `sqlite3.sqlite_version` (available since Python 3.2):

```python
# Before
_LOGGER.info(f'DB Connection Made: {sqlite3.version}')

# After
_LOGGER.info(f'DB Connection Made: {sqlite3.sqlite_version}')
```

Both provide the SQLite library version information for logging purposes.

## Testing

Verified that `sqlite3.sqlite_version` is the correct replacement — it has been available since Python 3.2 and returns the same type of version string.

Fixes #19644