### PR TITLE
Fixed incorrect editor representation of PhysX Character Controller co…

### DIFF
--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -47,11 +47,15 @@ namespace PhysX
                     ->EnumAttribute(SlopeBehaviour::PreventClimbing, "Prevent Climbing")
                     ->EnumAttribute(SlopeBehaviour::ForceSliding, "Force Sliding")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterControllerConfiguration::m_contactOffset,
-                        "Contact Offset", "Distance from the controller boundary where contact with surfaces can be resolved.")
+                        "Contact Offset",
+                        "Distance from the controller boundary where contact with surfaces can be resolved. Default value is 0.1, but a common value is around 10% of the radius.\n"
+                        "If the character is getting stuck often, consider increasing this value.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterControllerConfiguration::m_scaleCoefficient,
-                        "Scale", "Scales the controller. Usually less than 1.0 to ensure visual contact between the character and surface.")
+                        "Internal Body Scale",
+                        "Scales the internal kinematic body. A scale < 1 means the underlying kinematic body will not touch surrounding rigid bodies and only interact with the character controller's shapes.\n"
+                        "A scale >=1 means the kinematic body will touch and push surrounding rigid bodies, potentially resulting in wall tunneling or sudden movement explosion.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                     ;

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.h
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.h
@@ -40,7 +40,7 @@ namespace PhysX
 
         SlopeBehaviour m_slopeBehaviour = SlopeBehaviour::PreventClimbing; ///< Behaviour on surfaces above maximum slope.
         float m_contactOffset = 0.1f; ///< Extra distance outside the controller used to give smoother contact resolution.
-        float m_scaleCoefficient = 0.8f; ///< Scalar coefficient used to scale the controller, usually slightly smaller than 1.
+        float m_scaleCoefficient = 0.8f; ///< Scalar coefficient used to scale the internal kinematic controller, recommended to be less than 1 to prevent erratic interactions.
     };
 
     /// Manages callbacks for character controller collision filtering, collision notifications, and handling riding on objects.

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
@@ -169,9 +169,9 @@ namespace PhysX
                 ? AZ::Vector3::CreateAxisZ()
                 : m_configuration.m_upDirection.GetNormalized();
 
-            // PhysX uses the x-axis as the height direction of the controller, and so takes the shortest arc from the 
-            // x-axis to the up direction.  To obtain the same orientation in the LY co-ordinate system (which uses z
-            // as the height direction), we need to combine a rotation from the x-axis to the up direction with a 
+            // PhysX uses the x-axis as the height direction of the controller, and so takes the shortest arc from the
+            // x-axis to the up direction. To obtain the same orientation in the O3DE co-ordinate system (which uses z
+            // as the height direction), we need to combine a rotation from the x-axis to the up direction with a
             // rotation from the z-axis to the x-axis.
             const AZ::Quaternion upDirectionQuat = AZ::Quaternion::CreateShortestArc(AZ::Vector3::CreateAxisX(),
                 upDirectionNormalized) * AZ::Quaternion::CreateRotationY(AZ::Constants::HalfPi);

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
@@ -188,8 +188,8 @@ namespace PhysX
                 // draw the actual shape
                 LmbrCentral::CapsuleGeometrySystemRequestBus::Broadcast(
                     &LmbrCentral::CapsuleGeometrySystemRequestBus::Events::GenerateCapsuleMesh,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_radius,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_height,
+                    capsuleConfig.m_radius,
+                    capsuleConfig.m_height,
                     16, 8,
                     m_vertexBuffer,
                     m_indexBuffer,
@@ -203,8 +203,8 @@ namespace PhysX
                 // draw the shape inflated by the contact offset
                 LmbrCentral::CapsuleGeometrySystemRequestBus::Broadcast(
                     &LmbrCentral::CapsuleGeometrySystemRequestBus::Events::GenerateCapsuleMesh,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_radius + m_configuration.m_contactOffset,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_height + 2.0f * m_configuration.m_contactOffset,
+                    capsuleConfig.m_radius + m_configuration.m_contactOffset,
+                    capsuleConfig.m_height + 2.0f * m_configuration.m_contactOffset,
                     16, 8,
                     m_vertexBuffer,
                     m_indexBuffer,
@@ -222,7 +222,7 @@ namespace PhysX
                 const AZ::Transform controllerTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
                     upDirectionQuat, GetWorldTM().GetTranslation() + heightOffset * upDirectionNormalized);
 
-                const AZ::Vector3 boxHalfExtentsScaled = 0.5f * m_configuration.m_scaleCoefficient * boxConfig.m_dimensions;
+                const AZ::Vector3 boxHalfExtentsScaled = 0.5f * boxConfig.m_dimensions;
                 const AZ::Vector3 boxHalfExtentsScaledWithContactOffset = boxHalfExtentsScaled +
                     m_configuration.m_contactOffset * AZ::Vector3::CreateOne();
 


### PR DESCRIPTION

## What does this PR do?
This disables visually scaling the collider and improves the property name and description to be more clear.

The `Scale` property on the character collider visually scaled the capsule and box dimensions, but the property applies only to the internal kinematic body of the controller, and should typically be left at the default value 0.8. 

Fixes #2320 

## How was this PR tested?

_Please describe any testing performed._
Used PhysX visual debugger to validate that the collisions were comparable with different scale factors. Capsule center positions remain the same despite a smaller scale factor.
