### PR TITLE
Restore AssetProcessor Assets tab search field

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeFilterModel.cpp
@@ -24,7 +24,7 @@ namespace AssetProcessor
     {
         // If the search was changed, clear the asset that had visibility forced.
         m_pathToForceVisibleAsset.clear();
-        setFilterRegExp(newFilter);
+        setFilterRegularExpression(newFilter);
         setFilterCaseSensitivity(Qt::CaseInsensitive);
         invalidateFilter();
     }


### PR DESCRIPTION
## What does this PR do?

`FilterChanged()` still called the legacy `setFilterRegExp(QString)`, while `filterAcceptsRow()` reads `filterRegularExpression()` after the qt6 cherry-pick in #19282. 
The two setters write to independent slots in `QSortFilterProxyModel`, so the typed pattern never reached the reader and every row was accepted making the search fields appear inert.

<img width="812" height="367" alt="image" src="https://github.com/user-attachments/assets/6e45c369-3d45-4c5e-866a-565201ac155a" />

This fixes #19775 

The fix is already present in https://github.com/o3de/o3de/pull/19567 targeting development

## How was this PR tested?

Re-run `AssetProcessor` with the fix and confirmed filter applies now.
