### PR TITLE
Set engine.json->version 4.2.0->2.7.0

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -1,7 +1,5 @@
 {
     "engine_name": "o3de",
-    "O3DEVersion": "0.1.0.0",
-    "O3DEBuildNumber": 0,
     "display_version": "00.00",
     "version": "2.7.0",
     "api_versions": {

--- a/engine.json
+++ b/engine.json
@@ -3,7 +3,7 @@
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,
     "display_version": "00.00",
-    "version": "4.2.0",
+    "version": "2.7.0",
     "api_versions": {
         "editor": "1.0.0",
         "framework": "1.2.1",


### PR DESCRIPTION
## What does this PR do?

This PR set's the `engine.json` -> `version` tag to `2.7.0`, as discussed in https://discordapp.com/channels/805939474655346758/1477717691740459161
Some additional discussions are available in Github RFC: https://github.com/o3de/sig-release/pull/354

The problem I see is that we regress the version from `4.2.0` to `2.7.0`, which happened already in the history of O3DE and it was questioned by the users: https://github.com/o3de/o3de/pull/17903

When changing the version number I also decided to remove [deprecated](https://docs.o3de.org/docs/contributing/release-versioning-and-terms/) data:
```
    "O3DEVersion": "0.1.0.0",
    "O3DEBuildNumber": 0,
```

and I would like to highlight we did not update `display_version": "00.00",` for the last release.

## How was this PR tested?

No need to test the version change.