### PR TITLE
Security: Add bounds check on componentInputCount to prevent OOM DoS

### DIFF
--- a/Gems/Multiplayer/Code/Source/NetworkInput/NetworkInput.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkInput/NetworkInput.cpp
@@ -132,8 +132,27 @@ namespace Multiplayer
             return false;
         }
 
-        uint16_t componentInputCount = static_cast<uint16_t>(m_componentInputs.size());
+        // Security: Store the maximum component count to prevent unbounded allocation
+        // from malicious network input. The original size represents the valid component
+        // count for this entity - clients cannot legitimately need more than this.
+        const uint16_t maxComponentCount = static_cast<uint16_t>(m_componentInputs.size());
+        uint16_t componentInputCount = maxComponentCount;
         serializer.Serialize(componentInputCount, "ComponentInputCount");
+        
+        // Security: Clamp componentInputCount to prevent denial of service via
+        // unbounded memory allocation. A malicious client could otherwise send
+        // a very large count (e.g., 65535) causing massive memory allocation.
+        // Allow some headroom above the original size for delta compression scenarios,
+        // but cap at a reasonable maximum to prevent OOM attacks.
+        constexpr uint16_t MaxComponentCountHeadroom = 32;
+        const uint16_t absoluteMaxCount = maxComponentCount + MaxComponentCountHeadroom;
+        if (componentInputCount > absoluteMaxCount)
+        {
+            AZLOG_ERROR("Potentially malicious componentInputCount %u received, clamping to maximum %u",
+                componentInputCount, absoluteMaxCount);
+            componentInputCount = absoluteMaxCount;
+        }
+        
         m_componentInputs.resize(componentInputCount);
         if (serializer.GetSerializerMode() == AzNetworking::SerializerMode::WriteToObject)
         {


### PR DESCRIPTION
## Summary

The `NetworkInput::Serialize` method deserializes `componentInputCount` directly from network packets without validating it against the expected component count. A malicious client can send a very large `componentInputCount` value causing the server to allocate excessive memory, leading to out-of-memory and denial of service.

## Taint Flow Proof

```
Source:   serializer.Serialize(componentInputCount) — reads from network packet
Sink:     m_componentInputs.resize(componentInputCount) — allocates based on untrusted value
Path:     HandleSendClientInput → NetworkInputArray::Serialize → NetworkInput::Serialize → resize
```

No validation exists between the network read and the memory allocation.

## Impact

A single authenticated client can send a `SendClientInput` RPC with `componentInputCount=65535`, causing the server to allocate a vector of 65535 element pointers. This can rapidly exhaust server memory and crash the process, denying service to all players.

## Reproduction

1. Client connects to server
2. Client sends `SendClientInput` RPC with `componentInputCount=65535`
3. Server attempts to allocate vector of 65535 element pointers
4. Server OOM crash

## Fix

Added bounds check that:
1. Stores the original component count before deserialization
2. Clamps received `componentInputCount` to `original + 32` maximum
3. Logs warning when clamping potentially malicious values

## Files Changed

- `Gems/Multiplayer/Code/Source/NetworkInput/NetworkInput.cpp`