### PR TITLE
(Stabilization/26050) Fix a crash caused by incorrect dependency tree within the OpenParticleSystem gem

### DIFF
--- a/Gems/OpenParticleSystem/Code/CMakeLists.txt
+++ b/Gems/OpenParticleSystem/Code/CMakeLists.txt
@@ -79,7 +79,7 @@ ly_add_target(
             PUBLIC
                 Source/Runtime
         BUILD_DEPENDENCIES
-            PUBLIC
+            PRIVATE
                 ${gem_name}.Static
 )
 

--- a/Gems/OpenParticleSystem/Code/CMakeLists.txt
+++ b/Gems/OpenParticleSystem/Code/CMakeLists.txt
@@ -51,25 +51,6 @@ ly_add_target(
                 Include
 )
 
-ly_add_target(
-        NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
-        NAMESPACE Gem
-        FILES_CMAKE
-            openparticlesystem_files.cmake
-            openparticlesystem_shared_files.cmake
-        INCLUDE_DIRECTORIES
-            PUBLIC
-                Source
-                Source/Runtime
-        BUILD_DEPENDENCIES
-            PUBLIC
-                ${gem_name}.API
-                Gem::SimuCoreParticleModules.Static
-                Gem::Atom_RPI.Public
-                Gem::Atom_Feature_Common.Public
-                Gem::EMotionFX.Static
-                Gem::EMotionFX_Atom.Static
-)
 
 ly_add_target(
     NAME ${gem_name}.Static STATIC
@@ -77,12 +58,29 @@ ly_add_target(
     FILES_CMAKE
         openparticlesystem_files.cmake
     INCLUDE_DIRECTORIES
-        PRIVATE
+        PUBLIC
             Source/Runtime
     BUILD_DEPENDENCIES
         PUBLIC
-            Gem::${gem_name}
+            Gem::${gem_name}.API
             Gem::Atom_Utils.Static
+            Gem::Atom_Feature_Common.Public
+            Gem::EMotionFX.Static
+            AZ::AzCore
+            SimuCoreParticleModules.Static
+)
+
+ly_add_target(
+        NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+        NAMESPACE Gem
+        FILES_CMAKE
+            openparticlesystem_shared_files.cmake
+        INCLUDE_DIRECTORIES
+            PUBLIC
+                Source/Runtime
+        BUILD_DEPENDENCIES
+            PUBLIC
+                ${gem_name}.Static
 )
 
 ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
@@ -97,20 +95,15 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         AUTOMOC
         FILES_CMAKE
             openparticlesystem_editor_files.cmake
-        INCLUDE_DIRECTORIES
-            PUBLIC
-                Include
-                Source
-            PRIVATE
-                Source/Runtime
-                Source/Thumbnail
         COMPILE_DEFINITIONS
             PRIVATE
                 PARTICLE_EDITOR
+        INCLUDE_DIRECTORIES
+            PUBLIC
+                Source
         BUILD_DEPENDENCIES
             PUBLIC
                 Gem::${gem_name}.Static
-                Gem::${gem_name}
                 Legacy::EditorCore
             PRIVATE
                 Gem::Atom_RPI.Edit
@@ -126,10 +119,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             openparticlesystem_editor_shared_files.cmake
         INCLUDE_DIRECTORIES
             PRIVATE
-                Include
-                Source
                 Source/Runtime
-                Source/Thumbnail
         COMPILE_DEFINITIONS
             PRIVATE
                 PARTICLE_EDITOR
@@ -160,7 +150,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::Atom_RPI.Edit
                 Gem::Atom_RPI.Public
                 Gem::Atom_RHI.Public
-                Gem::${gem_name}
     )
 
     ly_add_target(
@@ -174,7 +163,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Source/Builder
         BUILD_DEPENDENCIES
             PRIVATE
-                Gem::${gem_name}
                 Gem::${gem_name}.Builder.Static
                 AZ::SceneCore
                 AZ::AssetBuilderSDK

--- a/Gems/OpenParticleSystem/Code/Source/Builder/BuilderComponent.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Builder/BuilderComponent.cpp
@@ -15,8 +15,8 @@
 
 #include <OpenParticleSystem/Asset/ParticleAsset.h>
 #include <OpenParticleSystem/Asset/ParticleAssetHandler.h>
-#include <Runtime/OpenParticleSystem/ParticleConfig.h>
-#include <Runtime/OpenParticleSystem/ParticleEditDataConfig.h>
+#include <OpenParticleSystem/ParticleConfig.h>
+#include <OpenParticleSystem/ParticleEditDataConfig.h>
 #include <Serializer/ParticleSourceData.h>
 
 namespace OpenParticle

--- a/Gems/OpenParticleSystem/Code/Source/OpenParticleSystemEditorModule.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/OpenParticleSystemEditorModule.cpp
@@ -9,15 +9,15 @@
 #include <OpenParticleSystemModuleInterface.h>
 #include <OpenParticleSystemEditorSystemComponent.h>
 
-#include <Runtime/OpenParticleSystem/ParticleComponent.h>
-#include <Runtime/OpenParticleSystem/SystemComponent.h>
+#include <OpenParticleSystem/ParticleComponent.h>
+#include <OpenParticleSystem/SystemComponent.h>
 
 #ifdef PARTICLE_EDITOR
 #include <Editor/DistributionCacheComponent.h>
 #include <Editor/EditorParticleComponent.h>
 #include <Editor/EditorSystemComponent.h>
 #include <OpenParticleSystemEditor/Viewport/OpenParticleViewportComponent.h>
-#include <ParticleMaterialThumbnailSystemComponent.h>
+#include <Thumbnail/ParticleMaterialThumbnailSystemComponent.h>
 #endif
 
 namespace OpenParticleSystem

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.h
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.h
@@ -15,7 +15,7 @@
 #include <OpenParticleSystem/ParticleRequestBus.h>
 #include <OpenParticleSystem/ParticleFeatureProcessorInterface.h>
 
-#include <Runtime/OpenParticleSystem/ParticleComponentConfig.h>
+#include <OpenParticleSystem/ParticleComponentConfig.h>
 
 namespace OpenParticle
 {

--- a/Gems/OpenParticleSystem/Code/Source/Serializer/ParticleBase.h
+++ b/Gems/OpenParticleSystem/Code/Source/Serializer/ParticleBase.h
@@ -16,7 +16,7 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
 
-#include <Runtime/OpenParticleSystem/ParticleConfig.h>
+#include <OpenParticleSystem/ParticleConfig.h>
 #include <Editor/EditorParticleSystemComponentRequestBus.h>
 
 namespace OpenParticle

--- a/Gems/OpenParticleSystem/Code/Source/Thumbnail/ParticleMaterialThumbnail.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Thumbnail/ParticleMaterialThumbnail.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <ParticleMaterialThumbnail.h>
+#include <Thumbnail/ParticleMaterialThumbnail.h>
 
 #include <AssetBrowser/Thumbnails/ProductThumbnail.h>
 #include <AssetBrowser/Thumbnails/SourceThumbnail.h>


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/19664 (Crash on installer version of OPS when running in a builder)

This issue was caused by a bad dependency tree in OPS module, which caused the `Builder` module to depend on the runtime game module.  This caused the CMake code which generates the list of "which dll files to load in which application" to put both the runtime gem module, and the builder module, which are mutually exclusive, in the same application (AssetBuilder.exe), leading to the assert message shown in the issue report #19664 

The dependency tree was like this:
```
    OpenParticleSystem.Builder depends on:
       OpenParticleSystem  (runtime gem dll)
       OpenParticleSystem.Builder.Static (static library)
```

I made it instead so that there is a static library for the runtime, and both the runtime gem dll and the builder static depend on that static library, but nothing depends on the final gem dlls, ie, the new structure is like this:

```
   OpenParticleSystem.Builder (builder gem module) depends on PRIVATELY:
      OpenParticleSystem.Builder.Static (static library), which in turn depends on:
          OpenParticleSystem.Editor.Static (static library) which in turn depends on:
             OpenParticleSystem.Static (static library)
   
   OpenParticleSystem (Runtime gem module) depends on PRIVATELY:
       OpenParticleSystem.Static (static library)
```

So no gem module is depending on any other gem module.

## How was this PR tested?

This was a 100% repro before hand and none after.
In addition, I verified that the actual regset files were generated correctly and made sure smoke testing worked (I was able to open the editor, process particles, have them render, use the particle editor, etc).

I also examined the generated regset files, which gives 100% confirmation - The regset files are what tells the system which DLL files to load into which application.  You can see the problem directly by examining them.

Before, the regset file for `assetbuilder` was telling it to load both modules:
```json
            "OpenParticleSystem": {
                "Targets": {
                    "OpenParticleSystem": {
                        "Modules":["OpenParticleSystem.dll"]
                    },
                    "OpenParticleSystem.Builder": {
                        "Modules":["OpenParticleSystem.Builder.Gem.dll"]
                    },
                    "OpenParticleSystem.Builders": {
                    }
                }
            },
```

After, it only specifies to load the builder module:
```json
            "OpenParticleSystem": {
                "Targets": {
                    "OpenParticleSystem.Builder": {
                        "Modules":["OpenParticleSystem.Builder.Gem.dll"]
                    },
                    "OpenParticleSystem.Builders": {
                    }
                }
            },
```