### PR TITLE
Fix a buffer overflow when loading 3D (Volumetric) texture in the editor

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/Utils.cpp
@@ -257,12 +257,13 @@ namespace ImageProcessingAtom
 
             u32 width = imageDescriptor.m_size.m_width;
             u32 height = imageDescriptor.m_size.m_height;
+            u32 depth = imageDescriptor.m_size.m_depth;
             u32 mipLevels = imageDescriptor.m_mipLevels;
             u32 arraySize = imageDescriptor.m_arraySize;
 
             height *= arraySize;
 
-            IImageObjectPtr outputImage = IImageObjectPtr(IImageObject::CreateImage(width, height, mipLevels, format));
+            IImageObjectPtr outputImage = IImageObjectPtr(IImageObject::CreateImage(width, height, depth, mipLevels, format));
 
             if (isSRGB)
             {
@@ -272,6 +273,11 @@ namespace ImageProcessingAtom
             if (imageDescriptor.m_isCubemap)
             {
                 outputImage->AddImageFlags(EIF_Cubemap);
+            }
+
+            if (imageDescriptor.m_dimension == AZ::RHI::ImageDimension::Image3D)
+            {
+                outputImage->AddImageFlags(EIF_Volumetexture);
             }
 
             // copy image data from asset to image object


### PR DESCRIPTION
## What does this PR do?

Asset thumbnailer didn't account for depth dimension of the texture, and allocated less pixel buffer than necessary for 3D textures. This commit fixes this bug.

## How was this PR tested?

Tested on windows 11. Attached a sample 3D texture for demostration.

[highFrequency.zip](https://github.com/user-attachments/files/27534695/highFrequency.zip)
