### PR TITLE
Fix editor crash creating an entity with no level loaded

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceDomGenerator.cpp
@@ -197,8 +197,27 @@ namespace AzToolsFramework
             }
             else
             {
+                // The focused or root instance may not have a registered template yet
+                // during transient states (for example, while generating undo nodes for
+                // an entity created before the level's root prefab template exists). Guard
+                // the lookup so it returns a null DOM instead of asserting and then
+                // dereferencing an empty template reference inside FindTemplateDom. Callers
+                // already tolerate a null output DOM (see
+                // PrefabPublicHandler::GenerateUndoNodesForEntityChangeAndUpdateCache,
+                // which skips when the before-state DOM is not a valid object).
+                const TemplateId focusedOrRootTemplateId = focusedOrRootInstance->GetTemplateId();
+                if (focusedOrRootTemplateId == InvalidTemplateId)
+                {
+                    AZ_Warning(
+                        "Prefab",
+                        false,
+                        "InstanceDomGenerator::GetEntityDomFromTemplate - "
+                        "The focused or root instance has no valid template yet. Output DOM will be null.");
+                    return;
+                }
+
                 // Retrieves the entity DOM from the template of the focused or root instance.
-                const PrefabDom& focusedTemplateDom = m_prefabSystemComponentInterface->FindTemplateDom(focusedOrRootInstance->GetTemplateId());
+                const PrefabDom& focusedTemplateDom = m_prefabSystemComponentInterface->FindTemplateDom(focusedOrRootTemplateId);
                 const PrefabDomValue* entityDomFromTemplate = relativeDomPathFromTopToEntity.Get(focusedTemplateDom);
                 if (!entityDomFromTemplate)
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -745,6 +745,19 @@ namespace AzToolsFramework
         {
             AzFramework::EntityContextId editorEntityContextId = AzToolsFramework::GetEntityContextId();
 
+            // A root prefab (level) must be assigned before entities can be created. During an
+            // async level load the root instance already exists with a container entity but its
+            // template is reset to InvalidTemplateId (see PrefabEditorEntityOwnershipService::Reset),
+            // so the "owning instance exists" check below would pass and undo DOM generation would
+            // then crash in FindTemplateDom. Reject early, mirroring the guard InstantiatePrefab
+            // already uses, so the request fails gracefully instead.
+            auto prefabEditorEntityOwnershipInterface = AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();
+            if (!prefabEditorEntityOwnershipInterface || !prefabEditorEntityOwnershipInterface->IsRootPrefabAssigned())
+            {
+                return AZ::Failure(AZStd::string(
+                    "Cannot add entity because no root prefab is assigned. Entities can only be created inside a loaded level."));
+            }
+
             // If the parent is invalid, parent to the container of the currently focused prefab.
             if (!parentId.IsValid())
             {


### PR DESCRIPTION
## What does this PR do?

Fixes #11832.

Creating an entity while no root prefab (level) is assigned crashes the Editor instead of failing cleanly. As #11832 notes, the normal UI paths for creating an entity are disabled with no level loaded, so this is reached programmatically (a tool or Python), e.g. `CreateNewEntity` / `CreateNewEntityAtPosition`.

`PrefabPublicHandler::CreateEntity`'s only precondition is that the parent's owning instance exists, not that a root prefab is assigned (its sibling `PrefabPublicHandler::InstantiatePrefab` does check `IsRootPrefabAssigned()`). With no root prefab assigned the root instance's template is `InvalidTemplateId`, so on current `development` `CreateEntity` proceeds, opens an undo batch, and undo DOM generation calls `FindTemplateDom(InvalidTemplateId)`, which asserts and then dereferences an empty optional. (The same `FindTemplateDom` assert is in the #11832 report; the intermediate path has shifted since 2022, but the cause is the same.)

- **Old behavior:** the Editor crashes on that `FindTemplateDom` assert; via the Python bus it surfaces as "Failed to construct proxy object".
- **New behavior:** `CreateEntity` returns a failure when no root prefab is assigned, mirroring `InstantiatePrefab`. `CreateNewEntityAtPosition` already turns that failure into a warning, matching the stable-with-a-warning behavior #11832 asks for.

The `CreateEntity` guard alone resolves #11832. As defense in depth (for the other undo paths that reach it), `InstanceDomGenerator::GetEntityDomFromTemplate` also returns a null DOM, which all of its callers already handle, instead of looking up an `InvalidTemplateId`. It can be dropped if a more minimal change is preferred.

This is a robustness fix, not a behavior change: it does not enable creating entities before a level is loaded (still unsupported, same as `InstantiatePrefab`). The caller is still responsible for ensuring a level is loaded; the operation now fails safely instead of crashing.

## How was this PR tested?

- The crash is the one tracked in #11832.
- Built on top of `development` (Linux, clang, profile): `AzToolsFramework.Tests` compiles clean, and the prefab unit tests (`*Prefab*` / `*InstanceDom*`) pass (149), no regression. These fixtures always have a root prefab assigned, so they exercise the guard's pass-through path, not the no-root path.
- Reproduced the no-root path at runtime in the editor (the path the unit tests do not cover): a `--runpython` script calls `CreateNewEntityAtPosition` with no level loaded. A build without this change asserts and crashes in `PrefabSystemComponent::FindTemplateDom` with `TemplateId 18446744073709551615` (`InvalidTemplateId`), matching #11832; a build with this change returns a failure from `CreateEntity` (no entity created) and the editor stays up, no assert. (This runtime check was on a 26.05 build, where the same `CreateEntity` to `FindTemplateDom` path lives; the compile and unit tests are on `development`.)
- A focused positive unit test (asserting `CreateEntity` fails when no root prefab is assigned) would need a synthetic "no root prefab" fixture, since the prefab fixtures always assign one in setup. Happy to add one in whatever form maintainers prefer.
