### PR TITLE
Added additional `PropertyVisibility` for `Tag` and `ContactEffset` to AzPhysics `ColliderConfiguration`

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
@@ -66,10 +66,12 @@ namespace Physics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_materialSlots, "", "")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetMaterialSlotsVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_tag, "Tag", "Tag used to identify colliders from one another")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetTagVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_restOffset, "Rest offset",
                         "Bodies will come to rest separated by the sum of their rest offset values (must be less than contact offset)")
                         ->Attribute(AZ::Edit::Attributes::Step, 1e-2f)
                         ->Attribute(AZ::Edit::Attributes::Max, 50.0f)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetContactOffsetVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnRestOffsetChanged)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_contactOffset, "Contact offset",
@@ -77,6 +79,7 @@ namespace Physics
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Step, 1e-2f)
                         ->Attribute(AZ::Edit::Attributes::Max, 50.0f)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetContactOffsetVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnContactOffsetChanged)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
                     ;
@@ -137,6 +140,16 @@ namespace Physics
     AZ::Crc32 ColliderConfiguration::GetOffsetVisibility() const
     {
         return GetPropertyVisibility(PropertyVisibility::Offset);
+    }
+
+    AZ::Crc32 ColliderConfiguration::GetTagVisibility() const
+    {
+        return GetPropertyVisibility(PropertyVisibility::Tag);
+    }
+
+    AZ::Crc32 ColliderConfiguration::GetContactOffsetVisibility() const
+    {
+        return GetPropertyVisibility(PropertyVisibility::ContactOffset);
     }
 
     AZ::Crc32 ColliderConfiguration::GetSimulatedPropertyVisibility() const

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
@@ -36,7 +36,9 @@ namespace Physics
             MaterialSelection = 1 << 1,
             IsTrigger = 1 << 2,
             IsVisible = 1 << 3, ///< @deprecated This property will be removed in a future release.
-            Offset = 1 << 4 ///< Whether the rotation and position offsets should be visible.
+            Offset = 1 << 4, ///< Whether the rotation and position offsets should be visible.
+            Tag = 1 << 5, ///< Whether the collider tag should be visible.
+            ContactOffset = 1 << 6 ///< Whether rest and contact offset values should be visible.
         };
 
         // Delta to ensure that contact offset is slightly larger than rest offset.
@@ -53,6 +55,8 @@ namespace Physics
         AZ::Crc32 GetCollisionLayerVisibility() const;
         AZ::Crc32 GetMaterialSlotsVisibility() const;
         AZ::Crc32 GetOffsetVisibility() const;
+        AZ::Crc32 GetTagVisibility() const;
+        AZ::Crc32 GetContactOffsetVisibility() const;
 
         AzPhysics::CollisionLayer m_collisionLayer; ///< Which collision layer is this collider on.
         AzPhysics::CollisionGroups::Id m_collisionGroupId; ///< Which layers does this collider collide with.
@@ -142,7 +146,7 @@ namespace Physics
         //! If vertices are returned but not indices you may assume the vertices are in triangle list format.
         //! @param vertices A buffer to be filled with vertices
         //! @param indices A buffer to be filled with indices
-        //! @param optionalBounds Optional AABB that, if provided, will limit the mesh returned to that AABB.  
+        //! @param optionalBounds Optional AABB that, if provided, will limit the mesh returned to that AABB.
         //!                       Currently only supported by the heightfield shape.
         virtual void GetGeometry(AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices,
             const AZ::Aabb* optionalBounds = nullptr) const = 0;


### PR DESCRIPTION
## What does this PR do?
Previously only some of the properties on `ColliderConfiguration` could have their editor visibility set. This expands this to all reflected fields to allow more flexible usage with other physics engines (Jolt, in this case).

This adds two new entries in the `PropertyVisibility` struct and two functions to return the current setting.

## How was this PR tested?

using the PhysX 5.1.1 `EditorColliderComponent`, I modified the visibility of fields by hiding Tag and rest/contact offset in the `Activate()` function.

```
void EditorColliderComponent::Activate()
{
    m_configuration.SetPropertyVisibility(Physics::ColliderConfiguration::Tag, false);
    m_configuration.SetPropertyVisibility(Physics::ColliderConfiguration::ContactOffset, false);

    ...
}
```
Before:
<img width="515" height="441" alt="Primitive Collider Default" src="https://github.com/user-attachments/assets/71f281ea-5117-4edd-afbb-f347d48f775f" />
After hiding:
<img width="521" height="377" alt="Primitive Collider Hidden Tag and Offset" src="https://github.com/user-attachments/assets/6670466b-f1e6-4e9c-bbaa-158fba3a09f2" />

The functionality of the body/collider was tested in game mode successfuly.