### PR TITLE
Fixes massive slowdown if SetMaterialProperties used

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
@@ -135,12 +135,24 @@ namespace AZ
 
         bool MaterialAssignment::RequiresLoading() const
         {
-            return
-                !m_materialInstancePreCreated &&
+            if (m_materialInstancePreCreated)
+            {
+                return false; // we are not in charge of foreign material instances owned by another system.
+            }
+
+            // we only need to trigger a load on valid assets that are not already loading and not already ready.
+
+            bool myAssetRequiresLoading =
+                m_materialAsset.GetId().IsValid() &&
                 !m_materialAsset.IsReady() &&
-                !m_materialAsset.IsLoading() &&
+                !m_materialAsset.IsLoading();
+
+            bool defaultAssetRequiresLoading =
+                m_defaultMaterialAsset.GetId().IsValid() &&
                 !m_defaultMaterialAsset.IsReady() &&
                 !m_defaultMaterialAsset.IsLoading();
+
+            return myAssetRequiresLoading || defaultAssetRequiresLoading;
         }
 
         bool MaterialAssignment::ApplyProperties()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -178,6 +178,12 @@ namespace AZ
 
         void MaterialComponentController::OnSystemTick()
         {
+            if (m_queuedLoadMaterials)
+            {
+                m_queuedLoadMaterials = false;
+                LoadMaterials();
+            }
+
             while (!m_notifiedMaterialAssets.empty())
             {
                 auto materialAsset = m_notifiedMaterialAssets.front();
@@ -185,11 +191,6 @@ namespace AZ
                 InitializeNotifiedMaterialAsset(materialAsset);
             }
 
-            if (m_queuedLoadMaterials)
-            {
-                m_queuedLoadMaterials = false;
-                LoadMaterials();
-            }
 
             if (m_queuedMaterialsCreatedNotification)
             {


### PR DESCRIPTION
## What does this PR do?

Fixes issue https://github.com/o3de/o3de/issues/19700

This fixes an issue where if SetMaterialProperties was used while a material was still loading, it would trigger another reload/reinitialize of the material, in a queue.

Each subsequent time Material properties was changed, this queued another reload, and so on, causing an endless amount of material reload and reinitializations, which caused a massive framerate drop.

This also caused the material properties not to actually be set, because they would be queued for when the material
finished loading, which never happened.

The fix is to swap the order of Load and Initialize the material in the System Tick.     This causes the load command to execute first, (which clears the slots and sets them to unloaded) and then the Material to reinitialize after that which updates the status of the slots and recognizes that it has completed loading (for any mats that have actually loaded)

## How was this PR tested?

It's a 100% repro with NewspaperDeliveryGame, just run it in the editor.  It calls SetMaterialProperty on every frame, including the first frame, which guarantees that a material is still loading, leading to a cumulative framerate drop to just 20fps.

Note that alt-tabbing out of the editor or game, causes the main tick to pause ticking, but the background queue to continue to be consumed, which means it "fixes" the problem because the material finishes loading and no longer causes the slowdown.


