### PR TITLE
Add DetourCrowd from recastnavigation

### DIFF
--- a/Gems/RecastNavigation/Code/CMakeLists.txt
+++ b/Gems/RecastNavigation/Code/CMakeLists.txt
@@ -34,6 +34,7 @@ ly_add_target(
             AZ::AzCore
             3rdParty::RecastNavigation::Recast
             3rdParty::RecastNavigation::Detour
+            3rdParty::RecastNavigation::DetourCrowd
 )
 
 # The ${gem_name}.Private.Object target is an internal target
@@ -57,6 +58,7 @@ ly_add_target(
             3rdParty::RecastNavigation::DebugUtils
             3rdParty::RecastNavigation::Detour
             3rdParty::RecastNavigation::Recast
+            3rdParty::RecastNavigation::DetourCrowd
             Gem::LmbrCentral.Static
             Gem::DebugDraw.API
 )

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentBus.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentBus.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace RecastNavigation
+{
+    //! Notification interface for per-agent crowd simulation events.
+    class DetourCrowdAgentNotifications
+        : public AZ::ComponentBus
+    {
+    public:
+        //! Notifies that an agent position has been updated by crowd simulation.
+        virtual void OnAgentPositionUpdated(const AZ::Vector3& worldPosition, const AZ::Vector3& worldVelocity) = 0;
+    };
+
+    //! Notification EBus addressed by agent entity id.
+    using DetourCrowdAgentNotificationBus = AZ::EBus<DetourCrowdAgentNotifications>;
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentBus.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentBus.h
@@ -16,8 +16,7 @@
 namespace RecastNavigation
 {
     //! Notification interface for per-agent crowd simulation events.
-    class DetourCrowdAgentNotifications
-        : public AZ::ComponentBus
+    class DetourCrowdAgentNotifications : public AZ::ComponentBus
     {
     public:
         //! Notifies that an agent position has been updated by crowd simulation.

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentBus.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentBus.h
@@ -11,6 +11,7 @@
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace RecastNavigation
 {
@@ -25,4 +26,19 @@ namespace RecastNavigation
 
     //! Notification EBus addressed by agent entity id.
     using DetourCrowdAgentNotificationBus = AZ::EBus<DetourCrowdAgentNotifications>;
+
+    //! Scripting reflection helper for @DetourCrowdAgentNotificationBus.
+    class DetourCrowdAgentNotificationHandler
+        : public DetourCrowdAgentNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
+    {
+    public:
+        AZ_EBUS_BEHAVIOR_BINDER(
+            DetourCrowdAgentNotificationHandler, "{AF6C3767-8ADD-45AD-8086-67ACF732E7C4}", AZ::SystemAllocator, OnAgentPositionUpdated);
+
+        void OnAgentPositionUpdated(const AZ::Vector3& worldPosition, const AZ::Vector3& worldVelocity) override
+        {
+            Call(FN_OnAgentPositionUpdated, worldPosition, worldVelocity);
+        }
+    };
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentParams.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentParams.h
@@ -10,19 +10,13 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/base.h>
 
 struct dtCrowdAgentParams;
 
-namespace AZ
-{
-    class ReflectContext;
-}
-
 namespace RecastNavigation
 {
-    class DetourCrowdNavigationComponent;
-
     //! Serializable/editable representation of Detour's dtCrowdAgentParams.
     class DetourCrowdAgentParams final
     {
@@ -31,6 +25,8 @@ namespace RecastNavigation
         AZ_TYPE_INFO(DetourCrowdAgentParams, "{626D6EFE-4E5D-4028-BF41-EEC95342D79A}");
 
         static void Reflect(AZ::ReflectContext* context);
+
+        dtCrowdAgentParams ToDetourCrowdAgentParams() const;
 
         float m_radius = 0.6f;
         float m_height = 2.0f;
@@ -46,10 +42,5 @@ namespace RecastNavigation
         bool m_optimizeTopology = false;
         AZ::u8 m_obstacleAvoidanceType = 0;
         AZ::u8 m_queryFilterType = 0;
-
-    private:
-        friend class DetourCrowdNavigationComponent;
-
-        dtCrowdAgentParams ToDetourCrowdAgentParams() const;
     };
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentParams.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdAgentParams.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/base.h>
+
+struct dtCrowdAgentParams;
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace RecastNavigation
+{
+    class DetourCrowdNavigationComponent;
+
+    //! Serializable/editable representation of Detour's dtCrowdAgentParams.
+    class DetourCrowdAgentParams final
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(DetourCrowdAgentParams, AZ::SystemAllocator);
+        AZ_TYPE_INFO(DetourCrowdAgentParams, "{626D6EFE-4E5D-4028-BF41-EEC95342D79A}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        float m_radius = 0.6f;
+        float m_height = 2.0f;
+        float m_maxAcceleration = 8.0f;
+        float m_maxSpeed = 3.5f;
+        float m_collisionQueryRange = 7.2f;
+        float m_pathOptimizationRange = 18.0f;
+        float m_separationWeight = 2.0f;
+        bool m_anticipateTurns = false;
+        bool m_obstacleAvoidance = false;
+        bool m_separation = false;
+        bool m_optimizeVisibility = false;
+        bool m_optimizeTopology = false;
+        AZ::u8 m_obstacleAvoidanceType = 0;
+        AZ::u8 m_queryFilterType = 0;
+
+    private:
+        friend class DetourCrowdNavigationComponent;
+
+        dtCrowdAgentParams ToDetourCrowdAgentParams() const;
+    };
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdNavigationBus.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdNavigationBus.h
@@ -22,13 +22,17 @@ namespace RecastNavigation
     {
     public:
         //! Adds an agent entity with the crowd component.
-        virtual AZ::Outcome<void, AZStd::string> AddAgent(AZ::EntityId agentEntityId, const DetourCrowdAgentParams& agentParams) = 0;
+        virtual AZ::Outcome<void, AZStd::string> AddAgent(
+            const AZ::EntityId& agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams) = 0;
 
         //! Removes a previously added agent entity.
         virtual AZ::Outcome<void, AZStd::string> RemoveAgent(AZ::EntityId agentEntityId) = 0;
 
         //! Sets the movement target for an agent in the crowd.
         virtual AZ::Outcome<void, AZStd::string> SetAgentMoveTarget(AZ::EntityId agentEntityId, const AZ::Vector3& targetPosition) = 0;
+
+        //! Clears the movement target for an agent in the crowd.
+        virtual AZ::Outcome<void, AZStd::string> ResetAgentMoveTarget(AZ::EntityId agentEntityId) = 0;
     };
 
     //! Request EBus for a crowd navigation component.

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdNavigationBus.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdNavigationBus.h
@@ -10,10 +10,10 @@
 
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/Math/Vector3.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/string/string.h>
 #include <RecastNavigation/DetourCrowdAgentParams.h>
-#include <AzCore/Math/Vector3.h>
 
 namespace RecastNavigation
 {
@@ -23,7 +23,7 @@ namespace RecastNavigation
     public:
         //! Adds an agent entity with the crowd component.
         virtual AZ::Outcome<void, AZStd::string> AddAgent(
-            const AZ::EntityId& agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams) = 0;
+            AZ::EntityId agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams) = 0;
 
         //! Removes a previously added agent entity.
         virtual AZ::Outcome<void, AZStd::string> RemoveAgent(AZ::EntityId agentEntityId) = 0;

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdNavigationBus.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourCrowdNavigationBus.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string.h>
+#include <RecastNavigation/DetourCrowdAgentParams.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace RecastNavigation
+{
+    //! Interface for crowd navigation API.
+    class DetourCrowdNavigationRequests : public AZ::ComponentBus
+    {
+    public:
+        //! Adds an agent entity with the crowd component.
+        virtual AZ::Outcome<void, AZStd::string> AddAgent(AZ::EntityId agentEntityId, const DetourCrowdAgentParams& agentParams) = 0;
+
+        //! Removes a previously added agent entity.
+        virtual AZ::Outcome<void, AZStd::string> RemoveAgent(AZ::EntityId agentEntityId) = 0;
+
+        //! Sets the movement target for an agent in the crowd.
+        virtual AZ::Outcome<void, AZStd::string> SetAgentMoveTarget(AZ::EntityId agentEntityId, const AZ::Vector3& targetPosition) = 0;
+    };
+
+    //! Request EBus for a crowd navigation component.
+    using DetourCrowdNavigationRequestBus = AZ::EBus<DetourCrowdNavigationRequests>;
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourObstacleAvoidanceParams.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourObstacleAvoidanceParams.h
@@ -10,19 +10,13 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/base.h>
 
 struct dtObstacleAvoidanceParams;
 
-namespace AZ
-{
-    class ReflectContext;
-}
-
 namespace RecastNavigation
 {
-    class DetourCrowdNavigationComponent;
-
     //! Serializable/editable representation of Detour's dtObstacleAvoidanceParams.
     class DetourObstacleAvoidanceParams final
     {
@@ -37,6 +31,8 @@ namespace RecastNavigation
         static DetourObstacleAvoidanceParams CreateGoodQuality();
         static DetourObstacleAvoidanceParams CreateHighQuality();
 
+        dtObstacleAvoidanceParams ToDetourObstacleAvoidanceParams() const;
+
         float m_velBias = 0.4f;
         float m_weightDesVel = 2.0f;
         float m_weightCurVel = 0.75f;
@@ -47,10 +43,5 @@ namespace RecastNavigation
         AZ::u8 m_adaptiveDivs = 7;
         AZ::u8 m_adaptiveRings = 2;
         AZ::u8 m_adaptiveDepth = 5;
-
-    private:
-        friend class DetourCrowdNavigationComponent;
-
-        dtObstacleAvoidanceParams ToDetourObstacleAvoidanceParams() const;
     };
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourObstacleAvoidanceParams.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/DetourObstacleAvoidanceParams.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/base.h>
+
+struct dtObstacleAvoidanceParams;
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace RecastNavigation
+{
+    class DetourCrowdNavigationComponent;
+
+    //! Serializable/editable representation of Detour's dtObstacleAvoidanceParams.
+    class DetourObstacleAvoidanceParams final
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(DetourObstacleAvoidanceParams, AZ::SystemAllocator);
+        AZ_TYPE_INFO(DetourObstacleAvoidanceParams, "{7A6D9C3B-0D57-417C-92FB-E89148FB2F37}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static DetourObstacleAvoidanceParams CreateLowQuality();
+        static DetourObstacleAvoidanceParams CreateMediumQuality();
+        static DetourObstacleAvoidanceParams CreateGoodQuality();
+        static DetourObstacleAvoidanceParams CreateHighQuality();
+
+        float m_velBias = 0.4f;
+        float m_weightDesVel = 2.0f;
+        float m_weightCurVel = 0.75f;
+        float m_weightSide = 0.75f;
+        float m_weightToi = 2.5f;
+        float m_horizTime = 2.5f;
+        AZ::u8 m_gridSize = 33;
+        AZ::u8 m_adaptiveDivs = 7;
+        AZ::u8 m_adaptiveRings = 2;
+        AZ::u8 m_adaptiveDepth = 5;
+
+    private:
+        friend class DetourCrowdNavigationComponent;
+
+        dtObstacleAvoidanceParams ToDetourObstacleAvoidanceParams() const;
+    };
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Include/RecastNavigation/RecastSmartPointer.h
+++ b/Gems/RecastNavigation/Code/Include/RecastNavigation/RecastSmartPointer.h
@@ -7,10 +7,11 @@
  */
 
 #pragma once
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <DetourCrowd.h>
 #include <DetourNavMesh.h>
 #include <DetourNavMeshQuery.h>
 #include <Recast.h>
-#include <AzCore/std/smart_ptr/unique_ptr.h>
 
 namespace RecastNavigation
 {
@@ -81,6 +82,15 @@ namespace RecastNavigation
         void operator ()(dtNavMeshQuery* p)
         {
             dtFreeNavMeshQuery(p);
+        }
+    };
+
+    template<>
+    struct CustomRecastDeleter<dtCrowd>
+    {
+        void operator()(dtCrowd* p)
+        {
+            dtFreeCrowd(p);
         }
     };
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RecastNavigation/NavMeshQuery.h"
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <Components/DetourCrowdNavigationComponent.h>
+#include <DetourCrowd.h>
+#include <RecastNavigation/DetourCrowdAgentBus.h>
+#include <RecastNavigation/NavMeshQuery.h>
+#include <RecastNavigation/RecastHelpers.h>
+#include <RecastNavigation/RecastNavigationMeshBus.h>
+#include <RecastNavigation/RecastSmartPointer.h>
+
+namespace RecastNavigation
+{
+    bool DetourCrowdNavigationComponent::InitializeCrowd()
+    {
+        if (!m_crowd)
+        {
+            m_crowd = RecastPointer<dtCrowd>(dtAllocCrowd());
+            if (!m_crowd)
+            {
+                AZ_Error("DetourCrowdNavigationComponent", false, "Failed to allocate dtCrowd object.");
+                return false;
+            }
+        }
+
+        AZStd::shared_ptr<NavMeshQuery> navMeshQuery;
+        RecastNavigationMeshRequestBus::EventResult(navMeshQuery, m_navQueryEntityId, &RecastNavigationMeshRequests::GetNavigationObject);
+        if (!navMeshQuery)
+        {
+            AZ_Warning(
+                "DetourCrowdNavigationComponent",
+                false,
+                "Navigation object is not available yet for entity '%s'. Crowd initialization postponed.",
+                m_navQueryEntityId.ToString().c_str());
+            return false;
+        }
+
+        NavMeshQuery::LockGuard lock(*navMeshQuery);
+        if (!lock.GetNavQuery())
+        {
+            AZ_Warning(
+                "DetourCrowdNavigationComponent",
+                false,
+                "Navigation query is not available yet for entity '%s'. Crowd initialization postponed.",
+                m_navQueryEntityId.ToString().c_str());
+            return false;
+        }
+
+        if (!m_crowd->init(m_maxAgents, m_maxAgentRadius, lock.GetNavMesh()))
+        {
+            AZ_Error("DetourCrowdNavigationComponent", false, "Failed to initialize dtCrowd.");
+            return false;
+        }
+
+        m_agentEntityToCrowdIndex.clear();
+        m_crowdIndexToAgentEntity.clear();
+
+        const AZ::u8 maxAvoidanceProfiles = DT_CROWD_MAX_OBSTAVOIDANCE_PARAMS;
+        if (m_obstacleAvoidanceParams.size() > static_cast<size_t>(maxAvoidanceProfiles))
+        {
+            AZ_Warning(
+                "DetourCrowdNavigationComponent",
+                false,
+                "Obstacle avoidance profile count (%zu) exceeds Detour max (%u). Extra profiles will be ignored.",
+                m_obstacleAvoidanceParams.size(),
+                maxAvoidanceProfiles);
+        }
+
+        const size_t profilesToApply = AZStd::min(static_cast<size_t>(maxAvoidanceProfiles), m_obstacleAvoidanceParams.size());
+        for (size_t profileIndex = 0; profileIndex < profilesToApply; ++profileIndex)
+        {
+            const dtObstacleAvoidanceParams detourParams = m_obstacleAvoidanceParams[profileIndex].ToDetourObstacleAvoidanceParams();
+            m_crowd->setObstacleAvoidanceParams(static_cast<int>(profileIndex), &detourParams);
+        }
+
+        return true;
+    }
+
+    void DetourCrowdNavigationComponent::OnNavigationMeshUpdated(AZ::EntityId navigationMeshEntity)
+    {
+        if (navigationMeshEntity == m_navQueryEntityId)
+        {
+            InitializeCrowd();
+        }
+    }
+
+    void DetourCrowdNavigationComponent::OnNavigationMeshBeganRecalculating([[maybe_unused]] AZ::EntityId navigationMeshEntity)
+    {
+    }
+
+    void DetourCrowdNavigationComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        if (!m_crowd || deltaTime <= 0.0f)
+        {
+            return;
+        }
+
+        m_crowd->update(deltaTime, nullptr);
+
+        AZStd::vector<AZStd::pair<AZ::EntityId, AZ::u32>> trackedAgents;
+        trackedAgents.reserve(m_agentEntityToCrowdIndex.size());
+        for (const auto& [agentEntityId, crowdIndex] : m_agentEntityToCrowdIndex)
+        {
+            trackedAgents.emplace_back(agentEntityId, crowdIndex);
+        }
+
+        for (const auto& [agentEntityId, crowdIndex] : trackedAgents)
+        {
+            const dtCrowdAgent* crowdAgent = m_crowd->getAgent(static_cast<int>(crowdIndex));
+            if (!crowdAgent || !crowdAgent->active)
+            {
+                continue;
+            }
+
+            const AZ::Vector3 worldPosition = RecastVector3::CreateFromFloatValuesWithoutAxisSwapping(crowdAgent->npos).AsVector3WithZup();
+            const AZ::Vector3 worldVelocity = RecastVector3::CreateFromFloatValuesWithoutAxisSwapping(crowdAgent->vel).AsVector3WithZup();
+            DetourCrowdAgentNotificationBus::Event(
+                agentEntityId, &DetourCrowdAgentNotifications::OnAgentPositionUpdated, worldPosition, worldVelocity);
+        }
+    }
+
+    AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::AddAgent(
+        AZ::EntityId agentEntityId, const DetourCrowdAgentParams& agentParams)
+    {
+        if (!agentEntityId.IsValid())
+        {
+            return AZ::Failure(AZStd::string("Cannot add agent: invalid entity id."));
+        }
+
+        if (!m_crowd)
+        {
+            return AZ::Failure(AZStd::string("Cannot add agent: crowd is not initialized."));
+        }
+
+        if (m_agentEntityToCrowdIndex.find(agentEntityId) != m_agentEntityToCrowdIndex.end())
+        {
+            return AZ::Failure(
+                AZStd::string::format("Cannot add agent: entity '%s' is already registered.", agentEntityId.ToString().c_str()));
+        }
+
+        const int maxAgents = m_crowd->getAgentCount();
+        if (maxAgents <= 0)
+        {
+            return AZ::Failure(AZStd::string("Cannot add agent: crowd has invalid max agent count."));
+        }
+
+        if (m_agentEntityToCrowdIndex.size() >= static_cast<size_t>(maxAgents))
+        {
+            return AZ::Failure(AZStd::string::format("Cannot add agent: crowd is full (%d agents).", maxAgents));
+        }
+
+        dtCrowdAgentParams detourParams = agentParams.ToDetourCrowdAgentParams();
+
+        // TODO: the position should be taken from the agent in other way
+        AZ::Vector3 worldPos = AZ::Vector3::CreateZero();
+        AZ::TransformBus::EventResult(worldPos, agentEntityId, &AZ::TransformBus::Events::GetWorldTranslation);
+
+        // Convert O3DE Z-up to Recast Y-up.
+        RecastVector3 recastPos = RecastVector3::CreateFromVector3SwapYZ(worldPos);
+
+        const int crowdIndex = m_crowd->addAgent(recastPos.GetData(), &detourParams);
+        if (crowdIndex < 0)
+        {
+            return AZ::Failure(AZStd::string("Cannot add agent: dtCrowd::addAgent failed."));
+        }
+
+        const AZ::u32 crowdIndexAsU32 = static_cast<AZ::u32>(crowdIndex);
+        const auto [agentToIndexIt, insertedAgentToIndex] = m_agentEntityToCrowdIndex.emplace(agentEntityId, crowdIndexAsU32);
+        if (!insertedAgentToIndex)
+        {
+            m_crowd->removeAgent(crowdIndex);
+            return AZ::Failure(
+                AZStd::string::format("Cannot add agent: failed to register entity '%s' mapping.", agentEntityId.ToString().c_str()));
+        }
+
+        const auto [indexToAgentIt, insertedIndexToAgent] = m_crowdIndexToAgentEntity.emplace(crowdIndexAsU32, agentEntityId);
+        if (!insertedIndexToAgent)
+        {
+            m_agentEntityToCrowdIndex.erase(agentToIndexIt);
+            m_crowd->removeAgent(crowdIndex);
+            return AZ::Failure(AZStd::string::format("Cannot add agent: crowd index %d is already tracked.", crowdIndex));
+        }
+
+        return AZ::Success();
+    }
+
+    AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::RemoveAgent(AZ::EntityId agentEntityId)
+    {
+        if (!agentEntityId.IsValid())
+        {
+            return AZ::Failure(AZStd::string("Cannot remove agent: invalid entity id."));
+        }
+
+        if (!m_crowd)
+        {
+            return AZ::Failure(AZStd::string("Cannot remove agent: crowd is not initialized."));
+        }
+
+        const auto it = m_agentEntityToCrowdIndex.find(agentEntityId);
+        if (it == m_agentEntityToCrowdIndex.end())
+        {
+            return AZ::Failure(
+                AZStd::string::format("Cannot remove agent: entity '%s' is not registered.", agentEntityId.ToString().c_str()));
+        }
+
+        const AZ::u32 crowdIndex = it->second;
+        m_agentEntityToCrowdIndex.erase(agentEntityId);
+        m_crowdIndexToAgentEntity.erase(crowdIndex);
+
+        m_crowd->removeAgent(crowdIndex);
+
+        return AZ::Success();
+    }
+
+    AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::SetAgentMoveTarget(
+        AZ::EntityId agentEntityId, const AZ::Vector3& targetPosition)
+    {
+        if (!agentEntityId.IsValid())
+        {
+            return AZ::Failure(AZStd::string("Cannot set move target: invalid entity id."));
+        }
+
+        if (!m_crowd)
+        {
+            return AZ::Failure(AZStd::string("Cannot set move target: crowd is not initialized."));
+        }
+
+        const auto it = m_agentEntityToCrowdIndex.find(agentEntityId);
+        if (it == m_agentEntityToCrowdIndex.end())
+        {
+            return AZ::Failure(
+                AZStd::string::format("Cannot set move target: entity '%s' is not registered.", agentEntityId.ToString().c_str()));
+        }
+
+        const int crowdIndex = static_cast<int>(it->second);
+        const dtCrowdAgent* agent = m_crowd->getAgent(crowdIndex);
+        if (!agent || !agent->active)
+        {
+            return AZ::Failure(AZStd::string::format(
+                "Cannot set move target: agent at crowd index %d is not active.", crowdIndex));
+        }
+
+        // Get the navigation mesh query to find the target polygon reference
+        AZStd::shared_ptr<NavMeshQuery> navMeshQuery;
+        RecastNavigationMeshRequestBus::EventResult(navMeshQuery, m_navQueryEntityId, &RecastNavigationMeshRequests::GetNavigationObject);
+        if (!navMeshQuery)
+        {
+            return AZ::Failure(AZStd::string("Cannot set move target: navigation mesh query is not available."));
+        }
+
+        NavMeshQuery::LockGuard lock(*navMeshQuery);
+        dtNavMeshQuery* query = lock.GetNavQuery();
+        if (!query)
+        {
+            return AZ::Failure(AZStd::string("Cannot set move target: failed to get navigation query."));
+        }
+
+        // Convert O3DE Z-up to Recast Y-up for target position
+        RecastVector3 recastTarget = RecastVector3::CreateFromVector3SwapYZ(targetPosition);
+        const float halfExtents[3] = { m_maxAgentRadius * 2.0f, m_maxAgentRadius * 4.0f, m_maxAgentRadius * 2.0f };
+
+        // Find the nearest polygon reference for the target position
+        dtPolyRef targetPoly = 0;
+        RecastVector3 nearestPoint;
+        const dtQueryFilter filter;
+        const dtStatus findPolyStatus = query->findNearestPoly(recastTarget.GetData(), halfExtents, &filter, &targetPoly, nearestPoint.GetData());
+        if (dtStatusFailed(findPolyStatus) || targetPoly == 0)
+        {
+            return AZ::Failure(
+                AZStd::string::format("Cannot set move target: could not find valid polygon for target position."));
+        }
+
+        // Request the crowd to move the agent to the target
+        if (!m_crowd->requestMoveTarget(crowdIndex, targetPoly, recastTarget.GetData()))
+        {
+            return AZ::Failure(
+                AZStd::string::format("Cannot set move target: dtCrowd::requestMoveTarget failed for agent %d.", crowdIndex));
+        }
+
+        return AZ::Success();
+    }
+
+    void DetourCrowdNavigationComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<DetourCrowdNavigationComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("NavQueryEntityId", &DetourCrowdNavigationComponent::m_navQueryEntityId)
+                ->Field("MaxAgents", &DetourCrowdNavigationComponent::m_maxAgents)
+                ->Field("MaxAgentRadius", &DetourCrowdNavigationComponent::m_maxAgentRadius)
+                ->Field("ObstacleAvoidanceParams", &DetourCrowdNavigationComponent::m_obstacleAvoidanceParams);
+
+            if (auto editContext = serialize->GetEditContext())
+            {
+                editContext
+                    ->Class<DetourCrowdNavigationComponent>(
+                        "Detour Crowd Navigation Component", "Provides crowd navigation features using DetourCrowd.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourCrowdNavigationComponent::m_navQueryEntityId,
+                        "Navigation Mesh",
+                        "Entity with Recast Navigation Mesh component")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourCrowdNavigationComponent::m_maxAgents,
+                        "Max Agents",
+                        "Maximum number of agents that can be managed by the crowd.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourCrowdNavigationComponent::m_maxAgentRadius,
+                        "Max Agent Radius",
+                        "Maximum radius of any agent that will be added to the crowd.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourCrowdNavigationComponent::m_obstacleAvoidanceParams,
+                        "Obstacle Avoidance Params",
+                        "Obstacle avoidance parameter profiles. Indices map to Detour quality levels.");
+            }
+        }
+    }
+
+    void DetourCrowdNavigationComponent::Activate()
+    {
+        if (!m_navQueryEntityId.IsValid())
+        {
+            // Default to looking for the navigation mesh component on the same entity if one is not specified.
+            m_navQueryEntityId = GetEntityId();
+        }
+
+        DetourCrowdNavigationRequestBus::Handler::BusConnect(GetEntityId());
+        RecastNavigationMeshNotificationBus::Handler::BusConnect(m_navQueryEntityId);
+        AZ::TickBus::Handler::BusConnect();
+
+        InitializeCrowd();
+    }
+
+    void DetourCrowdNavigationComponent::Deactivate()
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+        RecastNavigationMeshNotificationBus::Handler::BusDisconnect();
+        DetourCrowdNavigationRequestBus::Handler::BusDisconnect();
+        m_agentEntityToCrowdIndex.clear();
+        m_crowdIndexToAgentEntity.clear();
+        m_crowd = nullptr;
+    }
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "RecastNavigation/NavMeshQuery.h"
-#include <AzCore/Component/TransformBus.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -21,6 +20,16 @@
 
 namespace RecastNavigation
 {
+    AZStd::vector<DetourObstacleAvoidanceParams> DetourCrowdNavigationComponent::CreateDefaultObstacleAvoidanceParams()
+    {
+        return { DetourObstacleAvoidanceParams::CreateLowQuality(),
+                 DetourObstacleAvoidanceParams::CreateMediumQuality(),
+                 DetourObstacleAvoidanceParams::CreateGoodQuality(),
+                 DetourObstacleAvoidanceParams::CreateHighQuality() };
+    }
+
+    DetourCrowdNavigationComponent::DetourCrowdNavigationComponent() = default;
+
     bool DetourCrowdNavigationComponent::InitializeCrowd()
     {
         if (!m_crowd)
@@ -65,25 +74,35 @@ namespace RecastNavigation
         m_agentEntityToCrowdIndex.clear();
         m_crowdIndexToAgentEntity.clear();
 
+        // Choose parameter set based on mode
+        const AZStd::vector<DetourObstacleAvoidanceParams> simpleObstacleAvoidanceParams = CreateDefaultObstacleAvoidanceParams();
+        const AZStd::vector<DetourObstacleAvoidanceParams>& obstacleAvoidanceParams =
+            m_useAdvancedObstacleAvoidanceParams ? m_obstacleAvoidanceParams : simpleObstacleAvoidanceParams;
+
         const AZ::u8 maxAvoidanceProfiles = DT_CROWD_MAX_OBSTAVOIDANCE_PARAMS;
-        if (m_obstacleAvoidanceParams.size() > static_cast<size_t>(maxAvoidanceProfiles))
+        if (obstacleAvoidanceParams.size() > static_cast<size_t>(maxAvoidanceProfiles))
         {
             AZ_Warning(
                 "DetourCrowdNavigationComponent",
                 false,
                 "Obstacle avoidance profile count (%zu) exceeds Detour max (%u). Extra profiles will be ignored.",
-                m_obstacleAvoidanceParams.size(),
+                obstacleAvoidanceParams.size(),
                 maxAvoidanceProfiles);
         }
 
-        const size_t profilesToApply = AZStd::min(static_cast<size_t>(maxAvoidanceProfiles), m_obstacleAvoidanceParams.size());
+        const size_t profilesToApply = AZStd::min(static_cast<size_t>(maxAvoidanceProfiles), obstacleAvoidanceParams.size());
         for (size_t profileIndex = 0; profileIndex < profilesToApply; ++profileIndex)
         {
-            const dtObstacleAvoidanceParams detourParams = m_obstacleAvoidanceParams[profileIndex].ToDetourObstacleAvoidanceParams();
+            const dtObstacleAvoidanceParams detourParams = obstacleAvoidanceParams[profileIndex].ToDetourObstacleAvoidanceParams();
             m_crowd->setObstacleAvoidanceParams(static_cast<int>(profileIndex), &detourParams);
         }
 
         return true;
+    }
+
+    AZ::Crc32 DetourCrowdNavigationComponent::GetAdvancedObstacleAvoidanceParamsVisibility() const
+    {
+        return m_useAdvancedObstacleAvoidanceParams ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
     }
 
     void DetourCrowdNavigationComponent::OnNavigationMeshUpdated(AZ::EntityId navigationMeshEntity)
@@ -130,20 +149,30 @@ namespace RecastNavigation
     }
 
     AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::AddAgent(
-        AZ::EntityId agentEntityId, const DetourCrowdAgentParams& agentParams)
+        const AZ::EntityId& agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams)
     {
         if (!agentEntityId.IsValid())
         {
+            // TODO: remove debug
+            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: invalid entity id.");
             return AZ::Failure(AZStd::string("Cannot add agent: invalid entity id."));
         }
 
         if (!m_crowd)
         {
+            // TODO: remove debug
+            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd is not initialized.");
             return AZ::Failure(AZStd::string("Cannot add agent: crowd is not initialized."));
         }
 
         if (m_agentEntityToCrowdIndex.find(agentEntityId) != m_agentEntityToCrowdIndex.end())
         {
+            // TODO: remove debug
+            AZ_Error(
+                "DetourCrowdNavigationComponent",
+                false,
+                "Cannot add agent: entity '%s' is already registered.",
+                agentEntityId.ToString().c_str());
             return AZ::Failure(
                 AZStd::string::format("Cannot add agent: entity '%s' is already registered.", agentEntityId.ToString().c_str()));
         }
@@ -151,26 +180,28 @@ namespace RecastNavigation
         const int maxAgents = m_crowd->getAgentCount();
         if (maxAgents <= 0)
         {
+            // TODO: remove debug
+            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd has invalid max agent count.");
             return AZ::Failure(AZStd::string("Cannot add agent: crowd has invalid max agent count."));
         }
 
         if (m_agentEntityToCrowdIndex.size() >= static_cast<size_t>(maxAgents))
         {
+            // TODO: remove debug
+            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd is full (%d agents).", maxAgents);
             return AZ::Failure(AZStd::string::format("Cannot add agent: crowd is full (%d agents).", maxAgents));
         }
 
         dtCrowdAgentParams detourParams = agentParams.ToDetourCrowdAgentParams();
 
-        // TODO: the position should be taken from the agent in other way
-        AZ::Vector3 worldPos = AZ::Vector3::CreateZero();
-        AZ::TransformBus::EventResult(worldPos, agentEntityId, &AZ::TransformBus::Events::GetWorldTranslation);
-
         // Convert O3DE Z-up to Recast Y-up.
-        RecastVector3 recastPos = RecastVector3::CreateFromVector3SwapYZ(worldPos);
+        RecastVector3 recastPos = RecastVector3::CreateFromVector3SwapYZ(worldPosition);
 
         const int crowdIndex = m_crowd->addAgent(recastPos.GetData(), &detourParams);
         if (crowdIndex < 0)
         {
+            // TODO: remove debug
+            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: dtCrowd::addAgent failed.");
             return AZ::Failure(AZStd::string("Cannot add agent: dtCrowd::addAgent failed."));
         }
 
@@ -179,6 +210,12 @@ namespace RecastNavigation
         if (!insertedAgentToIndex)
         {
             m_crowd->removeAgent(crowdIndex);
+            // TODO: remove debug
+            AZ_Error(
+                "DetourCrowdNavigationComponent",
+                false,
+                "Cannot add agent: failed to register entity '%s' mapping.",
+                agentEntityId.ToString().c_str());
             return AZ::Failure(
                 AZStd::string::format("Cannot add agent: failed to register entity '%s' mapping.", agentEntityId.ToString().c_str()));
         }
@@ -188,32 +225,44 @@ namespace RecastNavigation
         {
             m_agentEntityToCrowdIndex.erase(agentToIndexIt);
             m_crowd->removeAgent(crowdIndex);
+            // TODO: remove debug
+            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd index %d is already tracked.", crowdIndex);
             return AZ::Failure(AZStd::string::format("Cannot add agent: crowd index %d is already tracked.", crowdIndex));
         }
 
         return AZ::Success();
     }
 
-    AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::RemoveAgent(AZ::EntityId agentEntityId)
+    AZ::Outcome<AZ::u32, AZStd::string> DetourCrowdNavigationComponent::GetCrowdIndexForAgent(AZ::EntityId agentEntityId) const
     {
         if (!agentEntityId.IsValid())
         {
-            return AZ::Failure(AZStd::string("Cannot remove agent: invalid entity id."));
+            return AZ::Failure(AZStd::string("Invalid entity id."));
         }
 
         if (!m_crowd)
         {
-            return AZ::Failure(AZStd::string("Cannot remove agent: crowd is not initialized."));
+            return AZ::Failure(AZStd::string("Crowd is not initialized."));
         }
 
         const auto it = m_agentEntityToCrowdIndex.find(agentEntityId);
         if (it == m_agentEntityToCrowdIndex.end())
         {
-            return AZ::Failure(
-                AZStd::string::format("Cannot remove agent: entity '%s' is not registered.", agentEntityId.ToString().c_str()));
+            return AZ::Failure(AZStd::string::format("Entity '%s' is not registered.", agentEntityId.ToString().c_str()));
         }
 
-        const AZ::u32 crowdIndex = it->second;
+        return AZ::Success(it->second);
+    }
+
+    AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::RemoveAgent(AZ::EntityId agentEntityId)
+    {
+        const AZ::Outcome<AZ::u32, AZStd::string> crowdIndexOutcome = GetCrowdIndexForAgent(agentEntityId);
+        if (!crowdIndexOutcome.IsSuccess())
+        {
+            return AZ::Failure(AZStd::string::format("Cannot remove agent: %s", crowdIndexOutcome.GetError().c_str()));
+        }
+
+        const AZ::u32 crowdIndex = crowdIndexOutcome.GetValue();
         m_agentEntityToCrowdIndex.erase(agentEntityId);
         m_crowdIndexToAgentEntity.erase(crowdIndex);
 
@@ -225,29 +274,17 @@ namespace RecastNavigation
     AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::SetAgentMoveTarget(
         AZ::EntityId agentEntityId, const AZ::Vector3& targetPosition)
     {
-        if (!agentEntityId.IsValid())
+        const AZ::Outcome<AZ::u32, AZStd::string> crowdIndexOutcome = GetCrowdIndexForAgent(agentEntityId);
+        if (!crowdIndexOutcome.IsSuccess())
         {
-            return AZ::Failure(AZStd::string("Cannot set move target: invalid entity id."));
+            return AZ::Failure(AZStd::string::format("Cannot set move target: %s", crowdIndexOutcome.GetError().c_str()));
         }
 
-        if (!m_crowd)
-        {
-            return AZ::Failure(AZStd::string("Cannot set move target: crowd is not initialized."));
-        }
-
-        const auto it = m_agentEntityToCrowdIndex.find(agentEntityId);
-        if (it == m_agentEntityToCrowdIndex.end())
-        {
-            return AZ::Failure(
-                AZStd::string::format("Cannot set move target: entity '%s' is not registered.", agentEntityId.ToString().c_str()));
-        }
-
-        const int crowdIndex = static_cast<int>(it->second);
+        const int crowdIndex = static_cast<int>(crowdIndexOutcome.GetValue());
         const dtCrowdAgent* agent = m_crowd->getAgent(crowdIndex);
         if (!agent || !agent->active)
         {
-            return AZ::Failure(AZStd::string::format(
-                "Cannot set move target: agent at crowd index %d is not active.", crowdIndex));
+            return AZ::Failure(AZStd::string::format("Cannot set move target: agent at crowd index %d is not active.", crowdIndex));
         }
 
         // Get the navigation mesh query to find the target polygon reference
@@ -273,11 +310,11 @@ namespace RecastNavigation
         dtPolyRef targetPoly = 0;
         RecastVector3 nearestPoint;
         const dtQueryFilter filter;
-        const dtStatus findPolyStatus = query->findNearestPoly(recastTarget.GetData(), halfExtents, &filter, &targetPoly, nearestPoint.GetData());
+        const dtStatus findPolyStatus =
+            query->findNearestPoly(recastTarget.GetData(), halfExtents, &filter, &targetPoly, nearestPoint.GetData());
         if (dtStatusFailed(findPolyStatus) || targetPoly == 0)
         {
-            return AZ::Failure(
-                AZStd::string::format("Cannot set move target: could not find valid polygon for target position."));
+            return AZ::Failure(AZStd::string::format("Cannot set move target: could not find valid polygon for target position."));
         }
 
         // Request the crowd to move the agent to the target
@@ -290,15 +327,40 @@ namespace RecastNavigation
         return AZ::Success();
     }
 
+    AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::ResetAgentMoveTarget(AZ::EntityId agentEntityId)
+    {
+        const AZ::Outcome<AZ::u32, AZStd::string> crowdIndexOutcome = GetCrowdIndexForAgent(agentEntityId);
+        if (!crowdIndexOutcome.IsSuccess())
+        {
+            return AZ::Failure(AZStd::string::format("Cannot reset move target: %s", crowdIndexOutcome.GetError().c_str()));
+        }
+
+        const int crowdIndex = static_cast<int>(crowdIndexOutcome.GetValue());
+        const dtCrowdAgent* agent = m_crowd->getAgent(crowdIndex);
+        if (!agent || !agent->active)
+        {
+            return AZ::Failure(AZStd::string::format("Cannot reset move target: agent at crowd index %d is not active.", crowdIndex));
+        }
+
+        if (!m_crowd->resetMoveTarget(crowdIndex))
+        {
+            return AZ::Failure(
+                AZStd::string::format("Cannot reset move target: dtCrowd::resetMoveTarget failed for agent %d.", crowdIndex));
+        }
+
+        return AZ::Success();
+    }
+
     void DetourCrowdNavigationComponent::Reflect(AZ::ReflectContext* context)
     {
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<DetourCrowdNavigationComponent, AZ::Component>()
-                ->Version(1)
+                ->Version(2)
                 ->Field("NavQueryEntityId", &DetourCrowdNavigationComponent::m_navQueryEntityId)
                 ->Field("MaxAgents", &DetourCrowdNavigationComponent::m_maxAgents)
                 ->Field("MaxAgentRadius", &DetourCrowdNavigationComponent::m_maxAgentRadius)
+                ->Field("UseAdvancedObstacleAvoidanceParams", &DetourCrowdNavigationComponent::m_useAdvancedObstacleAvoidanceParams)
                 ->Field("ObstacleAvoidanceParams", &DetourCrowdNavigationComponent::m_obstacleAvoidanceParams);
 
             if (auto editContext = serialize->GetEditContext())
@@ -325,11 +387,36 @@ namespace RecastNavigation
                         "Max Agent Radius",
                         "Maximum radius of any agent that will be added to the crowd.")
                     ->DataElement(
+                        AZ::Edit::UIHandlers::CheckBox,
+                        &DetourCrowdNavigationComponent::m_useAdvancedObstacleAvoidanceParams,
+                        "Manual Obstacle Avoidance Presets",
+                        "Direct control over avoidance parameters. Disable for preset profiles.")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &DetourCrowdNavigationComponent::m_obstacleAvoidanceParams,
                         "Obstacle Avoidance Params",
-                        "Obstacle avoidance parameter profiles. Indices map to Detour quality levels.");
+                        "Obstacle avoidance parameter profiles. Indices map to Detour quality levels.")
+                    ->Attribute(
+                        AZ::Edit::Attributes::Visibility, &DetourCrowdNavigationComponent::GetAdvancedObstacleAvoidanceParamsVisibility);
             }
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<DetourCrowdNavigationRequestBus>("DetourCrowdNavigationRequestBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "navigation")
+                ->Attribute(AZ::Script::Attributes::Category, "Recast Navigation")
+                ->Event("AddAgent", &DetourCrowdNavigationRequests::AddAgent)
+                ->Event("RemoveAgent", &DetourCrowdNavigationRequests::RemoveAgent)
+                ->Event("SetAgentMoveTarget", &DetourCrowdNavigationRequests::SetAgentMoveTarget)
+                ->Event("ResetAgentMoveTarget", &DetourCrowdNavigationRequests::ResetAgentMoveTarget);
+
+            behaviorContext->Class<DetourCrowdNavigationComponent>()->RequestBus("DetourCrowdNavigationRequestBus");
+
+            behaviorContext->EBus<DetourCrowdAgentNotificationBus>("DetourCrowdAgentNotificationBus")
+                ->Handler<DetourCrowdAgentNotificationHandler>();
         }
     }
 
@@ -337,8 +424,8 @@ namespace RecastNavigation
     {
         if (!m_navQueryEntityId.IsValid())
         {
-            // Default to looking for the navigation mesh component on the same entity if one is not specified.
-            m_navQueryEntityId = GetEntityId();
+            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot activate: NavQueryEntityId is invalid.");
+            return;
         }
 
         DetourCrowdNavigationRequestBus::Handler::BusConnect(GetEntityId());

--- a/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-#include "RecastNavigation/NavMeshQuery.h"
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -72,7 +71,6 @@ namespace RecastNavigation
         }
 
         m_agentEntityToCrowdIndex.clear();
-        m_crowdIndexToAgentEntity.clear();
 
         // Choose parameter set based on mode
         const AZStd::vector<DetourObstacleAvoidanceParams> simpleObstacleAvoidanceParams = CreateDefaultObstacleAvoidanceParams();
@@ -97,6 +95,7 @@ namespace RecastNavigation
             m_crowd->setObstacleAvoidanceParams(static_cast<int>(profileIndex), &detourParams);
         }
 
+        m_crowdInitialized = true;
         return true;
     }
 
@@ -107,7 +106,8 @@ namespace RecastNavigation
 
     void DetourCrowdNavigationComponent::OnNavigationMeshUpdated(AZ::EntityId navigationMeshEntity)
     {
-        if (navigationMeshEntity == m_navQueryEntityId)
+        // Only init if the crowd hasn't been set up yet. The dtNavMesh is updated in-place during recalculation.
+        if (navigationMeshEntity == m_navQueryEntityId && !m_crowdInitialized)
         {
             InitializeCrowd();
         }
@@ -149,30 +149,20 @@ namespace RecastNavigation
     }
 
     AZ::Outcome<void, AZStd::string> DetourCrowdNavigationComponent::AddAgent(
-        const AZ::EntityId& agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams)
+        AZ::EntityId agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams)
     {
         if (!agentEntityId.IsValid())
         {
-            // TODO: remove debug
-            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: invalid entity id.");
             return AZ::Failure(AZStd::string("Cannot add agent: invalid entity id."));
         }
 
         if (!m_crowd)
         {
-            // TODO: remove debug
-            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd is not initialized.");
             return AZ::Failure(AZStd::string("Cannot add agent: crowd is not initialized."));
         }
 
         if (m_agentEntityToCrowdIndex.find(agentEntityId) != m_agentEntityToCrowdIndex.end())
         {
-            // TODO: remove debug
-            AZ_Error(
-                "DetourCrowdNavigationComponent",
-                false,
-                "Cannot add agent: entity '%s' is already registered.",
-                agentEntityId.ToString().c_str());
             return AZ::Failure(
                 AZStd::string::format("Cannot add agent: entity '%s' is already registered.", agentEntityId.ToString().c_str()));
         }
@@ -180,15 +170,11 @@ namespace RecastNavigation
         const int maxAgents = m_crowd->getAgentCount();
         if (maxAgents <= 0)
         {
-            // TODO: remove debug
-            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd has invalid max agent count.");
             return AZ::Failure(AZStd::string("Cannot add agent: crowd has invalid max agent count."));
         }
 
         if (m_agentEntityToCrowdIndex.size() >= static_cast<size_t>(maxAgents))
         {
-            // TODO: remove debug
-            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd is full (%d agents).", maxAgents);
             return AZ::Failure(AZStd::string::format("Cannot add agent: crowd is full (%d agents).", maxAgents));
         }
 
@@ -200,36 +186,10 @@ namespace RecastNavigation
         const int crowdIndex = m_crowd->addAgent(recastPos.GetData(), &detourParams);
         if (crowdIndex < 0)
         {
-            // TODO: remove debug
-            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: dtCrowd::addAgent failed.");
             return AZ::Failure(AZStd::string("Cannot add agent: dtCrowd::addAgent failed."));
         }
 
-        const AZ::u32 crowdIndexAsU32 = static_cast<AZ::u32>(crowdIndex);
-        const auto [agentToIndexIt, insertedAgentToIndex] = m_agentEntityToCrowdIndex.emplace(agentEntityId, crowdIndexAsU32);
-        if (!insertedAgentToIndex)
-        {
-            m_crowd->removeAgent(crowdIndex);
-            // TODO: remove debug
-            AZ_Error(
-                "DetourCrowdNavigationComponent",
-                false,
-                "Cannot add agent: failed to register entity '%s' mapping.",
-                agentEntityId.ToString().c_str());
-            return AZ::Failure(
-                AZStd::string::format("Cannot add agent: failed to register entity '%s' mapping.", agentEntityId.ToString().c_str()));
-        }
-
-        const auto [indexToAgentIt, insertedIndexToAgent] = m_crowdIndexToAgentEntity.emplace(crowdIndexAsU32, agentEntityId);
-        if (!insertedIndexToAgent)
-        {
-            m_agentEntityToCrowdIndex.erase(agentToIndexIt);
-            m_crowd->removeAgent(crowdIndex);
-            // TODO: remove debug
-            AZ_Error("DetourCrowdNavigationComponent", false, "Cannot add agent: crowd index %d is already tracked.", crowdIndex);
-            return AZ::Failure(AZStd::string::format("Cannot add agent: crowd index %d is already tracked.", crowdIndex));
-        }
-
+        m_agentEntityToCrowdIndex.emplace(agentEntityId, static_cast<AZ::u32>(crowdIndex));
         return AZ::Success();
     }
 
@@ -264,8 +224,6 @@ namespace RecastNavigation
 
         const AZ::u32 crowdIndex = crowdIndexOutcome.GetValue();
         m_agentEntityToCrowdIndex.erase(agentEntityId);
-        m_crowdIndexToAgentEntity.erase(crowdIndex);
-
         m_crowd->removeAgent(crowdIndex);
 
         return AZ::Success();
@@ -441,7 +399,7 @@ namespace RecastNavigation
         RecastNavigationMeshNotificationBus::Handler::BusDisconnect();
         DetourCrowdNavigationRequestBus::Handler::BusDisconnect();
         m_agentEntityToCrowdIndex.clear();
-        m_crowdIndexToAgentEntity.clear();
         m_crowd = nullptr;
+        m_crowdInitialized = false;
     }
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.h
+++ b/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.h
@@ -8,16 +8,16 @@
 
 #pragma once
 
-#include "AzCore/Component/EntityId.h"
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 #include <DetourCrowd.h>
-#include <RecastNavigation/DetourObstacleAvoidanceParams.h>
 #include <RecastNavigation/DetourCrowdNavigationBus.h>
+#include <RecastNavigation/DetourObstacleAvoidanceParams.h>
 #include <RecastNavigation/RecastNavigationMeshBus.h>
 #include <RecastNavigation/RecastSmartPointer.h>
 
@@ -38,7 +38,7 @@ namespace RecastNavigation
 
         // DetourCrowdNavigationRequestBus overrides
         AZ::Outcome<void, AZStd::string> AddAgent(
-            const AZ::EntityId& agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams) override;
+            AZ::EntityId agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams) override;
         AZ::Outcome<void, AZStd::string> RemoveAgent(AZ::EntityId agentEntityId) override;
         AZ::Outcome<void, AZStd::string> SetAgentMoveTarget(AZ::EntityId agentEntityId, const AZ::Vector3& targetPosition) override;
         AZ::Outcome<void, AZStd::string> ResetAgentMoveTarget(AZ::EntityId agentEntityId) override;
@@ -66,8 +66,8 @@ namespace RecastNavigation
         bool m_useAdvancedObstacleAvoidanceParams = false;
         AZStd::vector<DetourObstacleAvoidanceParams> m_obstacleAvoidanceParams;
 
+        bool m_crowdInitialized = false;
         AZStd::unordered_map<AZ::EntityId, AZ::u32> m_agentEntityToCrowdIndex;
-        AZStd::unordered_map<AZ::u32, AZ::EntityId> m_crowdIndexToAgentEntity;
 
         RecastPointer<dtCrowd> m_crowd = nullptr;
     };

--- a/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.h
+++ b/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.h
@@ -32,18 +32,26 @@ namespace RecastNavigation
     public:
         AZ_COMPONENT(DetourCrowdNavigationComponent, "{FECA2921-AF33-4968-9E3C-802965F0E7A2}");
 
+        DetourCrowdNavigationComponent();
+
         static void Reflect(AZ::ReflectContext* context);
 
         // DetourCrowdNavigationRequestBus overrides
-        AZ::Outcome<void, AZStd::string> AddAgent(AZ::EntityId agentEntityId, const DetourCrowdAgentParams& agentParams) override;
+        AZ::Outcome<void, AZStd::string> AddAgent(
+            const AZ::EntityId& agentEntityId, const AZ::Vector3& worldPosition, const DetourCrowdAgentParams& agentParams) override;
         AZ::Outcome<void, AZStd::string> RemoveAgent(AZ::EntityId agentEntityId) override;
         AZ::Outcome<void, AZStd::string> SetAgentMoveTarget(AZ::EntityId agentEntityId, const AZ::Vector3& targetPosition) override;
+        AZ::Outcome<void, AZStd::string> ResetAgentMoveTarget(AZ::EntityId agentEntityId) override;
 
         void Activate() override;
         void Deactivate() override;
 
     private:
         bool InitializeCrowd();
+        AZ::Crc32 GetAdvancedObstacleAvoidanceParamsVisibility() const;
+        static AZStd::vector<DetourObstacleAvoidanceParams> CreateDefaultObstacleAvoidanceParams();
+
+        AZ::Outcome<AZ::u32, AZStd::string> GetCrowdIndexForAgent(AZ::EntityId agentEntityId) const;
 
         // AZ::TickBus::Handler overrides.
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
@@ -55,11 +63,8 @@ namespace RecastNavigation
         AZ::EntityId m_navQueryEntityId;
         int m_maxAgents = 100;
         float m_maxAgentRadius = 0.6f;
-        // TODO: fix these quality settings, as they multiply in the editor
-        AZStd::vector<DetourObstacleAvoidanceParams> m_obstacleAvoidanceParams = { DetourObstacleAvoidanceParams::CreateLowQuality(),
-                                                                                   DetourObstacleAvoidanceParams::CreateMediumQuality(),
-                                                                                   DetourObstacleAvoidanceParams::CreateGoodQuality(),
-                                                                                   DetourObstacleAvoidanceParams::CreateHighQuality() };
+        bool m_useAdvancedObstacleAvoidanceParams = false;
+        AZStd::vector<DetourObstacleAvoidanceParams> m_obstacleAvoidanceParams;
 
         AZStd::unordered_map<AZ::EntityId, AZ::u32> m_agentEntityToCrowdIndex;
         AZStd::unordered_map<AZ::u32, AZ::EntityId> m_crowdIndexToAgentEntity;

--- a/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.h
+++ b/Gems/RecastNavigation/Code/Source/Components/DetourCrowdNavigationComponent.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "AzCore/Component/EntityId.h"
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+#include <DetourCrowd.h>
+#include <RecastNavigation/DetourObstacleAvoidanceParams.h>
+#include <RecastNavigation/DetourCrowdNavigationBus.h>
+#include <RecastNavigation/RecastNavigationMeshBus.h>
+#include <RecastNavigation/RecastSmartPointer.h>
+
+namespace RecastNavigation
+{
+    class DetourCrowdNavigationComponent final
+        : public AZ::Component
+        , private AZ::TickBus::Handler
+        , public DetourCrowdNavigationRequestBus::Handler
+        , private RecastNavigationMeshNotificationBus::Handler
+    {
+    public:
+        AZ_COMPONENT(DetourCrowdNavigationComponent, "{FECA2921-AF33-4968-9E3C-802965F0E7A2}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        // DetourCrowdNavigationRequestBus overrides
+        AZ::Outcome<void, AZStd::string> AddAgent(AZ::EntityId agentEntityId, const DetourCrowdAgentParams& agentParams) override;
+        AZ::Outcome<void, AZStd::string> RemoveAgent(AZ::EntityId agentEntityId) override;
+        AZ::Outcome<void, AZStd::string> SetAgentMoveTarget(AZ::EntityId agentEntityId, const AZ::Vector3& targetPosition) override;
+
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        bool InitializeCrowd();
+
+        // AZ::TickBus::Handler overrides.
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+        // RecastNavigationMeshNotificationBus overrides.
+        void OnNavigationMeshUpdated(AZ::EntityId navigationMeshEntity) override;
+        void OnNavigationMeshBeganRecalculating(AZ::EntityId navigationMeshEntity) override;
+
+        AZ::EntityId m_navQueryEntityId;
+        int m_maxAgents = 100;
+        float m_maxAgentRadius = 0.6f;
+        // TODO: fix these quality settings, as they multiply in the editor
+        AZStd::vector<DetourObstacleAvoidanceParams> m_obstacleAvoidanceParams = { DetourObstacleAvoidanceParams::CreateLowQuality(),
+                                                                                   DetourObstacleAvoidanceParams::CreateMediumQuality(),
+                                                                                   DetourObstacleAvoidanceParams::CreateGoodQuality(),
+                                                                                   DetourObstacleAvoidanceParams::CreateHighQuality() };
+
+        AZStd::unordered_map<AZ::EntityId, AZ::u32> m_agentEntityToCrowdIndex;
+        AZStd::unordered_map<AZ::u32, AZ::EntityId> m_crowdIndexToAgentEntity;
+
+        RecastPointer<dtCrowd> m_crowd = nullptr;
+    };
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Misc/DetourCrowdAgentParams.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/DetourCrowdAgentParams.cpp
@@ -8,6 +8,7 @@
 
 #include <RecastNavigation/DetourCrowdAgentParams.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <DetourCrowd.h>
@@ -56,10 +57,10 @@ namespace RecastNavigation
 
     void DetourCrowdAgentParams::Reflect(AZ::ReflectContext* context)
     {
+        using Self = DetourCrowdAgentParams;
+
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            using Self = DetourCrowdAgentParams;
-
             serialize->Class<Self>()
                 ->Version(1)
                 ->Field("Radius", &Self::m_radius)
@@ -137,6 +138,26 @@ namespace RecastNavigation
                     ->Attribute(AZ::Edit::Attributes::Min, 0)
                     ->Attribute(AZ::Edit::Attributes::Max, DT_CROWD_MAX_QUERY_FILTER_TYPE);
             }
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<Self>("DetourCrowdAgentParams")
+                ->Constructor<>()
+                ->Property("radius", BehaviorValueProperty(&Self::m_radius))
+                ->Property("height", BehaviorValueProperty(&Self::m_height))
+                ->Property("maxAcceleration", BehaviorValueProperty(&Self::m_maxAcceleration))
+                ->Property("maxSpeed", BehaviorValueProperty(&Self::m_maxSpeed))
+                ->Property("collisionQueryRange", BehaviorValueProperty(&Self::m_collisionQueryRange))
+                ->Property("pathOptimizationRange", BehaviorValueProperty(&Self::m_pathOptimizationRange))
+                ->Property("separationWeight", BehaviorValueProperty(&Self::m_separationWeight))
+                ->Property("anticipateTurns", BehaviorValueProperty(&Self::m_anticipateTurns))
+                ->Property("obstacleAvoidance", BehaviorValueProperty(&Self::m_obstacleAvoidance))
+                ->Property("separation", BehaviorValueProperty(&Self::m_separation))
+                ->Property("optimizeVisibility", BehaviorValueProperty(&Self::m_optimizeVisibility))
+                ->Property("optimizeTopology", BehaviorValueProperty(&Self::m_optimizeTopology))
+                ->Property("obstacleAvoidanceType", BehaviorValueProperty(&Self::m_obstacleAvoidanceType))
+                ->Property("queryFilterType", BehaviorValueProperty(&Self::m_queryFilterType));
         }
     }
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Misc/DetourCrowdAgentParams.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/DetourCrowdAgentParams.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RecastNavigation/DetourCrowdAgentParams.h>
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <DetourCrowd.h>
+
+namespace RecastNavigation
+{
+    dtCrowdAgentParams DetourCrowdAgentParams::ToDetourCrowdAgentParams() const
+    {
+        dtCrowdAgentParams output{};
+        output.radius = m_radius;
+        output.height = m_height;
+        output.maxAcceleration = m_maxAcceleration;
+        output.maxSpeed = m_maxSpeed;
+        output.collisionQueryRange = m_collisionQueryRange;
+        output.pathOptimizationRange = m_pathOptimizationRange;
+        output.separationWeight = m_separationWeight;
+
+        output.updateFlags = 0;
+        if (m_anticipateTurns)
+        {
+            output.updateFlags |= DT_CROWD_ANTICIPATE_TURNS;
+        }
+        if (m_obstacleAvoidance)
+        {
+            output.updateFlags |= DT_CROWD_OBSTACLE_AVOIDANCE;
+        }
+        if (m_separation)
+        {
+            output.updateFlags |= DT_CROWD_SEPARATION;
+        }
+        if (m_optimizeVisibility)
+        {
+            output.updateFlags |= DT_CROWD_OPTIMIZE_VIS;
+        }
+        if (m_optimizeTopology)
+        {
+            output.updateFlags |= DT_CROWD_OPTIMIZE_TOPO;
+        }
+
+        output.obstacleAvoidanceType = m_obstacleAvoidanceType;
+        output.queryFilterType = m_queryFilterType;
+        output.userData = nullptr;
+
+        return output;
+    }
+
+    void DetourCrowdAgentParams::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            using Self = DetourCrowdAgentParams;
+
+            serialize->Class<Self>()
+                ->Version(1)
+                ->Field("Radius", &Self::m_radius)
+                ->Field("Height", &Self::m_height)
+                ->Field("Max Acceleration", &Self::m_maxAcceleration)
+                ->Field("Max Speed", &Self::m_maxSpeed)
+                ->Field("Collision Query Range", &Self::m_collisionQueryRange)
+                ->Field("Path Optimization Range", &Self::m_pathOptimizationRange)
+                ->Field("Separation Weight", &Self::m_separationWeight)
+                ->Field("Anticipate Turns", &Self::m_anticipateTurns)
+                ->Field("Obstacle Avoidance", &Self::m_obstacleAvoidance)
+                ->Field("Separation", &Self::m_separation)
+                ->Field("Optimize Visibility", &Self::m_optimizeVisibility)
+                ->Field("Optimize Topology", &Self::m_optimizeTopology)
+                ->Field("Obstacle Avoidance Type", &Self::m_obstacleAvoidanceType)
+                ->Field("Query Filter Type", &Self::m_queryFilterType);
+
+            if (AZ::EditContext* editContext = serialize->GetEditContext())
+            {
+                editContext->Class<Self>("Detour Crowd Agent Params", "Configuration parameters for a crowd agent.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_radius, "Radius", "Agent radius. [Limit: >= 0]")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_height, "Height", "Agent height. [Limit: > 0]")
+                    ->Attribute(AZ::Edit::Attributes::Min, AZ::Constants::FloatEpsilon)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &Self::m_maxAcceleration,
+                        "Max Acceleration",
+                        "Maximum allowed acceleration. [Limit: >= 0]")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_maxSpeed, "Max Speed", "Maximum allowed speed. [Limit: >= 0]")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &Self::m_collisionQueryRange,
+                        "Collision Query Range",
+                        "How close a collision element must be before being considered for steering. [Limit: > 0]")
+                    ->Attribute(AZ::Edit::Attributes::Min, AZ::Constants::FloatEpsilon)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &Self::m_pathOptimizationRange,
+                        "Path Optimization Range",
+                        "Path visibility optimization range. [Limit: > 0]")
+                    ->Attribute(AZ::Edit::Attributes::Min, AZ::Constants::FloatEpsilon)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &Self::m_separationWeight,
+                        "Separation Weight",
+                        "How aggressively other agents avoid this agent. [Limit: >= 0]")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &Self::m_anticipateTurns, "Anticipate Turns", "Enable DT_CROWD_ANTICIPATE_TURNS.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &Self::m_obstacleAvoidance,
+                        "Obstacle Avoidance",
+                        "Enable DT_CROWD_OBSTACLE_AVOIDANCE.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_separation, "Separation", "Enable DT_CROWD_SEPARATION.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &Self::m_optimizeVisibility, "Optimize Visibility", "Enable DT_CROWD_OPTIMIZE_VIS.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &Self::m_optimizeTopology, "Optimize Topology", "Enable DT_CROWD_OPTIMIZE_TOPO.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &Self::m_obstacleAvoidanceType,
+                        "Obstacle Avoidance Type",
+                        "Index of the avoidance configuration.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0)
+                    ->Attribute(AZ::Edit::Attributes::Max, DT_CROWD_MAX_OBSTAVOIDANCE_PARAMS)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &Self::m_queryFilterType,
+                        "Query Filter Type",
+                        "Index of the query filter used by this agent.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0)
+                    ->Attribute(AZ::Edit::Attributes::Max, DT_CROWD_MAX_QUERY_FILTER_TYPE);
+            }
+        }
+    }
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Misc/DetourObstacleAvoidanceParams.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/DetourObstacleAvoidanceParams.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RecastNavigation/DetourObstacleAvoidanceParams.h>
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <DetourObstacleAvoidance.h>
+
+namespace RecastNavigation
+{
+    dtObstacleAvoidanceParams DetourObstacleAvoidanceParams::ToDetourObstacleAvoidanceParams() const
+    {
+        dtObstacleAvoidanceParams output{};
+        output.velBias = m_velBias;
+        output.weightDesVel = m_weightDesVel;
+        output.weightCurVel = m_weightCurVel;
+        output.weightSide = m_weightSide;
+        output.weightToi = m_weightToi;
+        output.horizTime = m_horizTime;
+        output.gridSize = m_gridSize;
+        output.adaptiveDivs = m_adaptiveDivs;
+        output.adaptiveRings = m_adaptiveRings;
+        output.adaptiveDepth = m_adaptiveDepth;
+        return output;
+    }
+
+    DetourObstacleAvoidanceParams DetourObstacleAvoidanceParams::CreateLowQuality()
+    {
+        DetourObstacleAvoidanceParams params;
+        params.m_velBias = 0.5f;
+        params.m_adaptiveDivs = 5;
+        params.m_adaptiveRings = 2;
+        params.m_adaptiveDepth = 1;
+        return params;
+    }
+
+    DetourObstacleAvoidanceParams DetourObstacleAvoidanceParams::CreateMediumQuality()
+    {
+        DetourObstacleAvoidanceParams params;
+        params.m_velBias = 0.5f;
+        params.m_adaptiveDivs = 5;
+        params.m_adaptiveRings = 2;
+        params.m_adaptiveDepth = 2;
+        return params;
+    }
+
+    DetourObstacleAvoidanceParams DetourObstacleAvoidanceParams::CreateGoodQuality()
+    {
+        DetourObstacleAvoidanceParams params;
+        params.m_velBias = 0.5f;
+        params.m_adaptiveDivs = 7;
+        params.m_adaptiveRings = 2;
+        params.m_adaptiveDepth = 3;
+        return params;
+    }
+
+    DetourObstacleAvoidanceParams DetourObstacleAvoidanceParams::CreateHighQuality()
+    {
+        DetourObstacleAvoidanceParams params;
+        params.m_velBias = 0.5f;
+        params.m_adaptiveDivs = 7;
+        params.m_adaptiveRings = 3;
+        params.m_adaptiveDepth = 3;
+        return params;
+    }
+
+    void DetourObstacleAvoidanceParams::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            using DetourObstacleAvoidanceParams = DetourObstacleAvoidanceParams;
+
+            serialize->Class<DetourObstacleAvoidanceParams>()
+                ->Version(1)
+                ->Field("Vel Bias", &DetourObstacleAvoidanceParams::m_velBias)
+                ->Field("Weight Desired Velocity", &DetourObstacleAvoidanceParams::m_weightDesVel)
+                ->Field("Weight Current Velocity", &DetourObstacleAvoidanceParams::m_weightCurVel)
+                ->Field("Weight Side", &DetourObstacleAvoidanceParams::m_weightSide)
+                ->Field("Weight Time Of Impact", &DetourObstacleAvoidanceParams::m_weightToi)
+                ->Field("Horizon Time", &DetourObstacleAvoidanceParams::m_horizTime)
+                ->Field("Grid Size", &DetourObstacleAvoidanceParams::m_gridSize)
+                ->Field("Adaptive Divisions", &DetourObstacleAvoidanceParams::m_adaptiveDivs)
+                ->Field("Adaptive Rings", &DetourObstacleAvoidanceParams::m_adaptiveRings)
+                ->Field("Adaptive Depth", &DetourObstacleAvoidanceParams::m_adaptiveDepth);
+
+            if (AZ::EditContext* editContext = serialize->GetEditContext())
+            {
+                editContext
+                    ->Class<DetourObstacleAvoidanceParams>(
+                        "Detour Obstacle Avoidance Params", "Configuration parameters for obstacle avoidance.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DetourObstacleAvoidanceParams::m_velBias, "Vel Bias", "Velocity bias.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_weightDesVel,
+                        "Weight Desired Velocity",
+                        "Desired velocity weight.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_weightCurVel,
+                        "Weight Current Velocity",
+                        "Current velocity weight.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_weightSide,
+                        "Weight Side",
+                        "Preferred side weight.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_weightToi,
+                        "Weight Time Of Impact",
+                        "Collision time weight.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_horizTime,
+                        "Horizon Time",
+                        "Avoidance horizon time.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &DetourObstacleAvoidanceParams::m_gridSize, "Grid Size", "Sampling grid size.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 1)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_adaptiveDivs,
+                        "Adaptive Divisions",
+                        "Adaptive divisions count.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 1)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_adaptiveRings,
+                        "Adaptive Rings",
+                        "Adaptive rings count.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 1)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &DetourObstacleAvoidanceParams::m_adaptiveDepth,
+                        "Adaptive Depth",
+                        "Adaptive depth count.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 1);
+            }
+        }
+    }
+} // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Misc/DetourObstacleAvoidanceParams.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/DetourObstacleAvoidanceParams.cpp
@@ -8,6 +8,7 @@
 
 #include <RecastNavigation/DetourObstacleAvoidanceParams.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <DetourObstacleAvoidance.h>
@@ -72,82 +73,65 @@ namespace RecastNavigation
 
     void DetourObstacleAvoidanceParams::Reflect(AZ::ReflectContext* context)
     {
+        using Self = DetourObstacleAvoidanceParams;
+
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            using DetourObstacleAvoidanceParams = DetourObstacleAvoidanceParams;
-
-            serialize->Class<DetourObstacleAvoidanceParams>()
+            serialize->Class<Self>()
                 ->Version(1)
-                ->Field("Vel Bias", &DetourObstacleAvoidanceParams::m_velBias)
-                ->Field("Weight Desired Velocity", &DetourObstacleAvoidanceParams::m_weightDesVel)
-                ->Field("Weight Current Velocity", &DetourObstacleAvoidanceParams::m_weightCurVel)
-                ->Field("Weight Side", &DetourObstacleAvoidanceParams::m_weightSide)
-                ->Field("Weight Time Of Impact", &DetourObstacleAvoidanceParams::m_weightToi)
-                ->Field("Horizon Time", &DetourObstacleAvoidanceParams::m_horizTime)
-                ->Field("Grid Size", &DetourObstacleAvoidanceParams::m_gridSize)
-                ->Field("Adaptive Divisions", &DetourObstacleAvoidanceParams::m_adaptiveDivs)
-                ->Field("Adaptive Rings", &DetourObstacleAvoidanceParams::m_adaptiveRings)
-                ->Field("Adaptive Depth", &DetourObstacleAvoidanceParams::m_adaptiveDepth);
+                ->Field("Vel Bias", &Self::m_velBias)
+                ->Field("Weight Desired Velocity", &Self::m_weightDesVel)
+                ->Field("Weight Current Velocity", &Self::m_weightCurVel)
+                ->Field("Weight Side", &Self::m_weightSide)
+                ->Field("Weight Time Of Impact", &Self::m_weightToi)
+                ->Field("Horizon Time", &Self::m_horizTime)
+                ->Field("Grid Size", &Self::m_gridSize)
+                ->Field("Adaptive Divisions", &Self::m_adaptiveDivs)
+                ->Field("Adaptive Rings", &Self::m_adaptiveRings)
+                ->Field("Adaptive Depth", &Self::m_adaptiveDepth);
 
             if (AZ::EditContext* editContext = serialize->GetEditContext())
             {
-                editContext
-                    ->Class<DetourObstacleAvoidanceParams>(
-                        "Detour Obstacle Avoidance Params", "Configuration parameters for obstacle avoidance.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DetourObstacleAvoidanceParams::m_velBias, "Vel Bias", "Velocity bias.")
+                editContext->Class<Self>("Detour Obstacle Avoidance Params", "Configuration parameters for obstacle avoidance.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_velBias, "Vel Bias", "Velocity bias.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_weightDesVel,
-                        "Weight Desired Velocity",
-                        "Desired velocity weight.")
+                        AZ::Edit::UIHandlers::Default, &Self::m_weightDesVel, "Weight Desired Velocity", "Desired velocity weight.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_weightCurVel,
-                        "Weight Current Velocity",
-                        "Current velocity weight.")
+                        AZ::Edit::UIHandlers::Default, &Self::m_weightCurVel, "Weight Current Velocity", "Current velocity weight.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_weightSide,
-                        "Weight Side",
-                        "Preferred side weight.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_weightSide, "Weight Side", "Preferred side weight.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_weightToi,
-                        "Weight Time Of Impact",
-                        "Collision time weight.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_weightToi, "Weight Time Of Impact", "Collision time weight.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_horizTime,
-                        "Horizon Time",
-                        "Avoidance horizon time.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_horizTime, "Horizon Time", "Avoidance horizon time.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &DetourObstacleAvoidanceParams::m_gridSize, "Grid Size", "Sampling grid size.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_gridSize, "Grid Size", "Sampling grid size.")
                     ->Attribute(AZ::Edit::Attributes::Min, 1)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_adaptiveDivs,
-                        "Adaptive Divisions",
-                        "Adaptive divisions count.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_adaptiveDivs, "Adaptive Divisions", "Adaptive divisions count.")
                     ->Attribute(AZ::Edit::Attributes::Min, 1)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_adaptiveRings,
-                        "Adaptive Rings",
-                        "Adaptive rings count.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_adaptiveRings, "Adaptive Rings", "Adaptive rings count.")
                     ->Attribute(AZ::Edit::Attributes::Min, 1)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &DetourObstacleAvoidanceParams::m_adaptiveDepth,
-                        "Adaptive Depth",
-                        "Adaptive depth count.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Self::m_adaptiveDepth, "Adaptive Depth", "Adaptive depth count.")
                     ->Attribute(AZ::Edit::Attributes::Min, 1);
             }
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<Self>("DetourObstacleAvoidanceParams")
+                ->Constructor<>()
+                ->Property("velBias", BehaviorValueProperty(&Self::m_velBias))
+                ->Property("weightDesVel", BehaviorValueProperty(&Self::m_weightDesVel))
+                ->Property("weightCurVel", BehaviorValueProperty(&Self::m_weightCurVel))
+                ->Property("weightSide", BehaviorValueProperty(&Self::m_weightSide))
+                ->Property("weightToi", BehaviorValueProperty(&Self::m_weightToi))
+                ->Property("horizTime", BehaviorValueProperty(&Self::m_horizTime))
+                ->Property("gridSize", BehaviorValueProperty(&Self::m_gridSize))
+                ->Property("adaptiveDivs", BehaviorValueProperty(&Self::m_adaptiveDivs))
+                ->Property("adaptiveRings", BehaviorValueProperty(&Self::m_adaptiveRings))
+                ->Property("adaptiveDepth", BehaviorValueProperty(&Self::m_adaptiveDepth));
         }
     }
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/RecastNavigationModuleInterface.h
+++ b/Gems/RecastNavigation/Code/Source/RecastNavigationModuleInterface.h
@@ -6,12 +6,13 @@
  *
  */
 
-#include <RecastNavigationSystemComponent.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
+#include <Components/DetourCrowdNavigationComponent.h>
 #include <Components/DetourNavigationComponent.h>
 #include <Components/RecastNavigationMeshComponent.h>
 #include <Components/RecastNavigationPhysXProviderComponent.h>
+#include <RecastNavigationSystemComponent.h>
 
 namespace RecastNavigation
 {
@@ -28,11 +29,14 @@ namespace RecastNavigation
             // Add ALL components descriptors associated with this gem to m_descriptors.
             // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
             // This happens through the [MyComponent]::Reflect() function.
-            m_descriptors.insert(m_descriptors.end(), {
-                RecastNavigationSystemComponent::CreateDescriptor(),
-                DetourNavigationComponent::CreateDescriptor(),
-                RecastNavigationMeshComponent::CreateDescriptor(),
-                RecastNavigationPhysXProviderComponent::CreateDescriptor(),
+            m_descriptors.insert(
+                m_descriptors.end(),
+                {
+                    RecastNavigationSystemComponent::CreateDescriptor(),
+                    DetourCrowdNavigationComponent::CreateDescriptor(),
+                    DetourNavigationComponent::CreateDescriptor(),
+                    RecastNavigationMeshComponent::CreateDescriptor(),
+                    RecastNavigationPhysXProviderComponent::CreateDescriptor(),
                 });
         }
 

--- a/Gems/RecastNavigation/Code/Source/RecastNavigationSystemComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/RecastNavigationSystemComponent.cpp
@@ -6,14 +6,19 @@
  *
  */
 
-#include <RecastNavigationSystemComponent.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <RecastNavigation/DetourCrowdAgentParams.h>
+#include <RecastNavigation/DetourObstacleAvoidanceParams.h>
+#include <RecastNavigationSystemComponent.h>
 
 namespace RecastNavigation
 {
     void RecastNavigationSystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        DetourCrowdAgentParams::Reflect(context);
+        DetourObstacleAvoidanceParams::Reflect(context);
+
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<RecastNavigationSystemComponent, AZ::Component>()

--- a/Gems/RecastNavigation/Code/recastnavigation_api_files.cmake
+++ b/Gems/RecastNavigation/Code/recastnavigation_api_files.cmake
@@ -7,10 +7,14 @@
 #
 
 set(FILES
+    Include/RecastNavigation/DetourCrowdAgentParams.h
+    Include/RecastNavigation/DetourObstacleAvoidanceParams.h
     Include/RecastNavigation/NavMeshQuery.h
     Include/RecastNavigation/RecastHelpers.h
     Include/RecastNavigation/RecastSmartPointer.h
 
+    Include/RecastNavigation/DetourCrowdAgentBus.h
+    Include/RecastNavigation/DetourCrowdNavigationBus.h
     Include/RecastNavigation/DetourNavigationBus.h
     Include/RecastNavigation/RecastNavigationBus.h
     Include/RecastNavigation/RecastNavigationMeshBus.h

--- a/Gems/RecastNavigation/Code/recastnavigation_private_files.cmake
+++ b/Gems/RecastNavigation/Code/recastnavigation_private_files.cmake
@@ -11,6 +11,8 @@ set(FILES
     Source/RecastNavigationSystemComponent.cpp
     Source/RecastNavigationSystemComponent.h
 
+    Source/Components/DetourCrowdNavigationComponent.h
+    Source/Components/DetourCrowdNavigationComponent.cpp
     Source/Components/DetourNavigationComponent.h
     Source/Components/DetourNavigationComponent.cpp
     Source/Components/RecastNavigationMeshComponent.h
@@ -19,6 +21,8 @@ set(FILES
     Source/Components/RecastNavigationPhysXProviderComponent.cpp
 
     Source/Misc/RecastNavigationConstants.h
+    Source/Misc/DetourCrowdAgentParams.cpp
+    Source/Misc/DetourObstacleAvoidanceParams.cpp
     Source/Misc/RecastNavigationDebugDraw.h
     Source/Misc/RecastNavigationDebugDraw.cpp
     Source/Misc/RecastNavigationMeshConfig.h


### PR DESCRIPTION
## What does this PR do?

This PR extends the Recast Navigation support in O3DE by adding DetourCrowd - a component that controls agents (NPCs). It supports self collision avoidance and creates smooth looking movement.

## How was this PR tested?

By creating sample NPCs using the C++ API and ScriptCanvas described in the documentation link below.

## Documentation link
https://github.com/o3de/o3de.org/pull/2775