### PR TITLE
 Update splashscreen for 26.05.0 release

### DIFF
--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9231fddff1e84a49faf8e4a002ce95cdf00222d97b55c46b2f35589da957e80a
-size 2177025
+oid sha256:92290da114ef3cccd5c8afad1bc0de4b9060a522b08b4218e4d211d2793ecd8c
+size 1708521

--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39c933de9edf7d666ee7a59e28dc636b738594787a8e19fab561aece303915d4
-size 2968529
+oid sha256:e110285cab49c85ad2d2b433b9b99312ad284f8f65e5cc38391903cd1facffba
+size 2386778

--- a/Code/Editor/splashscreen_background.png
+++ b/Code/Editor/splashscreen_background.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e110285cab49c85ad2d2b433b9b99312ad284f8f65e5cc38391903cd1facffba
-size 2386778
+oid sha256:9231fddff1e84a49faf8e4a002ce95cdf00222d97b55c46b2f35589da957e80a
+size 2177025


### PR DESCRIPTION
## What does this PR do?

Updates the splash screen for 26.05.0 (see below)

<img width="2788" height="1530" alt="splashscreen_background" src="https://github.com/user-attachments/assets/86c1c235-a968-4cdc-bd31-a05d899eeca2" />

## How was this PR tested?

Will be building the binary in a separate fork, then validating it. It will be available at 

https://o3debinaries.org/new-splashscreen-26050/Latest/Windows/o3de_installer.exe
https://o3debinaries.org/new-splashscreen-26050/Latest/Linux/o3de_latest.deb