### PR TITLE
Switch to parallel_for in MotionMatching gem init

### DIFF
--- a/Gems/MotionMatching/Code/Source/MotionMatchingData.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingData.cpp
@@ -29,6 +29,8 @@
 #include <KdTree.h>
 #include <MotionMatchingData.h>
 
+#include <AzCore/Jobs/Algorithms.h>
+
 namespace EMotionFX::MotionMatching
 {
     AZ_CVAR_EXTERNED(bool, mm_multiThreadedInitialization);
@@ -109,25 +111,12 @@ namespace EMotionFX::MotionMatching
             }
             else // job system
             {
-                AZ::JobCompletion jobCompletion;
-
-                // Split-up the motion database into batches of frames and extract the feature values for each batch simultaneously.
-                for (size_t batchIndex = 0; batchIndex < numBatches; ++batchIndex)
-                {
-                    const size_t startFrame = batchIndex * s_numFramesPerBatch;
-                    const size_t endFrame = AZStd::min(startFrame + s_numFramesPerBatch, numFrames);
-
-                    // Create a job for every batch and extract the features simultaneously.
-                    AZ::JobContext* jobContext = nullptr;
-                    AZ::Job* job = AZ::CreateJobFunction([this, actorInstance, startFrame, endFrame]()
+                AZ::parallel_for((size_t)0, numBatches, [this, actorInstance, numFrames](size_t batchIndex) -> void
                         {
+                            const size_t startFrame = batchIndex * s_numFramesPerBatch;
+                            const size_t endFrame = AZStd::min(startFrame + s_numFramesPerBatch, numFrames);
                             ExtractFeatureValuesRange(actorInstance, m_frameDatabase, m_featureSchema, m_featureMatrix, startFrame, endFrame);
-                        }, /*isAutoDelete=*/true, jobContext);
-                    job->SetDependent(&jobCompletion);
-                    job->Start();
-                }
-
-                jobCompletion.StartAndWaitForCompletion();
+                        });
             }
         }
         else // Single-threaded


### PR DESCRIPTION
## What does this PR do?

The MotionMatching gem currently supports two multithreaded init implementations, one with the Jobs system (default) and one with TaskGraph.

The Jobs implementation is prone to dead lock when the number of worker threads is low. I'm not 100% what the culprit is, but I suspect it's due to its use of `AZ::JobCompletion`, and also related to the number of actor instances in the scene.

This change switches it to use `parallel_for`, which still relies on the Jobs system, but seems to not trigger the same issue. From a cursory glance it seems like parallel_for actually balances the work based on the number of available job threads.

This is probably the same issue as this: https://github.com/o3de/o3de/issues/5866#issuecomment-980468423
There's a [related workaround](https://github.com/aws-lumberyard-dev/o3de/commit/2b9f5264ae751afa32491eb25d00d20959e81f96) that bumps the min number of threads to 3, but in my case it only worked if I raise it to 5. So it's probably related to the content, so not a reliable fix.

## How was this PR tested?

1. [Downloaded our game](https://aramallo.itch.io/green-mikes-vhs) for Linux
2. Run with `./LD59.GameLauncher --cl_jobThreadsConcurrencyRatio 0`
3. Observe that it gets permanently stuck at start up, with the process CPU usage at 0%
4. After creating another build with this change, the game starts normally

This was tested on a Steam Deck and a Linux PC with a 12C/24T Ryzen CPU.

## Thoughts

I'm not familiar with O3DE's Jobs system/TaskGraph. Idk why there are two, why the MM gem supports both, and why one is [disabled by default](https://github.com/o3de/o3de/blob/57dd3be6b251c8debd6dda57f2bf14f919cfabd4/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp#L25). It may make more sense to keep only one implementation? The TaskGraph version seems like it might be better, since it didn't have this problem to begin with.