### PR TITLE
(Stabilization/26050) Prevents VHACD from generating 1024 hulls per mesh

### DIFF
--- a/Gems/PhysX/Core/Code/Source/Pipeline/MeshExporter.cpp
+++ b/Gems/PhysX/Core/Code/Source/Pipeline/MeshExporter.cpp
@@ -139,7 +139,7 @@ namespace PhysX
             if (serializeContext)
             {
                 serializeContext->Class<MeshExporter, AZ::SceneAPI::SceneCore::ExportingComponent>()
-                    ->Version(7 + (1<<PX_PHYSICS_VERSION_MAJOR)); // Use PhysX version to trigger assets recompilation
+                    ->Version(8 + (1<<PX_PHYSICS_VERSION_MAJOR)); // Use PhysX version to trigger assets recompilation
             }
         }
 

--- a/Gems/PhysX/Core/Code/Source/Pipeline/MeshGroup.h
+++ b/Gems/PhysX/Core/Code/Source/Pipeline/MeshGroup.h
@@ -164,14 +164,21 @@ namespace PhysX
             AZ::u32 GetMinEdgeLength() const;
 
         private:
-            AZ::u32 m_maxConvexHulls = 1024;
-            AZ::u32 m_resolution = 100000;
-            float m_minVolumePercentError = 1.0f;
-            AZ::u32 m_maxRecursionDepth = 10;
-            bool m_shrinkWrap = true;
-            FillMode m_fillMode = FillMode::FloodFill;
-            AZ::u32 m_maxNumVerticesPerConvexHull = 64;
-            AZ::u32 m_minEdgeLength = 2;
+            // Note that the new version of VHACD was updated.  The "meaning" of this maxConvexHulls parameter changed.
+            // Previously it would try to minimize the number of convex hulls and this provided an escape hatch for the
+            // algorithm to stop trying in case you gave it some insane model that would cause it to process forever.
+            // But in the new version, its going to try to create as many convex hulls as you specify, and then try to minimize
+            // the error of those convex hulls.  If you give it 1024 hulls, its going to use 1024 hulls, where previously it may
+            // have only used 4-5.   8 Should be enough for almost all "props" you place in the level (chairs, tables, vases,
+            // pillars, stalegtites, etc).  You can tweak this in the Mesh Export settings if you need more, for a specific mesh.
+            AZ::u32 m_maxConvexHulls = 8;
+            AZ::u32 m_resolution = 400000;               // default from vhacd.h
+            float m_minVolumePercentError = 1.0f;        // default from vhacd.h
+            AZ::u32 m_maxRecursionDepth = 10;            // default from vhacd.h
+            bool m_shrinkWrap = true;                    // default from vhacd.h
+            FillMode m_fillMode = FillMode::FloodFill;   // default from vhacd.h
+            AZ::u32 m_maxNumVerticesPerConvexHull = 64;  // default from vhacd.h
+            AZ::u32 m_minEdgeLength = 2;                 // default from vhacd.h
         };
 
         class MeshGroup


### PR DESCRIPTION
## What does this PR do?

Mitigates https://github.com/o3de/o3de/issues/19650

The VHACD library recently was updated, and the change made to the library changes the way it treats stopping conditions.

Previously, it would attempt to minimize hull use.  You'd give it an object, and it would exhaustively search for the best possible representation of that object.   It produced a really good approximiation, but had no real stopping point, a "Bad" object could take anywhere from seconds to years to process as it exhaustively recursed to find the minimum possible value.  It was an unbounded object BUT most of the time found a really good approximation in a reasonable amount of time, with outliers triggering excess ram/cpu usage very rarely.   It had a `max hulls` parameter that served as a kind of escape hatch - if it found itself in a situation where it generated that many hulls, it would stop, instead of continuing on for possibly forever.  Most of the time, it was able to find a small number of hulls, eg, 4 hulls for an elbow, even if `max hulls` was set to `1024`.  We set our `max hulls` to 1024 to handle those extreme rare cases.

Now, the new version works differently.    It treats `max hulls` as a **budget** instead, no longer as a stopping point.  It will try to minimize the error *using that many hulls*.  You are basically giving `max hulls` as a quality level.

This caused a regression where existing meshes would suddenly have 1024 hulls generated for them, since the `max hulls` value is now a budget/quality slider rather than an unlikely escape condition.  

This change tunes the default budget down to 8 hulls, which works for most simple props (pillars, tables, chairs, simple archways, platforms, and so on).  You can increase the budget in as needed for specific one-off cases.  There is no longer any way using this library to have it just "do the right thing" with this algorithm.  It has been declared deprecated for newer better ones, and we should consider moving to those ones soon.


## How was this PR tested?

Massive amounts of testing, see the issue report linked above, 
Before: (800+ hulls since `max hulls` is 1024)
<img width="274" height="348" alt="image" src="https://github.com/user-attachments/assets/3476fb7d-595e-46c0-b20a-ac5e94107b7b" />

After: 8 hulls since `max hulls` is 8.
<img width="248" height="393" alt="image" src="https://github.com/user-attachments/assets/39ecb00f-2c48-46fc-835c-3571d7c1468c" />

Entire Arm
<img width="448" height="914" alt="image" src="https://github.com/user-attachments/assets/ca35cee1-7412-41a1-bd7e-68aa7f4f0f00" />
