### PR TITLE
Add Canary AR and update AR to Clang 18

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -188,10 +188,17 @@ jobs:
           java-version: 17
 
       - name: Setup clang
+        # Use the official LLVM installer script so we can install arbitrary upstream Clang versions.
+        # Ref: https://apt.llvm.org/llvm.sh
+        #
+        # NOTE: This clang is the *host* compiler used on the Linux runner.
+        # The Android NDK provides its own clang toolchain for cross-compiling to Android.
         if: ${{ inputs.clang_version }}
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y clang-${{ inputs.clang_version }} lld-${{ inputs.clang_version }}
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh ${{ inputs.clang_version }}
+          sudo apt-get install -y lld-${{ inputs.clang_version }}
           echo "CC=$(which clang-${{ inputs.clang_version }})" >> $GITHUB_ENV
           echo "CXX=$(which clang++-${{ inputs.clang_version }})" >> $GITHUB_ENV
 
@@ -228,6 +235,7 @@ jobs:
           if [[ -n "${{ inputs.ndk_version }}" ]]; then
             echo "LY_NDK_DIR=$ANDROID_HOME/ndk/${{ env.NDK_VERSION }}" >> $GITHUB_ENV
           fi
+
           echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
           echo "JDK_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
           echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV

--- a/.github/workflows/ar-canary.yml
+++ b/.github/workflows/ar-canary.yml
@@ -40,7 +40,7 @@ env:
   CMAKE_VERSION: &cmake_version "4.2.3"
 
 jobs:
-  #### Android Canary — ubuntu-24.04 + NDK r28 + host Clang 19 ####
+  #### Android Canary - ubuntu-24.04 ####
   Android-Ubuntu24-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
     uses: ./.github/workflows/android-build.yml
@@ -88,7 +88,7 @@ jobs:
       gradle_version: "8.13"
       cmake_version: *cmake_version
 
-  #### Android Canary — ubuntu-22.04 + NDK r28 + host Clang 19 ####
+  #### Android Canary - ubuntu-22.04 ####
   Android-Ubuntu22-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
     uses: ./.github/workflows/android-build.yml
@@ -136,51 +136,7 @@ jobs:
       gradle_version: "8.13"
       cmake_version: *cmake_version
 
-  #### iOS Canary — macos-15 Apple Silicon ####
-  iOS-macOS15-Profile:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
-    uses: ./.github/workflows/ios-build.yml
-    with:
-      config: profile
-      image: macos-15
-      type: profile
-      last_artifact: false
-      cmake_version: *cmake_version
-
-  iOS-macOS15-Asset:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
-    needs: iOS-macOS15-Profile
-    uses: ./.github/workflows/ios-build.yml
-    with:
-      config: profile
-      image: macos-15
-      type: asset_profile
-      last_artifact: false
-      cmake_version: *cmake_version
-
-  #### iOS Canary — macos-15-intel ####
-  iOS-macOS15Intel-Profile:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
-    uses: ./.github/workflows/ios-build.yml
-    with:
-      config: profile
-      image: macos-15-intel
-      type: profile
-      last_artifact: false
-      cmake_version: *cmake_version
-
-  iOS-macOS15Intel-Asset:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
-    needs: iOS-macOS15Intel-Profile
-    uses: ./.github/workflows/ios-build.yml
-    with:
-      config: profile
-      image: macos-15-intel
-      type: asset_profile
-      last_artifact: false
-      cmake_version: *cmake_version
-
-  #### Linux Canary — ubuntu-24.04 + Clang 19 ####
+  #### Linux Canary - ubuntu-24.04 ####
   Linux-Ubuntu24-Clang19-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
     uses: ./.github/workflows/linux-build.yml
@@ -223,7 +179,7 @@ jobs:
       clang_version: "19"
       cmake_version: *cmake_version
 
-  #### Linux Canary — ubuntu-22.04 + Clang 19 ####
+  #### Linux Canary - ubuntu-22.04 ####
   Linux-Ubuntu22-Clang19-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
     uses: ./.github/workflows/linux-build.yml
@@ -266,7 +222,7 @@ jobs:
       clang_version: "19"
       cmake_version: *cmake_version
 
-  #### Mac Canary — macos-15 Apple Silicon ####
+  #### Mac Canary - macos-15 Apple Silicon ####
   Mac-macOS15-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
     uses: ./.github/workflows/mac-build.yml
@@ -288,7 +244,7 @@ jobs:
       last_artifact: false
       cmake_version: *cmake_version
 
-  #### Mac Canary — macos-15-intel ####
+  #### Mac Canary - macos-15-intel ####
   Mac-macOS15Intel-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
     uses: ./.github/workflows/mac-build.yml
@@ -310,7 +266,51 @@ jobs:
       last_artifact: false
       cmake_version: *cmake_version
 
-  #### Windows Canary — use latest installed v143 toolset on each runner image ####
+#### iOS Canary - macos-15 Apple Silicon ####
+  iOS-macOS15-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15
+      type: profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  iOS-macOS15-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    needs: iOS-macOS15-Profile
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15
+      type: asset_profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  #### iOS Canary - macos-15-intel ####
+  iOS-macOS15Intel-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15-intel
+      type: profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  iOS-macOS15Intel-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    needs: iOS-macOS15Intel-Profile
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15-intel
+      type: asset_profile
+      last_artifact: false
+      cmake_version: *cmake_version
+      
+  #### Windows Canary - use latest installed v143 toolset on each runner image ####
   Windows-2025-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
     uses: ./.github/workflows/windows-build.yml

--- a/.github/workflows/ar-canary.yml
+++ b/.github/workflows/ar-canary.yml
@@ -194,7 +194,7 @@ jobs:
       type: profile
       last_artifact: false
       clang_version: "19"
-      gcc_version: "12"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   Linux-Ubuntu22-Clang19-Asset:
@@ -315,7 +315,7 @@ jobs:
       type: asset_profile
       last_artifact: false
       cmake_version: *cmake_version
-      
+
   #### Windows Canary - use latest installed v143 toolset on each runner image ####
   Windows-2025-Profile:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}

--- a/.github/workflows/ar-canary.yml
+++ b/.github/workflows/ar-canary.yml
@@ -148,6 +148,7 @@ jobs:
       type: profile
       last_artifact: false
       clang_version: "19"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   Linux-Ubuntu24-Clang19-Asset:
@@ -162,6 +163,7 @@ jobs:
       type: asset_profile
       last_artifact: false
       clang_version: "19"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   Linux-Ubuntu24-Clang19-Test:
@@ -177,6 +179,7 @@ jobs:
       last_artifact: false
       desktop: true
       clang_version: "19"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   #### Linux Canary - ubuntu-22.04 ####
@@ -191,6 +194,7 @@ jobs:
       type: profile
       last_artifact: false
       clang_version: "19"
+      gcc_version: "12"
       cmake_version: *cmake_version
 
   Linux-Ubuntu22-Clang19-Asset:
@@ -205,6 +209,7 @@ jobs:
       type: asset_profile
       last_artifact: false
       clang_version: "19"
+      gcc_version: "12"
       cmake_version: *cmake_version
 
   Linux-Ubuntu22-Clang19-Test:
@@ -220,6 +225,7 @@ jobs:
       last_artifact: false
       desktop: true
       clang_version: "19"
+      gcc_version: "12"
       cmake_version: *cmake_version
 
   #### Mac Canary - macos-15 Apple Silicon ####

--- a/.github/workflows/ar-canary.yml
+++ b/.github/workflows/ar-canary.yml
@@ -51,7 +51,6 @@ jobs:
       platform: Android
       type: profile
       last_artifact: false
-      clang_version: "19"
       ndk_version: "28.0.12433566"
       gradle_version: "8.13"
       cmake_version: *cmake_version
@@ -67,7 +66,6 @@ jobs:
       platform: Android
       type: asset_profile
       last_artifact: false
-      clang_version: "19"
       ndk_version: "28.0.12433566"
       gradle_version: "8.13"
       cmake_version: *cmake_version
@@ -83,7 +81,6 @@ jobs:
       platform: Android
       type: gradle
       last_artifact: false
-      clang_version: "19"
       ndk_version: "28.0.12433566"
       gradle_version: "8.13"
       cmake_version: *cmake_version
@@ -99,7 +96,6 @@ jobs:
       platform: Android
       type: profile
       last_artifact: false
-      clang_version: "19"
       ndk_version: "28.0.12433566"
       gradle_version: "8.13"
       cmake_version: *cmake_version
@@ -115,7 +111,6 @@ jobs:
       platform: Android
       type: asset_profile
       last_artifact: false
-      clang_version: "19"
       ndk_version: "28.0.12433566"
       gradle_version: "8.13"
       cmake_version: *cmake_version
@@ -131,7 +126,6 @@ jobs:
       platform: Android
       type: gradle
       last_artifact: false
-      clang_version: "19"
       ndk_version: "28.0.12433566"
       gradle_version: "8.13"
       cmake_version: *cmake_version
@@ -209,7 +203,7 @@ jobs:
       type: asset_profile
       last_artifact: false
       clang_version: "19"
-      gcc_version: "12"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   Linux-Ubuntu22-Clang19-Test:
@@ -225,7 +219,7 @@ jobs:
       last_artifact: false
       desktop: true
       clang_version: "19"
-      gcc_version: "12"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   #### Mac Canary - macos-15 Apple Silicon ####

--- a/.github/workflows/ar-canary.yml
+++ b/.github/workflows/ar-canary.yml
@@ -1,0 +1,407 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+name: AR Canary
+
+run-name: ${{ format('AR Canary - {0}', github.ref_name) }}
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # Nightly at 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      android_build:
+        description: Build Android
+        type: boolean
+        default: true
+      ios_build:
+        description: Build iOS
+        type: boolean
+        default: true
+      linux_build:
+        description: Build Linux
+        type: boolean
+        default: true
+      mac_build:
+        description: Build Mac
+        type: boolean
+        default: true
+      windows_build:
+        description: Build Windows
+        type: boolean
+        default: true
+
+env:
+  CMAKE_VERSION: &cmake_version "4.2.3"
+
+jobs:
+  #### Android Canary — ubuntu-24.04 + NDK r28 + host Clang 19 ####
+  Android-Ubuntu24-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-24.04
+      platform: Android
+      type: profile
+      last_artifact: false
+      clang_version: "19"
+      ndk_version: "28.0.12433566"
+      gradle_version: "8.13"
+      cmake_version: *cmake_version
+
+  Android-Ubuntu24-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    needs: Android-Ubuntu24-Profile
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-24.04
+      platform: Android
+      type: asset_profile
+      last_artifact: false
+      clang_version: "19"
+      ndk_version: "28.0.12433566"
+      gradle_version: "8.13"
+      cmake_version: *cmake_version
+
+  Android-Ubuntu24-Gradle:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    needs: Android-Ubuntu24-Asset
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-24.04
+      platform: Android
+      type: gradle
+      last_artifact: false
+      clang_version: "19"
+      ndk_version: "28.0.12433566"
+      gradle_version: "8.13"
+      cmake_version: *cmake_version
+
+  #### Android Canary — ubuntu-22.04 + NDK r28 + host Clang 19 ####
+  Android-Ubuntu22-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Android
+      type: profile
+      last_artifact: false
+      clang_version: "19"
+      ndk_version: "28.0.12433566"
+      gradle_version: "8.13"
+      cmake_version: *cmake_version
+
+  Android-Ubuntu22-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    needs: Android-Ubuntu22-Profile
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Android
+      type: asset_profile
+      last_artifact: false
+      clang_version: "19"
+      ndk_version: "28.0.12433566"
+      gradle_version: "8.13"
+      cmake_version: *cmake_version
+
+  Android-Ubuntu22-Gradle:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.android_build }}
+    needs: Android-Ubuntu22-Asset
+    uses: ./.github/workflows/android-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Android
+      type: gradle
+      last_artifact: false
+      clang_version: "19"
+      ndk_version: "28.0.12433566"
+      gradle_version: "8.13"
+      cmake_version: *cmake_version
+
+  #### iOS Canary — macos-15 Apple Silicon ####
+  iOS-macOS15-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15
+      type: profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  iOS-macOS15-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    needs: iOS-macOS15-Profile
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15
+      type: asset_profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  #### iOS Canary — macos-15-intel ####
+  iOS-macOS15Intel-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15-intel
+      type: profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  iOS-macOS15Intel-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios_build }}
+    needs: iOS-macOS15Intel-Profile
+    uses: ./.github/workflows/ios-build.yml
+    with:
+      config: profile
+      image: macos-15-intel
+      type: asset_profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  #### Linux Canary — ubuntu-24.04 + Clang 19 ####
+  Linux-Ubuntu24-Clang19-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-24.04
+      platform: Linux
+      type: profile
+      last_artifact: false
+      clang_version: "19"
+      cmake_version: *cmake_version
+
+  Linux-Ubuntu24-Clang19-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    needs: Linux-Ubuntu24-Clang19-Profile
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-24.04
+      platform: Linux
+      type: asset_profile
+      last_artifact: false
+      clang_version: "19"
+      cmake_version: *cmake_version
+
+  Linux-Ubuntu24-Clang19-Test:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    needs: Linux-Ubuntu24-Clang19-Asset
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-24.04
+      platform: Linux
+      type: test_profile
+      last_artifact: false
+      desktop: true
+      clang_version: "19"
+      cmake_version: *cmake_version
+
+  #### Linux Canary — ubuntu-22.04 + Clang 19 ####
+  Linux-Ubuntu22-Clang19-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Linux
+      type: profile
+      last_artifact: false
+      clang_version: "19"
+      cmake_version: *cmake_version
+
+  Linux-Ubuntu22-Clang19-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    needs: Linux-Ubuntu22-Clang19-Profile
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Linux
+      type: asset_profile
+      last_artifact: false
+      clang_version: "19"
+      cmake_version: *cmake_version
+
+  Linux-Ubuntu22-Clang19-Test:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_build }}
+    needs: Linux-Ubuntu22-Clang19-Asset
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      compiler: clang
+      config: profile
+      image: ubuntu-22.04
+      platform: Linux
+      type: test_profile
+      last_artifact: false
+      desktop: true
+      clang_version: "19"
+      cmake_version: *cmake_version
+
+  #### Mac Canary — macos-15 Apple Silicon ####
+  Mac-macOS15-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
+    uses: ./.github/workflows/mac-build.yml
+    with:
+      config: profile
+      image: macos-15
+      type: profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  Mac-macOS15-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
+    needs: Mac-macOS15-Profile
+    uses: ./.github/workflows/mac-build.yml
+    with:
+      config: profile
+      image: macos-15
+      type: asset_profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  #### Mac Canary — macos-15-intel ####
+  Mac-macOS15Intel-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
+    uses: ./.github/workflows/mac-build.yml
+    with:
+      config: profile
+      image: macos-15-intel
+      type: profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  Mac-macOS15Intel-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.mac_build }}
+    needs: Mac-macOS15Intel-Profile
+    uses: ./.github/workflows/mac-build.yml
+    with:
+      config: profile
+      image: macos-15-intel
+      type: asset_profile
+      last_artifact: false
+      cmake_version: *cmake_version
+
+  #### Windows Canary — use latest installed v143 toolset on each runner image ####
+  Windows-2025-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2025
+      platform: Windows
+      type: profile
+      last_artifact: false
+      msvc_platform_toolset: "v143"
+      cmake_version: *cmake_version
+
+  Windows-2025-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    needs: Windows-2025-Profile
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2025
+      platform: Windows
+      type: asset_profile
+      last_artifact: false
+      msvc_platform_toolset: "v143"
+      cmake_version: *cmake_version
+
+  Windows-2025-Test:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    needs: Windows-2025-Asset
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2025
+      platform: Windows
+      type: test_cpu_profile
+      last_artifact: false
+      msvc_platform_toolset: "v143"
+      cmake_version: *cmake_version
+
+  Windows-2025-Release:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: release
+      image: windows-2025
+      platform: Windows
+      type: release
+      last_artifact: false
+      msvc_platform_toolset: "v143"
+      cmake_version: *cmake_version
+
+  Windows-2022-Profile:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2022
+      platform: Windows
+      type: profile
+      last_artifact: false
+      msvc_platform_toolset: "v143"
+      cmake_version: *cmake_version
+
+  Windows-2022-Asset:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    needs: Windows-2022-Profile
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2022
+      platform: Windows
+      type: asset_profile
+      last_artifact: false
+      msvc_platform_toolset: "v143"
+      cmake_version: *cmake_version
+
+  Windows-2022-Test:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.windows_build }}
+    needs: Windows-2022-Asset
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      compiler: msvc
+      config: profile
+      image: windows-2022
+      platform: Windows
+      type: test_cpu_profile
+      last_artifact: false
+      msvc_platform_toolset: "v143"
+      cmake_version: *cmake_version

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -62,6 +62,7 @@ jobs:
   # - msvc_toolset_version: MSVC toolset version to install (Windows only)
   # - msvc_platform_toolset: MSVC platform toolset name, e.g. v143 (Windows only)
   # - clang_version: Clang major version to install (Linux only)
+  # - gcc_version: gcc major version to install (Linux only)
   # - ndk_version: Android NDK version to install (Android only)
   # - cmake_version: CMake version constraint to use (all platforms)
   # - gradle_version: Gradle version to use (Android only)

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -145,7 +145,7 @@ jobs:
     with:
       compiler: clang
       config: profile
-      image: ubuntu-22.04
+      image: ubuntu-24.04
       platform: Linux
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
@@ -159,7 +159,7 @@ jobs:
     with:
       compiler: clang
       config: profile
-      image: ubuntu-22.04
+      image: ubuntu-24.04
       platform: Linux
       type: asset_profile
       clang_version: "14"
@@ -172,7 +172,7 @@ jobs:
     with:
       compiler: clang
       config: profile
-      image: ubuntu-22.04
+      image: ubuntu-24.04
       platform: Linux
       type: test_profile
       desktop: true

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -92,7 +92,6 @@ jobs:
       image: ubuntu-22.04
       platform: Android
       type: asset_profile
-      clang_version: "14"
       ndk_version: "25.1.8937393"
       gradle_version: "8.12"
       cmake_version: *cmake_version

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -149,7 +149,7 @@ jobs:
       platform: Linux
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
-      clang_version: "14"
+      clang_version: "18"
       cmake_version: *cmake_version
 
   Linux-Asset:
@@ -162,7 +162,7 @@ jobs:
       image: ubuntu-24.04
       platform: Linux
       type: asset_profile
-      clang_version: "14"
+      clang_version: "18"
       cmake_version: *cmake_version
 
   Linux-Test:
@@ -176,7 +176,7 @@ jobs:
       platform: Linux
       type: test_profile
       desktop: true
-      clang_version: "14"
+      clang_version: "18"
       cmake_version: *cmake_version
 
 #### Mac Build ####

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -150,7 +150,7 @@ jobs:
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
       clang_version: "18"
-      gcc_version: "12"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   Linux-Asset:
@@ -164,7 +164,7 @@ jobs:
       platform: Linux
       type: asset_profile
       clang_version: "18"
-      gcc_version: "12"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
   Linux-Test:
@@ -179,7 +179,7 @@ jobs:
       type: test_profile
       desktop: true
       clang_version: "18"
-      gcc_version: "12"
+      gcc_version: "14"
       cmake_version: *cmake_version
 
 #### Mac Build ####

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -145,11 +145,12 @@ jobs:
     with:
       compiler: clang
       config: profile
-      image: ubuntu-24.04
+      image: ubuntu-22.04
       platform: Linux
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
       clang_version: "18"
+      gcc_version: "12"
       cmake_version: *cmake_version
 
   Linux-Asset:
@@ -159,10 +160,11 @@ jobs:
     with:
       compiler: clang
       config: profile
-      image: ubuntu-24.04
+      image: ubuntu-22.04
       platform: Linux
       type: asset_profile
       clang_version: "18"
+      gcc_version: "12"
       cmake_version: *cmake_version
 
   Linux-Test:
@@ -172,11 +174,12 @@ jobs:
     with:
       compiler: clang
       config: profile
-      image: ubuntu-24.04
+      image: ubuntu-22.04
       platform: Linux
       type: test_profile
       desktop: true
       clang_version: "18"
+      gcc_version: "12"
       cmake_version: *cmake_version
 
 #### Mac Build ####

--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -150,7 +150,7 @@ jobs:
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
       clang_version: "18"
-      gcc_version: "14"
+      gcc_version: "13"
       cmake_version: *cmake_version
 
   Linux-Asset:
@@ -164,7 +164,7 @@ jobs:
       platform: Linux
       type: asset_profile
       clang_version: "18"
-      gcc_version: "14"
+      gcc_version: "13"
       cmake_version: *cmake_version
 
   Linux-Test:
@@ -179,7 +179,7 @@ jobs:
       type: test_profile
       desktop: true
       clang_version: "18"
-      gcc_version: "14"
+      gcc_version: "13"
       cmake_version: *cmake_version
 
 #### Mac Build ####

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -38,6 +38,9 @@ on:
       clang_version:
         required: false
         type: string
+      gcc_version:
+        required: false
+        type: string
       cmake_version:
         required: false
         type: string
@@ -173,6 +176,15 @@ jobs:
         uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # v4.2.3
         with:
           cmakeVersion: "${{ inputs.cmake_version }}"
+
+      - name: Set GCC version
+        # GitHub-hosted runners pre-install multiple GCC versions; this step selects the requested one
+        # via update-alternatives so Clang picks up the correct libstdc++ headers and libraries.
+        # ubuntu-24.04 ships gcc-12/13/14; ubuntu-22.04 ships gcc-9/10/11/12.
+        if: ${{ inputs.gcc_version }}
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc_version }} 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc_version }} 100
 
       - name: Install specific clang version
         # Use the official LLVM installer script so we can install arbitrary upstream Clang versions

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -161,7 +161,7 @@ jobs:
         continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         run: |
-          if [ -f ${{ github.workspace }}/cache.tar ]; then          
+          if [ -f ${{ github.workspace }}/cache.tar ]; then
             tar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
             rm ${{ github.workspace }}/cache.tar
             ccache --zero-stats --cleanup
@@ -175,10 +175,16 @@ jobs:
           cmakeVersion: "${{ inputs.cmake_version }}"
 
       - name: Install specific clang version
+        # Use the official LLVM installer script so we can install arbitrary upstream Clang versions
+        # on GitHub-hosted runners (beyond what's in the distro's default apt repositories).
+        #
+        # Ref: https://apt.llvm.org/llvm.sh
         if: ${{ inputs.compiler == 'clang' && inputs.clang_version }}
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y clang-${{ inputs.clang_version }} lld-${{ inputs.clang_version }}
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh ${{ inputs.clang_version }}
+          sudo apt-get install -y lld-${{ inputs.clang_version }}
           echo "CC=$(which clang-${{ inputs.clang_version }})" >> $GITHUB_ENV
           echo "CXX=$(which clang++-${{ inputs.clang_version }})" >> $GITHUB_ENV
 
@@ -216,7 +222,7 @@ jobs:
           export EXTRA_CMAKE_OPTIONS="-DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX"
           export DISPLAY=:0
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          if [ "${{ inputs.desktop }}" == "true" ]; then 
+          if [ "${{ inputs.desktop }}" == "true" ]; then
             Xvfb :0 -screen 0 1400x1050x16 & # Start X virtual framebuffer for tests
           fi
           python/python.sh -u scripts/build/ci_build.py --platform ${{ inputs.platform }} --type ${{ inputs.type }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -183,7 +183,7 @@ jobs:
         # ubuntu-24.04 ships gcc-12/13/14; ubuntu-22.04 ships gcc-9/10/11/12.
         if: ${{ inputs.gcc_version }}
         run: |
-          sudp apt-get install -y gcc-${{ inputs.gcc_version }} g++-${{ inputs.gcc_version }}
+          sudo apt-get install -y gcc-${{ inputs.gcc_version }} g++-${{ inputs.gcc_version }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc_version }} 100
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc_version }} 100
 

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -183,6 +183,7 @@ jobs:
         # ubuntu-24.04 ships gcc-12/13/14; ubuntu-22.04 ships gcc-9/10/11/12.
         if: ${{ inputs.gcc_version }}
         run: |
+          sudp apt-get install -y gcc-${{ inputs.gcc_version }} g++-${{ inputs.gcc_version }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc_version }} 100
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc_version }} 100
 

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -183,6 +183,8 @@ jobs:
         # ubuntu-24.04 ships gcc-12/13/14; ubuntu-22.04 ships gcc-9/10/11/12.
         if: ${{ inputs.gcc_version }}
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -y
           sudo apt-get install -y gcc-${{ inputs.gcc_version }} g++-${{ inputs.gcc_version }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc_version }} 100
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc_version }} 100

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -199,7 +199,7 @@ jobs:
           wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
           chmod +x /tmp/llvm.sh
           sudo /tmp/llvm.sh ${{ inputs.clang_version }}
-          sudo apt-get install -y lld-${{ inputs.clang_version }}
+          sudo apt-get install -y lld-${{ inputs.clang_version }} clang-tools-${{ inputs.clang_version }}
           echo "CC=$(which clang-${{ inputs.clang_version }})" >> $GITHUB_ENV
           echo "CXX=$(which clang++-${{ inputs.clang_version }})" >> $GITHUB_ENV
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -49,7 +49,7 @@ env:
   CMAKE_C_COMPILER_LAUNCHER: C:\ProgramData\Chocolatey\bin\ccache.exe
   CMAKE_CXX_COMPILER_LAUNCHER: C:\ProgramData\Chocolatey\bin\ccache.exe
 
-# Note: All 3P Github Actions use the commit hash for security reasons 
+# Note: All 3P Github Actions use the commit hash for security reasons
 # Avoid using the tag version, which is vulnerable to supply chain attacks
 
 jobs:
@@ -167,7 +167,7 @@ jobs:
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
-          if (Test-Path ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar) {          
+          if (Test-Path ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar) {
             tar -xvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
             rm ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
             ccache --zero-stats --cleanup
@@ -182,19 +182,30 @@ jobs:
 
       - name: Configure generator/toolset env for CMake
         # Set the environment variables for the CMake generator and toolset depending on CMake version
+        #
+        # Guard behavior:
+        # - If msvc_platform_toolset is not provided, do NOT set CMAKE_GENERATOR_TOOLSET.
+        # - If msvc_platform_toolset is provided and msvc_toolset_version is NOT, set toolset to just "v143" (no version pin).
+        # - If both are provided and CMake >= 3.25, pin version via "v143,version=14.xx".
         run: |
           $cap = cmake -E capabilities | ConvertFrom-Json
           $maj = [int]$cap.version.major
           $min = [int]$cap.version.minor
 
-          echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV 
+          echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
 
-          if ($maj -gt 3 -or ($maj -eq 3 -and $min -ge 25)) {
-            # CMake >= 3.25: support 'version='
-            echo "CMAKE_GENERATOR_TOOLSET=${{ inputs.msvc_platform_toolset }},version=${{ inputs.msvc_toolset_version }}" >> $env:GITHUB_ENV
-          } else {
-            # CMake 3.24: omit 'version='; MSBuild line is selected by msvc-dev-cmd
-            echo "CMAKE_GENERATOR_TOOLSET=${{ inputs.msvc_platform_toolset }}" >> $env:GITHUB_ENV
+          $platformToolset = "${{ inputs.msvc_platform_toolset }}"
+          $toolsetVersion  = "${{ inputs.msvc_toolset_version }}"
+
+          if (![string]::IsNullOrWhiteSpace($platformToolset)) {
+
+            if (($maj -gt 3 -or ($maj -eq 3 -and $min -ge 25)) -and ![string]::IsNullOrWhiteSpace($toolsetVersion)) {
+              # CMake >= 3.25: support 'version='
+              echo "CMAKE_GENERATOR_TOOLSET=$platformToolset,version=$toolsetVersion" >> $env:GITHUB_ENV
+            } else {
+              # CMake 3.24 (or no version requested): omit 'version='; MSBuild line is selected by msvc-dev-cmd
+              echo "CMAKE_GENERATOR_TOOLSET=$platformToolset" >> $env:GITHUB_ENV
+            }
           }
 
       - name: Install specific MSVC toolset
@@ -205,7 +216,12 @@ jobs:
             --installPath "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise" `
             --add "Microsoft.VisualStudio.Component.VC.${{ inputs.msvc_toolset_version }}.x86.x64" --quiet --wait
 
-      - name: Set MSBuild options
+      - name: Set MSBuild options (default toolset)
+        if: ${{ !inputs.msvc_toolset_version }}
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+
+      - name: Set MSBuild options (pinned toolset)
+        if: ${{ inputs.msvc_toolset_version }}
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
         with:
           toolset: ${{ inputs.msvc_toolset_version }}


### PR DESCRIPTION
## What does this PR do?

Adds a nightly AR Canary workflow (ar-canary.yml) that tests against a broader matrix of compilers and runner images than the standard AR to catch upcoming toolchain compatibility issues early. The canary covers Android, Linux, Mac, iOS, and Windows across two runner images each, using the latest available compiler versions (Clang 19, GCC 14, MSVC v143, NDK 28).

Also upgrades the standard AR Linux jobs from Clang 14 -> 18 with a matching GCC 13 for libstdc++, and switches both Linux and Android Clang installation to use the official llvm.sh script so arbitrary upstream versions can be installed beyond what distro apt repos carry.

## How was this PR tested?

Ran in my fork::

AR: https://github.com/amzn-changml/o3de/actions/runs/24979757656
AR Canary: https://github.com/amzn-changml/o3de/actions/runs/24979765236 (Note most jobs are failing due to timeout)
