### PR TITLE
Fixes MSVC compilation in MSVC toolchain 14.50

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Compat/VSCompat.h
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Compat/VSCompat.h
@@ -21,12 +21,12 @@
 // Section 1:  remove when we are on Qt6 exclusively
 // ----------------------------------------------------
 // QT5 unconditionally uses the (removed) stdext::make_checked_array_iterator
-#if defined(__cplusplus) && _MSC_VER >= 1938  // stdext is deprecated since VS 2022 17.8
+#if defined(__cplusplus) && _MSC_VER >= 1951  // stdext::make_checked_array_iterator was removed toolchain 14.51 (mscver 1951)
 namespace stdext
 {
     template<class _Ptr>
     [[nodiscard]]
-    constexpr _Ptr make_checked_array_iterator(_Ptr x, [[maybe_unused]] size_t size, [[maybe_unused]] size_t z = 0) noexcept
+    constexpr _Ptr make_checked_array_iterator(const _Ptr x, [[maybe_unused]] const size_t size, [[maybe_unused]] const size_t z = 0) noexcept
     {
         return x;
     }


### PR DESCRIPTION
## What does this PR do?

It turns out that microsoft's toolchain 14.50 still had the stdext::make_checked_array_iterator function, and it was removed in 14.51.

This causes a compiler in VS 2026 until you update to latest.

This change makes it so that it only uses the
patch to provide a dummy implementation of
make_checked_array_iterator if the toolchain is
14.51 or later.

## How was this PR tested?

Compile with VS 2022 Toolchain 14.3x
Compile with VS 2026 Toolchain 14.50 (original VS2026)
Compile with VS 2026 Toolchain 14.51 (updated may 2026), this is latest.

Affects only windows.

