### PR TITLE
Drop deprecated tkinter.tix from the project export settings UI

### DIFF
--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -27,23 +27,6 @@ try:
 except:
     tkinter_installed = False
 
-# Check if tix is installed or not
-tkinter_tix_installed = True
-try:
-    # `tix` won't be detected with a simple import, it won't raise an exception until
-    # tk attempts to create an object
-    import tkinter.tix as tkp
-
-    class CheckTix(tkp.Tk):
-
-        def __init__(self):
-            super().__init__()
-
-    CheckTix().destroy()
-
-except Exception as e:
-    tkinter_tix_installed = False
-
 from typing import List
 from enum import IntEnum
 
@@ -415,17 +398,14 @@ def _run_export_script(args: argparse, passthru_args: list) -> int:
         export_script = args.export_script
     
     if args.configure:
-        if tkinter_installed and tkinter_tix_installed:
+        if tkinter_installed:
             export_config = get_export_project_config(args.project_path)
             project_info = manifest.get_project_json_data(project_path=args.project_path)
             is_o3de_sdk = project_info.get('engine') == 'o3de-sdk'
             export_project_ui.MainWindow(export_config, is_o3de_sdk).configure_settings()
             return 0
         else:
-            if not tkinter_installed:
-                print("Unable to open the configure window. Required package 'tk' is not installed on this system.")
-            else:
-                print("Unable to open the configure window. Required package 'tix' is not installed on this system.")
+            print("Unable to open the configure window. Required package 'tk' is not installed on this system.")
             return 1
     
     return _export_script(export_script, args.project_path, passthru_args)

--- a/scripts/o3de/o3de/ui/export_project.py
+++ b/scripts/o3de/o3de/ui/export_project.py
@@ -6,7 +6,6 @@
 #
 
 import tkinter as tk
-import tkinter.tix as tkp
 from tkinter import ttk, filedialog, messagebox
 
 import os
@@ -20,7 +19,54 @@ EXPORT_SCRIPTS_PATH = pathlib.Path(__file__).parent.parent.parent / 'ExportScrip
 assert EXPORT_SCRIPTS_PATH.is_dir(), "Missing expected ExportScripts path"
 
 
-class MainWindow(tkp.Tk):
+class _ToolTip:
+    """Lightweight hover tooltip built on standard tkinter.
+
+    Provides the small subset of the tkinter.tix Balloon API this window
+    relies on (bind_widget(widget, balloonmsg=...)) so the export settings
+    UI no longer depends on tkinter.tix, which the Python standard library
+    has deprecated in favor of tkinter.ttk.
+    """
+
+    def __init__(self, master, delay_ms=600):
+        self._master = master
+        self._delay_ms = delay_ms
+        self._after_id = None
+        self._tip_window = None
+
+    def bind_widget(self, widget, balloonmsg='', **_kwargs):
+        widget.bind('<Enter>', lambda event: self._schedule(widget, balloonmsg), add='+')
+        widget.bind('<Leave>', lambda event: self._hide(), add='+')
+        widget.bind('<ButtonPress>', lambda event: self._hide(), add='+')
+
+    def _schedule(self, widget, message):
+        self._unschedule()
+        if message:
+            self._after_id = self._master.after(self._delay_ms, lambda: self._show(widget, message))
+
+    def _unschedule(self):
+        if self._after_id is not None:
+            self._master.after_cancel(self._after_id)
+            self._after_id = None
+
+    def _show(self, widget, message):
+        self._hide()
+        x = widget.winfo_rootx() + 20
+        y = widget.winfo_rooty() + widget.winfo_height() + 2
+        self._tip_window = tk.Toplevel(widget)
+        self._tip_window.wm_overrideredirect(True)
+        self._tip_window.wm_geometry(f'+{x}+{y}')
+        label = ttk.Label(self._tip_window, text=message, relief='solid', borderwidth=1, padding=(4, 2))
+        label.pack()
+
+    def _hide(self):
+        self._unschedule()
+        if self._tip_window is not None:
+            self._tip_window.destroy()
+            self._tip_window = None
+
+
+class MainWindow(tk.Tk):
     """
     Main Widget to manage the settings for Project Export based on an export config
     """
@@ -56,7 +102,7 @@ class MainWindow(tkp.Tk):
         self.main_frame = tk.Frame(self)
         self.main_frame.columnconfigure(0, weight=1)
         self.main_frame.grid(sticky=tk.NSEW)
-        self.tool_tip = tkp.Balloon(self.main_frame)
+        self.tool_tip = _ToolTip(self.main_frame)
 
         if not self.is_sdk:
             self.init_source_engine_build_options(self.main_frame)


### PR DESCRIPTION
The **Open Export Settings** window used `tkinter.tix` for its root window and a single `Balloon` tooltip. `tkinter.tix` is deprecated in the Python standard library in favor of `tkinter.ttk`, and it depends on the separate, unmaintained system `tix` package. On a clean Linux install that package is often absent, and even when present the engine's bundled Python may not find it because distributions install Tix outside the bundled Tcl's default search path. Either way **Open Export Settings** fails with:

```
_tkinter.TclError: can't find package Tix
```

## What changed

- **`scripts/o3de/o3de/ui/export_project.py`**: swap the root from `tkinter.tix.Tk` to `tkinter.Tk`, and replace the one Tix `Balloon` with a small standard-tkinter tooltip helper that keeps the same `bind_widget(widget, balloonmsg=...)` signature the call sites already use (no call-site changes). The window was already built with `ttk`.
- **`scripts/o3de/o3de/export_project.py`**: remove the now-unnecessary Tix availability pre-flight check and its "tix is not installed" branch; the configure window now gates only on `tkinter` being importable.

Result: project export settings no longer depends on the `tix` package on any platform.

## How it was tested

Ran the export-settings UI with the engine's bundled Python in the failing condition: no `TCLLIBPATH` set, so a system Tix is unfindable. That is the exact state where the current code throws `can't find package Tix`.

- Current code: fails with `_tkinter.TclError: can't find package Tix`.
- This change: constructs and renders the full window successfully; tooltips display correctly on hover; the existing `ttk` UI is unchanged.

## Compatibility (older and minimal distros)

This change lowers the runtime requirements rather than raising them, so it is safe for older and minimal Linux installs:

- O3DE ships its own Python (currently 3.10) via `get_python.sh`, identical on every platform, so the distribution's system Python version does not factor in here.
- The bundled Python's `_tkinter` already links Tk/Tcl 8.6, and this change keeps that. It removes only the separate `tix` extension, which is the piece most often absent on minimal or older installs.
- The window already used `ttk` (`ttk.Frame`, `ttk.Notebook`). The only widgets this change adds are `tkinter.Tk`, `tkinter.Toplevel`, and `ttk.Label`, all available since Tk 8.5.

Net effect: the export tool works on more systems, not fewer. Verified against the engine's bundled Python (Tk 8.6).

## Related

The missing-Tix failure was reported in #18291 and #18246; #18252 added a clearer message. Addresses #19793.
