### PR TITLE
(stabilization/26050) Fixes a number of issues with OPS for this release

### DIFF
--- a/Gems/OpenParticleSystem/Assets/Particles/inheritance.particle
+++ b/Gems/OpenParticleSystem/Assets/Particles/inheritance.particle
@@ -32,7 +32,7 @@
                 ]
             },
             "OpenParticle::InheritanceHandler": {
-                "emitterIndex": 0,
+                "emitterIndex": 1,
                 "emitterName": "father",
                 "calculateSpawnRate": true,
                 "spawnRate": 2.0,

--- a/Gems/OpenParticleSystem/Code/Source/Editor/ParticleEditDataConfig.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/ParticleEditDataConfig.cpp
@@ -936,8 +936,8 @@ namespace OpenParticle
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Show)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &OpenParticle::SpawnVelConcentrate::centre, "Centre",
-                        "The centre of the Concentrate.")
+                        AZ::Edit::UIHandlers::Default, &OpenParticle::SpawnVelConcentrate::centre, "Center",
+                        "The center of the Concentrate.")
                     ->DataElement(
                         AZ_CRC("DistCtrlHandler"), &OpenParticle::SpawnVelConcentrate::rateObject, "Rate",
                         "The rate of Concentrate.")

--- a/Gems/OpenParticleSystem/Code/Source/OpenParticleSystemEditorSystemComponent.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/OpenParticleSystemEditorSystemComponent.cpp
@@ -80,7 +80,7 @@ namespace OpenParticleSystem
         options.isPreview = true;
         options.showInMenu = true;
         options.showOnToolsToolbar = true;
-        options.toolbarIcon = ":/stylesheet/img/UI20/toolbar/particle.svg";
+        options.toolbarIcon = ":/OpenParticleSystem/Icons/Particle.svg";
 
         AzToolsFramework::RegisterViewPane<OpenParticleSystemEditor::OpenParticleSystemEditorWindow>(
             "(Preview) Particle Editor", LyViewPane::CategoryTools, options);

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleSystem.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleSystem.cpp
@@ -679,6 +679,20 @@ namespace OpenParticle
         EmitterInstance& instance, AZ::RPI::View& view, int meshIndex)
     {
         AZ_PROFILE_SCOPE(AzCore, "ParticleSystem::RenderParticle");
+        if (!instance.m_objSrg)
+        {
+            // note that sprite and mesh particles use the instance.m_objSrg, but the
+            // ribbon does not.
+            if (drawParam.item.drawArgs.type == SimuCore::ParticleCore::DrawType::LINEAR)
+            {
+                return; // this is a sprite particle
+            }
+            if (meshIndex >= 0)
+            {
+                return; // this is a mesh particle.
+            }
+        }
+
         auto& efd = instance.m_emitterForDrawPair[drawParam.shader.get()];
         auto pipeline = m_particleFp->Fetch(GetPipelineKey(drawParam.item.type));
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
@@ -343,7 +343,7 @@ namespace OpenParticleSystemEditor
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_SPAWN]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_PARTICLES:
-            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Particles"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Particles"), QIcon(":/OpenParticleSystem/Icons/Particle.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_PARTICLES]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_LOCATION:
@@ -367,7 +367,7 @@ namespace OpenParticleSystemEditor
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_FORCE]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_LIGHT:
-            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Light"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Light"), QIcon(":/stylesheet/img/UI20/toolbar/Lighting.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_LIGHT]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_SUBUV:

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleItemWidget.ui
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleItemWidget.ui
@@ -257,7 +257,7 @@ border-radius: 1px;</string>
          </property>
          <property name="icon">
           <iconset resource="../../../../../Code/Framework/AzQtComponents/AzQtComponents/Components/resources.qrc">
-           <normaloff>:/stylesheet/img/UI20/toolbar/particle.svg</normaloff>:/stylesheet/img/UI20/toolbar/particle.svg</iconset>
+           <normaloff>:/OpenParticleSystem/Icons/Particle.svg</normaloff>:/OpenParticleSystem/Icons/Particle.svg</iconset>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
## What does this PR do?

* Fixes a crash issue #19711
* Fixes the missing icons on toolbar as well as inside the particle editor.
* Fixes an invalid particle system itself, with wrong parenting info
* Fixes spelling "colour" to "color" in the particle editor

**Icons present in the particle editor and properties**
<img width="863" height="870" alt="Screenshot 2026-04-23 084223" src="https://github.com/user-attachments/assets/17f111e2-e9d4-4f69-93ca-e77fc4b3cc8f" />

**Toolbar**
<img width="902" height="188" alt="Screenshot 2026-04-23 083238" src="https://github.com/user-attachments/assets/111871ce-7f0f-4142-a7d9-82301616bdba" />

## How was this PR tested?

Manual testing.
