### PR TITLE
(stabilization/26050) make GetVariableId consistent for clang-14 and clang-18

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/Environment.h
+++ b/Code/Framework/AzCore/AzCore/EBus/Environment.h
@@ -202,9 +202,9 @@ namespace AZ
         */
         static EnvironmentVariable<Context> s_defaultGlobalContext;
 
-        // EBus traits should provide a valid unique name, so that handlers can 
+        // EBus traits should provide a valid unique name, so that handlers can
         // connect to the EBus across modules.
-        // This can fail on some compilers. If it fails, make sure that you give 
+        // This can fail on some compilers. If it fails, make sure that you give
         // each bus a unique name.
         static u32 GetVariableId();
     };
@@ -257,11 +257,15 @@ namespace AZ
         return globalContext;
     }
 
-    //////////////////////////////////////////////////////////////////////////
-    template<class Context>
-    u32 EBusEnvironmentStoragePolicy<Context>::GetVariableId()
-    {
-        static constexpr u32 NameCrc = Crc32(AZ_FUNCTION_SIGNATURE);
-        return NameCrc;
-    }
 } // namespace AZ
+
+// Defined outside namespace AZ so that AZ_FUNCTION_SIGNATURE (__PRETTY_FUNCTION__)
+// produces a fully qualified return type (e.g. "AZ::u32") regardless of
+// compiler version.
+// See: https://github.com/o3de/o3de/issues/19690
+template<class Context>
+AZ::u32 AZ::EBusEnvironmentStoragePolicy<Context>::GetVariableId()
+{
+    static constexpr AZ::u32 NameCrc = AZ::Crc32(AZ_FUNCTION_SIGNATURE);
+    return NameCrc;
+}


### PR DESCRIPTION
## What does this PR do?

This PR is a result of investigation of #19690.

It looks that `__PRETTY_FUNCTION__` behavior changed in clang 16. The returned type that is part of the function signature is no longer fully qualified when the function is namespaced. Since the string value differs the resulting CRC differs as well. CRC is calculated as `static constexpr` and embedded as an immediate value. When compiled in the context of SDK (with the clang-14 AZ_FUNCTION_SIGNATURE) it is a different value than in the context of project compiled under Ubuntu 24.04 and clang-18

I haven't found a direct reference documenting the change in how the PRETTY_FUNCTION works, I found some issue in boost::hana with godbolt examples though:
https://github.com/boostorg/hana/issues/518

Workaround / Solution:

Moving the `GetVariableId` function out of AZ namespace forces PRETTY_FUNCTION to fully qualify the returned type. So the behavior for both compiler versions converge.



## How was this PR tested?

1. Used #19690 as a referenced.
2. Confirmed replication.
3. Applied the change to `/opt/O3DE/26.05/Code/Framework/AzCore/AzCore/EBus/Environment.h`
4. Confirmed the box started rolling