### PR TITLE
Generic Asset Group now affects [New] menu, grouping assets.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchAssetTypeSelectorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchAssetTypeSelectorWidget.cpp
@@ -44,6 +44,9 @@ namespace AzToolsFramework
             std::sort(results.values.begin(), results.values.end(),
                 [](const QString& a, const QString& b) { return QString::compare(a, b, Qt::CaseInsensitive) < 0; });
 
+            // Build nested submenus from "/" in group strings (e.g. "GS/Core" -> [GS] -> [Core])
+            QMap<QString, QMenu*> groupMenuCache;
+
             for (QString& group : results.values)
             {
                 // Group "Other" should be in the end of the list, and "Hidden" should not be on the list at all
@@ -51,7 +54,33 @@ namespace AzToolsFramework
                 {
                     continue;
                 }
-                AddAssetTypeGroup(menu, group);
+
+                // Determine which menu to add the checkbox to
+                QMenu* targetMenu = menu;
+                int lastSlash = group.lastIndexOf('/');
+                if (lastSlash >= 0)
+                {
+                    QString parentPath = group.left(lastSlash);
+                    QStringList segments = parentPath.split('/', Qt::SkipEmptyParts);
+                    QString cacheKey;
+
+                    for (const QString& segment : segments)
+                    {
+                        if (!cacheKey.isEmpty())
+                        {
+                            cacheKey += '/';
+                        }
+                        cacheKey += segment;
+
+                        if (!groupMenuCache.contains(cacheKey))
+                        {
+                            groupMenuCache[cacheKey] = targetMenu->addMenu(segment);
+                        }
+                        targetMenu = groupMenuCache[cacheKey];
+                    }
+                }
+
+                AddAssetTypeGroup(targetMenu, group);
             }
             AddAssetTypeGroup(menu, "Other");
             menu->setLayoutDirection(Qt::LeftToRight);
@@ -111,7 +140,10 @@ namespace AzToolsFramework
 
             if (!results.values.empty())
             {
-                QCheckBox* checkbox = new QCheckBox(group, menu);
+                // Show only the leaf segment as the checkbox label (e.g. "Core" from "GS/Core")
+                int lastSlash = group.lastIndexOf('/');
+                QString displayLabel = (lastSlash >= 0) ? group.mid(lastSlash + 1) : group;
+                QCheckBox* checkbox = new QCheckBox(displayLabel, menu);
                 QWidgetAction* action = new QWidgetAction(menu);
                 action->setDefaultWidget(checkbox);
                 menu->addAction(action);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
@@ -60,7 +60,19 @@ namespace AzToolsFramework
                             groupFilter->SetAssetGroup(group);
 
                             AzQtComponents::SearchTypeFilter stFilter;
-                            stFilter.displayName = group;
+
+                            // Split "GS/Core" into category="GS", displayName="Core"
+                            int lastSlash = group.lastIndexOf('/');
+                            if (lastSlash >= 0)
+                            {
+                                stFilter.category = group.left(lastSlash);
+                                stFilter.displayName = group.mid(lastSlash + 1);
+                            }
+                            else
+                            {
+                                stFilter.displayName = group;
+                            }
+
                             stFilter.metadata = QVariant::fromValue(FilterConstType(groupFilter));
 
                             filters.push_back(stFilter);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -195,24 +195,99 @@ namespace AzToolsFramework
             // Add Create New Asset menu and populate it with all asset types that have GenericAssetHandler
             m_newAssetMenu = fileMenu->addMenu(tr("&New"));
 
+            // ----------------------------------------------------------------
+            // Build nested submenus from asset group strings
+            // e.g. "GS/Core" -> [GS] -> [Core] -> [assets]
+            // Single-entry groups are collapsed into their parent menu.
+            // ----------------------------------------------------------------
+
+            // Pass 1: Collect asset entries with their resolved group paths
+            struct NewMenuEntry
+            {
+                AZ::Data::AssetType assetType;
+                QString displayName;
+                QStringList groupSegments;
+            };
+            QVector<NewMenuEntry> menuEntries;
+
             for (const auto& assetType : m_genericAssetTypes)
             {
                 QString assetTypeName;
                 AZ::AssetTypeInfoBus::EventResult(assetTypeName, assetType, &AZ::AssetTypeInfo::GetAssetTypeDisplayName);
-
-                if (!assetTypeName.isEmpty())
+                if (assetTypeName.isEmpty())
                 {
-                    QAction* newAssetAction = m_newAssetMenu->addAction(assetTypeName);
-                    connect(
-                        newAssetAction,
-                        &QAction::triggered,
-                        this,
-                        [assetType, this]()
-                        {
-                            CreateAsset(assetType, AZ::Uuid::CreateNull());
-                        }
-                    );
+                    continue;
                 }
+
+                const char* groupRaw = nullptr;
+                AZ::AssetTypeInfoBus::EventResult(groupRaw, assetType, &AZ::AssetTypeInfo::GetGroup);
+                QString group = groupRaw ? QString(groupRaw).trimmed() : QString();
+
+                NewMenuEntry entry;
+                entry.assetType = assetType;
+                entry.displayName = assetTypeName;
+                entry.groupSegments = group.isEmpty()
+                    ? QStringList()
+                    : group.split('/', Qt::SkipEmptyParts);
+                menuEntries.push_back(entry);
+            }
+
+            // Pass 2: Count how many entries share each group prefix.
+            // A prefix path maps to the total number of entries underneath it.
+            QMap<QString, int> prefixCounts;
+            for (const auto& entry : menuEntries)
+            {
+                QString path;
+                for (const QString& seg : entry.groupSegments)
+                {
+                    if (!path.isEmpty())
+                    {
+                        path += '/';
+                    }
+                    path += seg;
+                    prefixCounts[path]++;
+                }
+            }
+
+            // Pass 3: Build menus, skipping group levels that contain only 1 entry
+            QMap<QString, QMenu*> groupMenuCache;
+
+            for (const auto& entry : menuEntries)
+            {
+                QMenu* targetMenu = m_newAssetMenu;
+
+                QString path;
+                for (const QString& segment : entry.groupSegments)
+                {
+                    if (!path.isEmpty())
+                    {
+                        path += '/';
+                    }
+                    path += segment;
+
+                    // Only create a submenu if this group level has more than 1 entry
+                    if (prefixCounts.value(path) <= 1)
+                    {
+                        continue;
+                    }
+
+                    if (!groupMenuCache.contains(path))
+                    {
+                        groupMenuCache[path] = targetMenu->addMenu(segment);
+                    }
+                    targetMenu = groupMenuCache[path];
+                }
+
+                QAction* newAssetAction = targetMenu->addAction(entry.displayName);
+                connect(
+                    newAssetAction,
+                    &QAction::triggered,
+                    this,
+                    [assetType = entry.assetType, this]()
+                    {
+                        CreateAsset(assetType, AZ::Uuid::CreateNull());
+                    }
+                );
             }
 
             QAction* openAssetAction = fileMenu->addAction("&Open...");


### PR DESCRIPTION
<img width="1107" height="363" alt="image" src="https://github.com/user-attachments/assets/c684b047-835a-4198-8893-ef92e8c7c49d" />

## What does this PR do?

Registered "Group" now enables nested [new] menu generation, as well as enabling slash separation of groups "GenomeStudios/Feature" to enable deeper nesting.

<img width="1091" height="367" alt="image" src="https://github.com/user-attachments/assets/7d4feafd-d2fe-47df-9b76-9e334489faf5" />

Original use for groups is Asset Browser filtration. Nested grouping now allows grouped tags.

<img width="637" height="413" alt="image" src="https://github.com/user-attachments/assets/14a12cb5-100f-43c1-abc6-af2a24a3acdb" />

Assets with only 1 entry in group, get promoted to the higher menu.

<img width="868" height="436" alt="image" src="https://github.com/user-attachments/assets/c7ee3da7-c320-45b4-b6ac-bb987cd3a18f" />



AI Assisted

## How was this PR tested?

Used in editor.

## Final Notes

I would probably suggest a better classification for the "Other" assets.