### PR TITLE
Asset browser fixes

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -865,6 +865,29 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                             tableView->MoveEntries();
                         }
                     });
+                // Open in another Asset Browser — navigate to the folder
+                menu->addAction(
+                    QObject::tr("Open in another Asset Browser"),
+                    [fullFilePath, thumbnailView, tableView]()
+                    {
+                        AzAssetBrowserWindow* newAssetBrowser = AzAssetBrowserMultiWindow::OpenNewAssetBrowserWindow();
+
+                        if (thumbnailView)
+                        {
+                            newAssetBrowser->SetCurrentMode(AssetBrowserMode::ThumbnailView);
+                        }
+                        else if (tableView)
+                        {
+                            newAssetBrowser->SetCurrentMode(AssetBrowserMode::TableView);
+                        }
+                        else
+                        {
+                            newAssetBrowser->SetCurrentMode(AssetBrowserMode::ListView);
+                        }
+
+                        newAssetBrowser->SelectAsset(fullFilePath.c_str(), true);
+                    });
+
                 AddCreateMenu(menu, fullFilePath);
             }
         }

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -865,7 +865,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                             tableView->MoveEntries();
                         }
                     });
-                // Open in another Asset Browser — navigate to the folder
+                // Open in another Asset Browser - navigate to the folder
                 menu->addAction(
                     QObject::tr("Open in another Asset Browser"),
                     [fullFilePath, thumbnailView, tableView]()

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -15,6 +15,8 @@
 
 // AzToolsFramework
 #include <AzCore/Console/IConsole.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Utils/Utils.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/API/ViewPaneOptions.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
@@ -36,6 +38,8 @@
 #include "AzAssetBrowser/AzAssetBrowserRequestHandler.h"
 #include "LyViewPaneNames.h"
 
+#include <QSettings>
+
 AZ_CVAR_API_EXTERNED(AZTF_API, bool, ed_useNewAssetBrowserListView);
 
 AZ_CVAR(bool, ed_useWIPAssetBrowserDesign, true, nullptr, AZ::ConsoleFunctorFlags::Null, "Use the in-progress new Asset Browser design");
@@ -46,6 +50,8 @@ static constexpr int s_narrowModeThreshold = 700;
 static constexpr int MinimumWidth = 328;
 
 using namespace AzToolsFramework::AssetBrowser;
+
+int AzAssetBrowserWindow::s_nextInstanceId = 0;
 
 namespace
 {
@@ -373,12 +379,78 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     m_ui->m_assetBrowserTreeViewWidget->SetIsAssetBrowserMainView();
     m_ui->m_thumbnailView->SetIsAssetBrowserMainView();
     m_ui->m_tableView->SetIsAssetBrowserMainView();
+
+    // Each browser instance gets a unique ID for saving/restoring its folder
+    m_instanceId = s_nextInstanceId++;
+
+    // Navigate to startup folder once asset cache is populated
+    AzToolsFramework::AssetBrowser::AssetBrowserComponentNotificationBus::Handler::BusConnect();
+
+    // If the cache is already ready (window opened after initial load), navigate now
+    bool isReady = false;
+    AzToolsFramework::AssetBrowser::AssetBrowserComponentRequestBus::BroadcastResult(
+        isReady, &AzToolsFramework::AssetBrowser::AssetBrowserComponentRequests::AreEntriesReady);
+    if (isReady)
+    {
+        QTimer::singleShot(0, this, [this]() { NavigateToStartupFolder(); });
+    }
 }
 
 AzAssetBrowserWindow::~AzAssetBrowserWindow()
 {
+    AzToolsFramework::AssetBrowser::AssetBrowserComponentNotificationBus::Handler::BusDisconnect();
+
+    // Save this browser's current folder for next session resume
+    QString visiblePath = m_ui->m_pathBreadCrumbs->currentPath();
+    if (!visiblePath.isEmpty())
+    {
+        QSettings settings;
+        settings.beginGroup("AssetBrowser");
+        settings.setValue(GetSettingsKey(), visiblePath);
+        settings.endGroup();
+        settings.sync();
+    }
+
     m_assetBrowserModel->DisableTickBus();
     m_ui->m_assetBrowserTreeViewWidget->SaveState();
+}
+
+void AzAssetBrowserWindow::OnAssetBrowserComponentReady()
+{
+    // Defer to allow the model/filter to finish updating after entries are populated
+    QTimer::singleShot(0, this, [this]() { NavigateToStartupFolder(); });
+}
+
+QString AzAssetBrowserWindow::GetSettingsKey() const
+{
+    return QString("LastFolder_%1").arg(m_instanceId);
+}
+
+void AzAssetBrowserWindow::NavigateToStartupFolder()
+{
+    // Try 1: Resume this browser's last session folder
+    QSettings settings;
+    settings.beginGroup("AssetBrowser");
+    QString lastFolder = settings.value(GetSettingsKey(), "").toString();
+    settings.endGroup();
+
+    if (!lastFolder.isEmpty())
+    {
+        // Use breadcrumbs-style path navigation which works for all folders
+        // including Gems and engine folders (not just project folders).
+        m_ui->m_assetBrowserTreeViewWidget->SelectFolderFromBreadcrumbsPath(lastFolder.toUtf8().constData());
+        if (m_ui->m_assetBrowserTreeViewWidget->selectionModel()->hasSelection())
+        {
+            return;
+        }
+    }
+
+    // Try 2: Navigate to Project/Assets
+    AZ::IO::FixedMaxPath projectPath = AZ::Utils::GetProjectPath();
+    AZ::IO::FixedMaxPath assetsPath = projectPath / "Assets";
+    m_ui->m_assetBrowserTreeViewWidget->SelectFolder(assetsPath.c_str());
+
+    // If that also fails, we stay at root (default behavior)
 }
 
 void AzAssetBrowserWindow::AddCreateMenu()
@@ -650,6 +722,16 @@ void AzAssetBrowserWindow::UpdateWidgetAfterFilter()
     {
         m_ui->m_assetBrowserListViewWidget->setVisible(hasFilter);
         m_ui->m_assetBrowserTreeViewWidget->setVisible(!hasFilter);
+    }
+
+    // When searching, switch the folder filter to Up propagation so that
+    // source files (which have folder ancestors) pass the folder filter.
+    // This allows folders containing matching files to remain visible in
+    // the sidebar tree.  Restore Down propagation when the search clears.
+    if (auto folderFilter = m_ui->m_searchWidget->GetFolderFilter())
+    {
+        using Dir = AzAssetBrowser::AssetBrowserEntryFilter::PropagateDirection;
+        folderFilter->SetFilterPropagation(hasFilter ? Dir::Up : Dir::Down);
     }
 
     if (hasFilter)

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.h
@@ -10,6 +10,8 @@
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Memory/SystemAllocator.h>
 
+#include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
+
 #include <QWidget>
 #include <QMenu>
 #endif
@@ -48,7 +50,9 @@ namespace AzToolsFramework
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
 
-class AzAssetBrowserWindow : public QWidget
+class AzAssetBrowserWindow
+    : public QWidget
+    , private AzToolsFramework::AssetBrowser::AssetBrowserComponentNotificationBus::Handler
 {
     Q_OBJECT
 public:
@@ -107,11 +111,23 @@ private:
         AzToolsFramework::AssetBrowser::AssetBrowserDisplayState::ListViewMode;
     AzToolsFramework::AssetBrowser::AssetBrowserMode m_currentMode = AzToolsFramework::AssetBrowser::AssetBrowserMode::ThumbnailView;
 
+    //////////////////////////////////////////////////////////////////////////
+    // AssetBrowserComponentNotificationBus::Handler
+    //////////////////////////////////////////////////////////////////////////
+    void OnAssetBrowserComponentReady() override;
+
+    //! Navigates to the startup folder using per-instance saved path > Project/Assets > root.
+    void NavigateToStartupFolder();
+    //! Returns the QSettings key for this browser instance's saved folder path.
+    QString GetSettingsKey() const;
+
     //! Updates breadcrumbs with the selectedEntry relative path if it's a folder or with the
     //! relative path of the first folder parent of the passed entry.
     //! Clears breadcrumbs if nullptr is passed or there's no folder parent.
     void UpdateBreadcrumbs(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* selectedEntry) const;
     bool m_inNarrowMode = false;
+    int m_instanceId = 0;
+    static int s_nextInstanceId;
 
 private Q_SLOTS:
     void CurrentIndexChangedSlot(const QModelIndex& idx) const;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/AssetFolderThumbnailView.cpp
@@ -897,7 +897,14 @@ namespace AzQtComponents
 
         if (m_showSearchResultsMode || !rootIndex().isValid())
         {
-            updateGeometriesInternal(model()->index(0, 0, {}), x, y);
+            // Iterate all top-level entries (scan folders). The model's invisible
+            // root has scan folders as direct children, so we must visit each one
+            // to show search results from every scope (project + gems).
+            const int topLevelCount = model()->rowCount({});
+            for (int i = 0; i < topLevelCount; ++i)
+            {
+                updateGeometriesInternal(model()->index(i, 0, {}), x, y);
+            }
         }
         else
         {
@@ -938,7 +945,7 @@ namespace AzQtComponents
                 continue;
             }
 
-            if (row > 0 && x + itemSize.width() > viewportWidth)
+            if (x + itemSize.width() > viewportWidth && x > m_config.viewportPadding)
             {
                 x = m_config.viewportPadding;
                 y += rowHeight;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -22,6 +22,7 @@
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryCache.h>
 #include <AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.h>
+#include <AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h>
 #include <AzToolsFramework/AssetBrowser/Thumbnails/FolderThumbnail.h>
 #include <AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.h>
 #include <AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.h>
@@ -117,6 +118,7 @@ namespace AzToolsFramework
         void AssetBrowserComponent::Reflect(AZ::ReflectContext* context)
         {
             AssetSystem::FileInfosNotificationMessage::Reflect(context);
+            AssetBrowserFavoritesProjectSettings::Reflect(context);
 
             AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
             if (serialize)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserListModel.cpp
@@ -143,11 +143,14 @@ namespace AzToolsFramework
 
             for (int currentRow = 0; currentRow < rows; ++currentRow)
             {
+                QModelIndex index = model->index(currentRow, 0, parent);
+                AssetBrowserEntry* entry = GetAssetEntry(m_filterModel->mapToSource(index));
+
+                // Only add source and product assets to the display map, subject to
+                // the display limit. But always continue traversing all scan folders
+                // so the search is complete across the entire asset database.
                 if (m_displayedItemsCounter < m_numberOfItemsDisplayed)
                 {
-                    QModelIndex index = model->index(currentRow, 0, parent);
-                    AssetBrowserEntry* entry = GetAssetEntry(m_filterModel->mapToSource(index));
-                    // We only want to see source and product assets.
                     if (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source ||
                         entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product)
                     {
@@ -155,22 +158,20 @@ namespace AzToolsFramework
                         m_rowMap[index] = row;
                         ++row;
 
-                        // We only want to increase the displayed counter if it is a parent (Source)
-                        // so we don't cut children entries.
                         if (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source)
                         {
                             ++m_displayedItemsCounter;
                         }
                     }
-
-                    if (model->hasChildren(index))
-                    {
-                        row = BuildListModelMap(model, index, row);
-                    }
                 }
-                else
+
+                // Always recurse into children regardless of display limit.
+                // The previous break here would skip entire scan folders once
+                // the limit was reached, causing search to miss results in
+                // later gems/scan folders.
+                if (model->hasChildren(index))
                 {
-                    break;
+                    row = BuildListModelMap(model, index, row);
                 }
             }
             return row;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.cpp
@@ -451,6 +451,27 @@ namespace AzToolsFramework
                 return false;
             }
 
+            // Project folder should always appear before other folders.
+            // The tree view sorts with Qt::DescendingOrder and the name
+            // comparator uses "> 0", so lessThan(project, other) must return
+            // false (not true) to place the project first in descending order.
+            if (GetEntryType() == AssetEntryType::Folder && other->GetEntryType() == AssetEntryType::Folder)
+            {
+                auto* leftFolder = azrtti_cast<const FolderAssetBrowserEntry*>(this);
+                auto* rightFolder = azrtti_cast<const FolderAssetBrowserEntry*>(other);
+                if (leftFolder && rightFolder)
+                {
+                    if (leftFolder->IsProjectFolder() && !rightFolder->IsProjectFolder())
+                    {
+                        return false;
+                    }
+                    if (!leftFolder->IsProjectFolder() && rightFolder->IsProjectFolder())
+                    {
+                        return true;
+                    }
+                }
+            }
+
             switch (sortMode)
             {
             case AssetEntrySortMode::FileType:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.cpp
@@ -45,6 +45,11 @@ namespace AzToolsFramework
             return m_isGemFolder;
         }
 
+        bool FolderAssetBrowserEntry::IsProjectFolder() const
+        {
+            return m_isProjectFolder;
+        }
+
         const AZ::Uuid& FolderAssetBrowserEntry::GetFolderUuid() const
         {
             return m_folderUuid;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.h
@@ -37,6 +37,7 @@ namespace AzToolsFramework
 
             bool IsScanFolder() const;
             bool IsGemFolder() const;
+            bool IsProjectFolder() const;
             const AZ::Uuid& GetFolderUuid() const;
 
             static const FolderAssetBrowserEntry* GetFolderByUuid(const AZ::Uuid& folderUuid);
@@ -47,6 +48,7 @@ namespace AzToolsFramework
         private:
             bool m_isScanFolder = false;
             bool m_isGemFolder = false;
+            bool m_isProjectFolder = false;
             AZ::Uuid m_folderUuid;
 
             AZ_DISABLE_COPY_MOVE(FolderAssetBrowserEntry);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
@@ -441,6 +441,7 @@ namespace AzToolsFramework
             folder->m_isScanFolder = isScanFolder;
             parent->AddChild(folder);
             folder->m_isGemFolder = m_gemNames.contains(folder->GetFullPath());
+            folder->m_isProjectFolder = (AZ::IO::PathView(folder->GetFullPath()) == m_projectPath);
             return folder;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
@@ -271,37 +271,7 @@ namespace AzToolsFramework
 
             for (const FavoriteRecord& record : projectSettings.m_items)
             {
-<<<<<<< Updated upstream
-                settings.setArrayIndex(index);
-
-                QString path = settings.value("entryPath", "").toString();
-                if (!path.isEmpty())
-                {
-                    AZStd::string filePath = AZ::IO::PathView(path.toUtf8().data()).LexicallyNormal().String();
-
-                    const auto itFile = EntryCache::GetInstance()->m_absolutePathToFileId.find(filePath);
-                    if (itFile == EntryCache::GetInstance()->m_absolutePathToFileId.end())
-                    {
-                        // Cache not populated yet - save the path so we don't lose it on next save
-                        m_unresolvedFavoritePaths.push_back(filePath);
-                        continue;
-                    }
-
-                    const auto itABEntry = EntryCache::GetInstance()->m_fileIdMap.find(itFile->second);
-                    if (itABEntry == EntryCache::GetInstance()->m_fileIdMap.end())
-                    {
-                        m_unresolvedFavoritePaths.push_back(filePath);
-                        continue;
-                    }
-
-                    AddFavoriteAsset(itABEntry->second);
-                }
-
-                bool isSearch = settings.value("favoriteSearch", false).toBool();
-                if (isSearch)
-=======
                 if (record.m_isSearch)
->>>>>>> Stashed changes
                 {
                     SearchAssetBrowserFavoriteItem* search = aznew SearchAssetBrowserFavoriteItem();
                     search->LoadFromRecord(record);
@@ -370,26 +340,9 @@ namespace AzToolsFramework
             AssetBrowserFavoritesProjectSettings projectSettings;
             projectSettings.m_items.reserve(m_favorites.size());
 
-<<<<<<< Updated upstream
-            int arrayIndex = 0;
-
-=======
-<<<<<<< Updated upstream
->>>>>>> Stashed changes
-            for (size_t index = 0; index < m_favorites.size(); index++)
-            {
-                AssetBrowserFavoriteItem* entry = m_favorites.at(index);
-
-<<<<<<< Updated upstream
-                settings.setArrayIndex(arrayIndex++);
-=======
-                settings.setArrayIndex(aznumeric_cast<int>(index));
-=======
             for (AssetBrowserFavoriteItem* entry : m_favorites)
             {
                 FavoriteRecord& record = projectSettings.m_items.emplace_back();
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
                 if (entry->GetFavoriteType() == AssetBrowserFavoriteItem::FavoriteType::AssetBrowserEntry)
                 {
@@ -404,22 +357,6 @@ namespace AzToolsFramework
                 }
             }
 
-<<<<<<< Updated upstream
-            // Preserve any favorite paths that could not be resolved during load
-            // (e.g. because the asset cache was not fully populated yet).
-            // This prevents favorites from being silently lost between sessions.
-            for (const auto& unresolvedPath : m_unresolvedFavoritePaths)
-            {
-                settings.setArrayIndex(arrayIndex++);
-                settings.setValue("entryPath", unresolvedPath.c_str());
-            }
-
-            settings.endArray();
-            settings.sync();
-=======
-<<<<<<< Updated upstream
-            settings.endArray();
-=======
             projectSettings.m_unresolvedPaths = m_unresolvedFavoritePaths;
 
             const AZStd::string registryPath = BuildFavoritesRegistryPath(GetProjectName());
@@ -436,8 +373,6 @@ namespace AzToolsFramework
             // Flush editorpreferences.setreg through the editor settings API so
             // the per-project user folder reflects the change immediately.
             EditorSettingsAPIBus::Broadcast(&EditorSettingsAPIBus::Events::SaveSettingsRegistryFile);
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
             AssetBrowserFavoritesNotificationBus::Broadcast(&AssetBrowserFavoritesNotificationBus::Events::FavoritesChanged);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
@@ -8,6 +8,7 @@
 
 #include "AssetBrowserFavoritesManager.h"
 
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/Module/Environment.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
@@ -21,6 +22,7 @@
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryUtils.h>
 #include <AzToolsFramework/AssetBrowser/Entries/FolderAssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoriteItem.h>
+#include <AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h>
 #include <AzToolsFramework/AssetBrowser/Favorites/EntryAssetBrowserFavoriteItem.h>
 #include <AzToolsFramework/AssetBrowser/Favorites/SearchAssetBrowserFavoriteItem.h>
 #include <AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesModel.h>
@@ -30,9 +32,9 @@
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserThumbnailView.h>
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
+#include <AzToolsFramework/Editor/EditorSettingsAPIBus.h>
 
 #include <QModelIndex>
-#include <QSettings>
 
 namespace AzToolsFramework
 {
@@ -220,6 +222,33 @@ namespace AzToolsFramework
             m_favorites.erase(m_favorites.begin(), m_favorites.end());
         }
 
+        // ============================================================
+        //  Settings Registry Path Helper
+        // ============================================================
+        //
+        //  Favorites are stored per-project in:
+        //      <ProjectPath>/user/Registry/editorpreferences.setreg
+        //  under the registry path:
+        //      /O3DE/Preferences/AssetBrowser/Favorites/<ProjectName>
+        //
+        //  Replaces the previous QSettings backing, which was platform-
+        //  specific (Windows registry on Windows) and global to the
+        //  machine rather than scoped to the project.
+        // ============================================================
+        static AZStd::string BuildFavoritesRegistryPath(const QString& projectName)
+        {
+            AZStd::string path = AssetBrowserFavoritesRegistryPrefix;
+            if (!projectName.isEmpty())
+            {
+                path += "/";
+                path += projectName.toUtf8().constData();
+            }
+            return path;
+        }
+
+        // ============================================================
+        //  Load Favorites from Settings Registry
+        // ============================================================
         void AssetBrowserFavoritesManager::LoadFavorites()
         {
             m_loading = true;
@@ -227,19 +256,22 @@ namespace AzToolsFramework
             ClearFavorites();
             m_unresolvedFavoritePaths.clear();
 
-            QSettings settings;
-            settings.beginGroup("AssetBrowserFavorites");
-
-            QString projectName = GetProjectName();
-            if (projectName.length() > 0)
+            auto* registry = AZ::SettingsRegistry::Get();
+            if (registry == nullptr)
             {
-                settings.beginGroup(GetProjectName());
+                m_loading = false;
+                AssetBrowserFavoritesNotificationBus::Broadcast(&AssetBrowserFavoritesNotificationBus::Events::FavoritesChanged);
+                return;
             }
 
-            int size = settings.beginReadArray("Items");
+            const AZStd::string registryPath = BuildFavoritesRegistryPath(GetProjectName());
 
-            for (int index = 0; index < size; index++)
+            AssetBrowserFavoritesProjectSettings projectSettings;
+            registry->GetObject(projectSettings, registryPath);
+
+            for (const FavoriteRecord& record : projectSettings.m_items)
             {
+<<<<<<< Updated upstream
                 settings.setArrayIndex(index);
 
                 QString path = settings.value("entryPath", "").toString();
@@ -267,10 +299,48 @@ namespace AzToolsFramework
 
                 bool isSearch = settings.value("favoriteSearch", false).toBool();
                 if (isSearch)
+=======
+                if (record.m_isSearch)
+>>>>>>> Stashed changes
                 {
                     SearchAssetBrowserFavoriteItem* search = aznew SearchAssetBrowserFavoriteItem();
-                    search->LoadSettings(settings);
+                    search->LoadFromRecord(record);
                     AddFavoriteItem(search);
+                    continue;
+                }
+
+                if (record.m_entryPath.empty())
+                {
+                    continue;
+                }
+
+                AZStd::string filePath = AZ::IO::PathView(record.m_entryPath).LexicallyNormal().String();
+
+                const auto itFile = EntryCache::GetInstance()->m_absolutePathToFileId.find(filePath);
+                if (itFile == EntryCache::GetInstance()->m_absolutePathToFileId.end())
+                {
+                    // Cache not populated yet - keep so it is not lost on next save
+                    m_unresolvedFavoritePaths.push_back(filePath);
+                    continue;
+                }
+
+                const auto itABEntry = EntryCache::GetInstance()->m_fileIdMap.find(itFile->second);
+                if (itABEntry == EntryCache::GetInstance()->m_fileIdMap.end())
+                {
+                    m_unresolvedFavoritePaths.push_back(filePath);
+                    continue;
+                }
+
+                AddFavoriteAsset(itABEntry->second);
+            }
+
+            // Carry forward any previously unresolved paths that this session also could not resolve.
+            for (const AZStd::string& path : projectSettings.m_unresolvedPaths)
+            {
+                if (AZStd::find(m_unresolvedFavoritePaths.begin(), m_unresolvedFavoritePaths.end(), path)
+                    == m_unresolvedFavoritePaths.end())
+                {
+                    m_unresolvedFavoritePaths.push_back(path);
                 }
             }
 
@@ -279,6 +349,9 @@ namespace AzToolsFramework
             AssetBrowserFavoritesNotificationBus::Broadcast(&AssetBrowserFavoritesNotificationBus::Events::FavoritesChanged);
         }
 
+        // ============================================================
+        //  Save Favorites to Settings Registry
+        // ============================================================
         void AssetBrowserFavoritesManager::SaveFavorites()
         {
             if (m_loading)
@@ -286,44 +359,52 @@ namespace AzToolsFramework
                 return;
             }
 
-            QSettings settings;
-            settings.beginGroup("AssetBrowserFavorites");
-
-            QString projectName = GetProjectName();
-            if (projectName.length() > 0)
+            auto* registry = AZ::SettingsRegistry::Get();
+            if (registry == nullptr)
             {
-                // Clear the group
-                settings.beginGroup(projectName);
-                settings.remove("");
-                settings.endGroup();
-
-                settings.beginGroup(projectName);
+                AZ_Warning("AssetBrowserFavorites", false,
+                    "Settings registry unavailable; favorites will not be persisted.");
+                return;
             }
 
-            settings.remove("");
-            settings.beginWriteArray("Items");
+            AssetBrowserFavoritesProjectSettings projectSettings;
+            projectSettings.m_items.reserve(m_favorites.size());
 
+<<<<<<< Updated upstream
             int arrayIndex = 0;
 
+=======
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
             for (size_t index = 0; index < m_favorites.size(); index++)
             {
                 AssetBrowserFavoriteItem* entry = m_favorites.at(index);
 
+<<<<<<< Updated upstream
                 settings.setArrayIndex(arrayIndex++);
+=======
+                settings.setArrayIndex(aznumeric_cast<int>(index));
+=======
+            for (AssetBrowserFavoriteItem* entry : m_favorites)
+            {
+                FavoriteRecord& record = projectSettings.m_items.emplace_back();
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 
                 if (entry->GetFavoriteType() == AssetBrowserFavoriteItem::FavoriteType::AssetBrowserEntry)
                 {
                     EntryAssetBrowserFavoriteItem* entryItem = static_cast<EntryAssetBrowserFavoriteItem*>(entry);
-                    settings.setValue("entryPath", entryItem->GetEntry()->GetFullPath().data());
+                    record.m_isSearch = false;
+                    record.m_entryPath = entryItem->GetEntry()->GetFullPath();
                 }
                 else if (entry->GetFavoriteType() == AssetBrowserFavoriteItem::FavoriteType::Search)
                 {
                     SearchAssetBrowserFavoriteItem* searchItem = static_cast<SearchAssetBrowserFavoriteItem*>(entry);
-                    settings.setValue("favoriteSearch", true);
-                    searchItem->SaveSettings(settings);
+                    searchItem->SaveToRecord(record);
                 }
             }
 
+<<<<<<< Updated upstream
             // Preserve any favorite paths that could not be resolved during load
             // (e.g. because the asset cache was not fully populated yet).
             // This prevents favorites from being silently lost between sessions.
@@ -335,6 +416,28 @@ namespace AzToolsFramework
 
             settings.endArray();
             settings.sync();
+=======
+<<<<<<< Updated upstream
+            settings.endArray();
+=======
+            projectSettings.m_unresolvedPaths = m_unresolvedFavoritePaths;
+
+            const AZStd::string registryPath = BuildFavoritesRegistryPath(GetProjectName());
+
+            // Clear the prior subtree so removed entries don't linger.
+            registry->Remove(registryPath);
+
+            if (!registry->SetObject(registryPath, projectSettings))
+            {
+                AZ_Warning("AssetBrowserFavorites", false,
+                    "Failed to write favorites to settings registry at %s", registryPath.c_str());
+            }
+
+            // Flush editorpreferences.setreg through the editor settings API so
+            // the per-project user folder reflects the change immediately.
+            EditorSettingsAPIBus::Broadcast(&EditorSettingsAPIBus::Events::SaveSettingsRegistryFile);
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 
             AssetBrowserFavoritesNotificationBus::Broadcast(&AssetBrowserFavoritesNotificationBus::Events::FavoritesChanged);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
@@ -75,6 +75,12 @@ namespace AzToolsFramework
             AddFavoriteItem(item);
 
             m_favoriteEntriesCache[favorite] = item;
+
+            // If this asset was previously unresolved, remove it from the unresolved list
+            AZStd::string normalizedPath = AZ::IO::PathView(favorite->GetFullPath()).LexicallyNormal().String();
+            m_unresolvedFavoritePaths.erase(
+                AZStd::remove(m_unresolvedFavoritePaths.begin(), m_unresolvedFavoritePaths.end(), normalizedPath),
+                m_unresolvedFavoritePaths.end());
         }
 
         void AssetBrowserFavoritesManager::AddFavoriteSearchButtonPressed(SearchWidget* searchWidget)
@@ -219,6 +225,7 @@ namespace AzToolsFramework
             m_loading = true;
 
             ClearFavorites();
+            m_unresolvedFavoritePaths.clear();
 
             QSettings settings;
             settings.beginGroup("AssetBrowserFavorites");
@@ -243,12 +250,15 @@ namespace AzToolsFramework
                     const auto itFile = EntryCache::GetInstance()->m_absolutePathToFileId.find(filePath);
                     if (itFile == EntryCache::GetInstance()->m_absolutePathToFileId.end())
                     {
+                        // Cache not populated yet — save the path so we don't lose it on next save
+                        m_unresolvedFavoritePaths.push_back(filePath);
                         continue;
                     }
 
                     const auto itABEntry = EntryCache::GetInstance()->m_fileIdMap.find(itFile->second);
                     if (itABEntry == EntryCache::GetInstance()->m_fileIdMap.end())
                     {
+                        m_unresolvedFavoritePaths.push_back(filePath);
                         continue;
                     }
 
@@ -293,11 +303,13 @@ namespace AzToolsFramework
             settings.remove("");
             settings.beginWriteArray("Items");
 
+            int arrayIndex = 0;
+
             for (size_t index = 0; index < m_favorites.size(); index++)
             {
                 AssetBrowserFavoriteItem* entry = m_favorites.at(index);
 
-                settings.setArrayIndex(aznumeric_cast<int>(index));
+                settings.setArrayIndex(arrayIndex++);
 
                 if (entry->GetFavoriteType() == AssetBrowserFavoriteItem::FavoriteType::AssetBrowserEntry)
                 {
@@ -312,7 +324,17 @@ namespace AzToolsFramework
                 }
             }
 
+            // Preserve any favorite paths that could not be resolved during load
+            // (e.g. because the asset cache was not fully populated yet).
+            // This prevents favorites from being silently lost between sessions.
+            for (const auto& unresolvedPath : m_unresolvedFavoritePaths)
+            {
+                settings.setArrayIndex(arrayIndex++);
+                settings.setValue("entryPath", unresolvedPath.c_str());
+            }
+
             settings.endArray();
+            settings.sync();
 
             AssetBrowserFavoritesNotificationBus::Broadcast(&AssetBrowserFavoritesNotificationBus::Events::FavoritesChanged);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.cpp
@@ -250,7 +250,7 @@ namespace AzToolsFramework
                     const auto itFile = EntryCache::GetInstance()->m_absolutePathToFileId.find(filePath);
                     if (itFile == EntryCache::GetInstance()->m_absolutePathToFileId.end())
                     {
-                        // Cache not populated yet — save the path so we don't lose it on next save
+                        // Cache not populated yet - save the path so we don't lose it on next save
                         m_unresolvedFavoritePaths.push_back(filePath);
                         continue;
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesManager.h
@@ -77,6 +77,10 @@ namespace AzToolsFramework
 
             AZStd::unordered_map<const AssetBrowserEntry*, AssetBrowserFavoriteItem*> m_favoriteEntriesCache;
 
+            // Paths that could not be resolved during LoadFavorites (cache not yet populated).
+            // These are preserved across saves so they are not lost between sessions.
+            AZStd::vector<AZStd::string> m_unresolvedFavoritePaths;
+
             QString GetProjectName();
             void AddFavoriteItem(AssetBrowserFavoriteItem* item);
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesModel.cpp
@@ -27,7 +27,6 @@
 #include <AzToolsFramework/AssetBrowser/Views/AssetBrowserViewUtils.h>
 
 #include <QModelIndex>
-#include <QSettings>
 
 namespace AzToolsFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h>
+
+namespace AzToolsFramework
+{
+    namespace AssetBrowser
+    {
+        // ============================================================
+        //  Reflection
+        // ============================================================
+
+        void FavoriteSearchTypeFilterRecord::Reflect(AZ::ReflectContext* context)
+        {
+            if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serialize->Class<FavoriteSearchTypeFilterRecord>()
+                    ->Version(1)
+                    ->Field("categoryKey", &FavoriteSearchTypeFilterRecord::m_categoryKey)
+                    ->Field("displayName", &FavoriteSearchTypeFilterRecord::m_displayName)
+                    ->Field("enabled", &FavoriteSearchTypeFilterRecord::m_enabled)
+                    ;
+            }
+        }
+
+        void FavoriteRecord::Reflect(AZ::ReflectContext* context)
+        {
+            if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serialize->Class<FavoriteRecord>()
+                    ->Version(1)
+                    ->Field("isSearch", &FavoriteRecord::m_isSearch)
+                    ->Field("entryPath", &FavoriteRecord::m_entryPath)
+                    ->Field("name", &FavoriteRecord::m_name)
+                    ->Field("searchTerm", &FavoriteRecord::m_searchTerm)
+                    ->Field("unusableProductsFilterActive", &FavoriteRecord::m_unusableProductsFilterActive)
+                    ->Field("engineFilterActive", &FavoriteRecord::m_engineFilterActive)
+                    ->Field("folderFilterActive", &FavoriteRecord::m_folderFilterActive)
+                    ->Field("typeFilters", &FavoriteRecord::m_typeFilters)
+                    ;
+            }
+        }
+
+        void AssetBrowserFavoritesProjectSettings::Reflect(AZ::ReflectContext* context)
+        {
+            FavoriteSearchTypeFilterRecord::Reflect(context);
+            FavoriteRecord::Reflect(context);
+
+            if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serialize->Class<AssetBrowserFavoritesProjectSettings>()
+                    ->Version(1)
+                    ->Field("items", &AssetBrowserFavoritesProjectSettings::m_items)
+                    ->Field("unresolvedPaths", &AssetBrowserFavoritesProjectSettings::m_unresolvedPaths)
+                    ;
+            }
+        }
+
+    } // namespace AssetBrowser
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+
+#include <AzToolsFramework/AzToolsFrameworkAPI.h>
+
+namespace AzToolsFramework
+{
+    namespace AssetBrowser
+    {
+        // ============================================================
+        //  Persistent Records for Asset Browser Favorites
+        // ============================================================
+        //
+        //  These records mirror the runtime AssetBrowserFavoriteItem
+        //  hierarchy but in a form that can be round-tripped through
+        //  AZ::SettingsRegistry::Set/GetObject and persisted in the
+        //  per-project editorpreferences.setreg file.
+        //
+        //  This replaces the previous QSettings-based persistence,
+        //  which was global to the machine and platform-specific.
+        // ============================================================
+
+        //! One enabled/disabled type filter as it appears on a saved search favorite.
+        struct AZTF_API FavoriteSearchTypeFilterRecord
+        {
+            AZ_TYPE_INFO(FavoriteSearchTypeFilterRecord, "{2C7C3F1D-3D55-4D2A-A0B6-2F92E0E2C8AA}");
+            AZ_CLASS_ALLOCATOR(FavoriteSearchTypeFilterRecord, AZ::SystemAllocator);
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            AZStd::string m_categoryKey;
+            AZStd::string m_displayName;
+            bool m_enabled = false;
+        };
+
+        //! One favorite slot. Acts as a discriminated union — m_isSearch
+        //! selects which fields are meaningful (entry path vs. search filter).
+        struct AZTF_API FavoriteRecord
+        {
+            AZ_TYPE_INFO(FavoriteRecord, "{6B79E0AF-3F5E-4D1A-9C1E-A8C61F6A38B1}");
+            AZ_CLASS_ALLOCATOR(FavoriteRecord, AZ::SystemAllocator);
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            // Discriminator
+            bool m_isSearch = false;
+
+            // Entry favorite (when !m_isSearch)
+            AZStd::string m_entryPath;
+
+            // Search favorite (when m_isSearch)
+            AZStd::string m_name;
+            AZStd::string m_searchTerm;
+            bool m_unusableProductsFilterActive = false;
+            bool m_engineFilterActive = false;
+            bool m_folderFilterActive = false;
+            AZStd::vector<FavoriteSearchTypeFilterRecord> m_typeFilters;
+        };
+
+        //! Top-level container persisted per project.
+        //! m_unresolvedPaths preserves entry favorites whose target asset was
+        //! not yet resolvable at load time, so they survive across sessions.
+        struct AZTF_API AssetBrowserFavoritesProjectSettings
+        {
+            AZ_TYPE_INFO(AssetBrowserFavoritesProjectSettings, "{F1C9AB1D-7E51-44B2-B6D4-5DE7A5C76A12}");
+            AZ_CLASS_ALLOCATOR(AssetBrowserFavoritesProjectSettings, AZ::SystemAllocator);
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            AZStd::vector<FavoriteRecord> m_items;
+            AZStd::vector<AZStd::string> m_unresolvedPaths;
+        };
+
+        //! Settings registry path prefix where favorites live.
+        //! Final path is: <prefix>/<projectName>
+        constexpr const char* AssetBrowserFavoritesRegistryPrefix = "/O3DE/Preferences/AssetBrowser/Favorites";
+
+    } // namespace AssetBrowser
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h
@@ -45,7 +45,7 @@ namespace AzToolsFramework
             bool m_enabled = false;
         };
 
-        //! One favorite slot. Acts as a discriminated union — m_isSearch
+        //! One favorite slot. Acts as a discriminated union -- m_isSearch
         //! selects which fields are meaningful (entry path vs. search filter).
         struct AZTF_API FavoriteRecord
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/SearchAssetBrowserFavoriteItem.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/SearchAssetBrowserFavoriteItem.cpp
@@ -8,6 +8,7 @@
 
 #include "AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoriteItem.h"
 #include "AzToolsFramework/AssetBrowser/Favorites/SearchAssetBrowserFavoriteItem.h"
+#include <AzToolsFramework/AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h>
 #include <AzToolsFramework/AssetBrowser/Search/SearchWidget.h>
 
 namespace AzToolsFramework
@@ -103,52 +104,47 @@ namespace AzToolsFramework
             searchWidget->SetFilterString(m_searchTerm);
         }
 
-        void SearchAssetBrowserFavoriteItem::LoadSettings(QSettings& settings)
+        void SearchAssetBrowserFavoriteItem::LoadFromRecord(const FavoriteRecord& record)
         {
-            m_name = settings.value("name").toString();
-            m_searchTerm = settings.value("searchTerm").toString();
-            m_unusableProductsFilterActive = settings.value("unusableProductsFilterActive").toBool();
-            m_engineFilterActive = settings.value("projectSourceFilterActive").toBool();
-            m_folderFilterActive = settings.value("folderFilterActive").toBool();
-
-            int filterCount = settings.beginReadArray("typeFilters");
+            m_name = QString::fromUtf8(record.m_name.c_str());
+            m_searchTerm = QString::fromUtf8(record.m_searchTerm.c_str());
+            m_unusableProductsFilterActive = record.m_unusableProductsFilterActive;
+            m_engineFilterActive = record.m_engineFilterActive;
+            m_folderFilterActive = record.m_folderFilterActive;
 
             qDeleteAll(m_typeFilters.begin(), m_typeFilters.end());
             m_typeFilters.clear();
-            m_typeFilters.reserve(filterCount);
+            m_typeFilters.reserve(static_cast<int>(record.m_typeFilters.size()));
 
-            for (int index = 0; index < filterCount; index++)
+            for (const FavoriteSearchTypeFilterRecord& filterRecord : record.m_typeFilters)
             {
                 SavedTypeFilter* typeFilter = aznew SavedTypeFilter();
-                
-                typeFilter->categoryKey = settings.value("categoryKey").toString();
-                typeFilter->displayName = settings.value("displayName").toString();
-                typeFilter->enabled = settings.value("enabled").toBool();
-
+                typeFilter->categoryKey = QString::fromUtf8(filterRecord.m_categoryKey.c_str());
+                typeFilter->displayName = QString::fromUtf8(filterRecord.m_displayName.c_str());
+                typeFilter->enabled = filterRecord.m_enabled;
                 m_typeFilters.append(typeFilter);
             }
-
-            settings.endArray();
         }
 
-        void SearchAssetBrowserFavoriteItem::SaveSettings(QSettings& settings)
+        void SearchAssetBrowserFavoriteItem::SaveToRecord(FavoriteRecord& record) const
         {
-            settings.setValue("name", m_name);
-            settings.setValue("searchTerm", m_searchTerm);
-            settings.setValue("unusableProductsFilterActive", m_unusableProductsFilterActive);
-            settings.setValue("projectSourceFilterActive", m_engineFilterActive);
-            settings.setValue("folderFilterActive", m_folderFilterActive);
+            record.m_isSearch = true;
+            record.m_name = m_name.toUtf8().constData();
+            record.m_searchTerm = m_searchTerm.toUtf8().constData();
+            record.m_unusableProductsFilterActive = m_unusableProductsFilterActive;
+            record.m_engineFilterActive = m_engineFilterActive;
+            record.m_folderFilterActive = m_folderFilterActive;
 
-            settings.beginWriteArray("typeFilters", m_typeFilters.size());
+            record.m_typeFilters.clear();
+            record.m_typeFilters.reserve(m_typeFilters.size());
 
-            for (auto typeFilter : m_typeFilters)
+            for (const SavedTypeFilter* typeFilter : m_typeFilters)
             {
-                settings.setValue("categoryKey", typeFilter->categoryKey);
-                settings.setValue("displayName", typeFilter->displayName);
-                settings.setValue("enabled", typeFilter->enabled);
+                FavoriteSearchTypeFilterRecord& filterRecord = record.m_typeFilters.emplace_back();
+                filterRecord.m_categoryKey = typeFilter->categoryKey.toUtf8().constData();
+                filterRecord.m_displayName = typeFilter->displayName.toUtf8().constData();
+                filterRecord.m_enabled = typeFilter->enabled;
             }
-
-            settings.endArray();
         }
 
         QString SearchAssetBrowserFavoriteItem::GetDefaultName()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/SearchAssetBrowserFavoriteItem.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Favorites/SearchAssetBrowserFavoriteItem.h
@@ -14,9 +14,16 @@
 
 #include <QList>
 #include <QString>
-#include <QSettings>
 #endif
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
+
+namespace AzToolsFramework
+{
+    namespace AssetBrowser
+    {
+        struct FavoriteRecord;
+    }
+}
 
 namespace AzToolsFramework
 {
@@ -49,8 +56,10 @@ namespace AzToolsFramework
             void SetupFromSearchWidget(SearchWidget* searchWidget);
             void WriteToSearchWidget(SearchWidget* searchWidget);
 
-            void LoadSettings(QSettings& settings);
-            void SaveSettings(QSettings& settings);
+            //! Hydrate this favorite from a serialized record (registry-backed persistence).
+            void LoadFromRecord(const FavoriteRecord& record);
+            //! Serialize this favorite into a record for registry persistence.
+            void SaveToRecord(FavoriteRecord& record) const;
 
             QString GetDefaultName();
         private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTableView.cpp
@@ -29,6 +29,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <QApplication>
+#include <QClipboard>
 #include <QDragMoveEvent>
 #include <QHeaderView>
 #include <QLineEdit>
@@ -199,6 +200,28 @@ namespace AzToolsFramework
                     DuplicateEntries();
                 });
             addAction(duplicateAction);
+
+            QAction* copyPathAction = new QAction("Copy Path Action", this);
+            copyPathAction->setShortcut(QKeySequence::Copy);
+            copyPathAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+            connect(
+                copyPathAction,
+                &QAction::triggered,
+                this,
+                [this]()
+                {
+                    auto selectedAssets = GetSelectedAssets();
+                    if (!selectedAssets.empty())
+                    {
+                        QStringList paths;
+                        for (const auto* entry : selectedAssets)
+                        {
+                            paths.append(entry->GetFullPath().c_str());
+                        }
+                        QApplication::clipboard()->setText(paths.join("\n"));
+                    }
+                });
+            addAction(copyPathAction);
 
             connect(
                 m_tableViewWidget,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -43,6 +43,8 @@
 #include <AzQtComponents/Components/Widgets/MessageBox.h>
 #include <AzQtComponents/DragAndDrop/MainWindowDragAndDrop.h>
 
+#include <QApplication>
+#include <QClipboard>
 #include <QDir>
 #include <QMenu>
 #include <QFile>
@@ -123,6 +125,25 @@ namespace AzToolsFramework
                     DuplicateEntries();
                 });
             addAction(duplicateAction);
+
+            QAction* copyPathAction = new QAction("Copy Path Action", this);
+            copyPathAction->setShortcut(QKeySequence::Copy);
+            copyPathAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+            connect(
+                copyPathAction, &QAction::triggered, this, [this]()
+                {
+                    auto selectedAssets = GetSelectedAssets();
+                    if (!selectedAssets.empty())
+                    {
+                        QStringList paths;
+                        for (const auto* entry : selectedAssets)
+                        {
+                            paths.append(entry->GetFullPath().c_str());
+                        }
+                        QApplication::clipboard()->setText(paths.join("\n"));
+                    }
+                });
+            addAction(copyPathAction);
 
             connect(this, &QAbstractItemView::clicked, this, &AssetBrowserTreeView::itemClicked);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -834,6 +834,8 @@ set(FILES
     AssetBrowser/Favorites/AssetBrowserFavoritesManager.h
     AssetBrowser/Favorites/AssetBrowserFavoritesModel.cpp
     AssetBrowser/Favorites/AssetBrowserFavoritesModel.h
+    AssetBrowser/Favorites/AssetBrowserFavoritesSettings.cpp
+    AssetBrowser/Favorites/AssetBrowserFavoritesSettings.h
     AssetBrowser/Favorites/AssetBrowserFavoriteItem.cpp
     AssetBrowser/Favorites/AssetBrowserFavoriteItem.h
     AssetBrowser/Favorites/EntryAssetBrowserFavoriteItem.cpp


### PR DESCRIPTION
## What does this PR do?
Introduces a handful of Asset Browser fixes:
- Browser Project Folder not Top Folder: https://github.com/o3de/o3de/issues/19404
- Thumbnail Search stops at first find: https://github.com/o3de/o3de/issues/19405
- Browser does not retain Favourites: https://github.com/o3de/o3de/issues/19451
- Default destination is poor: https://github.com/o3de/o3de/issues/19458
- Open in Seconds Asset browser support on folders: https://github.com/o3de/o3de/issues/19461

## How was this PR tested?

Used in Editor.

https://github.com/user-attachments/assets/4deb7f02-745d-43cc-86e3-cdd2f150e82d

= AI Assisted Implementation =