### PR TITLE
(development) Cherry-pick fixes `stabilization/26050` --> `development`

### DIFF
--- a/Assets/Editor/Prefabs/Empty.prefab
+++ b/Assets/Editor/Prefabs/Empty.prefab
@@ -48,5 +48,50 @@
                 "Parent Entity": ""
             }
         }
+    },
+    "Entities": {
+        "Entity_[385340316572]": {
+            "Id": "Entity_[385340316572]",
+            "Name": "Empty",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6869979625617682277
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3265657025421720267
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8225990753105089243
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1243064901843907726
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12650030112456318539
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11307660330476106858
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11421019595812600360
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5590740797091427330
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1585622147904486000,
+                    "Parent Entity": "ContainerEntity"
+                }
+            }
+        }
     }
 }

--- a/Assets/Editor/Prefabs/Empty.prefab
+++ b/Assets/Editor/Prefabs/Empty.prefab
@@ -48,50 +48,5 @@
                 "Parent Entity": ""
             }
         }
-    },
-    "Entities": {
-        "Entity_[385340316572]": {
-            "Id": "Entity_[385340316572]",
-            "Name": "Empty",
-            "Components": {
-                "EditorDisabledCompositionComponent": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 6869979625617682277
-                },
-                "EditorEntityIconComponent": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 3265657025421720267
-                },
-                "EditorEntitySortComponent": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 8225990753105089243
-                },
-                "EditorInspectorComponent": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 1243064901843907726
-                },
-                "EditorLockComponent": {
-                    "$type": "EditorLockComponent",
-                    "Id": 12650030112456318539
-                },
-                "EditorOnlyEntityComponent": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11307660330476106858
-                },
-                "EditorPendingCompositionComponent": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 11421019595812600360
-                },
-                "EditorVisibilityComponent": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 5590740797091427330
-                },
-                "TransformComponent": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 1585622147904486000,
-                    "Parent Entity": "ContainerEntity"
-                }
-            }
-        }
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialAssignment.cpp
@@ -135,12 +135,24 @@ namespace AZ
 
         bool MaterialAssignment::RequiresLoading() const
         {
-            return
-                !m_materialInstancePreCreated &&
+            if (m_materialInstancePreCreated)
+            {
+                return false; // we are not in charge of foreign material instances owned by another system.
+            }
+
+            // we only need to trigger a load on valid assets that are not already loading and not already ready.
+
+            bool myAssetRequiresLoading =
+                m_materialAsset.GetId().IsValid() &&
                 !m_materialAsset.IsReady() &&
-                !m_materialAsset.IsLoading() &&
+                !m_materialAsset.IsLoading();
+
+            bool defaultAssetRequiresLoading =
+                m_defaultMaterialAsset.GetId().IsValid() &&
                 !m_defaultMaterialAsset.IsReady() &&
                 !m_defaultMaterialAsset.IsLoading();
+
+            return myAssetRequiresLoading || defaultAssetRequiresLoading;
         }
 
         bool MaterialAssignment::ApplyProperties()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -178,6 +178,12 @@ namespace AZ
 
         void MaterialComponentController::OnSystemTick()
         {
+            if (m_queuedLoadMaterials)
+            {
+                m_queuedLoadMaterials = false;
+                LoadMaterials();
+            }
+
             while (!m_notifiedMaterialAssets.empty())
             {
                 auto materialAsset = m_notifiedMaterialAssets.front();
@@ -185,11 +191,6 @@ namespace AZ
                 InitializeNotifiedMaterialAsset(materialAsset);
             }
 
-            if (m_queuedLoadMaterials)
-            {
-                m_queuedLoadMaterials = false;
-                LoadMaterials();
-            }
 
             if (m_queuedMaterialsCreatedNotification)
             {

--- a/Gems/OpenParticleSystem/Assets/Particles/inheritance.particle
+++ b/Gems/OpenParticleSystem/Assets/Particles/inheritance.particle
@@ -32,7 +32,7 @@
                 ]
             },
             "OpenParticle::InheritanceHandler": {
-                "emitterIndex": 0,
+                "emitterIndex": 1,
                 "emitterName": "father",
                 "calculateSpawnRate": true,
                 "spawnRate": 2.0,

--- a/Gems/OpenParticleSystem/Code/Source/Editor/ParticleEditDataConfig.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/ParticleEditDataConfig.cpp
@@ -936,8 +936,8 @@ namespace OpenParticle
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Show)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &OpenParticle::SpawnVelConcentrate::centre, "Centre",
-                        "The centre of the Concentrate.")
+                        AZ::Edit::UIHandlers::Default, &OpenParticle::SpawnVelConcentrate::centre, "Center",
+                        "The center of the Concentrate.")
                     ->DataElement(
                         AZ_CRC("DistCtrlHandler"), &OpenParticle::SpawnVelConcentrate::rateObject, "Rate",
                         "The rate of Concentrate.")

--- a/Gems/OpenParticleSystem/Code/Source/OpenParticleSystemEditorSystemComponent.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/OpenParticleSystemEditorSystemComponent.cpp
@@ -80,7 +80,7 @@ namespace OpenParticleSystem
         options.isPreview = true;
         options.showInMenu = true;
         options.showOnToolsToolbar = true;
-        options.toolbarIcon = ":/stylesheet/img/UI20/toolbar/particle.svg";
+        options.toolbarIcon = ":/OpenParticleSystem/Icons/Particle.svg";
 
         AzToolsFramework::RegisterViewPane<OpenParticleSystemEditor::OpenParticleSystemEditorWindow>(
             "(Preview) Particle Editor", LyViewPane::CategoryTools, options);

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleSystem.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleSystem.cpp
@@ -679,6 +679,20 @@ namespace OpenParticle
         EmitterInstance& instance, AZ::RPI::View& view, int meshIndex)
     {
         AZ_PROFILE_SCOPE(AzCore, "ParticleSystem::RenderParticle");
+        if (!instance.m_objSrg)
+        {
+            // note that sprite and mesh particles use the instance.m_objSrg, but the
+            // ribbon does not.
+            if (drawParam.item.drawArgs.type == SimuCore::ParticleCore::DrawType::LINEAR)
+            {
+                return; // this is a sprite particle
+            }
+            if (meshIndex >= 0)
+            {
+                return; // this is a mesh particle.
+            }
+        }
+
         auto& efd = instance.m_emitterForDrawPair[drawParam.shader.get()];
         auto pipeline = m_particleFp->Fetch(GetPipelineKey(drawParam.item.type));
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
@@ -343,7 +343,7 @@ namespace OpenParticleSystemEditor
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_SPAWN]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_PARTICLES:
-            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Particles"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Particles"), QIcon(":/OpenParticleSystem/Icons/Particle.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_PARTICLES]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_LOCATION:
@@ -367,7 +367,7 @@ namespace OpenParticleSystemEditor
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_FORCE]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_LIGHT:
-            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Light"), QIcon(":/stylesheet/img/UI20/toolbar/particle.svg"));
+            SetClassName(QT_TRANSLATE_NOOP("OpenParticleSystem", "Light"), QIcon(":/stylesheet/img/UI20/toolbar/Lighting.svg"));
             ClickPropertyEditorWidget(PARTICLE_LINE_NAMES[WIDGET_LINE_LIGHT]);
             break;
         case OpenParticleSystemEditor::WIDGET_LINE_SUBUV:

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleItemWidget.ui
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleItemWidget.ui
@@ -257,7 +257,7 @@ border-radius: 1px;</string>
          </property>
          <property name="icon">
           <iconset resource="../../../../../Code/Framework/AzQtComponents/AzQtComponents/Components/resources.qrc">
-           <normaloff>:/stylesheet/img/UI20/toolbar/particle.svg</normaloff>:/stylesheet/img/UI20/toolbar/particle.svg</iconset>
+           <normaloff>:/OpenParticleSystem/Icons/Particle.svg</normaloff>:/OpenParticleSystem/Icons/Particle.svg</iconset>
          </property>
         </widget>
        </item>

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -47,11 +47,15 @@ namespace PhysX
                     ->EnumAttribute(SlopeBehaviour::PreventClimbing, "Prevent Climbing")
                     ->EnumAttribute(SlopeBehaviour::ForceSliding, "Force Sliding")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterControllerConfiguration::m_contactOffset,
-                        "Contact Offset", "Distance from the controller boundary where contact with surfaces can be resolved.")
+                        "Contact Offset",
+                        "Distance from the controller boundary where contact with surfaces can be resolved. Default value is 0.1, but a common value is around 10% of the radius.\n"
+                        "If the character is getting stuck often, consider increasing this value.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterControllerConfiguration::m_scaleCoefficient,
-                        "Scale", "Scales the controller. Usually less than 1.0 to ensure visual contact between the character and surface.")
+                        "Internal Body Scale",
+                        "Scales the internal kinematic body. A scale < 1 means the underlying kinematic body will not touch surrounding rigid bodies and only interact with the character controller's shapes.\n"
+                        "A scale >=1 means the kinematic body will touch and push surrounding rigid bodies, potentially resulting in wall tunneling or sudden movement explosion.")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                     ;

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.h
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/API/CharacterController.h
@@ -40,7 +40,7 @@ namespace PhysX
 
         SlopeBehaviour m_slopeBehaviour = SlopeBehaviour::PreventClimbing; ///< Behaviour on surfaces above maximum slope.
         float m_contactOffset = 0.1f; ///< Extra distance outside the controller used to give smoother contact resolution.
-        float m_scaleCoefficient = 0.8f; ///< Scalar coefficient used to scale the controller, usually slightly smaller than 1.
+        float m_scaleCoefficient = 0.8f; ///< Scalar coefficient used to scale the internal kinematic controller, recommended to be less than 1 to prevent erratic interactions.
     };
 
     /// Manages callbacks for character controller collision filtering, collision notifications, and handling riding on objects.

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
@@ -169,9 +169,9 @@ namespace PhysX
                 ? AZ::Vector3::CreateAxisZ()
                 : m_configuration.m_upDirection.GetNormalized();
 
-            // PhysX uses the x-axis as the height direction of the controller, and so takes the shortest arc from the 
-            // x-axis to the up direction.  To obtain the same orientation in the LY co-ordinate system (which uses z
-            // as the height direction), we need to combine a rotation from the x-axis to the up direction with a 
+            // PhysX uses the x-axis as the height direction of the controller, and so takes the shortest arc from the
+            // x-axis to the up direction. To obtain the same orientation in the O3DE co-ordinate system (which uses z
+            // as the height direction), we need to combine a rotation from the x-axis to the up direction with a
             // rotation from the z-axis to the x-axis.
             const AZ::Quaternion upDirectionQuat = AZ::Quaternion::CreateShortestArc(AZ::Vector3::CreateAxisX(),
                 upDirectionNormalized) * AZ::Quaternion::CreateRotationY(AZ::Constants::HalfPi);
@@ -188,8 +188,8 @@ namespace PhysX
                 // draw the actual shape
                 LmbrCentral::CapsuleGeometrySystemRequestBus::Broadcast(
                     &LmbrCentral::CapsuleGeometrySystemRequestBus::Events::GenerateCapsuleMesh,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_radius,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_height,
+                    capsuleConfig.m_radius,
+                    capsuleConfig.m_height,
                     16, 8,
                     m_vertexBuffer,
                     m_indexBuffer,
@@ -203,8 +203,8 @@ namespace PhysX
                 // draw the shape inflated by the contact offset
                 LmbrCentral::CapsuleGeometrySystemRequestBus::Broadcast(
                     &LmbrCentral::CapsuleGeometrySystemRequestBus::Events::GenerateCapsuleMesh,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_radius + m_configuration.m_contactOffset,
-                    m_configuration.m_scaleCoefficient * capsuleConfig.m_height + 2.0f * m_configuration.m_contactOffset,
+                    capsuleConfig.m_radius + m_configuration.m_contactOffset,
+                    capsuleConfig.m_height + 2.0f * m_configuration.m_contactOffset,
                     16, 8,
                     m_vertexBuffer,
                     m_indexBuffer,
@@ -222,7 +222,7 @@ namespace PhysX
                 const AZ::Transform controllerTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
                     upDirectionQuat, GetWorldTM().GetTranslation() + heightOffset * upDirectionNormalized);
 
-                const AZ::Vector3 boxHalfExtentsScaled = 0.5f * m_configuration.m_scaleCoefficient * boxConfig.m_dimensions;
+                const AZ::Vector3 boxHalfExtentsScaled = 0.5f * boxConfig.m_dimensions;
                 const AZ::Vector3 boxHalfExtentsScaledWithContactOffset = boxHalfExtentsScaled +
                     m_configuration.m_contactOffset * AZ::Vector3::CreateOne();
 

--- a/Gems/PhysX/Core/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/RigidBodyComponent.cpp
@@ -283,7 +283,8 @@ namespace PhysX
             AZ_Error("RigidBodyComponent", false, "Unable to retrieve simulated rigid body");
             return;
         }
-        
+
+        m_isEntityTransformSetManually = false;
         AZ::Transform transform = rigidBody->GetTransform();
         if (m_configuration.m_interpolateMotion)
         {
@@ -297,6 +298,7 @@ namespace PhysX
             entityTransform->SetWorldTM(newWorldTransform);
         }
         m_isLastMovementFromKinematicSource = false;
+        m_isEntityTransformSetManually = true;
     }
 
     void RigidBodyComponent::OnTransformChanged([[maybe_unused]] const AZ::Transform& local, const AZ::Transform& world)
@@ -310,6 +312,12 @@ namespace PhysX
                 (body->IsKinematic() && !m_isLastMovementFromKinematicSource))
             {
                 body->SetKinematicTarget(world);
+            }
+            else if (body->m_simulating && (!body->IsKinematic() && m_isEntityTransformSetManually))
+            {
+                AZ_Warning("RigidBodyComponent", false, "Transform of Entity \"%s\" with simulated body was set manually. Consider using kinematic body and calling SetKinematicTarget if done frequently.",
+                    GetEntity()->GetName().c_str());
+                body->SetTransform(world);
             }
             else if (!body->m_simulating)
             {

--- a/Gems/PhysX/Core/Code/Source/RigidBodyComponent.h
+++ b/Gems/PhysX/Core/Code/Source/RigidBodyComponent.h
@@ -167,8 +167,9 @@ namespace PhysX
         AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
 
         bool m_staticTransformAtActivation = false; ///< Whether the transform was static when the component last activated.
-        bool m_isLastMovementFromKinematicSource = false; ///< True when the source of the movement comes from SetKinematicTarget as opposed to coming from a Transform change
-        bool m_rigidBodyTransformNeedsUpdateOnPhysReEnable = false; ///< True if rigid body transform needs to be synced to the entity's when physics is re-enabled
+        bool m_isLastMovementFromKinematicSource = false; ///< True when the source of the movement comes from SetKinematicTarget as opposed to coming from a Transform change.
+        bool m_rigidBodyTransformNeedsUpdateOnPhysReEnable = false; ///< True if rigid body transform needs to be synced to the entity's when physics is re-enabled.
+        bool m_isEntityTransformSetManually = false; ///< False when PostPhysicsTick runs in order to handle user-set entity transform.
 
         AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler;
         AzPhysics::SimulatedBodyEvents::OnSyncTransform::Handler m_activeBodySyncTransformHandler;


### PR DESCRIPTION
## What does this PR do?

This is a merge of the changes committed to `stabilization/26050` to cherry-pick them into development.

The list of commits to pick from was generated by using the following command
```
git log --oneline upstream/development..upstream/stabilization/26050 --cherry-pick --right-only --reverse
```

The cherry-pick command was told to skip empty commits already commited using `--empty=drop`.

This resulted in a total of 5 commits, see below for each of them.

## How was this PR tested?

No testing performed - this is just a cherry -pick merge of fixes already applied.  We will have to test it with AR and then let it work through in development.

I manully checked each actual change's contents (**Changed Files**) to ensure no craziness.