### PR TITLE
Fixes buffer overflow crash when using ribbon particles and particle restart after stop

### DIFF
--- a/Gems/OpenParticleSystem/Code/SimuCore/modules/particle/core/src/core/ParticleRibbonRender.cpp
+++ b/Gems/OpenParticleSystem/Code/SimuCore/modules/particle/core/src/core/ParticleRibbonRender.cpp
@@ -10,6 +10,7 @@
 #include "particle/core/ParticlePool.h"
 #include "particle/core/ParticleDriver.h"
 #include "particle/core/ParticleHelper.h"
+#include "core/math/Constants.h"
 #include "core/math/Math.h"
 
 namespace SimuCore::ParticleCore {
@@ -175,7 +176,9 @@ namespace SimuCore::ParticleCore {
             segment.segmentLength = localDistance;
             segment.tangent0 = segments.empty() ? curDir.GetNormalized() : segments[segments.size() - 1].tangent1;
             segment.tangent1 = (1.f - config.curveTension) * (dir.GetNormalized());
-            segment.interpCount = static_cast<AZ::u32>(std::ceil(localDistance / config.tesselationFactor));
+
+            const float tesselationFactor = AZStd::GetMax(config.tesselationFactor, 1.f - SimuCore::ALMOST_ONE);
+            segment.interpCount = static_cast<AZ::u32>(std::ceil(localDistance / tesselationFactor));
 
             // each segment added to this map causes at least one quad to be generated even if there is 0 interp.
             // and segmentCount is used to calculate the total vertex and index count.

--- a/Gems/OpenParticleSystem/Code/SimuCore/modules/particle/core/src/core/ParticleRibbonRender.cpp
+++ b/Gems/OpenParticleSystem/Code/SimuCore/modules/particle/core/src/core/ParticleRibbonRender.cpp
@@ -176,7 +176,10 @@ namespace SimuCore::ParticleCore {
             segment.tangent0 = segments.empty() ? curDir.GetNormalized() : segments[segments.size() - 1].tangent1;
             segment.tangent1 = (1.f - config.curveTension) * (dir.GetNormalized());
             segment.interpCount = static_cast<AZ::u32>(std::ceil(localDistance / config.tesselationFactor));
-            segmentCount += segment.interpCount;
+
+            // each segment added to this map causes at least one quad to be generated even if there is 0 interp.
+            // and segmentCount is used to calculate the total vertex and index count.
+            segmentCount = segmentCount + (segment.interpCount == 0 ? 1 : segment.interpCount);
             totalDistance += localDistance;
             segment.tileV = totalDistance / config.tilingDistance;
             segment.distance = totalDistance;
@@ -200,6 +203,24 @@ namespace SimuCore::ParticleCore {
         auto& indexBufferView = indexBufferViews[world.viewKey.v];
         auto& ib = ibs[world.viewKey.v];
 
+        // Note that there is a condition where a ribbon could look like this:
+        // Segments (3)
+        // [0] : interpCount = 0    - 0 interpcount still generates 1 quad.
+        // [1] : interpCount = 1    - 1 interpcount means 1 quad is generated.
+        // [2] : interpCount = 2    - 2 interpcount means 2 quads are generated.
+
+        // Each "Ribbon" always calls FillHeadVertex() for the first segment, which uses up 2 indices, and 2 vertices.
+        // Each "Ribbon" always calls FillEndVertex() after the last one, which also uses up 4 indices and 2 vertices.
+        // So at the very least, a ribbon costs one quad (two triangles, which is 4 verts and 6 indices).
+        // 
+        // It also calls FillVertex() for each segment that is not the first one, which uses up 6 indices and 2 vertices (another quad)
+        // It also calls FillVertex() again for each interpCount greater than 1 to generate middle vertices (another quad each).
+
+        // "segmentCount" is calculated while building the particle ribbon segments, and represents
+        // the number of quads that will be rendered, including the interps.  so in this case, segmentCount will be
+        // 4 (1 for the first segment, 1 for second segment, 2 for the third segment since it has an extra interpcount).
+
+        // so to calculate the vertex count, its going to be 2 verts per segmentCount, plus 2 verts for the head/end of each ribbon.
         bool reCreateVb = false;
         AZ::u32 vertexCount = (segmentCount + ribbonCount) * 2;
         if (vertexCount > vb.size()) {
@@ -209,6 +230,7 @@ namespace SimuCore::ParticleCore {
             reCreateVb = true;
         }
 
+        // and to calculate the index count, its going to be 6 indexes per quad rendered.
         bool reCreateIb = false;
         AZ::u32 indexCount = segmentCount * INDEX_COUNT_IN_ONE_SEGMENT;
         if (indexCount > ib.size()) {

--- a/Gems/OpenParticleSystem/Code/Source/Editor/ParticleEditDataConfig.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/ParticleEditDataConfig.cpp
@@ -1450,7 +1450,7 @@ namespace OpenParticle
                         ->Attribute(AZ::Edit::Attributes::Visibility, &RibbonConfig::ModeChangToTrail)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &OpenParticle::RibbonConfig::tesselationFactor,
                         "Tesselation Factor",
-                        "The tesselation factor of the ribbon.")
+                        "Each time a ribbon segment grows longer than this value, it will be subdivided.  Lower values result in more (smoother) subdivisions, more resource use.")
                         ->Attribute(AZ::Edit::Attributes::Min, 1.f - SimuCore::ALMOST_ONE) 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &OpenParticle::RibbonConfig::curveTension,
                         "Curve Tension",

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.cpp
@@ -139,10 +139,9 @@ namespace OpenParticle
 
     void ParticleComponentController::Play()
     {
-        if (m_bNeedsReRegister)
+        if (!m_particleHandle.IsValid())
         {
-            m_bNeedsReRegister = false;
-            Register(); // restart it in case of play().
+            Register(); // restart it in case of play() after stop().
         }
 
         if (!m_particleHandle.IsValid())
@@ -175,7 +174,6 @@ namespace OpenParticle
         }
         AZ_TracePrintf("Particle", "Particle Stop %s", m_particleHandle->m_particleAsset.GetHint().data());
         Deregister();
-        m_bNeedsReRegister = true;
     }
 
     void ParticleComponentController::SetVisibility(bool visible)
@@ -265,6 +263,7 @@ namespace OpenParticle
         if (m_featureProcessor != nullptr && m_particleHandle.IsValid())
         {
             m_featureProcessor->ReleaseParticle(m_particleHandle);
+            m_particleHandle = {};
         }
     }
 

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.cpp
@@ -139,44 +139,54 @@ namespace OpenParticle
 
     void ParticleComponentController::Play()
     {
-        if (!m_particleHandle.IsValid()) {
-            AZ_Printf("Particle", "No particle asset found to Play");
+        if (m_bNeedsReRegister)
+        {
+            m_bNeedsReRegister = false;
+            Register(); // restart it in case of play().
+        }
+
+        if (!m_particleHandle.IsValid())
+        {
+            AZ_Warning("Particle", false, "ParticleComponentController::Play - No particle asset found to Play");
             return;
         }
-        AZ_Printf("Particle", "Particle Play %s", m_particleHandle->m_particleAsset.GetHint().data());
+        AZ_TracePrintf("Particle", "Particle Play %s", m_particleHandle->m_particleAsset.GetHint().data());
         m_particleHandle->m_status = ParticleStatus::PLAYING;
 
     }
 
     void ParticleComponentController::Pause()
     {
-        if (!m_particleHandle.IsValid()) {
-            AZ_Printf("Particle", "No particle asset found to PAUSE");
+        if (!m_particleHandle.IsValid())
+        {
+            AZ_Warning("Particle", false, "ParticleComponentController::Pause - No particle asset found to PAUSE");
             return;
         }
-        AZ_Printf("Particle", "Particle Pause %s", m_particleHandle->m_particleAsset.GetHint().data());
+        AZ_TracePrintf("Particle", "Particle Pause %s", m_particleHandle->m_particleAsset.GetHint().data());
         m_particleHandle->m_status = ParticleStatus::PAUSED;
     }
 
     void ParticleComponentController::Stop()
     {
-        if (!m_particleHandle.IsValid()) {
-            AZ_Printf("Particle", "No particle asset found to STOP");
+        if (!m_particleHandle.IsValid())
+        {
+            AZ_Warning("Particle", false, "ParticleComponentController::Stop - No particle asset found to Stop");
             return;
         }
-        AZ_Printf("Particle", "Particle Stop %s", m_particleHandle->m_particleAsset.GetHint().data());
+        AZ_TracePrintf("Particle", "Particle Stop %s", m_particleHandle->m_particleAsset.GetHint().data());
         Deregister();
+        m_bNeedsReRegister = true;
     }
 
     void ParticleComponentController::SetVisibility(bool visible)
     {
-        AZ_Printf("Particle", "Particle Show %s", m_entityId.ToString().c_str());
+        AZ_TracePrintf("Particle", "Particle Show %s", m_entityId.ToString().c_str());
         SetVisible(visible);
     }
 
     bool ParticleComponentController::GetVisibility() const
     {
-        AZ_Printf("Particle", "Particle Show %s", m_entityId.ToString().c_str());
+        AZ_TracePrintf("Particle", "Particle Show %s", m_entityId.ToString().c_str());
         return m_isVisible;
     }
 

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.h
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.h
@@ -79,5 +79,6 @@ namespace OpenParticle
         ParticleFeatureProcessorInterface* m_featureProcessor = nullptr;
         ParticleFeatureProcessorInterface::ParticleHandle m_particleHandle;
         bool m_isVisible = true;
+        bool m_bNeedsReRegister = false;
     };
 }

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.h
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleComponentController.h
@@ -79,6 +79,5 @@ namespace OpenParticle
         ParticleFeatureProcessorInterface* m_featureProcessor = nullptr;
         ParticleFeatureProcessorInterface::ParticleHandle m_particleHandle;
         bool m_isVisible = true;
-        bool m_bNeedsReRegister = false;
     };
 }


### PR DESCRIPTION
## What does this PR do?

Ribbon Particles had an off-by-one error in the buffer size calculation, and would make smaller index/vertex buffers than the fill buffers function actually filled.

This change also fixes a bug where if a particle was ever told to "stop" it could never "play" ever again.

## How was this PR tested?

Ribbon Particles example particle is used in the viewport, with a script canvas that tells it to start/stop/play.  

Prior to this change, it would crash when played.  Note that ASAN finds this issue immediately, without ASAN its a random crash.
