### PR TITLE
fix: typo 'boostrap' to 'bootstrap' in PythonToolGem template

### DIFF
--- a/Templates/PythonToolGem/Template/Editor/Scripts/bootstrap.py
+++ b/Templates/PythonToolGem/Template/Editor/Scripts/bootstrap.py
@@ -5,14 +5,14 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 # -------------------------------------------------------------------------
-"""${SanitizedCppName}\\editor\\scripts\\boostrap.py
+"""${SanitizedCppName}\\editor\\scripts\\bootstrap.py
 Generated from O3DE PythonToolGem Template"""
 
 import az_qt_helpers
 from ${SanitizedNameLower}_dialog import ${SanitizedCppName}Dialog
 
 if __name__ == "__main__":
-    print("${SanitizedCppName}.boostrap, Generated from O3DE PythonToolGem Template")
+    print("${SanitizedCppName}.bootstrap, Generated from O3DE PythonToolGem Template")
 
     try:
         import azlmbr.editor as editor


### PR DESCRIPTION
## Summary

Fixes #14632

The PythonToolGem template contains a typo: 'boostrap' instead of 'bootstrap' in two places (module docstring and print statement). This typo propagates to every project created from the template.

## Root Cause

The template file at lines 8 and 15 uses the misspelled 'boostrap' instead of 'bootstrap'.

## Fix

Changed both occurrences of 'boostrap' to 'bootstrap'.

## Changes

- `Templates/PythonToolGem/Template/Editor/Scripts/bootstrap.py`: 2 occurrences fixed (+2 -2 lines)

## Testing

- Verified no remaining occurrences of 'boostrap' in the file
- The correct spelling matches the actual filename 'bootstrap.py'
- Template file is static, no runtime testing needed