### PR TITLE
Fix EditorComponentAPI: unwrap GenericComponentWrapper for PropertyTreeEditor

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h>
+#include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <AzToolsFramework/Entity/EditorEntityActionComponent.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h>
@@ -22,6 +23,27 @@
 
 namespace AzToolsFramework
 {
+    namespace
+    {
+        // For a non-EditorComponentBase component added via the editor, the live
+        // pointer returned by Entity::GetComponents() is a GenericComponentWrapper.
+        // GetUnderlyingComponentType() returns the type of the wrapped template
+        // component (correct), but the instance pointer stays as the wrapper unless
+        // we explicitly unwrap. PropertyTreeEditor needs the (instance, type) pair
+        // to refer to the same object, otherwise its InstanceDataHierarchy walks
+        // the wrapper's memory while believing it's the wrapped class.
+        void* UnwrapInstanceForReflection(AZ::Component* component)
+        {
+            if (auto* wrapper = azrtti_cast<AzToolsFramework::Components::GenericComponentWrapper*>(component))
+            {
+                if (AZ::Component* tmpl = wrapper->GetTemplate())
+                {
+                    return reinterpret_cast<void*>(tmpl);
+                }
+            }
+            return reinterpret_cast<void*>(component);
+        }
+    }
     namespace Components
     {
         //! Helper class for scripting.
@@ -562,7 +584,7 @@ namespace AzToolsFramework
                 return EditorComponentAPIRequests::PropertyOutcome{ AZStd::unexpect, PropertyOutcome::ErrorType("GetComponentProperty - Component Instance is Invalid.") };
             }
 
-            PropertyTreeEditor pte = PropertyTreeEditor(reinterpret_cast<void*>(component), component->GetUnderlyingComponentType());
+            PropertyTreeEditor pte = PropertyTreeEditor(UnwrapInstanceForReflection(component), component->GetUnderlyingComponentType());
 
             if (m_usePropertyVisibility)
             {
@@ -582,7 +604,7 @@ namespace AzToolsFramework
                 return EditorComponentAPIRequests::PropertyOutcome{ AZStd::unexpect, PropertyOutcome::ErrorType("SetComponentProperty - Component Instance is Invalid.") };
             }
 
-            PropertyTreeEditor pte = PropertyTreeEditor(reinterpret_cast<void*>(component), component->GetUnderlyingComponentType());
+            PropertyTreeEditor pte = PropertyTreeEditor(UnwrapInstanceForReflection(component), component->GetUnderlyingComponentType());
 
             if (m_usePropertyVisibility)
             {
@@ -610,7 +632,7 @@ namespace AzToolsFramework
                 return false;
             }
 
-            PropertyTreeEditor pte = PropertyTreeEditor(reinterpret_cast<void*>(component), component->GetUnderlyingComponentType());
+            PropertyTreeEditor pte = PropertyTreeEditor(UnwrapInstanceForReflection(component), component->GetUnderlyingComponentType());
 
             if (m_usePropertyVisibility)
             {
@@ -630,7 +652,7 @@ namespace AzToolsFramework
                 return { AZStd::string("BuildComponentPropertyList - Component Instance is Invalid.") };
             }
 
-            PropertyTreeEditor pte = PropertyTreeEditor(reinterpret_cast<void*>(component), component->GetUnderlyingComponentType());
+            PropertyTreeEditor pte = PropertyTreeEditor(UnwrapInstanceForReflection(component), component->GetUnderlyingComponentType());
 
             if (m_usePropertyVisibility)
             {


### PR DESCRIPTION
## What does this PR do?

Fixes #19770.

`EditorComponentAPIComponent::SetComponentProperty` (and `GetComponentProperty`, `CompareComponentProperty`, `BuildComponentPropertyList`) construct a `PropertyTreeEditor` from `(reinterpret_cast<void*>(component), component->GetUnderlyingComponentType())`. When `component` is a `GenericComponentWrapper` (which it is for any component that doesn't inherit from `EditorComponentBase`, e.g. the stock `InputConfigurationComponent`), the pointer refers to the wrapper but the typeId refers to the wrapped class. `PropertyTreeEditor` then walks the wrapper's memory as if it were the wrapped class.

For an `Asset<T>` field this lands inside the wrapper's `m_displayName` storage. The resulting non-null `m_assetData` pointer crashes the next `SetComponentProperty`'s `Asset<>::Release()` with `AssetCommon.cpp`'s `AZ_Assert(m_useCount > 0)`. `GetComponentProperty` silently returns garbage `AssetId` bytes instead — same root cause, no assert path.

This PR adds a small `UnwrapInstanceForReflection` helper in an anonymous namespace inside `EditorComponentAPIComponent.cpp`. The helper returns `wrapper->GetTemplate()` for a `GenericComponentWrapper`, and the component itself otherwise. The four call sites that build a `PropertyTreeEditor` now pass `UnwrapInstanceForReflection(component)` instead of `reinterpret_cast<void*>(component)`, so the `(instance, type)` pair handed to `PropertyTreeEditor` refers to the same object. This mirrors the typeId-side unwrap that `AZ::Component::GetUnderlyingComponentType()` already performs, and reuses the same `GetTemplate()` helper that the existing `FindWrappedComponentForEntity<T>` uses.

`EditorComponentBase`-derived components (Mesh, Lua Script, etc.) aren't wrapped, so the unwrap is a no-op (`azrtti_cast` returns null and the helper returns the component pointer unchanged).

Open to a different shape — e.g. moving the unwrap inside `PropertyTreeEditor`'s constructor so any caller is safe by default — if reviewers prefer that.

## How was this PR tested?

Reproduced the crash on the linked issue's repro before the patch, then built `libAzToolsFramework.so` with this change and re-ran. Verbatim test output after the patch:

```
PRE-set readback : {00000000-0000-0000-0000-000000000000}:0
Setting asset_id : {0E98ABD6-E619-5C16-9B27-D9096E4B159A}:0
Set IsSuccess    : True
POST-set readback: {0E98ABD6-E619-5C16-9B27-D9096E4B159A}:0
survived
```

- Editor no longer crashes on `SetComponentProperty`.
- Pre-set `GetComponentProperty` returns a clean null `AssetId` (the unpatched build returns garbage).
- Post-set readback returns exactly the `AssetId` that was set.
- `Asset<ModelAsset>` (Mesh) and `Asset<ScriptAsset>` (Lua Script) round-trips — which already worked — continue to work after the patch.

Reproduced on `stabilization/26050` (the relevant lines in `EditorComponentAPIComponent.cpp` and `GenericComponentWrapper.h` are identical on `development` at the PR's base commit).
