### PR TITLE
Remove system cmake dependancy and use bundled cmake in Linux

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -94,9 +94,15 @@ namespace O3DE::ProjectManager
             return AZ::Success(QString{ cmakeInstalledPath });
         }
 
-        AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform([[maybe_unused]] const ProjectInfo& projectInfo)
+        AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform(const ProjectInfo& projectInfo)
         {
-            // Query the version of cmake that is installed
+            // Validate that cmake is installed
+            auto cmakeProcessEnvResult = SetupCommandLineProcessEnvironment();
+            if (!cmakeProcessEnvResult.IsSuccess())
+            {
+                return AZ::Failure(cmakeProcessEnvResult.GetError());
+            }
+
             if (auto queryCmakeVersionQuery = FindSupportedCMake(); !queryCmakeVersionQuery.IsSuccess())
             {
                 return queryCmakeVersionQuery;

--- a/cmake/Platform/Linux/Packaging/postinst.in
+++ b/cmake/Platform/Linux/Packaging/postinst.in
@@ -15,6 +15,20 @@ set -o errexit # exit on the first failure encountered
     ln -s -f @CPACK_PACKAGING_INSTALL_PREFIX@/bin/Linux/profile/Default/AssetProcessor /usr/local/bin/o3de.assetprocessor
     ln -s -f @CPACK_PACKAGING_INSTALL_PREFIX@/bin/Linux/profile/Default/Editor /usr/local/bin/o3de.editor
 
+    # Extract the bundled CMake into cmake/runtime/ so it is available without a system cmake.
+    CMAKE_REDIST_DIR="@CPACK_PACKAGING_INSTALL_PREFIX@/Tools/Redistributables/CMake"
+    CMAKE_RUNTIME_DIR="@CPACK_PACKAGING_INSTALL_PREFIX@/cmake/runtime"
+    CMAKE_PACKAGE_NAME="cmake-@CPACK_DESIRED_CMAKE_VERSION@-linux-x86_64"
+
+    if [ -f "${CMAKE_REDIST_DIR}/${CMAKE_PACKAGE_NAME}.tar.gz" ]; then
+        mkdir -p "${CMAKE_RUNTIME_DIR}"
+        tar -xzf "${CMAKE_REDIST_DIR}/${CMAKE_PACKAGE_NAME}.tar.gz" -C "${CMAKE_REDIST_DIR}"
+        if [ -d "${CMAKE_REDIST_DIR}/${CMAKE_PACKAGE_NAME}" ]; then
+            cp -a "${CMAKE_REDIST_DIR}/${CMAKE_PACKAGE_NAME}"/* "${CMAKE_RUNTIME_DIR}"/
+            rm -rf "${CMAKE_REDIST_DIR}/${CMAKE_PACKAGE_NAME}"
+        fi
+    fi
+
     # Generate the desktop icon
     DESKTOP_ICON_FILE=/usr/share/applications/o3de.desktop
 

--- a/cmake/Platform/Linux/Packaging/postrm.in
+++ b/cmake/Platform/Linux/Packaging/postrm.in
@@ -15,4 +15,5 @@ set -o errexit # exit on the first failure encountered
     rm -f /usr/local/bin/o3de.assetprocessor
     rm -f /usr/local/bin/o3de.editor
     rm -f /usr/share/applications/o3de.desktop
+    rm -rf @CPACK_PACKAGING_INSTALL_PREFIX@/cmake/runtime
 }

--- a/cmake/Platform/Linux/Packaging_linux.cmake
+++ b/cmake/Platform/Linux/Packaging_linux.cmake
@@ -35,7 +35,8 @@ elseif("$ENV{O3DE_PACKAGE_TYPE}" STREQUAL "DEB")
     # Define all the debian package dependencies needed to build and run
     set(package_dependencies
         # Required Tools
-        "cmake (>=3.24)"                        # Cmake required (minimum version 3.24.0)
+        # CMake is bundled with the package and extracted during post-install
+        # into cmake/runtime/. Users may override via LY_CMAKE_PATH or PATH.
         "clang (>=12.0)"                        # Clang required (minimum version 12.0)
         ninja-build
         # Build Libraries

--- a/python/get_python.bat
+++ b/python/get_python.bat
@@ -31,9 +31,14 @@ REM If cmake is not found on path, try a known location at LY_CMAKE_PATH
 where /Q cmake
 IF NOT !ERRORLEVEL!==0 (
     IF "%LY_CMAKE_PATH%"=="" (
-        ECHO ERROR: CMake was not found on the PATH and LY_CMAKE_PATH is not defined.
-        ECHO Please ensure CMake is on the path or set LY_CMAKE_PATH.
-        EXIT /b 1
+        REM Check for the bundled cmake that ships with the installer at <engineRoot>\cmake\runtime\bin
+        IF EXIST "%CMD_DIR%\..\cmake\runtime\bin\cmake.exe" (
+            SET "LY_CMAKE_PATH=%CMD_DIR%\..\cmake\runtime\bin"
+        ) ELSE (
+            ECHO ERROR: CMake was not found on the PATH and LY_CMAKE_PATH is not defined.
+            ECHO Please ensure CMake is on the path or set LY_CMAKE_PATH.
+            EXIT /b 1
+        )
     )
 
     PATH !LY_CMAKE_PATH!;!PATH!

--- a/python/get_python.sh
+++ b/python/get_python.sh
@@ -88,9 +88,15 @@ fi
 
 if ! [ -x "$(command -v cmake)" ]; then
     if [ -z ${LY_CMAKE_PATH} ]; then
-        echo "ERROR: Could not find cmake on the PATH and LY_CMAKE_PATH is not defined, cannot continue."
-        echo "Please add cmake to your PATH, or define LY_CMAKE_PATH"
-        exit 1
+        # Check for the bundled cmake that ships with the installer at <engineRoot>/cmake/runtime/bin
+        BUNDLED_CMAKE_PATH="$DIR/../cmake/runtime/bin"
+        if [ -x "${BUNDLED_CMAKE_PATH}/cmake" ]; then
+            export LY_CMAKE_PATH="${BUNDLED_CMAKE_PATH}"
+        else
+            echo "ERROR: Could not find cmake on the PATH and LY_CMAKE_PATH is not defined, cannot continue."
+            echo "Please add cmake to your PATH, or define LY_CMAKE_PATH"
+            exit 1
+        fi
     fi
 
     export PATH=$LY_CMAKE_PATH:$PATH


### PR DESCRIPTION
## What does this PR do?

The Linux DEB package requires `cmake (>=3.24)` as a system dependency even though CMake 4.2.3 is already bundled in the package. The bundled archive was never extracted, so the system dependency existed as a workaround.

This PR removes the system cmake dependency, extracts the bundled cmake to `cmake/runtime/` during post-install (matching the path the Project Manager already expects per PR #19564), and cleans it up on removal. The `get_python.sh` and `get_python.bat` scripts now auto-detect the bundled cmake at `<engineRoot>/cmake/runtime/bin` as a fallback when cmake isn't on PATH and `LY_CMAKE_PATH` isn't set.

Also fixes a bug where the Linux `FindSupportedCompilerForPlatform()` was missing a `SetupCommandLineProcessEnvironment()` call that the Windows version already had, which caused the Project Manager build button to fail to find cmake even though the cmake GUI button worked.

Resolves https://github.com/o3de/o3de/issues/19699 and fixes issues with https://github.com/o3de/o3de/issues/19574

## How was this PR tested?

Installed the DEB package on Ubuntu 24.04 without system cmake. Verified the bundled cmake extracts correctly, the o3de binary bootstraps Python on first run, `get_python.sh` works standalone, and both the Project Manager build and cmake GUI buttons find cmake. Verified `postrm` cleans up on removal.
