### PR TITLE
[Wayland] Allow Qt tools to force XCB.

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -3495,7 +3495,21 @@ extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
         AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_AddBuildSystemTargetSpecialization(
             registry, Editor::GetBuildTargetName());
 
-        AZ::Interface<AZ::IConsole>::Get()->PerformCommand("sv_isDedicated false");
+        AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
+        console->PerformCommand("sv_isDedicated false");
+#ifdef AZ_PLATFORM_LINUX
+        //Ensure we don't use Wayland implementations when Qt is using Xcb.
+        auto platformName = QGuiApplication::platformName();
+        if (platformName == "wayland")
+        {
+            //If a user already disabled it, we should re-enable it.
+            console->PerformCommand("wl_enable 1");
+        }
+        else
+        {
+            console->PerformCommand("wl_enable 0");
+        }
+#endif
 
         if (!AZToolsApp.Start())
         {

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandApplication.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandApplication.cpp
@@ -52,16 +52,29 @@ namespace AzFramework
 {
     class WaylandConnectionManagerImpl
         : public WaylandConnectionManagerBus::Handler
+        , public WaylandDisplayProvider
     {
     public:
         WaylandConnectionManagerImpl()
-            : m_waylandDisplay(wl_display_connect(nullptr))
         {
-            AZ_Error("Application", m_waylandDisplay != nullptr, "Failed to connect to Wayland Display.");
-            m_fd = wl_display_get_fd(m_waylandDisplay.get());
+            if (WaylandDisplayProviderInterface::Get() == nullptr)
+            {
+                WaylandDisplayProviderInterface::Register(this);
+                m_waylandDisplay = wl_display_connect(nullptr);
+                AZ_Error("Application", m_waylandDisplay != nullptr, "Failed to connect to Wayland Display.");
+                m_fd = wl_display_get_fd(m_waylandDisplay);
+                m_queue = nullptr;
+            }
+            else
+            {
+                m_waylandDisplay = WaylandDisplayProviderInterface::Get()->GetWaylandDisplay();
+                m_fd = WaylandDisplayProviderInterface::Get()->GetDisplayFD();
+                m_queue = wl_display_create_queue_with_name(m_waylandDisplay, "o3de-queue");
+            }
 
-            m_registry = wl_display_get_registry(m_waylandDisplay.get());
+            m_registry = wl_display_get_registry(m_waylandDisplay);
             AZ_Error("Application", m_registry != nullptr, "Failed to get Wayland Registry.");
+            wl_proxy_set_queue(reinterpret_cast<wl_proxy*>(m_registry), m_queue);
 
             m_xkbContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
             AZ_Error("Application", m_xkbContext != nullptr, "Failed to get XKB context.");
@@ -76,21 +89,42 @@ namespace AzFramework
             WaylandConnectionManagerBus::Handler::BusDisconnect();
             wl_registry_destroy(m_registry);
             wl_compositor_destroy(m_compositor);
+
+            if (m_queue != nullptr)
+            {
+                wl_event_queue_destroy(m_queue);
+            }
+
+            if (WaylandConnectionManagerInterface::Get() == this)
+            {
+                //We created the display
+                wl_display_disconnect(m_waylandDisplay);
+                m_waylandDisplay = nullptr;
+                m_fd = -1;
+                WaylandDisplayProviderInterface::Unregister(this);
+            }
+
         }
 
         void DoRoundtrip() const override
         {
-            wl_display_roundtrip(m_waylandDisplay.get());
+            if (m_queue)
+            {
+                wl_display_roundtrip_queue(m_waylandDisplay, m_queue);
+                return;
+            }
+
+            wl_display_roundtrip(m_waylandDisplay);
         }
 
         void CheckErrors() const override
         {
-            int errorCode = wl_display_get_error(m_waylandDisplay.get());
+            int errorCode = wl_display_get_error(m_waylandDisplay);
             if (errorCode == EPROTO)
             {
                 const wl_interface* anInterface;
                 uint32_t interfaceId;
-                auto code = wl_display_get_protocol_error(m_waylandDisplay.get(), &anInterface, &interfaceId);
+                auto code = wl_display_get_protocol_error(m_waylandDisplay, &anInterface, &interfaceId);
                 if (anInterface != nullptr)
                 {
                     WaylandInterfaceNotificationsBus::Event(
@@ -116,7 +150,12 @@ namespace AzFramework
 
         wl_display* GetWaylandDisplay() const override
         {
-            return m_waylandDisplay.get();
+            return m_waylandDisplay;
+        }
+
+        wl_event_queue* GetWaylandEventQueue() const override
+        {
+            return m_queue;
         }
 
         wl_registry* GetWaylandRegistry() const override
@@ -169,7 +208,8 @@ namespace AzFramework
 
     private:
         int m_fd = -1;
-        WaylandUniquePtr<wl_display, wl_display_disconnect> m_waylandDisplay = nullptr;
+        wl_display* m_waylandDisplay = nullptr;
+        wl_event_queue* m_queue = nullptr;
         wl_registry* m_registry = nullptr;
         wl_compositor* m_compositor = nullptr;
         xkb_context* m_xkbContext = nullptr;
@@ -238,7 +278,7 @@ namespace AzFramework
 
     bool WaylandApplication::HasEventsWaiting() const
     {
-        int fd = m_waylandConnectionManager->GetDisplayFD();
+        int fd = WaylandDisplayProviderInterface::Get()->GetDisplayFD();
         struct pollfd pfd = {fd, POLLIN};
 
         return poll(&pfd, 1, 0) > 0;
@@ -246,9 +286,52 @@ namespace AzFramework
 
     void WaylandApplication::PumpSystemEventLoopOnce()
     {
-        if (wl_display* display = m_waylandConnectionManager->GetWaylandDisplay())
+        auto display = WaylandDisplayProviderInterface::Get()->GetWaylandDisplay();
+        auto queue = WaylandConnectionManagerInterface::Get()->GetWaylandEventQueue();
+
+        if (queue)
         {
-            if (wl_display_dispatch_pending(display) == 0)
+            wl_display_dispatch_queue_pending(display, queue);
+            m_waylandConnectionManager->CheckErrors();
+            return;
+        }
+
+        if (wl_display_dispatch_pending(display) == 0)
+        {
+            // no pending events, read new events
+            wl_display_flush(display);
+            wl_display_prepare_read(display);
+
+            if (HasEventsWaiting())
+            {
+                wl_display_read_events(display);
+                wl_display_dispatch_pending(display);
+            }
+            else
+            {
+                wl_display_cancel_read(display);
+            }
+        }
+
+        m_waylandConnectionManager->CheckErrors();
+    }
+
+    void WaylandApplication::PumpSystemEventLoopUntilEmpty()
+    {
+        auto display = WaylandDisplayProviderInterface::Get()->GetWaylandDisplay();
+        auto queue = WaylandConnectionManagerInterface::Get()->GetWaylandEventQueue();
+
+        if (queue)
+        {
+            while (wl_display_dispatch_queue_pending(display, queue) > 0) {}
+            m_waylandConnectionManager->CheckErrors();
+            return;
+        }
+
+        while (true)
+        {
+            int num_dispatched_events = wl_display_dispatch_pending(display);
+            if (num_dispatched_events == 0)
             {
                 // no pending events, read new events
                 wl_display_flush(display);
@@ -262,46 +345,18 @@ namespace AzFramework
                 else
                 {
                     wl_display_cancel_read(display);
+                    break; // no events are pending
                 }
             }
-        }
-        m_waylandConnectionManager->CheckErrors();
-    }
-
-    void WaylandApplication::PumpSystemEventLoopUntilEmpty()
-    {
-        if (wl_display* display = m_waylandConnectionManager->GetWaylandDisplay())
-        {
-            while (true)
+            else if (num_dispatched_events == -1)
             {
-                int num_dispatched_events = wl_display_dispatch_pending(display);
-                if (num_dispatched_events == 0)
-                {
-                    // no pending events, read new events
-                    wl_display_flush(display);
-                    wl_display_prepare_read(display);
-
-                    if (HasEventsWaiting())
-                    {
-                        wl_display_read_events(display);
-                        wl_display_dispatch_pending(display);
-                    }
-                    else
-                    {
-                        wl_display_cancel_read(display);
-                        break; // no events are pending
-                    }
-                }
-                else if (num_dispatched_events == -1)
-                {
-                    // error
-                    m_waylandConnectionManager->CheckErrors();
-                    return;
-                }
-                else
-                {
-                    break;
-                }
+                // error
+                m_waylandConnectionManager->CheckErrors();
+                return;
+            }
+            else
+            {
+                break;
             }
         }
         m_waylandConnectionManager->CheckErrors();

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandConnectionManager.h
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandConnectionManager.h
@@ -17,6 +17,20 @@
 struct xkb_context;
 namespace AzFramework
 {
+    //We should only have one display connection,
+    //either Qt or AzFramework::WaylandConnectionManagerImpl will try to be the provider for this.
+    class WaylandDisplayProvider
+    {
+    public:
+        AZ_RTTI(WaylandDisplayProvider, "{5C0FB229-0D37-42A2-B6DE-513BB421D6DA}");
+        virtual ~WaylandDisplayProvider() = default;
+
+        virtual int GetDisplayFD() const = 0;
+        virtual wl_display* GetWaylandDisplay() const = 0;
+    };
+
+    using WaylandDisplayProviderInterface = AZ::Interface<WaylandDisplayProvider>;
+
     class WaylandConnectionManager
     {
     public:
@@ -26,8 +40,9 @@ namespace AzFramework
         virtual void DoRoundtrip() const = 0;
         virtual void CheckErrors() const = 0;
 
-        virtual int GetDisplayFD() const = 0;
-        virtual wl_display* GetWaylandDisplay() const = 0;
+        //Returns null when it's unnecessary; we use event queues when someone else is providing the
+        // display connection for us (Qt) so we don't mess with their default event queue.
+        virtual wl_event_queue* GetWaylandEventQueue() const = 0;
         virtual wl_registry* GetWaylandRegistry() const = 0;
         virtual wl_compositor* GetWaylandCompositor() const = 0;
 

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceKeyboard.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceKeyboard.cpp
@@ -25,15 +25,7 @@ namespace AzFramework
         void* data, wl_keyboard*, uint32_t serial, wl_surface* surface, wl_array* keys)
     {
         auto self = static_cast<WaylandInputDeviceKeyboard*>(data);
-        if (surface != nullptr)
-        {
-            if (auto wnw = static_cast<WaylandNativeWindow*>(wl_surface_get_user_data(surface)))
-            {
-                wnw->SetKeyboardFocus(self);
-                self->m_focusedWindow = wnw;
-            }
-        }
-
+        self->m_focusedWindow = static_cast<NativeWindowHandle>(surface);
         self->m_currentSerial = serial;
 
         uint32_t* key;
@@ -47,13 +39,7 @@ namespace AzFramework
                                                    wl_surface* surface)
     {
         auto self = static_cast<WaylandInputDeviceKeyboard*>(data);
-        if (surface != nullptr)
-        {
-            if (auto wnw = static_cast<WaylandNativeWindow*>(wl_surface_get_user_data(surface)))
-            {
-                wnw->SetKeyboardFocus(nullptr);
-            }
-        }
+        self->m_focusedWindow = nullptr;
 
         self->m_focusedWindow = nullptr;
         self->m_currentSerial = UINT32_MAX;

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceKeyboard.h
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceKeyboard.h
@@ -12,6 +12,7 @@
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Protocols/SeatManager.h>
 #include <AzFramework/WaylandConnectionManager.h>
+#include <AzFramework/Windowing/WindowBus.h>
 
 #include <xkbcommon/xkbcommon.h>
 
@@ -86,6 +87,6 @@ namespace AzFramework
 
         bool m_inTextMode = false;
 
-        class WaylandNativeWindow* m_focusedWindow = nullptr;
+        NativeWindowHandle m_focusedWindow = nullptr;
     };
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceMouse.cpp
@@ -56,15 +56,7 @@ namespace AzFramework
         wl_fixed_t surface_y)
     {
         auto self = static_cast<WaylandInputDeviceMouse*>(data);
-        if (surface != nullptr)
-        {
-            if (auto wnw = static_cast<WaylandNativeWindow*>(wl_surface_get_user_data(surface)))
-            {
-                wnw->SetPointerFocus(self);
-                self->m_focusedWindow = wnw;
-            }
-        }
-
+        self->m_focusedWindow = static_cast<NativeWindowHandle>(surface);
         self->m_currentSerial = serial;
 
         self->m_axisEvent.m_eventMask |= PointerEventMask::POINTER_EVENT_ENTER;
@@ -79,14 +71,6 @@ namespace AzFramework
                                                wl_surface* surface)
     {
         auto self = static_cast<WaylandInputDeviceMouse*>(data);
-
-        if (surface != nullptr)
-        {
-            if (auto wnw = static_cast<WaylandNativeWindow*>(wl_surface_get_user_data(surface)))
-            {
-                wnw->SetPointerFocus(nullptr);
-            }
-        }
         self->m_focusedWindow = nullptr;
 
         // I don't really see a need to save the pointer leave serial
@@ -105,7 +89,9 @@ namespace AzFramework
         self->m_position = AZ::Vector2((float)wl_fixed_to_double(surface_x), (float)wl_fixed_to_double(surface_y));
         if (self->m_focusedWindow)
         {
-            self->m_position *= self->m_focusedWindow->GetDpiScaleFactor();
+            float dpiScaleFactor = 1.0f;
+            WindowRequestBus::EventResult(dpiScaleFactor, self->m_focusedWindow, &WindowRequests::GetDpiScaleFactor);
+            self->m_position *= dpiScaleFactor;
         }
     }
 
@@ -346,7 +332,8 @@ namespace AzFramework
     {
         if (m_focusedWindow)
         {
-            const auto windowSize = m_focusedWindow->GetClientAreaSize();
+            WindowSize windowSize = {};
+            WindowRequestBus::EventResult(windowSize, m_focusedWindow, &WindowRequests::GetClientAreaSize);
             return m_position / AZ::Vector2((float)windowSize.m_width, (float)windowSize.m_height);
         }
 
@@ -402,6 +389,11 @@ namespace AzFramework
             return;
         }
 
+        if (m_pointer == nullptr)
+        {
+            return;
+        }
+
         if (!visible)
         {
             wl_pointer_set_cursor(m_pointer, m_currentSerial, nullptr, 0, 0);
@@ -416,6 +408,11 @@ namespace AzFramework
 
     void WaylandInputDeviceMouse::InternalConstrainMouse(bool wantConstraints)
     {
+        if (m_pointer == nullptr)
+        {
+            return;
+        }
+
         if (wantConstraints)
         {
             if (m_lockedPointer != nullptr)
@@ -436,15 +433,15 @@ namespace AzFramework
             auto constraints = reinterpret_cast<zwp_pointer_constraints_v1*>(proxy);
             if (constraints)
             {
-                void* constraintWindowRawPtr = nullptr;
+                NativeWindowHandle constraintWindow = nullptr;
                 InputSystemCursorConstraintRequestBus::BroadcastResult(
-                    constraintWindowRawPtr,
+                    constraintWindow,
                     &InputSystemCursorConstraintRequestBus::Events::GetSystemCursorConstraintWindow);
-                auto constraintWlWindow = static_cast<WaylandNativeWindow*>(constraintWindowRawPtr);
-                if (constraintWlWindow == nullptr)
+
+                if (constraintWindow == nullptr)
                 {
                     // Use focused
-                    constraintWlWindow = m_focusedWindow;
+                    constraintWindow = m_focusedWindow;
                 }
 
                 // Remove our old region
@@ -455,7 +452,9 @@ namespace AzFramework
                     (int32_t)m_currentRegion.m_width,
                     (int32_t)m_currentRegion.m_height);
 
-                const auto constraintSize = constraintWlWindow->GetClientAreaSize();
+                WindowSize constraintSize = {};
+                WindowRequestBus::EventResult(constraintSize, constraintWindow, &WindowRequests::GetClientAreaSize);
+
                 m_currentRegion = {0, 0, constraintSize.m_width, constraintSize.m_height};
                 wl_region_add(
                     m_confinedRegion,
@@ -466,22 +465,19 @@ namespace AzFramework
 
                 m_lockedPointer = zwp_pointer_constraints_v1_lock_pointer(
                     constraints,
-                    (wl_surface*)m_focusedWindow->GetWindowHandle(),
+                    static_cast<wl_surface*>(constraintWindow),
                     m_pointer,
                     m_confinedRegion,
                     ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
-
-                return;
             }
         }
         else
         {
             if (m_lockedPointer)
             {
-                // Dont want constraints anymore
+                // Don't want constraints anymore
                 zwp_locked_pointer_v1_destroy(m_lockedPointer);
                 m_lockedPointer = nullptr;
-                return;
             }
         }
     }

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceMouse.h
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInputDeviceMouse.h
@@ -99,7 +99,7 @@ namespace AzFramework
 
         uint32_t m_currentSerial = UINT32_MAX;
         AzFramework::SystemCursorState m_cursorState = SystemCursorState::Unknown;
-        class WaylandNativeWindow* m_focusedWindow = nullptr;
+        NativeWindowHandle m_focusedWindow = nullptr;
 
         AZ::Vector2 m_position = AZ::Vector2::CreateZero();
 

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInterface.h
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandInterface.h
@@ -24,23 +24,6 @@ reinterpret_cast<char*>(pos) < (static_cast<char*>((array)->data) + (array)->siz
 
 namespace AzFramework
 {
-    template<auto Callable>
-    struct WaylandDeleterFreeFunctionWrapper
-    {
-        using value_type = decltype(Callable);
-        static constexpr value_type s_value = Callable;
-        constexpr operator value_type() const noexcept
-        {
-            return s_value;
-        }
-    };
-
-    template<typename T, auto fn>
-    using WaylandUniquePtr = AZStd::unique_ptr<T, WaylandDeleterFreeFunctionWrapper<fn>>;
-
-    template<typename T>
-    using WaylandStdFreePtr = WaylandUniquePtr<T, ::free>;
-
     // EBus to help with registry
     class WaylandRegistryEvents
     {
@@ -90,12 +73,12 @@ namespace AzFramework
 
     using WaylandInterfaceNotificationsBus = AZ::EBus<WaylandInterfaceNotifications, WaylandInterfaceNotificationsBusTraits>;
 
-    //Ebus to get a Wayland proxy
+    //Ebus to get a Wayland proxy from an interface name.
     class WaylandProxyBusEvents
     {
     public:
         AZ_RTTI(WaylandProxyBusEvents, "{ECE07457-9F6E-4C5D-AE9A-DA7F1A366392}")
-        virtual ~WaylandProxyBusEvents() = default;;
+        virtual ~WaylandProxyBusEvents() = default;
 
         virtual wl_proxy* GetProxy(AZ::Crc32 interface) = 0;
     };

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandNativeWindow.cpp
@@ -218,9 +218,13 @@ namespace AzFramework
         , m_surface(nullptr)
         , m_xdgSurface(nullptr)
     {
+        if (auto displayManager = AzFramework::WaylandDisplayProviderInterface::Get())
+        {
+            m_display = displayManager->GetWaylandDisplay();
+        }
+
         if (auto connectionManager = AzFramework::WaylandConnectionManagerInterface::Get())
         {
-            m_display = connectionManager->GetWaylandDisplay();
             m_compositor = connectionManager->GetWaylandCompositor();
         }
 
@@ -519,16 +523,6 @@ namespace AzFramework
         }
 
         InternalUpdateBufferScale();
-    }
-
-    void WaylandNativeWindow::SetPointerFocus(WaylandInputDeviceMouse* pointer)
-    {
-        m_focusedCursor = pointer;
-    }
-
-    void WaylandNativeWindow::SetKeyboardFocus(WaylandInputDeviceKeyboard* keyboard)
-    {
-        m_focusedKeyboard = keyboard;
     }
 
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandNativeWindow.h
+++ b/Code/Framework/AzFramework/Platform/Common/Wayland/AzFramework/WaylandNativeWindow.h
@@ -76,9 +76,6 @@ namespace AzFramework
         void InternalUpdateBufferScale();
         void InternalUpdateScaleFactor(float newScale);
 
-        void SetPointerFocus(WaylandInputDeviceMouse* pointer);
-        void SetKeyboardFocus(WaylandInputDeviceKeyboard* keyboard);
-
     private:
         static void SurfaceEnter(void* data, wl_surface* wl_surface, wl_output* output);
         static void SurfaceLeave(void* data, wl_surface* wl_surface, wl_output* output);
@@ -115,9 +112,6 @@ namespace AzFramework
 
         WindowSize m_recommendedGeoBounds = {};
         wl_output* m_currentEnteredOutput = nullptr;
-
-        WaylandInputDeviceMouse* m_focusedCursor = nullptr;
-        WaylandInputDeviceKeyboard* m_focusedKeyboard = nullptr;
 
         uint32_t m_currentRefreshMhz = 0;
         float m_dpiScaleFactor = 1.0f;

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Components/NativeUISystemComponent_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Components/NativeUISystemComponent_Linux.cpp
@@ -23,6 +23,10 @@
 #include <AzFramework/WaylandNativeWindow.h>
 #include <AzFramework/WaylandInputDeviceMouse.h>
 #include <AzFramework/WaylandInputDeviceKeyboard.h>
+
+#include <AzCore/Console/IConsole.h>
+//Used so Qt can force us to use xcb and lets users also change the behavior.
+AZ_CVAR(bool, wl_enable, true, nullptr, AZ::ConsoleFunctorFlags::Null, "Try to use Wayland when applicable");
 #endif
 
 // libevdev could be used for other devices in the future (Can do keyboard, mouse, etc), so it doesn't belong in the gamepad
@@ -171,7 +175,7 @@ namespace AzFramework
 #if PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB && PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
         //Check for a Wayland env var if we also support X11
         const char* waylandEnvVar = getenv("WAYLAND_DISPLAY");
-        if (waylandEnvVar != nullptr && strlen(waylandEnvVar) > 0)
+        if (wl_enable && waylandEnvVar != nullptr && strlen(waylandEnvVar) > 0)
         {
             g_useWayland = true;
             AZ_Printf("NativeUISystemComponent", "Using Wayland, found WAYLAND_DISPLAY env var.");
@@ -179,6 +183,10 @@ namespace AzFramework
 #elif PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND && !PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
         //Only supports Wayland.
         g_useWayland = true;
+        if (!wl_enable)
+        {
+            AZ_Warning("NativeUISystemComponent", false, "Requested Wayland to be disabled, but only Wayland is supported. Continuing with Wayland anyway, expect issues.");
+        }
 #endif
 
         m_applicationImplFactory = AZStd::make_unique<LinuxApplicationImplFactory>();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Linux/RHI/WSISurface_Linux.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Linux/RHI/WSISurface_Linux.cpp
@@ -28,9 +28,9 @@ namespace AZ
             Instance& instance = Instance::GetInstance();
 
 #if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
-            if (auto wlConnection = AzFramework::WaylandConnectionManagerInterface::Get())
+            if (auto displayProvider = AzFramework::WaylandDisplayProviderInterface::Get())
             {
-                wl_display* display = wlConnection->GetWaylandDisplay();
+                wl_display* display = displayProvider->GetWaylandDisplay();
                 if(display == nullptr){
                     AZ_Error("AtomVulkan_RHI", display!=nullptr, "Unable to get Wayland Display.");
                     return RHI::ResultCode::Fail;


### PR DESCRIPTION
## What does this PR do?

This is a fix back-ported from my Qt6 work that allows you to build with `PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND` without it crashing your editor tools, and also contains some Wayland code cleanup.

Right now, if you build with Wayland enabled, your editor tools will fail to work, as by default AzFramework will open a Wayland display connection and expect Qt to also use Wayland.
With this PR, CryEdit now tells AzFramework whether it should attempt to use the Wayland code or not, using a CVar.

I went with a CVar since it also gives users an easy way to force XCB for the GameLauncher.

## How was this PR tested?

Fedora 43, launched the editor and GameLauncher with Wayland support enabled and disabled.

## Why not wait for Qt6 for these changes?
It's taking me a while to work on due to real-life issues currently, so I want to get these base changes up while I slowly work on Qt6.