### PR TITLE
[stabilization] Add articulation offset. (#19594)

### DIFF
--- a/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
+++ b/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
@@ -124,7 +124,8 @@ namespace PhysX
                 ->Field("Motor configuration", &ArticulationLinkConfiguration::m_motorConfiguration)
                 ->Field("Armature", &ArticulationLinkConfiguration::m_armature)
                 ->Field("Friction", &ArticulationLinkConfiguration::m_jointFriction)
-                ->Field("Sensor Configurations", &ArticulationLinkConfiguration::m_sensorConfigs);
+                ->Field("Sensor Configuration", &ArticulationLinkConfiguration::m_sensorConfigs)
+                ->Field("Offset", &ArticulationLinkConfiguration::m_offset);
         }
     }
 

--- a/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.h
+++ b/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.h
@@ -84,6 +84,8 @@ namespace PhysX
         float m_sleepMinEnergy = 0.005f; // Relevant to the root link only
         float m_maxAngularVelocity = 100.0f;
 
+        float m_offset = 0.f;
+
         bool m_startAsleep = false;
         bool m_gravityEnabled = true;
 

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
@@ -100,10 +100,10 @@ namespace PhysX
     {
         return m_articulationLinks;
     }
-
 #if (PX_PHYSICS_VERSION_MAJOR == 5)
     void ArticulationLinkComponent::Activate()
     {
+        m_offsetInCorrectUnits = m_config.HingePropertiesVisible() ? AZ::DegToRad(m_config.m_offset) : m_config.m_offset;
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         if (!sceneInterface)
         {
@@ -367,12 +367,29 @@ namespace PhysX
 
         if (parentLink)
         {
+
             physx::PxArticulationJointReducedCoordinate* inboundJoint =
                 thisPxLink->getInboundJoint()->is<physx::PxArticulationJointReducedCoordinate>();
-            // Sets the joint pose in the lead link actor frame.
-            inboundJoint->setParentPose(PxMathConvert(thisLinkData.m_jointLeadLocalFrame));
+            AZ::Transform offsetTransform {AZ::Transform::Identity()};
             // Sets the joint pose in the follower link actor frame.
-            inboundJoint->setChildPose(PxMathConvert(thisLinkData.m_jointFollowerLocalFrame));
+            if (!AZ::IsClose(articulationLinkConfiguration.m_offset , 0.f))
+            {
+                if (articulationLinkConfiguration.m_articulationJointType == ArticulationJointType::Hinge)
+                {
+                    AZ_TracePrintf("PhysX", "Applying offset of %f deg to joint between %s and its parent link", articulationLinkConfiguration.m_offset, thisPxLink->getName());
+                    offsetTransform.SetFromEulerDegrees(AZ::Vector3(articulationLinkConfiguration.m_offset,0,0));
+                }
+                else if (articulationLinkConfiguration.m_articulationJointType == ArticulationJointType::Prismatic)
+                {
+                    AZ_TracePrintf("PhysX", "Applying offset of %f meters to joint between %s and its parent link",  articulationLinkConfiguration.m_offset, thisPxLink->getName());
+                    offsetTransform.SetTranslation(AZ::Vector3(articulationLinkConfiguration.m_offset,0,0));
+                }
+            }
+
+            // Sets the joint pose in the lead link actor frame.
+            inboundJoint->setParentPose(PxMathConvert(thisLinkData.m_jointLeadLocalFrame* offsetTransform));
+
+            inboundJoint->setChildPose(PxMathConvert(thisLinkData.m_jointFollowerLocalFrame ) );
             // Sets the joint type and limits.
             switch (articulationLinkConfiguration.m_articulationJointType)
             {
@@ -385,9 +402,10 @@ namespace PhysX
                 {
                     // The lower limit should be strictly smaller than the higher limit.
                     physx::PxArticulationLimit limits;
-                    limits.low = AZ::DegToRad(AZStd::min(
+
+                    limits.low = AZ::DegToRad( -articulationLinkConfiguration.m_offset + AZStd::min(
                         articulationLinkConfiguration.m_angularLimitNegative, articulationLinkConfiguration.m_angularLimitPositive));
-                    limits.high = AZ::DegToRad(AZStd::max(
+                    limits.high = AZ::DegToRad( -articulationLinkConfiguration.m_offset +  AZStd::max(
                         articulationLinkConfiguration.m_angularLimitNegative, articulationLinkConfiguration.m_angularLimitPositive));
 
                     // From PhysX documentation: If the limits should be equal, use PxArticulationMotion::eLOCKED
@@ -451,9 +469,9 @@ namespace PhysX
                 {
                     // The lower limit should be strictly smaller than the higher limit.
                     physx::PxArticulationLimit limits;
-                    limits.low =
+                    limits.low = -articulationLinkConfiguration.m_offset +
                         AZStd::min(articulationLinkConfiguration.m_linearLimitLower, articulationLinkConfiguration.m_linearLimitUpper);
-                    limits.high =
+                    limits.high = -articulationLinkConfiguration.m_offset +
                         AZStd::max(articulationLinkConfiguration.m_linearLimitLower, articulationLinkConfiguration.m_linearLimitUpper);
 
                     // From PhysX documentation: If the limits should be equal, use PxArticulationMotion::eLOCKED
@@ -649,7 +667,7 @@ namespace PhysX
         if (auto* joint = GetDriveJoint())
         {
             PHYSX_SCENE_WRITE_LOCK(m_link->getScene());
-            const physx::PxArticulationLimit limit(limitPair.first, limitPair.second);
+            const physx::PxArticulationLimit limit(limitPair.first - m_offsetInCorrectUnits, limitPair.second  - m_offsetInCorrectUnits);
             joint->setLimitParams(GetPxArticulationAxis(jointAxis), limit);
         }
     }
@@ -660,7 +678,7 @@ namespace PhysX
         {
             PHYSX_SCENE_READ_LOCK(m_link->getScene());
             const auto limit = joint->getLimitParams(GetPxArticulationAxis(jointAxis));
-            return { limit.low, limit.high };
+            return { limit.low + m_offsetInCorrectUnits, limit.high + m_offsetInCorrectUnits };
         }
         return { -AZ::Constants::FloatMax, AZ::Constants::FloatMax };
     }
@@ -763,7 +781,7 @@ namespace PhysX
         if (auto* joint = GetDriveJoint())
         {
             PHYSX_SCENE_WRITE_LOCK(m_link->getScene());
-            joint->setDriveTarget(GetPxArticulationAxis(jointAxis), target);
+            joint->setDriveTarget(GetPxArticulationAxis(jointAxis), target - m_offsetInCorrectUnits);
         }
     }
 
@@ -772,7 +790,7 @@ namespace PhysX
         if (auto* joint = GetDriveJoint())
         {
             PHYSX_SCENE_READ_LOCK(m_link->getScene());
-            return joint->getDriveTarget(GetPxArticulationAxis(jointAxis));
+            return joint->getDriveTarget(GetPxArticulationAxis(jointAxis) ) + m_offsetInCorrectUnits;
         }
         return 0.0f;
     }
@@ -801,7 +819,7 @@ namespace PhysX
         if (auto* joint = GetDriveJoint())
         {
             PHYSX_SCENE_READ_LOCK(m_link->getScene());
-            return joint->getJointPosition(GetPxArticulationAxis(jointAxis));
+            return joint->getJointPosition(GetPxArticulationAxis(jointAxis)) + m_offsetInCorrectUnits ;
         }
         return 0.0f;
     }

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.h
@@ -151,6 +151,7 @@ namespace PhysX
         using EntityIdSensorIndexListPair = AZStd::pair<AZ::EntityId, AZStd::vector<AZ::u32>>;
         AZStd::unordered_map<AZ::EntityId, AZStd::vector<AZ::u32>> m_sensorIndicesByEntityId;
         bool m_enabled = true;
+        float m_offsetInCorrectUnits = 0.0f;
     };
 
     //! Utility function for detecting if the current entity is the root of articulation.

--- a/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
@@ -207,6 +207,17 @@ namespace PhysX
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Sensors")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(0, &ArticulationLinkConfiguration::m_sensorConfigs, "Sensor Configurations", "Sensor configurations")
+                    ->EndGroup()
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Joint Offset")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                           AZ::Edit::UIHandlers::Default,
+                           &ArticulationLinkConfiguration::m_offset,
+                           "Offset",
+                           "Zero-position offset for the joint. For hinge joints the value is in degrees; "
+                           "for prismatic joints the value is in meters. Limits, drive targets, and reported "
+                           "positions are all expressed relative to this offset.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDofJointType)
                     ->EndGroup();
             }
         }


### PR DESCRIPTION
## What does this PR do?

This PR cherry-picks #19594 from `development` to `stabilization`. The original PR was opened just after the cutoff date and did not make it to the release branch. After using it in multiple projects with a success, we believe it is a worthy change for the upcoming release.

The feature adds the offset which is set to 0 by default, hence it does not influence anything when not used. The change is local, i.e., it does not propagate to other Gems or systems. We believe there is an extremely low risk it would break anything during the stabilization stage.

## How was this PR tested?

The code was tested with the real-life example from https://github.com/o3de/o3de-extras/pull/1025
