### PR TITLE
OpenParticleSystem/ParticleBuilder: declare material JobDependency by path on cold cache

### DIFF
--- a/Gems/OpenParticleSystem/Code/Source/Builder/ParticleBuilder.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Builder/ParticleBuilder.cpp
@@ -112,18 +112,37 @@ namespace OpenParticle
             descriptor.m_critical = false;
             descriptor.m_priority = 1; // since this is an entry point asset, we should prioritize it above the background
 
-            // make it depend on the materials it references.
-            // We didn't actually load them since we only need their assetid, not their data, at this stage.
-            // We need to load it during job processing to check if its the right material type, but not now.
+            // Declare a JobDependency on each emitter's referenced material so
+            // the material is baked before this particle job runs. Two forms
+            // for the dependency identification are supported, in priority order:
+            //
+            // 1. AssetId UUID: present when the deserializer's catalog lookup
+            //    succeeded (warm cache, or object-form material reference in the
+            //    .particle JSON).
+            // 2. Asset hint string: a path preserved by the deserializer when the
+            //    legacy string-form material reference could not yet be resolved
+            //    against the asset catalog (cold cache). Without this fallback,
+            //    the JobDependency would be silently skipped on a cold cache and
+            //    the particle's ProcessJob would fail with "no material assigned
+            //    to render in emitter ..." -- a class of error that previously
+            //    required a second AP pass to clear.
             for (const auto& emitter : sourceData.m_emitters)
             {
+                AssetBuilderSDK::SourceFileDependency dep;
                 if (emitter->m_material.GetId().IsValid())
                 {
-                    AssetBuilderSDK::SourceFileDependency dep;
                     dep.m_sourceFileDependencyUUID = emitter->m_material.GetId().m_guid;
-                    descriptor.m_jobDependencyList.push_back(AssetBuilderSDK::JobDependency(
-                        "Material Builder", platformInfo.m_identifier, AssetBuilderSDK::JobDependencyType::Order, dep));
                 }
+                else if (!emitter->m_material.GetHint().empty())
+                {
+                    dep.m_sourceFileDependencyPath = emitter->m_material.GetHint();
+                }
+                else
+                {
+                    continue;
+                }
+                descriptor.m_jobDependencyList.push_back(AssetBuilderSDK::JobDependency(
+                    "Material Builder", platformInfo.m_identifier, AssetBuilderSDK::JobDependencyType::Order, dep));
             }
             response.m_createJobOutputs.push_back(descriptor);
         }

--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
@@ -549,9 +549,22 @@ namespace OpenParticle
             {
                 destField = AZ::Data::AssetManager::Instance().FindOrCreateAsset<T>(resultId, loadBehavior);
             }
+            else
+            {
+                // Preserve the original path string even when the asset catalog
+                // does not yet know about the referenced asset (cold cache).
+                // Without this, downstream builders that walk this object's
+                // references at CreateJobs time (notably ParticleBuilder for
+                // emitter material refs) lose the path information and cannot
+                // declare a JobDependency, which causes the dependent's job to
+                // be scheduled before its upstream dep is baked and fail with a
+                // generic "no material assigned to render" error on the first
+                // pass. A second AP pass then succeeds against the warmed cache.
+                destField.SetHint(sourceAssetPath);
+            }
         }
 
-        if (destField.GetId().IsValid())
+        if (destField.GetId().IsValid() || !destField.GetHint().empty())
         {
             return JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::Success);
         }


### PR DESCRIPTION
Fixes #19755.

## What this fixes

`ParticleBuilder::CreateJobs` declares a `JobDependency` on each emitter's referenced material so AP schedules the material's bake ahead of the particle's. On a cold cache (fresh checkout, CI runner with no pre-warmed Cache dir), the legacy string-form material reference in the `.particle` JSON cannot yet be resolved against the asset catalog because the material itself has not been processed. `ConvertSourceFileNameToAsset` (`Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp:547`) calls `FindAssetIdFromFileName`, gets an invalid AssetId back, and drops the original path string. The emitter's `m_material` ends up with neither a UUID nor any path hint, and `ParticleBuilder::CreateJobs` silently skips the JobDependency declaration (the existing `if (emitter->m_material.GetId().IsValid())` check fails closed).

AP then schedules the particle's job ahead of the material's job in alphabetic order, and the particle's `ProcessJob` fails at `ParticleAssetData::CreateParticleAsset` with:

```
ParticleAssetData: Cannot create particle data - no material assigned to render in emitter Emitter
ParticleBuilder: Failed to create particle asset '<path>/preWarm.particle'!
```

A second AP pass succeeds (the material is now in the cache from pass 1), which is the current de facto workaround upstream uses when AR's `Mac-Asset` / `Android-Asset` / `iOS-Asset` jobs fail on `preWarm.particle`. Recent affected runs (linked in #19755):

- [25863484203](https://github.com/o3de/o3de/actions/runs/25863484203) (development AR, Mac-Asset + Android-Asset, 2026-05-14)
- [25745112482](https://github.com/o3de/o3de/actions/runs/25745112482) (PR CI, iOS-Asset, 2026-05-12)

## How

Two surgical changes, no behavior change on the warm-cache path:

1. **`ParticleSystemSerializer.cpp`'s `ConvertSourceFileNameToAsset`**: when the input is a string path AND the catalog lookup returns an invalid AssetId, preserve the original path string on the Asset's hint field via `SetHint()`. The path information then survives even when the catalog is cold.

2. **`ParticleBuilder.cpp`'s `CreateJobs` material-dependency loop**: if the material's AssetId is invalid but its hint is non-empty (the cold-cache case from change 1), declare the `SourceFileDependency` by `m_sourceFileDependencyPath` instead of by `m_sourceFileDependencyUUID`. The path-based form is documented in `AssetBuilderSDK.h` to work with AP's watch-folder resolution.

The path-based dependency is functionally equivalent to the UUID-based one for AP scheduling -- both tell AP to bake the referenced source file before the dependent's job runs.

## Risk

- **Warm-cache builds**: no change in behavior. `if (GetId().IsValid())` still wins. The new branches are only taken when the existing code's gate fails closed.
- **Cold-cache builds**: previously silently dropped JobDependency declaration. Now declares by path. This is the fix.
- **Object-form material references** (`iterator->value.IsObject()` branch in the deserializer, ~line 531): unaffected. `AZ::Data::Asset<>`'s normal JSON serialization already provides both AssetId and hint in this form, so the warm path runs as before.

## Out of scope (note for future)

The same path-preservation gap affects `m_model` and `m_skeletonModel` references that `ConvertSourceFileNameToAsset` also handles. Change 1 preserves their hints too as a side effect, but `ParticleBuilder::CreateJobs` does not currently declare `JobDependency` on models, so the user-visible fix is materials-only here. If model-side JobDependencies are added later, they will benefit from the same hint preservation.

## Test plan

- [x] Local repro on Fedora 44 against `o3de-multiplayersample`: without this fix, cold-cache AP batch fails 1 of ~6011 assets (`preWarm.particle`); second pass succeeds.
- [ ] With this branch built and dropped into the engine: cold-cache AP batch should succeed in one pass. (Pending an engine rebuild on my end; intend to validate against `o3de-multiplayersample` + report the result on this PR before requesting review.)
- [ ] AR `Mac-Asset` / `Android-Asset` / `iOS-Asset` first-pass should clean up; the current "re-run failed jobs" workaround for these platforms should become unnecessary on this branch.

## Discovery

Caught via an O3DE Linux RPM packaging integration test (`tests/multiplayersample-build-test.sh` in https://github.com/nickschuetz/o3de-rpm) running a full `AssetProcessorBatch` over `o3de-multiplayersample` on an installed engine. The 2-pass workaround in that test prompted the upstream filing in #19755, where the AR-log signature search uncovered that this bug has been silently failing on Mac / Android / iOS asset jobs in this repo's own CI for at least two days. cc sig/graphics-audio.