### PR TITLE
Fix for choppy mouse movement in FlyCameraInputComponent and replace Cry_Math types

### DIFF
--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include "FlyCameraInputComponent.h"
 
 #include <ISystem.h>
@@ -22,8 +23,6 @@
 #include <AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Input/Devices/Touch/InputDeviceTouch.h>
-
-#include <MathConversion.h>
 
 #include <Atom/RPI.Public/ViewProviderBus.h>
 #include <Atom/RPI.Public/View.h>
@@ -49,14 +48,21 @@ namespace
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void DrawThumbstick([[maybe_unused]] Vec2 initialPosition,
-        [[maybe_unused]] Vec2 currentPosition,
+    void DrawThumbstick([[maybe_unused]] AZ::Vector2 initialPosition,
+        [[maybe_unused]] AZ::Vector2 currentPosition,
         [[maybe_unused]] int textureId)
     {
         // [GFX TODO] Get Atom test fly cam virtual thumbsticks working on mobile
         // we do not have any 2D drawing capability like IDraw2d in Atom yet
     }
 }
+
+//////////////////////////////////////////////////////////////////////////////
+constexpr static float Invert(const bool invert) //! return -1.0f if inverted, 1.0f otherwise
+{
+    constexpr float Dir[] = { 1.0f, -1.0f };
+    return Dir[aznumeric_cast<int>(invert)];
+};
 
 //////////////////////////////////////////////////////////////////////////////
 const AZ::Crc32 FlyCameraInputComponent::UnknownInputChannelId("unknown_input_channel_id");
@@ -180,17 +186,18 @@ void FlyCameraInputComponent::OnTick(float deltaTime, AZ::ScriptTimePoint /*time
     const AZ::Vector3 forward = worldTransform.GetBasisY();
     const AZ::Vector3 up = worldTransform.GetBasisZ();
 
-    const AZ::Vector3 movement = (forward * m_movement.y) + (right * m_movement.x) + (up * m_movement.z);
+    const AZ::Vector3 movement = (forward * m_movement.GetY()) + (right * m_movement.GetX()) + (up * m_movement.GetZ());
     const AZ::Vector3 newPosition = worldTransform.GetTranslation() + (movement * moveSpeed);
     worldTransform.SetTranslation(newPosition);
-
-    const Vec2 invertedRotation(m_InvertRotationInputAxisX ? m_rotation.x : -m_rotation.x,
-        m_InvertRotationInputAxisY ? m_rotation.y : -m_rotation.y);
-
-    // Update rotation (not sure how to do this properly using just AZ::Quaternion)
-    const Vector3 rotation = worldTransform.GetRotation().GetEulerDegreesZYX();
-    const Vector3 newRotation = rotation + Vector3(invertedRotation.y, 0.f, invertedRotation.x) * m_rotationSpeed;
-    worldTransform.SetRotation(Quaternion::CreateFromEulerDegreesZYX(newRotation));
+            
+    const float deltaPitch = m_rotation.GetY() * -Invert(m_InvertRotationInputAxisY);
+    const float deltaYaw = m_rotation.GetX() * -Invert(m_InvertRotationInputAxisX);
+    
+    m_rotation = AZ::Vector2::CreateZero();
+    
+    const AZ::Vector3 currentRotation = worldTransform.GetRotation().GetEulerDegreesZYX();
+    const AZ::Vector3 newRotaion = currentRotation + AZ::Vector3(deltaPitch, 0.0f, deltaYaw) * m_rotationSpeed;
+    worldTransform.SetRotation(Quaternion::CreateFromEulerDegreesZYX(newRotaion));
 
     AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, worldTransform);
 }
@@ -219,8 +226,9 @@ bool FlyCameraInputComponent::OnInputChannelEventFiltered(const InputChannel& in
         {
             float defaultViewWidth = GetViewWidth();
             float defaultViewHeight = GetViewHeight();
-            const Vec2 screenPosition(positionData2D->m_normalizedPosition.GetX() * defaultViewWidth,
-                                      positionData2D->m_normalizedPosition.GetY() * defaultViewHeight);
+            
+            const AZ::Vector2 screenPosition(positionData2D->m_normalizedPosition.GetX() * defaultViewWidth,
+                                             positionData2D->m_normalizedPosition.GetY() * defaultViewHeight);
             OnTouchEvent(inputChannel, screenPosition);
         }
     }
@@ -245,15 +253,15 @@ bool FlyCameraInputComponent::GetIsEnabled()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-float Snap_s360(float val)
+float Clamp360Deg(float val)
 {
     if (val < 0.0f)
     {
-        val = f32(360.0f + fmodf(val, 360.0f));
+        val =  aznumeric_cast<float>(360.0f + AZStd::fmod(val, 360.0f));
     }
     else if (val >= 360.0f)
     {
-        val = f32(fmodf(val, 360.0f));
+        val =  aznumeric_cast<float>(AZStd::fmod(val, 360.0f));
     }
     return val;
 }
@@ -264,11 +272,15 @@ void FlyCameraInputComponent::OnMouseEvent(const InputChannel& inputChannel)
     const InputChannelId& channelId = inputChannel.GetInputChannelId();
     if (channelId == InputDeviceMouse::Movement::X)
     {
-        m_rotation.x = Snap_s360(inputChannel.GetValue() * m_mouseSensitivity);
+        m_rotation.SetX(
+            Clamp360Deg(m_rotation.GetX() + inputChannel.GetValue() * m_mouseSensitivity)
+        );
     }
     else if (channelId == InputDeviceMouse::Movement::Y)
     {
-        m_rotation.y = Snap_s360(inputChannel.GetValue() * m_mouseSensitivity);
+        m_rotation.SetY(
+            Clamp360Deg(m_rotation.GetY() + inputChannel.GetValue() * m_mouseSensitivity)
+        );
     }
 }
 
@@ -283,32 +295,32 @@ void FlyCameraInputComponent::OnKeyboardEvent(const InputChannel& inputChannel)
     const InputChannelId& channelId = inputChannel.GetInputChannelId();
     if (channelId == InputDeviceKeyboard::Key::AlphanumericW)
     {
-        m_movement.y = inputChannel.GetValue();
+        m_movement.SetY(inputChannel.GetValue());
     }
     
     if (channelId == InputDeviceKeyboard::Key::AlphanumericA)
     {
-        m_movement.x = -inputChannel.GetValue();
+        m_movement.SetX(-inputChannel.GetValue());
     }
     
     if (channelId == InputDeviceKeyboard::Key::AlphanumericS)
     {
-        m_movement.y = -inputChannel.GetValue();
+        m_movement.SetY(-inputChannel.GetValue());
     }
     
     if (channelId == InputDeviceKeyboard::Key::AlphanumericD)
     {
-        m_movement.x = inputChannel.GetValue();
+        m_movement.SetX(inputChannel.GetValue());
     }
 
     if(channelId == InputDeviceKeyboard::Key::AlphanumericE)
     {
-        m_movement.z = inputChannel.GetValue();
+        m_movement.SetZ(inputChannel.GetValue());
     }
 
     if(channelId == InputDeviceKeyboard::Key::AlphanumericQ)
     {
-        m_movement.z = -inputChannel.GetValue();
+        m_movement.SetZ(-inputChannel.GetValue());
     }
 }
 
@@ -318,42 +330,42 @@ void FlyCameraInputComponent::OnGamepadEvent(const InputChannel& inputChannel)
     const InputChannelId& channelId = inputChannel.GetInputChannelId();
     if (channelId == InputDeviceGamepad::ThumbStickAxis1D::LX)
     {
-        m_movement.x = inputChannel.GetValue();
+        m_movement.SetX(inputChannel.GetValue());
     }
     
     if (channelId == InputDeviceGamepad::ThumbStickAxis1D::LY)
     {
-        m_movement.y = inputChannel.GetValue();
+        m_movement.SetY(inputChannel.GetValue());
     }
 
     if (channelId == InputDeviceGamepad::Trigger::L2)
     {
-        m_movement.z = -inputChannel.GetValue();
+        m_movement.SetZ(-inputChannel.GetValue());
     }
 
     if (channelId == InputDeviceGamepad::Trigger::R2)
     {
-        m_movement.z = inputChannel.GetValue();
+        m_movement.SetZ(inputChannel.GetValue());
     }
 
     if (channelId == InputDeviceGamepad::ThumbStickAxis1D::RX)
     {
-        m_rotation.x = inputChannel.GetValue();
+        m_rotation.SetX(inputChannel.GetValue());
     }
     
     if (channelId == InputDeviceGamepad::ThumbStickAxis1D::RY)
     {
-        m_rotation.y = inputChannel.GetValue();
+        m_rotation.SetY(inputChannel.GetValue());
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void FlyCameraInputComponent::OnTouchEvent(const InputChannel& inputChannel, const Vec2& screenPosition)
+void FlyCameraInputComponent::OnTouchEvent(const InputChannel& inputChannel, const AZ::Vector2& screenPosition)
 {
     if (inputChannel.IsStateBegan())
     {
         const float screenCentreX = GetViewWidth() * 0.5f;
-        if (screenPosition.x <= screenCentreX)
+        if (screenPosition.GetX() <= screenCentreX)
         {
             if (m_leftFingerId == UnknownInputChannelId)
             {
@@ -387,7 +399,7 @@ void FlyCameraInputComponent::OnTouchEvent(const InputChannel& inputChannel, con
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void FlyCameraInputComponent::OnVirtualLeftThumbstickEvent(const InputChannel& inputChannel, const Vec2& screenPosition)
+void FlyCameraInputComponent::OnVirtualLeftThumbstickEvent(const InputChannel& inputChannel, const AZ::Vector2& screenPosition)
 {
     if (inputChannel.GetInputChannelId().GetNameCrc32() != m_leftFingerId)
     {
@@ -400,7 +412,7 @@ void FlyCameraInputComponent::OnVirtualLeftThumbstickEvent(const InputChannel& i
         {
             // Stop movement
             m_leftFingerId = UnknownInputChannelId;
-            m_movement = ZERO;
+            m_movement = AZ::Vector3::CreateZero();
         }
         break;
 
@@ -410,11 +422,11 @@ void FlyCameraInputComponent::OnVirtualLeftThumbstickEvent(const InputChannel& i
             const float discRadius = GetViewWidth() * m_virtualThumbstickRadiusAsPercentageOfScreenWidth;
             const float distScalar = 1.0f / discRadius;
 
-            Vec2 dist = screenPosition - m_leftDownPosition;
+            AZ::Vector2 dist = screenPosition - m_leftDownPosition;
             dist *= distScalar;
 
-            m_movement.x = AZ::GetClamp(dist.x, -1.0f, 1.0f);
-            m_movement.y = AZ::GetClamp(-dist.y, -1.0f, 1.0f);
+            m_movement.SetX(AZ::GetClamp(dist.GetX(), -1.0f, 1.0f));
+            m_movement.SetY(AZ::GetClamp(-dist.GetY(), -1.0f, 1.0f));
 
             DrawThumbstick(m_leftDownPosition, screenPosition, m_thumbstickTextureId);
         }
@@ -423,7 +435,7 @@ void FlyCameraInputComponent::OnVirtualLeftThumbstickEvent(const InputChannel& i
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void FlyCameraInputComponent::OnVirtualRightThumbstickEvent(const InputChannel& inputChannel, const Vec2& screenPosition)
+void FlyCameraInputComponent::OnVirtualRightThumbstickEvent(const InputChannel& inputChannel, const AZ::Vector2& screenPosition)
 {
     if (inputChannel.GetInputChannelId().GetNameCrc32() != m_rightFingerId)
     {
@@ -436,7 +448,7 @@ void FlyCameraInputComponent::OnVirtualRightThumbstickEvent(const InputChannel& 
         {
             // Stop rotation
             m_rightFingerId = UnknownInputChannelId;
-            m_rotation = ZERO;
+            m_rotation = AZ::Vector2::CreateZero();
         }
         break;
 
@@ -446,11 +458,11 @@ void FlyCameraInputComponent::OnVirtualRightThumbstickEvent(const InputChannel& 
             const float discRadius = GetViewWidth() * m_virtualThumbstickRadiusAsPercentageOfScreenWidth;
             const float distScalar = 1.0f / discRadius;
 
-            Vec2 dist = screenPosition - m_rightDownPosition;
+            AZ::Vector2 dist = screenPosition - m_rightDownPosition;
             dist *= distScalar;
 
-            m_rotation.x = AZ::GetClamp(dist.x, -1.0f, 1.0f);
-            m_rotation.y = AZ::GetClamp(dist.y, -1.0f, 1.0f);
+            m_rotation.SetX(AZ::GetClamp(dist.GetX(), -1.0f, 1.0f));
+            m_rotation.SetY(AZ::GetClamp(dist.GetY(), -1.0f, 1.0f));
 
             DrawThumbstick(m_rightDownPosition, screenPosition, m_thumbstickTextureId);
         }
@@ -473,4 +485,3 @@ float FlyCameraInputComponent::GetViewHeight() const
     Camera::CameraRequestBus::EventResult(viewHeight, GetEntityId(), &Camera::CameraRequestBus::Events::GetFrustumHeight);
     return viewHeight;
 }
-

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.h
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.h
@@ -5,11 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #pragma once
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzFramework/Input/Events/InputChannelEventListener.h>
-#include <Cry_Math.h>
+
 #include <AtomBridge/FlyCameraInputBus.h>
 
 namespace AZ
@@ -51,9 +53,9 @@ namespace AZ
             void OnMouseEvent(const AzFramework::InputChannel& inputChannel);
             void OnKeyboardEvent(const AzFramework::InputChannel& inputChannel);
             void OnGamepadEvent(const AzFramework::InputChannel& inputChannel);
-            void OnTouchEvent(const AzFramework::InputChannel& inputChannel, const Vec2& screenPosition);
-            void OnVirtualLeftThumbstickEvent(const AzFramework::InputChannel& inputChannel, const Vec2& screenPosition);
-            void OnVirtualRightThumbstickEvent(const AzFramework::InputChannel& inputChannel, const Vec2& screenPosition);
+            void OnTouchEvent(const AzFramework::InputChannel& inputChannel, const AZ::Vector2& screenPosition);
+            void OnVirtualLeftThumbstickEvent(const AzFramework::InputChannel& inputChannel, const AZ::Vector2& screenPosition);
+            void OnVirtualRightThumbstickEvent(const AzFramework::InputChannel& inputChannel, const AZ::Vector2& screenPosition);
 
             float GetViewWidth() const;
             float GetViewHeight() const;
@@ -73,13 +75,13 @@ namespace AZ
             bool m_isEnabled = true;
 
             // Run-time Properties
-            Vec3 m_movement = ZERO;
-            Vec2 m_rotation = ZERO;
+            AZ::Vector3 m_movement = AZ::Vector3::CreateZero(); ///< Movement per tick
+            AZ::Vector2 m_rotation = AZ::Vector2::CreateZero(); ///< Accumulated rotation input per tick
 
-            Vec2 m_leftDownPosition = ZERO;
+            AZ::Vector2 m_leftDownPosition = AZ::Vector2::CreateZero();
             AZ::Crc32 m_leftFingerId = UnknownInputChannelId;
 
-            Vec2 m_rightDownPosition = ZERO;
+            AZ::Vector2 m_rightDownPosition = AZ::Vector2::CreateZero();
             AZ::Crc32 m_rightFingerId = UnknownInputChannelId;
 
             int m_thumbstickTextureId = 0;


### PR DESCRIPTION
## What does this PR do?
Previously, the `FlyCameraInputComponent` exhibited choppy camera movement when using a mouse, particularly at high polling rates. This adds mouse delta accumulation instead of overwriting the value each frame, and rearranges the `OnTick` to use a new `constexpr Invert` function.

It also replaces all use of Cry_Math types with O3DE-native math and functions.

_Please add links to any issues, RFCs or other items that are relevant to this PR._
#10672 #19087 #13457 

## How was this PR tested?
Component was tested in editor and full screen game mode, as well as X and Y invert states.

https://github.com/user-attachments/assets/1d7ed13c-1064-40f8-a580-f3576bccd450

