### PR TITLE
Fix typo: 'a empty xx' should be 'an empty xx'

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
@@ -1093,7 +1093,7 @@ namespace AZ
             }
             else
             {
-                // if we are a different asset (or being swapped with a empty) then we just swap as usual.
+                // if we are a different asset (or being swapped with an empty) then we just swap as usual.
                 AZStd::swap(m_assetHint, rhs.m_assetHint);
             }
 

--- a/Code/Framework/AzCore/AzCore/IO/Path/Path.h
+++ b/Code/Framework/AzCore/AzCore/IO/Path/Path.h
@@ -447,7 +447,7 @@ namespace AZ::IO
         //! Constructs a Path by constructing it's internal out of a value_type*
         //! The preferred separator is set to the parameter
         constexpr BasicPath(const value_type* pathString, const char preferredSeparator) noexcept;
-        //! Constructs a empty Path with the preferred separator set to the parameter
+        //! Constructs an empty Path with the preferred separator set to the parameter
         explicit constexpr BasicPath(const char preferredSeparator) noexcept;
 
         template <typename InputIt>

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -1028,7 +1028,7 @@ namespace AZ
             {
                 if (*deprecatedName == '\0')
                 {
-                    AZ_Warning("BehaviorContext", false, "Deprecated name can't be a empty string!", deprecatedName);
+                    AZ_Warning("BehaviorContext", false, "Deprecated name can't be an empty string!", deprecatedName);
                 }
                 else if (m_ebuses.find(deprecatedName) != m_ebuses.end())
                 {

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -186,7 +186,7 @@ namespace AZ
     SettingsRegistryImpl::SettingsRegistryImpl()
     {
         m_serializationSettings.m_keepDefaults = true;
-        // Initialize the setting registry with a empty json object '{}'
+        // Initialize the setting registry with an empty json object '{}'
         m_settings.SetObject();
     }
 

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryTests.cpp
@@ -1385,7 +1385,7 @@ namespace SettingsRegistryTests
         // Initialize the Settings Registry with an Object at /TestObject/IntValue
         m_registry->MergeSettings(R"({ "TestObject": { "IntValue": 7 } })", AZ::SettingsRegistryInterface::Format::JsonMergePatch);
 
-        // Merging a file with a empty JSON Object should be effectively a no-op.
+        // Merging a file with an empty JSON Object should be effectively a no-op.
         // There are some changes in the settings registry to record the merge history for introspection purposes.
         auto outcome = m_registry->MergeSettingsFile(path->Native(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, {});
         EXPECT_TRUE(outcome);

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -21,7 +21,7 @@ namespace O3DE::ProjectManager
     {
         // The list of clang C/C++ compiler command lines to validate on the host Linux system
         // Only Ubuntu has clang++-<version> symlinks, other linux distros do not,
-        // so a empty string entry is added to the end
+        // so an empty string entry is added to the end
         const QStringList SupportedClangVersions = {"-13", "-12", "-11", "-10", "-9", "-8", "-7", "-6.0", ""};
 
         QChar GetPlatformPathEnvSeparator()

--- a/scripts/o3de.bat
+++ b/scripts/o3de.bat
@@ -30,4 +30,3 @@ EXIT /b 1
 :end
 EXIT /b %ERRORLEVEL%
 
-

--- a/scripts/o3de/tests/test_repo_properties.py
+++ b/scripts/o3de/tests/test_repo_properties.py
@@ -265,7 +265,7 @@ class TestEditRepoProperties:
                          None, None, None, None,
                          None, None, None, None, None,
                          0),
-            # test remove project with a empty parameter
+            # test remove project with an empty parameter
             pytest.param(pathlib.Path('F:/repotest'),'RepoRemove', 
                          None, None, None, None,
                          'project1 project2', '', None, [{'project_name':'project1'}, {'project_name':'project2'}],


### PR DESCRIPTION
## What does this PR do?

Fix typo
'a empty xx' should be 'an empty xx'

