### PR TITLE
(stabilization/26050) Fix PlayAnimation when called multiple times

### DIFF
--- a/Gems/EMotionFX/Code/Include/Integration/SimpleMotionComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/SimpleMotionComponentBus.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <AzCore/EBus/EBus.h>
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/ComponentBus.h>
+#include <AzCore/EBus/EBus.h>
 
 namespace EMotionFX
 {
@@ -36,7 +37,7 @@ namespace EMotionFX
             virtual float GetPlayTime() const = 0;
             virtual float GetDuration() const = 0;
             virtual void Motion(AZ::Data::AssetId assetId) = 0;
-            virtual AZ::Data::AssetId  GetMotion() const = 0;
+            virtual AZ::Data::AssetId GetMotion() const = 0;
             virtual void BlendInTime(float time) = 0;
             virtual float GetBlendInTime() const = 0;
             virtual void BlendOutTime(float time) = 0;
@@ -44,5 +45,5 @@ namespace EMotionFX
             virtual void PlayMotion() = 0;
         };
         using SimpleMotionComponentRequestBus = AZ::EBus<SimpleMotionComponentRequests>;
-    }
-}
+    } // namespace Integration
+} // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
@@ -260,20 +260,25 @@ namespace EMotionFX
 
         void SimpleMotionComponent::PlayMotion()
         {
-            // In case of existing motion instance, play it.
-            if (SimpleMotionComponent::CheckMotionInstance(m_motionInstance))
+            if (CheckMotionInstance(m_lastMotionInstance))
             {
-                auto motionInstance = SimpleMotionComponent::StartMotionInternal(m_motionInstance, m_configuration);
-                if (SimpleMotionComponent::CheckMotionInstance(motionInstance) && (motionInstance != m_motionInstance))
+                RemoveMotionInstanceFromActor(m_lastMotionInstance);
+                m_lastMotionInstance = nullptr;
+            }
+
+            if (CheckMotionInstance(m_motionInstance))
+            {
+                if (m_configuration.m_blendOutTime > 0.0f)
                 {
-                    if (SimpleMotionComponent::CheckMotionInstance(m_lastMotionInstance))
-                    {
-                        RemoveMotionInstanceFromActor(m_lastMotionInstance);
-                    }
+                    m_lastMotionInstance = m_motionInstance;
+                    m_lastMotionInstance->Stop(m_configuration.m_blendOutTime);
                 }
-                m_lastMotionInstance = m_motionInstance;
-                m_motionInstance = motionInstance;
-                return;
+                else
+                {
+                    RemoveMotionInstanceFromActor(m_motionInstance);
+                }
+
+                m_motionInstance = nullptr;
             }
 
             constexpr const bool deleteOnZeroWeight = false;  // was true
@@ -548,6 +553,10 @@ namespace EMotionFX
             info.m_blendOutTime = cfg.m_blendOutTime;
             info.m_inPlace = cfg.m_inPlace;
             info.m_freezeAtLastFrame = cfg.m_freezeAtLastFrame;
+
+            // Replaying an existing motion instance must clear its previous playback state.
+            motionInstance->InitFromPlayBackInfo(info, false);
+            motionInstance->ResetTimes();
             return actorInstance->GetMotionSystem()->PlayMotion(motionInstance, &info);
         }
 

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorSimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorSimpleMotionComponent.cpp
@@ -164,20 +164,25 @@ namespace EMotionFX
                 return;
             }
 
-            // In case of existing motion instance, play it.
+            if (SimpleMotionComponent::CheckMotionInstance(m_lastMotionInstance))
+            {
+                RemoveMotionInstanceFromActor(m_lastMotionInstance);
+                m_lastMotionInstance = nullptr;
+            }
+
             if (SimpleMotionComponent::CheckMotionInstance(m_motionInstance))
             {
-                auto motionInstance = SimpleMotionComponent::StartMotionInternal(m_motionInstance, m_configuration);
-                if (SimpleMotionComponent::CheckMotionInstance(motionInstance) && (motionInstance != m_motionInstance))
+                if (m_configuration.m_blendOutTime > 0.0f)
                 {
-                    if (SimpleMotionComponent::CheckMotionInstance(m_lastMotionInstance))
-                    {
-                        RemoveMotionInstanceFromActor(m_lastMotionInstance);
-                    }
+                    m_lastMotionInstance = m_motionInstance;
+                    m_lastMotionInstance->Stop(m_configuration.m_blendOutTime);
                 }
-                m_lastMotionInstance = m_motionInstance;
-                m_motionInstance = motionInstance;
-                return;
+                else
+                {
+                    RemoveMotionInstanceFromActor(m_motionInstance);
+                }
+
+                m_motionInstance = nullptr;
             }
 
             // The Editor allows scrubbing back and forth on animation blending transitions, so don't delete  motion instances if it's blend weight is zero.

--- a/Gems/EMotionFX/Code/Tests/SimpleMotionComponentBusTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/SimpleMotionComponentBusTests.cpp
@@ -14,6 +14,7 @@
 #include <EMotionFX/Source/MotionSet.h>
 #include <EMotionFX/Source/Motion.h>
 #include <EMotionFX/Source/MotionInstance.h>
+#include <EMotionFX/Source/MotionSystem.h>
 #include <Integration/Components/ActorComponent.h>
 #include <Integration/Components/AnimGraphComponent.h>
 #include <Integration/Components/SimpleMotionComponent.h>
@@ -248,6 +249,37 @@ namespace EMotionFX
 
         const MotionInstance* motionInstanceAfterPlayMotion = m_simpleMotionComponent->GetMotionInstance();
         EXPECT_NE(motionInstanceAfterPlayMotion, nullptr);
+    }
+
+    // Test PlayMotion
+    TEST_F(SimpleMotionComponentBusTests, PlayMotionRestartsExistingMotionInstance)
+    {
+        const float expectedPlayTime = 1.5f;
+        const float errMargin = 0.001f;
+        const MotionInstance* initialMotionInstance = m_simpleMotionComponent->GetMotionInstance();
+        ASSERT_NE(initialMotionInstance, nullptr);
+        ASSERT_NE(initialMotionInstance->GetActorInstance(), nullptr);
+        MotionSystem* motionSystem = initialMotionInstance->GetActorInstance()->GetMotionSystem();
+        ASSERT_NE(motionSystem, nullptr);
+
+        Integration::SimpleMotionComponentRequestBus::Event(
+            m_entityId, &Integration::SimpleMotionComponentRequestBus::Events::PlayTime, expectedPlayTime);
+
+        float playTime = 0.0f;
+        Integration::SimpleMotionComponentRequestBus::EventResult(
+            playTime, m_entityId, &Integration::SimpleMotionComponentRequestBus::Events::GetPlayTime);
+        EXPECT_NEAR(playTime, expectedPlayTime, errMargin);
+
+        Integration::SimpleMotionComponentRequestBus::Event(m_entityId, &Integration::SimpleMotionComponentRequestBus::Events::PlayMotion);
+
+        const MotionInstance* replayedMotionInstance = m_simpleMotionComponent->GetMotionInstance();
+        EXPECT_NE(replayedMotionInstance, nullptr);
+        EXPECT_EQ(replayedMotionInstance->GetActorInstance()->GetMotionSystem(), motionSystem);
+
+        Integration::SimpleMotionComponentRequestBus::EventResult(
+            playTime, m_entityId, &Integration::SimpleMotionComponentRequestBus::Events::GetPlayTime);
+        EXPECT_NEAR(playTime, 0.0f, errMargin);
+        EXPECT_EQ(motionSystem->GetNumMotionInstances(), 1);
     }
 
     // Test MirrorMotion


### PR DESCRIPTION
Closes #19663

## What does this PR do?

There are two problems in the code that cause the issue in #19663 and one compile problem fixed in this PR.
Note, that the animation freezes and cannot be replayed 


1. `StartMotionInternal()` is reusing the same _MotionInstance_ after the first play, which never rewinds (elapsed time, loop counters, or frozen state) before starting again. Therefore, it is impossible to play the animation twice in the current implementation.

2. Resetting time in _MotionInstance_ alone does not help, as the same _MotionInstance_ is added to the active list all over again, hence being updated multiple times per frame (the playback gets faster every time). As there is no safe public API to _restart in place_, it is necessary to discard the current runtime motion instance on replay and start a fresh one, while keeping the existing blend logic intact. The same change needs to be applied in both Editor and Game components.

3. The third issue is a missing header in `SimpleMotionComponentBus`: the bus uses `AZ::Data::AssetId`, but in some implementations (see my _TestComponent_) it does not know it. This file was _clang-formatted_, hence we get into the formatted code at some point (I skipped formatting the other modified files, as it created a large diff).

Note, that 1. and 2. are just workarounds. This piece of code requires a serious rewrite, as noticed in https://github.com/o3de/o3de/pull/18908

The test was added to verify my implementation.

## How was this PR tested?

Used asset from https://github.com/o3de/buongiorno-sample
The asset can be downloaded here (put it in `Assets` folder in your project):
[AnimationTest.zip](https://github.com/user-attachments/files/26373474/AnimationTest.zip)
```shell
cd Project ; tree Assets
Assets
├── AnimationTest.prefab
└── Pigeon
    ├── Pigeon_ActorDefinition.fbx
    ├── Pigeon_AO.png
    ├── Pigeon_BaseColor.png
    ├── Pigeon.fbx
    ├── Pigeon.material
    ├── Pigeon_Normal.png
    ├── Pigeon_Peck.fbx
    └── Pigeon_Roughness.png
```

The code used to trigger the animation in the loop requires `Gem::EMotionFX.Static` linkage.
The header:
```cpp
#pragma once

#include <AzCore/Component/Component.h>
#include <AzCore/Component/TickBus.h>

namespace AllTemplates
{
    class TestComponent
        : public AZ::Component
        , private AZ::TickBus::Handler
    {
    public:
        AZ_COMPONENT(TestComponent, "{86FBBEB7-530C-492A-B38D-B803334FCFE0}", AZ::Component);
        TestComponent() = default;
        ~TestComponent() = default;
        void Activate() override;
        void Deactivate() override;
        static void Reflect(AZ::ReflectContext* context);

    private:
        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;

        AZStd::chrono::steady_clock::time_point m_lastTickTime;
    };
} // namespace AllTemplates
```

The source:
```cpp
#include "TestComponent.h"

#include <AzCore/Asset/AssetCommon.h>
#include <AzCore/Serialization/EditContext.h>
#include <AzCore/Serialization/SerializeContext.h>
#include <Integration/SimpleMotionComponentBus.h>

namespace AllTemplates
{
    void TestComponent::Activate()
    {
        m_lastTickTime = AZStd::chrono::steady_clock::now();
        AZ::TickBus::Handler::BusConnect();
    }

    void TestComponent::Deactivate()
    {
        AZ::TickBus::Handler::BusDisconnect();
    }

    void TestComponent::Reflect(AZ::ReflectContext* context)
    {
        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
        {
            serialize->Class<TestComponent, AZ::Component>()->Version(1);
            if (AZ::EditContext* ec = serialize->GetEditContext())
            {
                ec->Class<TestComponent>("TestComponent", "A sample test component")
                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "TestComponent")
                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                    ->Attribute(AZ::Edit::Attributes::Category, "Test");
            }
        }
    }

    void TestComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
    {
        static constexpr float tickInterval = 5.0f;
        const auto now = AZStd::chrono::steady_clock::now();
        if (AZStd::chrono::duration_cast<AZStd::chrono::seconds>(now - m_lastTickTime).count() >= tickInterval)
        {
            AZ_Error("JHDEBUG", false, "TestComponent: play animation *****************************************");
            EMotionFX::Integration::SimpleMotionComponentRequestBus::Event(
                GetEntityId(), &EMotionFX::Integration::SimpleMotionComponentRequestBus::Events::PlayMotion);

            m_lastTickTime = now;
        }
    }
} // namespace AllTemplates

```