### PR TITLE
BuiltInPackages: gate googlebenchmark fetch on LY_DISABLE_TEST_MODULES

### DIFF
--- a/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
+++ b/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
@@ -22,7 +22,10 @@ ly_associate_package(PACKAGE_NAME freetype-2.11.1-rev1-android                  
 ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.11.288-rev2-android                TARGETS AWSNativeSDK                PACKAGE_HASH 61620cb4c79f752328e4722fa36020dabe04167d83c94a0d302c08f3efa367b7)
 ly_associate_package(PACKAGE_NAME Lua-5.4.4-rev1-android                            TARGETS Lua                     PACKAGE_HASH 2adda1831577336454090f249baf09519f41bb73160cd1d5b5b33564729af4a2)
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-android                         TARGETS mikkelsen               PACKAGE_HASH 075e8e4940884971063b5a9963014e2e517246fa269c07c7dc55b8cf2cd99705)
+if (NOT LY_DISABLE_TEST_MODULES)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev2-android                TARGETS GoogleBenchmark         PACKAGE_HASH 972c1fd1dec3d1cecd7b05f1064e47e20775ea4ba211a08a53c4d1c7c1ccc905)
+endif()
+
 ly_associate_package(PACKAGE_NAME png-1.6.37-rev2-android                           TARGETS PNG                     PACKAGE_HASH c2240299251d97d963d2e9f4320fbc384bfb2e1b1e073419d1171df0e8ea983d)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-android                  TARGETS libsamplerate           PACKAGE_HASH bf13662afe65d02bcfa16258a4caa9b875534978227d6f9f36c9cfa92b3fb12b)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1o-rev2-android                       TARGETS OpenSSL                 PACKAGE_HASH 28fa781be8fa233e3074b08e5d6d5064d1a5a5cffc80b04e1bb8d407aca459a0)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
@@ -24,7 +24,10 @@ ly_associate_package(PACKAGE_NAME freetype-2.11.1-rev1-linux-aarch64            
 ly_associate_package(PACKAGE_NAME Lua-5.4.4-rev1-linux-aarch64                               TARGETS Lua                         PACKAGE_HASH 4d30067fc494ac27acd72b0bf18099c19c0a44ac9bd46b23db66ad780e72374a)
 ly_associate_package(PACKAGE_NAME mcpp-2.7.2_az.1-rev1-linux-aarch64                         TARGETS mcpp                        PACKAGE_HASH 817d31b94d1217b6e47bd5357b3a07a79ab6aa93452c65ff56831d0590c5169d)
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-linux-aarch64                            TARGETS mikkelsen                   PACKAGE_HASH 62f3f316c971239a2b86d7c47a68fee9be744de3a4f9b00533b32f33a4764f8b)
+if (NOT LY_DISABLE_TEST_MODULES)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev1-linux-aarch64                   TARGETS GoogleBenchmark             PACKAGE_HASH 06fbfeaba2aeae20197da631019e52105dc1f69e702151a76c6aba2c27c03acb)
+endif()
+
 ly_associate_package(PACKAGE_NAME qt-5.15.2-rev9-linux-aarch64                               TARGETS Qt                          PACKAGE_HASH da80840ecd3f7a074edecbb3dedb1ff36c568cfe4943e18d9559e9fca9f151bc)
 ly_associate_package(PACKAGE_NAME png-1.6.37-rev2-linux-aarch64                              TARGETS PNG                         PACKAGE_HASH fcf646c1b1b4163000efdb56d7c8f086b6ce0a520da5c8d3ffce4e1329ae798a)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-linux-aarch64                     TARGETS libsamplerate               PACKAGE_HASH 751484da1527432cd19263909f69164d67b25644f87ec1d4ec974a343defacea)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
@@ -24,7 +24,10 @@ ly_associate_package(PACKAGE_NAME freetype-2.11.1-rev1-linux                    
 ly_associate_package(PACKAGE_NAME Lua-5.4.4-rev1-linux                              TARGETS Lua                         PACKAGE_HASH d582362c3ef90e1ef175a874abda2265839ffc2e40778fa293f10b443b4697ac)
 ly_associate_package(PACKAGE_NAME mcpp-2.7.2_az.2-rev1-linux                        TARGETS mcpp                        PACKAGE_HASH df7a998d0bc3fedf44b5bdebaf69ddad6033355b71a590e8642445ec77bc6c41)
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-linux                           TARGETS mikkelsen                   PACKAGE_HASH 5973b1e71a64633588eecdb5b5c06ca0081f7be97230f6ef64365cbda315b9c8)
+if (NOT LY_DISABLE_TEST_MODULES)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev1-linux                  TARGETS GoogleBenchmark             PACKAGE_HASH 230e1881e31490820f0bd2059df4741455b52809ac73367e278e1e821ac89c9b)
+endif()
+
 ly_associate_package(PACKAGE_NAME qt-5.15.2-rev9-linux                              TARGETS Qt                          PACKAGE_HASH db4bcd2003262f4d8c7d7da832758824fc24e53da5895edef743f67a64a5c734)
 ly_associate_package(PACKAGE_NAME png-1.6.37-rev2-linux                             TARGETS PNG                         PACKAGE_HASH 5c82945a1648905a5c4c5cee30dfb53a01618da1bf58d489610636c7ade5adf5)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-linux                    TARGETS libsamplerate               PACKAGE_HASH 41643c31bc6b7d037f895f89d8d8d6369e906b92eff42b0fe05ee6a100f06261)

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
@@ -27,7 +27,10 @@ ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.11.288-rev1-mac                
 ly_associate_package(PACKAGE_NAME Lua-5.4.4-rev1-mac                                TARGETS Lua                         PACKAGE_HASH b44daae6bfdf092c7935e4aebafded6772853250c6f0a209866a1ac599857d58)
 ly_associate_package(PACKAGE_NAME mcpp-2.7.2_az.2-rev1-mac                          TARGETS mcpp                        PACKAGE_HASH be9558905c9c49179ef3d7d84f0a5472415acdf7fe2d76eb060d9431723ddf2e)
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-mac                             TARGETS mikkelsen                   PACKAGE_HASH 83af99ca8bee123684ad254263add556f0cf49486c0b3e32e6d303535714e505)
+if (NOT LY_DISABLE_TEST_MODULES)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev1-mac                    TARGETS GoogleBenchmark             PACKAGE_HASH a1c8793eb1760905290065929b45600a4b4457345fcc129fce253d1a8980bbce)
+endif()
+
 ly_associate_package(PACKAGE_NAME openimageio-opencolorio-2.3.17-rev3-mac           TARGETS OpenImageIO OpenColorIO OpenColorIO::Runtime OpenImageIO::Tools::Binaries OpenImageIO::Tools::PythonPlugins PACKAGE_HASH bc322f9e28d519ab5959a638b38ee3b773fefb868802823fad2396ab4f7bcbc8)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1o-rev1-mac                           TARGETS OpenSSL                     PACKAGE_HASH 73a4bd7856b53edf5ab9d2ff1d31ebb02301be818680a59206ce8ec5940f3468)
 ly_associate_package(PACKAGE_NAME OpenEXR-3.1.3-rev4-mac                            TARGETS OpenEXR Imath               PACKAGE_HASH 927b8ca6cc5815fa8ee4efe6ea2845487cba2540f7958d537692e7c9481a68fc)

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac_arm64.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac_arm64.cmake
@@ -28,7 +28,10 @@ ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.11.361-rev1-mac-arm64          
 ly_associate_package(PACKAGE_NAME Lua-5.4.4-rev1-mac-arm64                          TARGETS Lua                         PACKAGE_HASH b44daae6bfdf092c7935e4aebafded6772853250c6f0a209866a1ac599857d58)
 ly_associate_package(PACKAGE_NAME mcpp-2.7.2_az.2-rev1-mac-arm64                    TARGETS mcpp                        PACKAGE_HASH 7826e3cdb70940c3efa788ab28ba02133ad494a123ae5c71ff38732ba1dabfef)
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-mac-arm64                       TARGETS mikkelsen                   PACKAGE_HASH 83af99ca8bee123684ad254263add556f0cf49486c0b3e32e6d303535714e505)
+if (NOT LY_DISABLE_TEST_MODULES)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev1-mac-arm64              TARGETS GoogleBenchmark             PACKAGE_HASH a1c8793eb1760905290065929b45600a4b4457345fcc129fce253d1a8980bbce)
+endif()
+
 ly_associate_package(PACKAGE_NAME openimageio-opencolorio-2.3.17-rev3-mac-arm64     TARGETS OpenImageIO OpenColorIO OpenColorIO::Runtime OpenImageIO::Tools::Binaries OpenImageIO::Tools::PythonPlugins PACKAGE_HASH bc322f9e28d519ab5959a638b38ee3b773fefb868802823fad2396ab4f7bcbc8)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1w-rev1-mac-arm64                     TARGETS OpenSSL                     PACKAGE_HASH 3367bdf98e73cf2413eb495853972aa4ccd29c2ef58392fa7b7fa99001b1e2e0)
 ly_associate_package(PACKAGE_NAME OpenEXR-3.4.4-rev1-mac-arm64                      TARGETS OpenEXR                     PACKAGE_HASH 4a093f5ca03836631dc66166b8f493925d0445467219efcbca3a5a0ee2ccbf4b)

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -28,7 +28,10 @@ ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.11.288-rev1-windows            
 ly_associate_package(PACKAGE_NAME Lua-5.4.4-rev1-windows                                TARGETS Lua                         PACKAGE_HASH 8ac853288712267ec9763be152a9274ce87b54728b8add97e2ba73c0fd5a0345)
 ly_associate_package(PACKAGE_NAME mcpp-2.7.2_az.2-rev1-windows                          TARGETS mcpp                        PACKAGE_HASH 794789aba639bfe2f4e8fcb4424d679933dd6290e523084aa0a4e287ac44acb2)
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-windows                             TARGETS mikkelsen                   PACKAGE_HASH 872c4d245a1c86139aa929f2b465b63ea4ea55b04ced50309135dd4597457a4e)
+if (NOT LY_DISABLE_TEST_MODULES)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev1-windows                    TARGETS GoogleBenchmark             PACKAGE_HASH a19e41670b46ec1676b51f9d6ad862443c56415d61b505383c19909fb02feb9e)
+endif()
+
 ly_associate_package(PACKAGE_NAME d3dx12-headers-rev1-windows                           TARGETS d3dx12                      PACKAGE_HASH 088c637159fba4a3e4c0cf08fb4921906fd4cca498939bd239db7c54b5b2f804)
 ly_associate_package(PACKAGE_NAME pyside2-5.15.2.1-py3.10-rev6-windows                  TARGETS pyside2                     PACKAGE_HASH 6c4e99af920cda5f34dc2a495c42f38381179543f062dc72a12147a8a660a681)
 ly_associate_package(PACKAGE_NAME openimageio-opencolorio-2.3.17-rev4-windows           TARGETS OpenImageIO OpenColorIO OpenColorIO::Runtime OpenImageIO::Tools::Binaries OpenImageIO::Tools::PythonPlugins PACKAGE_HASH d542198653b33640268a999de542c9c5adf4a29322ed04858c730bc82eb34b09)

--- a/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
+++ b/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
@@ -22,7 +22,10 @@ ly_associate_package(PACKAGE_NAME freetype-2.11.1-rev1-ios       TARGETS Freetyp
 ly_associate_package(PACKAGE_NAME AWSNativeSDK-1.11.288-rev2-ios TARGETS AWSNativeSDK                PACKAGE_HASH bea50bcade9f322bdc540bdf84dba9103cb993b6e021c8836cc7777ef4a44015)
 ly_associate_package(PACKAGE_NAME Lua-5.4.4-rev1-ios             TARGETS Lua             PACKAGE_HASH 82f27bf6c745c98395dcea7ec72f82cb5254fd19fca9f5ac7a6246527a30bacb)
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-ios          TARGETS mikkelsen       PACKAGE_HASH 976aaa3ccd8582346132a10af253822ccc5d5bcc9ea5ba44d27848f65ee88a8a)
+if (NOT LY_DISABLE_TEST_MODULES)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.7.0-rev1-ios TARGETS GoogleBenchmark PACKAGE_HASH 05addc0d87e5a3f3b0eed50aea107fdead05da232c4212e8c3662a53f15f8b08)
+endif()
+
 ly_associate_package(PACKAGE_NAME png-1.6.37-rev3-ios            TARGETS PNG             PACKAGE_HASH b476f7d3686a08c4adaec6a6e889db1138483863ddf7b0c7b4fafb553951e87c)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-ios   TARGETS libsamplerate   PACKAGE_HASH 7656b961697f490d4f9c35d2e61559f6fc38c32102e542a33c212cd618fc2119)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1o-rev1-ios        TARGETS OpenSSL         PACKAGE_HASH 1325bbb2dcc97fe33d8db71e4b0a61e95e9e77558e3ce6767a1b5d330240f78f)


### PR DESCRIPTION
## Summary

The googlebenchmark 3rdParty package is fetched from `packages.o3de.org` unconditionally on every cmake configure across all 7 `BuiltInPackages` platform files (Linux x86_64 + aarch64, Windows, Mac, Mac arm64, Android, iOS), even when the user has explicitly disabled test modules via `-DLY_DISABLE_TEST_MODULES=ON`.

`googlebenchmark` is consumed exclusively by benchmark-test code:
- 53 `*Benchmark*.cpp` / `*PerformanceTests.cpp` files in `Code/Framework/Az*/Tests/` + `Code/Tools/AssetProcessor/native/tests/`
- AzTest framework header (`Code/Framework/AzTest/AzTest/AzTest.h`) — but the include is guarded by `#if defined(HAVE_BENCHMARK)`, so it doesn't fire when tests aren't built.
- AzTest's `BUILD_DEPENDENCIES PRIVATE 3rdParty::GoogleBenchmark` line — only meaningful when AzTest itself builds, which doesn't happen when `LY_DISABLE_TEST_MODULES=ON`.

When `LY_DISABLE_TEST_MODULES=ON` is set, AzTest doesn't build, the benchmark `.cpp` files don't compile, the `GoogleBenchmark` cmake target is created but never linked into anything. The fetch (and on Linux the resulting tarball pull from `packages.o3de.org`'s CDN) is pure waste — wasted bandwidth, wasted disk, wasted cmake configure time.

This PR gates the unconditional `ly_associate_package(... googlebenchmark...)` call on `NOT LY_DISABLE_TEST_MODULES`. Builds that opt out of test modules also opt out of fetching the test-only 3rdParty dependency.

Behavior-preserving in the default case (`LY_DISABLE_TEST_MODULES=FALSE`, which is the default per `cmake/PAL.cmake:451`). Only changes behavior when the user has explicitly opted out of tests — and that change is a strict improvement (drop a fetch that wouldn't have linked anywhere).

Companion-shape PR to o3de/o3de#19733 (AzCore drop redundant `<Lua/lobject.h>` include) — both shrink the upstream-fetched 3rdParty surface for downstream packagers (Linux distro builds, CI containers, etc.) without changing default-configuration behavior.

## Test plan

- [ ] Verify default builds (`LY_DISABLE_TEST_MODULES` not set, or set to `FALSE`) still fetch and link googlebenchmark — i.e. verify the benchmark tests still build and run on a default cmake configure.
- [ ] Verify `cmake -DLY_DISABLE_TEST_MODULES=ON ...` skips the googlebenchmark fetch entirely — `3rdParty::GoogleBenchmark` cmake target should not exist in the configured project.