### PR TITLE
SamplerState fix

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertyValueSerializer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPropertyValueSerializer.cpp
@@ -104,6 +104,11 @@ namespace AZ
                     resultCode = LoadVariant<Vector2>(*property, Vector2::CreateZero(), inputValue, context);
                 }
 
+                if(resultCode.GetProcessing() != JsonSerializationResult::Processing::Completed)
+                {
+                    resultCode = LoadVariant<RHI::SamplerState>(*property, RHI::SamplerState{}, inputValue, context);
+                }
+
                 if(resultCode.GetProcessing() == JsonSerializationResult::Processing::Completed)
                 {
                     result.Combine(resultCode);
@@ -182,6 +187,10 @@ namespace AZ
             else if (property->Is<AZStd::string>())
             {
                 result.Combine(ContinueStoring(outputValue, &property->GetValue<AZStd::string>(), nullptr, azrtti_typeid<AZStd::string>(), context));
+            }
+            else if (property->Is<RHI::SamplerState>())
+            {
+                result.Combine(ContinueStoring(outputValue, &property->GetValue<RHI::SamplerState>(), nullptr, azrtti_typeid<RHI::SamplerState>(), context));
             }
             else
             {


### PR DESCRIPTION
SamplerState was never actually supported in JsonMaterialPropertyValueSerializer. It was an omission spanning two changes:

Initial commit a10351f38d (March 2021) — The variant type was originally defined (without SamplerState). The early serializer only handled basic types.

Commit 6b8c39e976 (October 2024) by Karl Haubenwallner — "Add MaterialShaderParameter as a layer between MaterialProperties and Srg-Values to place Material Parameters in a Structured Buffer" — This is when RHI::SamplerState was added to the MaterialPropertyValue variant. But the corresponding JsonMaterialPropertyValueSerializer was never updated to handle the new variant member.

So when the variant was expanded in October 2024 to support SamplerState, the JSON serializer was overlooked and it continued to only handle the original types. The JsonMaterialPropertyValueSourceDataSerializer (for .materialtype files) did get SamplerState support, but the runtime .material serializer didn't.

## What does this PR do?
Fixes a bug where .material files with SamplerState properties fail to save and load correctly in Material Editor, producing JSON serialization errors and data loss.

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_

Old behavior: JsonMaterialPropertyValueSerializer did not handle RHI::SamplerState in its Load or Store methods. Saving a material with a SamplerState property (e.g. any material using Eye.materialtype) produced warnings and partially stored the value.


New behavior: SamplerState values serialize and deserialize correctly. Materials with SamplerState properties save without warnings and load with their values intact.

Root cause: When RHI::SamplerState was added to the MaterialPropertyValue variant (commit 6b8c39e976), the corresponding JSON serializer in MaterialPropertyValueSerializer.cpp was not updated. The source data serializer (JsonMaterialPropertyValueSourceDataSerializer) already had support — only the runtime serializer was missing.

Fix details:

Added SamplerState to Store for serialization
Added SamplerState to the object fallback chain in Load

_Please add links to any issues, RFCs or other items that are relevant to this PR._


## How was this PR tested?
Opened Material Editor with a .material using Eye.materialtype (which has a ClampSampler property)
Modified and saved — no more JSON warnings
Closed and reopened — SamplerState values persisted correctly