### PR TITLE
(Stabilization/26050) Fixes a crash when dragging and dropping in standalone applications

### DIFF
--- a/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
+++ b/Gems/MiniAudio/3rdParty/Findminiaudio.cmake
@@ -66,6 +66,12 @@ endfunction()
 Getminiaudio()
 unset(Getminiaudio)
 
+# MiniAudio by default calls CoInitializeEx and CoUninitialize, repeatedly,
+# and sets the flags field to whatever you set MA_COINIIT_VALUE to. It does this on the main thread.
+# This needs to be the same as any other calls to CoInitializeEx on the main thread, which in O3DE's
+# case is 2 (STA mode)
+target_compile_definitions(miniaudio PRIVATE "MA_COINIT_VALUE=2")
+
 get_property(this_gem_root GLOBAL PROPERTY "@GEMROOT:${gem_name}@")
 ly_get_engine_relative_source_dir(${this_gem_root} relative_this_gem_root)
 


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/19657

When an O3DE app starts up it initializes Qt.  Qt then initializes com using CoIninitalizeEx with flags set to 2 (STA mode).

However, later on, miniaudio calls CoInitializeEx with whatever the value of flags you set in MA_COINIT_VALUE preprocessor directive, 0 by default, which reinitializes COM in Multithreaded mode, causing drag and drop events to come from an unexpected thread from that point on.

This change sets MA_COINIT_VALUE to 2, removing the conflict - MiniAudio now inits with flags 2 which is the STA mode, causing drag and drop to come from the main thread instead.

## How was this PR tested?

Just testing to make sure the crash disappeared.  Its a 100% repro in debug on windows.
After this fix, no issue.
