### PR TITLE
Gem-based Level Loading and Saving

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -33,6 +33,7 @@
 #include <Core/Widgets/ViewportSettingsWidgets.h>
 #include <CryEdit.h>
 #include <EditorCoreAPI.h>
+#include <LevelRoots.h>
 #include <Editor/EditorViewportCamera.h>
 #include <Editor/EditorViewportSettings.h>
 #include <Editor/Undo/Undo.h>
@@ -2247,6 +2248,7 @@ bool EditorActionsHandler::IsRecentFileEntryValid(const QString& entry, const QS
         return false;
     }
 
+    // Project-rooted level (legacy fast path).
     const QDir gameDir(gameFolderPath);
     QDir dir(entry); // actually pointing at file, first cdUp() gets us the parent dir
     while (dir.cdUp())
@@ -2257,7 +2259,9 @@ bool EditorActionsHandler::IsRecentFileEntryValid(const QString& entry, const QS
         }
     }
 
-    return false;
+    // Gem-rooted level: a recent file living under any active gem's source
+    // tree is also a valid Open Recent target.
+    return LevelRoots::IsPathUnderActiveSource(entry);
 }
 
 void EditorActionsHandler::OpenLevelByRecentFileEntryIndex(int index)
@@ -2331,9 +2335,24 @@ void EditorActionsHandler::UpdateRecentFileActions()
 
         if (index < recentFilesSize)
         {
-            // If the index is valid, use it to populate the action's name and then increment for the next menu item.
+            // For project-rooted entries, GetDisplayName already produces a
+            // path relative to the project. For gem-rooted entries it falls
+            // back to the absolute path, so swap in the LevelRoots helper
+            // which renders the file as "<GemName>/Levels/...".
             QString displayName;
             recentFiles->GetDisplayName(displayName, index, sCurDir);
+
+            const QString& absoluteEntry = (*recentFiles)[index];
+            if (!LevelRoots::IsPathUnderActiveSource(absoluteEntry))
+            {
+                // Fall through with whatever GetDisplayName produced.
+            }
+            else if (QDir::cleanPath(displayName).compare(QDir::cleanPath(absoluteEntry), Qt::CaseInsensitive) == 0)
+            {
+                // GetDisplayName left the absolute path intact (gem-rooted case);
+                // replace it with the gem-aware short form.
+                displayName = LevelRoots::FormatRelativeDisplay(absoluteEntry);
+            }
 
             m_actionManagerInterface->SetActionName(
                 actionIdentifier, AZStd::string::format("%i | %s", counter + 1, displayName.toUtf8().data()));

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2522,7 +2522,7 @@ void CCryEditApp::OnUpdatePlayGame(QAction* action)
 }
 
 //////////////////////////////////////////////////////////////////////////
-CCryEditApp::ECreateLevelResult CCryEditApp::CreateLevel(const QString& templateName, const QString& levelName, QString& fullyQualifiedLevelName /* ={} */)
+CCryEditApp::ECreateLevelResult CCryEditApp::CreateLevel(const QString& templateName, const QString& levelName, QString& fullyQualifiedLevelName /* ={} */, const QString& levelsRootAbsolutePath /* ={} */)
 {
     // If we are creating a new level and we're in simulate mode, then switch it off before we do anything else
     if (GetIEditor()->GetGameEngine() && GetIEditor()->GetGameEngine()->GetSimulationMode())
@@ -2551,7 +2551,18 @@ CCryEditApp::ECreateLevelResult CCryEditApp::CreateLevel(const QString& template
     }
 
     QString cryFileName = levelName.mid(levelName.lastIndexOf('/') + 1, levelName.length() - levelName.lastIndexOf('/') + 1);
-    QString levelPath = QStringLiteral("%1/Levels/%2/").arg(Path::GetEditingGameDataFolder().c_str(), levelName);
+    // Compose the absolute level folder. When the caller specifies a root
+    // (e.g. a gem root), use it directly; otherwise fall back to the
+    // project's "Levels" folder for backwards compatibility.
+    QString levelPath;
+    if (!levelsRootAbsolutePath.isEmpty())
+    {
+        levelPath = QStringLiteral("%1/%2/").arg(levelsRootAbsolutePath, levelName);
+    }
+    else
+    {
+        levelPath = QStringLiteral("%1/Levels/%2/").arg(Path::GetEditingGameDataFolder().c_str(), levelName);
+    }
     fullyQualifiedLevelName = levelPath + cryFileName + EditorUtils::LevelFile::GetDefaultFileExtension();
 
     //_MAX_PATH includes null terminator, so we actually want to cap at _MAX_PATH-1
@@ -2719,7 +2730,7 @@ bool CCryEditApp::CreateLevel(bool& wasCreateLevelOperationCancelled)
     GetIEditor()->StartLevelErrorReportRecording();
 
     QString fullyQualifiedLevelName;
-    ECreateLevelResult result = CreateLevel(dlg.GetTemplateName(), levelNameWithPath, fullyQualifiedLevelName);
+    ECreateLevelResult result = CreateLevel(dlg.GetTemplateName(), levelNameWithPath, fullyQualifiedLevelName, dlg.GetLevelsFolder());
 
     if (result == ECLR_ALREADY_EXISTS)
     {

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -127,7 +127,12 @@ public:
     void SetEditorWindowTitle(QString sTitleStr = QString(), QString sPreTitleStr = QString(), QString sPostTitleStr = QString());
     RecentFileList* GetRecentFileList();
     virtual void AddToRecentFileList(const QString& lpszPathName);
-    ECreateLevelResult CreateLevel(const QString& templateName, const QString& levelName, QString& fullyQualifiedLevelName);
+    // levelsRootAbsolutePath: absolute path of the "Levels" container the
+    // new level should live inside. Empty (default) means the project's
+    // own "Levels" folder, preserving legacy behaviour for all existing
+    // callers (including Python). The New Level dialog passes a gem root
+    // through this parameter when the user picks a non-project root.
+    ECreateLevelResult CreateLevel(const QString& templateName, const QString& levelName, QString& fullyQualifiedLevelName, const QString& levelsRootAbsolutePath = QString());
     bool FirstInstance(bool bForceNewInstance = false);
     void InitFromCommandLine(CEditCommandLineInfo& cmdInfo);
     bool CheckIfAlreadyRunning();

--- a/Code/Editor/CryEditPy.cpp
+++ b/Code/Editor/CryEditPy.cpp
@@ -27,6 +27,7 @@
 #include "Core/QtEditorApplication.h"
 #include "CheckOutDialog.h"
 #include "GameEngine.h"
+#include "LevelRoots.h"
 #include "ViewManager.h"
 #include "EditorViewportCamera.h"
 
@@ -115,41 +116,54 @@ namespace
 
         if (!QFile::exists(levelPath))
         {
-            // if the input path can't be found, let's automatically add on the game folder and the levels
-            QString levelsDir = QString("%1/%2").arg(Path::GetEditingGameDataFolder().c_str()).arg("Levels");
+            const QString originalInput = levelPath;
 
-            // now let's check if they pre-pended directories (Samples/SomeLevelName)
-            QString levelFileName = levelPath;
-            QStringList splitLevelPath = levelPath.contains('/') ? levelPath.split('/') : levelPath.split('\\');
-            if (splitLevelPath.length() > 1)
+            // Compose a candidate "<root>/<input>/<basename>[.ext]" against
+            // a given root. Returns the file path that exists on disk, or
+            // an empty string if neither extension matches.
+            auto resolveAgainstRoot = [&](const QString& rootAbsolute) -> QString
             {
-                // take the last one as the level directory name and the level file name in that directory
-                levelFileName = splitLevelPath.last();
+                QString candidate = originalInput;
+                QString fileName = candidate;
+                const QStringList split = candidate.contains('/') ? candidate.split('/') : candidate.split('\\');
+                if (split.length() > 1)
+                {
+                    // pre-pended directories ("Samples/SomeLevelName"); the trailing
+                    // segment is both the level folder name and the file basename.
+                    fileName = split.last();
+                }
+
+                candidate = rootAbsolute / candidate / fileName;
+
+                if (!fileName.endsWith(oldExtension) && !fileName.endsWith(defaultExtension))
+                {
+                    const QString newPath = candidate + defaultExtension;
+                    const QString oldPath = candidate + oldExtension;
+                    candidate = QFileInfo(oldPath).exists() ? oldPath : newPath;
+                }
+
+                return QFile::exists(candidate) ? candidate : QString();
+            };
+
+            // Try the project's Levels folder first, then walk every gem
+            // root that exposes a Levels folder. The first hit wins.
+            QString resolved;
+            const QVector<LevelRoots::Root> roots = LevelRoots::Enumerate();
+            for (const LevelRoots::Root& root : roots)
+            {
+                resolved = resolveAgainstRoot(root.absolutePath);
+                if (!resolved.isEmpty())
+                {
+                    break;
+                }
             }
 
-            levelPath = levelsDir / levelPath / levelFileName;
-
-            // make sure the level path includes the cry extension, if needed
-            if (!levelFileName.endsWith(oldExtension) && !levelFileName.endsWith(defaultExtension))
-            {
-                QString newLevelPath = levelPath + defaultExtension;
-                QString oldLevelPath = levelPath + oldExtension;
-
-                // Check if there is a .cry file, otherwise assume it is a new .ly file
-                if (QFileInfo(oldLevelPath).exists())
-                {
-                    levelPath = oldLevelPath;
-                }
-                else
-                {
-                    levelPath = newLevelPath;
-                }
-            }
-
-            if (!QFile::exists(levelPath))
+            if (resolved.isEmpty())
             {
                 return false;
             }
+
+            levelPath = resolved;
         }
         const bool addToMostRecentFileList = false;
         auto newDocument = CCryEditApp::instance()->OpenDocumentFile(levelPath.toUtf8().data(),

--- a/Code/Editor/LevelFileDialog.cpp
+++ b/Code/Editor/LevelFileDialog.cpp
@@ -14,12 +14,16 @@
 #include <AzFramework/API/ApplicationAPI.h>
 
 // Qt
-#include <QMessageBox>
+#include <QComboBox>
 #include <QInputDialog>
+#include <QLabel>
+#include <QMessageBox>
 #include <QRegularExpression>
+#include <QSignalBlocker>
 
 // Editor
 #include "LevelTreeModel.h"
+#include "LevelRoots.h"
 #include "CryEditDoc.h"
 #include "API/ToolsApplicationAPI.h"
 
@@ -68,6 +72,11 @@ CLevelFileDialog::CLevelFileDialog(bool openDialog, QWidget* parent)
         ui->treeView->expandToDepth(1);
         ui->newFolderButton->setVisible(false);
         ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Open"));
+
+        // Open keeps the legacy multi-root tree, so the target combo is
+        // hidden entirely.
+        ui->targetRootLabel->setVisible(false);
+        ui->targetRootCombo->setVisible(false);
     }
     else
     {
@@ -80,13 +89,47 @@ CLevelFileDialog::CLevelFileDialog(bool openDialog, QWidget* parent)
         setTabOrder(ui->nameLineEdit, ui->filterLineEdit);
 
         connect(ui->nameLineEdit, &QLineEdit::textChanged, this, &CLevelFileDialog::OnNameChanged);
+
+        // Save As exposes a target combo so the user explicitly picks the
+        // owning root before naming the level. The tree below is then
+        // filtered to that one target, which keeps "save into an empty
+        // gem" unambiguous.
+        m_saveTargetRoots = LevelRoots::Enumerate(LevelRoots::Mode::AllActive);
+        QSignalBlocker blocker(ui->targetRootCombo);
+        ui->targetRootCombo->clear();
+        for (const LevelRoots::Root& root : m_saveTargetRoots)
+        {
+            ui->targetRootCombo->addItem(root.displayName, root.absolutePath);
+        }
+        ui->targetRootCombo->setCurrentIndex(0);
+        connect(
+            ui->targetRootCombo,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &CLevelFileDialog::OnTargetRootChanged);
     }
 
     // reject invalid file names
     ui->nameLineEdit->setValidator(new QRegularExpressionValidator(QRegularExpression("^[a-zA-Z0-9_\\-./]*$"), ui->nameLineEdit));
 
+    // Default to the project root until the user selects something. Enumerate()
+    // is guaranteed to return the project root as the first entry.
+    const QVector<LevelRoots::Root> roots = LevelRoots::Enumerate();
+    if (!roots.isEmpty())
+    {
+        m_selectedRoot = roots.front().absolutePath;
+        m_selectedRootIsProject = roots.front().isProject;
+    }
+
     ReloadTree();
-    LoadLastUsedLevelPath();
+    // Open restores the last-used level so the user lands on what they
+    // were working on. Save As intentionally does not - the user expects
+    // a clean slate (project root, empty name) so they don't accidentally
+    // overwrite the previous Save As target by reflex.
+    if (m_bOpenDialog)
+    {
+        LoadLastUsedLevelPath();
+    }
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
@@ -206,8 +249,15 @@ bool CLevelFileDialog::IsValidLevelSelected()
 QString CLevelFileDialog::GetLevelPath() const
 {
     const QString enteredPath = GetEnteredPath();
-    const QString levelPath = QString("%1/%2/%3").arg(Path::GetEditingGameDataFolder().c_str()).arg(kLevelsFolder).arg(enteredPath);
-    return levelPath;
+
+    // m_selectedRoot already points to the absolute "Levels" folder of the
+    // currently-targeted root (project by default, or whichever gem the user
+    // navigated into in the tree).
+    const QString rootPath = !m_selectedRoot.isEmpty()
+        ? m_selectedRoot
+        : QString("%1/%2").arg(Path::GetEditingGameDataFolder().c_str()).arg(kLevelsFolder);
+
+    return QStringLiteral("%1/%2").arg(rootPath, enteredPath);
 }
 
 QString CLevelFileDialog::GetEnteredPath() const
@@ -267,7 +317,19 @@ void CLevelFileDialog::OnTreeSelectionChanged()
     const QModelIndexList indexes = ui->treeView->selectionModel()->selectedIndexes();
     if (!indexes.isEmpty())
     {
-        ui->nameLineEdit->setText(NameForIndex(indexes.first()));
+        const QModelIndex selected = indexes.first();
+
+        // Update the active root before regenerating the displayed name, so
+        // GetLevelPath() and validation reflect the root the user clicked
+        // into (project vs. one of the gem roots).
+        const QString rootPath = selected.data(LevelTreeModel::RootPathRole).toString();
+        if (!rootPath.isEmpty())
+        {
+            m_selectedRoot = rootPath;
+            m_selectedRootIsProject = selected.data(LevelTreeModel::IsProjectRootRole).toBool();
+        }
+
+        ui->nameLineEdit->setText(NameForIndex(selected));
     }
 }
 
@@ -357,7 +419,42 @@ void CLevelFileDialog::OnNameChanged()
 
 void CLevelFileDialog::ReloadTree()
 {
-    m_model->ReloadTree(m_bOpenDialog);
+    if (m_bOpenDialog)
+    {
+        // Open keeps a tree with every gem that already has an
+        // Assets/Levels folder so the user can browse all of them at once.
+        m_model->ReloadTree(m_bOpenDialog, LevelRoots::Mode::ExistingOnly);
+        return;
+    }
+
+    // Save As shows only the contents of the currently-selected target
+    // root. Defaults to the first entry (the project) until the user
+    // picks something else.
+    if (m_saveTargetRoots.isEmpty())
+    {
+        m_model->ReloadTree(m_bOpenDialog, LevelRoots::Mode::AllActive);
+        return;
+    }
+
+    const int index = ui->targetRootCombo->currentIndex();
+    const int safeIndex = (index >= 0 && index < m_saveTargetRoots.size()) ? index : 0;
+    const LevelRoots::Root& root = m_saveTargetRoots[safeIndex];
+    m_model->ReloadTreeFromRoot(m_bOpenDialog, root);
+    m_selectedRoot = root.absolutePath;
+    m_selectedRootIsProject = root.isProject;
+
+    // Auto-expand the single root so the user immediately sees its
+    // contents (or its emptiness, for a fresh gem).
+    const QModelIndex rootIndex = m_filterModel->index(0, 0);
+    if (rootIndex.isValid())
+    {
+        ui->treeView->expand(rootIndex);
+    }
+}
+
+void CLevelFileDialog::OnTargetRootChanged(int /*index*/)
+{
+    ReloadTree();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -462,10 +559,15 @@ bool CLevelFileDialog::ValidateLevelPath(const QString& levelPath) const
         return false;
     }
 
-    // Make sure that no folder before the last in the name contains a level
+    // Make sure that no folder before the last in the name contains a level.
+    // Walk from the active root (project or gem) so the check matches the
+    // location the user is actually saving into.
     if (splittedPath.size() > 1)
     {
-        QString currentPath = (Path::GetEditingGameDataFolder() + "/" + kLevelsFolder).c_str();
+        QString currentPath = !m_selectedRoot.isEmpty()
+            ? m_selectedRoot
+            : QString::fromUtf8((Path::GetEditingGameDataFolder() + "/" + kLevelsFolder).c_str());
+
         for (size_t i = 0; i < splittedPath.size() - 1; ++i)
         {
             currentPath += "/" + splittedPath[static_cast<int>(i)];
@@ -486,6 +588,11 @@ void CLevelFileDialog::SaveLastUsedLevelPath()
 
     XmlNodeRef lastUsedLevelPathNode = XmlHelpers::CreateXmlNode("lastusedlevelpath");
     lastUsedLevelPathNode->setAttr("path", ui->nameLineEdit->text().toUtf8().data());
+    // Persist which root the relative "path" is anchored to, so the next
+    // session can re-open a level that lives under a gem rather than the
+    // project. Older preset files that omit this attribute are still
+    // interpreted as project-relative (legacy behaviour).
+    lastUsedLevelPathNode->setAttr("root", m_selectedRoot.toUtf8().data());
     lastUsedLevelPathNode->saveToFile(settingPath.toUtf8().data());
 }
 
@@ -502,13 +609,49 @@ void CLevelFileDialog::LoadLastUsedLevelPath()
     QString lastLoadedFileName;
     lastUsedLevelPathNode->getAttr("path", lastLoadedFileName);
 
+    QString lastUsedRoot;
+    lastUsedLevelPathNode->getAttr("root", lastUsedRoot);
+
     if (m_filterModel->rowCount() < 1)
     {
         // Defensive, doesn't happen
         return;
     }
 
-    QModelIndex currentIndex = m_filterModel->index(0, 0); // Start with "Levels/" node
+    // In Save As mode the tree is filtered to one root, so move the combo
+    // to the persisted root first; that triggers ReloadTree() and rebuilds
+    // the tree under that root before we walk it for the level entry.
+    if (!m_bOpenDialog && !lastUsedRoot.isEmpty() && !m_saveTargetRoots.isEmpty())
+    {
+        for (int i = 0; i < m_saveTargetRoots.size(); ++i)
+        {
+            if (m_saveTargetRoots[i].absolutePath.compare(lastUsedRoot, Qt::CaseInsensitive) == 0)
+            {
+                ui->targetRootCombo->setCurrentIndex(i);
+                break;
+            }
+        }
+    }
+
+    // Locate the top-level node that matches the persisted root. Falls back
+    // to the first root (the project) for older preset files that did not
+    // record one.
+    QModelIndex currentIndex = m_filterModel->index(0, 0);
+    if (!lastUsedRoot.isEmpty())
+    {
+        for (int i = 0, n = m_filterModel->rowCount(); i < n; ++i)
+        {
+            const QModelIndex candidate = m_filterModel->index(i, 0);
+            if (candidate.data(LevelTreeModel::RootPathRole).toString().compare(lastUsedRoot, Qt::CaseInsensitive) == 0)
+            {
+                currentIndex = candidate;
+                m_selectedRoot = lastUsedRoot;
+                m_selectedRootIsProject = candidate.data(LevelTreeModel::IsProjectRootRole).toBool();
+                break;
+            }
+        }
+    }
+
     QStringList segments = Path::SplitIntoSegments(lastLoadedFileName);
     for (auto it = segments.cbegin(), end = segments.cend(); it != end; ++it)
     {

--- a/Code/Editor/LevelFileDialog.h
+++ b/Code/Editor/LevelFileDialog.h
@@ -14,7 +14,10 @@
 #if !defined(Q_MOC_RUN)
 #include <QDialog>
 #include <QScopedPointer>
+#include <QVector>
 #endif
+
+#include "LevelRoots.h"
 
 namespace Ui {
     class LevelFileDialog;
@@ -42,6 +45,7 @@ protected Q_SLOTS:
     void OnNewFolder();
     void OnFilterChanged();
     void OnNameChanged();
+    void OnTargetRootChanged(int index);
 protected:
     void ReloadTree();
     bool ValidateSaveLevelPath(QString& errorMessage) const;
@@ -66,6 +70,16 @@ private:
     const bool m_bOpenDialog;
     LevelTreeModel* const m_model;
     LevelTreeModelFilter* const m_filterModel;
+
+    // Absolute path of the root currently driving the dialog. Defaults to
+    // the project's "Levels" folder; updated whenever the tree selection
+    // changes so that the line-edit text is interpreted relative to the
+    // root the user is actually browsing.
+    QString m_selectedRoot;
+    bool m_selectedRootIsProject = true;
+
+    // Save As only: cached root list backing the target combo.
+    QVector<LevelRoots::Root> m_saveTargetRoots;
 };
 
 #endif // CRYINCLUDE_EDITOR_LEVELFILEDIALOG_H

--- a/Code/Editor/LevelFileDialog.ui
+++ b/Code/Editor/LevelFileDialog.ui
@@ -21,6 +21,19 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="targetRootLabel">
+     <property name="text">
+      <string>Target:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="targetRootCombo"/>
+   </item>
+   <item>
     <widget class="QLabel" name="filterLabel">
      <property name="text">
       <string>Filter:</string>

--- a/Code/Editor/LevelRoots.cpp
+++ b/Code/Editor/LevelRoots.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "EditorDefs.h"
+
+#include "LevelRoots.h"
+
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzFramework/Gem/GemInfo.h>
+
+#include <QDir>
+#include <QFileInfo>
+
+#include <algorithm>
+
+namespace LevelRoots
+{
+    //======================================================================
+    // Constants
+    //======================================================================
+    static constexpr const char* kLevelsFolderName = "Levels";
+
+    //======================================================================
+    // Internal helpers
+    //======================================================================
+    static QString MakeProjectLevelsPath()
+    {
+        const QString projectRoot = QString::fromUtf8(Path::GetEditingGameDataFolder().c_str());
+        return QDir::cleanPath(QStringLiteral("%1/%2").arg(projectRoot, kLevelsFolderName));
+    }
+
+    static bool DirectoryExists(const QString& path)
+    {
+        return QFileInfo(path).isDir();
+    }
+
+    //======================================================================
+    // Public API
+    //======================================================================
+    QVector<Root> Enumerate(Mode mode)
+    {
+        QVector<Root> roots;
+
+        //--- Project root (always listed) ---
+        Root projectRoot;
+        projectRoot.displayName = QStringLiteral("Levels");
+        projectRoot.absolutePath = MakeProjectLevelsPath();
+        projectRoot.isProject = true;
+        roots.push_back(projectRoot);
+
+        //--- Active gems ---
+        AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
+        if (!settingsRegistry)
+        {
+            return roots;
+        }
+
+        AZStd::vector<AzFramework::GemInfo> gemInfoList;
+        if (!AzFramework::GetGemsInfo(gemInfoList, *settingsRegistry))
+        {
+            return roots;
+        }
+
+        for (const AzFramework::GemInfo& gem : gemInfoList)
+        {
+            for (const AZ::IO::Path& sourcePath : gem.m_absoluteSourcePaths)
+            {
+                AZ::IO::Path candidate = sourcePath;
+                candidate /= AzFramework::GemInfo::GetGemAssetFolder();
+                candidate /= kLevelsFolderName;
+
+                const QString candidateQt = QString::fromUtf8(candidate.c_str());
+                // ExistingOnly drops gems whose Assets/Levels folder is
+                // missing; AllActive keeps every active gem so the user
+                // can create the very first level there.
+                if (mode == Mode::ExistingOnly && !DirectoryExists(candidateQt))
+                {
+                    continue;
+                }
+
+                Root gemRoot;
+                gemRoot.displayName = QStringLiteral("%1/%2")
+                                          .arg(QString::fromUtf8(gem.m_gemName.c_str()))
+                                          .arg(kLevelsFolderName);
+                gemRoot.absolutePath = QDir::cleanPath(candidateQt);
+                gemRoot.isProject = false;
+
+                // De-dupe in the unusual case where two source paths point to the same folder.
+                const auto exists = std::any_of(roots.begin(), roots.end(), [&](const Root& r) {
+                    return r.absolutePath.compare(gemRoot.absolutePath, Qt::CaseInsensitive) == 0;
+                });
+                if (!exists)
+                {
+                    roots.push_back(gemRoot);
+                }
+            }
+        }
+
+        // Alphabetize gem entries by display name. The project root stays
+        // at index 0 so it is always the default option in any combo or
+        // tree fed by this list.
+        if (roots.size() > 1)
+        {
+            std::sort(roots.begin() + 1, roots.end(), [](const Root& a, const Root& b) {
+                return a.displayName.localeAwareCompare(b.displayName) < 0;
+            });
+        }
+
+        return roots;
+    }
+
+    //----------------------------------------------------------------------
+    // Returns true if "child" sits anywhere under "parent". Shared by the
+    // path-membership and display-formatting helpers.
+    //----------------------------------------------------------------------
+    static bool IsContainedIn(const QString& child, const QString& parent)
+    {
+        if (parent.isEmpty())
+        {
+            return false;
+        }
+        const QDir parentDir(parent);
+        QDir cursor(child); // initially points at the file itself
+        while (cursor.cdUp())
+        {
+            if (cursor == parentDir)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    QString FormatRelativeDisplay(const QString& absolutePath)
+    {
+        if (absolutePath.isEmpty())
+        {
+            return absolutePath;
+        }
+
+        const QString cleaned = QDir::cleanPath(absolutePath);
+
+        //--- Project-rooted: strip the project prefix (legacy form). ---
+        const QString projectRoot = QDir::cleanPath(
+            QString::fromUtf8(Path::GetEditingGameDataFolder().c_str()));
+        if (!projectRoot.isEmpty() && IsContainedIn(cleaned, projectRoot))
+        {
+            return QDir::toNativeSeparators(QDir(projectRoot).relativeFilePath(cleaned));
+        }
+
+        //--- Gem-rooted: prefix with the gem's display name. ---
+        AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
+        if (settingsRegistry)
+        {
+            AZStd::vector<AzFramework::GemInfo> gemInfoList;
+            if (AzFramework::GetGemsInfo(gemInfoList, *settingsRegistry))
+            {
+                for (const AzFramework::GemInfo& gem : gemInfoList)
+                {
+                    for (const AZ::IO::Path& sourcePath : gem.m_absoluteSourcePaths)
+                    {
+                        const QString gemSource = QDir::cleanPath(QString::fromUtf8(sourcePath.c_str()));
+                        if (!IsContainedIn(cleaned, gemSource))
+                        {
+                            continue;
+                        }
+
+                        QString relativeUnderGem = QDir(gemSource).relativeFilePath(cleaned);
+
+                        // Drop a leading "Assets/" so the on-disk layout is
+                        // hidden in the UI and gem levels read as
+                        // "<GemName>/Levels/...".
+                        const QString assetsPrefix =
+                            QString::fromUtf8(AzFramework::GemInfo::GetGemAssetFolder()) + QStringLiteral("/");
+                        if (relativeUnderGem.startsWith(assetsPrefix, Qt::CaseInsensitive))
+                        {
+                            relativeUnderGem.remove(0, assetsPrefix.size());
+                        }
+
+                        const QString gemName = QString::fromUtf8(gem.m_gemName.c_str());
+                        return QDir::toNativeSeparators(QStringLiteral("%1/%2").arg(gemName, relativeUnderGem));
+                    }
+                }
+            }
+        }
+
+        //--- Fallback: return the input as-is, with native separators. ---
+        return QDir::toNativeSeparators(cleaned);
+    }
+
+    bool IsPathUnderActiveSource(const QString& absolutePath)
+    {
+        if (absolutePath.isEmpty())
+        {
+            return false;
+        }
+
+        const QString normalized = QDir::cleanPath(absolutePath);
+
+        //--- Project root (whole project tree, not just Levels/) ---
+        const QString projectRoot = QString::fromUtf8(Path::GetEditingGameDataFolder().c_str());
+        if (IsContainedIn(normalized, projectRoot))
+        {
+            return true;
+        }
+
+        //--- Every active gem's full source tree ---
+        AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
+        if (!settingsRegistry)
+        {
+            return false;
+        }
+
+        AZStd::vector<AzFramework::GemInfo> gemInfoList;
+        if (!AzFramework::GetGemsInfo(gemInfoList, *settingsRegistry))
+        {
+            return false;
+        }
+
+        for (const AzFramework::GemInfo& gem : gemInfoList)
+        {
+            for (const AZ::IO::Path& sourcePath : gem.m_absoluteSourcePaths)
+            {
+                if (IsContainedIn(normalized, QString::fromUtf8(sourcePath.c_str())))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/Code/Editor/LevelRoots.h
+++ b/Code/Editor/LevelRoots.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#ifndef CRYINCLUDE_EDITOR_LEVELROOTS_H
+#define CRYINCLUDE_EDITOR_LEVELROOTS_H
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <QString>
+#include <QVector>
+#endif
+
+namespace LevelRoots
+{
+    //----------------------------------------------------------------------
+    // Description of a single source root that the editor treats as a
+    // "Levels" container.
+    //
+    // The project root is always present (even when its Levels folder does
+    // not yet exist on disk), so that "Save As" / "New Level" can create
+    // the first level for a fresh project. Gem roots are added only when
+    // the corresponding folder actually exists on disk.
+    //----------------------------------------------------------------------
+    struct Root
+    {
+        QString displayName;   // "Levels" for the project, "<GemName>/Levels" for a gem
+        QString absolutePath;  // absolute path to the Levels folder on disk
+        bool isProject = false;
+    };
+
+    //----------------------------------------------------------------------
+    // Determines which active gems are surfaced as roots.
+    //   ExistingOnly  - only gems whose "Assets/Levels" folder already
+    //                   exists on disk. Right for open / browse surfaces.
+    //   AllActive     - every active gem, even if its "Assets/Levels"
+    //                   folder is empty or missing. Right for save / new
+    //                   surfaces, where the folder will be created on
+    //                   demand by CFileUtil::CreatePath.
+    //----------------------------------------------------------------------
+    enum class Mode
+    {
+        ExistingOnly,
+        AllActive
+    };
+
+    //----------------------------------------------------------------------
+    // Returns the project Levels root followed by every active gem that
+    // matches the requested mode. The list ordering is stable and safe to
+    // use as the order of top-level items in a tree view.
+    //----------------------------------------------------------------------
+    QVector<Root> Enumerate(Mode mode = Mode::ExistingOnly);
+
+    //----------------------------------------------------------------------
+    // Returns true when absolutePath sits anywhere underneath the project
+    // root or any active gem's source path. Used to decide whether a
+    // recent-file entry should be visible in the launch screen / Open
+    // Recent menu (so gem-rooted levels are not filtered out).
+    //----------------------------------------------------------------------
+    bool IsPathUnderActiveSource(const QString& absolutePath);
+
+    //----------------------------------------------------------------------
+    // Returns a short, user-facing form of an absolute level file path.
+    //   - Project file:    relative to the project (e.g. "Levels/MyLevel/MyLevel.prefab").
+    //   - Gem file under <gem>/Assets/Levels/...: rewritten as
+    //                      "<GemName>/Levels/MyLevel/MyLevel.prefab"
+    //                      (the "Assets/" segment is dropped to match the
+    //                      naming convention used elsewhere in the editor).
+    //   - Gem file outside Assets/Levels: "<GemName>/<gemRelative>".
+    //   - Anything else:   the absolutePath, unchanged.
+    // Always uses native separators in the result.
+    //----------------------------------------------------------------------
+    QString FormatRelativeDisplay(const QString& absolutePath);
+}
+
+#endif // CRYINCLUDE_EDITOR_LEVELROOTS_H

--- a/Code/Editor/LevelTreeModel.cpp
+++ b/Code/Editor/LevelTreeModel.cpp
@@ -12,9 +12,7 @@
 
 // Editor
 #include "LevelFileDialog.h"
-
-// Folder in which levels are stored
-static const char kLevelsFolder[] = "Levels";
+#include "LevelRoots.h"
 
 LevelTreeModelFilter::LevelTreeModelFilter(QObject* parent)
     : QSortFilterProxyModel(parent)
@@ -100,22 +98,44 @@ QVariant LevelTreeModel::data(const QModelIndex& index, int role) const
     return QStandardItemModel::data(index, role);
 }
 
-void LevelTreeModel::ReloadTree(bool recurseIfNoLevels)
+void LevelTreeModel::ReloadTree(bool recurseIfNoLevels, LevelRoots::Mode mode)
 {
     clear();
 
-    QString levelsFolder = QString("%1/%2").arg(Path::GetEditingGameDataFolder().c_str()).arg(kLevelsFolder);
-    QStandardItem* root = new QStandardItem(kLevelsFolder);
-    root->setData(levelsFolder, FullPathRole);
-    root->setEditable(false);
-    invisibleRootItem()->appendRow(root);
-    ReloadTree(root, recurseIfNoLevels);
+    // One top-level root per "Levels" container we discovered: the project,
+    // followed by every active gem matching the requested mode.
+    const QVector<LevelRoots::Root> roots = LevelRoots::Enumerate(mode);
+    for (const LevelRoots::Root& rootInfo : roots)
+    {
+        QStandardItem* rootItem = new QStandardItem(rootInfo.displayName);
+        rootItem->setData(rootInfo.absolutePath, FullPathRole);
+        rootItem->setData(rootInfo.absolutePath, RootPathRole);
+        rootItem->setData(rootInfo.isProject, IsProjectRootRole);
+        rootItem->setEditable(false);
+        invisibleRootItem()->appendRow(rootItem);
+        ReloadTree(rootItem, recurseIfNoLevels);
+    }
+}
+
+void LevelTreeModel::ReloadTreeFromRoot(bool recurseIfNoLevels, const LevelRoots::Root& root)
+{
+    clear();
+
+    QStandardItem* rootItem = new QStandardItem(root.displayName);
+    rootItem->setData(root.absolutePath, FullPathRole);
+    rootItem->setData(root.absolutePath, RootPathRole);
+    rootItem->setData(root.isProject, IsProjectRootRole);
+    rootItem->setEditable(false);
+    invisibleRootItem()->appendRow(rootItem);
+    ReloadTree(rootItem, recurseIfNoLevels);
 }
 
 void LevelTreeModel::ReloadTree(QStandardItem* root, bool recurseIfNoLevels)
 {
     QStringList levelFiles;
     const QString parentFullPath = root->data(FullPathRole).toString();
+    const QString rootPath = root->data(RootPathRole).toString();
+    const bool isProjectRoot = root->data(IsProjectRootRole).toBool();
     const bool isLevelFolder = CLevelFileDialog::CheckLevelFolder(parentFullPath, &levelFiles);
     root->setData(isLevelFolder, IsLevelFolderRole);
 
@@ -131,6 +151,8 @@ void LevelTreeModel::ReloadTree(QStandardItem* root, bool recurseIfNoLevels)
         {
             auto child = new QStandardItem(subFolder);
             child->setData(parentFullPath + "/" + subFolder, FullPathRole);
+            child->setData(rootPath, RootPathRole);
+            child->setData(isProjectRoot, IsProjectRootRole);
             child->setEditable(false);
             root->appendRow(child);
             ReloadTree(child, recurseIfNoLevels);
@@ -146,6 +168,8 @@ void LevelTreeModel::ReloadTree(QStandardItem* root, bool recurseIfNoLevels)
             {
                 auto child = new QStandardItem(levelFile);
                 child->setData(root->data(FullPathRole).toString() + "/" + levelFile, FullPathRole);
+                child->setData(rootPath, RootPathRole);
+                child->setData(isProjectRoot, IsProjectRootRole);
                 child->setData(false, IsLevelFolderRole);
                 child->setEditable(false);
                 root->appendRow(child);
@@ -164,6 +188,8 @@ void LevelTreeModel::AddItem(const QString& name, const QModelIndex& parent)
     {
         const QString parentPath = parent.data(FullPathRole).toString();
         item->setData(parentPath + "/" + name, FullPathRole);
+        item->setData(parent.data(RootPathRole).toString(), RootPathRole);
+        item->setData(parent.data(IsProjectRootRole).toBool(), IsProjectRootRole);
         parentItem->appendRow(item);
     }
 }

--- a/Code/Editor/LevelTreeModel.h
+++ b/Code/Editor/LevelTreeModel.h
@@ -14,6 +14,9 @@
 #include <QStandardItemModel>
 #include <QSortFilterProxyModel>
 #endif
+
+#include "LevelRoots.h"
+
 class QString;
 class QStandardItem;
 
@@ -38,12 +41,26 @@ public:
     enum Role
     {
         FullPathRole = Qt::UserRole + 1,
-        IsLevelFolderRole
+        IsLevelFolderRole,
+        // Absolute path of the top-level root this node belongs to. Set on
+        // every item so the dialog can resolve a selected item back to its
+        // owning root without walking up the tree.
+        RootPathRole,
+        // True for the project's own root; used to keep project-only
+        // affordances (e.g. validation messages) consistent.
+        IsProjectRootRole
     };
 
     explicit LevelTreeModel(QObject* parent = nullptr);
     ~LevelTreeModel();
-    void ReloadTree(bool recurseIfNoLevels);
+    // mode = Mode::ExistingOnly only surfaces gems that already have an
+    // Assets/Levels folder (browse / open). Mode::AllActive surfaces every
+    // active gem so the user can create the first level inside one (save).
+    void ReloadTree(bool recurseIfNoLevels, LevelRoots::Mode mode = LevelRoots::Mode::ExistingOnly);
+    // Reload the tree from a single explicit root. Used by the Save As
+    // dialog after the user picks a target from the combo box - the tree
+    // then shows just that root's contents instead of every available one.
+    void ReloadTreeFromRoot(bool recurseIfNoLevels, const LevelRoots::Root& root);
     void AddItem(const QString& name, const QModelIndex& parent); // Called when clicking "New folder"
     QVariant data(const QModelIndex& index, int role) const override;
 private:

--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -13,6 +13,8 @@
 #include "NewLevelDialog.h"
 
 // Qt
+#include <QComboBox>
+#include <QLabel>
 #include <QPushButton>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -20,6 +22,7 @@
 #include <QToolButton>
 #include <QListWidgetItem>
 #include <QRegularExpression>
+#include <QSignalBlocker>
 
 #include <ui_NewLevelDialog.h>
 
@@ -73,6 +76,11 @@ CNewLevelDialog::CNewLevelDialog(QWidget* pParent /*=nullptr*/)
     setStyleSheet("QListWidget::item {height: 148px; padding-left: 0px; padding-right: 0px; background-color: transparent;}");
     InitTemplateListWidget();
 
+    // Populate the "Root" combo box from the project + active gems, then
+    // hide it entirely if the project is the only available root so the
+    // dialog looks identical for legacy projects.
+    PopulateRootSelector();
+
     // Level name only supports ASCII characters
     QRegularExpression rx("[_a-zA-Z0-9-]+");
     QValidator* validator = new QRegularExpressionValidator(rx, this);
@@ -81,7 +89,7 @@ CNewLevelDialog::CNewLevelDialog(QWidget* pParent /*=nullptr*/)
     validator = new LevelFolderValidator(this);
     ui->LEVEL_FOLDERS->lineEdit()->setValidator(validator);
     ui->LEVEL_FOLDERS->setErrorToolTip(
-        QString("The location must be a folder underneath the current project's %1 folder. (%2)")
+        QString("The location must be a folder underneath the selected %1 root. (%2)")
             .arg(kNewLevelDialog_LevelsFolder)
             .arg(GetLevelsFolder()));
 
@@ -239,16 +247,85 @@ void CNewLevelDialog::OnInitDialog()
 //////////////////////////////////////////////////////////////////////////
 void CNewLevelDialog::ReloadLevelFolder()
 {
+    // Use the active root's absolute path as the displayed location. This
+    // keeps GetLevel()'s "relative to the active root" computation
+    // unambiguous - feeding a literal "Levels/" placeholder back through
+    // QDir::relativeFilePath returns the placeholder unchanged, which then
+    // duplicates the Levels segment when CreateLevel reassembles the path.
     ui->LEVEL_FOLDERS->lineEdit()->clear();
-    ui->LEVEL_FOLDERS->setText(QString(kNewLevelDialog_LevelsFolder) + '/');
+    ui->LEVEL_FOLDERS->setText(GetLevelsFolder());
 }
 
 QString CNewLevelDialog::GetLevelsFolder() const
 {
+    // Resolve to whichever root the user has currently selected (project by
+    // default, or one of the gems exposed via the LEVEL_ROOT combo).
+    if (const LevelRoots::Root* root = CurrentRoot())
+    {
+        return QDir(root->absolutePath).absolutePath();
+    }
+
     QDir projectDir = QDir(Path::GetEditingGameDataFolder().c_str());
     QDir projectLevelsDir = QDir(QStringLiteral("%1/%2").arg(projectDir.absolutePath()).arg(kNewLevelDialog_LevelsFolder));
 
     return projectLevelsDir.absolutePath();
+}
+
+//======================================================================
+// Root selector
+//======================================================================
+void CNewLevelDialog::PopulateRootSelector()
+{
+    // The New Level dialog is a save flow, so include every active gem
+    // even if its Assets/Levels folder is missing - CreateLevel will mkdir
+    // any missing intermediate directories on first save.
+    m_roots = LevelRoots::Enumerate(LevelRoots::Mode::AllActive);
+
+    QComboBox* combo = ui->LEVEL_ROOT;
+    QSignalBlocker blocker(combo);
+    combo->clear();
+    for (const LevelRoots::Root& root : m_roots)
+    {
+        combo->addItem(root.displayName, root.absolutePath);
+    }
+    combo->setCurrentIndex(0);
+
+    connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &CNewLevelDialog::OnRootSelected);
+
+    // Hide the row for legacy single-root projects so the dialog stays
+    // visually identical when no gem advertises a Levels folder.
+    const bool multipleRoots = m_roots.size() > 1;
+    if (auto* label = findChild<QLabel*>(QStringLiteral("LEVEL_ROOT_LABEL")))
+    {
+        label->setVisible(multipleRoots);
+    }
+    combo->setVisible(multipleRoots);
+}
+
+const LevelRoots::Root* CNewLevelDialog::CurrentRoot() const
+{
+    const int index = ui->LEVEL_ROOT ? ui->LEVEL_ROOT->currentIndex() : 0;
+    if (index >= 0 && index < m_roots.size())
+    {
+        return &m_roots[index];
+    }
+    return nullptr;
+}
+
+void CNewLevelDialog::OnRootSelected(int /*index*/)
+{
+    // Anchor the location field to the new root's absolute path so that
+    // GetLevel()'s relative-path computation produces just "<levelName>"
+    // and CreateLevel doesn't end up doubling the "Levels" segment.
+    m_levelFolders = GetLevelsFolder();
+    UpdateData(false);
+    ui->LEVEL_FOLDERS->setErrorToolTip(
+        QString("The location must be a folder underneath the selected %1 root. (%2)")
+            .arg(kNewLevelDialog_LevelsFolder)
+            .arg(GetLevelsFolder()));
+    // Re-validate; UpdateData(true) is a no-op since the line edit already
+    // matches m_levelFolders, but the OK button enable state depends on it.
+    OnLevelNameChange();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/NewLevelDialog.h
+++ b/Code/Editor/NewLevelDialog.h
@@ -13,7 +13,10 @@
 #include <QScopedPointer>
 #include <QAbstractButton>
 #include <QDialog>
+#include <QVector>
 #endif
+
+#include "LevelRoots.h"
 
 namespace Ui {
     class CNewLevelDialog;
@@ -29,6 +32,7 @@ public:
     ~CNewLevelDialog();
 
     QString GetLevel() const;
+    QString GetLevelsFolder() const; // Absolute path of the active root's Levels folder
     bool ValidateLevel();
     QString GetTemplateName() const;
 
@@ -37,7 +41,6 @@ protected:
     void OnInitDialog();
     void ReloadLevelFolder();
     void showEvent(QShowEvent* event) override;
-    QString GetLevelsFolder() const;
     void InitTemplateListWidget() const;
 
 protected slots:
@@ -45,10 +48,20 @@ protected slots:
     void OnClearButtonClicked();
     void PopupAssetPicker();
     void OnStartup();
+    void OnRootSelected(int index);
+
+private:
+    void PopulateRootSelector();
+    const LevelRoots::Root* CurrentRoot() const;
 
 public:
     QString         m_level;
     QString         m_levelFolders;
     QScopedPointer<Ui::CNewLevelDialog> ui;
     bool m_initialized;
+
+private:
+    // Cached list of "Levels" roots (project + active gems with a Levels
+    // folder). Drives the "Root" combo box and GetLevelsFolder().
+    QVector<LevelRoots::Root> m_roots;
 };

--- a/Code/Editor/NewLevelDialog.ui
+++ b/Code/Editor/NewLevelDialog.ui
@@ -37,6 +37,22 @@
     <widget class="QGroupBox" name="STATIC_GROUP1">
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">
+       <widget class="QLabel" name="LEVEL_ROOT_LABEL">
+        <property name="text">
+         <string>Root</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+        <property name="buddy">
+         <cstring>LEVEL_ROOT</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="LEVEL_ROOT"/>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="STATIC2">
         <property name="text">
          <string>Name</string>
@@ -49,14 +65,14 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QLineEdit" name="LEVEL">
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="STATIC1">
         <property name="minimumSize">
          <size>
@@ -75,7 +91,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="AzQtComponents::BrowseEdit" name="LEVEL_FOLDERS" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">

--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
@@ -41,6 +41,7 @@
 #include "MainWindow.h"
 #include "CryEdit.h"
 #include "LevelFileDialog.h"
+#include "LevelRoots.h"
 
 #include <WelcomeScreen/ui_WelcomeScreenDialog.h>
 
@@ -208,8 +209,13 @@ void WelcomeScreenDialog::SetRecentFileList(RecentFileList* pList)
         {
             if (CFileUtil::Exists(recentFile, false))
             {
-                QString sCurEntryDir = recentFile.left(nCurDir);
-                if (sCurEntryDir.compare(sCurDir, Qt::CaseInsensitive) == 0)
+                // Accept project-rooted entries (legacy fast path) or any
+                // entry that lives inside an active gem's source tree, so
+                // gem-rooted levels show up alongside project ones.
+                const QString sCurEntryDir = recentFile.left(nCurDir);
+                const bool isProjectRooted = sCurEntryDir.compare(sCurDir, Qt::CaseInsensitive) == 0;
+                const bool isGemRooted = !isProjectRooted && LevelRoots::IsPathUnderActiveSource(recentFile);
+                if (isProjectRooted || isGemRooted)
                 {
                     QString fullPath = recentFile;
                     const QString name = Path::GetFile(fullPath);
@@ -218,7 +224,10 @@ void WelcomeScreenDialog::SetRecentFileList(RecentFileList* pList)
                     fullPath = Path::ToUnixPath(fullPath.toLower());
                     fullPath = Path::AddSlash(fullPath);
 
-                    if (fullPath.contains(gamePath))
+                    // For project-rooted levels keep the original belt-and-braces
+                    // gamePath substring check; gem-rooted entries already passed
+                    // the active-source check above and skip it.
+                    if (isGemRooted || fullPath.contains(gamePath))
                     {
                         if (gSettings.prefabSystem)
                         {

--- a/Code/Editor/editor_lib_files.cmake
+++ b/Code/Editor/editor_lib_files.cmake
@@ -256,6 +256,8 @@ set(FILES
     StartupTraceHandler.h
     LevelTreeModel.cpp
     LevelTreeModel.h
+    LevelRoots.cpp
+    LevelRoots.h
     Include/Command.h
     Include/HitContext.h
     Include/ICommandManager.h


### PR DESCRIPTION
## What does this PR do?

Introduces Level Loading and Saving, and file memory from gem based level directories. Allowing extra-project-based level sources.

Updated:
- Welcome Screen
- Open Recent
- Open Level
- Save Level As
- New Level

Interfaces and level management now accommodate gem/Assets/Levels based level detection. When saving or creating new, level target can be set to any active gems, if the gem has no past levels, the file structure will be made for the new level file to be created.

Open filters to only the level files available. Create new and Save As filter down to the scope of only the target. Save As Overwrite works fine still.

Home Screen can remember levels from Gems as well.

AI Assisted - Claude Code: Opus 4.7

## How was this PR tested?

Usage within the editor.


https://github.com/user-attachments/assets/d04c0835-281c-45e4-a9cc-df7115731212
