### PR TITLE
Colour gradient primitive and QtField

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/ColorGradient.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/ColorGradient.cpp
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/ColorGradient.h>
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <algorithm>
+
+namespace AZ
+{
+    // =======================================================================
+    // Internal Sampling Helpers
+    // =======================================================================
+    // Single-responsibility samplers. Both assume the input vector is sorted
+    // ascending by markerPosition.
+
+    namespace Internal
+    {
+        static AZ::Color SampleColorTrack(float t, const AZStd::vector<ColorGradientMarker>& slider)
+        {
+            if (slider.empty())
+            {
+                return AZ::Color::CreateZero();
+            }
+
+            if (t <= slider.front().markerPosition) { return slider.front().markerColor; }
+            if (t >= slider.back().markerPosition)  { return slider.back().markerColor; }
+
+            for (size_t i = 0; i + 1 < slider.size(); ++i)
+            {
+                const auto& a = slider[i];
+                const auto& b = slider[i + 1];
+                if (t >= a.markerPosition && t <= b.markerPosition)
+                {
+                    const float span = b.markerPosition - a.markerPosition;
+                    const float localT = (span > 0.f) ? (t - a.markerPosition) / span : 0.f;
+                    return a.markerColor.Lerp(b.markerColor, localT);
+                }
+            }
+
+            return slider.back().markerColor;
+        }
+
+        static float SampleAlphaTrack(float t, const AZStd::vector<AlphaGradientMarker>& slider)
+        {
+            if (slider.empty())
+            {
+                return 1.f;
+            }
+
+            if (t <= slider.front().markerPosition) { return slider.front().markerAlpha; }
+            if (t >= slider.back().markerPosition)  { return slider.back().markerAlpha; }
+
+            for (size_t i = 0; i + 1 < slider.size(); ++i)
+            {
+                const auto& a = slider[i];
+                const auto& b = slider[i + 1];
+                if (t >= a.markerPosition && t <= b.markerPosition)
+                {
+                    const float span = b.markerPosition - a.markerPosition;
+                    const float localT = (span > 0.f) ? (t - a.markerPosition) / span : 0.f;
+                    return a.markerAlpha + (b.markerAlpha - a.markerAlpha) * localT;
+                }
+            }
+
+            return slider.back().markerAlpha;
+        }
+
+        static AZ::Color ForceOpaque(const AZ::Color& in)
+        {
+            return AZ::Color(in.GetR(), in.GetG(), in.GetB(), 1.f);
+        }
+
+        template <typename MarkerT>
+        static void SortByPosition(AZStd::vector<MarkerT>& v)
+        {
+            if (v.empty()) { return; }
+            std::sort(
+                v.begin(), v.end(),
+                [](const MarkerT& a, const MarkerT& b) { return a.markerPosition < b.markerPosition; });
+        }
+    }
+
+    // =======================================================================
+    // ColorGradientMarker Reflection
+    // =======================================================================
+
+    void ColorGradientMarker::Reflect(ReflectContext* context)
+    {
+        if (auto* sc = azrtti_cast<SerializeContext*>(context))
+        {
+            sc->Class<ColorGradientMarker>()
+                ->Version(1)
+                ->Field("markerColor", &ColorGradientMarker::markerColor)
+                ->Field("markerPosition", &ColorGradientMarker::markerPosition)
+                ;
+
+            if (EditContext* ec = sc->GetEditContext())
+            {
+                ec->Class<ColorGradientMarker>("ColorGradientMarker", "Pins an RGB color at a normalized position along the gradient.")
+                    ->DataElement(nullptr, &ColorGradientMarker::markerColor, "Color", "The RGB color at this marker.")
+                    ->DataElement(nullptr, &ColorGradientMarker::markerPosition, "Position", "Normalized position in [0,1].")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1.f)
+                    ;
+            }
+        }
+
+        if (auto* bc = azrtti_cast<BehaviorContext*>(context))
+        {
+            bc->Class<ColorGradientMarker>("ColorGradientMarker")
+                ->Attribute(AZ::Script::Attributes::Category, "Color Gradient")
+                ->Property("markerColor", BehaviorValueProperty(&ColorGradientMarker::markerColor))
+                ->Property("markerPosition", BehaviorValueProperty(&ColorGradientMarker::markerPosition))
+                ;
+        }
+    }
+
+    // =======================================================================
+    // AlphaGradientMarker Reflection
+    // =======================================================================
+
+    void AlphaGradientMarker::Reflect(ReflectContext* context)
+    {
+        if (auto* sc = azrtti_cast<SerializeContext*>(context))
+        {
+            sc->Class<AlphaGradientMarker>()
+                ->Version(1)
+                ->Field("markerAlpha", &AlphaGradientMarker::markerAlpha)
+                ->Field("markerPosition", &AlphaGradientMarker::markerPosition)
+                ;
+
+            if (EditContext* ec = sc->GetEditContext())
+            {
+                ec->Class<AlphaGradientMarker>("AlphaGradientMarker", "Pins a scalar opacity at a normalized position along the gradient.")
+                    ->DataElement(nullptr, &AlphaGradientMarker::markerAlpha, "Alpha", "Opacity at this marker, in [0,1].")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1.f)
+                    ->DataElement(nullptr, &AlphaGradientMarker::markerPosition, "Position", "Normalized position in [0,1].")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1.f)
+                    ;
+            }
+        }
+
+        if (auto* bc = azrtti_cast<BehaviorContext*>(context))
+        {
+            bc->Class<AlphaGradientMarker>("AlphaGradientMarker")
+                ->Attribute(AZ::Script::Attributes::Category, "Color Gradient")
+                ->Property("markerAlpha", BehaviorValueProperty(&AlphaGradientMarker::markerAlpha))
+                ->Property("markerPosition", BehaviorValueProperty(&AlphaGradientMarker::markerPosition))
+                ;
+        }
+    }
+
+    // =======================================================================
+    // ColorGradient (RGBA)
+    // =======================================================================
+
+    void ColorGradient::SortGradients()
+    {
+        Internal::SortByPosition(colorSlider);
+        Internal::SortByPosition(alphaSlider);
+        sorted = true;
+    }
+
+    AZ::Color ColorGradient::EvaluateColor(float t)
+    {
+        if (!sorted) { SortGradients(); }
+        return Internal::ForceOpaque(Internal::SampleColorTrack(t, colorSlider));
+    }
+
+    float ColorGradient::EvaluateAlpha(float t)
+    {
+        if (!sorted) { SortGradients(); }
+        return Internal::SampleAlphaTrack(t, alphaSlider);
+    }
+
+    AZ::Color ColorGradient::EvaluateGradient(float t)
+    {
+        if (!sorted) { SortGradients(); }
+        const AZ::Color rgb = Internal::SampleColorTrack(t, colorSlider);
+        const float a = Internal::SampleAlphaTrack(t, alphaSlider);
+        return AZ::Color(rgb.GetR(), rgb.GetG(), rgb.GetB(), a);
+    }
+
+    void ColorGradient::Reflect(ReflectContext* context)
+    {
+        if (auto* sc = azrtti_cast<SerializeContext*>(context))
+        {
+            sc->Class<ColorGradient>()
+                ->Version(1)
+                ->Field("colorSlider", &ColorGradient::colorSlider)
+                ->Field("alphaSlider", &ColorGradient::alphaSlider)
+                ;
+
+            if (EditContext* ec = sc->GetEditContext())
+            {
+                ec->Class<ColorGradient>("Color Gradient", "RGB and alpha gradient sampled by a normalized position in [0,1].")
+                    ->DataElement(nullptr, &ColorGradient::colorSlider, "Color Slider", "Color track markers.")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true)
+                    ->DataElement(nullptr, &ColorGradient::alphaSlider, "Alpha Slider", "Alpha track markers.")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true)
+                    ;
+            }
+        }
+
+        if (auto* bc = azrtti_cast<BehaviorContext*>(context))
+        {
+            bc->Class<ColorGradient>("ColorGradient")
+                ->Attribute(AZ::Script::Attributes::Category, "Color Gradient")
+                ->Method("EvaluateColor", &ColorGradient::EvaluateColor)
+                ->Method("EvaluateAlpha", &ColorGradient::EvaluateAlpha)
+                ->Method("EvaluateGradient", &ColorGradient::EvaluateGradient)
+                ->Method("SortGradients", &ColorGradient::SortGradients)
+                ;
+        }
+    }
+
+    // =======================================================================
+    // ColorGradientRGB (RGB only)
+    // =======================================================================
+
+    void ColorGradientRGB::SortGradients()
+    {
+        Internal::SortByPosition(colorSlider);
+        sorted = true;
+    }
+
+    AZ::Color ColorGradientRGB::EvaluateColor(float t)
+    {
+        if (!sorted) { SortGradients(); }
+        return Internal::ForceOpaque(Internal::SampleColorTrack(t, colorSlider));
+    }
+
+    void ColorGradientRGB::Reflect(ReflectContext* context)
+    {
+        if (auto* sc = azrtti_cast<SerializeContext*>(context))
+        {
+            sc->Class<ColorGradientRGB>()
+                ->Version(1)
+                ->Field("colorSlider", &ColorGradientRGB::colorSlider)
+                ;
+
+            if (EditContext* ec = sc->GetEditContext())
+            {
+                ec->Class<ColorGradientRGB>("Color Gradient (RGB)", "RGB-only gradient sampled by a normalized position in [0,1].")
+                    ->DataElement(nullptr, &ColorGradientRGB::colorSlider, "Color Slider", "Color track markers.")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true)
+                    ;
+            }
+        }
+
+        if (auto* bc = azrtti_cast<BehaviorContext*>(context))
+        {
+            bc->Class<ColorGradientRGB>("ColorGradientRGB")
+                ->Attribute(AZ::Script::Attributes::Category, "Color Gradient")
+                ->Method("EvaluateColor", &ColorGradientRGB::EvaluateColor)
+                ->Method("SortGradients", &ColorGradientRGB::SortGradients)
+                ;
+        }
+    }
+}

--- a/Code/Framework/AzCore/AzCore/Math/ColorGradient.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/ColorGradient.cpp
@@ -20,59 +20,58 @@ namespace AZ
     // =======================================================================
     // Internal Sampling Helpers
     // =======================================================================
-    // Single-responsibility samplers. Both assume the input vector is sorted
-    // ascending by markerPosition.
+    // One templated sampler covers both tracks. Caller supplies the empty
+    // fallback, a value accessor that pulls the marker's value field, and a
+    // lerp callable. Assumes the input vector is sorted ascending by
+    // m_markerPosition.
 
     namespace Internal
     {
-        static AZ::Color SampleColorTrack(float t, const AZStd::vector<ColorGradientMarker>& slider)
+        template <typename MarkerT, typename ValueT, typename ValueOf, typename Lerp>
+        static ValueT SampleTrack(
+            float t,
+            const AZStd::vector<MarkerT>& slider,
+            ValueT emptyFallback,
+            ValueOf valueOf,
+            Lerp lerp)
         {
             if (slider.empty())
             {
-                return AZ::Color::CreateZero();
+                return emptyFallback;
             }
 
-            if (t <= slider.front().markerPosition) { return slider.front().markerColor; }
-            if (t >= slider.back().markerPosition)  { return slider.back().markerColor; }
+            if (t <= slider.front().m_markerPosition) { return valueOf(slider.front()); }
+            if (t >= slider.back().m_markerPosition)  { return valueOf(slider.back()); }
 
             for (size_t i = 0; i + 1 < slider.size(); ++i)
             {
                 const auto& a = slider[i];
                 const auto& b = slider[i + 1];
-                if (t >= a.markerPosition && t <= b.markerPosition)
+                if (t >= a.m_markerPosition && t <= b.m_markerPosition)
                 {
-                    const float span = b.markerPosition - a.markerPosition;
-                    const float localT = (span > 0.f) ? (t - a.markerPosition) / span : 0.f;
-                    return a.markerColor.Lerp(b.markerColor, localT);
+                    const float span = b.m_markerPosition - a.m_markerPosition;
+                    const float localT = (span > 0.f) ? (t - a.m_markerPosition) / span : 0.f;
+                    return lerp(valueOf(a), valueOf(b), localT);
                 }
             }
 
-            return slider.back().markerColor;
+            return valueOf(slider.back());
+        }
+
+        static AZ::Color SampleColorTrack(float t, const AZStd::vector<ColorGradientMarker>& slider)
+        {
+            return SampleTrack<ColorGradientMarker, AZ::Color>(
+                t, slider, AZ::Color::CreateZero(),
+                [](const ColorGradientMarker& m) { return m.m_markerColor; },
+                [](const AZ::Color& a, const AZ::Color& b, float l) { return a.Lerp(b, l); });
         }
 
         static float SampleAlphaTrack(float t, const AZStd::vector<AlphaGradientMarker>& slider)
         {
-            if (slider.empty())
-            {
-                return 1.f;
-            }
-
-            if (t <= slider.front().markerPosition) { return slider.front().markerAlpha; }
-            if (t >= slider.back().markerPosition)  { return slider.back().markerAlpha; }
-
-            for (size_t i = 0; i + 1 < slider.size(); ++i)
-            {
-                const auto& a = slider[i];
-                const auto& b = slider[i + 1];
-                if (t >= a.markerPosition && t <= b.markerPosition)
-                {
-                    const float span = b.markerPosition - a.markerPosition;
-                    const float localT = (span > 0.f) ? (t - a.markerPosition) / span : 0.f;
-                    return a.markerAlpha + (b.markerAlpha - a.markerAlpha) * localT;
-                }
-            }
-
-            return slider.back().markerAlpha;
+            return SampleTrack<AlphaGradientMarker, float>(
+                t, slider, 1.f,
+                [](const AlphaGradientMarker& m) { return m.m_markerAlpha; },
+                [](float a, float b, float l) { return a + (b - a) * l; });
         }
 
         static AZ::Color ForceOpaque(const AZ::Color& in)
@@ -86,7 +85,7 @@ namespace AZ
             if (v.empty()) { return; }
             std::sort(
                 v.begin(), v.end(),
-                [](const MarkerT& a, const MarkerT& b) { return a.markerPosition < b.markerPosition; });
+                [](const MarkerT& a, const MarkerT& b) { return a.m_markerPosition < b.m_markerPosition; });
         }
     }
 
@@ -100,15 +99,15 @@ namespace AZ
         {
             sc->Class<ColorGradientMarker>()
                 ->Version(1)
-                ->Field("markerColor", &ColorGradientMarker::markerColor)
-                ->Field("markerPosition", &ColorGradientMarker::markerPosition)
+                ->Field("markerColor", &ColorGradientMarker::m_markerColor)
+                ->Field("markerPosition", &ColorGradientMarker::m_markerPosition)
                 ;
 
             if (EditContext* ec = sc->GetEditContext())
             {
                 ec->Class<ColorGradientMarker>("ColorGradientMarker", "Pins an RGB color at a normalized position along the gradient.")
-                    ->DataElement(nullptr, &ColorGradientMarker::markerColor, "Color", "The RGB color at this marker.")
-                    ->DataElement(nullptr, &ColorGradientMarker::markerPosition, "Position", "Normalized position in [0,1].")
+                    ->DataElement(nullptr, &ColorGradientMarker::m_markerColor, "Color", "The RGB color at this marker.")
+                    ->DataElement(nullptr, &ColorGradientMarker::m_markerPosition, "Position", "Normalized position in [0,1].")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.f)
                         ->Attribute(AZ::Edit::Attributes::Max, 1.f)
                     ;
@@ -119,8 +118,8 @@ namespace AZ
         {
             bc->Class<ColorGradientMarker>("ColorGradientMarker")
                 ->Attribute(AZ::Script::Attributes::Category, "Color Gradient")
-                ->Property("markerColor", BehaviorValueProperty(&ColorGradientMarker::markerColor))
-                ->Property("markerPosition", BehaviorValueProperty(&ColorGradientMarker::markerPosition))
+                ->Property("markerColor", BehaviorValueProperty(&ColorGradientMarker::m_markerColor))
+                ->Property("markerPosition", BehaviorValueProperty(&ColorGradientMarker::m_markerPosition))
                 ;
         }
     }
@@ -135,17 +134,17 @@ namespace AZ
         {
             sc->Class<AlphaGradientMarker>()
                 ->Version(1)
-                ->Field("markerAlpha", &AlphaGradientMarker::markerAlpha)
-                ->Field("markerPosition", &AlphaGradientMarker::markerPosition)
+                ->Field("markerAlpha", &AlphaGradientMarker::m_markerAlpha)
+                ->Field("markerPosition", &AlphaGradientMarker::m_markerPosition)
                 ;
 
             if (EditContext* ec = sc->GetEditContext())
             {
                 ec->Class<AlphaGradientMarker>("AlphaGradientMarker", "Pins a scalar opacity at a normalized position along the gradient.")
-                    ->DataElement(nullptr, &AlphaGradientMarker::markerAlpha, "Alpha", "Opacity at this marker, in [0,1].")
+                    ->DataElement(nullptr, &AlphaGradientMarker::m_markerAlpha, "Alpha", "Opacity at this marker, in [0,1].")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.f)
                         ->Attribute(AZ::Edit::Attributes::Max, 1.f)
-                    ->DataElement(nullptr, &AlphaGradientMarker::markerPosition, "Position", "Normalized position in [0,1].")
+                    ->DataElement(nullptr, &AlphaGradientMarker::m_markerPosition, "Position", "Normalized position in [0,1].")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.f)
                         ->Attribute(AZ::Edit::Attributes::Max, 1.f)
                     ;
@@ -156,8 +155,8 @@ namespace AZ
         {
             bc->Class<AlphaGradientMarker>("AlphaGradientMarker")
                 ->Attribute(AZ::Script::Attributes::Category, "Color Gradient")
-                ->Property("markerAlpha", BehaviorValueProperty(&AlphaGradientMarker::markerAlpha))
-                ->Property("markerPosition", BehaviorValueProperty(&AlphaGradientMarker::markerPosition))
+                ->Property("markerAlpha", BehaviorValueProperty(&AlphaGradientMarker::m_markerAlpha))
+                ->Property("markerPosition", BehaviorValueProperty(&AlphaGradientMarker::m_markerPosition))
                 ;
         }
     }
@@ -168,28 +167,28 @@ namespace AZ
 
     void ColorGradient::SortGradients()
     {
-        Internal::SortByPosition(colorSlider);
-        Internal::SortByPosition(alphaSlider);
-        sorted = true;
+        Internal::SortByPosition(m_colorSlider);
+        Internal::SortByPosition(m_alphaSlider);
+        m_sorted = true;
     }
 
     AZ::Color ColorGradient::EvaluateColor(float t)
     {
-        if (!sorted) { SortGradients(); }
-        return Internal::ForceOpaque(Internal::SampleColorTrack(t, colorSlider));
+        if (!m_sorted) { SortGradients(); }
+        return Internal::ForceOpaque(Internal::SampleColorTrack(t, m_colorSlider));
     }
 
     float ColorGradient::EvaluateAlpha(float t)
     {
-        if (!sorted) { SortGradients(); }
-        return Internal::SampleAlphaTrack(t, alphaSlider);
+        if (!m_sorted) { SortGradients(); }
+        return Internal::SampleAlphaTrack(t, m_alphaSlider);
     }
 
     AZ::Color ColorGradient::EvaluateGradient(float t)
     {
-        if (!sorted) { SortGradients(); }
-        const AZ::Color rgb = Internal::SampleColorTrack(t, colorSlider);
-        const float a = Internal::SampleAlphaTrack(t, alphaSlider);
+        if (!m_sorted) { SortGradients(); }
+        const AZ::Color rgb = Internal::SampleColorTrack(t, m_colorSlider);
+        const float a = Internal::SampleAlphaTrack(t, m_alphaSlider);
         return AZ::Color(rgb.GetR(), rgb.GetG(), rgb.GetB(), a);
     }
 
@@ -199,17 +198,17 @@ namespace AZ
         {
             sc->Class<ColorGradient>()
                 ->Version(1)
-                ->Field("colorSlider", &ColorGradient::colorSlider)
-                ->Field("alphaSlider", &ColorGradient::alphaSlider)
+                ->Field("colorSlider", &ColorGradient::m_colorSlider)
+                ->Field("alphaSlider", &ColorGradient::m_alphaSlider)
                 ;
 
             if (EditContext* ec = sc->GetEditContext())
             {
                 ec->Class<ColorGradient>("Color Gradient", "RGB and alpha gradient sampled by a normalized position in [0,1].")
-                    ->DataElement(nullptr, &ColorGradient::colorSlider, "Color Slider", "Color track markers.")
+                    ->DataElement(nullptr, &ColorGradient::m_colorSlider, "Color Slider", "Color track markers.")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true)
-                    ->DataElement(nullptr, &ColorGradient::alphaSlider, "Alpha Slider", "Alpha track markers.")
+                    ->DataElement(nullptr, &ColorGradient::m_alphaSlider, "Alpha Slider", "Alpha track markers.")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true)
                     ;
@@ -234,14 +233,14 @@ namespace AZ
 
     void ColorGradientRGB::SortGradients()
     {
-        Internal::SortByPosition(colorSlider);
-        sorted = true;
+        Internal::SortByPosition(m_colorSlider);
+        m_sorted = true;
     }
 
     AZ::Color ColorGradientRGB::EvaluateColor(float t)
     {
-        if (!sorted) { SortGradients(); }
-        return Internal::ForceOpaque(Internal::SampleColorTrack(t, colorSlider));
+        if (!m_sorted) { SortGradients(); }
+        return Internal::ForceOpaque(Internal::SampleColorTrack(t, m_colorSlider));
     }
 
     void ColorGradientRGB::Reflect(ReflectContext* context)
@@ -250,13 +249,13 @@ namespace AZ
         {
             sc->Class<ColorGradientRGB>()
                 ->Version(1)
-                ->Field("colorSlider", &ColorGradientRGB::colorSlider)
+                ->Field("colorSlider", &ColorGradientRGB::m_colorSlider)
                 ;
 
             if (EditContext* ec = sc->GetEditContext())
             {
                 ec->Class<ColorGradientRGB>("Color Gradient (RGB)", "RGB-only gradient sampled by a normalized position in [0,1].")
-                    ->DataElement(nullptr, &ColorGradientRGB::colorSlider, "Color Slider", "Color track markers.")
+                    ->DataElement(nullptr, &ColorGradientRGB::m_colorSlider, "Color Slider", "Color track markers.")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true)
                     ;

--- a/Code/Framework/AzCore/AzCore/Math/ColorGradient.h
+++ b/Code/Framework/AzCore/AzCore/Math/ColorGradient.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Color.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/std/containers/vector.h>
+
+namespace AZ
+{
+    class ReflectContext;
+
+    // =======================================================================
+    // Color Gradient Markers
+    // =======================================================================
+    // A ColorGradient is defined by two independent tracks sampled over the
+    // normalized range [0, 1]: a Color track (RGB) and an Alpha track (scalar
+    // opacity). Each track is a list of markers; each marker pins a value at
+    // a position in [0, 1].
+
+    //! Pins an RGB color at a normalized position along a ColorGradient.
+    //! The alpha channel of markerColor is carried for Qt/ColorPicker
+    //! convenience but is forced opaque when sampled.
+    struct AZCORE_API ColorGradientMarker
+    {
+        AZ_TYPE_INFO(ColorGradientMarker, "{3F2A8E14-5B9C-4D7E-A123-6E8F9B0C1D2E}");
+        AZ_CLASS_ALLOCATOR(ColorGradientMarker, AZ::SystemAllocator);
+
+        AZ::Color markerColor = AZ::Color::CreateOne();
+        float     markerPosition = 0.f;
+
+        static void Reflect(ReflectContext* context);
+    };
+
+    //! Pins a scalar opacity at a normalized position along a ColorGradient.
+    struct AZCORE_API AlphaGradientMarker
+    {
+        AZ_TYPE_INFO(AlphaGradientMarker, "{7C4D1F62-9A3B-4E58-B821-5D6A9C0F3E4F}");
+        AZ_CLASS_ALLOCATOR(AlphaGradientMarker, AZ::SystemAllocator);
+
+        float markerAlpha = 1.f;
+        float markerPosition = 0.f;
+
+        static void Reflect(ReflectContext* context);
+    };
+
+    // =======================================================================
+    // Color Gradient (RGBA)
+    // =======================================================================
+    // Samples a composed RGBA color along [0, 1] from an independent Color
+    // track and Alpha track.
+
+    struct AZCORE_API ColorGradient
+    {
+        AZ_TYPE_INFO(ColorGradient, "{E1B5D837-2C94-4A6F-9D73-1F8A4B7E5C90}");
+        AZ_CLASS_ALLOCATOR(ColorGradient, AZ::SystemAllocator);
+
+        AZStd::vector<ColorGradientMarker> colorSlider;
+        AZStd::vector<AlphaGradientMarker> alphaSlider;
+        bool sorted = false;
+
+        //! Sorts both tracks ascending by markerPosition.
+        void SortGradients();
+
+        //! Samples the Color track at t in [0, 1]. Returns RGB with A = 1.
+        AZ::Color EvaluateColor(float t);
+
+        //! Samples the Alpha track at t in [0, 1].
+        float EvaluateAlpha(float t);
+
+        //! Samples both tracks and returns the composed RGBA at t in [0, 1].
+        AZ::Color EvaluateGradient(float t);
+
+        static void Reflect(ReflectContext* context);
+    };
+
+    // =======================================================================
+    // Color Gradient (RGB only)
+    // =======================================================================
+    // Sibling type for fields that do not need an alpha track. Shares the
+    // marker struct and color sampling logic.
+
+    struct AZCORE_API ColorGradientRGB
+    {
+        AZ_TYPE_INFO(ColorGradientRGB, "{A9D4C672-8B31-4F5E-9A47-2E5B8D1C3F04}");
+        AZ_CLASS_ALLOCATOR(ColorGradientRGB, AZ::SystemAllocator);
+
+        AZStd::vector<ColorGradientMarker> colorSlider;
+        bool sorted = false;
+
+        void SortGradients();
+        AZ::Color EvaluateColor(float t);
+
+        static void Reflect(ReflectContext* context);
+    };
+}

--- a/Code/Framework/AzCore/AzCore/Math/ColorGradient.h
+++ b/Code/Framework/AzCore/AzCore/Math/ColorGradient.h
@@ -26,15 +26,15 @@ namespace AZ
     // a position in [0, 1].
 
     //! Pins an RGB color at a normalized position along a ColorGradient.
-    //! The alpha channel of markerColor is carried for Qt/ColorPicker
+    //! The alpha channel of m_markerColor is carried for Qt/ColorPicker
     //! convenience but is forced opaque when sampled.
     struct AZCORE_API ColorGradientMarker
     {
         AZ_TYPE_INFO(ColorGradientMarker, "{3F2A8E14-5B9C-4D7E-A123-6E8F9B0C1D2E}");
         AZ_CLASS_ALLOCATOR(ColorGradientMarker, AZ::SystemAllocator);
 
-        AZ::Color markerColor = AZ::Color::CreateOne();
-        float     markerPosition = 0.f;
+        AZ::Color m_markerColor = AZ::Color::CreateOne();
+        float     m_markerPosition = 0.f;
 
         static void Reflect(ReflectContext* context);
     };
@@ -45,8 +45,8 @@ namespace AZ
         AZ_TYPE_INFO(AlphaGradientMarker, "{7C4D1F62-9A3B-4E58-B821-5D6A9C0F3E4F}");
         AZ_CLASS_ALLOCATOR(AlphaGradientMarker, AZ::SystemAllocator);
 
-        float markerAlpha = 1.f;
-        float markerPosition = 0.f;
+        float m_markerAlpha = 1.f;
+        float m_markerPosition = 0.f;
 
         static void Reflect(ReflectContext* context);
     };
@@ -62,11 +62,11 @@ namespace AZ
         AZ_TYPE_INFO(ColorGradient, "{E1B5D837-2C94-4A6F-9D73-1F8A4B7E5C90}");
         AZ_CLASS_ALLOCATOR(ColorGradient, AZ::SystemAllocator);
 
-        AZStd::vector<ColorGradientMarker> colorSlider;
-        AZStd::vector<AlphaGradientMarker> alphaSlider;
-        bool sorted = false;
+        AZStd::vector<ColorGradientMarker> m_colorSlider;
+        AZStd::vector<AlphaGradientMarker> m_alphaSlider;
+        bool m_sorted = false;
 
-        //! Sorts both tracks ascending by markerPosition.
+        //! Sorts both tracks ascending by m_markerPosition.
         void SortGradients();
 
         //! Samples the Color track at t in [0, 1]. Returns RGB with A = 1.
@@ -92,8 +92,8 @@ namespace AZ
         AZ_TYPE_INFO(ColorGradientRGB, "{A9D4C672-8B31-4F5E-9A47-2E5B8D1C3F04}");
         AZ_CLASS_ALLOCATOR(ColorGradientRGB, AZ::SystemAllocator);
 
-        AZStd::vector<ColorGradientMarker> colorSlider;
-        bool sorted = false;
+        AZStd::vector<ColorGradientMarker> m_colorSlider;
+        bool m_sorted = false;
 
         void SortGradients();
         AZ::Color EvaluateColor(float t);

--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -24,6 +24,7 @@
 #include <AzCore/Math/MathMatrixSerializer.h>
 #include <AzCore/Math/MathVectorSerializer.h>
 #include <AzCore/Math/Color.h>
+#include <AzCore/Math/ColorGradient.h>
 #include <AzCore/Math/ColorSerializer.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Transform.h>
@@ -370,6 +371,10 @@ namespace AZ
             Aabb::Reflect(context);
             Obb::Reflect(context);
             Color::Reflect(context);
+            ColorGradientMarker::Reflect(context);
+            AlphaGradientMarker::Reflect(context);
+            ColorGradient::Reflect(context);
+            ColorGradientRGB::Reflect(context);
             Vector2::Reflect(context);
             Vector3::Reflect(context);
             Vector4::Reflect(context);

--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -254,6 +254,8 @@ namespace AZ
             const static AZ::Crc32 Button = AZ_CRC_CE("Button");
             const static AZ::Crc32 CheckBox = AZ_CRC_CE("CheckBox");
             const static AZ::Crc32 Color = AZ_CRC_CE("Color");
+            const static AZ::Crc32 ColorGradient = AZ_CRC_CE("ColorGradient");
+            const static AZ::Crc32 ColorGradientRGB = AZ_CRC_CE("ColorGradientRGB");
             const static AZ::Crc32 ComboBox = AZ_CRC_CE("ComboBox");
             const static AZ::Crc32 RadioButton = AZ_CRC_CE("RadioButton");
             const static AZ::Crc32 EntityId = AZ_CRC_CE("EntityId");

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -288,6 +288,8 @@ set(FILES
     Math/Color.cpp
     Math/Color.h
     Math/Color.inl
+    Math/ColorGradient.cpp
+    Math/ColorGradient.h
     Math/ColorSerializer.h
     Math/ColorSerializer.cpp
     Math/Crc.cpp
@@ -419,6 +421,8 @@ set(FILES
     Math/PackedVector4.h
     Math/Color.h
     Math/Color.cpp
+    Math/ColorGradient.h
+    Math/ColorGradient.cpp
     Math/ColorSerializer.h
     Math/ColorSerializer.cpp
     Memory/AllocationRecords.cpp

--- a/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
@@ -10,11 +10,12 @@
 #include <AzCore/IO/GenericStreams.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/ColorGradient.h>
-#include <AzCore/Math/MathReflection.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
+
+#include <cmath>
 
 using namespace AZ;
 
@@ -44,17 +45,18 @@ namespace UnitTest
 
         bool GradientsEqual(const ColorGradient& a, const ColorGradient& b)
         {
+            constexpr float kTolerance = 0.001f;
             if (a.colorSlider.size() != b.colorSlider.size()) return false;
             if (a.alphaSlider.size() != b.alphaSlider.size()) return false;
             for (size_t i = 0; i < a.colorSlider.size(); ++i)
             {
-                if (a.colorSlider[i].markerPosition != b.colorSlider[i].markerPosition) return false;
-                if (!(a.colorSlider[i].markerColor == b.colorSlider[i].markerColor)) return false;
+                if (std::fabs(a.colorSlider[i].markerPosition - b.colorSlider[i].markerPosition) > kTolerance) return false;
+                if (!a.colorSlider[i].markerColor.IsClose(b.colorSlider[i].markerColor, kTolerance)) return false;
             }
             for (size_t i = 0; i < a.alphaSlider.size(); ++i)
             {
-                if (a.alphaSlider[i].markerPosition != b.alphaSlider[i].markerPosition) return false;
-                if (a.alphaSlider[i].markerAlpha != b.alphaSlider[i].markerAlpha) return false;
+                if (std::fabs(a.alphaSlider[i].markerPosition - b.alphaSlider[i].markerPosition) > kTolerance) return false;
+                if (std::fabs(a.alphaSlider[i].markerAlpha - b.alphaSlider[i].markerAlpha) > kTolerance) return false;
             }
             return true;
         }
@@ -64,10 +66,12 @@ namespace UnitTest
     // ColorGradient Sampling
     // =======================================================================
 
-    TEST(MATH_ColorGradient, EvaluateColor_EmptyReturnsZero)
+    TEST(MATH_ColorGradient, EvaluateColor_EmptyReturnsBlackOpaque)
     {
+        // EvaluateColor's contract is "RGB with A=1", so an empty color
+        // track samples to opaque black rather than fully transparent zero.
         ColorGradient g;
-        EXPECT_THAT(g.EvaluateColor(0.5f), IsClose(Color::CreateZero()));
+        EXPECT_THAT(g.EvaluateColor(0.5f), IsClose(Color(0.0f, 0.0f, 0.0f, 1.0f)));
     }
 
     TEST(MATH_ColorGradient, EvaluateColor_SingleStopIsConstant)
@@ -189,8 +193,13 @@ namespace UnitTest
         void SetUp() override
         {
             UnitTest::LeakDetectionFixture::SetUp();
+            // SerializeContext's constructor invokes MathReflect internally,
+            // so all AzCore math types - including ColorGradient and its
+            // markers - are already registered. Calling MathReflect again
+            // here would trigger a duplicate-registration error and drop the
+            // second pass's Field() bindings, which is what made the
+            // round-trip fail to find the type's fields.
             m_context = AZStd::make_unique<SerializeContext>();
-            MathReflect(m_context.get());
         }
 
         void TearDown() override

--- a/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
@@ -30,33 +30,33 @@ namespace UnitTest
         ColorGradientMarker MakeColorMarker(const Color& c, float p)
         {
             ColorGradientMarker m;
-            m.markerColor = c;
-            m.markerPosition = p;
+            m.m_markerColor = c;
+            m.m_markerPosition = p;
             return m;
         }
 
         AlphaGradientMarker MakeAlphaMarker(float a, float p)
         {
             AlphaGradientMarker m;
-            m.markerAlpha = a;
-            m.markerPosition = p;
+            m.m_markerAlpha = a;
+            m.m_markerPosition = p;
             return m;
         }
 
         bool GradientsEqual(const ColorGradient& a, const ColorGradient& b)
         {
             constexpr float kTolerance = 0.001f;
-            if (a.colorSlider.size() != b.colorSlider.size()) return false;
-            if (a.alphaSlider.size() != b.alphaSlider.size()) return false;
-            for (size_t i = 0; i < a.colorSlider.size(); ++i)
+            if (a.m_colorSlider.size() != b.m_colorSlider.size()) return false;
+            if (a.m_alphaSlider.size() != b.m_alphaSlider.size()) return false;
+            for (size_t i = 0; i < a.m_colorSlider.size(); ++i)
             {
-                if (std::fabs(a.colorSlider[i].markerPosition - b.colorSlider[i].markerPosition) > kTolerance) return false;
-                if (!a.colorSlider[i].markerColor.IsClose(b.colorSlider[i].markerColor, kTolerance)) return false;
+                if (std::fabs(a.m_colorSlider[i].m_markerPosition - b.m_colorSlider[i].m_markerPosition) > kTolerance) return false;
+                if (!a.m_colorSlider[i].m_markerColor.IsClose(b.m_colorSlider[i].m_markerColor, kTolerance)) return false;
             }
-            for (size_t i = 0; i < a.alphaSlider.size(); ++i)
+            for (size_t i = 0; i < a.m_alphaSlider.size(); ++i)
             {
-                if (std::fabs(a.alphaSlider[i].markerPosition - b.alphaSlider[i].markerPosition) > kTolerance) return false;
-                if (std::fabs(a.alphaSlider[i].markerAlpha - b.alphaSlider[i].markerAlpha) > kTolerance) return false;
+                if (std::fabs(a.m_alphaSlider[i].m_markerPosition - b.m_alphaSlider[i].m_markerPosition) > kTolerance) return false;
+                if (std::fabs(a.m_alphaSlider[i].m_markerAlpha - b.m_alphaSlider[i].m_markerAlpha) > kTolerance) return false;
             }
             return true;
         }
@@ -77,7 +77,7 @@ namespace UnitTest
     TEST(MATH_ColorGradient, EvaluateColor_SingleStopIsConstant)
     {
         ColorGradient g;
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.2f, 0.4f, 0.6f, 1.f), 0.5f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.2f, 0.4f, 0.6f, 1.f), 0.5f));
         EXPECT_THAT(g.EvaluateColor(0.f),  IsClose(Color(0.2f, 0.4f, 0.6f, 1.f)));
         EXPECT_THAT(g.EvaluateColor(0.5f), IsClose(Color(0.2f, 0.4f, 0.6f, 1.f)));
         EXPECT_THAT(g.EvaluateColor(1.f),  IsClose(Color(0.2f, 0.4f, 0.6f, 1.f)));
@@ -86,8 +86,8 @@ namespace UnitTest
     TEST(MATH_ColorGradient, EvaluateColor_LerpsBetweenTwoStops)
     {
         ColorGradient g;
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
         const Color mid = g.EvaluateColor(0.5f);
         EXPECT_NEAR(mid.GetR(), 0.5f, 0.001f);
         EXPECT_NEAR(mid.GetG(), 0.0f, 0.001f);
@@ -98,8 +98,8 @@ namespace UnitTest
     TEST(MATH_ColorGradient, EvaluateColor_ClampsOutsideRange)
     {
         ColorGradient g;
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.1f, 0.2f, 0.3f, 1.f), 0.25f));
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.7f, 0.8f, 0.9f, 1.f), 0.75f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.1f, 0.2f, 0.3f, 1.f), 0.25f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.7f, 0.8f, 0.9f, 1.f), 0.75f));
         EXPECT_THAT(g.EvaluateColor(-1.f), IsClose(Color(0.1f, 0.2f, 0.3f, 1.f)));
         EXPECT_THAT(g.EvaluateColor(2.f),  IsClose(Color(0.7f, 0.8f, 0.9f, 1.f)));
     }
@@ -108,7 +108,7 @@ namespace UnitTest
     {
         ColorGradient g;
         // Even if user stored a translucent color on the color track, EvaluateColor forces A=1.
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.5f, 0.25f, 0.0f), 0.5f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.5f, 0.25f, 0.0f), 0.5f));
         EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, 0.001f);
     }
 
@@ -121,8 +121,8 @@ namespace UnitTest
     TEST(MATH_ColorGradient, EvaluateAlpha_LerpsBetweenTwoStops)
     {
         ColorGradient g;
-        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.f, 0.f));
-        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(1.f, 1.f));
+        g.m_alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.f, 0.f));
+        g.m_alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(1.f, 1.f));
         EXPECT_NEAR(g.EvaluateAlpha(0.25f), 0.25f, 0.001f);
         EXPECT_NEAR(g.EvaluateAlpha(0.75f), 0.75f, 0.001f);
     }
@@ -130,10 +130,10 @@ namespace UnitTest
     TEST(MATH_ColorGradient, EvaluateGradient_CombinesColorAndAlpha)
     {
         ColorGradient g;
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 1.f, 0.f, 1.f), 0.f));
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 0.f, 1.f), 1.f));
-        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.2f, 0.f));
-        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.8f, 1.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 1.f, 0.f, 1.f), 0.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 0.f, 1.f), 1.f));
+        g.m_alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.2f, 0.f));
+        g.m_alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.8f, 1.f));
 
         const Color at25 = g.EvaluateGradient(0.25f);
         EXPECT_NEAR(at25.GetR(), 0.0f,  0.001f);
@@ -149,23 +149,23 @@ namespace UnitTest
     TEST(MATH_ColorGradient, SortGradients_HandlesOutOfOrderInsertion)
     {
         ColorGradient g;
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 1.f));
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 1.f, 0.f, 1.f), 0.5f));
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 0.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 1.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 1.f, 0.f, 1.f), 0.5f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 0.f));
         g.SortGradients();
-        EXPECT_NEAR(g.colorSlider[0].markerPosition, 0.f,  0.001f);
-        EXPECT_NEAR(g.colorSlider[1].markerPosition, 0.5f, 0.001f);
-        EXPECT_NEAR(g.colorSlider[2].markerPosition, 1.f,  0.001f);
+        EXPECT_NEAR(g.m_colorSlider[0].m_markerPosition, 0.f,  0.001f);
+        EXPECT_NEAR(g.m_colorSlider[1].m_markerPosition, 0.5f, 0.001f);
+        EXPECT_NEAR(g.m_colorSlider[2].m_markerPosition, 1.f,  0.001f);
     }
 
     TEST(MATH_ColorGradient, SampleWithoutSort_FirstEvaluateAutoSorts)
     {
         ColorGradient g;
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
-        ASSERT_FALSE(g.sorted);
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
+        ASSERT_FALSE(g.m_sorted);
         const Color mid = g.EvaluateColor(0.5f);
-        EXPECT_TRUE(g.sorted);
+        EXPECT_TRUE(g.m_sorted);
         EXPECT_NEAR(mid.GetR(), 0.5f, 0.001f);
         EXPECT_NEAR(mid.GetB(), 0.5f, 0.001f);
     }
@@ -177,8 +177,8 @@ namespace UnitTest
     TEST(MATH_ColorGradientRGB, EvaluateColor_BehavesLikeColorTrack)
     {
         ColorGradientRGB g;
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
-        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
+        g.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
         EXPECT_NEAR(g.EvaluateColor(0.5f).GetR(), 0.5f, 0.001f);
         EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, 0.001f);
     }
@@ -195,10 +195,7 @@ namespace UnitTest
             UnitTest::LeakDetectionFixture::SetUp();
             // SerializeContext's constructor invokes MathReflect internally,
             // so all AzCore math types - including ColorGradient and its
-            // markers - are already registered. Calling MathReflect again
-            // here would trigger a duplicate-registration error and drop the
-            // second pass's Field() bindings, which is what made the
-            // round-trip fail to find the type's fields.
+            // markers - are already registered.
             m_context = AZStd::make_unique<SerializeContext>();
         }
 
@@ -214,10 +211,10 @@ namespace UnitTest
     TEST_F(ColorGradientReflectionFixture, SerializeRoundTrip_PreservesMarkers)
     {
         ColorGradient original;
-        original.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.1f, 0.2f, 0.3f, 1.f), 0.0f));
-        original.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.7f, 0.8f, 0.9f, 1.f), 1.0f));
-        original.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.25f, 0.0f));
-        original.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.75f, 1.0f));
+        original.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.1f, 0.2f, 0.3f, 1.f), 0.0f));
+        original.m_colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.7f, 0.8f, 0.9f, 1.f), 1.0f));
+        original.m_alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.25f, 0.0f));
+        original.m_alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.75f, 1.0f));
 
         AZStd::vector<char> buffer;
         IO::ByteContainerStream<decltype(buffer)> stream(&buffer);

--- a/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
@@ -6,10 +6,13 @@
  *
  */
 
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/IO/GenericStreams.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/ColorGradient.h>
 #include <AzCore/Math/MathReflection.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/Utils.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
 
@@ -82,10 +85,10 @@ namespace UnitTest
         g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
         g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
         const Color mid = g.EvaluateColor(0.5f);
-        EXPECT_NEAR(mid.GetR(), 0.5f, Constants::Tolerance);
-        EXPECT_NEAR(mid.GetG(), 0.0f, Constants::Tolerance);
-        EXPECT_NEAR(mid.GetB(), 0.5f, Constants::Tolerance);
-        EXPECT_NEAR(mid.GetA(), 1.0f, Constants::Tolerance);
+        EXPECT_NEAR(mid.GetR(), 0.5f, 0.001f);
+        EXPECT_NEAR(mid.GetG(), 0.0f, 0.001f);
+        EXPECT_NEAR(mid.GetB(), 0.5f, 0.001f);
+        EXPECT_NEAR(mid.GetA(), 1.0f, 0.001f);
     }
 
     TEST(MATH_ColorGradient, EvaluateColor_ClampsOutsideRange)
@@ -102,13 +105,13 @@ namespace UnitTest
         ColorGradient g;
         // Even if user stored a translucent color on the color track, EvaluateColor forces A=1.
         g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.5f, 0.25f, 0.0f), 0.5f));
-        EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, Constants::Tolerance);
+        EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, 0.001f);
     }
 
     TEST(MATH_ColorGradient, EvaluateAlpha_EmptyReturnsOne)
     {
         ColorGradient g;
-        EXPECT_NEAR(g.EvaluateAlpha(0.5f), 1.f, Constants::Tolerance);
+        EXPECT_NEAR(g.EvaluateAlpha(0.5f), 1.f, 0.001f);
     }
 
     TEST(MATH_ColorGradient, EvaluateAlpha_LerpsBetweenTwoStops)
@@ -116,8 +119,8 @@ namespace UnitTest
         ColorGradient g;
         g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.f, 0.f));
         g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(1.f, 1.f));
-        EXPECT_NEAR(g.EvaluateAlpha(0.25f), 0.25f, Constants::Tolerance);
-        EXPECT_NEAR(g.EvaluateAlpha(0.75f), 0.75f, Constants::Tolerance);
+        EXPECT_NEAR(g.EvaluateAlpha(0.25f), 0.25f, 0.001f);
+        EXPECT_NEAR(g.EvaluateAlpha(0.75f), 0.75f, 0.001f);
     }
 
     TEST(MATH_ColorGradient, EvaluateGradient_CombinesColorAndAlpha)
@@ -129,14 +132,14 @@ namespace UnitTest
         g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.8f, 1.f));
 
         const Color at25 = g.EvaluateGradient(0.25f);
-        EXPECT_NEAR(at25.GetR(), 0.0f,  Constants::Tolerance);
-        EXPECT_NEAR(at25.GetG(), 0.75f, Constants::Tolerance);
-        EXPECT_NEAR(at25.GetB(), 0.0f,  Constants::Tolerance);
-        EXPECT_NEAR(at25.GetA(), 0.35f, Constants::Tolerance);
+        EXPECT_NEAR(at25.GetR(), 0.0f,  0.001f);
+        EXPECT_NEAR(at25.GetG(), 0.75f, 0.001f);
+        EXPECT_NEAR(at25.GetB(), 0.0f,  0.001f);
+        EXPECT_NEAR(at25.GetA(), 0.35f, 0.001f);
 
         const Color at75 = g.EvaluateGradient(0.75f);
-        EXPECT_NEAR(at75.GetG(), 0.25f, Constants::Tolerance);
-        EXPECT_NEAR(at75.GetA(), 0.65f, Constants::Tolerance);
+        EXPECT_NEAR(at75.GetG(), 0.25f, 0.001f);
+        EXPECT_NEAR(at75.GetA(), 0.65f, 0.001f);
     }
 
     TEST(MATH_ColorGradient, SortGradients_HandlesOutOfOrderInsertion)
@@ -146,9 +149,9 @@ namespace UnitTest
         g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 1.f, 0.f, 1.f), 0.5f));
         g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 0.f));
         g.SortGradients();
-        EXPECT_NEAR(g.colorSlider[0].markerPosition, 0.f,  Constants::Tolerance);
-        EXPECT_NEAR(g.colorSlider[1].markerPosition, 0.5f, Constants::Tolerance);
-        EXPECT_NEAR(g.colorSlider[2].markerPosition, 1.f,  Constants::Tolerance);
+        EXPECT_NEAR(g.colorSlider[0].markerPosition, 0.f,  0.001f);
+        EXPECT_NEAR(g.colorSlider[1].markerPosition, 0.5f, 0.001f);
+        EXPECT_NEAR(g.colorSlider[2].markerPosition, 1.f,  0.001f);
     }
 
     TEST(MATH_ColorGradient, SampleWithoutSort_FirstEvaluateAutoSorts)
@@ -159,8 +162,8 @@ namespace UnitTest
         ASSERT_FALSE(g.sorted);
         const Color mid = g.EvaluateColor(0.5f);
         EXPECT_TRUE(g.sorted);
-        EXPECT_NEAR(mid.GetR(), 0.5f, Constants::Tolerance);
-        EXPECT_NEAR(mid.GetB(), 0.5f, Constants::Tolerance);
+        EXPECT_NEAR(mid.GetR(), 0.5f, 0.001f);
+        EXPECT_NEAR(mid.GetB(), 0.5f, 0.001f);
     }
 
     // =======================================================================
@@ -172,8 +175,8 @@ namespace UnitTest
         ColorGradientRGB g;
         g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
         g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
-        EXPECT_NEAR(g.EvaluateColor(0.5f).GetR(), 0.5f, Constants::Tolerance);
-        EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, Constants::Tolerance);
+        EXPECT_NEAR(g.EvaluateColor(0.5f).GetR(), 0.5f, 0.001f);
+        EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, 0.001f);
     }
 
     // =======================================================================

--- a/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/ColorGradientTests.cpp
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/ColorGradient.h>
+#include <AzCore/Math/MathReflection.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+
+using namespace AZ;
+
+namespace UnitTest
+{
+    // =======================================================================
+    // Helpers
+    // =======================================================================
+
+    namespace GradientTestHelpers
+    {
+        ColorGradientMarker MakeColorMarker(const Color& c, float p)
+        {
+            ColorGradientMarker m;
+            m.markerColor = c;
+            m.markerPosition = p;
+            return m;
+        }
+
+        AlphaGradientMarker MakeAlphaMarker(float a, float p)
+        {
+            AlphaGradientMarker m;
+            m.markerAlpha = a;
+            m.markerPosition = p;
+            return m;
+        }
+
+        bool GradientsEqual(const ColorGradient& a, const ColorGradient& b)
+        {
+            if (a.colorSlider.size() != b.colorSlider.size()) return false;
+            if (a.alphaSlider.size() != b.alphaSlider.size()) return false;
+            for (size_t i = 0; i < a.colorSlider.size(); ++i)
+            {
+                if (a.colorSlider[i].markerPosition != b.colorSlider[i].markerPosition) return false;
+                if (!(a.colorSlider[i].markerColor == b.colorSlider[i].markerColor)) return false;
+            }
+            for (size_t i = 0; i < a.alphaSlider.size(); ++i)
+            {
+                if (a.alphaSlider[i].markerPosition != b.alphaSlider[i].markerPosition) return false;
+                if (a.alphaSlider[i].markerAlpha != b.alphaSlider[i].markerAlpha) return false;
+            }
+            return true;
+        }
+    }
+
+    // =======================================================================
+    // ColorGradient Sampling
+    // =======================================================================
+
+    TEST(MATH_ColorGradient, EvaluateColor_EmptyReturnsZero)
+    {
+        ColorGradient g;
+        EXPECT_THAT(g.EvaluateColor(0.5f), IsClose(Color::CreateZero()));
+    }
+
+    TEST(MATH_ColorGradient, EvaluateColor_SingleStopIsConstant)
+    {
+        ColorGradient g;
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.2f, 0.4f, 0.6f, 1.f), 0.5f));
+        EXPECT_THAT(g.EvaluateColor(0.f),  IsClose(Color(0.2f, 0.4f, 0.6f, 1.f)));
+        EXPECT_THAT(g.EvaluateColor(0.5f), IsClose(Color(0.2f, 0.4f, 0.6f, 1.f)));
+        EXPECT_THAT(g.EvaluateColor(1.f),  IsClose(Color(0.2f, 0.4f, 0.6f, 1.f)));
+    }
+
+    TEST(MATH_ColorGradient, EvaluateColor_LerpsBetweenTwoStops)
+    {
+        ColorGradient g;
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
+        const Color mid = g.EvaluateColor(0.5f);
+        EXPECT_NEAR(mid.GetR(), 0.5f, Constants::Tolerance);
+        EXPECT_NEAR(mid.GetG(), 0.0f, Constants::Tolerance);
+        EXPECT_NEAR(mid.GetB(), 0.5f, Constants::Tolerance);
+        EXPECT_NEAR(mid.GetA(), 1.0f, Constants::Tolerance);
+    }
+
+    TEST(MATH_ColorGradient, EvaluateColor_ClampsOutsideRange)
+    {
+        ColorGradient g;
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.1f, 0.2f, 0.3f, 1.f), 0.25f));
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.7f, 0.8f, 0.9f, 1.f), 0.75f));
+        EXPECT_THAT(g.EvaluateColor(-1.f), IsClose(Color(0.1f, 0.2f, 0.3f, 1.f)));
+        EXPECT_THAT(g.EvaluateColor(2.f),  IsClose(Color(0.7f, 0.8f, 0.9f, 1.f)));
+    }
+
+    TEST(MATH_ColorGradient, EvaluateColor_AlwaysOpaque)
+    {
+        ColorGradient g;
+        // Even if user stored a translucent color on the color track, EvaluateColor forces A=1.
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.5f, 0.25f, 0.0f), 0.5f));
+        EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, Constants::Tolerance);
+    }
+
+    TEST(MATH_ColorGradient, EvaluateAlpha_EmptyReturnsOne)
+    {
+        ColorGradient g;
+        EXPECT_NEAR(g.EvaluateAlpha(0.5f), 1.f, Constants::Tolerance);
+    }
+
+    TEST(MATH_ColorGradient, EvaluateAlpha_LerpsBetweenTwoStops)
+    {
+        ColorGradient g;
+        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.f, 0.f));
+        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(1.f, 1.f));
+        EXPECT_NEAR(g.EvaluateAlpha(0.25f), 0.25f, Constants::Tolerance);
+        EXPECT_NEAR(g.EvaluateAlpha(0.75f), 0.75f, Constants::Tolerance);
+    }
+
+    TEST(MATH_ColorGradient, EvaluateGradient_CombinesColorAndAlpha)
+    {
+        ColorGradient g;
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 1.f, 0.f, 1.f), 0.f));
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 0.f, 1.f), 1.f));
+        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.2f, 0.f));
+        g.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.8f, 1.f));
+
+        const Color at25 = g.EvaluateGradient(0.25f);
+        EXPECT_NEAR(at25.GetR(), 0.0f,  Constants::Tolerance);
+        EXPECT_NEAR(at25.GetG(), 0.75f, Constants::Tolerance);
+        EXPECT_NEAR(at25.GetB(), 0.0f,  Constants::Tolerance);
+        EXPECT_NEAR(at25.GetA(), 0.35f, Constants::Tolerance);
+
+        const Color at75 = g.EvaluateGradient(0.75f);
+        EXPECT_NEAR(at75.GetG(), 0.25f, Constants::Tolerance);
+        EXPECT_NEAR(at75.GetA(), 0.65f, Constants::Tolerance);
+    }
+
+    TEST(MATH_ColorGradient, SortGradients_HandlesOutOfOrderInsertion)
+    {
+        ColorGradient g;
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 1.f));
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 1.f, 0.f, 1.f), 0.5f));
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 0.f));
+        g.SortGradients();
+        EXPECT_NEAR(g.colorSlider[0].markerPosition, 0.f,  Constants::Tolerance);
+        EXPECT_NEAR(g.colorSlider[1].markerPosition, 0.5f, Constants::Tolerance);
+        EXPECT_NEAR(g.colorSlider[2].markerPosition, 1.f,  Constants::Tolerance);
+    }
+
+    TEST(MATH_ColorGradient, SampleWithoutSort_FirstEvaluateAutoSorts)
+    {
+        ColorGradient g;
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
+        ASSERT_FALSE(g.sorted);
+        const Color mid = g.EvaluateColor(0.5f);
+        EXPECT_TRUE(g.sorted);
+        EXPECT_NEAR(mid.GetR(), 0.5f, Constants::Tolerance);
+        EXPECT_NEAR(mid.GetB(), 0.5f, Constants::Tolerance);
+    }
+
+    // =======================================================================
+    // ColorGradientRGB Sampling
+    // =======================================================================
+
+    TEST(MATH_ColorGradientRGB, EvaluateColor_BehavesLikeColorTrack)
+    {
+        ColorGradientRGB g;
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(1.f, 0.f, 0.f, 1.f), 0.f));
+        g.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.f, 0.f, 1.f, 1.f), 1.f));
+        EXPECT_NEAR(g.EvaluateColor(0.5f).GetR(), 0.5f, Constants::Tolerance);
+        EXPECT_NEAR(g.EvaluateColor(0.5f).GetA(), 1.0f, Constants::Tolerance);
+    }
+
+    // =======================================================================
+    // Reflection Round-trip
+    // =======================================================================
+
+    class ColorGradientReflectionFixture : public ::UnitTest::LeakDetectionFixture
+    {
+    public:
+        void SetUp() override
+        {
+            UnitTest::LeakDetectionFixture::SetUp();
+            m_context = AZStd::make_unique<SerializeContext>();
+            MathReflect(m_context.get());
+        }
+
+        void TearDown() override
+        {
+            m_context.reset();
+            UnitTest::LeakDetectionFixture::TearDown();
+        }
+
+        AZStd::unique_ptr<SerializeContext> m_context;
+    };
+
+    TEST_F(ColorGradientReflectionFixture, SerializeRoundTrip_PreservesMarkers)
+    {
+        ColorGradient original;
+        original.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.1f, 0.2f, 0.3f, 1.f), 0.0f));
+        original.colorSlider.push_back(GradientTestHelpers::MakeColorMarker(Color(0.7f, 0.8f, 0.9f, 1.f), 1.0f));
+        original.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.25f, 0.0f));
+        original.alphaSlider.push_back(GradientTestHelpers::MakeAlphaMarker(0.75f, 1.0f));
+
+        AZStd::vector<char> buffer;
+        IO::ByteContainerStream<decltype(buffer)> stream(&buffer);
+        EXPECT_TRUE(Utils::SaveObjectToStream(stream, DataStream::ST_BINARY, &original, m_context.get()));
+
+        stream.Seek(0, IO::GenericStream::ST_SEEK_BEGIN);
+        ColorGradient restored;
+        EXPECT_TRUE(Utils::LoadObjectFromStreamInPlace(stream, restored, m_context.get()));
+
+        EXPECT_TRUE(GradientTestHelpers::GradientsEqual(original, restored));
+    }
+}

--- a/Code/Framework/AzCore/Tests/Math/MathTest.h
+++ b/Code/Framework/AzCore/Tests/Math/MathTest.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Math/MathUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
 
 #if AZ_DEBUG_BUILD
@@ -20,6 +21,13 @@
 
 namespace UnitTest::Constants
 {
+    // Re-export of the canonical AZ::Constants values so test code can write
+    // UnitTest::Constants::Pi etc. without qualifying the engine namespace.
+    static const float Tolerance = AZ::Constants::Tolerance;
+    static const float Pi        = AZ::Constants::Pi;
+    static const float HalfPi    = AZ::Constants::HalfPi;
+    static const float QuarterPi = AZ::Constants::QuarterPi;
+
 #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
     // Larger tolerance is needed when using NEON.
     static const float SimdTolerance = 0.005f;

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -113,6 +113,7 @@ set(FILES
     Math/AabbTests.cpp
     Math/CapsuleTests.cpp
     Math/ColorTests.cpp
+    Math/ColorGradientTests.cpp
     Math/CrcTests.cpp
     Math/CrcTestsCompileTimeLiterals.h
     Math/FrustumTests.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
@@ -190,7 +190,7 @@ namespace AzToolsFramework
 
     float GradientStopsTrack::stopPositionAt(size_t index) const
     {
-        return m_kind == Kind::Color ? m_colorStops[index].markerPosition : m_alphaStops[index].markerPosition;
+        return m_kind == Kind::Color ? m_colorStops[index].m_markerPosition : m_alphaStops[index].m_markerPosition;
     }
 
     int GradientStopsTrack::positionToPixel(float position) const
@@ -250,7 +250,7 @@ namespace AzToolsFramework
     AZ::Color GradientStopsTrack::sampleColorAt(float t) const
     {
         AZ::ColorGradient tmp;
-        tmp.colorSlider = m_colorStops;
+        tmp.m_colorSlider = m_colorStops;
         tmp.SortGradients();
         return tmp.EvaluateColor(t);
     }
@@ -258,7 +258,7 @@ namespace AzToolsFramework
     float GradientStopsTrack::sampleAlphaAt(float t) const
     {
         AZ::ColorGradient tmp;
-        tmp.alphaSlider = m_alphaStops;
+        tmp.m_alphaSlider = m_alphaStops;
         tmp.SortGradients();
         return tmp.EvaluateAlpha(t);
     }
@@ -269,16 +269,16 @@ namespace AzToolsFramework
         if (m_kind == Kind::Color)
         {
             AZ::ColorGradientMarker m;
-            m.markerColor = sampleColorAt(t);
-            m.markerPosition = t;
+            m.m_markerColor = sampleColorAt(t);
+            m.m_markerPosition = t;
             m_colorStops.push_back(m);
             m_selected = m_colorStops.size() - 1;
         }
         else
         {
             AZ::AlphaGradientMarker m;
-            m.markerAlpha = sampleAlphaAt(t);
-            m.markerPosition = t;
+            m.m_markerAlpha = sampleAlphaAt(t);
+            m.m_markerPosition = t;
             m_alphaStops.push_back(m);
             m_selected = m_alphaStops.size() - 1;
         }
@@ -292,8 +292,8 @@ namespace AzToolsFramework
     {
         if (!m_selected.has_value()) { return; }
         t = std::clamp(t, 0.f, 1.f);
-        if (m_kind == Kind::Color) { m_colorStops[*m_selected].markerPosition = t; }
-        else                       { m_alphaStops[*m_selected].markerPosition = t; }
+        if (m_kind == Kind::Color) { m_colorStops[*m_selected].m_markerPosition = t; }
+        else                       { m_alphaStops[*m_selected].m_markerPosition = t; }
         // No consolidation here: a moving marker must pass freely through
         // other stops without consuming them. The evaluator handles coincident
         // positions deterministically.
@@ -305,7 +305,7 @@ namespace AzToolsFramework
     {
         if (m_kind != Kind::Color || !m_selected.has_value()) { return; }
         AZ::Color opaque(rgb.GetR(), rgb.GetG(), rgb.GetB(), 1.f);
-        m_colorStops[*m_selected].markerColor = opaque;
+        m_colorStops[*m_selected].m_markerColor = opaque;
         update();
         emit stopsChanged();
     }
@@ -313,7 +313,7 @@ namespace AzToolsFramework
     void GradientStopsTrack::setSelectedAlpha(float alpha)
     {
         if (m_kind != Kind::Alpha || !m_selected.has_value()) { return; }
-        m_alphaStops[*m_selected].markerAlpha = std::clamp(alpha, 0.f, 1.f);
+        m_alphaStops[*m_selected].m_markerAlpha = std::clamp(alpha, 0.f, 1.f);
         update();
         emit stopsChanged();
     }
@@ -325,14 +325,14 @@ namespace AzToolsFramework
         if (m_kind == Kind::Color)
         {
             auto src = m_colorStops[*m_selected];
-            src.markerPosition = std::clamp(src.markerPosition + offset, 0.f, 1.f);
+            src.m_markerPosition = std::clamp(src.m_markerPosition + offset, 0.f, 1.f);
             m_colorStops.push_back(src);
             m_selected = m_colorStops.size() - 1;
         }
         else
         {
             auto src = m_alphaStops[*m_selected];
-            src.markerPosition = std::clamp(src.markerPosition + offset, 0.f, 1.f);
+            src.m_markerPosition = std::clamp(src.m_markerPosition + offset, 0.f, 1.f);
             m_alphaStops.push_back(src);
             m_selected = m_alphaStops.size() - 1;
         }
@@ -393,7 +393,7 @@ namespace AzToolsFramework
             QColor triFill;
             if (m_kind == Kind::Color)
             {
-                const AZ::Color& c = m_colorStops[i].markerColor;
+                const AZ::Color& c = m_colorStops[i].m_markerColor;
                 triFill.setRedF(static_cast<qreal>(c.GetR()));
                 triFill.setGreenF(static_cast<qreal>(c.GetG()));
                 triFill.setBlueF(static_cast<qreal>(c.GetB()));
@@ -446,7 +446,7 @@ namespace AzToolsFramework
                 painter.fillRect(QRect(cubeInner.left(),        cubeInner.top() + half, half, half), dark);
                 painter.fillRect(QRect(cubeInner.left() + half, cubeInner.top() + half, half, half), light);
 
-                QColor whiteOverlay(255, 255, 255, static_cast<int>(m_alphaStops[i].markerAlpha * 255.f));
+                QColor whiteOverlay(255, 255, 255, static_cast<int>(m_alphaStops[i].m_markerAlpha * 255.f));
                 painter.fillRect(cubeInner, whiteOverlay);
             }
 
@@ -531,9 +531,9 @@ namespace AzToolsFramework
             // Use the standard AzQtComponents color picker so the double-click
             // affordance matches the inline inspector swatch experience.
             const AZ::Color initial(
-                m_colorStops[*m_selected].markerColor.GetR(),
-                m_colorStops[*m_selected].markerColor.GetG(),
-                m_colorStops[*m_selected].markerColor.GetB(),
+                m_colorStops[*m_selected].m_markerColor.GetR(),
+                m_colorStops[*m_selected].m_markerColor.GetG(),
+                m_colorStops[*m_selected].m_markerColor.GetB(),
                 1.f);
             const AZ::Color picked = AzQtComponents::ColorPicker::getColor(
                 AzQtComponents::ColorPicker::Configuration::RGB,
@@ -605,7 +605,7 @@ namespace AzToolsFramework
 
         // Alpha track (top).
         m_alphaTrack = new GradientStopsTrack(GradientStopsTrack::Kind::Alpha, this);
-        m_alphaTrack->setAlphaStops(m_working.alphaSlider);
+        m_alphaTrack->setAlphaStops(m_working.m_alphaSlider);
         m_alphaTrack->setVisible(m_alphaEnabled);
         root->addWidget(m_alphaTrack);
 
@@ -618,7 +618,7 @@ namespace AzToolsFramework
 
         // Color track (bottom).
         m_colorTrack = new GradientStopsTrack(GradientStopsTrack::Kind::Color, this);
-        m_colorTrack->setColorStops(m_working.colorSlider);
+        m_colorTrack->setColorStops(m_working.m_colorSlider);
         root->addWidget(m_colorTrack);
 
         // Inspector row.
@@ -722,9 +722,9 @@ namespace AzToolsFramework
 
     void ColorGradientEditorDialog::rebuildFromTracks()
     {
-        m_working.colorSlider = m_colorTrack->colorStops();
-        m_working.alphaSlider = m_alphaTrack->alphaStops();
-        m_working.sorted = false;
+        m_working.m_colorSlider = m_colorTrack->colorStops();
+        m_working.m_alphaSlider = m_alphaTrack->alphaStops();
+        m_working.m_sorted = false;
         m_working.SortGradients();
         refreshPreview();
     }
@@ -767,7 +767,7 @@ namespace AzToolsFramework
             m_colorField->setVisible(true);
             m_alphaSpin->setVisible(false);
 
-            const AZ::Color& cur = m_activeTrack->colorStops()[idx].markerColor;
+            const AZ::Color& cur = m_activeTrack->colorStops()[idx].m_markerColor;
             QColor q;
             q.setRedF(static_cast<qreal>(cur.GetR()));
             q.setGreenF(static_cast<qreal>(cur.GetG()));
@@ -776,7 +776,7 @@ namespace AzToolsFramework
             m_colorField->setValue(q);
 
             m_positionSpin->blockSignals(true);
-            m_positionSpin->setValue(m_activeTrack->colorStops()[idx].markerPosition * 100.0);
+            m_positionSpin->setValue(m_activeTrack->colorStops()[idx].m_markerPosition * 100.0);
             m_positionSpin->blockSignals(false);
         }
         else
@@ -785,10 +785,10 @@ namespace AzToolsFramework
             m_colorField->setVisible(false);
             m_alphaSpin->setVisible(true);
             m_alphaSpin->blockSignals(true);
-            m_alphaSpin->setValue(static_cast<double>(m_activeTrack->alphaStops()[idx].markerAlpha));
+            m_alphaSpin->setValue(static_cast<double>(m_activeTrack->alphaStops()[idx].m_markerAlpha));
             m_alphaSpin->blockSignals(false);
             m_positionSpin->blockSignals(true);
-            m_positionSpin->setValue(m_activeTrack->alphaStops()[idx].markerPosition * 100.0);
+            m_positionSpin->setValue(m_activeTrack->alphaStops()[idx].m_markerPosition * 100.0);
             m_positionSpin->blockSignals(false);
         }
     }
@@ -1015,16 +1015,16 @@ namespace AzToolsFramework
                        top.colorStops.begin(), top.colorStops.end(),
                        snap.colorStops.begin(),
                        [](const AZ::ColorGradientMarker& a, const AZ::ColorGradientMarker& b) {
-                           return a.markerPosition == b.markerPosition
-                               && a.markerColor == b.markerColor;
+                           return a.m_markerPosition == b.m_markerPosition
+                               && a.m_markerColor == b.m_markerColor;
                        });
             const bool sameAlpha = top.alphaStops.size() == snap.alphaStops.size()
                 && std::equal(
                        top.alphaStops.begin(), top.alphaStops.end(),
                        snap.alphaStops.begin(),
                        [](const AZ::AlphaGradientMarker& a, const AZ::AlphaGradientMarker& b) {
-                           return a.markerPosition == b.markerPosition
-                               && a.markerAlpha == b.markerAlpha;
+                           return a.m_markerPosition == b.m_markerPosition
+                               && a.m_markerAlpha == b.m_markerAlpha;
                        });
             if (sameColor && sameAlpha) { return; }
         }
@@ -1080,9 +1080,9 @@ namespace AzToolsFramework
             m_activeTrack = m_colorTrack;
         }
 
-        m_working.colorSlider = m_colorTrack->colorStops();
-        m_working.alphaSlider = m_alphaTrack->alphaStops();
-        m_working.sorted = false;
+        m_working.m_colorSlider = m_colorTrack->colorStops();
+        m_working.m_alphaSlider = m_alphaTrack->alphaStops();
+        m_working.m_sorted = false;
         m_working.SortGradients();
 
         refreshPreview();
@@ -1156,19 +1156,19 @@ namespace AzToolsFramework
     {
         // Only flag when a subsequent instance diverges from the first one we
         // read. Structural comparison is enough for the indicator.
-        auto sameColor = instance.colorSlider.size() == m_value.colorSlider.size()
+        auto sameColor = instance.m_colorSlider.size() == m_value.m_colorSlider.size()
                       && std::equal(
-                             instance.colorSlider.begin(), instance.colorSlider.end(),
-                             m_value.colorSlider.begin(),
+                             instance.m_colorSlider.begin(), instance.m_colorSlider.end(),
+                             m_value.m_colorSlider.begin(),
                              [](const AZ::ColorGradientMarker& a, const AZ::ColorGradientMarker& b) {
-                                 return a.markerPosition == b.markerPosition && a.markerColor == b.markerColor;
+                                 return a.m_markerPosition == b.m_markerPosition && a.m_markerColor == b.m_markerColor;
                              });
-        auto sameAlpha = instance.alphaSlider.size() == m_value.alphaSlider.size()
+        auto sameAlpha = instance.m_alphaSlider.size() == m_value.m_alphaSlider.size()
                       && std::equal(
-                             instance.alphaSlider.begin(), instance.alphaSlider.end(),
-                             m_value.alphaSlider.begin(),
+                             instance.m_alphaSlider.begin(), instance.m_alphaSlider.end(),
+                             m_value.m_alphaSlider.begin(),
                              [](const AZ::AlphaGradientMarker& a, const AZ::AlphaGradientMarker& b) {
-                                 return a.markerPosition == b.markerPosition && a.markerAlpha == b.markerAlpha;
+                                 return a.m_markerPosition == b.m_markerPosition && a.m_markerAlpha == b.m_markerAlpha;
                              });
         if (!sameColor || !sameAlpha)
         {
@@ -1197,19 +1197,19 @@ namespace AzToolsFramework
         {
             QString out(kClipboardHeader);
             out.append(QLatin1Char('\n'));
-            for (const auto& c : g.colorSlider)
+            for (const auto& c : g.m_colorSlider)
             {
                 out.append(QStringLiteral("C %1 %2 %3 %4\n")
-                    .arg(static_cast<qreal>(c.markerColor.GetR()), 0, 'g', 7)
-                    .arg(static_cast<qreal>(c.markerColor.GetG()), 0, 'g', 7)
-                    .arg(static_cast<qreal>(c.markerColor.GetB()), 0, 'g', 7)
-                    .arg(static_cast<qreal>(c.markerPosition), 0, 'g', 7));
+                    .arg(static_cast<qreal>(c.m_markerColor.GetR()), 0, 'g', 7)
+                    .arg(static_cast<qreal>(c.m_markerColor.GetG()), 0, 'g', 7)
+                    .arg(static_cast<qreal>(c.m_markerColor.GetB()), 0, 'g', 7)
+                    .arg(static_cast<qreal>(c.m_markerPosition), 0, 'g', 7));
             }
-            for (const auto& a : g.alphaSlider)
+            for (const auto& a : g.m_alphaSlider)
             {
                 out.append(QStringLiteral("A %1 %2\n")
-                    .arg(static_cast<qreal>(a.markerAlpha), 0, 'g', 7)
-                    .arg(static_cast<qreal>(a.markerPosition), 0, 'g', 7));
+                    .arg(static_cast<qreal>(a.m_markerAlpha), 0, 'g', 7)
+                    .arg(static_cast<qreal>(a.m_markerPosition), 0, 'g', 7));
             }
             return out;
         }
@@ -1230,16 +1230,16 @@ namespace AzToolsFramework
                 if (tokens[0] == QLatin1String("C") && tokens.size() == 5)
                 {
                     AZ::ColorGradientMarker m;
-                    m.markerColor = AZ::Color(tokens[1].toFloat(), tokens[2].toFloat(), tokens[3].toFloat(), 1.f);
-                    m.markerPosition = tokens[4].toFloat();
-                    parsed.colorSlider.push_back(m);
+                    m.m_markerColor = AZ::Color(tokens[1].toFloat(), tokens[2].toFloat(), tokens[3].toFloat(), 1.f);
+                    m.m_markerPosition = tokens[4].toFloat();
+                    parsed.m_colorSlider.push_back(m);
                 }
                 else if (tokens[0] == QLatin1String("A") && tokens.size() == 3)
                 {
                     AZ::AlphaGradientMarker m;
-                    m.markerAlpha = tokens[1].toFloat();
-                    m.markerPosition = tokens[2].toFloat();
-                    parsed.alphaSlider.push_back(m);
+                    m.m_markerAlpha = tokens[1].toFloat();
+                    m.m_markerPosition = tokens[2].toFloat();
+                    parsed.m_alphaSlider.push_back(m);
                 }
             }
             parsed.SortGradients();
@@ -1345,15 +1345,15 @@ namespace AzToolsFramework
     {
         // RGB-only: extract only the color slider, drop alpha track.
         AZ::ColorGradient full = GUI->value();
-        instance.colorSlider = full.colorSlider;
-        instance.sorted = false;
+        instance.m_colorSlider = full.m_colorSlider;
+        instance.m_sorted = false;
         instance.SortGradients();
     }
 
     bool AZColorGradientRGBPropertyHandler::ReadValuesIntoGUI(size_t index, PropertyColorGradientCtrl* GUI, const property_t& instance, InstanceDataNode* /*node*/)
     {
         AZ::ColorGradient wrapper;
-        wrapper.colorSlider = instance.colorSlider;
+        wrapper.m_colorSlider = instance.m_colorSlider;
         wrapper.SortGradients();
         if (index == 0) { GUI->beginReadPass(wrapper); }
         else            { GUI->addReadInstance(wrapper); }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
@@ -642,6 +642,7 @@ namespace AzToolsFramework
         m_positionSpin->setSingleStep(1.0);
         m_positionSpin->setDecimals(1);
 
+        inspector->addStretch(1);
         inspector->addWidget(m_valueLabel);
         inspector->addWidget(m_colorField);
         inspector->addWidget(m_alphaSpin);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
@@ -1,0 +1,1375 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "PropertyColorGradientCtrl.hxx"
+#include "PropertyColorCtrl.hxx"
+#include "PropertyQTConstants.h"
+
+#include <AzQtComponents/Components/Widgets/ColorPicker.h>
+#include <AzQtComponents/Utilities/Conversions.h>
+
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
+#include <QBoxLayout>
+#include <QColorDialog>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLinearGradient>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QAbstractSpinBox>
+#include <QAction>
+#include <QApplication>
+#include <QClipboard>
+#include <QContextMenuEvent>
+#include <QMenu>
+#include <QString>
+#include <QStringList>
+AZ_POP_DISABLE_WARNING
+
+#include <algorithm>
+
+namespace AzToolsFramework
+{
+    // =======================================================================
+    // Local Constants
+    // =======================================================================
+
+    namespace GradientCtrlConstants
+    {
+        static constexpr int    kBarHeight       = 48;
+        static constexpr int    kAlphaTrackHeight = 24;   // cube (10) + gap (2) + triangle (10) + 2 padding
+        static constexpr int    kColorTrackHeight = 24;   // triangle (10) + gap (2) + cube (10) + 2 padding
+        static constexpr int    kTriangleWidth   = 10;
+        static constexpr int    kTriangleHeight  = 10;
+        static constexpr int    kCubeSize        = 10;    // outer frame
+        static constexpr int    kCubeInnerSize   = 8;     // inner colored fill
+        static constexpr int    kCubeGap         = 2;     // gap between triangle base and cube top
+        static constexpr int    kInlineHeight    = 20;
+        static constexpr int    kDialogWidth     = 600;
+        static constexpr int    kCheckerSize     = 8;
+        static constexpr int    kDragOffThreshold = 25;   // vertical distance to drag a marker off to delete it
+        static constexpr float  kDuplicateOffset = 0.05f;
+    }
+
+    // =======================================================================
+    // GradientBarWidget
+    // =======================================================================
+
+    GradientBarWidget::GradientBarWidget(QWidget* parent)
+        : QWidget(parent)
+    {
+        setMinimumHeight(GradientCtrlConstants::kInlineHeight);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::MinimumExpanding);
+    }
+
+    void GradientBarWidget::setGradient(const AZ::ColorGradient& gradient)
+    {
+        m_gradient = gradient;
+        m_gradient.SortGradients();
+        update();
+    }
+
+    void GradientBarWidget::setAlphaEnabled(bool enabled)
+    {
+        m_alphaEnabled = enabled;
+        update();
+    }
+
+    void GradientBarWidget::setMixed(bool mixed)
+    {
+        if (m_mixed == mixed) { return; }
+        m_mixed = mixed;
+        update();
+    }
+
+    void GradientBarWidget::paintEvent(QPaintEvent* /*event*/)
+    {
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, false);
+
+        const QRect area = rect();
+
+        // Multi-edit with divergent values: show a neutral grey field crossed
+        // with an X to indicate the displayed gradient is not representative
+        // of every selected entity.
+        if (m_mixed)
+        {
+            painter.fillRect(area, QColor(90, 90, 90));
+            painter.setPen(QPen(QColor(30, 30, 30), 2));
+            painter.drawLine(area.topLeft(),    area.bottomRight());
+            painter.drawLine(area.topRight(),   area.bottomLeft());
+            painter.setPen(QColor(30, 30, 30));
+            painter.drawRect(area.adjusted(0, 0, -1, -1));
+            return;
+        }
+
+        // Checkerboard backdrop to visualize transparency.
+        const int cs = GradientCtrlConstants::kCheckerSize;
+        for (int y = area.top(); y < area.bottom(); y += cs)
+        {
+            for (int x = area.left(); x < area.right(); x += cs)
+            {
+                const bool dark = ((x / cs) + (y / cs)) % 2 == 0;
+                painter.fillRect(QRect(x, y, cs, cs), dark ? QColor(80, 80, 80) : QColor(120, 120, 120));
+            }
+        }
+
+        if (area.width() <= 0)
+        {
+            return;
+        }
+
+        // Sample the gradient once per pixel column along the bar.
+        for (int x = 0; x < area.width(); ++x)
+        {
+            const float t = static_cast<float>(x) / static_cast<float>(area.width() - 1);
+            AZ::Color sampled = m_alphaEnabled ? m_gradient.EvaluateGradient(t) : m_gradient.EvaluateColor(t);
+            QColor c;
+            c.setRedF(static_cast<qreal>(sampled.GetR()));
+            c.setGreenF(static_cast<qreal>(sampled.GetG()));
+            c.setBlueF(static_cast<qreal>(sampled.GetB()));
+            c.setAlphaF(m_alphaEnabled ? static_cast<qreal>(sampled.GetA()) : 1.0);
+            painter.fillRect(QRect(area.left() + x, area.top(), 1, area.height()), c);
+        }
+
+        painter.setPen(QColor(30, 30, 30));
+        painter.drawRect(area.adjusted(0, 0, -1, -1));
+    }
+
+    // =======================================================================
+    // GradientStopsTrack
+    // =======================================================================
+
+    GradientStopsTrack::GradientStopsTrack(Kind kind, QWidget* parent)
+        : QWidget(parent)
+        , m_kind(kind)
+    {
+        const int h = kind == Kind::Color ? GradientCtrlConstants::kColorTrackHeight
+                                          : GradientCtrlConstants::kAlphaTrackHeight;
+        setMinimumHeight(h);
+        setFixedHeight(h);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        setFocusPolicy(Qt::StrongFocus);
+    }
+
+    void GradientStopsTrack::setColorStops(const AZStd::vector<AZ::ColorGradientMarker>& stops)
+    {
+        m_colorStops = stops;
+        m_selected.reset();
+        update();
+    }
+
+    void GradientStopsTrack::setAlphaStops(const AZStd::vector<AZ::AlphaGradientMarker>& stops)
+    {
+        m_alphaStops = stops;
+        m_selected.reset();
+        update();
+    }
+
+    void GradientStopsTrack::setSelectedIndex(AZStd::optional<size_t> index)
+    {
+        m_selected = index;
+        update();
+        emit selectionChanged();
+    }
+
+    size_t GradientStopsTrack::stopCount() const
+    {
+        return m_kind == Kind::Color ? m_colorStops.size() : m_alphaStops.size();
+    }
+
+    float GradientStopsTrack::stopPositionAt(size_t index) const
+    {
+        return m_kind == Kind::Color ? m_colorStops[index].markerPosition : m_alphaStops[index].markerPosition;
+    }
+
+    int GradientStopsTrack::positionToPixel(float position) const
+    {
+        const int w = width();
+        if (w <= 0) { return 0; }
+        return static_cast<int>(std::clamp(position, 0.f, 1.f) * (w - 1));
+    }
+
+    float GradientStopsTrack::pixelToPosition(int pixel) const
+    {
+        const int w = width();
+        if (w <= 1) { return 0.f; }
+        const float t = static_cast<float>(pixel) / static_cast<float>(w - 1);
+        return std::clamp(t, 0.f, 1.f);
+    }
+
+    QRect GradientStopsTrack::triangleRect(float position) const
+    {
+        const int x = positionToPixel(position);
+        const int half = GradientCtrlConstants::kTriangleWidth / 2;
+        // Each track's triangle hugs the edge closest to the gradient bar so
+        // the tip visually touches the bar. Alpha track sits above the bar:
+        // triangle anchors at the BOTTOM of its widget. Color track sits below
+        // the bar: triangle anchors at the TOP of its widget.
+        const int y = (m_kind == Kind::Alpha)
+            ? (height() - GradientCtrlConstants::kTriangleHeight)
+            : 0;
+        return QRect(x - half, y, GradientCtrlConstants::kTriangleWidth, GradientCtrlConstants::kTriangleHeight);
+    }
+
+    AZStd::optional<size_t> GradientStopsTrack::hitTest(const QPoint& point) const
+    {
+        const size_t n = stopCount();
+        for (size_t i = 0; i < n; ++i)
+        {
+            const float pos = stopPositionAt(i);
+            const QRect tri = triangleRect(pos);
+            if (tri.adjusted(-2, -2, 2, 2).contains(point))
+            {
+                return i;
+            }
+            // Preview cube hit region (both tracks have a cube at the tail end).
+            const int cubeX = tri.center().x() - GradientCtrlConstants::kCubeSize / 2;
+            const int cubeY = (m_kind == Kind::Alpha)
+                ? (tri.top() - GradientCtrlConstants::kCubeGap - GradientCtrlConstants::kCubeSize)
+                : (tri.bottom() + GradientCtrlConstants::kCubeGap);
+            const QRect cube(cubeX, cubeY, GradientCtrlConstants::kCubeSize, GradientCtrlConstants::kCubeSize);
+            if (cube.adjusted(-2, -2, 2, 2).contains(point))
+            {
+                return i;
+            }
+        }
+        return AZStd::nullopt;
+    }
+
+    AZ::Color GradientStopsTrack::sampleColorAt(float t) const
+    {
+        AZ::ColorGradient tmp;
+        tmp.colorSlider = m_colorStops;
+        tmp.SortGradients();
+        return tmp.EvaluateColor(t);
+    }
+
+    float GradientStopsTrack::sampleAlphaAt(float t) const
+    {
+        AZ::ColorGradient tmp;
+        tmp.alphaSlider = m_alphaStops;
+        tmp.SortGradients();
+        return tmp.EvaluateAlpha(t);
+    }
+
+    void GradientStopsTrack::addStopAt(float t)
+    {
+        t = std::clamp(t, 0.f, 1.f);
+        if (m_kind == Kind::Color)
+        {
+            AZ::ColorGradientMarker m;
+            m.markerColor = sampleColorAt(t);
+            m.markerPosition = t;
+            m_colorStops.push_back(m);
+            m_selected = m_colorStops.size() - 1;
+        }
+        else
+        {
+            AZ::AlphaGradientMarker m;
+            m.markerAlpha = sampleAlphaAt(t);
+            m.markerPosition = t;
+            m_alphaStops.push_back(m);
+            m_selected = m_alphaStops.size() - 1;
+        }
+        update();
+        emit selectionChanged();
+        emit stopsChanged();
+        emit editCommitted();
+    }
+
+    void GradientStopsTrack::setSelectedPosition(float t)
+    {
+        if (!m_selected.has_value()) { return; }
+        t = std::clamp(t, 0.f, 1.f);
+        if (m_kind == Kind::Color) { m_colorStops[*m_selected].markerPosition = t; }
+        else                       { m_alphaStops[*m_selected].markerPosition = t; }
+        // No consolidation here: a moving marker must pass freely through
+        // other stops without consuming them. The evaluator handles coincident
+        // positions deterministically.
+        update();
+        emit stopsChanged();
+    }
+
+    void GradientStopsTrack::setSelectedColor(const AZ::Color& rgb)
+    {
+        if (m_kind != Kind::Color || !m_selected.has_value()) { return; }
+        AZ::Color opaque(rgb.GetR(), rgb.GetG(), rgb.GetB(), 1.f);
+        m_colorStops[*m_selected].markerColor = opaque;
+        update();
+        emit stopsChanged();
+    }
+
+    void GradientStopsTrack::setSelectedAlpha(float alpha)
+    {
+        if (m_kind != Kind::Alpha || !m_selected.has_value()) { return; }
+        m_alphaStops[*m_selected].markerAlpha = std::clamp(alpha, 0.f, 1.f);
+        update();
+        emit stopsChanged();
+    }
+
+    void GradientStopsTrack::duplicateSelected()
+    {
+        if (!m_selected.has_value()) { return; }
+        const float offset = GradientCtrlConstants::kDuplicateOffset;
+        if (m_kind == Kind::Color)
+        {
+            auto src = m_colorStops[*m_selected];
+            src.markerPosition = std::clamp(src.markerPosition + offset, 0.f, 1.f);
+            m_colorStops.push_back(src);
+            m_selected = m_colorStops.size() - 1;
+        }
+        else
+        {
+            auto src = m_alphaStops[*m_selected];
+            src.markerPosition = std::clamp(src.markerPosition + offset, 0.f, 1.f);
+            m_alphaStops.push_back(src);
+            m_selected = m_alphaStops.size() - 1;
+        }
+        update();
+        emit selectionChanged();
+        emit stopsChanged();
+        emit editCommitted();
+    }
+
+    void GradientStopsTrack::removeSelected()
+    {
+        if (!m_selected.has_value()) { return; }
+        if (stopCount() <= 1) { return; }
+        const size_t sel = *m_selected;
+        if (m_kind == Kind::Color) { m_colorStops.erase(m_colorStops.begin() + sel); }
+        else                       { m_alphaStops.erase(m_alphaStops.begin() + sel); }
+        m_selected.reset();
+        update();
+        emit selectionChanged();
+        emit stopsChanged();
+        emit editCommitted();
+    }
+
+    void GradientStopsTrack::paintEvent(QPaintEvent* /*event*/)
+    {
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+
+        const size_t n = stopCount();
+        for (size_t i = 0; i < n; ++i)
+        {
+            const float pos = stopPositionAt(i);
+            const QRect tri = triangleRect(pos);
+
+            // Alpha track sits above the gradient bar: tip points DOWN toward
+            // the bar below (base at top of widget, tip at bottom of triangle
+            // rect).
+            // Color track sits below the gradient bar: tip points UP toward
+            // the bar above (tip at top of triangle rect, base at bottom).
+            QPainterPath path;
+            if (m_kind == Kind::Alpha)
+            {
+                path.moveTo(tri.left(), tri.top());
+                path.lineTo(tri.right(), tri.top());
+                path.lineTo(tri.center().x(), tri.bottom());
+            }
+            else
+            {
+                path.moveTo(tri.center().x(), tri.top());
+                path.lineTo(tri.left(), tri.bottom());
+                path.lineTo(tri.right(), tri.bottom());
+            }
+            path.closeSubpath();
+
+            // Triangle fill: color track uses the marker colour; alpha track
+            // uses a fixed neutral (light grey) so the arrow is always legible
+            // regardless of the stop's alpha value.
+            QColor triFill;
+            if (m_kind == Kind::Color)
+            {
+                const AZ::Color& c = m_colorStops[i].markerColor;
+                triFill.setRedF(static_cast<qreal>(c.GetR()));
+                triFill.setGreenF(static_cast<qreal>(c.GetG()));
+                triFill.setBlueF(static_cast<qreal>(c.GetB()));
+            }
+            else
+            {
+                triFill = QColor(220, 220, 220);
+            }
+
+            const bool isSel = m_selected.has_value() && *m_selected == i;
+            const bool isDeletePreview = isSel && m_pendingDelete;
+            QColor outline;
+            int outlineWidth;
+            if (isDeletePreview)        { outline = QColor(255, 60, 60);  outlineWidth = 2; }
+            else if (isSel)             { outline = QColor(255, 200, 0);  outlineWidth = 2; }
+            else                        { outline = QColor(20, 20, 20);   outlineWidth = 1; }
+            painter.setBrush(triFill);
+            painter.setPen(QPen(outline, outlineWidth));
+            painter.drawPath(path);
+
+            // Preview cube at the tail end of the arrow. Outer frame = 10px,
+            // inner display = 8px. Color track: inner is solid marker colour.
+            // Alpha track: inner is a mini checkerboard overlaid with
+            // semi-transparent white, so full opacity reads as white, zero
+            // reads as the grid.
+            const int cubeX = tri.center().x() - GradientCtrlConstants::kCubeSize / 2;
+            const int cubeY = (m_kind == Kind::Alpha)
+                ? (tri.top() - GradientCtrlConstants::kCubeGap - GradientCtrlConstants::kCubeSize)
+                : (tri.bottom() + GradientCtrlConstants::kCubeGap);
+            const QRect cubeOuter(cubeX, cubeY, GradientCtrlConstants::kCubeSize, GradientCtrlConstants::kCubeSize);
+            const int innerOffset = (GradientCtrlConstants::kCubeSize - GradientCtrlConstants::kCubeInnerSize) / 2;
+            const QRect cubeInner(cubeX + innerOffset, cubeY + innerOffset,
+                                  GradientCtrlConstants::kCubeInnerSize, GradientCtrlConstants::kCubeInnerSize);
+
+            painter.setRenderHint(QPainter::Antialiasing, false);
+
+            if (m_kind == Kind::Color)
+            {
+                painter.fillRect(cubeInner, triFill);
+            }
+            else
+            {
+                // 4-square mini checkerboard, then semi-transparent white overlay
+                // with opacity set to the stop's alpha value.
+                const int half = GradientCtrlConstants::kCubeInnerSize / 2;
+                const QColor dark(80, 80, 80);
+                const QColor light(170, 170, 170);
+                painter.fillRect(QRect(cubeInner.left(),        cubeInner.top(),        half, half), light);
+                painter.fillRect(QRect(cubeInner.left() + half, cubeInner.top(),        half, half), dark);
+                painter.fillRect(QRect(cubeInner.left(),        cubeInner.top() + half, half, half), dark);
+                painter.fillRect(QRect(cubeInner.left() + half, cubeInner.top() + half, half, half), light);
+
+                QColor whiteOverlay(255, 255, 255, static_cast<int>(m_alphaStops[i].markerAlpha * 255.f));
+                painter.fillRect(cubeInner, whiteOverlay);
+            }
+
+            painter.setBrush(Qt::NoBrush);
+            painter.setPen(QPen(outline, outlineWidth));
+            painter.drawRect(cubeOuter);
+            painter.setRenderHint(QPainter::Antialiasing, true);
+        }
+    }
+
+    void GradientStopsTrack::mousePressEvent(QMouseEvent* event)
+    {
+        setFocus();
+        if (event->button() == Qt::LeftButton)
+        {
+            auto hit = hitTest(event->pos());
+            if (hit.has_value())
+            {
+                m_selected = hit;
+                m_dragging = true;
+                update();
+                emit selectionChanged();
+            }
+            else
+            {
+                addStopAt(pixelToPosition(event->pos().x()));
+                m_dragging = true;
+            }
+        }
+    }
+
+    void GradientStopsTrack::mouseMoveEvent(QMouseEvent* event)
+    {
+        if (m_dragging && m_selected.has_value() && (event->buttons() & Qt::LeftButton))
+        {
+            // Drag-off-to-delete: flag the marker as pending delete when the
+            // cursor leaves the widget vertically by more than the threshold.
+            const int y = event->pos().y();
+            const bool outside = (y < -GradientCtrlConstants::kDragOffThreshold)
+                              || (y > height() + GradientCtrlConstants::kDragOffThreshold);
+            if (outside != m_pendingDelete)
+            {
+                m_pendingDelete = outside;
+                update();
+            }
+            setSelectedPosition(pixelToPosition(event->pos().x()));
+        }
+        if (!(event->buttons() & Qt::LeftButton))
+        {
+            m_dragging = false;
+            m_pendingDelete = false;
+        }
+    }
+
+    void GradientStopsTrack::mouseReleaseEvent(QMouseEvent* /*event*/)
+    {
+        const bool wasDragging = m_dragging;
+        const bool wantDelete = wasDragging && m_pendingDelete;
+        m_dragging = false;
+        m_pendingDelete = false;
+        if (wantDelete)
+        {
+            // removeSelected already emits editCommitted.
+            removeSelected();
+        }
+        else if (wasDragging)
+        {
+            // A drag that moved a stop without deleting it is one commit.
+            emit editCommitted();
+        }
+        update();
+    }
+
+    void GradientStopsTrack::mouseDoubleClickEvent(QMouseEvent* event)
+    {
+        auto hit = hitTest(event->pos());
+        if (hit.has_value() && m_kind == Kind::Color)
+        {
+            m_selected = hit;
+            emit selectionChanged();
+
+            // Use the standard AzQtComponents color picker so the double-click
+            // affordance matches the inline inspector swatch experience.
+            const AZ::Color initial(
+                m_colorStops[*m_selected].markerColor.GetR(),
+                m_colorStops[*m_selected].markerColor.GetG(),
+                m_colorStops[*m_selected].markerColor.GetB(),
+                1.f);
+            const AZ::Color picked = AzQtComponents::ColorPicker::getColor(
+                AzQtComponents::ColorPicker::Configuration::RGB,
+                initial,
+                QStringLiteral("Stop Color"),
+                QString(),
+                QStringList(),
+                this);
+            setSelectedColor(AZ::Color(picked.GetR(), picked.GetG(), picked.GetB(), 1.f));
+            emit editCommitted();
+        }
+    }
+
+    void GradientStopsTrack::keyPressEvent(QKeyEvent* event)
+    {
+        if (event->key() == Qt::Key_Delete)
+        {
+            removeSelected();
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_D && (event->modifiers() & Qt::ControlModifier))
+        {
+            duplicateSelected();
+            event->accept();
+            return;
+        }
+        // Arrow-key nudge on the selected stop. Shift = coarse step.
+        if ((event->key() == Qt::Key_Left || event->key() == Qt::Key_Right) && m_selected.has_value())
+        {
+            const float step = (event->modifiers() & Qt::ShiftModifier) ? 0.10f : 0.01f;
+            const float dir = event->key() == Qt::Key_Left ? -1.f : 1.f;
+            setSelectedPosition(stopPositionAt(*m_selected) + dir * step);
+            emit editCommitted();
+            event->accept();
+            return;
+        }
+        QWidget::keyPressEvent(event);
+    }
+
+    // =======================================================================
+    // ColorGradientEditorDialog
+    // =======================================================================
+
+    ColorGradientEditorDialog::ColorGradientEditorDialog(const AZ::ColorGradient& initial, bool alphaEnabled, bool multiEdit, QWidget* parent)
+        : QDialog(parent)
+        , m_working(initial)
+        , m_alphaEnabled(alphaEnabled)
+    {
+        setWindowTitle(multiEdit
+            ? QStringLiteral("Color Gradient Editor (multi-edit: applies to all selected)")
+            : QStringLiteral("Color Gradient Editor"));
+        setMinimumWidth(GradientCtrlConstants::kDialogWidth);
+        m_working.SortGradients();
+
+        auto* root = new QVBoxLayout(this);
+        root->setContentsMargins(8, 8, 8, 8);
+        root->setSpacing(6);
+
+        if (multiEdit)
+        {
+            auto* banner = new QLabel(
+                QStringLiteral("This edit will be written to every selected entity's gradient field."),
+                this);
+            banner->setStyleSheet(QStringLiteral("color: #ffcc00; font-weight: bold;"));
+            banner->setWordWrap(true);
+            root->addWidget(banner);
+        }
+
+        // Alpha track (top).
+        m_alphaTrack = new GradientStopsTrack(GradientStopsTrack::Kind::Alpha, this);
+        m_alphaTrack->setAlphaStops(m_working.alphaSlider);
+        m_alphaTrack->setVisible(m_alphaEnabled);
+        root->addWidget(m_alphaTrack);
+
+        // Preview bar.
+        m_preview = new GradientBarWidget(this);
+        m_preview->setMinimumHeight(GradientCtrlConstants::kBarHeight);
+        m_preview->setAlphaEnabled(m_alphaEnabled);
+        m_preview->setGradient(m_working);
+        root->addWidget(m_preview);
+
+        // Color track (bottom).
+        m_colorTrack = new GradientStopsTrack(GradientStopsTrack::Kind::Color, this);
+        m_colorTrack->setColorStops(m_working.colorSlider);
+        root->addWidget(m_colorTrack);
+
+        // Inspector row.
+        auto* inspector = new QHBoxLayout();
+        inspector->setSpacing(8);
+
+        m_valueLabel = new QLabel(QStringLiteral("Color"), this);
+        // Use the standard O3DE color field so the swatch + text + native
+        // ColorPicker are driven by the same widget developers see everywhere.
+        m_colorField = new PropertyColorCtrl(this);
+        m_colorField->setAlphaChannelEnabled(false);
+        m_alphaSpin = new QDoubleSpinBox(this);
+        m_alphaSpin->setRange(0.0, 1.0);
+        m_alphaSpin->setSingleStep(0.01);
+        m_alphaSpin->setDecimals(3);
+        m_alphaSpin->setVisible(false);
+
+        auto* positionLabel = new QLabel(QStringLiteral("Position %"), this);
+        m_positionSpin = new QDoubleSpinBox(this);
+        m_positionSpin->setRange(0.0, 100.0);
+        m_positionSpin->setSingleStep(1.0);
+        m_positionSpin->setDecimals(1);
+
+        inspector->addWidget(m_valueLabel);
+        inspector->addWidget(m_colorField);
+        inspector->addWidget(m_alphaSpin);
+        inspector->addSpacing(12);
+        inspector->addWidget(positionLabel);
+        inspector->addWidget(m_positionSpin);
+        inspector->addStretch(1);
+        root->addLayout(inspector);
+
+        // OK / Cancel. Disable auto-default on both so Enter inside a spin box
+        // only commits the field, rather than closing the dialog.
+        auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+        if (auto* okBtn = buttons->button(QDialogButtonBox::Ok))
+        {
+            okBtn->setDefault(false);
+            okBtn->setAutoDefault(false);
+        }
+        if (auto* cancelBtn = buttons->button(QDialogButtonBox::Cancel))
+        {
+            cancelBtn->setDefault(false);
+            cancelBtn->setAutoDefault(false);
+        }
+        root->addWidget(buttons);
+        connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+        connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+        // Wire tracks to dialog updates.
+        connect(m_alphaTrack, &GradientStopsTrack::stopsChanged, this, &ColorGradientEditorDialog::onAlphaTrackChanged);
+        connect(m_colorTrack, &GradientStopsTrack::stopsChanged, this, &ColorGradientEditorDialog::onColorTrackChanged);
+        connect(m_alphaTrack, &GradientStopsTrack::selectionChanged, this, [this]()
+        {
+            if (m_alphaTrack->selectedIndex().has_value())
+            {
+                m_activeTrack = m_alphaTrack;
+                QSignalBlocker blocker(m_colorTrack);
+                m_colorTrack->setSelectedIndex(AZStd::nullopt);
+            }
+            onSelectionChanged();
+        });
+        connect(m_colorTrack, &GradientStopsTrack::selectionChanged, this, [this]()
+        {
+            if (m_colorTrack->selectedIndex().has_value())
+            {
+                m_activeTrack = m_colorTrack;
+                QSignalBlocker blocker(m_alphaTrack);
+                m_alphaTrack->setSelectedIndex(AZStd::nullopt);
+            }
+            onSelectionChanged();
+        });
+
+        connect(m_positionSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ColorGradientEditorDialog::onPositionChanged);
+        // PropertyColorCtrl emits valueChanged on every picker drag frame, so
+        // we only live-update the marker there (no undo snapshot). Snapshots
+        // are pushed on actual commit signals (text commit / picker accepted).
+        connect(m_colorField, &PropertyColorCtrl::valueChanged,     this, &ColorGradientEditorDialog::onColorFieldLiveChanged);
+        connect(m_colorField, &PropertyColorCtrl::editingFinished,  this, &ColorGradientEditorDialog::onColorFieldCommitted);
+        connect(m_colorField, &PropertyColorCtrl::colorSelected,    this, &ColorGradientEditorDialog::onColorFieldCommitted);
+        connect(m_colorField, &PropertyColorCtrl::rejected,         this, &ColorGradientEditorDialog::onColorFieldRejected);
+        connect(m_alphaSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &ColorGradientEditorDialog::onAlphaSpinChanged);
+
+        // Commit-point wiring for the in-dialog undo stack. Granular steps are
+        // pushed here; the outer RPE is only notified once, when the dialog
+        // closes.
+        connect(m_alphaTrack, &GradientStopsTrack::editCommitted, this, &ColorGradientEditorDialog::pushUndoSnapshot);
+        connect(m_colorTrack, &GradientStopsTrack::editCommitted, this, &ColorGradientEditorDialog::pushUndoSnapshot);
+        connect(m_positionSpin, &QDoubleSpinBox::editingFinished, this, &ColorGradientEditorDialog::pushUndoSnapshot);
+        connect(m_alphaSpin,    &QDoubleSpinBox::editingFinished, this, &ColorGradientEditorDialog::pushUndoSnapshot);
+
+        m_activeTrack = m_colorTrack;
+        refreshInspector();
+
+        // Seed the undo stack with the opening state so the user can undo all
+        // the way back to how the dialog appeared.
+        m_undoStack.push_back(captureSnapshot());
+        m_undoCursor = 0;
+    }
+
+    void ColorGradientEditorDialog::rebuildFromTracks()
+    {
+        m_working.colorSlider = m_colorTrack->colorStops();
+        m_working.alphaSlider = m_alphaTrack->alphaStops();
+        m_working.sorted = false;
+        m_working.SortGradients();
+        refreshPreview();
+    }
+
+    void ColorGradientEditorDialog::refreshPreview()
+    {
+        m_preview->setGradient(m_working);
+    }
+
+    void ColorGradientEditorDialog::onAlphaTrackChanged()
+    {
+        rebuildFromTracks();
+    }
+
+    void ColorGradientEditorDialog::onColorTrackChanged()
+    {
+        rebuildFromTracks();
+    }
+
+    void ColorGradientEditorDialog::refreshInspector()
+    {
+        if (!m_activeTrack || !m_activeTrack->selectedIndex().has_value())
+        {
+            m_valueLabel->setText(QStringLiteral("(no selection)"));
+            m_colorField->setVisible(false);
+            m_alphaSpin->setVisible(false);
+            m_positionSpin->setEnabled(false);
+            m_positionSpin->blockSignals(true);
+            m_positionSpin->setValue(0.0);
+            m_positionSpin->blockSignals(false);
+            return;
+        }
+
+        const size_t idx = *m_activeTrack->selectedIndex();
+        m_positionSpin->setEnabled(true);
+
+        if (m_activeTrack->kind() == GradientStopsTrack::Kind::Color)
+        {
+            m_valueLabel->setText(QStringLiteral("Color"));
+            m_colorField->setVisible(true);
+            m_alphaSpin->setVisible(false);
+
+            const AZ::Color& cur = m_activeTrack->colorStops()[idx].markerColor;
+            QColor q;
+            q.setRedF(static_cast<qreal>(cur.GetR()));
+            q.setGreenF(static_cast<qreal>(cur.GetG()));
+            q.setBlueF(static_cast<qreal>(cur.GetB()));
+            QSignalBlocker block(m_colorField);
+            m_colorField->setValue(q);
+
+            m_positionSpin->blockSignals(true);
+            m_positionSpin->setValue(m_activeTrack->colorStops()[idx].markerPosition * 100.0);
+            m_positionSpin->blockSignals(false);
+        }
+        else
+        {
+            m_valueLabel->setText(QStringLiteral("Alpha"));
+            m_colorField->setVisible(false);
+            m_alphaSpin->setVisible(true);
+            m_alphaSpin->blockSignals(true);
+            m_alphaSpin->setValue(static_cast<double>(m_activeTrack->alphaStops()[idx].markerAlpha));
+            m_alphaSpin->blockSignals(false);
+            m_positionSpin->blockSignals(true);
+            m_positionSpin->setValue(m_activeTrack->alphaStops()[idx].markerPosition * 100.0);
+            m_positionSpin->blockSignals(false);
+        }
+    }
+
+    void ColorGradientEditorDialog::onSelectionChanged()
+    {
+        refreshInspector();
+    }
+
+    void ColorGradientEditorDialog::onPositionChanged(double normalized)
+    {
+        if (!m_activeTrack) { return; }
+        m_activeTrack->setSelectedPosition(static_cast<float>(normalized / 100.0));
+    }
+
+    void ColorGradientEditorDialog::onColorFieldLiveChanged()
+    {
+        // Called on every intermediate frame while the picker is open. Just
+        // push the new colour into the selected stop so the preview updates
+        // live; do NOT snapshot here or the undo stack fills with per-frame
+        // micro-states that erode the colour on Ctrl+Z.
+        if (!m_activeTrack || m_activeTrack->kind() != GradientStopsTrack::Kind::Color) { return; }
+        if (!m_activeTrack->selectedIndex().has_value()) { return; }
+
+        const QColor q = m_colorField->value();
+        AZ::Color az(
+            static_cast<float>(q.redF()),
+            static_cast<float>(q.greenF()),
+            static_cast<float>(q.blueF()),
+            1.f);
+        m_activeTrack->setSelectedColor(az);
+    }
+
+    void ColorGradientEditorDialog::onColorFieldCommitted()
+    {
+        // Single snapshot per committed colour edit (picker OK or text edit
+        // return). onColorFieldLiveChanged has already pushed the final colour
+        // into the marker.
+        pushUndoSnapshot();
+    }
+
+    void ColorGradientEditorDialog::onColorFieldRejected()
+    {
+        // Picker was cancelled. PropertyColorCtrl has already reverted its
+        // internal colour to the pre-open value but does not re-emit
+        // valueChanged on Cancel, so re-sync the marker manually.
+        onColorFieldLiveChanged();
+        // No snapshot: the undo stack already has the pre-edit state on top.
+    }
+
+    void ColorGradientEditorDialog::onAlphaSpinChanged(double value)
+    {
+        if (!m_activeTrack || m_activeTrack->kind() != GradientStopsTrack::Kind::Alpha) { return; }
+        m_activeTrack->setSelectedAlpha(static_cast<float>(value));
+    }
+
+    void ColorGradientEditorDialog::showEvent(QShowEvent* event)
+    {
+        QDialog::showEvent(event);
+        // Intercept application-wide mouse presses so we can commit when the
+        // user clicks anywhere outside the dialog (and outside any spawned
+        // child popup such as the AzQtComponents color picker).
+        qApp->installEventFilter(this);
+    }
+
+    void ColorGradientEditorDialog::hideEvent(QHideEvent* event)
+    {
+        qApp->removeEventFilter(this);
+        QDialog::hideEvent(event);
+    }
+
+    bool ColorGradientEditorDialog::eventFilter(QObject* watched, QEvent* event)
+    {
+        // While a child modal (e.g. the color picker) is active, let it own
+        // all input. We re-engage the filter once it closes.
+        QWidget* modal = QApplication::activeModalWidget();
+        if (modal && modal != this)
+        {
+            return QDialog::eventFilter(watched, event);
+        }
+
+        auto isDescendantOfDialog = [this](QWidget* w)
+        {
+            for (QWidget* p = w; p; p = p->parentWidget())
+            {
+                if (p == this) { return true; }
+            }
+            return false;
+        };
+
+        if (event->type() == QEvent::KeyPress)
+        {
+            // Intercept undo / redo at the application level so child widgets
+            // like QLineEdit (inside PropertyColorCtrl) do not consume Ctrl+Z
+            // for their own text-undo before the dialog gets a chance.
+            auto* ke = static_cast<QKeyEvent*>(event);
+            const bool ctrl  = (ke->modifiers() & Qt::ControlModifier)  != 0;
+            const bool shift = (ke->modifiers() & Qt::ShiftModifier)    != 0;
+            if (auto* w = qobject_cast<QWidget*>(watched))
+            {
+                if (isDescendantOfDialog(w))
+                {
+                    const bool isUndo = ctrl && !shift && ke->key() == Qt::Key_Z;
+                    const bool isRedo = (ctrl && ke->key() == Qt::Key_Y)
+                                     || (ctrl && shift && ke->key() == Qt::Key_Z);
+                    if (isUndo || isRedo)
+                    {
+                        // Force any in-progress spin-box edit to commit before
+                        // stepping the stack. clearFocus triggers focusOutEvent
+                        // which interprets pending text and emits editingFinished,
+                        // which pushes the snapshot we are about to walk past.
+                        if (auto* spin = qobject_cast<QAbstractSpinBox*>(QApplication::focusWidget()))
+                        {
+                            spin->clearFocus();
+                        }
+                        if (isUndo) { undo(); } else { redo(); }
+                        return true;
+                    }
+                }
+            }
+        }
+        else if (event->type() == QEvent::MouseButtonPress)
+        {
+            if (auto* w = qobject_cast<QWidget*>(watched))
+            {
+                if (!isDescendantOfDialog(w))
+                {
+                    accept();
+                    return true;
+                }
+                // Click on a non-focusable child (dialog background, labels)
+                // does not change focus on its own in Qt. Commit any active
+                // editor by clearing its focus so editingFinished fires and
+                // the inspector visibly deselects.
+                if (w->focusPolicy() == Qt::NoFocus)
+                {
+                    QWidget* focused = QApplication::focusWidget();
+                    if (focused && focused != w && isDescendantOfDialog(focused))
+                    {
+                        focused->clearFocus();
+                    }
+                }
+            }
+        }
+
+        return QDialog::eventFilter(watched, event);
+    }
+
+    void ColorGradientEditorDialog::keyPressEvent(QKeyEvent* event)
+    {
+        // Staged Enter: if focus is in a spin box, let the field commit its value
+        // and swallow the key so the dialog does not accept. When no spin box is
+        // focused, Enter approves the whole gradient.
+        if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
+        {
+            QWidget* focused = focusWidget();
+            if (auto* spin = qobject_cast<QAbstractSpinBox*>(focused))
+            {
+                // Commit typed text into the spin's value, then EXPLICITLY
+                // apply that value to the marker through the matching change
+                // handler. This avoids any dependency on valueChanged vs
+                // editingFinished signal order, which is keyboardTracking-
+                // sensitive and can leave m_working out of sync when Enter
+                // fires. After that, clear focus for the visible deselect and
+                // push the snapshot.
+                spin->interpretText();
+                if (spin == m_positionSpin) { onPositionChanged(m_positionSpin->value()); }
+                else if (spin == m_alphaSpin) { onAlphaSpinChanged(m_alphaSpin->value()); }
+                spin->clearFocus();
+                pushUndoSnapshot();
+                event->accept();
+                return;
+            }
+            accept();
+            return;
+        }
+
+        // In-dialog undo / redo. These never reach the outer editor; only the
+        // final accepted state is written to the RPE.
+        const bool ctrl = (event->modifiers() & Qt::ControlModifier) != 0;
+        const bool shift = (event->modifiers() & Qt::ShiftModifier) != 0;
+        if (ctrl && !shift && event->key() == Qt::Key_Z)
+        {
+            undo();
+            event->accept();
+            return;
+        }
+        if ((ctrl && event->key() == Qt::Key_Y) || (ctrl && shift && event->key() == Qt::Key_Z))
+        {
+            redo();
+            event->accept();
+            return;
+        }
+
+        QDialog::keyPressEvent(event);
+    }
+
+    // =======================================================================
+    // In-dialog Undo Stack
+    // =======================================================================
+
+    ColorGradientEditorDialog::UndoSnapshot ColorGradientEditorDialog::captureSnapshot() const
+    {
+        UndoSnapshot snap;
+        snap.colorStops = m_colorTrack->colorStops();
+        snap.alphaStops = m_alphaTrack->alphaStops();
+        snap.selectedKind = m_activeTrack ? m_activeTrack->kind() : GradientStopsTrack::Kind::Color;
+        snap.selectedIndex = m_activeTrack ? m_activeTrack->selectedIndex() : AZStd::nullopt;
+        return snap;
+    }
+
+    void ColorGradientEditorDialog::pushUndoSnapshot()
+    {
+        UndoSnapshot snap = captureSnapshot();
+
+        // Coalesce identical-stops snapshots so a no-op editingFinished does
+        // not clutter the stack. Selection-only changes are still not pushed
+        // because onSelectionChanged never calls this function.
+        if (!m_undoStack.empty())
+        {
+            const UndoSnapshot& top = m_undoStack[m_undoCursor];
+            const bool sameColor = top.colorStops.size() == snap.colorStops.size()
+                && std::equal(
+                       top.colorStops.begin(), top.colorStops.end(),
+                       snap.colorStops.begin(),
+                       [](const AZ::ColorGradientMarker& a, const AZ::ColorGradientMarker& b) {
+                           return a.markerPosition == b.markerPosition
+                               && a.markerColor == b.markerColor;
+                       });
+            const bool sameAlpha = top.alphaStops.size() == snap.alphaStops.size()
+                && std::equal(
+                       top.alphaStops.begin(), top.alphaStops.end(),
+                       snap.alphaStops.begin(),
+                       [](const AZ::AlphaGradientMarker& a, const AZ::AlphaGradientMarker& b) {
+                           return a.markerPosition == b.markerPosition
+                               && a.markerAlpha == b.markerAlpha;
+                       });
+            if (sameColor && sameAlpha) { return; }
+        }
+
+        // Discard any "future" redo states beyond the cursor before pushing.
+        if (m_undoCursor + 1 < m_undoStack.size())
+        {
+            m_undoStack.erase(m_undoStack.begin() + m_undoCursor + 1, m_undoStack.end());
+        }
+        m_undoStack.push_back(std::move(snap));
+        m_undoCursor = m_undoStack.size() - 1;
+    }
+
+    void ColorGradientEditorDialog::undo()
+    {
+        if (m_undoCursor == 0) { return; }
+        --m_undoCursor;
+        applyUndoSnapshot(m_undoStack[m_undoCursor]);
+    }
+
+    void ColorGradientEditorDialog::redo()
+    {
+        if (m_undoCursor + 1 >= m_undoStack.size()) { return; }
+        ++m_undoCursor;
+        applyUndoSnapshot(m_undoStack[m_undoCursor]);
+    }
+
+    void ColorGradientEditorDialog::applyUndoSnapshot(const UndoSnapshot& snapshot)
+    {
+        // Preserve the user's CURRENT selection across undo - undo steps the
+        // data, not the pointer to which marker the user is working on. If
+        // the currently-selected index no longer exists in the restored
+        // state, clear the selection.
+        GradientStopsTrack::Kind currentKind = m_activeTrack ? m_activeTrack->kind() : GradientStopsTrack::Kind::Color;
+        AZStd::optional<size_t> currentIndex = m_activeTrack ? m_activeTrack->selectedIndex() : AZStd::nullopt;
+
+        QSignalBlocker blockAlpha(m_alphaTrack);
+        QSignalBlocker blockColor(m_colorTrack);
+        m_colorTrack->setColorStops(snapshot.colorStops);
+        m_alphaTrack->setAlphaStops(snapshot.alphaStops);
+
+        GradientStopsTrack* target = (currentKind == GradientStopsTrack::Kind::Color) ? m_colorTrack : m_alphaTrack;
+        const size_t count = (currentKind == GradientStopsTrack::Kind::Color)
+            ? snapshot.colorStops.size()
+            : snapshot.alphaStops.size();
+        if (currentIndex.has_value() && *currentIndex < count)
+        {
+            target->setSelectedIndex(*currentIndex);
+            m_activeTrack = target;
+        }
+        else
+        {
+            m_activeTrack = m_colorTrack;
+        }
+
+        m_working.colorSlider = m_colorTrack->colorStops();
+        m_working.alphaSlider = m_alphaTrack->alphaStops();
+        m_working.sorted = false;
+        m_working.SortGradients();
+
+        refreshPreview();
+        refreshInspector();
+    }
+
+    // =======================================================================
+    // PropertyColorGradientCtrl
+    // =======================================================================
+
+    PropertyColorGradientCtrl::PropertyColorGradientCtrl(QWidget* parent)
+        : QWidget(parent)
+    {
+        auto* layout = new QHBoxLayout(this);
+        layout->setContentsMargins(1, 0, 1, 0);
+        layout->setSpacing(0);
+
+        m_preview = new GradientBarWidget(this);
+        m_preview->setFixedHeight(GradientCtrlConstants::kInlineHeight);
+        m_preview->setCursor(Qt::PointingHandCursor);
+        m_preview->setToolTip(QStringLiteral("Click to edit gradient | Right-click for copy / paste"));
+
+        layout->addWidget(m_preview, 1);
+    }
+
+    void PropertyColorGradientCtrl::setValue(const AZ::ColorGradient& v)
+    {
+        m_value = v;
+        m_value.SortGradients();
+        m_preview->setGradient(m_value);
+    }
+
+    void PropertyColorGradientCtrl::setAlphaEnabled(bool enabled)
+    {
+        m_alphaEnabled = enabled;
+        m_preview->setAlphaEnabled(enabled);
+    }
+
+    void PropertyColorGradientCtrl::mousePressEvent(QMouseEvent* event)
+    {
+        if (event->button() == Qt::LeftButton)
+        {
+            openEditorDialog();
+            event->accept();
+            return;
+        }
+        QWidget::mousePressEvent(event);
+    }
+
+    void PropertyColorGradientCtrl::openEditorDialog()
+    {
+        ColorGradientEditorDialog dlg(m_value, m_alphaEnabled, m_multiEdit, this);
+        if (dlg.exec() == QDialog::Accepted)
+        {
+            m_value = dlg.result();
+            m_value.SortGradients();
+            m_preview->setGradient(m_value);
+            emit valueChanged();
+            emit editingFinished();
+        }
+    }
+
+    void PropertyColorGradientCtrl::beginReadPass(const AZ::ColorGradient& firstInstance)
+    {
+        m_multiEdit = false;
+        setValue(firstInstance);
+        m_preview->setMixed(false);
+    }
+
+    void PropertyColorGradientCtrl::addReadInstance(const AZ::ColorGradient& instance)
+    {
+        // Only flag when a subsequent instance diverges from the first one we
+        // read. Structural comparison is enough for the indicator.
+        auto sameColor = instance.colorSlider.size() == m_value.colorSlider.size()
+                      && std::equal(
+                             instance.colorSlider.begin(), instance.colorSlider.end(),
+                             m_value.colorSlider.begin(),
+                             [](const AZ::ColorGradientMarker& a, const AZ::ColorGradientMarker& b) {
+                                 return a.markerPosition == b.markerPosition && a.markerColor == b.markerColor;
+                             });
+        auto sameAlpha = instance.alphaSlider.size() == m_value.alphaSlider.size()
+                      && std::equal(
+                             instance.alphaSlider.begin(), instance.alphaSlider.end(),
+                             m_value.alphaSlider.begin(),
+                             [](const AZ::AlphaGradientMarker& a, const AZ::AlphaGradientMarker& b) {
+                                 return a.markerPosition == b.markerPosition && a.markerAlpha == b.markerAlpha;
+                             });
+        if (!sameColor || !sameAlpha)
+        {
+            m_multiEdit = true;
+            m_preview->setMixed(true);
+        }
+    }
+
+    // =======================================================================
+    // Context Menu + Clipboard Serialization
+    // =======================================================================
+    // Plain text format so copied gradients can be pasted into other gradient
+    // fields or reviewed in a text editor:
+    //
+    //   AZ_COLOR_GRADIENT v1
+    //   C r g b position
+    //   C r g b position
+    //   A alpha position
+    //   A alpha position
+
+    namespace
+    {
+        static constexpr const char* kClipboardHeader = "AZ_COLOR_GRADIENT v1";
+
+        QString SerializeGradient(const AZ::ColorGradient& g)
+        {
+            QString out(kClipboardHeader);
+            out.append(QLatin1Char('\n'));
+            for (const auto& c : g.colorSlider)
+            {
+                out.append(QStringLiteral("C %1 %2 %3 %4\n")
+                    .arg(static_cast<qreal>(c.markerColor.GetR()), 0, 'g', 7)
+                    .arg(static_cast<qreal>(c.markerColor.GetG()), 0, 'g', 7)
+                    .arg(static_cast<qreal>(c.markerColor.GetB()), 0, 'g', 7)
+                    .arg(static_cast<qreal>(c.markerPosition), 0, 'g', 7));
+            }
+            for (const auto& a : g.alphaSlider)
+            {
+                out.append(QStringLiteral("A %1 %2\n")
+                    .arg(static_cast<qreal>(a.markerAlpha), 0, 'g', 7)
+                    .arg(static_cast<qreal>(a.markerPosition), 0, 'g', 7));
+            }
+            return out;
+        }
+
+        bool DeserializeGradient(const QString& text, AZ::ColorGradient& out)
+        {
+            const QStringList lines = text.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+            if (lines.isEmpty() || !lines.front().startsWith(QLatin1String(kClipboardHeader)))
+            {
+                return false;
+            }
+
+            AZ::ColorGradient parsed;
+            for (int i = 1; i < lines.size(); ++i)
+            {
+                const QStringList tokens = lines[i].split(QLatin1Char(' '), Qt::SkipEmptyParts);
+                if (tokens.isEmpty()) { continue; }
+                if (tokens[0] == QLatin1String("C") && tokens.size() == 5)
+                {
+                    AZ::ColorGradientMarker m;
+                    m.markerColor = AZ::Color(tokens[1].toFloat(), tokens[2].toFloat(), tokens[3].toFloat(), 1.f);
+                    m.markerPosition = tokens[4].toFloat();
+                    parsed.colorSlider.push_back(m);
+                }
+                else if (tokens[0] == QLatin1String("A") && tokens.size() == 3)
+                {
+                    AZ::AlphaGradientMarker m;
+                    m.markerAlpha = tokens[1].toFloat();
+                    m.markerPosition = tokens[2].toFloat();
+                    parsed.alphaSlider.push_back(m);
+                }
+            }
+            parsed.SortGradients();
+            out = parsed;
+            return true;
+        }
+    }
+
+    void PropertyColorGradientCtrl::copyToClipboard()
+    {
+        QApplication::clipboard()->setText(SerializeGradient(m_value));
+    }
+
+    void PropertyColorGradientCtrl::pasteFromClipboard()
+    {
+        AZ::ColorGradient parsed;
+        if (DeserializeGradient(QApplication::clipboard()->text(), parsed))
+        {
+            m_value = parsed;
+            m_preview->setGradient(m_value);
+            emit valueChanged();
+            emit editingFinished();
+        }
+    }
+
+    void PropertyColorGradientCtrl::contextMenuEvent(QContextMenuEvent* event)
+    {
+        QMenu menu(this);
+        QAction* copyAction = menu.addAction(QStringLiteral("Copy Gradient"));
+        QAction* pasteAction = menu.addAction(QStringLiteral("Paste Gradient"));
+
+        // Paste is only enabled when the clipboard carries a gradient payload.
+        AZ::ColorGradient preview;
+        pasteAction->setEnabled(DeserializeGradient(QApplication::clipboard()->text(), preview));
+
+        QAction* chosen = menu.exec(event->globalPos());
+        if (chosen == copyAction)       { copyToClipboard(); }
+        else if (chosen == pasteAction) { pasteFromClipboard(); }
+
+        // Consume so the component's outer context menu does not also fire.
+        event->accept();
+    }
+
+    // =======================================================================
+    // AZColorGradientPropertyHandler (RGBA)
+    // =======================================================================
+
+    QWidget* AZColorGradientPropertyHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyColorGradientCtrl* ctrl = aznew PropertyColorGradientCtrl(parent);
+        ctrl->setAlphaEnabled(true);
+        connect(ctrl, &PropertyColorGradientCtrl::valueChanged, this, [ctrl]()
+        {
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, ctrl);
+        });
+        connect(ctrl, &PropertyColorGradientCtrl::editingFinished, this, [ctrl]()
+        {
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, ctrl);
+        });
+        return ctrl;
+    }
+
+    void AZColorGradientPropertyHandler::ConsumeAttribute(PropertyColorGradientCtrl* /*GUI*/, AZ::u32 /*attrib*/, PropertyAttributeReader* /*attrValue*/, const char* /*debugName*/)
+    {
+    }
+
+    void AZColorGradientPropertyHandler::WriteGUIValuesIntoProperty(size_t /*index*/, PropertyColorGradientCtrl* GUI, property_t& instance, InstanceDataNode* /*node*/)
+    {
+        instance = GUI->value();
+    }
+
+    bool AZColorGradientPropertyHandler::ReadValuesIntoGUI(size_t index, PropertyColorGradientCtrl* GUI, const property_t& instance, InstanceDataNode* /*node*/)
+    {
+        if (index == 0) { GUI->beginReadPass(instance); }
+        else            { GUI->addReadInstance(instance); }
+        return false;
+    }
+
+    // =======================================================================
+    // AZColorGradientRGBPropertyHandler (RGB only)
+    // =======================================================================
+
+    QWidget* AZColorGradientRGBPropertyHandler::CreateGUI(QWidget* parent)
+    {
+        PropertyColorGradientCtrl* ctrl = aznew PropertyColorGradientCtrl(parent);
+        ctrl->setAlphaEnabled(false);
+        connect(ctrl, &PropertyColorGradientCtrl::valueChanged, this, [ctrl]()
+        {
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, ctrl);
+        });
+        connect(ctrl, &PropertyColorGradientCtrl::editingFinished, this, [ctrl]()
+        {
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, ctrl);
+        });
+        return ctrl;
+    }
+
+    void AZColorGradientRGBPropertyHandler::ConsumeAttribute(PropertyColorGradientCtrl* /*GUI*/, AZ::u32 /*attrib*/, PropertyAttributeReader* /*attrValue*/, const char* /*debugName*/)
+    {
+    }
+
+    void AZColorGradientRGBPropertyHandler::WriteGUIValuesIntoProperty(size_t /*index*/, PropertyColorGradientCtrl* GUI, property_t& instance, InstanceDataNode* /*node*/)
+    {
+        // RGB-only: extract only the color slider, drop alpha track.
+        AZ::ColorGradient full = GUI->value();
+        instance.colorSlider = full.colorSlider;
+        instance.sorted = false;
+        instance.SortGradients();
+    }
+
+    bool AZColorGradientRGBPropertyHandler::ReadValuesIntoGUI(size_t index, PropertyColorGradientCtrl* GUI, const property_t& instance, InstanceDataNode* /*node*/)
+    {
+        AZ::ColorGradient wrapper;
+        wrapper.colorSlider = instance.colorSlider;
+        wrapper.SortGradients();
+        if (index == 0) { GUI->beginReadPass(wrapper); }
+        else            { GUI->addReadInstance(wrapper); }
+        return false;
+    }
+
+    // =======================================================================
+    // Registration
+    // =======================================================================
+
+    void RegisterColorGradientPropertyHandlers()
+    {
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew AZColorGradientPropertyHandler());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, aznew AZColorGradientRGBPropertyHandler());
+    }
+}
+
+#include "UI/PropertyEditor/moc_PropertyColorGradientCtrl.cpp"

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
@@ -10,6 +10,7 @@
 #include "PropertyColorCtrl.hxx"
 #include "PropertyQTConstants.h"
 
+#include <AzCore/Debug/Trace.h>
 #include <AzQtComponents/Components/Widgets/ColorPicker.h>
 #include <AzQtComponents/Utilities/Conversions.h>
 
@@ -32,7 +33,9 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
 #include <QApplication>
 #include <QClipboard>
 #include <QContextMenuEvent>
+#include <QKeySequence>
 #include <QMenu>
+#include <QShortcut>
 #include <QString>
 #include <QStringList>
 AZ_POP_DISABLE_WARNING
@@ -291,13 +294,17 @@ namespace AzToolsFramework
 
     void GradientStopsTrack::setSelectedPosition(float t)
     {
-        if (!m_selected.has_value()) { return; }
+        if (!m_selected.has_value())
+        {
+            AZ_Printf("GradientCtrl", "setSelectedPosition: NO SELECTION - skip");
+            return;
+        }
         t = std::clamp(t, 0.f, 1.f);
+        AZ_Printf("GradientCtrl",
+            "setSelectedPosition: kind=%d index=%zu t=%f",
+            static_cast<int>(m_kind), *m_selected, t);
         if (m_kind == Kind::Color) { m_colorStops[*m_selected].m_markerPosition = t; }
         else                       { m_alphaStops[*m_selected].m_markerPosition = t; }
-        // No consolidation here: a moving marker must pass freely through
-        // other stops without consuming them. The evaluator handles coincident
-        // positions deterministically.
         update();
         emit stopsChanged();
     }
@@ -460,12 +467,19 @@ namespace AzToolsFramework
 
     void GradientStopsTrack::mousePressEvent(QMouseEvent* event)
     {
+        AZ_Printf("GradientCtrl",
+            "Track::mousePressEvent: ENTRY kind=%d (about to setFocus, prev focus=%p)",
+            static_cast<int>(m_kind), (void*)QApplication::focusWidget());
         setFocus();
+        AZ_Printf("GradientCtrl",
+            "Track::mousePressEvent: AFTER setFocus, focus=%p",
+            (void*)QApplication::focusWidget());
         if (event->button() == Qt::LeftButton)
         {
             auto hit = hitTest(event->pos());
             if (hit.has_value())
             {
+                AZ_Printf("GradientCtrl", "Track::mousePressEvent: HIT existing marker idx=%zu", *hit);
                 m_selected = hit;
                 m_dragging = true;
                 update();
@@ -473,6 +487,7 @@ namespace AzToolsFramework
             }
             else
             {
+                AZ_Printf("GradientCtrl", "Track::mousePressEvent: MISS - adding new stop");
                 addStopAt(pixelToPosition(event->pos().x()));
                 m_dragging = true;
             }
@@ -584,6 +599,12 @@ namespace AzToolsFramework
         , m_working(initial)
         , m_alphaEnabled(alphaEnabled)
     {
+        // Allow setFocus(this) to actually grab focus on the dialog itself.
+        // QDialog's default focusPolicy is NoFocus, which would silently
+        // discard our setFocus calls and leave focus null - which prevents
+        // WidgetWithChildrenShortcut shortcuts from activating.
+        setFocusPolicy(Qt::StrongFocus);
+
         setWindowTitle(multiEdit
             ? QStringLiteral("Color Gradient Editor (multi-edit: applies to all selected)")
             : QStringLiteral("Color Gradient Editor"));
@@ -707,10 +728,22 @@ namespace AzToolsFramework
         // Commit-point wiring for the in-dialog undo stack. Granular steps are
         // pushed here; the outer RPE is only notified once, when the dialog
         // closes.
-        connect(m_alphaTrack, &GradientStopsTrack::editCommitted, this, &ColorGradientEditorDialog::pushUndoSnapshot);
-        connect(m_colorTrack, &GradientStopsTrack::editCommitted, this, &ColorGradientEditorDialog::pushUndoSnapshot);
-        connect(m_positionSpin, &QDoubleSpinBox::editingFinished, this, &ColorGradientEditorDialog::pushUndoSnapshot);
-        connect(m_alphaSpin,    &QDoubleSpinBox::editingFinished, this, &ColorGradientEditorDialog::pushUndoSnapshot);
+        connect(m_alphaTrack, &GradientStopsTrack::editCommitted, this, [this]() {
+            AZ_Printf("GradientCtrl", "alphaTrack::editCommitted FIRED -> pushUndoSnapshot");
+            pushUndoSnapshot();
+        });
+        connect(m_colorTrack, &GradientStopsTrack::editCommitted, this, [this]() {
+            AZ_Printf("GradientCtrl", "colorTrack::editCommitted FIRED -> pushUndoSnapshot");
+            pushUndoSnapshot();
+        });
+        connect(m_positionSpin, &QDoubleSpinBox::editingFinished, this, [this]() {
+            AZ_Printf("GradientCtrl", "m_positionSpin::editingFinished FIRED -> pushUndoSnapshot");
+            pushUndoSnapshot();
+        });
+        connect(m_alphaSpin, &QDoubleSpinBox::editingFinished, this, [this]() {
+            AZ_Printf("GradientCtrl", "m_alphaSpin::editingFinished FIRED -> pushUndoSnapshot");
+            pushUndoSnapshot();
+        });
 
         m_activeTrack = m_colorTrack;
         refreshInspector();
@@ -719,6 +752,57 @@ namespace AzToolsFramework
         // the way back to how the dialog appeared.
         m_undoStack.push_back(captureSnapshot());
         m_undoCursor = 0;
+
+        // Widget-scoped shortcuts. These take priority over the editor's
+        // global Ctrl+Z / Ctrl+Y QActions while the dialog or any of its
+        // children own focus, so the keystrokes actually reach our handlers
+        // instead of being eaten by the main-window menu actions.
+        auto installShortcut = [this](const QKeySequence& seq, auto slot)
+        {
+            auto* sc = new QShortcut(seq, this);
+            // WindowShortcut fires whenever the dialog is the active top-level
+            // window, regardless of which descendant (or none) has focus. This
+            // is what we want: while the modal gradient editor is open, the
+            // user's Ctrl+Z should always go to OUR undo, not to any global
+            // editor QAction.
+            sc->setContext(Qt::WindowShortcut);
+            connect(sc, &QShortcut::activated, this, slot);
+        };
+
+        installShortcut(QKeySequence(QKeySequence::Undo), [this]() {
+            AZ_Printf("GradientCtrl", "Shortcut Undo activated focused=%p", (void*)QApplication::focusWidget());
+            // If a line edit inside the dialog has focus, defer to its own
+            // text-undo so typing can be reverted.
+            if (auto* le = qobject_cast<QLineEdit*>(QApplication::focusWidget()))
+            {
+                AZ_Printf("GradientCtrl", "Shortcut Undo: line edit -> text undo");
+                le->undo();
+                return;
+            }
+            undo();
+        });
+        installShortcut(QKeySequence(QKeySequence::Redo), [this]() {
+            AZ_Printf("GradientCtrl", "Shortcut Redo activated");
+            if (auto* le = qobject_cast<QLineEdit*>(QApplication::focusWidget()))
+            {
+                le->redo();
+                return;
+            }
+            redo();
+        });
+        installShortcut(QKeySequence(static_cast<int>(Qt::CTRL) | static_cast<int>(Qt::SHIFT) | static_cast<int>(Qt::Key_Z)), [this]() {
+            AZ_Printf("GradientCtrl", "Shortcut Ctrl+Shift+Z activated");
+            if (auto* le = qobject_cast<QLineEdit*>(QApplication::focusWidget()))
+            {
+                le->redo();
+                return;
+            }
+            redo();
+        });
+        installShortcut(QKeySequence(static_cast<int>(Qt::CTRL) | static_cast<int>(Qt::Key_D)), [this]() {
+            AZ_Printf("GradientCtrl", "Shortcut Ctrl+D activated");
+            if (m_activeTrack) { m_activeTrack->duplicateSelected(); }
+        });
     }
 
     void ColorGradientEditorDialog::rebuildFromTracks()
@@ -801,6 +885,12 @@ namespace AzToolsFramework
 
     void ColorGradientEditorDialog::onPositionChanged(double normalized)
     {
+        AZ_Printf("GradientCtrl",
+            "onPositionChanged: ENTRY normalized=%f activeTrack=%p activeTrack.selected=%s",
+            normalized, (void*)m_activeTrack,
+            (m_activeTrack && m_activeTrack->selectedIndex().has_value())
+                ? AZStd::to_string(*m_activeTrack->selectedIndex()).c_str()
+                : "(none)");
         if (!m_activeTrack) { return; }
         m_activeTrack->setSelectedPosition(static_cast<float>(normalized / 100.0));
     }
@@ -882,6 +972,17 @@ namespace AzToolsFramework
 
         if (event->type() == QEvent::KeyPress)
         {
+            // Diagnostic: log every key event the filter sees so we can tell
+            // when Ctrl+Z / Enter / etc. are reaching us vs being consumed
+            // upstream by another widget's built-in shortcut.
+            {
+                auto* keyEvent = static_cast<QKeyEvent*>(event);
+                AZ_Printf("GradientCtrl",
+                    "eventFilter KeyPress: key=%d mods=%d watched=%p focused=%p (modal=%p this=%p)",
+                    keyEvent->key(), static_cast<int>(keyEvent->modifiers()),
+                    (void*)watched, (void*)QApplication::focusWidget(),
+                    (void*)QApplication::activeModalWidget(), (void*)this);
+            }
             // Intercept undo / redo at the application level so child widgets
             // like QLineEdit (inside PropertyColorCtrl) do not consume Ctrl+Z
             // for their own text-undo before the dialog gets a chance.
@@ -896,6 +997,53 @@ namespace AzToolsFramework
                     // colour text field) reverts the typed value and exits
                     // the field, leaving the dialog open. Outside any editor
                     // it falls through to QDialog's default reject().
+                    if (ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter)
+                    {
+                        QWidget* focused = QApplication::focusWidget();
+                        AZ_Printf("GradientCtrl",
+                            "eventFilter Enter: watched=%p focused=%p (this=%p posSpin=%p alphaSpin=%p colorField=%p)",
+                            (void*)watched, (void*)focused, (void*)this,
+                            (void*)m_positionSpin, (void*)m_alphaSpin, (void*)m_colorField);
+                        QAbstractSpinBox* spin = nullptr;
+                        for (QWidget* p = focused; p; p = p->parentWidget())
+                        {
+                            if (auto* s = qobject_cast<QAbstractSpinBox*>(p)) { spin = s; break; }
+                        }
+                        AZ_Printf("GradientCtrl",
+                            "eventFilter Enter: walk found spin=%p", (void*)spin);
+                        if (spin == m_positionSpin)
+                        {
+                            AZ_Printf("GradientCtrl", "eventFilter Enter: position spin path - commit + grab dialog focus + push");
+                            spin->interpretText();
+                            onPositionChanged(m_positionSpin->value());
+                            spin->clearFocus();
+                            // Explicitly grab focus on the dialog so subsequent
+                            // Ctrl+Z events arrive at the dialog (and our app
+                            // event filter) rather than at the line edit, which
+                            // would consume them as text-undo.
+                            this->setFocus(Qt::OtherFocusReason);
+                            AZ_Printf("GradientCtrl",
+                                "eventFilter Enter: post-handoff focused=%p (this=%p)",
+                                (void*)QApplication::focusWidget(), (void*)this);
+                            pushUndoSnapshot();
+                            return true;
+                        }
+                        if (spin == m_alphaSpin)
+                        {
+                            AZ_Printf("GradientCtrl", "eventFilter Enter: alpha spin path - commit + grab dialog focus + push");
+                            spin->interpretText();
+                            onAlphaSpinChanged(m_alphaSpin->value());
+                            spin->clearFocus();
+                            this->setFocus(Qt::OtherFocusReason);
+                            AZ_Printf("GradientCtrl",
+                                "eventFilter Enter: post-handoff focused=%p (this=%p)",
+                                (void*)QApplication::focusWidget(), (void*)this);
+                            pushUndoSnapshot();
+                            return true;
+                        }
+                        AZ_Printf("GradientCtrl", "eventFilter Enter: falling through (not in our spin)");
+                    }
+
                     if (ke->key() == Qt::Key_Escape)
                     {
                         QWidget* focused = QApplication::focusWidget();
@@ -967,22 +1115,95 @@ namespace AzToolsFramework
                     accept();
                     return true;
                 }
-                // Click on a non-focusable child (dialog background, labels)
-                // does not change focus on its own in Qt. Commit any active
-                // editor by clearing its focus so editingFinished fires and
-                // the inspector visibly deselects.
-                if (w->focusPolicy() == Qt::NoFocus)
+
+                auto isInside = [](QWidget* container, QWidget* candidate)
                 {
+                    if (!container || !candidate) { return false; }
+                    for (QWidget* p = candidate; p; p = p->parentWidget())
+                    {
+                        if (p == container) { return true; }
+                    }
+                    return false;
+                };
+
+                const bool inField = isInside(m_positionSpin, w)
+                                  || isInside(m_alphaSpin, w)
+                                  || isInside(m_colorField, w);
+                const bool inTrack = isInside(m_colorTrack, w)
+                                  || isInside(m_alphaTrack, w);
+
+                if (!inField && !inTrack)
+                {
+                    // Empty-area click: behave like Tab-out from the active
+                    // editor (clear focus -> editingFinished -> commit) AND
+                    // deselect any highlighted marker so the inspector
+                    // clears. Anything that is neither a track nor a field
+                    // counts as empty space (preview bar, labels, dialog
+                    // background, button bar).
                     QWidget* focused = QApplication::focusWidget();
                     if (focused && focused != w && isDescendantOfDialog(focused))
                     {
                         focused->clearFocus();
                     }
+                    if (m_colorTrack) { m_colorTrack->setSelectedIndex(AZStd::nullopt); }
+                    if (m_alphaTrack) { m_alphaTrack->setSelectedIndex(AZStd::nullopt); }
                 }
             }
         }
 
         return QDialog::eventFilter(watched, event);
+    }
+
+    void ColorGradientEditorDialog::mousePressEvent(QMouseEvent* event)
+    {
+        // Mouse presses that land on a focusable child (track / spin / color
+        // field / button) are accepted by that child and never reach this
+        // override. Anything that bubbles up to the dialog itself - the
+        // gradient bar, dialog background, labels, layout gaps - is "blank
+        // space" by definition.
+        //
+        // Staged blur:
+        //   Step 1) If a child of the dialog currently has focus, blur it
+        //           (Tab-out). This commits any active editor without
+        //           clearing the highlighted marker.
+        //   Step 2) If no descendant has focus, drop the marker selection.
+        // A second blank click is therefore needed to fully deselect when
+        // the user was mid-edit.
+        QWidget* focused = QApplication::focusWidget();
+        bool focusedDescendant = false;
+        if (focused && focused != this)
+        {
+            for (QWidget* p = focused; p; p = p->parentWidget())
+            {
+                if (p == this) { focusedDescendant = true; break; }
+            }
+        }
+
+        AZ_Printf("GradientCtrl",
+            "dialog::mousePressEvent: ENTRY focused=%p focusedDescendant=%d",
+            (void*)focused, focusedDescendant);
+
+        if (focusedDescendant)
+        {
+            AZ_Printf("GradientCtrl", "dialog::mousePressEvent: STAGE 1 - clearFocus + grab dialog focus + push");
+            focused->clearFocus();
+            // Hand focus to the dialog itself so subsequent Ctrl+Z reaches our
+            // event filter instead of being absorbed by a still-listening line
+            // edit's text-undo shortcut.
+            this->setFocus(Qt::OtherFocusReason);
+            AZ_Printf("GradientCtrl",
+                "dialog::mousePressEvent: post-handoff focused=%p",
+                (void*)QApplication::focusWidget());
+            pushUndoSnapshot();
+        }
+        else
+        {
+            AZ_Printf("GradientCtrl", "dialog::mousePressEvent: STAGE 2 - deselecting markers");
+            if (m_colorTrack) { m_colorTrack->setSelectedIndex(AZStd::nullopt); }
+            if (m_alphaTrack) { m_alphaTrack->setSelectedIndex(AZStd::nullopt); }
+        }
+
+        QDialog::mousePressEvent(event);
     }
 
     void ColorGradientEditorDialog::reject()
@@ -1037,15 +1258,21 @@ namespace AzToolsFramework
         if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
         {
             QWidget* focused = focusWidget();
-            if (auto* spin = qobject_cast<QAbstractSpinBox*>(focused))
+
+            // focusWidget() may return the spin's internal QLineEdit (focus
+            // proxy) rather than the QAbstractSpinBox itself, so the direct
+            // qobject_cast can fail. Walk parents to find an enclosing spin
+            // reliably for both routes.
+            QAbstractSpinBox* spin = qobject_cast<QAbstractSpinBox*>(focused);
+            if (!spin)
             {
-                // Commit typed text into the spin's value, then EXPLICITLY
-                // apply that value to the marker through the matching change
-                // handler. This avoids any dependency on valueChanged vs
-                // editingFinished signal order, which is keyboardTracking-
-                // sensitive and can leave m_working out of sync when Enter
-                // fires. After that, clear focus for the visible deselect and
-                // push the snapshot.
+                for (QWidget* p = focused; p; p = p->parentWidget())
+                {
+                    if (auto* s = qobject_cast<QAbstractSpinBox*>(p)) { spin = s; break; }
+                }
+            }
+            if (spin == m_positionSpin || spin == m_alphaSpin)
+            {
                 spin->interpretText();
                 if (spin == m_positionSpin) { onPositionChanged(m_positionSpin->value()); }
                 else if (spin == m_alphaSpin) { onAlphaSpinChanged(m_alphaSpin->value()); }
@@ -1108,11 +1335,22 @@ namespace AzToolsFramework
         snap.alphaStops = m_alphaTrack->alphaStops();
         snap.selectedKind = m_activeTrack ? m_activeTrack->kind() : GradientStopsTrack::Kind::Color;
         snap.selectedIndex = m_activeTrack ? m_activeTrack->selectedIndex() : AZStd::nullopt;
+        AZ_Printf("GradientCtrl",
+            "captureSnapshot: colorStops=%zu alphaStops=%zu activeKind=%d selectedIndex=%s",
+            snap.colorStops.size(), snap.alphaStops.size(),
+            static_cast<int>(snap.selectedKind),
+            snap.selectedIndex.has_value()
+                ? AZStd::to_string(*snap.selectedIndex).c_str()
+                : "(none)");
         return snap;
     }
 
     void ColorGradientEditorDialog::pushUndoSnapshot()
     {
+        AZ_Printf("GradientCtrl",
+            "pushUndoSnapshot: ENTRY stack.size=%zu cursor=%zu",
+            m_undoStack.size(), m_undoCursor);
+
         UndoSnapshot snap = captureSnapshot();
 
         // Coalesce identical-stops snapshots so a no-op editingFinished does
@@ -1137,7 +1375,16 @@ namespace AzToolsFramework
                            return a.m_markerPosition == b.m_markerPosition
                                && a.m_markerAlpha == b.m_markerAlpha;
                        });
-            if (sameColor && sameAlpha) { return; }
+            AZ_Printf("GradientCtrl",
+                "pushUndoSnapshot: coalesce check sameColor=%d sameAlpha=%d (top.color=%zu snap.color=%zu top.alpha=%zu snap.alpha=%zu)",
+                sameColor, sameAlpha,
+                top.colorStops.size(), snap.colorStops.size(),
+                top.alphaStops.size(), snap.alphaStops.size());
+            if (sameColor && sameAlpha)
+            {
+                AZ_Printf("GradientCtrl", "pushUndoSnapshot: SKIP (coalesced - state unchanged)");
+                return;
+            }
         }
 
         // Discard any "future" redo states beyond the cursor before pushing.
@@ -1147,24 +1394,46 @@ namespace AzToolsFramework
         }
         m_undoStack.push_back(std::move(snap));
         m_undoCursor = m_undoStack.size() - 1;
+        AZ_Printf("GradientCtrl",
+            "pushUndoSnapshot: PUSHED stack.size=%zu cursor=%zu",
+            m_undoStack.size(), m_undoCursor);
     }
 
     void ColorGradientEditorDialog::undo()
     {
-        if (m_undoCursor == 0) { return; }
+        AZ_Printf("GradientCtrl",
+            "undo: ENTRY stack.size=%zu cursor=%zu",
+            m_undoStack.size(), m_undoCursor);
+        if (m_undoCursor == 0)
+        {
+            AZ_Printf("GradientCtrl", "undo: AT BOTTOM, no-op");
+            return;
+        }
         --m_undoCursor;
+        AZ_Printf("GradientCtrl", "undo: stepping to cursor=%zu", m_undoCursor);
         applyUndoSnapshot(m_undoStack[m_undoCursor]);
     }
 
     void ColorGradientEditorDialog::redo()
     {
-        if (m_undoCursor + 1 >= m_undoStack.size()) { return; }
+        AZ_Printf("GradientCtrl",
+            "redo: ENTRY stack.size=%zu cursor=%zu",
+            m_undoStack.size(), m_undoCursor);
+        if (m_undoCursor + 1 >= m_undoStack.size())
+        {
+            AZ_Printf("GradientCtrl", "redo: AT TOP, no-op");
+            return;
+        }
         ++m_undoCursor;
+        AZ_Printf("GradientCtrl", "redo: stepping to cursor=%zu", m_undoCursor);
         applyUndoSnapshot(m_undoStack[m_undoCursor]);
     }
 
     void ColorGradientEditorDialog::applyUndoSnapshot(const UndoSnapshot& snapshot)
     {
+        AZ_Printf("GradientCtrl",
+            "applyUndoSnapshot: ENTRY snapshot.colorStops=%zu snapshot.alphaStops=%zu",
+            snapshot.colorStops.size(), snapshot.alphaStops.size());
         // Preserve the user's CURRENT selection across undo - undo steps the
         // data, not the pointer to which marker the user is working on. If
         // the currently-selected index no longer exists in the restored

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.cpp
@@ -20,6 +20,7 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
 #include <QDoubleSpinBox>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QLineEdit>
 #include <QLinearGradient>
 #include <QMouseEvent>
 #include <QPainter>
@@ -891,6 +892,53 @@ namespace AzToolsFramework
             {
                 if (isDescendantOfDialog(w))
                 {
+                    // Escape inside a focused text editor (spin box or the
+                    // colour text field) reverts the typed value and exits
+                    // the field, leaving the dialog open. Outside any editor
+                    // it falls through to QDialog's default reject().
+                    if (ke->key() == Qt::Key_Escape)
+                    {
+                        QWidget* focused = QApplication::focusWidget();
+
+                        // focusWidget() can return the spin's internal QLineEdit
+                        // (focus proxy) OR the spin itself depending on Qt's
+                        // focus-routing path. Walk parents from both the focused
+                        // widget and the event recipient (w) so either case
+                        // resolves to the spin.
+                        QAbstractSpinBox* spin = nullptr;
+                        for (QWidget* p = focused; p; p = p->parentWidget())
+                        {
+                            if (auto* s = qobject_cast<QAbstractSpinBox*>(p)) { spin = s; break; }
+                        }
+                        if (!spin)
+                        {
+                            for (QWidget* p = w; p; p = p->parentWidget())
+                            {
+                                if (auto* s = qobject_cast<QAbstractSpinBox*>(p)) { spin = s; break; }
+                            }
+                        }
+                        if (spin && isDescendantOfDialog(spin))
+                        {
+                            // QAbstractSpinBox::lineEdit() is protected;
+                            // findChild reaches it through the public API.
+                            if (auto* le = spin->findChild<QLineEdit*>()) { le->undo(); }
+                            spin->clearFocus();
+                            return true;
+                        }
+
+                        // Plain QLineEdit (PropertyColorCtrl's text field).
+                        if (auto* le = qobject_cast<QLineEdit*>(focused))
+                        {
+                            if (isDescendantOfDialog(le))
+                            {
+                                le->undo();
+                                le->clearFocus();
+                                return true;
+                            }
+                        }
+                        // No focused editor: fall through to QDialog default.
+                    }
+
                     const bool isUndo = ctrl && !shift && ke->key() == Qt::Key_Z;
                     const bool isRedo = (ctrl && ke->key() == Qt::Key_Y)
                                      || (ctrl && shift && ke->key() == Qt::Key_Z);
@@ -937,6 +985,50 @@ namespace AzToolsFramework
         return QDialog::eventFilter(watched, event);
     }
 
+    void ColorGradientEditorDialog::reject()
+    {
+        // If a field inside the dialog is currently being edited, treat the
+        // cancel as a field-revert instead of a dialog-cancel. This catches
+        // every path that leads to reject() including the Cancel button's
+        // implicit Esc shortcut (a QEvent::Shortcut that the KeyPress-only
+        // event filter does not see).
+        QWidget* focused = QApplication::focusWidget();
+
+        auto isInside = [](QWidget* container, QWidget* candidate)
+        {
+            if (!container || !candidate) { return false; }
+            for (QWidget* p = candidate; p; p = p->parentWidget())
+            {
+                if (p == container) { return true; }
+            }
+            return false;
+        };
+
+        if (isInside(m_positionSpin, focused))
+        {
+            if (auto* le = m_positionSpin->findChild<QLineEdit*>()) { le->undo(); }
+            m_positionSpin->clearFocus();
+            return;
+        }
+        if (isInside(m_alphaSpin, focused))
+        {
+            if (auto* le = m_alphaSpin->findChild<QLineEdit*>()) { le->undo(); }
+            m_alphaSpin->clearFocus();
+            return;
+        }
+        if (isInside(m_colorField, focused))
+        {
+            if (auto* le = m_colorField->findChild<QLineEdit*>())
+            {
+                le->undo();
+                le->clearFocus();
+            }
+            return;
+        }
+
+        QDialog::reject();
+    }
+
     void ColorGradientEditorDialog::keyPressEvent(QKeyEvent* event)
     {
         // Staged Enter: if focus is in a spin box, let the field commit its value
@@ -962,6 +1054,25 @@ namespace AzToolsFramework
                 event->accept();
                 return;
             }
+
+            // Enter inside the colour text field: QLineEdit's returnPressed
+            // already fired and PropertyColorCtrl::OnEditingFinished committed
+            // the value through the existing signal chain. Just consume the
+            // event so the dialog does not also approve, and release focus
+            // for visual consistency with the spin path.
+            if (m_colorField)
+            {
+                for (QWidget* p = focused; p; p = p->parentWidget())
+                {
+                    if (p == m_colorField)
+                    {
+                        if (auto* le = m_colorField->findChild<QLineEdit*>()) { le->clearFocus(); }
+                        event->accept();
+                        return;
+                    }
+                }
+            }
+
             accept();
             return;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.hxx
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzToolsFramework/AzToolsFrameworkAPI.h>
+
+#if !defined(Q_MOC_RUN)
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/ColorGradient.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/optional.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
+#include <QDialog>
+#include <QWidget>
+AZ_POP_DISABLE_WARNING
+#endif
+
+class QDoubleSpinBox;
+class QPushButton;
+class QLabel;
+class QHBoxLayout;
+class QVBoxLayout;
+
+namespace AzToolsFramework
+{
+    class PropertyColorCtrl;
+    // =======================================================================
+    // GradientBarWidget
+    // =======================================================================
+    // Paints a live RGBA gradient preview over a checkerboard backdrop.
+    // Read-only: does not handle input.
+
+    class AZTF_API GradientBarWidget : public QWidget
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(GradientBarWidget, AZ::SystemAllocator);
+
+        explicit GradientBarWidget(QWidget* parent = nullptr);
+
+        void setGradient(const AZ::ColorGradient& gradient);
+        void setAlphaEnabled(bool enabled);
+        void setMixed(bool mixed);
+
+    protected:
+        void paintEvent(QPaintEvent* event) override;
+
+    private:
+        AZ::ColorGradient m_gradient;
+        bool              m_alphaEnabled { true };
+        bool              m_mixed { false };
+    };
+
+    // =======================================================================
+    // GradientStopsTrack
+    // =======================================================================
+    // One stops track (color or alpha). Hit-test, drag, add-on-empty-click,
+    // highlight selection, Del to remove.
+
+    class AZTF_API GradientStopsTrack : public QWidget
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(GradientStopsTrack, AZ::SystemAllocator);
+
+        enum class Kind { Color, Alpha };
+
+        GradientStopsTrack(Kind kind, QWidget* parent = nullptr);
+
+        void setColorStops(const AZStd::vector<AZ::ColorGradientMarker>& stops);
+        void setAlphaStops(const AZStd::vector<AZ::AlphaGradientMarker>& stops);
+
+        const AZStd::vector<AZ::ColorGradientMarker>& colorStops() const { return m_colorStops; }
+        const AZStd::vector<AZ::AlphaGradientMarker>& alphaStops() const { return m_alphaStops; }
+
+        AZStd::optional<size_t> selectedIndex() const { return m_selected; }
+        void setSelectedIndex(AZStd::optional<size_t> index);
+
+        //! Samples the provided tracks to get the blended value at normalized t.
+        AZ::Color sampleColorAt(float t) const;
+        float     sampleAlphaAt(float t) const;
+
+        //! Track arrow triangles point toward the gradient bar.
+        Kind kind() const { return m_kind; }
+
+        //! Duplicate the currently selected stop at a position offset, clamped.
+        void duplicateSelected();
+        //! Remove the selected stop if safe (respects minimum 1 stop).
+        void removeSelected();
+
+        //! Commit the position/value of the currently selected stop.
+        void setSelectedPosition(float t);
+        void setSelectedColor(const AZ::Color& rgb);
+        void setSelectedAlpha(float alpha);
+
+    signals:
+        void selectionChanged();
+        //! Live value change; fires during drags and field edits, used for preview repaint.
+        void stopsChanged();
+        //! Discrete commit point; fires after drag release, add, remove, duplicate, and color pick.
+        //! Used by the dialog to push an undo snapshot.
+        void editCommitted();
+
+    protected:
+        void paintEvent(QPaintEvent* event) override;
+        void mousePressEvent(QMouseEvent* event) override;
+        void mouseMoveEvent(QMouseEvent* event) override;
+        void mouseReleaseEvent(QMouseEvent* event) override;
+        void mouseDoubleClickEvent(QMouseEvent* event) override;
+        void keyPressEvent(QKeyEvent* event) override;
+
+    private:
+        QRect triangleRect(float position) const;
+        int   positionToPixel(float position) const;
+        float pixelToPosition(int pixel) const;
+        AZStd::optional<size_t> hitTest(const QPoint& point) const;
+        void  addStopAt(float t);
+        size_t stopCount() const;
+        float stopPositionAt(size_t index) const;
+
+        Kind m_kind;
+        AZStd::vector<AZ::ColorGradientMarker> m_colorStops;
+        AZStd::vector<AZ::AlphaGradientMarker> m_alphaStops;
+        AZStd::optional<size_t> m_selected;
+        bool m_dragging { false };
+        bool m_pendingDelete { false };
+    };
+
+    // =======================================================================
+    // ColorGradientEditorDialog
+    // =======================================================================
+    // Popup dialog that assembles the preview bar, alpha track (top), color
+    // track (bottom), and the selected-stop inspector. Commits on OK.
+
+    class AZTF_API ColorGradientEditorDialog : public QDialog
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(ColorGradientEditorDialog, AZ::SystemAllocator);
+
+        ColorGradientEditorDialog(const AZ::ColorGradient& initial, bool alphaEnabled, bool multiEdit, QWidget* parent = nullptr);
+
+        const AZ::ColorGradient& result() const { return m_working; }
+
+    protected:
+        void keyPressEvent(QKeyEvent* event) override;
+        void showEvent(QShowEvent* event) override;
+        void hideEvent(QHideEvent* event) override;
+        bool eventFilter(QObject* watched, QEvent* event) override;
+
+    private slots:
+        void onAlphaTrackChanged();
+        void onColorTrackChanged();
+        void onSelectionChanged();
+        void onPositionChanged(double normalized);
+        void onColorFieldLiveChanged();
+        void onColorFieldCommitted();
+        void onColorFieldRejected();
+        void onAlphaSpinChanged(double value);
+
+    private:
+        // In-dialog granular undo snapshot. Stores track vectors directly so
+        // undo preserves exact insertion order and selection index.
+        struct UndoSnapshot
+        {
+            AZStd::vector<AZ::ColorGradientMarker> colorStops;
+            AZStd::vector<AZ::AlphaGradientMarker> alphaStops;
+            GradientStopsTrack::Kind selectedKind { GradientStopsTrack::Kind::Color };
+            AZStd::optional<size_t>  selectedIndex;
+        };
+
+        void rebuildFromTracks();
+        void refreshInspector();
+        void refreshPreview();
+
+        // In-dialog granular undo. Snapshots are pushed at discrete commit
+        // points (drag release, field edits, add, remove, duplicate, color
+        // pick). On dialog accept the outer RPE sees a single Pre/Post write.
+        void pushUndoSnapshot();
+        void undo();
+        void redo();
+        void applyUndoSnapshot(const UndoSnapshot& snapshot);
+        UndoSnapshot captureSnapshot() const;
+
+        AZ::ColorGradient  m_working;
+        bool               m_alphaEnabled { true };
+
+        AZStd::vector<UndoSnapshot> m_undoStack;
+        size_t m_undoCursor { 0 };
+
+        GradientBarWidget* m_preview { nullptr };
+        GradientStopsTrack* m_alphaTrack { nullptr };
+        GradientStopsTrack* m_colorTrack { nullptr };
+
+        // Inspector row
+        QLabel*            m_valueLabel { nullptr };
+        PropertyColorCtrl* m_colorField { nullptr };
+        QDoubleSpinBox*    m_alphaSpin { nullptr };
+        QDoubleSpinBox*    m_positionSpin { nullptr };
+
+        // Tracks which track owns the selection (color or alpha)
+        GradientStopsTrack* m_activeTrack { nullptr };
+    };
+
+    // =======================================================================
+    // PropertyColorGradientCtrl
+    // =======================================================================
+    // Inline widget shown in the RPE row. A preview bar + "Edit..." button
+    // that opens the editor dialog. Commits the new gradient when the dialog
+    // closes with OK.
+
+    class AZTF_API PropertyColorGradientCtrl : public QWidget
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(PropertyColorGradientCtrl, AZ::SystemAllocator);
+
+        explicit PropertyColorGradientCtrl(QWidget* parent = nullptr);
+
+        const AZ::ColorGradient& value() const { return m_value; }
+        void setValue(const AZ::ColorGradient& v);
+
+        void setAlphaEnabled(bool enabled);
+        bool alphaEnabled() const { return m_alphaEnabled; }
+
+        //! RPE multi-edit support. The first instance of a refresh pass calls
+        //! beginReadPass() with its value; subsequent instances call
+        //! addReadInstance() so we can detect divergence without overwriting.
+        void beginReadPass(const AZ::ColorGradient& firstInstance);
+        void addReadInstance(const AZ::ColorGradient& instance);
+        bool isMultiEdit() const { return m_multiEdit; }
+
+    signals:
+        void valueChanged();
+        void editingFinished();
+
+    protected:
+        void mousePressEvent(QMouseEvent* event) override;
+        void contextMenuEvent(QContextMenuEvent* event) override;
+
+    private:
+        void openEditorDialog();
+        void copyToClipboard();
+        void pasteFromClipboard();
+
+        GradientBarWidget* m_preview { nullptr };
+        AZ::ColorGradient  m_value;
+        bool               m_alphaEnabled { true };
+        bool               m_multiEdit { false };
+    };
+
+    // =======================================================================
+    // Property Handlers
+    // =======================================================================
+    // Registered by PropertyManagerComponent so any reflected AZ::ColorGradient
+    // or AZ::ColorGradientRGB field picks up the gradient editor automatically.
+
+    class AZTF_API AZColorGradientPropertyHandler
+        : public QObject
+        , public PropertyHandler<AZ::ColorGradient, PropertyColorGradientCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(AZColorGradientPropertyHandler, AZ::SystemAllocator);
+
+        AZ::u32 GetHandlerName() const override { return AZ::Edit::UIHandlers::ColorGradient; }
+        bool    IsDefaultHandler() const override { return true; }
+
+        QWidget* CreateGUI(QWidget* parent) override;
+        void ConsumeAttribute(PropertyColorGradientCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        void WriteGUIValuesIntoProperty(size_t index, PropertyColorGradientCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
+        bool ReadValuesIntoGUI(size_t index, PropertyColorGradientCtrl* GUI, const property_t& instance, InstanceDataNode* node) override;
+    };
+
+    class AZTF_API AZColorGradientRGBPropertyHandler
+        : public QObject
+        , public PropertyHandler<AZ::ColorGradientRGB, PropertyColorGradientCtrl>
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(AZColorGradientRGBPropertyHandler, AZ::SystemAllocator);
+
+        AZ::u32 GetHandlerName() const override { return AZ::Edit::UIHandlers::ColorGradientRGB; }
+        bool    IsDefaultHandler() const override { return true; }
+
+        QWidget* CreateGUI(QWidget* parent) override;
+        void ConsumeAttribute(PropertyColorGradientCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        void WriteGUIValuesIntoProperty(size_t index, PropertyColorGradientCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
+        bool ReadValuesIntoGUI(size_t index, PropertyColorGradientCtrl* GUI, const property_t& instance, InstanceDataNode* node) override;
+    };
+
+    AZTF_API void RegisterColorGradientPropertyHandlers();
+}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.hxx
@@ -156,6 +156,13 @@ namespace AzToolsFramework
         void hideEvent(QHideEvent* event) override;
         bool eventFilter(QObject* watched, QEvent* event) override;
 
+    public Q_SLOTS:
+        // Override to intercept the "cancel" action regardless of trigger
+        // path (Esc keypress, Esc shortcut on Cancel button, X close, etc.).
+        // When a spin or line-edit field inside the dialog has focus, revert
+        // its typed value and release focus instead of closing the dialog.
+        void reject() override;
+
     private slots:
         void onAlphaTrackChanged();
         void onColorTrackChanged();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorGradientCtrl.hxx
@@ -152,6 +152,7 @@ namespace AzToolsFramework
 
     protected:
         void keyPressEvent(QKeyEvent* event) override;
+        void mousePressEvent(QMouseEvent* event) override;
         void showEvent(QShowEvent* event) override;
         void hideEvent(QHideEvent* event) override;
         bool eventFilter(QObject* watched, QEvent* event) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -22,6 +22,7 @@ namespace AzToolsFramework
     AZTF_API void RegisterDoubleSpinBoxHandlers();
     AZTF_API void RegisterDoubleSliderHandlers();
     AZTF_API void RegisterColorPropertyHandlers();
+    AZTF_API void RegisterColorGradientPropertyHandlers();
     AZTF_API void RegisterStringLineEditHandler();
     AZTF_API void RegisterBoolComboBoxHandler();
     AZTF_API void RegisterCheckBoxHandlers();
@@ -231,6 +232,7 @@ namespace AzToolsFramework
             RegisterDoubleSpinBoxHandlers();
             RegisterDoubleSliderHandlers();
             RegisterColorPropertyHandlers();
+            RegisterColorGradientPropertyHandlers();
             RegisterStringLineEditHandler();
             RegisterBoolComboBoxHandler();
             RegisterCheckBoxHandlers();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -550,6 +550,8 @@ set(FILES
     UI/PropertyEditor/PropertyCheckBoxCtrl.cpp
     UI/PropertyEditor/PropertyColorCtrl.hxx
     UI/PropertyEditor/PropertyColorCtrl.cpp
+    UI/PropertyEditor/PropertyColorGradientCtrl.hxx
+    UI/PropertyEditor/PropertyColorGradientCtrl.cpp
     UI/PropertyEditor/PropertyDoubleSliderCtrl.hxx
     UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
     UI/PropertyEditor/PropertyDoubleSpinCtrl.hxx


### PR DESCRIPTION
Has undo mistakes for positional changes. Needs to select other marker for undo, cannot undo from position spinnerbox change alone.

## What does this PR do?

Implements a brand new gradient field input and editor.

## How was this PR tested?

In editor. However undo is not working exactly as correct.


https://github.com/user-attachments/assets/00d75de1-9840-4a7c-94c1-555deedd9823


AI Assisted - Claude Code: Opus 4.7