### PR TITLE
use project-local AzTestRunner for SDK-installed builds

### DIFF
--- a/cmake/LYTestWrappers.cmake
+++ b/cmake/LYTestWrappers.cmake
@@ -404,7 +404,7 @@ function(ly_add_googletest)
         endif()
 
         # If command is not supplied attempts, uses the AzTestRunner to run googletest on the supplied NAME
-        set(full_test_command $<TARGET_FILE:AZ::AzTestRunner> $<TARGET_FILE:${build_target}> AzRunUnitTests)
+        set(full_test_command $<TARGET_FILE_DIR:${build_target}>/$<TARGET_FILE_NAME:AZ::AzTestRunner> $<TARGET_FILE:${build_target}> AzRunUnitTests)
         # Add AzTestRunner as a build dependency
         ly_add_dependencies(${build_target} AZ::AzTestRunner)
         # Start the test target params and dd the command runner command
@@ -499,7 +499,7 @@ function(ly_add_googlebenchmark)
         endif()
 
         # If command is not supplied attempts, uses the AzTestRunner to run googlebenchmarks on the supplied TARGET
-        set(full_test_command $<TARGET_FILE:AZ::AzTestRunner> $<TARGET_FILE:${build_target}> AzRunBenchmarks ${output_format_args})
+        set(full_test_command $<TARGET_FILE_DIR:${build_target}>/$<TARGET_FILE_NAME:AZ::AzTestRunner> $<TARGET_FILE:${build_target}> AzRunBenchmarks ${output_format_args})
         # Start the test target params and dd the command runner command
         # Ideally, we would populate the full command procedurally but the generator expressions won't be expanded by the time we need this data
         set(LY_TEST_PARAMS "AzRunUnitTests")


### PR DESCRIPTION
## What does this PR do?

This PR fixes running tests with SDK-installed builds. It invokes the local copy of `AzTestRunner` in `ly_add_googletest` and `ly_add_googlebenchmark`.                                                                                                                   
This fixes #19115.

When a project consumes O3DE as an installed SDK, `AZ::AzTestRunner` is an `IMPORTED` target whose `IMPORTED_LOCATION` points into the SDK tree, e.g. `/opt/O3DE/26.05/bin/<cfg>/AzTestRunner`. Invoking it from there breaks tests in two distinct ways:
- Runtime library resolution. `AzTestRunner` is linked with `RPATH=$ORIGIN`. When CTest runs it directly from the SDK install dir, `$ORIGIN` expands to the SDK's `bin/<cfg>`, and the loader cannot find the consumer project's freshly-built `.so`s (which live in the project's own `build/linux/bin/<cfg>/`). Tests fail to load without `LD_LIBRARY_PATH` workarounds.
 - Engine-root / project discovery. `AzTestRunner` walks up the filesystem from its launch path looking for `project.json` and `Cache/` to anchor `SettingsRegistry` and asset paths. Launched from the SDK tree, it can't find the correct path and asset paths then resolve into `/opt/...` rather than the project, leading to confusing test-time misbehavior.                                                                                                                                                                  
                                                                       
In a unified engine-source build, `AzTestRunner` is already co-located with the test targets in `bin/<cfg>/`, the new generator expression resolves to the same file the old one did.

### Currently out of scope:
I have noticed similar pattern under `cmake/TestImpactFramework/LYTestImpactFramework.cmake:525` uses the same `$<TARGET_FILE:AzTestRunner>` pattern. I am not familiar with TIAF is and how to replicate the issue

## How was this PR tested?

Tests were performed during parallel work on cleaning tests for o3de-extras SimulationInterfaces Gem (currently drafted at https://github.com/o3de/o3de-extras/pull/1051) While fixing the o3de-extras side i found that actual root cause should be addressed engine side...

I used patch to apply and remove the change on the installed sdk to avoid install rebuilds:
`sudo patch -p1 -d /opt/O3DE/26.05 < sdk_aztestrunner_local.patch`