### PR TITLE
AzCore/Script: drop redundant <Lua/lobject.h> include

### DIFF
--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -25,11 +25,10 @@
 extern "C" {
 #   include <Lua/lualib.h>
 #   include <Lua/lauxlib.h>
-#   include <Lua/lobject.h>
 
-    // versions of LUA before 5.3.x used to define a union that contained a double, a pointer, and a long
-    // as L_Umaxalign.  Newer versions define those inner types in the macro LUAI_MAXALIGN instead but
-    // no longer actually declare a union around it.  For backward compatibility we define the same one here
+    // Lua < 5.3.x defined a union containing double + pointer + long as L_Umaxalign. Lua 5.3+ replaced the
+    // union with the LUAI_MAXALIGN macro (defined in luaconf.h, public API; also used in lauxlib.h's
+    // luaL_Buffer). Wrap it in a union here so existing call sites can keep using sizeof(L_Umaxalign).
     union L_Umaxalign { LUAI_MAXALIGN; };
 }
 


### PR DESCRIPTION
### Summary

`Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp`'s `extern "C"` block (around line 25) includes the **internal** Lua header `<Lua/lobject.h>` solely to obtain the `LUAI_MAXALIGN` macro, which is then used to define a backward-compat `union L_Umaxalign` (consumed in `sizeof()` expressions at four call sites for alignment-padded userdata sizing).

`LUAI_MAXALIGN` is part of Lua's **public** API:

- Defined in `luaconf.h` (Lua's documented public configuration header) — the `@@` doc-comment marker is Lua's convention for public config macros
- *Used* in `lauxlib.h`'s public `luaL_Buffer` struct definition

The existing `<Lua/lualib.h>` and `<Lua/lauxlib.h>` includes in the same `extern "C"` block already pull `luaconf.h` transitively (`lualib.h` → `lua.h` → `luaconf.h`, and `lauxlib.h` → `luaconf.h` directly), so `LUAI_MAXALIGN` is in scope without `<Lua/lobject.h>`.

### Why this matters

Linux distributions that ship Lua public-API-only — Fedora's `lua-devel`, Debian's `liblua5.4-dev`, Alpine's `lua5.4-dev`, etc. — never ship internal Lua headers like `lobject.h`, `lstate.h`, `lstring.h`. As a result, packagers building O3DE against system Lua have been blocked by this single include since the bundled-Lua era. With the include removed, system-Lua packaging becomes trivially possible. Bundled-Lua builds get the brittleness reduction for free.

### What changes

One file (`Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp`); one line removed (the `<Lua/lobject.h>` include); the adjacent comment block is also polished to document the public-API path so the next reader doesn't reach for `lobject.h` again.

```diff
 extern "C" {
 #   include <Lua/lualib.h>
 #   include <Lua/lauxlib.h>
-#   include <Lua/lobject.h>

-    // versions of LUA before 5.3.x used to define a union that contained a double, a pointer, and a long
-    // as L_Umaxalign.  Newer versions define those inner types in the macro LUAI_MAXALIGN instead but
-    // no longer actually declare a union around it.  For backward compatibility we define the same one here
+    // Lua < 5.3.x defined a union containing double + pointer + long as L_Umaxalign. Lua 5.3+ replaced the
+    // union with the LUAI_MAXALIGN macro (defined in luaconf.h, public API; also used in lauxlib.h's
+    // luaL_Buffer). Wrap it in a union here so existing call sites can keep using sizeof(L_Umaxalign).
     union L_Umaxalign { LUAI_MAXALIGN; };
 }
```

### Evidence the change is safe

**Isolated compile test** (against Lua 5.4.8):

```cpp
extern "C" {
#   include <lua.h>
#   include <lualib.h>
#   include <lauxlib.h>
    // NOT including <lobject.h>

    union L_Umaxalign { LUAI_MAXALIGN; };
}

#include <cstddef>

int main() { return static_cast<int>(sizeof(L_Umaxalign)); }
```

Compiles, links, and resolves `sizeof(L_Umaxalign)` to a real positive integer at runtime. So the public-API include chain alone is sufficient.

**Full O3DE build** (against Lua 5.4.8 on Fedora 44 — same code-path through `%prep`-applied carry-patch + `cmake -DLY_USE_SYSTEM_LUA=ON`): build succeeds; engine binaries' auto-Requires picks up `liblua-5.4.so()(64bit)` + `lua-libs`. So the engine actually links system Lua end-to-end with this change in place.

### What's preserved

- Same union (`L_Umaxalign`)
- Same `sizeof()` behavior at the four call sites in the same file
- Same alignment math
- Cross-platform: works on Linux (Lua 5.4.x via system package), Windows (Lua 5.4.x with the same public headers), macOS (same)

### Side benefits

- Removing the internal-header include reduces brittleness — if future Lua versions reorganize internals, AzCore won't be affected.
- Enables `system_lua` activation on Linux distros that ship Lua public-API-only.

### Test plan

- [x] AzCore compiles cleanly with the change (verified locally on Fedora 44 + Lua 5.4.8 via `rpmbuild` / system Lua)
- [x] Engine binaries auto-Require `liblua-5.4.so()(64bit)` (system Lua is being linked)
- [ ] Existing AzCore tests (and any Lua scripting tests) pass unchanged in CI

### Background

Found while auditing what blocks system-Lua packaging on Fedora 44. The bundled Lua at `packages.o3de.org` ships internal headers; system Lua packages typically don't. Discovered the include is the only blocker; everything else (bcond plumbing, find module, etc.) is solvable on the packaging side once the include is dropped. Full audit notes available on request.