### PR TITLE
Material Component Binding-by-label Variable parameter & solver.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentConfig.h
@@ -28,6 +28,13 @@ namespace AZ
             static void Reflect(ReflectContext* context);
 
             MaterialAssignmentMap m_materials;
+
+            //! Pending material overrides keyed by slot display label. Resolved to entries in m_materials
+            //! once the associated model is ready and labels are queryable. Survives mesh swaps so the
+            //! same authored override re-binds against a new model that exposes a slot with the same label.
+            //! Use case: prefab authoring pipelines that do not have access to SceneAPI MaterialUid
+            //! stable IDs at generation time can write by-label entries and let the runtime bind them.
+            AZStd::unordered_map<AZStd::string, MaterialAssignment> m_materialsByLabel;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentConfig.cpp
@@ -63,8 +63,9 @@ namespace AZ
                 serializeContext->RegisterGenericType<DeprecatedMaterialAssignmentMap>();
 
                 serializeContext->Class<MaterialComponentConfig, ComponentConfig>()
-                    ->Version(3, MaterialComponentConfigVersionConverter)
+                    ->Version(4, MaterialComponentConfigVersionConverter)
                     ->Field("materials", &MaterialComponentConfig::m_materials)
+                    ->Field("materialsByLabel", &MaterialComponentConfig::m_materialsByLabel)
                     ;
             }
 
@@ -77,6 +78,7 @@ namespace AZ
                     ->Constructor()
                     ->Constructor<const MaterialComponentConfig&>()
                     ->Property("materials", BehaviorValueProperty(&MaterialComponentConfig::m_materials))
+                    ->Property("materialsByLabel", BehaviorValueProperty(&MaterialComponentConfig::m_materialsByLabel))
                     ;
             }
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -260,6 +260,11 @@ namespace AZ
             MaterialConsumerRequestBus::EventResult(
                 m_defaultMaterialMap, m_entityId, &MaterialConsumerRequestBus::Events::GetDefaultMaterialMap);
 
+            // Resolve any by-label overrides against the now-known slot labels. By-label entries are kept
+            // intact so they survive future mesh swaps; they are projected into m_materials as side data.
+            // Explicit m_materials entries always win when both exist for the same slot.
+            ResolveMaterialsByLabel();
+
             // Build tables of all referenced materials so that we can load and look up defaults
             for (const auto& [materialAssignmentId, materialAssignment] : m_defaultMaterialMap)
             {
@@ -301,6 +306,50 @@ namespace AZ
             if (!anyQueued)
             {
                 QueueMaterialsUpdatedNotification();
+            }
+        }
+
+        void MaterialComponentController::ResolveMaterialsByLabel()
+        {
+            if (m_configuration.m_materialsByLabel.empty())
+            {
+                return;
+            }
+
+            // Pull the current label set from the associated material consumer (typically the MeshComponent).
+            // If the model has not yet been loaded, the returned map contains only the default-slot label
+            // and no resolution will succeed this pass; the by-label entries remain pending.
+            MaterialAssignmentLabelMap labels;
+            MaterialConsumerRequestBus::EventResult(
+                labels, m_entityId, &MaterialConsumerRequestBus::Events::GetMaterialLabels);
+
+            // Build a lookup from label string to the general (non-LOD) slot id. By-label overrides apply
+            // to every LOD with a matching label, so only IsSlotIdOnly() ids are valid targets.
+            AZStd::unordered_map<AZStd::string, MaterialAssignmentId> labelToGeneralId;
+            labelToGeneralId.reserve(labels.size());
+            for (const auto& [id, label] : labels)
+            {
+                if (id.IsSlotIdOnly())
+                {
+                    labelToGeneralId[label] = id;
+                }
+            }
+
+            // Project each resolvable by-label entry into m_materials. Explicit m_materials entries are not
+            // overwritten so that hand-authored or upstream-imported keyed overrides always win.
+            for (const auto& [label, assignment] : m_configuration.m_materialsByLabel)
+            {
+                const auto labelIt = labelToGeneralId.find(label);
+                if (labelIt == labelToGeneralId.end())
+                {
+                    continue;
+                }
+
+                const MaterialAssignmentId& resolvedId = labelIt->second;
+                if (m_configuration.m_materials.find(resolvedId) == m_configuration.m_materials.end())
+                {
+                    m_configuration.m_materials[resolvedId] = assignment;
+                }
             }
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -99,6 +99,11 @@ namespace AZ
             void OnSystemTick() override;
 
             void LoadMaterials();
+            //! Project entries from m_configuration.m_materialsByLabel into m_configuration.m_materials by
+            //! resolving each label string against the live material consumer's slot labels. Called from
+            //! LoadMaterials() once m_defaultMaterialMap has been refreshed. Non-destructive: entries in
+            //! m_materialsByLabel are kept so the mapping re-resolves after future mesh swaps.
+            void ResolveMaterialsByLabel();
             // Typically called from thread context of Data::AssetBus::MultiHandler::OnAssetXXX.
             void InitializeMaterialInstance(Data::Asset<Data::AssetData> asset);
             // Must be called on main thread.


### PR DESCRIPTION
## What does this PR do?

This PR adds a secondary variable list for materials, identified by the label of the mesh's material list.

This is to enable generative prefabs that, when being first processed and loaded, can bind materials to it's material component slots.

This allows https://github.com/GenomeStudios/Unity_to_O3DE_Converter/ to create a fully configured prefab set complete with components, overrides, meshes, materials, colliders, rigidbodies, and lights.

## How was this PR tested?

Using the converter, prefabs are successfully loading with both their default material, as well as multiple materials in its material slot list.

[Demo Video of Converter Running](https://youtu.be/amyFFLV5Dck)

## Additional Notes

This utility proves out a robust range of benefits that this PR can empower:
- While the converter sources it's configuration data from Unity assets, a user interface can be made with the same genertive components to create o3de content from scratch, like rapidly building prefabs from amalgamations of meshes materials components and entities.
- The converter is multi-platform now, which enables unity and unreal and things, but that also means Lumberyard could be created as a conversion platform, which would allow us to actually mass process the open sourced assets now.


## Generated Explanation of Changes
Material Component: by-label override resolution

Add MaterialComponentConfig::m_materialsByLabel as a sidecar map for material overrides keyed by slot display label, resolved against the mesh's live slot labels in LoadMaterials(). Lets prefab authoring pipelines that lack SceneAPI MaterialUid stable IDs at generation time write overrides by name and have the controller bind them once the mesh is ready. Resolution is non-destructive: by-label entries stay intact so they rebind across mesh swaps. Explicit m_materials entries take precedence when both exist for the same slot.

- MaterialComponentConfig: bumped serialize version 3 -> 4, reflected new field on both SerializeContext and BehaviorContext. New field defaults to empty for pre-v4 data; no version converter needed.
- MaterialComponentController: added ResolveMaterialsByLabel() called from LoadMaterials() after m_defaultMaterialMap is refreshed.

Fixes the case where converter-generated prefabs lose non-default material overrides on first activation because the synthetic stable IDs they emit (materials.{0}, materials.{1}, ...) never match the SceneAPI-derived stable IDs the model actually exposes.

AI Assisted - Claude Code: Opus 4.7