### PR TITLE
(cherry pick from dev) Fix for the UV offsets not working on vulkan

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/DetailMapsPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/DetailMapsPropertyGroup.json
@@ -167,16 +167,32 @@
                                 "translateXProperty": "offsetU",
                                 "translateYProperty": "offsetV",
                                 "rotateDegreesProperty": "rotateDegrees",
-                                "float3x3ShaderInput": "m_detailUvMatrix",
-                                "float3x3InverseShaderInput": "m_detailUvMatrixInverse",
+                                "float3x3ShaderInput": "m_detailUvMatrixRow0",
+                                "float3x3InverseShaderInput": "m_detailUvMatrixInverseRow0",
                                 "shaderParameters": [
                                     {
-                                        "name": "m_detailUvMatrix",
-                                        "type": "float3x3"
+                                        "name": "m_detailUvMatrixRow0",
+                                        "type": "float4"
                                     },
                                     {
-                                        "name": "m_detailUvMatrixInverse",
-                                        "type": "float3x3"
+                                        "name": "m_detailUvMatrixRow1",
+                                        "type": "float4"
+                                    },
+                                    {
+                                        "name": "m_detailUvMatrixRow2",
+                                        "type": "float4"
+                                    },
+                                    {
+                                        "name": "m_detailUvMatrixInverseRow0",
+                                        "type": "float4"
+                                    },
+                                    {
+                                        "name": "m_detailUvMatrixInverseRow1",
+                                        "type": "float4"
+                                    },
+                                    {
+                                        "name": "m_detailUvMatrixInverseRow2",
+                                        "type": "float4"
                                     }
                                 ]
                             }

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/UvPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/UvPropertyGroup.json
@@ -77,16 +77,32 @@
                 "translateXProperty": "offsetU",
                 "translateYProperty": "offsetV",
                 "rotateDegreesProperty": "rotateDegrees",
-                "float3x3ShaderInput": "m_uvMatrix",
-                "float3x3InverseShaderInput": "m_uvMatrixInverse",
+                "float3x3ShaderInput": "m_uvMatrixRow0",
+                "float3x3InverseShaderInput": "m_uvMatrixInverseRow0",
                 "shaderParameters": [
                     {
-                        "name": "m_uvMatrix",
-                        "type": "float3x3"
+                        "name": "m_uvMatrixRow0",
+                        "type": "float4"
                     },
                     {
-                        "name": "m_uvMatrixInverse",
-                        "type": "float3x3"
+                        "name": "m_uvMatrixRow1",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixRow2",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixInverseRow0",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixInverseRow1",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixInverseRow2",
+                        "type": "float4"
                     }
                 ]
             }

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_LayerProperties.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_LayerProperties.json
@@ -180,11 +180,19 @@
                                 "translateXProperty": "offsetU",
                                 "translateYProperty": "offsetV",
                                 "rotateDegreesProperty": "rotateDegrees",
-                                "float3x3ShaderInput": "m_uvMatrix",
+                                "float3x3ShaderInput": "m_uvMatrixRow0",
                                 "shaderParameters": [
                                     {
-                                        "name": "m_uvMatrix",
-                                        "type": "float3x3"
+                                        "name": "m_uvMatrixRow0",
+                                        "type": "float4"
+                                    },
+                                    {
+                                        "name": "m_uvMatrixRow1",
+                                        "type": "float4"
+                                    },
+                                    {
+                                        "name": "m_uvMatrixRow2",
+                                        "type": "float4"
                                     }
                                 ]
                             }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Materials/SceneMaterialSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Materials/SceneMaterialSrg.azsli
@@ -47,6 +47,10 @@ Texture2D GetMaterialTexture(const int readIndex)
     return Bindless::GetTexture2D(localReadIndex);
 }
 
+// CAUTION: MaterialParameters structs loaded here must NOT contain float3x3/float3x4/float4x4 matrix members.
+// There is a known Vulkan/row_major bug where matrix types inside ByteAddressBuffer structs are read with
+// incorrect memory layout on Vulkan. Store matrices as separate row_major float4 rows and reconstruct
+// the float3x3 in shader code manually. See UvPropertyGroup.json and ParticleMeshMaterialParameters.azsli for an example.
 const MaterialParameters GetMaterialParameters(const int materialTypeId, const int materialInstanceId)
 {
     // The ByteAddressBuffers referenced in the SceneMaterialSrg hold the MaterialParameters for all MaterialTypes

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -55,7 +55,7 @@ Surface EvaluateSurface_BasePBR(
     surface.vertexNormal = vertexNormal;
     float2 normalUv = uvs[params.m_normalMapUvIndex];
 
-    real3x3 uvMatrix = params.m_normalMapUvIndex == 0 ? real3x3(params.m_uvMatrix) : CreateIdentity3x3_real(); // By design, only UV0 is allowed to apply transforms.
+    real3x3 uvMatrix = params.m_normalMapUvIndex == 0 ? real3x3(params.m_uvMatrixRow0.xyz, params.m_uvMatrixRow1.xyz, params.m_uvMatrixRow2.xyz) : CreateIdentity3x3_real(); // By design, only UV0 is allowed to apply transforms.
     if (customDerivatives)
     {
         surface.normal = GetNormalInputWS(GetMaterialTexture(params.m_normalMap), GetMaterialTextureSampler(), normalUv, params.m_flipNormalX, params.m_flipNormalY, isFrontFace, vertexNormal,

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_VertexEval.azsli
@@ -44,7 +44,8 @@ VsOutput EvaluateVertexGeometry_BasePBR(
 
 #if MATERIAL_USES_VERTEX_UV
     // By design, only UV0 is allowed to apply transforms.
-    output.uvs[0] = mul(params.m_uvMatrix, float3(uv0, 1.0)).xy;
+    float3 _uv0h = float3(uv0, 1.0);
+    output.uvs[0] = float2(dot(params.m_uvMatrixRow0.xyz, _uv0h), dot(params.m_uvMatrixRow1.xyz, _uv0h));
     output.uvs[1] = uv1;
 #endif // MATERIAL_USES_VERTEX_UV
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_SurfaceEval.azsli
@@ -59,12 +59,12 @@ Surface EvaluateSurface_EnhancedPBR(
     
     surface.vertexNormal = real3(normalWS);
     float2 normalUv = uvs[params.m_normalMapUvIndex];
-    real3x3 uvMatrix = params.m_normalMapUvIndex == 0 ? real3x3(params.m_uvMatrix) : CreateIdentity3x3_real(); // By design, only UV0 is allowed to apply transforms.
+    real3x3 uvMatrix = params.m_normalMapUvIndex == 0 ? real3x3(params.m_uvMatrixRow0.xyz, params.m_uvMatrixRow1.xyz, params.m_uvMatrixRow2.xyz) : CreateIdentity3x3_real(); // By design, only UV0 is allowed to apply transforms.
     real detailLayerNormalFactor = real(params.m_detail_normal_factor) * detailLayerBlendFactor;
     float3 normal = GetDetailedNormalInputWS(
         isFrontFace, normalWS,
         tangents[params.m_normalMapUvIndex],      bitangents[params.m_normalMapUvIndex],      GetMaterialTexture(params.m_normalMap),             GetMaterialTextureSampler(), normalUv, params.m_normalFactor,  params.m_flipNormalX,         params.m_flipNormalY,         uvMatrix,                         o_normal_useTexture,
-        tangents[params.m_detail_allMapsUvIndex], bitangents[params.m_detail_allMapsUvIndex], GetMaterialTexture(params.m_detail_normal_texture), GetMaterialTextureSampler(), detailUv, detailLayerNormalFactor,      params.m_detail_normal_flipX, params.m_detail_normal_flipY, real3x3(params.m_detailUvMatrix), o_detail_normal_useTexture,
+        tangents[params.m_detail_allMapsUvIndex], bitangents[params.m_detail_allMapsUvIndex], GetMaterialTexture(params.m_detail_normal_texture), GetMaterialTextureSampler(), detailUv, detailLayerNormalFactor,      params.m_detail_normal_flipX, params.m_detail_normal_flipY, real3x3(params.m_detailUvMatrixRow0.xyz, params.m_detailUvMatrixRow1.xyz, params.m_detailUvMatrixRow2.xyz), o_detail_normal_useTexture,
         uvDxDy, customDerivatives);
 
     surface.normal = real3(normal);
@@ -160,7 +160,7 @@ Surface EvaluateSurface_EnhancedPBR(
     {
         if(o_clearCoat_enabled)
         {
-            real3x3 uvMatrix = params.m_clearCoatNormalMapUvIndex == 0 ? real3x3(params.m_uvMatrix) : CreateIdentity3x3_real();
+            real3x3 uvMatrix = params.m_clearCoatNormalMapUvIndex == 0 ? real3x3(params.m_uvMatrixRow0.xyz, params.m_uvMatrixRow1.xyz, params.m_uvMatrixRow2.xyz) : CreateIdentity3x3_real();
             GetClearCoatInputs(GetMaterialTexture(params.m_clearCoatInfluenceMap), uvs[params.m_clearCoatInfluenceMapUvIndex], real(params.m_clearCoatFactor), o_clearCoat_factor_useTexture,
                                GetMaterialTexture(params.m_clearCoatRoughnessMap), uvs[params.m_clearCoatRoughnessMapUvIndex], real(params.m_clearCoatRoughness), o_clearCoat_roughness_useTexture,
                                GetMaterialTexture(params.m_clearCoatNormalMap),    uvs[params.m_clearCoatNormalMapUvIndex], normalWS, o_clearCoat_normal_useTexture, real(params.m_clearCoatNormalStrength),

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/MultilayerParallaxDepth.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/MultilayerParallaxDepth.azsli
@@ -25,8 +25,8 @@
      inout float depthCS,
      out bool isClipped)
 {
-    real3x3 uvMatrix = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrix) : CreateIdentity3x3_real();
-    real3x3 uvMatrixInverse = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrixInverse) : CreateIdentity3x3_real();
+    real3x3 uvMatrix = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrixRow0.xyz, params.m_uvMatrixRow1.xyz, params.m_uvMatrixRow2.xyz) : CreateIdentity3x3_real();
+    real3x3 uvMatrixInverse = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrixInverseRow0.xyz, params.m_uvMatrixInverseRow1.xyz, params.m_uvMatrixInverseRow2.xyz) : CreateIdentity3x3_real();
 
     real parallaxOverallOffset = real(params.m_displacementMax);
     real parallaxOverallFactor = real(params.m_displacementMax) - real(params.m_displacementMin);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/ParallaxDepth.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/ParallaxDepth.azsli
@@ -26,8 +26,8 @@
      inout float depthCS,
      out bool isClipped)
 {
-    real3x3 uvMatrix = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrix) : CreateIdentity3x3_real();
-    real3x3 uvMatrixInverse = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrixInverse) : CreateIdentity3x3_real();
+    real3x3 uvMatrix = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrixRow0.xyz, params.m_uvMatrixRow1.xyz, params.m_uvMatrixRow2.xyz) : CreateIdentity3x3_real();
+    real3x3 uvMatrixInverse = params.m_parallaxUvIndex == 0 ? real3x3(params.m_uvMatrixInverseRow0.xyz, params.m_uvMatrixInverseRow1.xyz, params.m_uvMatrixInverseRow2.xyz) : CreateIdentity3x3_real();
     
     float heightmapScale = float(params.m_heightmapScale);
     float heightmapOffset = float(params.m_heightmapOffset);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardTransformDetailUvs.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardTransformDetailUvs.azsli
@@ -13,6 +13,8 @@ void TransformDetailUvs(const MaterialParameters params, in float2 IN[UvSetCount
     // the same transform to both UV sets because the detail map feature forces the same UV set to be used for all detail maps.
     // Note we might be able to combine these into a single UV similar to what Skin.materialtype does,
     // but we would need to address how it works with the parallax code below that indexes into the m_detailUV array.
-    OUT[0] = mul(params.m_detailUvMatrix, float3(IN[0], 1.0)).xy;
-    OUT[1] = mul(params.m_detailUvMatrix, float3(IN[1], 1.0)).xy;
+    float3 _duv0h = float3(IN[0], 1.0);
+    float3 _duv1h = float3(IN[1], 1.0);
+    OUT[0] = float2(dot(params.m_detailUvMatrixRow0.xyz, _duv0h), dot(params.m_detailUvMatrixRow1.xyz, _duv0h));
+    OUT[1] = float2(dot(params.m_detailUvMatrixRow0.xyz, _duv1h), dot(params.m_detailUvMatrixRow1.xyz, _duv1h));
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Silhouette/SilhouetteGather_MaterialSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Silhouette/SilhouetteGather_MaterialSrg.azsli
@@ -17,7 +17,9 @@ struct MaterialParameters {
     float m_depthBias;
     float m_outlineSize;
     float m_padding0;
-    float3x3 m_uvMatrix;
+    float4 m_uvMatrixRow0;
+    float4 m_uvMatrixRow1;
+    float4 m_uvMatrixRow2;
 };
 
 ShaderResourceGroup MaterialSrg : SRG_PerMaterial
@@ -27,6 +29,8 @@ ShaderResourceGroup MaterialSrg : SRG_PerMaterial
 
 const MaterialParameters GetMaterialParameters()
 {
-    return MaterialSrg::m_params;
+    MaterialParameters params = MaterialSrg::m_params;
+    // m_uvMatrixRow0/1/2 are read directly from the SRG (no float3x3 copy needed).
+    return params;
 }
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_SurfaceEval.azsli
@@ -182,7 +182,7 @@ Surface EvaluateSurface_Skin(
         bool applyOverlay = true;
         surface.normal = ApplyNormalMapOverlayWS(applyOverlay, vertexNormal, normalTS, tangents[params.m_normalMapUvIndex], bitangents[params.m_normalMapUvIndex], 
                                                  GetMaterialTexture(params.m_detail_normal_texture), GetMaterialTextureSampler(), detailUv, params.m_detail_normal_flipX, params.m_detail_normal_flipY, 
-                                                 detailLayerNormalFactor, tangents[params.m_detail_allMapsUvIndex], bitangents[params.m_detail_allMapsUvIndex], real3x3(params.m_detailUvMatrix), uvDxDy, customDerivatives);
+                                                 detailLayerNormalFactor, tangents[params.m_detail_allMapsUvIndex], bitangents[params.m_detail_allMapsUvIndex], real3x3(params.m_detailUvMatrixRow0.xyz, params.m_detailUvMatrixRow1.xyz, params.m_detailUvMatrixRow2.xyz), uvDxDy, customDerivatives);
     }
     else
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_VertexEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/Skin/Skin_VertexEval.azsli
@@ -63,7 +63,8 @@ VsOutput EvaluateVertexGeometry_Skin(
     // The detail layer has a dedicated UV transform which we apply here. The detail layer does have the option of using
     // either UV0 or UV1, in either case we apply the transform.
     output.detailUvs[0] = params.m_detail_allMapsUvIndex == 0 ? uv0_tiled : uv1_unwrapped;
-    output.detailUvs[0] = mul(params.m_detailUvMatrix, float3(output.detailUvs[0], 1.0)).xy;
+    float3 _duvh = float3(output.detailUvs[0], 1.0);
+    output.detailUvs[0] = float2(dot(params.m_detailUvMatrixRow0.xyz, _duvh), dot(params.m_detailUvMatrixRow1.xyz, _duvh));
     output.detailUvs[1] = output.detailUvs[0];
 
 #endif // MATERIAL_USES_VERTEX_DETAIL_UV

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_Common.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_Common.azsli
@@ -298,7 +298,8 @@ float3 GetLayerDepthValues(const MaterialParameters params, float2 uv, float2 uv
             float2 layerUv = uv;
             if(params.m_parallaxUvIndex == 0)
             {
-                layerUv = mul(params.m_layer1_m_uvMatrix, float3(uv, 1.0)).xy;
+                float3 _l1uvh = float3(uv, 1.0); 
+                layerUv = float2(dot(params.m_layer1_m_uvMatrixRow0.xyz, _l1uvh), dot(params.m_layer1_m_uvMatrixRow1.xyz, _l1uvh));
             }
 
             layerDepthValues.r = SampleDepthFromHeightmap(GetMaterialTexture(params.m_layer1_m_heightmap), GetMaterialTextureSampler(), layerUv, uv_ddx, uv_ddy).m_depth;
@@ -315,7 +316,8 @@ float3 GetLayerDepthValues(const MaterialParameters params, float2 uv, float2 uv
             float2 layerUv = uv;
             if(params.m_parallaxUvIndex == 0)
             {
-                layerUv = mul(params.m_layer2_m_uvMatrix, float3(uv, 1.0)).xy;
+                float3 _l2uvh = float3(uv, 1.0); 
+                layerUv = float2(dot(params.m_layer2_m_uvMatrixRow0.xyz, _l2uvh), dot(params.m_layer2_m_uvMatrixRow1.xyz, _l2uvh));
             }
 
             layerDepthValues.g = SampleDepthFromHeightmap(GetMaterialTexture(params.m_layer2_m_heightmap), GetMaterialTextureSampler(), layerUv, uv_ddx, uv_ddy).m_depth;
@@ -333,7 +335,8 @@ float3 GetLayerDepthValues(const MaterialParameters params, float2 uv, float2 uv
             float2 layerUv = uv;
             if(params.m_parallaxUvIndex == 0)
             {
-                layerUv = mul(params.m_layer3_m_uvMatrix, float3(uv, 1.0)).xy;
+                float3 _l3uvh = float3(uv, 1.0); 
+                layerUv = float2(dot(params.m_layer3_m_uvMatrixRow0.xyz, _l3uvh), dot(params.m_layer3_m_uvMatrixRow1.xyz, _l3uvh));
             }
 
             layerDepthValues.b = SampleDepthFromHeightmap(GetMaterialTexture(params.m_layer3_m_heightmap), GetMaterialTextureSampler(), layerUv, uv_ddx, uv_ddy).m_depth;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardMultilayerPBR/StandardMultilayerPBR_SurfaceEval.azsli
@@ -91,10 +91,11 @@ ProcessedMaterialInputs ProcessStandardMaterialInputs(StandardMaterialInputs inp
     ProcessedMaterialInputs result;
 
     float2 transformedUv[UvSetCount];
-    transformedUv[0] = mul(inputs.m_uvMatrix, float3(inputs.m_vertexUv[0], 1.0)).xy;
+    float3 _mlUv0h = float3(inputs.m_vertexUv[0], 1.0);
+    transformedUv[0] = float2(dot(inputs.m_uvMatrix[0], _mlUv0h), dot(inputs.m_uvMatrix[1], _mlUv0h));
     transformedUv[1] = inputs.m_vertexUv[1];
 
-    real3x3 normalUvMatrix = inputs.m_normalMapUvIndex == 0 ? real3x3(inputs.m_uvMatrix) : real3x3(CreateIdentity3x3());
+    real3x3 normalUvMatrix = inputs.m_normalMapUvIndex == 0 ? real3x3(inputs.m_uvMatrix) : CreateIdentity3x3_real();
     result.m_normalTS = GetNormalInputTS(inputs.m_normalMap, inputs.m_sampler, transformedUv[inputs.m_normalMapUvIndex], inputs.m_flipNormalX, inputs.m_flipNormalY, normalUvMatrix, inputs.m_normal_useTexture, real(inputs.m_normalFactor), uvDxDy, customDerivatives);
 
     real3 sampledBaseColor = GetBaseColorInput(inputs.m_baseColorMap, inputs.m_sampler, transformedUv[inputs.m_baseColorMapUvIndex], real3(inputs.m_baseColor.rgb), inputs.m_baseColor_useTexture, uvDxDy, customDerivatives);
@@ -110,7 +111,7 @@ ProcessedMaterialInputs ProcessStandardMaterialInputs(StandardMaterialInputs inp
     result.m_clearCoat.InitializeToZero();
     if(inputs.m_clearCoatEnabled)
     {
-        real3x3 clearCoatUvMatrix = inputs.m_clearCoatNormalMapUvIndex == 0 ? real3x3(inputs.m_uvMatrix) : real3x3(CreateIdentity3x3());
+        real3x3 clearCoatUvMatrix = inputs.m_clearCoatNormalMapUvIndex == 0 ? real3x3(inputs.m_uvMatrix) : CreateIdentity3x3_real();
         GetClearCoatInputs(inputs.m_clearCoatInfluenceMap, transformedUv[inputs.m_clearCoatInfluenceMapUvIndex], real(inputs.m_clearCoatFactor), inputs.m_clearCoat_factor_useTexture,
                             inputs.m_clearCoatRoughnessMap, transformedUv[inputs.m_clearCoatRoughnessMapUvIndex], real(inputs.m_clearCoatRoughness), inputs.m_clearCoat_roughness_useTexture,
                             inputs.m_clearCoatNormalMap,    transformedUv[inputs.m_clearCoatNormalMapUvIndex], inputs.m_normal, inputs.m_clearCoat_normal_useTexture, real(inputs.m_clearCoatNormalStrength),
@@ -125,7 +126,7 @@ ProcessedMaterialInputs ProcessStandardMaterialInputs(StandardMaterialInputs inp
 #define FILL_STANDARD_MATERIAL_INPUTS(inputs, srgLayerPrefix, optionsLayerPrefix, blendWeight)                     \
     inputs.m_sampler = GetMaterialTextureSampler();                                                                \
     inputs.m_vertexUv = uvs;                                                                                       \
-    inputs.m_uvMatrix = srgLayerPrefix##m_uvMatrix;                                                                \
+    inputs.m_uvMatrix = float3x3(srgLayerPrefix##m_uvMatrixRow0.xyz, srgLayerPrefix##m_uvMatrixRow1.xyz, srgLayerPrefix##m_uvMatrixRow2.xyz); \
     inputs.m_normal = normalWS;                                                                                    \
     inputs.m_tangents = tangents;                                                                                  \
     inputs.m_bitangents = bitangents;                                                                              \

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceEval.azsli
@@ -66,7 +66,7 @@ Surface EvaluateSurface_StandardPBR(
     {
         if(o_clearCoat_enabled)
         {
-            real3x3 uvMatrix = params.m_clearCoatNormalMapUvIndex == 0 ? real3x3(params.m_uvMatrix) : CreateIdentity3x3_real();
+            real3x3 uvMatrix = params.m_clearCoatNormalMapUvIndex == 0 ? real3x3(params.m_uvMatrixRow0.xyz, params.m_uvMatrixRow1.xyz, params.m_uvMatrixRow2.xyz) : CreateIdentity3x3_real();
             GetClearCoatInputs(GetMaterialTexture(params.m_clearCoatInfluenceMap), uvs[params.m_clearCoatInfluenceMapUvIndex], real(params.m_clearCoatFactor), o_clearCoat_factor_useTexture,
                                GetMaterialTexture(params.m_clearCoatRoughnessMap), uvs[params.m_clearCoatRoughnessMapUvIndex], real(params.m_clearCoatRoughness), o_clearCoat_roughness_useTexture,
                                GetMaterialTexture(params.m_clearCoatNormalMap),    uvs[params.m_clearCoatNormalMapUvIndex], vertexNormal, o_clearCoat_normal_useTexture, real(params.m_clearCoatNormalStrength),

--- a/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.cpp
@@ -25,7 +25,7 @@ namespace AZ
                     ;
 
                 serializeContext->Class<Transform2DFunctor, RPI::MaterialFunctor>()
-                    ->Version(2)
+                    ->Version(3)
                     ->Field("transformOrder", &Transform2DFunctor::m_transformOrder)
                     ->Field("center", &Transform2DFunctor::m_center)
                     ->Field("scale", &Transform2DFunctor::m_scale)
@@ -34,8 +34,12 @@ namespace AZ
                     ->Field("translateX", &Transform2DFunctor::m_translateX)
                     ->Field("translateY", &Transform2DFunctor::m_translateY)
                     ->Field("rotateDegrees", &Transform2DFunctor::m_rotateDegrees)
-                    ->Field("transformMatrix", &Transform2DFunctor::m_transformMatrix)
-                    ->Field("transformMatrixInverse", &Transform2DFunctor::m_transformMatrixInverse)
+                    ->Field("transformMatrixRow0", &Transform2DFunctor::m_transformMatrixRow0)
+                    ->Field("transformMatrixRow1", &Transform2DFunctor::m_transformMatrixRow1)
+                    ->Field("transformMatrixRow2", &Transform2DFunctor::m_transformMatrixRow2)
+                    ->Field("transformMatrixInverseRow0", &Transform2DFunctor::m_transformMatrixInverseRow0)
+                    ->Field("transformMatrixInverseRow1", &Transform2DFunctor::m_transformMatrixInverseRow1)
+                    ->Field("transformMatrixInverseRow2", &Transform2DFunctor::m_transformMatrixInverseRow2)
                     ;
             }
         }
@@ -55,36 +59,49 @@ namespace AZ
 
             Matrix3x3 transform = CreateUvTransformMatrix(desc, m_transformOrder);
 
-            context.GetMaterialShaderParameter()->SetParameter(m_transformMatrix, transform);
-            if (m_transformMatrixInverse.GetIndex().IsValid())
+            // Store each matrix as 3 separate row_major float4s (w=0) to avoid the Vulkan structured buffer bug with float3x3.
+            auto SetMatrixRows = [&context](
+                MaterialShaderParameterNameIndex& row0,
+                MaterialShaderParameterNameIndex& row1,
+                MaterialShaderParameterNameIndex& row2,
+                const Matrix3x3& mat)
             {
-                context.GetMaterialShaderParameter()->SetParameter(m_transformMatrixInverse, transform.GetInverseFull());
+                context.GetMaterialShaderParameter()->SetParameter(row0, Vector4(mat.GetRow(0), 0.0f));
+                context.GetMaterialShaderParameter()->SetParameter(row1, Vector4(mat.GetRow(1), 0.0f));
+                context.GetMaterialShaderParameter()->SetParameter(row2, Vector4(mat.GetRow(2), 0.0f));
+            };
+
+            SetMatrixRows(m_transformMatrixRow0, m_transformMatrixRow1, m_transformMatrixRow2, transform);
+            if (m_transformMatrixInverseRow0.GetIndex().IsValid())
+            {
+                SetMatrixRows(m_transformMatrixInverseRow0, m_transformMatrixInverseRow1, m_transformMatrixInverseRow2, transform.GetInverseFull());
             }
         }
 
         bool Transform2DFunctor::UpdateShaderParameterConnections(const RPI::MaterialShaderParameterLayout* layout)
         {
             bool valid = true;
-            if (m_transformMatrix.ValidateOrFindIndex(layout) == false)
+            auto ValidateRow = [&](RPI::MaterialShaderParameterNameIndex& idx) -> bool
             {
-                AZ_Error(
-                    "Transform2DFunctorSourceData", false, "Could not find shader parameter '%s'", m_transformMatrix.GetName().GetCStr());
-                valid &= false;
-            }
-
-            // There are some cases where the matrix is required but the inverse is not, and the shader parameters only have the regular
-            // matrix.
-            if (!m_transformMatrixInverse.GetName().IsEmpty())
-            {
-                if (m_transformMatrixInverse.ValidateOrFindIndex(layout) == false)
+                if (idx.ValidateOrFindIndex(layout) == false)
                 {
-                    AZ_Error(
-                        "Transform2DFunctorSourceData",
-                        false,
-                        "Could not find shader parameter '%s'",
-                        m_transformMatrixInverse.GetName().GetCStr());
-                    valid &= false;
+                    AZ_Error("Transform2DFunctorSourceData", false, "Could not find shader parameter '%s'", idx.GetName().GetCStr());
+                    valid = false;
+                    return false;
                 }
+                return true;
+            };
+
+            ValidateRow(m_transformMatrixRow0);
+            ValidateRow(m_transformMatrixRow1);
+            ValidateRow(m_transformMatrixRow2);
+
+            // There are some cases where the matrix is required but the inverse is not.
+            if (!m_transformMatrixInverseRow0.GetName().IsEmpty())
+            {
+                ValidateRow(m_transformMatrixInverseRow0);
+                ValidateRow(m_transformMatrixInverseRow1);
+                ValidateRow(m_transformMatrixInverseRow2);
             }
             return valid;
         }

--- a/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctor.h
@@ -45,8 +45,13 @@ namespace AZ
             RPI::MaterialPropertyIndex m_rotateDegrees; //!< index of material property for rotating
 
             // Shader setting output...
-            RPI::MaterialShaderParameterNameIndex m_transformMatrix; //!< the index of a float3x3 shader input
-            RPI::MaterialShaderParameterNameIndex m_transformMatrixInverse; //!< the index of the inverse float3x3 shader input
+            // Each matrix is stored as 3 separate row_major float4 rows to work around a Vulkan structured buffer bug with float3x3.
+            RPI::MaterialShaderParameterNameIndex m_transformMatrixRow0; //!< Row 0 of the UV transform matrix (float4, w unused)
+            RPI::MaterialShaderParameterNameIndex m_transformMatrixRow1; //!< Row 1 of the UV transform matrix (float4, w unused)
+            RPI::MaterialShaderParameterNameIndex m_transformMatrixRow2; //!< Row 2 of the UV transform matrix (float4, w unused)
+            RPI::MaterialShaderParameterNameIndex m_transformMatrixInverseRow0; //!< Row 0 of the inverse UV transform matrix (float4, w unused)
+            RPI::MaterialShaderParameterNameIndex m_transformMatrixInverseRow1; //!< Row 1 of the inverse UV transform matrix (float4, w unused)
+            RPI::MaterialShaderParameterNameIndex m_transformMatrixInverseRow2; //!< Row 2 of the inverse UV transform matrix (float4, w unused)
         };
 
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctorSourceData.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctorSourceData.cpp
@@ -20,7 +20,7 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<Transform2DFunctorSourceData, RPI::MaterialFunctorSourceData>()
-                    ->Version(4) // added base class
+                    ->Version(4)
                     ->Field("transformOrder", &Transform2DFunctorSourceData::m_transformOrder)
                     ->Field("centerProperty", &Transform2DFunctorSourceData::m_center)
                     ->Field("scaleProperty", &Transform2DFunctorSourceData::m_scale)
@@ -62,10 +62,28 @@ namespace AZ
             AddMaterialPropertyDependency(functor, functor->m_translateY);
             AddMaterialPropertyDependency(functor, functor->m_rotateDegrees);
 
-            functor->m_transformMatrix = MaterialShaderParameterNameIndex{ m_transformMatrix, context.GetNameContext() };
+            // Derive Row1/Row2 names by replacing the trailing "Row0" suffix on the Row0 base name.
+            auto MakeRowName = [](const AZStd::string& row0Name, int row) -> AZStd::string
+            {
+                AZStd::string result = row0Name;
+                const AZStd::string suffix0 = "Row0";
+                auto pos = result.rfind(suffix0);
+                if (pos != AZStd::string::npos)
+                {
+                    result.replace(pos, suffix0.size(), AZStd::string::format("Row%d", row));
+                }
+                return result;
+            };
+
+            functor->m_transformMatrixRow0 = MaterialShaderParameterNameIndex{ m_transformMatrix, context.GetNameContext() };
+            functor->m_transformMatrixRow1 = MaterialShaderParameterNameIndex{ MakeRowName(m_transformMatrix, 1), context.GetNameContext() };
+            functor->m_transformMatrixRow2 = MaterialShaderParameterNameIndex{ MakeRowName(m_transformMatrix, 2), context.GetNameContext() };
+
             if (m_transformMatrixInverse.empty() == false)
             {
-                functor->m_transformMatrixInverse = MaterialShaderParameterNameIndex{ m_transformMatrixInverse, context.GetNameContext() };
+                functor->m_transformMatrixInverseRow0 = MaterialShaderParameterNameIndex{ m_transformMatrixInverse, context.GetNameContext() };
+                functor->m_transformMatrixInverseRow1 = MaterialShaderParameterNameIndex{ MakeRowName(m_transformMatrixInverse, 1), context.GetNameContext() };
+                functor->m_transformMatrixInverseRow2 = MaterialShaderParameterNameIndex{ MakeRowName(m_transformMatrixInverse, 2), context.GetNameContext() };
             }
             functor->m_transformOrder = m_transformOrder;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctorSourceData.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/Transform2DFunctorSourceData.h
@@ -44,8 +44,10 @@ namespace AZ
             AZStd::string m_rotateDegrees; //!< material property for rotating
 
             // Shader setting outputs...
-            AZStd::string m_transformMatrix;          //!< name of a float3x3 shader input
-            AZStd::string m_transformMatrixInverse;   //!< name of the inverse float3x3 shader input
+            // The base name (e.g. "m_uvMatrixRow0") for the three row_major float4 rows of the transform matrix.
+            // Row1 and Row2 are derived by replacing the trailing "Row0" suffix with "Row1" / "Row2".
+            AZStd::string m_transformMatrix;          //!< base name (Row0) of the UV transform matrix rows
+            AZStd::string m_transformMatrixInverse;   //!< base name (Row0) of the inverse UV transform matrix rows
         };
 
     } // namespace Render

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialTypeAsset.h
@@ -216,7 +216,10 @@ namespace AZ
             //! Contains actions to perform for each material update version.
             MaterialVersionUpdates m_materialVersionUpdates;
 
-            //! Describes the layout of the MaterialParameter - struct
+            //! Describes the layout of the MaterialParameter - struct.
+            //! CAUTION: Do NOT add AZ::Matrix3x3, AZ::Matrix3x4, or AZ::Matrix4x4 parameters via this layout until the
+            //! Vulkan/row_major structured buffer bug is resolved. Store matrices as separate row_major float4 rows instead.
+            //! See MaterialShaderParameterLayout.cpp for details and UvPropertyGroup.json for a worked example.
             MaterialShaderParameterLayout m_materialShaderParameterLayout;
 
             bool m_isNonSerializedDataInitialized = false;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialShaderParameterLayout.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialShaderParameterLayout.cpp
@@ -53,6 +53,9 @@ namespace AZ::RPI
         template<> struct StructuredBufferTypeSize<bool> { static const size_t value = sizeof(int32_t); };
         template<> struct GpuTypeName<bool> { static constexpr const char* value = "bool"; };
         
+        // CAUTION: float3x3 (and other matrices) have a known Vulkan/row_major bug when used inside structured buffers
+        // (ByteAddressBuffer / MaterialParameters struct). Avoid adding new float3x3 or float3x4 shader parameters until
+        // this is resolved. Prefer storing matrices as 3-4 explicit row_major float4 rows and performing mul() manually.
         template<> struct StructuredBufferTypeSize<AZ::Matrix3x3> { static const size_t value = sizeof(float) * AZ::Matrix3x3::RowCount * AZ::Matrix3x3::ColCount; };
         template<> struct GpuTypeName<AZ::Matrix3x3> { static constexpr const char* value = "float3x3"; };
         
@@ -132,12 +135,11 @@ namespace AZ::RPI
     {
         AZStd::string typeName{ GpuTypeName<T>::value };
         // Hack: AZSL complains about the layout of variables following a float3x3. So add a float4 as padding
-        if (!m_descriptors.empty() && m_descriptors.back().m_typeName == "float3x3" && typeName != "float3x3" &&
-            !name.starts_with("m_pad_matrix"))
-        {
-            AddMaterialParameter<Vector4>(AZStd::string::format("m_pad_matrix_%d", m_matrixPaddingIndex++), true);
-        }
-
+    if (!m_descriptors.empty() && m_descriptors.back().m_typeName == "float3x3" && typeName != "float3x3" &&
+        !name.starts_with("m_pad_matrix"))
+    {
+        AddMaterialParameter<Vector4>(AZStd::string::format("m_pad_matrix_%d", m_matrixPaddingIndex++), true);
+    }
         MaterialShaderParameterLayout::Index parameterIndex{ GetParameterIndex(name) };
         if (!parameterIndex.IsValid())
         {

--- a/Gems/OpenParticleSystem/Assets/Materials/OpenParticle/Types/MaterialInputs/UvPropertyGroup.json
+++ b/Gems/OpenParticleSystem/Assets/Materials/OpenParticle/Types/MaterialInputs/UvPropertyGroup.json
@@ -77,16 +77,32 @@
                 "translateXProperty": "offsetU",
                 "translateYProperty": "offsetV",
                 "rotateDegreesProperty": "rotateDegrees",
-                "float3x3ShaderInput": "m_uvMatrix",
-                "float3x3InverseShaderInput": "m_uvMatrixInverse",
+                "float3x3ShaderInput": "m_uvMatrixRow0",
+                "float3x3InverseShaderInput": "m_uvMatrixInverseRow0",
                 "shaderParameters": [
                     {
-                        "name": "m_uvMatrix",
-                        "type": "float3x3"
+                        "name": "m_uvMatrixRow0",
+                        "type": "float4"
                     },
                     {
-                        "name": "m_uvMatrixInverse",
-                        "type": "float3x3"
+                        "name": "m_uvMatrixRow1",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixRow2",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixInverseRow0",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixInverseRow1",
+                        "type": "float4"
+                    },
+                    {
+                        "name": "m_uvMatrixInverseRow2",
+                        "type": "float4"
                     }
                 ]
             }

--- a/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/ParticleMesh.azsl
+++ b/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/ParticleMesh.azsl
@@ -83,7 +83,7 @@ struct VSOutput
 
 void TransformUvs(in float2 IN[UvSetCount], out float2 OUT[UvSetCount])
 {
-    OUT[0] = mul(GetMaterialParameters().m_uvMatrix, float3(IN[0], 1.0)).xy;
+    OUT[0] = MulUvMatrix(GetMaterialParameters(), IN[0]);
     OUT[1] = IN[1];
 }
 

--- a/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/ParticleMeshMaterialEval.azsli
+++ b/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/ParticleMeshMaterialEval.azsli
@@ -18,7 +18,7 @@ void EvaluateStandardSurface(
     // ------- Normal -------
 
     float2 normalUv = uv[params.m_normalMapUvIndex];
-    float3x3 uvMatrix = params.m_normalMapUvIndex == 0 ? params.m_uvMatrix : CreateIdentity3x3(); // By design, only UV0 is allowed to apply transforms.
+    float3x3 uvMatrix = params.m_normalMapUvIndex == 0 ? GetUvMatrix(params) : CreateIdentity3x3(); // By design, only UV0 is allowed to apply transforms.
     // custom uv derivatives not used, pass a default value
     float4 defaultUvDxDy = float4(0.0f, 0.0f, 0.0f, 0.0f);
     surface.normal = GetNormalInputWS(GetMaterialTexture(params.m_normalMap), GetMaterialTextureSampler(), normalUv, params.m_flipNormalX, params.m_flipNormalY, isFrontFace, vertexNormal,
@@ -65,7 +65,7 @@ void EvaluateStandardSurface(
     {
         if(o_clearCoat_enabled)
         {
-            float3x3 uvMatrix = params.m_clearCoatNormalMapUvIndex == 0 ? params.m_uvMatrix : CreateIdentity3x3();
+            float3x3 uvMatrix = params.m_clearCoatNormalMapUvIndex == 0 ? GetUvMatrix(params) : CreateIdentity3x3();
             GetClearCoatInputs(GetMaterialTexture(params.m_clearCoatInfluenceMap), uv[params.m_clearCoatInfluenceMapUvIndex], params.m_clearCoatFactor, o_clearCoat_factor_useTexture,
                                GetMaterialTexture(params.m_clearCoatRoughnessMap), uv[params.m_clearCoatRoughnessMapUvIndex], params.m_clearCoatRoughness, o_clearCoat_roughness_useTexture,
                                GetMaterialTexture(params.m_clearCoatNormalMap),    uv[params.m_clearCoatNormalMapUvIndex], vertexNormal, o_clearCoat_normal_useTexture, params.m_clearCoatNormalStrength,

--- a/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/ParticleMeshMaterialParameters.azsli
+++ b/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/ParticleMeshMaterialParameters.azsli
@@ -56,6 +56,35 @@ struct MaterialParameters {
     float    m_opacityFactor;
     float    m_opacityAffectsSpecularFactor;
     float    m_emissiveIntensity;
-    float3x3 m_uvMatrix;
-    float3x3 m_uvMatrixInverse;
+    // NOTE: float3x3 is NOT used here due to a Vulkan/row_major bug with matrices inside structured buffers (ByteAddressBuffer).
+    // Instead, each matrix is stored as 3 explicit row_major float4 rows (w component unused).
+    // Use MulUvMatrix(params, uv) / MulUvMatrixInverse(params, uv) instead of direct mul().
+    float4 m_uvMatrixRow0;
+    float4 m_uvMatrixRow1;
+    float4 m_uvMatrixRow2;
+    float4 m_uvMatrixInverseRow0;
+    float4 m_uvMatrixInverseRow1;
+    float4 m_uvMatrixInverseRow2;
 };
+
+float3x3 GetUvMatrix(MaterialParameters params)
+{
+    return float3x3(params.m_uvMatrixRow0.xyz, params.m_uvMatrixRow1.xyz, params.m_uvMatrixRow2.xyz);
+}
+
+float3x3 GetUvMatrixInverse(MaterialParameters params)
+{
+    return float3x3(params.m_uvMatrixInverseRow0.xyz, params.m_uvMatrixInverseRow1.xyz, params.m_uvMatrixInverseRow2.xyz);
+}
+
+float2 MulUvMatrix(MaterialParameters params, float2 uv)
+{
+    float3 uvh = float3(uv, 1.0);
+    return float3(dot(params.m_uvMatrixRow0.xyz, uvh), dot(params.m_uvMatrixRow1.xyz, uvh), dot(params.m_uvMatrixRow2.xyz, uvh)).xy;
+}
+
+float2 MulUvMatrixInverse(MaterialParameters params, float2 uv)
+{
+    float3 uvh = float3(uv, 1.0);
+    return float3(dot(params.m_uvMatrixInverseRow0.xyz, uvh), dot(params.m_uvMatrixInverseRow1.xyz, uvh), dot(params.m_uvMatrixInverseRow2.xyz, uvh)).xy;
+}

--- a/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/StandardpbrParameters.azsli
+++ b/Gems/OpenParticleSystem/Assets/Shaders/OpenParticle/StandardpbrParameters.azsli
@@ -54,7 +54,14 @@ struct MaterialParameters {
     float    m_opacityFactor;
     float    m_opacityAffectsSpecularFactor;
     float    m_emissiveIntensity;
-    float3x3 m_uvMatrix;
-    float3x3 m_uvMatrixInverse;
+    // NOTE: float3x3 is NOT used here due to a Vulkan/row_major bug with matrices inside structured buffers (ByteAddressBuffer).
+    // Instead, each matrix is stored as 3 explicit row_major float4 rows (w component unused).
+    // Use MulUvMatrix(params, uv) / MulUvMatrixInverse(params, uv) instead of direct mul().
+    float4 m_uvMatrixRow0;
+    float4 m_uvMatrixRow1;
+    float4 m_uvMatrixRow2;
+    float4 m_uvMatrixInverseRow0;
+    float4 m_uvMatrixInverseRow1;
+    float4 m_uvMatrixInverseRow2;
 }; 
 


### PR DESCRIPTION
## What does this PR do?
Cherry-picks the fix for UV offset/transforms from `development` to `stabilization`

## How was this PR tested?

Basic testing - on windows, creating and modifying materials with uv changes, works as before.

Note that the original PR was https://github.com/o3de/o3de/pull/19725, contributed by @Styx-Hc 
Other members have tested the `development` version of this fix on Linux, Ubuntu

There were no merges or conflicts, it applied cleanly.