### PR TITLE
Fix editor crash assigning a Lua script that exposes properties

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
@@ -765,6 +765,18 @@ namespace AzToolsFramework
         {
             LSV_BEGIN(m_scriptComponent.m_context->NativeContext(), 0);
 
+            // Guard against re-entrant loads. When the assigned script asset is
+            // already in memory, QueueLoad can dispatch OnAssetReady synchronously
+            // while a LoadScript is still unwinding, re-entering this routine and
+            // letting two passes run the script and rebuild the property buffers
+            // against the same script context at once, which corrupts memory. The
+            // outer pass completes the load, so the nested call can be skipped.
+            if (m_isLoadingScript)
+            {
+                return;
+            }
+            m_isLoadingScript = true;
+
             // At this point we're loading the script to populate the properties.
             // Disable debugging during this stage as the game is not running yet.
             bool pausedBreakpoints = false;
@@ -820,6 +832,7 @@ namespace AzToolsFramework
             }
 
             m_loadingNewScript = false;
+            m_isLoadingScript = false;
         }
 
         bool ScriptEditorComponent::LoadProperties()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
@@ -110,6 +110,10 @@ namespace AzToolsFramework
 
             AZStd::string m_customName;
             bool m_loadingNewScript = false;
+            // Guards against re-entrant LoadScript (e.g. a synchronous OnAssetReady
+            // dispatched while a load is already in progress), which can corrupt the
+            // shared script context and property buffers.
+            bool m_isLoadingScript = false;
         };
     } // namespace Component
 } // namespace AzToolsFramework


### PR DESCRIPTION
## What does this PR do?

Assigning a Lua Script asset to a Lua Script component (`AzToolsFramework::Components::ScriptEditorComponent`), either in the Inspector or through the editor component API, can intermittently crash the Editor with a segfault, preceded by an "[AssetDatabase] No handler was registered for this asset" error whose logged asset type is a different readable string fragment each time (a buffer being read as a type id).

`ScriptEditorComponent::LoadScript()` is re-entrant by construction: `Activate()` / `ScriptHasChanged()` call `m_scriptAsset.QueueLoad()` and connect `AZ::Data::AssetBus`, and `OnAssetReady()` calls `LoadScript()` again. `LoadScript()` loads the script into the shared `AZ::ScriptContext` and rebuilds the component's property buffers, so a second `LoadScript()` entered before the first returns runs that work twice against the same context. The crash signature above (a wrong asset type read from memory) and the fact that it does not reproduce under a debugger are both consistent with that re-entrancy corrupting shared state. I was not able to capture a stack trace (the crash is timing-sensitive and the debugger perturbs it away), so the precise corruption site is inferred from the signature rather than pinned with a debugger or sanitizer.

- **Old behavior:** an intermittent segfault on script assignment, after the "No handler was registered for this asset" error.
- **New behavior:** a one-shot re-entrancy guard in `LoadScript()` returns early if a load is already in progress, so the routine never runs nested. The change is one bool member plus an early return at the top of `LoadScript()`, cleared at its single exit alongside the existing `m_loadingNewScript = false`.

Re-entering `LoadScript()` is never useful here (it reloads the same asset into the same context), so suppressing the nested call is safe.

## How was this PR tested?

Built `AzToolsFramework` with the guard (Linux, clang, profile) and exercised the repro through the editor: before the change, assigning a Lua script that declares a `Properties` table to a Lua Script component intermittently produced the segfault described above (it did not reproduce under gdb, consistent with the timing); after the change, the same assignments completed without the crash. This is empirical before/after evidence, not a proof that every timing is covered.

Reproduce: add a Lua Script component to an entity and assign a `.luac` whose source has a `Properties` table (for example one with a `SpawnableScriptAssetRef` default), with the asset already in cache. The crash is intermittent; it was most repeatable under `--autotest_mode`.

Caveats: no stack trace or ASan/valgrind pinpoint of the corruption (it evaporates under tooling), so the precise corruption site is inferred. There is no automated regression test in this PR: a faithful one needs a fixture that drives the nested `LoadScript` (the synchronous `OnAssetReady` re-entrancy) inside the unit harness, and I have not yet found a reliable way to drive that re-entry deterministically in `AzToolsFramework.Tests`. Happy to add one in whatever form maintainers prefer, or to pair on the right harness hook.
