### PR TITLE
(stabilization/26050) Fixes spurious "Lacks 'Entities' Container" error

### DIFF
--- a/Assets/Editor/Prefabs/Empty.prefab
+++ b/Assets/Editor/Prefabs/Empty.prefab
@@ -48,50 +48,5 @@
                 "Parent Entity": ""
             }
         }
-    },
-    "Entities": {
-        "Entity_[385340316572]": {
-            "Id": "Entity_[385340316572]",
-            "Name": "Empty",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 6869979625617682277
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 3265657025421720267
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8225990753105089243
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 1243064901843907726
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 12650030112456318539
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11307660330476106858
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 11421019595812600360
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 5590740797091427330
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 1585622147904486000,
-                    "Parent Entity": "ContainerEntity"
-                }
-            }
-        }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -614,84 +614,91 @@ namespace AzToolsFramework
                 const AZStd::string containerEntityAlias(containerEntityAliasIt->value.GetString());
 
                 const auto entitiesIt = templateDomRef.FindMember(PrefabDomUtils::EntitiesName);
-                if (entitiesIt == templateDomRef.MemberEnd() || !entitiesIt->value.IsObject())
+                if (entitiesIt != templateDomRef.MemberEnd() && !entitiesIt->value.IsObject())
                 {
-                    AZ_Error("Prefab", false, "'%s' lacks 'Entities' container.", path.c_str());
+                    AZ_Error("Prefab", false, "'%s' 'Entities' should be an Object, but is not", path.c_str());
                     return false;
                 }
 
+                // it is valid to have no "entities" in a prefab.  
+                // Prefabs could be:  Empty: no instances, no entities
+                //                    Just references to other prefabs: Instances, but no entities
+                //                    Just plain loose entities of their own: Entities, no instances
                 bool result = true;
-                // Search through entities for their TransformComponents
-                for (auto entityIt = entitiesIt->value.MemberBegin(); entityIt != entitiesIt->value.MemberEnd(); ++entityIt)
+                if (entitiesIt != templateDomRef.MemberEnd())
                 {
-                    // More information for logs
-                    constexpr const auto unknownName = "[unknown]";
-                    AZStd::string entityAlias = unknownName;
-                    const auto entityAliasIt = entityIt->value.FindMember(PrefabDomUtils::EntityIdName);
-                    if (entityAliasIt != entityIt->value.MemberEnd() && entityAliasIt->value.IsString())
+                    // Search through entities for their TransformComponents
+                    for (auto entityIt = entitiesIt->value.MemberBegin(); entityIt != entitiesIt->value.MemberEnd(); ++entityIt)
                     {
-                        entityAlias = entityAliasIt->value.GetString();
-                    }
-                    AZStd::string entityName = unknownName;
-                    const auto entityNameIt = entityIt->value.FindMember("Name");
-                    if (entityNameIt != entityIt->value.MemberEnd() && entityNameIt->value.IsString())
-                    {
-                        entityName = entityNameIt->value.GetString();
-                    }
+                        // More information for logs
+                        constexpr const auto unknownName = "[unknown]";
+                        AZStd::string entityAlias = unknownName;
+                        const auto entityAliasIt = entityIt->value.FindMember(PrefabDomUtils::EntityIdName);
+                        if (entityAliasIt != entityIt->value.MemberEnd() && entityAliasIt->value.IsString())
+                        {
+                            entityAlias = entityAliasIt->value.GetString();
+                        }
+                        AZStd::string entityName = unknownName;
+                        const auto entityNameIt = entityIt->value.FindMember("Name");
+                        if (entityNameIt != entityIt->value.MemberEnd() && entityNameIt->value.IsString())
+                        {
+                            entityName = entityNameIt->value.GetString();
+                        }
 
-                    const auto componentsIt = entityIt->value.FindMember(PrefabDomUtils::ComponentsName);
-                    if (componentsIt == entityIt->value.MemberEnd() || !componentsIt->value.IsObject())
-                    {
-                        result = false;
-                        AZ_Error("Prefab", false, "'%s' lacks 'Components' container in Entity (%s, '%s').",
-                            path.c_str(), entityAlias.c_str(), entityName.c_str());
-                        continue;
-                    }
-
-                    // Search current entity object for TransformComponent looping through components
-                    for (auto componentIt = componentsIt->value.MemberBegin(); componentIt != componentsIt->value.MemberEnd();
-                         ++componentIt)
-                    {
-                        const auto componentsTypeIt = componentIt->value.FindMember(PrefabDomUtils::TypeName);
-                        if (componentsTypeIt == componentIt->value.MemberEnd() || !componentsTypeIt->value.IsString())
+                        const auto componentsIt = entityIt->value.FindMember(PrefabDomUtils::ComponentsName);
+                        if (componentsIt == entityIt->value.MemberEnd() || !componentsIt->value.IsObject())
                         {
                             result = false;
-                            AZStd::string componentName = componentIt->name.GetString();
-                            AZ_Error("Prefab", false, "'%s' lacks '$type' sub-object in a component object of Entity (%s, '%s').",
+                            AZ_Error("Prefab", false, "'%s' lacks 'Components' container in Entity (%s, '%s').",
                                 path.c_str(), entityAlias.c_str(), entityName.c_str());
                             continue;
                         }
-                        
-                        AZStd::string componentAlias(componentsTypeIt->value.GetString());
 
-
-                        if (!TransformComponentNames.contains(componentAlias))
+                        // Search current entity object for TransformComponent looping through components
+                        for (auto componentIt = componentsIt->value.MemberBegin(); componentIt != componentsIt->value.MemberEnd();
+                            ++componentIt)
                         {
-                            continue; // not the component we are looking for
-                        }
+                            const auto componentsTypeIt = componentIt->value.FindMember(PrefabDomUtils::TypeName);
+                            if (componentsTypeIt == componentIt->value.MemberEnd() || !componentsTypeIt->value.IsString())
+                            {
+                                result = false;
+                                AZStd::string componentName = componentIt->name.GetString();
+                                AZ_Error("Prefab", false, "'%s' lacks '$type' sub-object in a component object of Entity (%s, '%s').",
+                                    path.c_str(), entityAlias.c_str(), entityName.c_str());
+                                continue;
+                            }
+                            
+                            AZStd::string componentAlias(componentsTypeIt->value.GetString());
 
-                        constexpr const auto parentObjectName = "Parent Entity";
-                        auto parentIt = componentIt->value.FindMember(parentObjectName);
-                        if (parentIt == componentIt->value.MemberEnd() || !parentIt->value.IsString())
-                        {
-                            result = false;
-                            AZ_Error("Prefab", false, "'%s' lacks 'Parent Entity' object in TransformComponent of Entity (%s, '%s').",
-                                path.c_str(), entityAlias.c_str(), entityName.c_str());
-                            break; // one TransformComponent for an Entity -> invalid
-                        }
 
-                        if (AZStd::string(parentIt->value.GetString()).empty()) // parent link empty ?
-                        {
-                            // Re-link this entity under the ContainerEntity using its Alias
-                            parentIt->value.SetString(rapidjson::StringRef(containerEntityAlias.c_str()), templateDomRef.GetAllocator());
+                            if (!TransformComponentNames.contains(componentAlias))
+                            {
+                                continue; // not the component we are looking for
+                            }
 
-                            result = false; // report that changes were needed and made 
-                            AZ_Error("Prefab", false,
-                                "'%s' lacks 'Parent Entity' value in TransformComponent of Entity (%s, '%s')"
-                                "\nEntity re-linked under the root container '%s'.",
-                                path.c_str(), entityAlias.c_str(), entityName.c_str(), containerEntityAlias.c_str());
+                            constexpr const auto parentObjectName = "Parent Entity";
+                            auto parentIt = componentIt->value.FindMember(parentObjectName);
+                            if (parentIt == componentIt->value.MemberEnd() || !parentIt->value.IsString())
+                            {
+                                result = false;
+                                AZ_Error("Prefab", false, "'%s' lacks 'Parent Entity' object in TransformComponent of Entity (%s, '%s').",
+                                    path.c_str(), entityAlias.c_str(), entityName.c_str());
+                                break; // one TransformComponent for an Entity -> invalid
+                            }
+
+                            if (AZStd::string(parentIt->value.GetString()).empty()) // parent link empty ?
+                            {
+                                // Re-link this entity under the ContainerEntity using its Alias
+                                parentIt->value.SetString(rapidjson::StringRef(containerEntityAlias.c_str()), templateDomRef.GetAllocator());
+
+                                result = false; // report that changes were needed and made 
+                                AZ_Error("Prefab", false,
+                                    "'%s' lacks 'Parent Entity' value in TransformComponent of Entity (%s, '%s')"
+                                    "\nEntity re-linked under the root container '%s'.",
+                                    path.c_str(), entityAlias.c_str(), entityName.c_str(), containerEntityAlias.c_str());
+                            }
+                            break; // single TransformComponent for an Entity -> evaluated
                         }
-                        break; // single TransformComponent for an Entity -> evaluated
                     }
                 }
                 return result;


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/18768

Prefabs are generally
* A container entity to hold all the other stuff in it
* A list of instances of other prefabs
* A list of loose entities inside this prefab

It is not an error for a prefab to have no loose entities, and its not an error for a prefab to have no instances of other prefabs, so it should not emit an error when it is missing one or both of those entries.

## How was this PR tested?

* Manual testing using the "base_empty" prefab from Atom
* Tested to make sure no error message is emitted from the doctored "empty" prefab that lacks this property
* CI Build testing local run to success.
