### PR TITLE
Update readme for post-26.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 
 O3DE (Open 3D Engine) is an open-source, real-time, multi-platform 3D engine that enables developers and content creators to build AAA games, cinema-quality 3D worlds, and high-fidelity simulations without any fees or commercial obligations.
 
+## Documentation
+
+For the full O3DE documentation, visit [https://o3de.org/docs/](https://o3de.org/docs/).
+
 ## Contribute
 For information about contributing to Open 3D Engine, visit [https://o3de.org/docs/contributing/](https://o3de.org/docs/contributing/).
 
 ## Roadmap
 For information about upcoming work and features, please visit [https://o3de.org/roadmap](https://o3de.org/roadmap). Progress against the roadmap is tracked [here](https://github.com/orgs/o3de/projects/56/views/2).
+
+## Prebuilt Installer
+
+If you don't want to build the engine from source, prebuilt installers are available:
+
+*   [Windows](https://o3debinaries.org/download/windows.html)
+*   [Linux](https://o3debinaries.org/download/linux.html)
 
 ## Download and Install
 
@@ -39,13 +50,21 @@ For the latest details and system requirements, refer to [System Requirements](h
 
 #### Windows
 
-*   Visual Studio 2019 16.9.2 minimum (All editions supported, including Community): [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)
-    *   Check [System Requirements](https://o3de.org/docs/welcome-guide/requirements/) for other supported versions.
+*   Visual Studio 2019 latest (All editions supported, including Community): [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)
     *   Install the following workloads:
         *   Game Development with C++
         *   MSVC v142 - VS 2019 C++ x64/x86
         *   C++ 2019 redistributable update
-*   CMake 3.24.0 minimum: [https://cmake.org/download/#latest](https://cmake.org/download/#latest) (Release Candidate versions are not supported)
+*   CMake 3.30 minimum: [https://cmake.org/download/#latest](https://cmake.org/download/#latest) (Release Candidate versions are not supported)
+    *   CMake 3.30 is currently a soft requirement and will become a hard requirement after release 26.05.
+    *   CMake 4.2.3 is bundled with the [prebuilt installer](https://o3debinaries.org/download/windows.html).
+
+#### Linux
+
+*   Clang 14 minimum
+*   CMake 3.30 minimum: [https://cmake.org/download/#latest](https://cmake.org/download/#latest) (Release Candidate versions are not supported)
+    *   CMake 3.30 is currently a soft requirement and will become a hard requirement after release 26.05.
+    *   CMake 4.2.3 is bundled with the [prebuilt installer](https://o3debinaries.org/download/linux.html).
 
 #### Optional
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ O3DE (Open 3D Engine) is an open-source, real-time, multi-platform 3D engine tha
 For the full O3DE documentation, visit [https://o3de.org/docs/](https://o3de.org/docs/).
 
 ## Contribute
+
 For information about contributing to Open 3D Engine, visit [https://o3de.org/docs/contributing/](https://o3de.org/docs/contributing/).
 
 ## Roadmap
+
 For information about upcoming work and features, please visit [https://o3de.org/roadmap](https://o3de.org/roadmap). Progress against the roadmap is tracked [here](https://github.com/orgs/o3de/projects/56/views/2).
 
 ## Prebuilt Installer
@@ -71,79 +73,139 @@ For the latest details and system requirements, refer to [System Requirements](h
 *   Wwise audio SDK
     *   For the latest version requirements and setup instructions, refer to the [Wwise Audio Engine Gem](https://o3de.org/docs/user-guide/gems/reference/audio/wwise/audio-engine-wwise/) reference in the documentation.
 
-### Quick start engine setup
+### Quick start: Building the engine
 
-To set up a project-centric source engine, complete the following steps. For other build options, refer to [Setting up O3DE from GitHub](https://o3de.org/docs/welcome-guide/setup/setup-from-github/) in the documentation.
+For a complete setup guide, refer to [Setting up O3DE from GitHub](https://o3de.org/docs/welcome-guide/setup/setup-from-github/) in the documentation.
 
-1.  Create a writable folder to cache downloadable third-party packages. You can also use this to store other redistributable SDKs.
-    
-1.  Install the following redistributables:
-    - Visual Studio and VC++ redistributable can be installed to any location.
-    - CMake can be installed to any location, as long as it's available in the system path.
+#### Windows
 
-1.  Configure the engine source into a solution using this command line, replacing `<your build path>`, `<your source path>`, and `<3rdParty package path>` with the paths you've created:
+1.  Bootstrap the O3DE Python runtime:
     ```
-    cmake -B <your build path> -S <your source path> -G "Visual Studio 16" -DLY_3RDPARTY_PATH=<3rdParty package path>
+    python\get_python.bat
     ```
-    
-    Example:
-    ```
-    cmake -B C:\o3de\build\windows -S C:\o3de -G "Visual Studio 16" -DLY_3RDPARTY_PATH=C:\o3de-packages
-    ```
-    
-    > Note:  Do not use trailing slashes for the <3rdParty package path>.
 
-1.  Alternatively, you can do this through the CMake GUI:
-    
-    1.  Start `cmake-gui.exe`.
-    1.  Select the local path of the repo under "Where is the source code".
-    1.  Select a path where to build binaries under "Where to build the binaries".
-    1.  Click **Add Entry** and add a cache entry for the <3rdParty package path> folder you created, using the following values:
-        1.  **Name:** LY_3RDPARTY_PATH
-        1.  **Type:** STRING
-        1.  **Value:** `<3rdParty package path>`
-    1.  Click **Configure**.
-    1.  Wait for the key values to populate. Update or add any additional fields that are needed for your project.
-    1.  Click **Generate**.
-    
-1.  Register the engine with this command:
+1.  Register the engine:
     ```
     scripts\o3de.bat register --this-engine
     ```
 
-1.  The configuration of the solution is complete. You are now ready to create a project and build the engine.
-
-For more details on the steps above, refer to [Setting up O3DE from GitHub](https://o3de.org/docs/welcome-guide/setup/setup-from-github/) in the documentation.
-
-### Setting up new projects and building the engine
-
-1. From the O3DE repo folder, set up a new project using the `o3de create-project` command.
+1.  Configure a solution, replacing `<build path>` and `<3rdParty package path>` with your chosen locations:
     ```
-    scripts\o3de.bat create-project --project-path <your new project path>
-    ```
-
-1. Configure a solution for your project.
-    ```
-    cmake -B <your project build path> -S <your new project source path> -G "Visual Studio 16"
+    cmake -B <build path> -S . -G "Visual Studio 16 2019" -DLY_3RDPARTY_PATH=<3rdParty package path>
     ```
 
     Example:
     ```
-    cmake -B C:\my-project\build\windows -S C:\my-project -G "Visual Studio 16"
+    cmake -B C:\o3de\build\windows -S C:\o3de -G "Visual Studio 16 2019" -DLY_3RDPARTY_PATH=C:\o3de-packages
     ```
-    
-    > Note:  Do not use trailing slashes for the <3rdParty cache path>.
 
-1. Build the project, Asset Processor, and Editor to binaries by running this command inside your project:
+    > Note: Do not use trailing slashes for the `<3rdParty package path>`.
+
+1.  Build the Editor:
     ```
-    cmake --build <your project build path> --target <New Project Name>.GameLauncher Editor --config profile -- /m
+    cmake --build <build path> --target Editor --config profile -- /m
     ```
-    
-    > Note: Your project name used in the build target is the same as the directory name of your project.
 
-This will compile after some time and binaries will be available in the project build path you've specified, under `bin/profile`.
+#### Linux
 
-For a complete tutorial on project configuration, see [Creating Projects Using the Command Line Interface](https://o3de.org/docs/welcome-guide/create/creating-projects-using-cli/) in the documentation.
+1.  Bootstrap the O3DE Python runtime:
+    ```
+    python/get_python.sh
+    ```
+
+1.  Register the engine:
+    ```
+    scripts/o3de.sh register --this-engine
+    ```
+
+1.  Configure a solution, replacing `<build path>` and `<3rdParty package path>` with your chosen locations:
+    ```
+    cmake -B <build path> -S . -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=<3rdParty package path> -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14
+    ```
+
+    Example:
+    ```
+    cmake -B ~/o3de/build/linux -S ~/o3de -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=~/o3de-packages -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14
+    ```
+
+    > Note: Do not use trailing slashes for the `<3rdParty package path>`.
+
+1.  Build the Editor:
+    ```
+    cmake --build <build path> --target Editor --config profile
+    ```
+
+### Quick start: Building a project
+
+For a complete guide, refer to [Creating Projects Using the Command Line Interface](https://o3de.org/docs/welcome-guide/create/creating-projects-using-cli/) in the documentation.
+
+#### Windows
+
+1.  Create a new project from the O3DE repo folder:
+    ```
+    scripts\o3de.bat create-project --project-path <your new project path>
+    ```
+
+1.  Register the project with the engine:
+    ```
+    scripts\o3de.bat register --project-path <your new project path>
+    ```
+
+1.  Configure a solution for the project:
+    ```
+    cmake -B <project build path> -S <your new project path> -G "Visual Studio 16 2019" -DLY_3RDPARTY_PATH=<3rdParty package path>
+    ```
+
+    Example:
+    ```
+    cmake -B C:\my-project\build\windows -S C:\my-project -G "Visual Studio 16 2019" -DLY_3RDPARTY_PATH=C:\o3de-packages
+    ```
+
+    > Note: Do not use trailing slashes for the `<3rdParty package path>`.
+
+1.  Build the project, Asset Processor, and Editor:
+    ```
+    cmake --build <project build path> --target <ProjectName>.GameLauncher Editor --config profile -- /m
+    ```
+
+    > Note: The build target name matches the project directory name. Binaries will be available under `bin/profile`.
+
+#### Linux
+
+1.  Create a new project from the O3DE repo folder:
+    ```
+    scripts/o3de.sh create-project --project-path <your new project path>
+    ```
+
+1.  Register the project with the engine:
+    ```
+    scripts/o3de.sh register --project-path <your new project path>
+    ```
+
+1.  Configure a solution for the project:
+    ```
+    cmake -B <project build path> -S <your new project path> -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=<3rdParty package path> -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14
+    ```
+
+    Example:
+    ```
+    cmake -B ~/my-project/build/linux -S ~/my-project -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=~/o3de-packages -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14
+    ```
+
+1.  Build the project, Asset Processor, and Editor:
+    ```
+    cmake --build <project build path> --target <ProjectName>.GameLauncher Editor --config profile
+    ```
+
+    > Note: The build target name matches the project directory name. Binaries will be available under `bin/profile`.
+
+### Script-only projects
+
+Script-only projects contain no C++ code and use scripting languages such as Lua. They do not require a compiler, but **must** be built against a prebuilt O3DE installation — building a script-only project against a source engine is not supported.
+
+On Windows, script-only projects also require the `Ninja Multi-Config` generator; the Visual Studio generator does not support script-only mode.
+
+For setup instructions, refer to [Setting up O3DE from GitHub](https://o3de.org/docs/welcome-guide/setup/setup-from-github/) in the documentation.
 
 ## Code Contributors
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ For the latest details and system requirements, refer to [System Requirements](h
 
 #### Windows
 
-*   Visual Studio 2019 latest (All editions supported, including Community): [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)
+*   Visual Studio 2022 latest (All editions supported, including Community): [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)
     *   Install the following workloads:
         *   Game Development with C++
-        *   MSVC v142 - VS 2019 C++ x64/x86
-        *   C++ 2019 redistributable update
+        *   MSVC v142 - VS 2019 C++ x64/x86 minimum
+        *   C++ 2019 redistributable update (C++ 2022 redistributable recommended)
 *   CMake 3.30 minimum: [https://cmake.org/download/#latest](https://cmake.org/download/#latest) (Release Candidate versions are not supported)
     *   CMake 3.30 is currently a soft requirement and will become a hard requirement after release 26.05.
     *   CMake 4.2.3 is bundled with the [prebuilt installer](https://o3debinaries.org/download/windows.html).


### PR DESCRIPTION
## What does this PR do?

Updates the readme quick start instructions and requirements for CMake after the 26.05 release

## How was this PR tested?

Ran through the instructions, but will need other folks in @o3de/sig-docs to validate