### PR TITLE
Fix use-after-free in ScriptComponent::DestroyEntityTable on shutdown

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
@@ -536,7 +536,24 @@ namespace AzFramework
 
         if (m_table != LUA_NOREF)
         {
-            lua_State* lua = m_context->NativeContext();
+            // The owning ScriptContext can already be gone if this component is
+            // deactivated during application shutdown: ScriptSystemComponent::Deactivate
+            // disconnects ScriptSystemRequestBus and deletes every context, but a
+            // leftover spawned entity is then torn down by the SpawnableEntitiesManager
+            // (via the game entity context) afterwards. The cached m_context would dangle,
+            // and lua_rawgeti below would use-after-free the freed lua_State. Re-query the
+            // live context (as Init() does) and abandon the table when the VM is gone --
+            // it is being freed wholesale anyway, so there is nothing to release.
+            AZ::ScriptContext* context = nullptr;
+            AZ::ScriptSystemRequestBus::BroadcastResult(
+                context, &AZ::ScriptSystemRequestBus::Events::GetContext, m_contextId);
+            if (!context)
+            {
+                m_table = LUA_NOREF;
+                return;
+            }
+
+            lua_State* lua = context->NativeContext();
             LSV_BEGIN(lua, 0);
 
             // call OnDeactivate


### PR DESCRIPTION
Fixes #19804.

### Description

When the application shuts down, `ScriptSystemComponent::Deactivate` disconnects `ScriptSystemRequestBus` and deletes every `ScriptContext`. A scripted entity deactivated afterwards (for example a leftover spawnable torn down by the `SpawnableEntitiesManager` during `CSystem::ShutDown`) then runs `ScriptComponent::DestroyEntityTable`, which dereferenced the cached `m_context` and called `lua_rawgeti` on the already-freed `lua_State`, crashing the launcher on quit. The full backtrace and root-cause walkthrough are in #19804.

The fix re-queries the live context via `ScriptSystemRequestBus::GetContext` (the same call `Init` already uses to obtain it) and abandons the table reference when no context is returned, since the script VM is being freed wholesale and there is nothing left to release. Normal deactivation, where the context is still alive, is unchanged (the re-query returns the same context).

### How was this PR tested?

The crash reproduces reliably on quit in a project that keeps a pool of Lua-scripted spawnable entities (it happens on every quit path, including window close). The fix is reasoned to prevent it: after `ScriptSystemComponent::Deactivate` disconnects the bus, `GetContext` returns null, so `DestroyEntityTable` abandons the table instead of touching the freed `lua_State`. Honest caveat: it has not been validated by a local engine build (a full build is impractical on my setup) or by running the fixed binary; it mirrors the existing `Init` context lookup so it is compile-safe by inspection, and I am relying on CI for the multi-platform build. Reviewers running the engine can confirm the runtime behavior quickly.

### Notes

- Cross-platform, platform-agnostic core C++ (no PAL / `#ifdef`); should build on all CI platforms.
- Tradeoff: this skips the entity's `OnDeactivate` Lua callback when the context is already gone (it cannot run on a freed VM anyway). If preserving `OnDeactivate` during shutdown matters, the alternative is fixing the system-component teardown order (option 2 in #19804) so the `ScriptContext` outlives entity destruction. Happy to switch approaches if reviewers prefer.
- Diff: `Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp`, +18/-1.
