### PR TITLE
Update engine.json version to 2.6.0 for the 26.05 release

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -3,7 +3,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "4.2.0",
+    "version": "2.6.0",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.2.1",


### PR DESCRIPTION
## What does this PR do?

Bumps the engine version for the 26.05 release. Note the last released version was `2.5.2`

NOTE: Do not cherry pick this into the development branch, This is for mainline only

## How was this PR tested?

Will be testing in the installer build and fork branch
