### PR TITLE
Fix Qt moc issue

### DIFF
--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -15,8 +15,8 @@
 
 // Qt
 #include <QCheckBox>
-#include <QLabel>
 #include <QInputDialog>
+#include <QLabel>
 
 #include <AtomLyIntegration/AtomViewportDisplayInfo/AtomViewportInfoDisplayBus.h>
 
@@ -36,13 +36,13 @@
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/std/algorithm.h>
 #include <AzFramework/API/ApplicationAPI.h>
+#include <AzQtComponents/Components/Widgets/CheckBox.h>
 #include <AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h>
 #include <AzToolsFramework/ActionManager/Menu/MenuManagerInternalInterface.h>
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/Viewport/ViewportSettings.h>
 #include <AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h>
-#include <AzQtComponents/Components/Widgets/CheckBox.h>
 #include <Editor/EditorSettingsAPIBus.h>
 #include <EditorModeFeedback/EditorStateRequestsBus.h>
 
@@ -276,7 +276,7 @@ inline double Round(double fVal, double fStep)
     return fVal;
 }
 
- namespace
+namespace
 {
     void PyToggleHelpers()
     {
@@ -323,5 +323,4 @@ namespace AzToolsFramework
     }
 } // namespace AzToolsFramework
 
-#include "ViewportTitleDlg.moc"
 #include <moc_ViewportTitleDlg.cpp>


### PR DESCRIPTION
## What does this PR do?

This change removes the manual `#include "ViewportTitleDlg.moc"` and keeps only `#include <moc_ViewportTitleDlg.cpp>`, which matches where `Q_OBJECT` is declared (`ViewportTitleDlg.h`).
This resolves the build error complaining that `ViewportTitleDlg.cpp` includes a moc file without containing a Qt meta-object macro:
```
[build] ---------------
[build] "/home/jhanca/devroot/2604/o3de/Code/Editor/ViewportTitleDlg.cpp"
[build] includes the moc file "ViewportTitleDlg.moc", but does not contain a Q_OBJECT, Q_GADGET, Q_NAMESPACE or Q_NAMESPACE_EXPORT macro.
[build] 
```

`clang-format` was run , which introduced the remaining changes. I decided to keep them due to the size of the diff. Step-by-step we will get the codebase formatted correctly.

## How was this PR tested?

No more warning when building.
