### PR TITLE
AssetBuilder: add child-side parent-death watchdog

### DIFF
--- a/Code/Tools/AssetProcessor/AssetBuilder/main.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilder/main.cpp
@@ -14,8 +14,57 @@
 // so it can be always running in the culture-invariant locale.
 #include <locale.h>
 
+#if defined(AZ_PLATFORM_LINUX) || defined(AZ_PLATFORM_MAC)
+#include <unistd.h>
+#include <thread>
+#include <chrono>
+
+namespace
+{
+    // Child-side parent-death watchdog. Polls getppid(); if the parent
+    // process dies (we get reparented to init / systemd-user), exit
+    // cleanly so we don't accumulate as an orphan across AP restarts.
+    //
+    // This replaces ProcessLauncher's m_tetherLifetime path
+    // (prctl(PR_SET_PDEATHSIG, SIGTERM)) which is unsafe to use from
+    // short-lived forking threads. The kernel binds PDEATHSIG to the
+    // THREAD that called fork(), not the parent PROCESS; AssetProcessor's
+    // BuilderManager forks builders from short-lived TaskWorker threads,
+    // so the prctl approach gets every spawned builder SIGTERM'd within
+    // milliseconds. Child-side polling is independent of the launching
+    // thread's lifetime.
+    //
+    // 2s polling = negligible CPU, max orphan-lifetime of 2 seconds.
+    void StartParentDeathWatchdog()
+    {
+        const pid_t parentAtStartup = getppid();
+        if (parentAtStartup <= 1)
+        {
+            // Launched without a meaningful parent (already init's child);
+            // no watchdog needed.
+            return;
+        }
+        std::thread([parentAtStartup]()
+        {
+            for (;;)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(2));
+                if (::getppid() != parentAtStartup)
+                {
+                    _exit(0);
+                }
+            }
+        }).detach();
+    }
+}
+#endif
+
 int main(int argc, char** argv)
 {
+#if defined(AZ_PLATFORM_LINUX) || defined(AZ_PLATFORM_MAC)
+    StartParentDeathWatchdog();
+#endif
+
     // globally set the application locale to the culture-invariant locale.
     // This should cause all reading and writing under all threads to use the invariant locale
     // So that the application can be run in any locale and still produce the same output.


### PR DESCRIPTION

When AssetProcessor dies (crash, SIGKILL, ungraceful shutdown), the resident AssetBuilders it previously spawned get reparented to PID 1 (or the user's systemd instance) and keep running indefinitely. Each AP restart spawns a fresh resident pool without adopting the orphans, so they accumulate across restarts -- roughly 300 MB RSS each, plus held file descriptors and shared-memory segments.

This patch addresses the symptom by adding a small detached watchdog thread to AssetBuilder's `main()`. The thread polls `getppid()` every 2 seconds; when the parent PID changes (we've been reparented), the builder calls `_exit(0)`. Independent of any threading-model assumptions on the AP side; ~12 LOC; negligible runtime cost.

POSIX (Linux + Mac) implementation only. The same orphan-lifetime bug exists on Windows but the appropriate mechanism differs (`OpenProcess(PROCESS_SYNCHRONIZE) + WaitForSingleObject` on a parent process handle in the watchdog thread). A Windows port can follow as a separate change.

### Why not `m_tetherLifetime = true`

The engine's existing `m_tetherLifetime` mechanism on Linux uses `prctl(PR_SET_PDEATHSIG, SIGTERM)`. Per `prctl(2)`, that signal fires when the **THREAD that called `fork()`** terminates, not when the parent process terminates. AssetProcessor's `BuilderManager::LaunchProcess` is called from short-lived TaskWorker threads that retire immediately after the spawn returns -- so setting `m_tetherLifetime = true` causes the kernel to SIGTERM every freshly-spawned builder within milliseconds of `fork()`. We verified this empirically.

The structural fix (refactor BuilderManager to spawn from a long-lived thread) is tracked in a separate design issue (link TBD). The watchdog here is the focused, low-risk fix for the user-visible orphan symptom; it composes cleanly with any future BuilderManager refactor.

### Reproduction (without this patch)

1. Open Editor in a project; let AP spawn its resident builder pool.
2. `kill -9 <AssetProcessor-pid>`
3. `ps -o pid,ppid,comm -C AssetBuilder`

Before this patch: resident AssetBuilders persist with PPID 1 (or the user systemd PID) and keep running until manually killed.

After this patch: resident AssetBuilders detect the reparenting within 2 seconds and exit cleanly. `ps` shows zero AssetBuilder processes with non-AP parents.

### Risk assessment

- One detached thread per AssetBuilder process. Sleeps 2 seconds between checks; CPU cost is rounding error.
- 2-second max orphan lifetime is acceptable for the orphan-cleanup use case.
- Behavior on standalone launch (parent is shell or systemd-user): watchdog detects shell exit and exits with it -- intuitive.
- Behavior on AP launch (parent is AP): watchdog stays idle until AP dies.
- Behavior on launch with `parentAtStartup <= 1` (e.g., launched by init directly, unusual): watchdog skips entirely, so we don't self-exit immediately.
- `_exit(0)` is used (not `exit()`) to skip C++ destructors -- the builder's parent has already died, no point in graceful teardown.

### Test plan

1. Build green on Linux + Mac.
2. Open Editor in a project (PM -> Open Editor). Confirm resident builder pool spawns normally.
3. `kill -9 <AssetProcessor-pid>`. Confirm builder pool exits within 2-3 seconds (`ps -C AssetBuilder` returns no rows).
4. Clean-shutdown regression: close Editor normally. Confirm builders shut down via the existing IPC shutdown path with no errors, no premature watchdog firing.

---

Refs: #19745 (design issue), #19746 (companion doc-comment PR)
