### PR TITLE
Stars: Make exposure, radius, and twinkle rate accessible via ebus and expose the methods to behavior context for scripting

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/StarsComponentRequestBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/StarsComponentRequestBus.names
@@ -1,0 +1,146 @@
+{
+    "entries": [
+        {
+            "base": "StarsComponentRequestBus",
+            "context": "EBusSender",
+            "variant": "",
+            "details": {
+                "name": "Stars Component Request Bus"
+            },
+            "methods": [
+                {
+                    "base": "Set Stars Radius Factor",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Stars Radius Factor"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Stars Radius Factor is invoked"
+                    },
+                    "details": {
+                        "name": "Set Stars Radius Factor"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "Get Stars Twinkle Rate",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Stars Twinkle Rate"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Stars Twinkle Rate is invoked"
+                    },
+                    "details": {
+                        "name": "Get Stars Twinkle Rate"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "Set Stars Exposure",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Stars Exposure"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Stars Exposure is invoked"
+                    },
+                    "details": {
+                        "name": "Set Stars Exposure"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "Get Stars Radius Factor",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Stars Radius Factor"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Stars Radius Factor is invoked"
+                    },
+                    "details": {
+                        "name": "Get Stars Radius Factor"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "Set Stars Twinkle Rate",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Set Stars Twinkle Rate"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Set Stars Twinkle Rate is invoked"
+                    },
+                    "details": {
+                        "name": "Set Stars Twinkle Rate"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "Get Stars Exposure",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Get Stars Exposure"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Get Stars Exposure is invoked"
+                    },
+                    "details": {
+                        "name": "Get Stars Exposure"
+                    },
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/Stars/Code/Include/Stars/StarsBus.h
+++ b/Gems/Stars/Code/Include/Stars/StarsBus.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Stars/StarsTypeIds.h>
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+
+namespace AZ::Render
+{
+    class StarsRequests
+    {
+    public:
+        AZ_RTTI(StarsRequests, StarsRequestsTypeId);
+        virtual ~StarsRequests() = default;
+    };
+
+    class StarsBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using StarsRequestBus = AZ::EBus<StarsRequests, StarsBusTraits>;
+    using StarsInterface = AZ::Interface<StarsRequests>;
+
+} // namespace AZ::Render

--- a/Gems/Stars/Code/Include/Stars/StarsComponentBus.h
+++ b/Gems/Stars/Code/Include/Stars/StarsComponentBus.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace AZ::Render
+{
+    class StarsComponentRequests : public AZ::ComponentBus
+    {
+    public:
+        ~StarsComponentRequests() override = default;
+
+        virtual float GetStarsExposure() const = 0;
+        virtual void SetStarsExposure(float exposure) = 0;
+        virtual float GetStarsRadiusFactor() const = 0;
+        virtual void SetStarsRadiusFactor(float radiusFactor) = 0;
+        virtual float GetStarsTwinkleRate() const = 0;
+        virtual void SetStarsTwinkleRate(float twinkleRate) = 0;
+    };
+
+    using StarsComponentRequestBus = AZ::EBus<StarsComponentRequests>;
+
+    class StarsComponentNotifications : public AZ::ComponentBus
+    {
+    };
+
+    using StarsComponentNotificationBus = AZ::EBus<StarsComponentNotifications>;
+
+    class StarsComponentNotificationHandler
+        : public StarsComponentNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
+    {
+    };
+} // namespace AZ::Render

--- a/Gems/Stars/Code/Include/Stars/StarsTypeIds.h
+++ b/Gems/Stars/Code/Include/Stars/StarsTypeIds.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AZ::Render
+{
+    // System Component TypeIds
+    inline constexpr const char* StarsSystemComponentTypeId = "{16A6D162-72FC-4E57-8B54-FED5D6177066}";
+    inline constexpr const char* StarsEditorSystemComponentTypeId = "{096F46EC-C312-454F-B856-66140F494790}";
+
+    // Module derived classes TypeIds
+    inline constexpr const char* StarsModuleInterfaceTypeId = "{9180C4B7-AC79-4773-B3E1-F3413DDFB575}";
+    inline constexpr const char* StarsModuleTypeId = "{7028B679-AF74-485D-B1BF-94CEA6DDDF78}";
+    // The Editor Module by default is mutually exclusive with the Client Module
+    // so they use the Same TypeId
+    inline constexpr const char* StarsEditorModuleTypeId = StarsModuleTypeId;
+
+    // Interface TypeIds
+    inline constexpr const char* StarsRequestsTypeId = "{0273D624-94B1-44A0-9D16-159BCCF1E91E}";
+} // namespace AZ::Render

--- a/Gems/Stars/Code/Source/EditorStarsComponent.cpp
+++ b/Gems/Stars/Code/Source/EditorStarsComponent.cpp
@@ -11,7 +11,7 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <StarsFeatureProcessor.h>
 
-namespace AZ::Render 
+namespace AZ::Render
 {
     void EditorStarsComponent::Reflect(AZ::ReflectContext* context)
     {

--- a/Gems/Stars/Code/Source/StarsComponentController.cpp
+++ b/Gems/Stars/Code/Source/StarsComponentController.cpp
@@ -24,6 +24,23 @@ namespace AZ::Render
                 ->Field("TwinkleRate", &StarsComponentConfig::m_twinkleRate)
                 ;
         }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<StarsComponentRequestBus>("StarsComponentRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "scene")
+                ->Attribute(AZ::Script::Attributes::Category, "Stars")
+                ->Event("Get Stars Exposure", &StarsComponentRequests::GetStarsExposure)
+                ->Event("Set Stars Exposure", &StarsComponentRequests::SetStarsExposure)
+                ->Event("Get Stars Radius Factor", &StarsComponentRequests::GetStarsRadiusFactor)
+                ->Event("Set Stars Radius Factor", &StarsComponentRequests::SetStarsRadiusFactor)
+                ->Event("Get Stars Twinkle Rate", &StarsComponentRequests::GetStarsTwinkleRate)
+                ->Event("Set Stars Twinkle Rate", &StarsComponentRequests::SetStarsTwinkleRate)
+                ;
+
+            behaviorContext->Class<StarsComponentController>()->RequestBus("StarsComponentRequestBus");
+        }
     }
 
     void StarsComponentController::Reflect(ReflectContext* context)
@@ -63,6 +80,7 @@ namespace AZ::Render
     {
         EnableFeatureProcessor(entityId);
 
+        StarsComponentRequestBus::Handler::BusConnect(entityId);
         TransformNotificationBus::Handler::BusConnect(entityId);
     }
 
@@ -154,7 +172,7 @@ namespace AZ::Render
             for (uint32_t i = 0; i < numStars; ++i)
             {
                 stream.Read(starSize, &star);
-                
+
                 position[0] = -cosf(AZ::DegToRad(star.declination)) * sinf(AZ::DegToRad(star.ascension * 15.0f));
                 position[1] = cosf(AZ::DegToRad(star.declination)) * cosf(AZ::DegToRad(star.ascension * 15.0f));
                 position[2] = sinf(AZ::DegToRad(star.declination));
@@ -174,6 +192,7 @@ namespace AZ::Render
     {
         TransformNotificationBus::Handler::BusDisconnect();
         Data::AssetBus::MultiHandler::BusDisconnect();
+        StarsComponentRequestBus::Handler::BusDisconnect();
 
         DisableFeatureProcessor();
     }
@@ -205,5 +224,38 @@ namespace AZ::Render
         {
             m_starsFeatureProcessor->SetOrientation(world.GetRotation());
         }
+    }
+
+    float StarsComponentController::GetStarsExposure() const
+    {
+        return m_configuration.m_exposure;
+    }
+
+    void StarsComponentController::SetStarsExposure(float exposure)
+    {
+        m_configuration.m_exposure = exposure;
+        m_starsFeatureProcessor->SetExposure(m_configuration.m_exposure);
+    }
+
+    float StarsComponentController::GetStarsRadiusFactor() const
+    {
+        return m_configuration.m_radiusFactor;
+    }
+
+    void StarsComponentController::SetStarsRadiusFactor(float radiusFactor)
+    {
+        m_configuration.m_radiusFactor = radiusFactor;
+        m_starsFeatureProcessor->SetRadiusFactor(m_configuration.m_radiusFactor);
+    }
+
+    float StarsComponentController::GetStarsTwinkleRate() const
+    {
+        return m_configuration.m_twinkleRate;
+    }
+
+    void StarsComponentController::SetStarsTwinkleRate(float twinkleRate)
+    {
+        m_configuration.m_twinkleRate = twinkleRate;
+        m_starsFeatureProcessor->SetTwinkleRate(m_configuration.m_twinkleRate);
     }
 }

--- a/Gems/Stars/Code/Source/StarsComponentController.h
+++ b/Gems/Stars/Code/Source/StarsComponentController.h
@@ -12,6 +12,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <StarsComponentConfig.h>
+#include <Stars/StarsComponentBus.h>
 
 namespace AZ::RPI
 {
@@ -25,6 +26,7 @@ namespace AZ::Render
     class StarsComponentController final
         : private TransformNotificationBus::Handler
         , private Data::AssetBus::MultiHandler
+        , public StarsComponentRequestBus::Handler
     {
     public:
         friend class EditorStarsComponent;
@@ -42,6 +44,13 @@ namespace AZ::Render
         void Deactivate();
         void SetConfiguration(const StarsComponentConfig& config);
         const StarsComponentConfig& GetConfiguration() const;
+
+        float GetStarsExposure() const override;
+        void SetStarsExposure(float exposure) override;
+        float GetStarsRadiusFactor() const override;
+        void SetStarsRadiusFactor(float radiusFactor) override;
+        float GetStarsTwinkleRate() const override;
+        void SetStarsTwinkleRate(float twinkleRate) override;
 
     private:
         AZ_DISABLE_COPY(StarsComponentController);

--- a/Gems/Stars/Code/Source/StarsSystemComponent.cpp
+++ b/Gems/Stars/Code/Source/StarsSystemComponent.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <StarsAsset.h>
 #include <StarsFeatureProcessor.h>
+#include <Stars/StarsTypeIds.h>
 
 namespace AZ::Render
 {
@@ -39,10 +40,12 @@ namespace AZ::Render
     {
         m_starsAssetHandler = aznew AZ::Render::StarsAssetHandler();
         m_starsAssetHandler->Register();
+        StarsRequestBus::Handler::BusConnect();
     }
 
     void StarsSystemComponent::Deactivate()
     {
+        StarsRequestBus::Handler::BusDisconnect();
         m_starsAssetHandler->Unregister();
         delete m_starsAssetHandler;
     }

--- a/Gems/Stars/Code/Source/StarsSystemComponent.h
+++ b/Gems/Stars/Code/Source/StarsSystemComponent.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include <Stars/StarsBus.h>
 
 namespace AZ::Render
 {
@@ -16,6 +17,7 @@ namespace AZ::Render
 
     class StarsSystemComponent
         : public AZ::Component
+        , protected StarsRequestBus::Handler
     {
     public:
         AZ_COMPONENT(StarsSystemComponent, "{ce10f0f9-5fe3-4376-8ccf-d56ec780005d}");
@@ -37,4 +39,4 @@ namespace AZ::Render
         AZ::Render::StarsAssetHandler* m_starsAssetHandler;
     };
 
-} // namespace AZ::Render 
+} // namespace AZ::Render

--- a/Gems/Stars/Code/stars_headers_files.cmake
+++ b/Gems/Stars/Code/stars_headers_files.cmake
@@ -8,4 +8,7 @@
 
 set(FILES
     Include/Stars/StarsFeatureProcessorInterface.h
+    Include/Stars/StarsTypeIds.h
+    Include/Stars/StarsBus.h
+    Include/Stars/StarsComponentBus.h
 )


### PR DESCRIPTION
Stars: Make exposure, radius, and twinkle rate accessible via ebus and expose the methods to behavior context for scripting

## What does this PR do?

Adds the ability to retrieve and modify the Stars component's exposure, radius factor, and twinkle rate via the ebus or scripts.

## How was this PR tested?

By applying these changes against 2510.1 and trying out the associated script canvas nodes.

Here's an example of the radius factor being varied over time:

https://github.com/user-attachments/assets/96f8bf8c-fd1d-4d9f-8d4b-a50897fc6d37