### PR TITLE
reopen preWarm particle to migrate it to new formats

### DIFF
--- a/Gems/OpenParticleSystem/Assets/Particles/preWarm.particle
+++ b/Gems/OpenParticleSystem/Assets/Particles/preWarm.particle
@@ -1,7 +1,8 @@
 {
     "name": "ParticleSystem",
     "systemConfig": {
-        "loop": true
+        "loop": true,
+        "parallel": true
     },
     "preWarm": {
         "warmupTime": 5.0,
@@ -19,7 +20,14 @@
                 "duration": 5.0,
                 "loop": true
             },
-            "material": "Materials/OpenParticle/ParticleSpriteEmit.material",
+            "material": {
+                "assetId": {
+                    "guid": "{B866A670-33AC-5775-B5AB-894DF9967B67}",
+                    "subId": 0
+                },
+                "loadBehavior": "PreLoad",
+                "assetHint": "materials/openparticle/particlespriteemit.azmaterial"
+            },
             "OpenParticle::SpriteConfig": {
                 "facing": "CAMERA_RECTANGLE",
                 "sortId": 0,
@@ -35,7 +43,7 @@
                     "isUniform": false,
                     "distType": "Constant",
                     "distIndex": [
-                        1
+                        0
                     ]
                 }
             },


### PR DESCRIPTION
## What does this PR do?

This PR migrates the preWarm.particle to new format.

Reopening applied three changes:
- new material format
- adjusted distIndex (looks good, matches distType)
- apply parallel = true - don't know what this is but matches other particle assets

## How was this PR tested?

- Rerun the Asset Processor build for preWarm.particle
- Confirmed 0 errors, 0 warnings