### PR TITLE
ProcessWatcher: document prctl(PR_SET_PDEATHSIG) threading constraint

### DIFF
--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessWatcher_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessWatcher_Linux.cpp
@@ -333,6 +333,30 @@ namespace AzFramework
         {
             if (processLaunchInfo.m_tetherLifetime)
             {
+                // NOTE: prctl(PR_SET_PDEATHSIG) binds the death signal to
+                // the THREAD that called fork(), NOT to the parent
+                // PROCESS. From prctl(2):
+                //
+                //   "The 'parent' in this case is considered to be the
+                //    thread that created this process using fork(2). In
+                //    other words, the signal is sent when the thread
+                //    terminates, not when the entire parent process
+                //    terminates."
+                //
+                // m_tetherLifetime is therefore only safe to use when
+                // LaunchProcess is called from a long-lived thread (e.g.,
+                // the engine's main UI thread). Callers that invoke this
+                // from a short-lived worker thread (task pool, QRunnable,
+                // std::async, etc.) will have their freshly-spawned child
+                // SIGTERM'd within milliseconds of fork, as the launching
+                // thread retires.
+                //
+                // For callers that cannot guarantee a long-lived launching
+                // thread, prefer a child-side parent-death watchdog
+                // instead. See AssetBuilder's StartParentDeathWatchdog
+                // (Code/Tools/AssetProcessor/AssetBuilder/main.cpp) for a
+                // reference implementation using a getppid() polling
+                // thread inside the spawned child process.
                 prctl(PR_SET_PDEATHSIG, SIGTERM);
                 if (getppid() != parentPid)
                 {


### PR DESCRIPTION

`processLaunchInfo.m_tetherLifetime = true` triggers `prctl(PR_SET_PDEATHSIG, SIGTERM)` in the child. Per `prctl(2)`, that signal fires when the THREAD that called `fork()` terminates, not when the parent PROCESS terminates -- a subtle distinction that's easy to miss when reading just the engine API surface.

Consumers that invoke `LaunchProcess` from a short-lived thread (task pool, QRunnable, `std::async`, etc.) will have their freshly-spawned child SIGTERM'd within milliseconds of `fork()`, as the launching thread retires immediately after the spawn returns.

This was missed when AssetProcessor's `BuilderManager` was tested with `m_tetherLifetime = true` enabled: BuilderManager forks builders from TaskWorker pool threads that retire immediately, and every spawned AssetBuilder got SIGTERM'd within ~21 ms of fork. (Tracked separately; see linked issue.)

This change adds a 20-line warning comment next to the `prctl` call documenting the precondition, the symptom pattern when it's violated, and pointing future callers at the child-side watchdog pattern as an alternative.

Doc-only change; no behavior change.

### Test plan

- Verify the file still compiles on Linux. (No code change; should be trivial.)
- Verify the existing m_tetherLifetime call sites (currently just the Multiplayer gem) are unaffected.

### Companion changes

This is the smallest, lowest-risk piece of a three-PR cluster addressing the AssetBuilder orphan bug:

- **(This PR)** Doc comment on the prctl threading constraint.
- **`assetbuilder-parent-death-watchdog`** Child-side parent-death watchdog in AssetBuilder's main() that prevents orphan accumulation, independent of the launching thread's lifetime.
- **(Issue, not PR yet)** BuilderManager refactor to fork from a dedicated long-lived spawn thread, which would also re-enable `m_tetherLifetime = true` correctly.

The three pieces compose. This doc comment is independently useful even if the other two never land.

---

Refs: #19745
