### PR TITLE
fix(cmake): no-fast-math prefixed with PRIVATE

### DIFF
--- a/cmake/Platform/Common/GCC/Configurations_gcc.cmake
+++ b/cmake/Platform/Common/GCC/Configurations_gcc.cmake
@@ -47,8 +47,6 @@ if(LY_GCC_BUILD_FOR_GPROF)
     set(LY_GCC_GPROF_FLAGS "-pg")
 endif()
 
-set(O3DE_COMPILE_OPTION_DISABLE_FAST_MATH PRIVATE -fno-fast-math)
-
 ly_append_configurations_options(
     DEFINES_PROFILE
         _FORTIFY_SOURCE=2


### PR DESCRIPTION
no-fast-math is disabled twice in this file, and in the second encounter it puts a PRIVATE in the compiler flags. This leads to weird gcc error messages complaining about a missing linker script PRIVATE.

## What does this PR do?

Remove a duplication and move o3de one step closer to build with gcc

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

gcc only - this only affects the gcc setup.
