### PR TITLE
Selecting file entities outside of outliner deselects the outliner

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
@@ -20,13 +20,31 @@
 
 #include <AzQtComponents/Components/Style.h>
 
+#include <QApplication>
 #include <QDrag>
 #include <QHeaderView>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QTimer>
 
 namespace AzToolsFramework
 {
+    // Helper: walks up the widget parent chain to check if the widget is inside
+    // Returns true if the widget is inside an Asset Browser panel.
+    static bool IsInsideAssetBrowser(QWidget* widget)
+    {
+        while (widget)
+        {
+            const char* className = widget->metaObject()->className();
+            if (qstrcmp(className, "AzAssetBrowserWindow") == 0)
+            {
+                return true;
+            }
+            widget = widget->parentWidget();
+        }
+        return false;
+    }
+
     EntityOutlinerTreeView::EntityOutlinerTreeView(QWidget* pParent)
         : AzQtComponents::StyledTreeView(pParent)
         , m_queuedMouseEvent(nullptr)
@@ -50,6 +68,17 @@ namespace AzToolsFramework
         FocusModeNotificationBus::Handler::BusConnect(editorEntityContextId);
 
         viewport()->setMouseTracking(true);
+
+        // Clear outliner selection when ANY widget inside an Asset Browser gains focus.
+        // This covers both direct (outliner -> asset browser) and indirect (viewport -> asset browser)
+        // transitions, since focusOutEvent alone only fires when the tree view itself loses focus.
+        connect(qApp, &QApplication::focusChanged, this, [this](QWidget* /*old*/, QWidget* now)
+        {
+            if (now && IsInsideAssetBrowser(now) && selectionModel() && selectionModel()->hasSelection())
+            {
+                selectionModel()->clearSelection();
+            }
+        });
     }
 
     EntityOutlinerTreeView::~EntityOutlinerTreeView()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -332,6 +332,12 @@ namespace AzToolsFramework
 
     void EntityOutlinerWidget::OnPrefabEditScopeChanged()
     {
+        // Clear the outliner selection when entering/exiting prefab edit mode
+        // so the inspector doesn't show stale entity data from a different scope.
+        if (m_gui->m_objectTree->selectionModel())
+        {
+            m_gui->m_objectTree->selectionModel()->clearSelection();
+        }
         update();
     }
 


### PR DESCRIPTION
## What does this PR do?

Outliner clears selection on Asset Browser focus. This prevents entering "rename" when selecting back to the outliner entity.

The reason this is important is because you re-select the entity to restore the inspector window details after highlighting something else.

Fixes: https://github.com/o3de/o3de/issues/19394

## How was this PR tested?

Test: Select an entity in outliner. Select a file browser element that changes inspector window. Select the entity again to restore the inspector window. 
Entity Element in Outliner should NOT enter rename.


https://github.com/user-attachments/assets/c5c6f672-a539-46df-90fe-67419676801f


= AI Assisted Implementation =