### PR TITLE
Split opaque Unlit into a dedicated shader path

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit.materialtype
@@ -204,6 +204,10 @@
             "tag": "forward"
         },
         {
+            "file": "../../Shaders/Unlit/UnlitOpaque.shader",
+            "tag": "opaque"
+        },
+        {
             "file": "../../Shaders/Unlit/UnlitTransparent.shader",
             "tag": "transparent"
         },

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit_OpacityState.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Unlit_OpacityState.lua
@@ -36,26 +36,35 @@ function Process(context)
 
     context:SetShaderOptionValue_bool("o_opacity_useTexture", enableOpacityTexture)
 
-    local isBlended = opacityMode == OpacityMode_Blended
+    local useOpaquePath = opacityMode == OpacityMode_Opaque
+    local useBlendedPath = opacityMode == OpacityMode_Blended
+    local useForwardPath = opacityMode == OpacityMode_Cutout
 
     if context:HasShaderWithTag("forward") then
         local shader = context:GetShaderByTag("forward")
         if shader then
-            shader:SetEnabled(not isBlended)
+            shader:SetEnabled(useForwardPath)
         end
     end
 
     if context:HasShaderWithTag("depth") then
         local shader = context:GetShaderByTag("depth")
         if shader then
-            shader:SetEnabled(not isBlended)
+            shader:SetEnabled(useForwardPath)
         end
     end
 
     if context:HasShaderWithTag("transparent") then
         local shader = context:GetShaderByTag("transparent")
         if shader then
-            shader:SetEnabled(isBlended)
+            shader:SetEnabled(useBlendedPath)
+        end
+    end
+
+    if context:HasShaderWithTag("opaque") then
+        local shader = context:GetShaderByTag("opaque")
+        if shader then
+            shader:SetEnabled(useOpaquePath)
         end
     end
 end

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitOpaque.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitOpaque.azsl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "UnlitShared.azsli"
+
+struct OpaqueOutput
+{
+    float4 m_color : SV_Target0;
+};
+
+VertexShaderOutput MainVS(VertexShaderInput IN, uint instanceId : SV_InstanceID)
+{
+    return TransformVertex(IN, instanceId);
+}
+
+OpaqueOutput MainPS(VertexShaderOutput IN)
+{
+    OpaqueOutput OUT;
+
+    float3 baseColor = UnlitColorSrg::m_unlitColor;
+    float4 sampledBaseColor = SampleBaseColorTexture(IN);
+
+    if (o_baseColor_useTexture)
+    {
+        baseColor *= sampledBaseColor.rgb;
+    }
+
+    OUT.m_color = float4(baseColor, 1.0);
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitOpaque.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Unlit/UnlitOpaque.shader
@@ -1,0 +1,29 @@
+{
+    "Source": "UnlitOpaque.azsl",
+
+    "RasterState": {
+        "CullMode": "Back"
+    },
+
+    "DepthStencilState": {
+        "Depth": {
+            "Enable": true,
+            "CompareFunc": "GreaterEqual"
+        }
+    },
+
+    "ProgramSettings": {
+        "EntryPoints": [
+            {
+                "name": "MainVS",
+                "type": "Vertex"
+            },
+            {
+                "name": "MainPS",
+                "type": "Fragment"
+            }
+        ]
+    },
+
+    "DrawList": "transparent"
+}


### PR DESCRIPTION
## What does this PR do?

This PR updates the `Unlit` shader implementation added in the previous PR.

Changes in this update:
- fixes white edge/line artifacts that were visible on some opaque meshes

Old behavior:
- the updated `Unlit` shader could produce visible white lines on opaque meshes

New behavior:
- opaque `Unlit` uses a dedicated shader path and no longer shows the same white edge artifacts

## How was this PR tested?

Manual validation in Editor:
- tested `Opaque`, `Cutout`, and `Blended` modes on `Unlit`
- verified that the white line artifacts previously seen in `Opaque` no longer appeared with the final shader path
- verified that `Blended`, `Double-sided`, `Cast Shadows`, and `Billboard` behavior remained functional

