### PR TITLE
Manually setting transform of simulating dynamic rigid bodies now works correctly

### DIFF
--- a/Gems/PhysX/Core/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/RigidBodyComponent.cpp
@@ -283,7 +283,8 @@ namespace PhysX
             AZ_Error("RigidBodyComponent", false, "Unable to retrieve simulated rigid body");
             return;
         }
-        
+
+        m_isEntityTransformSetManually = false;
         AZ::Transform transform = rigidBody->GetTransform();
         if (m_configuration.m_interpolateMotion)
         {
@@ -297,6 +298,7 @@ namespace PhysX
             entityTransform->SetWorldTM(newWorldTransform);
         }
         m_isLastMovementFromKinematicSource = false;
+        m_isEntityTransformSetManually = true;
     }
 
     void RigidBodyComponent::OnTransformChanged([[maybe_unused]] const AZ::Transform& local, const AZ::Transform& world)
@@ -310,6 +312,12 @@ namespace PhysX
                 (body->IsKinematic() && !m_isLastMovementFromKinematicSource))
             {
                 body->SetKinematicTarget(world);
+            }
+            else if (body->m_simulating && (!body->IsKinematic() && m_isEntityTransformSetManually))
+            {
+                AZ_Warning("RigidBodyComponent", false, "Transform of Entity \"%s\" with simulated body was set manually. Consider using kinematic body and calling SetKinematicTarget if done frequently.",
+                    GetEntity()->GetName().c_str());
+                body->SetTransform(world);
             }
             else if (!body->m_simulating)
             {

--- a/Gems/PhysX/Core/Code/Source/RigidBodyComponent.h
+++ b/Gems/PhysX/Core/Code/Source/RigidBodyComponent.h
@@ -167,8 +167,9 @@ namespace PhysX
         AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
 
         bool m_staticTransformAtActivation = false; ///< Whether the transform was static when the component last activated.
-        bool m_isLastMovementFromKinematicSource = false; ///< True when the source of the movement comes from SetKinematicTarget as opposed to coming from a Transform change
-        bool m_rigidBodyTransformNeedsUpdateOnPhysReEnable = false; ///< True if rigid body transform needs to be synced to the entity's when physics is re-enabled
+        bool m_isLastMovementFromKinematicSource = false; ///< True when the source of the movement comes from SetKinematicTarget as opposed to coming from a Transform change.
+        bool m_rigidBodyTransformNeedsUpdateOnPhysReEnable = false; ///< True if rigid body transform needs to be synced to the entity's when physics is re-enabled.
+        bool m_isEntityTransformSetManually = false; ///< False when PostPhysicsTick runs in order to handle user-set entity transform.
 
         AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler;
         AzPhysics::SimulatedBodyEvents::OnSyncTransform::Handler m_activeBodySyncTransformHandler;


### PR DESCRIPTION
## What does this PR do?

This enables the user to manually set the transform of an entity with a dynamic rigid body without disabling physics simulation first. It also displays a warning message recommending the use of a kinematic body if it is required to do so frequently.

GHI #2541 requests this change, and also addresses #2640.

## How was this PR tested?

1. Create entity with dynamic body
2. Create Script Canvas script which sets linear velocity and then calls Set Transform multiple times while box is simulating
3. Observe no jittering or sudden jumping from set location to previous
