### PR TITLE
Fix Linux gamepad support when only the libevdev runtime is installed

### DIFF
--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Input/LibEVDevWrapper.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Input/LibEVDevWrapper.cpp
@@ -13,11 +13,41 @@ namespace AzFramework
 {
     LibEVDevWrapper::LibEVDevWrapper()
     {
-        m_libevdevHandle = AZ::DynamicModuleHandle::Create("libevdev.so");
-        if (!m_libevdevHandle->Load())
+        // Try the unversioned name first (present when the -dev/-devel package is
+        // installed), then fall back to the versioned runtime SONAMEs that ship
+        // with the shared library itself. Most end-user systems only have the
+        // runtime package, which provides libevdev.so.2 but not the unversioned
+        // libevdev.so symlink, so loading only "libevdev.so" silently disabled
+        // gamepad support on an otherwise correctly configured machine. dlopen
+        // resolves these SONAMEs through the dynamic linker cache.
+        //
+        // The versioned names are passed with correctModuleName = false: name
+        // correction appends the platform library extension (".so") when the name
+        // does not already end with it, which would turn "libevdev.so.2" into
+        // "libevdev.so.2.so" and never resolve.
+        struct LibraryCandidate
         {
-            AZ_Info("Input", "libevdev.so not found - gamepad support disabled.  Install libevdev2 to enable.\n");
-            m_libevdevHandle.reset();
+            const char* m_name;
+            bool m_correctModuleName;
+        };
+        constexpr LibraryCandidate candidates[] = {
+            { "libevdev.so", true },
+            { "libevdev.so.2", false },
+            { "libevdev.so.1", false },
+        };
+        for (const LibraryCandidate& candidate : candidates)
+        {
+            auto handle = AZ::DynamicModuleHandle::Create(candidate.m_name, candidate.m_correctModuleName);
+            if (handle && handle->Load())
+            {
+                m_libevdevHandle = AZStd::move(handle);
+                break;
+            }
+        }
+
+        if (!m_libevdevHandle)
+        {
+            AZ_Info("Input", "libevdev not found - gamepad support disabled.  Install libevdev to enable.\n");
             return;
         }
 


### PR DESCRIPTION
## What does this PR do?

On Linux, the game-pad backend loads libevdev by dlopen-ing the unversioned library name `libevdev.so` (`Code/Framework/AzFramework/Platform/Linux/AzFramework/Input/LibEVDevWrapper.cpp`). That unversioned name is a linker symlink provided only by the development package (`libevdev-dev` / `libevdev-devel`). A system that has just the runtime package provides the versioned SONAME (`libevdev.so.2`) but not the unversioned `libevdev.so` symlink, so the load fails and all game-pad support is silently disabled, even though libevdev is installed and the controller is otherwise usable.

This is the normal end-user situation: someone running a packaged game installs the runtime libevdev, not the `-devel` package, and their controller does not work with no clear reason (a single info-level log line).

This fixes a gap in the original Linux game-pad support added in #17437.

- **Old behavior:** if `libevdev.so` (the unversioned symlink) is absent, gamepad support is disabled, regardless of whether the libevdev runtime is present.
- **New behavior:** the loader tries `libevdev.so` first (so a development setup is unchanged), then falls back to the versioned runtime SONAMEs that ship with the shared library itself (`libevdev.so.2`, `libevdev.so.1`), and uses the first that loads. `dlopen` resolves these through the dynamic linker cache.

Implementation note: the versioned names are created with `correctModuleName = false`. The default name correction appends the platform library extension when the name does not already end with it, which would turn `libevdev.so.2` into `libevdev.so.2.so` and never resolve.

This is a robustness fix, isolated to the Linux platform input code. There is no API or behavior change beyond which library file is loaded, and the previously-working case (unversioned symlink present) is tried first and unchanged.

## How was this PR tested?

Root cause confirmed by a controlled A/B on Fedora 44 (libevdev 1.13.6): with `libevdev-devel` removed (only `libevdev.so.2` present, no unversioned `libevdev.so`), a controller is not detected in a packaged game; reinstalling `libevdev-devel` (which restores the `libevdev.so` symlink) makes the same controller work again, with no other change. This isolates the unversioned-symlink dependency as the cause.

Built the `AzFramework` target with the change (Linux, clang, profile): compiles with no errors or warnings, and the rebuilt `libAzFramework.so` contains the new candidate names and load path (verified in the binary).

Not yet exercised at runtime through the fallback path itself: the packaged-game build I tested with links its own (unpatched) `libAzFramework.so`, and hot-swapping a `development`-built library over a release-built one risks an ABI mismatch, so I did not use that as a test. Running the fallback live would require building the game's engine from this branch. Happy to do that or adjust the approach if maintainers prefer.
