### PR TITLE
Fix a case-sensitivity issue with the include folders for RecastNavigation

### DIFF
--- a/Gems/RecastNavigation/3rdParty/FindRecastNavigation.cmake
+++ b/Gems/RecastNavigation/3rdParty/FindRecastNavigation.cmake
@@ -103,18 +103,18 @@ function(GetRecast)
     FetchContent_GetProperties(RecastNavigation BINARY_DIR recastnavigation_binary_dir)
     
     # install header files
-    ly_install(DIRECTORY ${recastnavigation_source_dir}/Recast/include DESTINATION include/recastnavigation COMPONENT CORE)
-    ly_install(DIRECTORY ${recastnavigation_source_dir}/DebugUtils/include DESTINATION include/recastnavigation COMPONENT CORE)
-    ly_install(DIRECTORY ${recastnavigation_source_dir}/Detour/include DESTINATION include/recastnavigation COMPONENT CORE)
-    ly_install(DIRECTORY ${recastnavigation_source_dir}/DetourCrowd/include DESTINATION include/recastnavigation COMPONENT CORE)
-    ly_install(DIRECTORY ${recastnavigation_source_dir}/DetourTileCache/include DESTINATION include/recastnavigation COMPONENT CORE)
+    ly_install(DIRECTORY ${recastnavigation_source_dir}/Recast/Include DESTINATION Include/recastnavigation COMPONENT CORE)
+    ly_install(DIRECTORY ${recastnavigation_source_dir}/DebugUtils/Include DESTINATION Include/recastnavigation COMPONENT CORE)
+    ly_install(DIRECTORY ${recastnavigation_source_dir}/Detour/Include DESTINATION Include/recastnavigation COMPONENT CORE)
+    ly_install(DIRECTORY ${recastnavigation_source_dir}/DetourCrowd/Include DESTINATION Include/recastnavigation COMPONENT CORE)
+    ly_install(DIRECTORY ${recastnavigation_source_dir}/DetourTileCache/Include DESTINATION Include/recastnavigation COMPONENT CORE)
 
     # note that recast also generates a version.h file, which we could copy here, but the name "version.h" is way too easy
     # and generic to conflict with others, and it does not actually use "version.h" itself in any way.  if this becomes a problem
     # in the future, we can always copy it with a unique name, or add a subfolder for it to live in.
     
     # install license file.
-    ly_install(FILES ${recastnavigation_source_dir}/License.txt DESTINATION include/recastnavigation COMPONENT CORE)
+    ly_install(FILES ${recastnavigation_source_dir}/License.txt DESTINATION Include/recastnavigation COMPONENT CORE)
     
     # signal that find_package(Recast) has succeeded.
     # we have to set it on the PARENT_SCOPE since we're in a function 

--- a/Gems/RecastNavigation/3rdParty/Installer/FindRecastNavigation.cmake
+++ b/Gems/RecastNavigation/3rdParty/Installer/FindRecastNavigation.cmake
@@ -34,7 +34,7 @@ foreach(recastLibrary ${recastLibraries})
     target_compile_definitions(3rdParty::RecastNavigation::${recastLibrary} INTERFACE DT_POLYREF64)
     ly_target_include_system_directories(TARGET 3rdParty::RecastNavigation::${recastLibrary} 
         INTERFACE 
-            "${LY_ROOT_FOLDER}/include/recastnavigation")
+            "${LY_ROOT_FOLDER}/Include/recastnavigation")
 endforeach()
 
 # notify O3DE That we have satisfied the RecastNavigation find_package requirements.


### PR DESCRIPTION
## What does this PR do?

The include directories for RecastNavigation are all capital letters - for example, if you actually go to https://github.com/recastnavigation/recastnavigation/tree/main/Detour and look, its capital I `Include`

However, we were copying things and registering on lower case, thus working on windows, but not on case sensitive OSs.

## How was this PR tested?

Testing with regular and installer on Linux Ubuntu 25.10.

