### PR TITLE
DeleteFile success when file does not exist

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/ProductAsset.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ProductAsset.cpp
@@ -44,7 +44,7 @@ namespace AssetProcessor
             AZ_TracePrintf(
                 AssetProcessor::ConsoleChannel, "Was expecting to delete product file %s but it already appears to be gone.\n",
                 m_absolutePath.c_str());
-            return false;
+            return true;
         }
 
         if(sendNotification)


### PR DESCRIPTION
## What does this PR do?

This PR changes the status of the `DeleteFIle` method to _success_ if the file does not exist on the disk. One could argue what is the meaning of the _success_ in such case:
- The final goal is achieved, i.e., the file does not exist.
- The success of the method, that found the file and removed it.

The original implementation was assuming the latter, it was changed to the first one for `AssetProcessor` cases, as we mainly care about the final outcome.

Example log after removing the level from both project and Cache folder:
```
[build] AssetProcessor: Deleting file levels/asdf/asdf.spawnable because either its source file Levels/asdf/asdf.prefab was removed or the builder did not emit this job.
[build] AssetProcessor: Was expecting to delete product file /home/jhanca/devroot/projects/TestProject2605/Cache/linux/levels/asdf/asdf.spawnable but it already appears to be gone.
[build] AssetProcessor: Failed to delete product files for linux/levels/asdf/asdf.spawnable
[build] AssetProcessor: Delete failed on /home/jhanca/devroot/projects/TestProject2605/Levels/asdf/asdf.prefab. Will retry!
```

I saw this set of four messages 1265 times (it did what is promised: _Will retry!_).

## How was this PR tested?

- created a level called _asdf_, closed Editor
- removed the level (`find | grep asdf | xargs rm -rf`)
- started Editor again
