### PR TITLE
fix(gcc): avoid anonymous union with non-trivial types

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardPass.cpp
@@ -56,7 +56,7 @@ namespace AZ
             {
                 if (attachment->m_lifetime == RHI::AttachmentLifetimeType::Transient)
                 {
-                    if (attachment->m_descriptor.m_type == RHI::AttachmentType::Image)
+                    if (attachment->m_descriptor.type() == RHI::AttachmentType::Image)
                     {
                         // Force update image attachment descriptor to sync up size and format
                         attachment->Update();
@@ -64,7 +64,7 @@ namespace AZ
                         attachment->m_lifetime = RHI::AttachmentLifetimeType::Imported;
 
                         // update image descriptor to new size and samples
-                        RHI::ImageDescriptor &imageDesc = attachment->m_descriptor.m_image;
+                        RHI::ImageDescriptor &imageDesc = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
 
                         imageDesc.m_multisampleState.m_samples = 2;
                         imageDesc.m_size.m_width /= 2;
@@ -117,7 +117,7 @@ namespace AZ
             // So we can preserve the render target from current frame
             for (RPI::Ptr<RPI::PassAttachment>& attachment : m_ownedAttachments)
             {
-                if (attachment->m_descriptor.m_type == RHI::AttachmentType::Image)
+                if (attachment->m_descriptor.type() == RHI::AttachmentType::Image)
                 {
                     Data::Instance<RPI::AttachmentImage> nextAttachment = GetAttachmentImage(attachment->m_name, m_frameOffset);
                     if (nextAttachment)

--- a/Gems/Atom/Feature/Common/Code/Source/ColorGrading/LutGenerationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ColorGrading/LutGenerationPass.cpp
@@ -65,7 +65,7 @@ namespace AZ
                 RHI::Size lutSize{ lutResolution * lutResolution, lutResolution, 1 };
 
                 RPI::Ptr<RPI::PassAttachment> attachment = FindOwnedAttachment(Name{ "ColorGradingLut" });
-                RHI::ImageDescriptor& imageDescriptor = attachment->m_descriptor.m_image;
+                RHI::ImageDescriptor& imageDescriptor = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
                 imageDescriptor.m_size = lutSize;
                 SetViewportScissorFromImageSize(lutSize);
             }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CascadedShadowmapsPass.cpp
@@ -112,12 +112,12 @@ namespace AZ
             // [GFX TODO][ATOM-2470] stop caring about attachment
             RPI::Ptr<RPI::PassAttachment> attachment = m_ownedAttachments.front();
             AZ_Assert(attachment, "[CascadedShadowmapsPass %s] Cannot find shadowmap image attachment.", GetPathName().GetCStr());
-            AZ_Assert(attachment->m_descriptor.m_type == RHI::AttachmentType::Image, "[CascadedShadowmapsPass %s] requires an image attachment", GetPathName().GetCStr());
+            AZ_Assert(attachment->m_descriptor.type() == RHI::AttachmentType::Image, "[CascadedShadowmapsPass %s] requires an image attachment", GetPathName().GetCStr());
 
             RPI::PassAttachmentBinding& binding = GetOutputBinding(0);
             binding.SetAttachment(attachment);
 
-            RHI::ImageDescriptor& imageDescriptor = attachment->m_descriptor.m_image;
+            RHI::ImageDescriptor& imageDescriptor = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
             const uint32_t shadowmapWidth = static_cast<uint32_t>(m_atlas.GetBaseShadowmapSize());
             imageDescriptor.m_size = RHI::Size(shadowmapWidth, shadowmapWidth, 1);
             imageDescriptor.m_arraySize = m_atlas.GetArraySliceCount();

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/EsmShadowmapsPass.cpp
@@ -193,9 +193,9 @@ namespace AZ
                 return;
             }
 
-            AZ_Assert(inputBinding.GetAttachment()->m_descriptor.m_type == RHI::AttachmentType::Image, "[EsmShadowmapsPass %s] input attachment requires an image attachment", GetPathName().GetCStr());
-            m_shadowmapImageSize = inputBinding.GetAttachment()->m_descriptor.m_image.m_size;
-            m_shadowmapArraySize = inputBinding.GetAttachment()->m_descriptor.m_image.m_arraySize;
+            AZ_Assert(inputBinding.GetAttachment()->m_descriptor.type() == RHI::AttachmentType::Image, "[EsmShadowmapsPass %s] input attachment requires an image attachment", GetPathName().GetCStr());
+            m_shadowmapImageSize = inputBinding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
+            m_shadowmapArraySize = inputBinding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_arraySize;
 
             const AZStd::span<const RPI::Ptr<RPI::Pass>>& children = GetChildren();
             AZ_Assert(children.size() == EsmChildPassKindCount, "[EsmShadowmapsPass '%s'] The count of children is wrong.", GetPathName().GetCStr());

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
@@ -144,7 +144,7 @@ namespace AZ
             // The sizeSource contains the original depth buffer
             const RPI::PassAttachmentBinding* sizeSource = tileBuffer->m_sizeSource;
             const RHI::UnifiedAttachmentDescriptor& depthBufferDescriptor = sizeSource->GetAttachment()->m_descriptor;
-            return depthBufferDescriptor.m_image.m_size;
+            return depthBufferDescriptor.get<RHI::ImageAttachment>().m_image.m_size;
         }
 
         void LightCullingPass::SetConstantdataToSRG()
@@ -181,7 +181,7 @@ namespace AZ
         AZ::RHI::Size LightCullingPass::GetTileDataBufferResolution()
         {
             auto binding = GetInputBinding(m_tileDataIndex).GetAttachment().get();
-            return binding->m_descriptor.m_image.m_size;
+            return binding->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
         }
 
         // Used to convert a compute shader threadGroup.xy coordinate into a 0 to 1 screen uv coordinate

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingRemap.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingRemap.cpp
@@ -127,7 +127,7 @@ namespace AZ
         AZ::RHI::Size LightCullingRemap::GetTileDataBufferResolution()
         {
             auto binding = GetInputOutputBinding(m_tileDataIndex).GetAttachment().get();
-            return binding->m_descriptor.m_image.m_size;
+            return binding->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
         }
 
         void LightCullingRemap::Init()

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingTilePreparePass.cpp
@@ -65,7 +65,7 @@ namespace AZ
             AZ_Assert(GetInputBinding(0).m_name == AZ::Name("Depth"), "LightCullingTilePrepare: Expecting slot 0 to be the depth buffer");
 
             const RPI::PassAttachment* attachment = GetInputBinding(0).GetAttachment().get();
-            return attachment->m_descriptor.m_image.m_size;
+            return attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
         }
 
         AZStd::array<float, 2> LightCullingTilePreparePass::ComputeUnprojectConstants() const
@@ -115,7 +115,7 @@ namespace AZ
             AZ_Assert(GetInputBinding(0).m_name == AZ::Name("Depth"), "LightCullingTilePrepare: Expecting slot 0 to be the depth buffer");
 
             const RPI::PassAttachment* attachment = GetInputBinding(0).GetAttachment().get();
-            return attachment->m_descriptor.m_image.m_multisampleState;
+            return attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_multisampleState;
         }
 
         AZ::RPI::ShaderOptionGroup LightCullingTilePreparePass::CreateShaderOptionGroup()

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperPass.cpp
@@ -64,7 +64,7 @@ namespace AZ
             // display mapper parameters.
             if (m_pipelineOutput && m_pipelineOutput->GetAttachment())
             {
-                m_displayBufferFormat = m_pipelineOutput->GetAttachment()->m_descriptor.m_image.m_format;
+                m_displayBufferFormat = m_pipelineOutput->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_format;
             }
 
             if (m_displayBufferFormat != RHI::Format::Unknown)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
@@ -80,11 +80,11 @@ namespace AZ
 
             if (attachment != nullptr)
             {
-                m_paramsUpdated |= (m_inputWidth != attachment->m_descriptor.m_image.m_size.m_width);
-                m_paramsUpdated |= (m_inputHeight != attachment->m_descriptor.m_image.m_size.m_height);
+                m_paramsUpdated |= (m_inputWidth != attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width);
+                m_paramsUpdated |= (m_inputHeight != attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_height);
 
-                m_inputWidth = attachment->m_descriptor.m_image.m_size.m_width;
-                m_inputHeight = attachment->m_descriptor.m_image.m_size.m_height;
+                m_inputWidth = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width;
+                m_inputHeight = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_height;
             }
             else
             {
@@ -276,7 +276,7 @@ namespace AZ
             m_kernelRadiusData.clear();
 
             RPI::PassAttachment* inOutAttachment = GetInputOutputBinding(0).GetAttachment().get();
-            uint32_t imageWidth = inOutAttachment->m_descriptor.m_image.m_size.m_width;
+            uint32_t imageWidth = inOutAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width;
 
             // Horizontal & vertical pass shared the same kernel
             for (uint32_t i = 0; i < Render::Bloom::MaxStageCount; ++i)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
@@ -81,11 +81,11 @@ namespace AZ
 
             if (inAttachment != nullptr && outAttachment != nullptr)
             {
-                m_inputWidth = inAttachment->m_descriptor.m_image.m_size.m_width;
-                m_inputHeight = inAttachment->m_descriptor.m_image.m_size.m_height;
+                m_inputWidth = inAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width;
+                m_inputHeight = inAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_height;
 
-                m_outputWidth = outAttachment->m_descriptor.m_image.m_size.m_width;
-                m_outputHeight = outAttachment->m_descriptor.m_image.m_size.m_height;
+                m_outputWidth = outAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width;
+                m_outputHeight = outAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_height;
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
@@ -122,7 +122,7 @@ namespace AZ
 
             RHI::Size sourceImageSize;
             RPI::PassAttachment* inputAttachment = GetInputBinding(0).GetAttachment().get();
-            sourceImageSize = inputAttachment->m_descriptor.m_image.m_size;
+            sourceImageSize = inputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             // Update shader constant
             m_shaderResourceGroup->SetConstant(m_sourceImageTexelSizeInputIndex, AZ::Vector2(1.0f / static_cast<float>(sourceImageSize.m_width), 1.0f / static_cast<float>(sourceImageSize.m_height)));

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/ChromaticAberrationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/ChromaticAberrationPass.cpp
@@ -88,7 +88,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "ChromaticAberrationPass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             constants.m_outputSize[0] = size.m_width;
             constants.m_outputSize[1] = size.m_height;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldMaskPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthOfFieldMaskPass.cpp
@@ -88,7 +88,7 @@ namespace AZ
             const RPI::PassAttachmentBinding& attachmentBinding = attachmentBindings[0];
             if (attachmentBinding.GetAttachment())
             {
-                RHI::Size size = attachmentBinding.GetAttachment()->m_descriptor.m_image.m_size;
+                RHI::Size size = attachmentBinding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
                 m_inputResolutionInverse[0] = 1.0f / size.m_width;
                 m_inputResolutionInverse[1] = 1.0f / size.m_height;
             }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthUpsamplePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/DepthUpsamplePass.cpp
@@ -49,8 +49,8 @@ namespace AZ
 
             AZ_Assert(inputAttachment != nullptr, "DepthUpsamplePass: Input binding has no attachment!");
             AZ_Assert(outputAttachment != nullptr, "DepthUpsamplePass: Output binding has no attachment!");
-            RHI::Size inputSize = inputAttachment->m_descriptor.m_image.m_size;
-            RHI::Size outputSize = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size inputSize = inputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
+            RHI::Size outputSize = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             upsampleConstants.m_inputPixelSize[0] = 1.0f / float(inputSize.m_width);
             upsampleConstants.m_inputPixelSize[1] = 1.0f / float(inputSize.m_height);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FastDepthAwareBlurPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FastDepthAwareBlurPasses.cpp
@@ -66,7 +66,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "FastDepthAwareBlurHorPass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             m_passConstants.InitializeFromSize(size);
 
@@ -108,7 +108,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "FastDepthAwareBlurVerPass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             m_passConstants.InitializeFromSize(size);
 

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FilmGrainPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/FilmGrainPass.cpp
@@ -105,7 +105,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "FilmGrainPass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             constants.m_outputSize[0] = size.m_width;
             constants.m_outputSize[1] = size.m_height;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LookModificationTransformPass.cpp
@@ -44,7 +44,7 @@ namespace AZ
             RHI::Format swapChainFormat = RHI::Format::Unknown;
             if (m_pipelineOutput && m_pipelineOutput->GetAttachment())
             {
-                swapChainFormat = m_pipelineOutput->GetAttachment()->m_descriptor.m_image.m_format;
+                swapChainFormat = m_pipelineOutput->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_format;
             }
 
             // Update the children passes

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/LuminanceHistogramGeneratorPass.cpp
@@ -74,7 +74,7 @@ namespace AZ
             const auto& binding = GetInputBinding(0);
             AZ_Assert(binding.m_name == AZ::Name("ColorInput"), "ColorInput was expected to be the first input");
             const RPI::PassAttachment* colorBuffer = binding.GetAttachment().get();
-            return colorBuffer->m_descriptor.m_image.m_size;
+            return colorBuffer->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
         }
 
         void LuminanceHistogramGeneratorPass::BuildInternal()

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/MotionBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/MotionBlurPass.cpp
@@ -87,7 +87,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "MotionBlurPass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             constants.m_outputSize[0] = size.m_width;
             constants.m_outputSize[1] = size.m_height;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/NewDepthOfFieldPasses.cpp
@@ -119,7 +119,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "NewDepthOfFieldTileReducePass: Output binding has no attachment!");
-            RHI::Size outputSize = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size outputSize = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             // The algorithm outputs the min/max CoC values from a 16x16 region using 8x8 threads
             u32 targetThreadCountX = outputSize.m_width * 8;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/PaniniProjectionPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/PaniniProjectionPass.cpp
@@ -87,7 +87,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "PaniniProjectionPass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             constants.m_outputSize[0] = size.m_width;
             constants.m_outputSize[1] = size.m_height;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SMAABasePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SMAABasePass.cpp
@@ -104,7 +104,7 @@ namespace AZ
             const RPI::PassAttachmentBinding* sizeSource = attachment->m_sizeSource;
             AZ_Assert(sizeSource != nullptr, "Binding sizeSource of attachment is null.");
             AZ_Assert(sizeSource->GetAttachment() != nullptr, "Attachment of sizeSource is null.");
-            AZ::RHI::Size size = sizeSource->GetAttachment()->m_descriptor.m_image.m_size;
+            AZ::RHI::Size size = sizeSource->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             return AZ::Vector4(
                 1.0f / static_cast<float>(size.m_width),

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SsaoPasses.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SsaoPasses.cpp
@@ -180,7 +180,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "SsaoComputePass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             ssaoConstants.m_outputSize[0] = size.m_width;
             ssaoConstants.m_outputSize[1] = size.m_height;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -56,7 +56,8 @@ namespace AZ::Render
         };
 
         TaaConstants cb;
-        RHI::Size inputSize = m_lastFrameAccumulationBinding->GetAttachment()->m_descriptor.m_image.m_size;
+        RHI::Size inputSize =
+            m_lastFrameAccumulationBinding->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
         cb.m_size[0] = inputSize.m_width;
         cb.m_size[1] = inputSize.m_height;
         cb.m_rcpSize[0] = 1.0f / inputSize.m_width;
@@ -75,7 +76,7 @@ namespace AZ::Render
 
     void TaaPass::FrameBeginInternal(FramePrepareParams params)
     {
-        RHI::Size inputSize = m_inputColorBinding->GetAttachment()->m_descriptor.m_image.m_size;
+        RHI::Size inputSize = m_inputColorBinding->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
         Vector2 rcpInputSize = Vector2(1.0f / inputSize.m_width, 1.0f / inputSize.m_height);
         RPI::ViewPtr view = GetRenderPipeline()->GetFirstView(GetPipelineViewTag());
         if (view)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/VignettePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/VignettePass.cpp
@@ -87,7 +87,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "VignettePass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             constants.m_outputSize[0] = size.m_width;
             constants.m_outputSize[1] = size.m_height;

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/WhiteBalancePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/WhiteBalancePass.cpp
@@ -89,7 +89,7 @@ namespace AZ
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
 
             AZ_Assert(outputAttachment != nullptr, "WhiteBalancePass: Output binding has no attachment!");
-            RHI::Size size = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             constants.m_outputSize[0] = size.m_width;
             constants.m_outputSize[1] = size.m_height;

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurChildPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurChildPass.cpp
@@ -29,7 +29,7 @@ namespace AZ
             RPI::PassAttachment* inputAttachment = GetInputBinding(0).GetAttachment().get();
             AZ_Assert(inputAttachment, "ReflectionScreenSpaceBlurChildPass: Input binding has no attachment!");
 
-            RHI::Size size = inputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = inputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             if (m_imageSize != size)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
@@ -117,8 +117,8 @@ namespace AZ
 
             // retrieve the reflection attachment
             RPI::PassAttachment* reflectionImageAttachment = GetInputOutputBinding(0).GetAttachment().get();
-            m_imageSize = reflectionImageAttachment->m_descriptor.m_image.m_size;
-            m_mipLevels = aznumeric_cast<uint32_t>(reflectionImageAttachment->m_descriptor.m_image.m_mipLevels);
+            m_imageSize = reflectionImageAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
+            m_mipLevels = aznumeric_cast<uint32_t>(reflectionImageAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_mipLevels);
 
             // create transient attachments, one for each blur mip level
             AZStd::vector<RPI::PassAttachment*> transientPassAttachments;
@@ -190,7 +190,7 @@ namespace AZ
             RPI::PassAttachment* inputAttachment = GetInputOutputBinding(0).GetAttachment().get();
             AZ_Assert(inputAttachment, "ReflectionScreenSpaceBlurChildPass: Input binding has no attachment!");
 
-            RHI::Size size = inputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = inputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
             if (m_imageSize != size)
             {
                 m_imageSize = size;
@@ -199,7 +199,7 @@ namespace AZ
                 for (auto& ownedAttachment : m_ownedAttachments)
                 {
                     RHI::Size mipSize = m_imageSize.GetReducedMip(mip);
-                    ownedAttachment->m_descriptor.m_image.m_size = mipSize;
+                    ownedAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size = mipSize;
                     mip++;
                 }
             }

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.cpp
@@ -42,7 +42,7 @@ namespace AZ
 
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
             AZ_Assert(outputAttachment, "ReflectionScreenSpaceCompositePass: Output binding has no attachment!");
-            RHI::Size outputImageSize = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size outputImageSize = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             const SSROptions& ssrOptions = specularReflectionsFeatureProcessor->GetSSROptions();
 

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearChildPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearChildPass.cpp
@@ -36,7 +36,7 @@ namespace AZ
             RPI::PassAttachment* inputAttachment = GetInputBinding(0).GetAttachment().get();
             AZ_Assert(inputAttachment, "ReflectionScreenSpaceDownsampleDepthLinearChildPass: Input binding has no attachment!");
 
-            RHI::Size size = inputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = inputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
             bool halfResolution = specularReflectionsFeatureProcessor->GetSSROptions().m_halfResolution;
 
             if (m_imageSize != size || m_halfResolution != halfResolution)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceDownsampleDepthLinearPass.cpp
@@ -70,8 +70,8 @@ namespace AZ
 
             // retrieve DownsampledDepthLinear attachment
             RPI::PassAttachment* downsampledDepthLinearImageAttachment = GetInputOutputBinding(0).GetAttachment().get();
-            m_imageSize = downsampledDepthLinearImageAttachment->m_descriptor.m_image.m_size;
-            m_mipLevels = aznumeric_cast<uint32_t>(downsampledDepthLinearImageAttachment->m_descriptor.m_image.m_mipLevels);
+            m_imageSize = downsampledDepthLinearImageAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
+            m_mipLevels = aznumeric_cast<uint32_t>(downsampledDepthLinearImageAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_mipLevels);
 
             // call ParentPass::BuildInternal() first to configure the slots and auto-add the empty bindings,
             // then we will assign attachments to the bindings

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.cpp
@@ -38,7 +38,7 @@ namespace AZ
 
             RHI::ImageViewDescriptor viewDesc = RHI::ImageViewDescriptor::Create(RHI::Format::R16G16B16A16_FLOAT, 0, 0);
             RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(0, 0, 0, 0);
-            m_historyAttachmentImage[m_currentHistoryAttachmentImage] = RPI::AttachmentImage::Create(*pool.get(), historyAttachment->m_descriptor.m_image, Name(historyAttachment->m_path.GetCStr()), &clearValue, &viewDesc);
+            m_historyAttachmentImage[m_currentHistoryAttachmentImage] = RPI::AttachmentImage::Create(*pool.get(), historyAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image, Name(historyAttachment->m_path.GetCStr()), &clearValue, &viewDesc);
 
             historyAttachment->m_importedResource = m_historyAttachmentImage[m_currentHistoryAttachmentImage];
         }
@@ -46,7 +46,7 @@ namespace AZ
         void ReflectionScreenSpaceFilterPass::BuildInternal()
         {
             // retrieve the input reflection image descriptor to get the size
-            RHI::ImageDescriptor reflectionImageDesc = m_ownedAttachments[0]->m_descriptor.m_image;
+            RHI::ImageDescriptor reflectionImageDesc = m_ownedAttachments[0]->m_descriptor.get<RHI::ImageAttachment>().m_image;
 
             // create the history attachment
             RHI::ImageBindFlags imageBindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
@@ -86,14 +86,14 @@ namespace AZ
             // retrieve reflection input attachment
             const RPI::Ptr<RPI::PassAttachment>& reflectionInputAttachment = m_reflectionInputAttachmentBinding->GetAttachment();
             AZ_Assert(reflectionInputAttachment, "ReflectionScreenSpaceFilterPass: Reflection input binding has no attachment!");
-            RHI::ImageDescriptor& reflectionImageDescriptor = reflectionInputAttachment->m_descriptor.m_image;
+            RHI::ImageDescriptor& reflectionImageDescriptor = reflectionInputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
 
             // retrieve output attachment
             RPI::PassAttachmentBinding& outputBinding = GetOutputBinding(0);
             const RPI::Ptr<RPI::PassAttachment>& outputAttachment = outputBinding.GetAttachment();
             AZ_Assert(outputAttachment, "ReflectionScreenSpaceFilterPass: Output binding has no attachment!");
 
-            RHI::ImageDescriptor& outputImageDescriptor = outputAttachment->m_descriptor.m_image;
+            RHI::ImageDescriptor& outputImageDescriptor = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
 
             const SSROptions& ssrOptions = specularReflectionsFeatureProcessor->GetSSROptions();
 
@@ -118,8 +118,8 @@ namespace AZ
             RPI::Ptr<RPI::PassAttachment> historyAttachment = m_historyAttachmentBinding->GetAttachment();
             historyAttachment->Update();
 
-            RHI::Size& historyImageSize = historyAttachment->m_descriptor.m_image.m_size;
-            RHI::Size& reflectionImageSize = m_ownedAttachments[0]->m_descriptor.m_image.m_size;
+            RHI::Size& historyImageSize = historyAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
+            RHI::Size& reflectionImageSize = m_ownedAttachments[0]->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             if (historyImageSize != reflectionImageSize)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
@@ -45,7 +45,7 @@ namespace AZ
             previousFrameImageAttachment->m_lifetime = RHI::AttachmentLifetimeType::Imported;
 
             // set the bind flags
-            RHI::ImageDescriptor& imageDesc = previousFrameImageAttachment->m_descriptor.m_image;
+            RHI::ImageDescriptor& imageDesc = previousFrameImageAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
             imageDesc.m_bindFlags |= RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
 
             // create the image attachment
@@ -69,7 +69,7 @@ namespace AZ
 
             RPI::PassAttachment* outputAttachment = GetOutputBinding(0).GetAttachment().get();
             AZ_Assert(outputAttachment, "ReflectionScreenSpaceTracePass: Output binding has no attachment!");
-            RHI::Size outputImageSize = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size outputImageSize = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             const SSROptions& ssrOptions = specularReflectionsFeatureProcessor->GetSSROptions();
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.cpp
@@ -59,7 +59,7 @@ namespace AZ
         RHI::Size FullscreenShadowPass::GetDepthBufferDimensions()
         {
             RPI::PassAttachmentBinding* outputBinding = RPI::Pass::FindAttachmentBinding(m_outputName);
-            auto outputDim = outputBinding->GetAttachment()->m_descriptor.m_image.m_size;
+            auto outputDim = outputBinding->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
             AZ_Assert(outputDim.m_width > 0 && outputDim.m_height > 0, "Height and width are not valid\n");
             return outputDim;
         }
@@ -67,7 +67,7 @@ namespace AZ
         uint16_t FullscreenShadowPass::GetDepthBufferMSAACount()
         {
             RPI::PassAttachmentBinding* inputBinding = RPI::Pass::FindAttachmentBinding(m_depthInputName);
-            return inputBinding->GetAttachment()->m_descriptor.m_image.m_multisampleState.m_samples;
+            return inputBinding->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_multisampleState.m_samples;
         }       
 
         void FullscreenShadowPass::SetConstantData()

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedAttachmentDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/UnifiedAttachmentDescriptor.h
@@ -12,13 +12,32 @@
 #include <Atom/RHI.Reflect/BufferViewDescriptor.h>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
 #include <Atom/RHI.Reflect/ImageViewDescriptor.h>
+#include <AzCore/std/containers/variant.h>
 
 namespace AZ::RHI
 {
+    struct ImageAttachment
+    {
+        ImageDescriptor m_image;
+        ImageViewDescriptor m_imageView;
+    };
+    struct BufferAttachment
+    {
+        BufferDescriptor m_buffer;
+        BufferViewDescriptor m_bufferView;
+    };
+    struct ResolveAttachment
+    {
+    };
+    struct UninitializedAttachment
+    {
+    };
     //! A unified attachment descriptor used to store either an image or a buffer descriptor.
     //! Used primarily to simplify pass attachment logic while supporting both attachment types.
     struct ATOM_RHI_REFLECT_API UnifiedAttachmentDescriptor
+        : AZStd::variant<ImageAttachment, BufferAttachment, ResolveAttachment, UninitializedAttachment>
     {
+        using Base = AZStd::variant<ImageAttachment, BufferAttachment, ResolveAttachment, UninitializedAttachment>;
         UnifiedAttachmentDescriptor();
         UnifiedAttachmentDescriptor(const BufferDescriptor& bufferDescriptor);
         UnifiedAttachmentDescriptor(const ImageDescriptor& imageDescriptor);
@@ -27,20 +46,35 @@ namespace AZ::RHI
 
         HashValue64 GetHash(HashValue64 seed = HashValue64{ 0 }) const;
 
-        /// Differentiates between an image, buffer and resolve attachment
-        AttachmentType m_type = AttachmentType::Uninitialized;
+        template<class T>
+        constexpr decltype(auto) get() &
+        {
+            return AZStd::get<T>(*this);
+        }
 
-        union {
-            struct
-            {
-                BufferDescriptor m_buffer;
-                BufferViewDescriptor m_bufferView;
-            };
-            struct
-            {
-                ImageDescriptor m_image;
-                ImageViewDescriptor m_imageView;
-            };
-        };
+        template<class T>
+        constexpr decltype(auto) get() const&
+        {
+            return AZStd::get<T>(*this);
+        }
+
+        template<class T>
+        constexpr decltype(auto) get() &&
+        {
+            return AZStd::get<T>(AZStd::move(*this));
+        }
+
+        template<class T>
+        constexpr decltype(auto) get() const&&
+        {
+            return AZStd::get<T>(AZStd::move(*this));
+        }
+
+        constexpr auto type() const -> AttachmentType
+        {
+            return std::array{
+                AttachmentType::Image, AttachmentType::Buffer, AttachmentType::Resolve, AttachmentType::Uninitialized
+            }[index()];
+        }
     };
 } // namespace AZ::RHI

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/UnifiedAttachmentDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/UnifiedAttachmentDescriptor.cpp
@@ -17,32 +17,24 @@ namespace AZ::RHI
     }
 
     UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(const BufferDescriptor& bufferDescriptor)
-        : m_buffer(bufferDescriptor)
-        , m_bufferView(BufferViewDescriptor{})
-        , m_type(AttachmentType::Buffer)
+        : Base{ BufferAttachment{ bufferDescriptor } }
     {
     }
 
     UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(const ImageDescriptor& imageDescriptor)
-        : m_image(imageDescriptor)
-        , m_imageView(ImageViewDescriptor{})
-        , m_type(AttachmentType::Image)
+        : Base{ ImageAttachment{ imageDescriptor } }
     {
     }
 
     UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(
         const BufferDescriptor& bufferDescriptor, const BufferViewDescriptor& bufferViewDescriptor)
-        : m_buffer(bufferDescriptor)
-        , m_bufferView(bufferViewDescriptor)
-        , m_type(AttachmentType::Buffer)
+        : Base{ BufferAttachment{ bufferDescriptor, bufferViewDescriptor } }
     {
     }
 
     UnifiedAttachmentDescriptor::UnifiedAttachmentDescriptor(
         const ImageDescriptor& imageDescriptor, const ImageViewDescriptor& imageViewDescriptor)
-        : m_image(imageDescriptor)
-        , m_imageView(imageViewDescriptor)
-        , m_type(AttachmentType::Image)
+        : Base{ ImageAttachment{ imageDescriptor, imageViewDescriptor } }
     {
     }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -143,7 +143,7 @@ namespace AZ
                 }
                 else
                 {
-                    m_bufferAttachmentByteSize = attachment->m_descriptor.m_buffer.m_byteCount;
+                    m_bufferAttachmentByteSize = attachment->m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_byteCount;
                 }
                 m_readbackItems.push_back({});
                 auto& item = m_readbackItems.back();
@@ -158,7 +158,7 @@ namespace AZ
                 }
                 else
                 {
-                    m_imageDescriptor = attachment->m_descriptor.m_image;
+                    m_imageDescriptor = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
                 }
 
                 m_imageMipsRange = (mipsRange != nullptr)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -229,17 +229,17 @@ namespace AZ
                 dest->m_lifetime = RHI::AttachmentLifetimeType::Transient;
 
                 // Set bind flags to CopyWrite. Other bind flags will be auto-inferred by pass system
-                if (dest->m_descriptor.m_type == RHI::AttachmentType::Image)
+                if (dest->m_descriptor.type() == RHI::AttachmentType::Image)
                 {
-                    dest->m_descriptor.m_image.m_bindFlags = RHI::ImageBindFlags::CopyWrite;
+                    dest->m_descriptor.get<RHI::ImageAttachment>().m_image.m_bindFlags = RHI::ImageBindFlags::CopyWrite;
                 }
-                else if (dest->m_descriptor.m_type == RHI::AttachmentType::Buffer)
+                else if (dest->m_descriptor.type() == RHI::AttachmentType::Buffer)
                 {
-                    dest->m_descriptor.m_buffer.m_bindFlags = RHI::BufferBindFlags::CopyWrite;
-                    if (dest->m_descriptor.m_bufferView.m_elementCount == 0)
+                    dest->m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_bindFlags = RHI::BufferBindFlags::CopyWrite;
+                    if (dest->m_descriptor.get<RHI::BufferAttachment>().m_bufferView.m_elementCount == 0)
                     {
-                        dest->m_descriptor.m_bufferView =
-                            RHI::BufferViewDescriptor::CreateRaw(0, static_cast<uint32_t>(dest->m_descriptor.m_buffer.m_byteCount));
+                        dest->m_descriptor.get<RHI::BufferAttachment>().m_bufferView =
+                            RHI::BufferViewDescriptor::CreateRaw(0, static_cast<uint32_t>(dest->m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_byteCount));
                     }
                 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -248,7 +248,7 @@ namespace AZ
             AZ_Assert(outputAttachment->GetAttachmentType() == RHI::AttachmentType::Image,
                 "[FullscreenTrianglePass %s] output of FullScreenTrianglePass must be an image", GetPathName().GetCStr());
 
-            RHI::Size targetImageSize = outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size targetImageSize = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
             m_viewportState.m_maxX = static_cast<float>(targetImageSize.m_width);
             m_viewportState.m_maxY = static_cast<float>(targetImageSize.m_height);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -717,7 +717,7 @@ namespace AZ
             if (desc.m_lifetime == RHI::AttachmentLifetimeType::Imported)
             {
                 attachment->m_path = desc.m_name;
-                if (attachment->m_descriptor.m_type == RHI::AttachmentType::Buffer)
+                if (attachment->m_descriptor.type() == RHI::AttachmentType::Buffer)
                 {
                     Data::Asset<BufferAsset> bufferAsset = AssetUtils::LoadAssetById<BufferAsset>(desc.m_assetRef.m_assetId, AssetUtils::TraceLevel::None);
 
@@ -732,7 +732,7 @@ namespace AZ
                         }
                     }
                 }
-                else if (attachment->m_descriptor.m_type == RHI::AttachmentType::Image)
+                else if (attachment->m_descriptor.type() == RHI::AttachmentType::Image)
                 {
                     Data::Asset<AttachmentImageAsset> imageAsset = AssetUtils::LoadAssetById<AttachmentImageAsset>(desc.m_assetRef.m_assetId, AssetUtils::TraceLevel::None);
 
@@ -1031,7 +1031,7 @@ namespace AZ
             {
                 if (attachment->m_lifetime == RHI::AttachmentLifetimeType::Transient)
                 {
-                    switch (attachment->m_descriptor.m_type)
+                    switch (attachment->m_descriptor.type())
                     {
                     case RHI::AttachmentType::Image:
                         attachmentDatabase.CreateTransientImage(attachment->GetTransientImageDescriptor());
@@ -1714,7 +1714,7 @@ namespace AZ
 
             // update the image attachment descriptor to sync up size and format
             attachment->Update(true);
-            RHI::ImageDescriptor& imageDesc = attachment->m_descriptor.m_image;
+            RHI::ImageDescriptor& imageDesc = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
 
             // The Format Source had no valid attachment
             if (imageDesc.m_format == RHI::Format::Unknown)
@@ -1949,10 +1949,10 @@ namespace AZ
                     stringOutput += " (";
 
                     // Images will have the format: AttachmentName (Image, 1920, 1080)
-                    if (binding.GetAttachment()->m_descriptor.m_type == RHI::AttachmentType::Image)
+                    if (binding.GetAttachment()->m_descriptor.type() == RHI::AttachmentType::Image)
                     {
                         stringOutput += "Image";
-                        RHI::ImageDescriptor& desc = binding.GetAttachment()->m_descriptor.m_image;
+                        RHI::ImageDescriptor& desc = binding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image;
                         uint32_t dimensions = static_cast<uint32_t>(desc.m_dimension);
                         for (uint32_t i = 0; i < dimensions; ++i)
                         {
@@ -1974,10 +1974,10 @@ namespace AZ
                         }
                     }
                     // Buffers will have the format: AttachmentName (Buffer, 4092 bytes)
-                    else if (binding.GetAttachment()->m_descriptor.m_type == RHI::AttachmentType::Buffer)
+                    else if (binding.GetAttachment()->m_descriptor.type() == RHI::AttachmentType::Buffer)
                     {
                         stringOutput += "Buffer, ";
-                        stringOutput += AZStd::to_string(binding.GetAttachment()->m_descriptor.m_buffer.m_byteCount);
+                        stringOutput += AZStd::to_string(binding.GetAttachment()->m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_byteCount);
                         stringOutput += " bytes";
                     }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -60,12 +60,12 @@ namespace AZ
 
         void PassAttachment::ValidateDeviceFormats(const AZStd::vector<RHI::Format>& formatFallbacks, RHI::FormatCapabilities capabilities)
         {
-            if (m_descriptor.m_type == RHI::AttachmentType::Image)
+            if (m_descriptor.type() == RHI::AttachmentType::Image)
             {
-                RHI::Format format = m_descriptor.m_image.m_format;
+                RHI::Format format = m_descriptor.get<RHI::ImageAttachment>().m_image.m_format;
                 capabilities |= RHI::FormatCapabilities::Sample;
                 AZStd::string formatLocation = AZStd::string::format("PassAttachment [%s]", m_name.GetCStr());
-                m_descriptor.m_image.m_format = RHI::ValidateFormat(format, formatLocation.c_str(), formatFallbacks);
+                m_descriptor.get<RHI::ImageAttachment>().m_image.m_format = RHI::ValidateFormat(format, formatLocation.c_str(), formatFallbacks);
             }
         }
 
@@ -80,7 +80,7 @@ namespace AZ
 
         RHI::AttachmentType PassAttachment::GetAttachmentType() const
         {
-            return m_descriptor.m_type;
+            return m_descriptor.type();
         }
 
         void PassAttachment::ComputePathName(const Name& passPath)
@@ -96,11 +96,11 @@ namespace AZ
                 m_path.GetCStr());
 
             AZ_Assert(
-                m_descriptor.m_type == RHI::AttachmentType::Image,
+                m_descriptor.type() == RHI::AttachmentType::Image,
                 "Error, building a transient image descriptor for an attachment that is not an image: %s",
                 m_path.GetCStr());
 
-            return RHI::TransientImageDescriptor(GetAttachmentId(), m_descriptor.m_image);
+            return RHI::TransientImageDescriptor(GetAttachmentId(), m_descriptor.get<RHI::ImageAttachment>().m_image);
         }
 
         const RHI::TransientBufferDescriptor PassAttachment::GetTransientBufferDescriptor() const
@@ -111,16 +111,16 @@ namespace AZ
                 m_path.GetCStr());
 
             AZ_Assert(
-                m_descriptor.m_type == RHI::AttachmentType::Buffer,
+                m_descriptor.type() == RHI::AttachmentType::Buffer,
                 "Error, building a transient buffer descriptor for an attachment that is not a buffer: %s",
                 m_path.GetCStr());
 
-            return RHI::TransientBufferDescriptor(GetAttachmentId(), m_descriptor.m_buffer);
+            return RHI::TransientBufferDescriptor(GetAttachmentId(), m_descriptor.get<RHI::BufferAttachment>().m_buffer);
         }
 
         void PassAttachment::Update(bool updateImportedAttachments)
         {
-            if (m_descriptor.m_type == RHI::AttachmentType::Image &&
+            if (m_descriptor.type() == RHI::AttachmentType::Image &&
                 (m_lifetime == RHI::AttachmentLifetimeType::Transient || updateImportedAttachments == true))
             {
                 UpdateImageFormat();
@@ -130,12 +130,12 @@ namespace AZ
 
                 if (m_generateFullMipChain)
                 {
-                    uint32_t width = m_descriptor.m_image.m_size.m_width;
-                    uint32_t height = m_descriptor.m_image.m_size.m_height;
+                    uint32_t width = m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width;
+                    uint32_t height = m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_height;
 
                     double maxDimension = static_cast<double>(AZStd::max(width, height));
                     double mipMapLevels = floor(log2(maxDimension)) + 1;
-                    m_descriptor.m_image.m_mipLevels = static_cast<uint16_t>(mipMapLevels);
+                    m_descriptor.get<RHI::ImageAttachment>().m_image.m_mipLevels = static_cast<uint16_t>(mipMapLevels);
                 }
             }
         }
@@ -145,19 +145,19 @@ namespace AZ
             // Auto-infer image and buffer bind flags...
             if (GetAttachmentType() == RHI::AttachmentType::Image)
             {
-                m_descriptor.m_image.m_bindFlags |= RHI::GetImageBindFlags(binding.m_scopeAttachmentUsage, binding.GetAttachmentAccess());
+                m_descriptor.get<RHI::ImageAttachment>().m_image.m_bindFlags |= RHI::GetImageBindFlags(binding.m_scopeAttachmentUsage, binding.GetAttachmentAccess());
             }
             else if (GetAttachmentType() == RHI::AttachmentType::Buffer)
             {
                 bool isInputAssembly = RHI::CheckBitsAny(
-                    m_descriptor.m_buffer.m_bindFlags, RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::DynamicInputAssembly);
-                bool isConstant = RHI::CheckBitsAny(m_descriptor.m_buffer.m_bindFlags, RHI::BufferBindFlags::Constant);
+                    m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_bindFlags, RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::DynamicInputAssembly);
+                bool isConstant = RHI::CheckBitsAny(m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_bindFlags, RHI::BufferBindFlags::Constant);
 
                 // Since InputAssembly and Constant cannot be inferred they are set manually. If those flags are set we don't want to add
                 // inferred flags on top as it may have a performance penalty
                 if (!isInputAssembly && !isConstant)
                 {
-                    m_descriptor.m_buffer.m_bindFlags |=
+                    m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_bindFlags |=
                         RHI::GetBufferBindFlags(binding.m_scopeAttachmentUsage, binding.GetAttachmentAccess());
                 }
             }
@@ -173,15 +173,15 @@ namespace AZ
             m_updatingImageFormat = true;
             if (m_getFormatFromPipeline && m_renderPipelineSource)
             {
-                m_descriptor.m_image.m_format = m_renderPipelineSource->GetRenderSettings().m_format;
+                m_descriptor.get<RHI::ImageAttachment>().m_image.m_format = m_renderPipelineSource->GetRenderSettings().m_format;
             }
             else if (m_formatSource)
             {
                 auto& refAttachment = m_formatSource->GetAttachment();
-                if (refAttachment && refAttachment->m_descriptor.m_type == RHI::AttachmentType::Image)
+                if (refAttachment && refAttachment->m_descriptor.type() == RHI::AttachmentType::Image)
                 {
                     refAttachment->UpdateImageFormat();
-                    m_descriptor.m_image.m_format = refAttachment->m_descriptor.m_image.m_format;
+                    m_descriptor.get<RHI::ImageAttachment>().m_image.m_format = refAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_format;
                 }
             }
             m_updatingImageFormat = false;
@@ -197,15 +197,15 @@ namespace AZ
             m_updatingMultisampleState = true;
             if (m_getMultisampleStateFromPipeline && m_renderPipelineSource)
             {
-                m_descriptor.m_image.m_multisampleState = m_renderPipelineSource->GetRenderSettings().m_multisampleState;
+                m_descriptor.get<RHI::ImageAttachment>().m_image.m_multisampleState = m_renderPipelineSource->GetRenderSettings().m_multisampleState;
             }
             else if (m_multisampleSource)
             {
                 auto& refAttachment = m_multisampleSource->GetAttachment();
-                if (refAttachment && refAttachment->m_descriptor.m_type == RHI::AttachmentType::Image)
+                if (refAttachment && refAttachment->m_descriptor.type() == RHI::AttachmentType::Image)
                 {
                     refAttachment->UpdateImageMultisampleState();
-                    m_descriptor.m_image.m_multisampleState = refAttachment->m_descriptor.m_image.m_multisampleState;
+                    m_descriptor.get<RHI::ImageAttachment>().m_image.m_multisampleState = refAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_multisampleState;
                 }
             }
             m_updatingMultisampleState = false;
@@ -221,16 +221,16 @@ namespace AZ
             m_updatingSize = true;
             if (m_getSizeFromPipeline && m_renderPipelineSource)
             {
-                m_descriptor.m_image.m_size = m_renderPipelineSource->GetRenderSettings().m_size;
+                m_descriptor.get<RHI::ImageAttachment>().m_image.m_size = m_renderPipelineSource->GetRenderSettings().m_size;
             }
             else if (m_sizeSource)
             {
                 auto& refAttachment = m_sizeSource->GetAttachment();
-                if (refAttachment && refAttachment->m_descriptor.m_type == RHI::AttachmentType::Image)
+                if (refAttachment && refAttachment->m_descriptor.type() == RHI::AttachmentType::Image)
                 {
                     refAttachment->UpdateImageSize();
-                    RHI::Size sourceSize = refAttachment->m_descriptor.m_image.m_size;
-                    m_descriptor.m_image.m_size = m_sizeMultipliers.ApplyModifiers(sourceSize);
+                    RHI::Size sourceSize = refAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
+                    m_descriptor.get<RHI::ImageAttachment>().m_image.m_size = m_sizeMultipliers.ApplyModifiers(sourceSize);
                 }
             }
             m_updatingSize = false;
@@ -247,10 +247,10 @@ namespace AZ
             if (m_arraySizeSource)
             {
                 auto& refAttachment = m_arraySizeSource->GetAttachment();
-                if (refAttachment && refAttachment->m_descriptor.m_type == RHI::AttachmentType::Image)
+                if (refAttachment && refAttachment->m_descriptor.type() == RHI::AttachmentType::Image)
                 {
                     refAttachment->UpdateImageArraySize();
-                    m_descriptor.m_image.m_arraySize = refAttachment->m_descriptor.m_image.m_arraySize;
+                    m_descriptor.get<RHI::ImageAttachment>().m_image.m_arraySize = refAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_arraySize;
                 }
             }
             m_updatingArraySize = false;
@@ -328,11 +328,11 @@ namespace AZ
                 {
                     if (attachment->GetAttachmentType() == RHI::AttachmentType::Buffer)
                     {
-                        m_unifiedScopeDesc.SetAsBuffer(attachment->m_descriptor.m_bufferView);
+                        m_unifiedScopeDesc.SetAsBuffer(attachment->m_descriptor.get<RHI::BufferAttachment>().m_bufferView);
                     }
                     else if (attachment->GetAttachmentType() == RHI::AttachmentType::Image)
                     {
-                        m_unifiedScopeDesc.SetAsImage(attachment->m_descriptor.m_imageView);
+                        m_unifiedScopeDesc.SetAsImage(attachment->m_descriptor.get<RHI::ImageAttachment>().m_imageView);
                     }
                 }
                 else if (attachment->m_lifetime == RHI::AttachmentLifetimeType::Imported)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -127,8 +127,8 @@ namespace AZ
             // Build viewport and scissor from target binding if specified
             if (viewportTarget)
             {
-                u32 targetWidth = viewportTarget->GetAttachment()->m_descriptor.m_image.m_size.m_width;
-                u32 targetHeight = viewportTarget->GetAttachment()->m_descriptor.m_image.m_size.m_height;
+                u32 targetWidth = viewportTarget->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width;
+                u32 targetHeight = viewportTarget->GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_height;
                 m_scissorState = RHI::Scissor(0, 0, targetWidth, targetHeight);
                 m_viewportState = RHI::Viewport(0, static_cast<float>(targetWidth), 0, static_cast<float>(targetHeight));
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -97,7 +97,7 @@ namespace AZ
                 if (binding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::DepthStencil)
                 {
                     subpassLayoutBuilder.DepthStencilAttachment(
-                        binding.GetAttachment()->m_descriptor.m_image.m_format,
+                        binding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_format,
                         binding.GetAttachment()->GetAttachmentId(),
                         binding.m_unifiedScopeDesc.m_loadStoreAction,
                         binding.GetAttachmentAccess(),
@@ -109,7 +109,7 @@ namespace AZ
                 if (binding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::ShadingRate)
                 {
                     subpassLayoutBuilder.ShadingRateAttachment(
-                        binding.GetAttachment()->m_descriptor.m_image.m_format, binding.GetAttachment()->GetAttachmentId());
+                        binding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_format, binding.GetAttachment()->GetAttachmentId());
                     continue;
                 }
 
@@ -129,7 +129,7 @@ namespace AZ
 
                 if (binding.m_scopeAttachmentUsage == RHI::ScopeAttachmentUsage::RenderTarget)
                 {
-                    RHI::Format format = binding.GetAttachment()->m_descriptor.m_image.m_format;
+                    RHI::Format format = binding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_format;
                     subpassLayoutBuilder.RenderTargetAttachment(
                         format,
                         binding.GetAttachment()->GetAttachmentId(),
@@ -193,13 +193,13 @@ namespace AZ
                     if (!wasSet)
                     {
                         // save multi-sample state found in the first output color attachment
-                        outputMultiSampleState = binding.GetAttachment()->m_descriptor.m_image.m_multisampleState;
+                        outputMultiSampleState = binding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_multisampleState;
                         wasSet = true;
                     }
                     else if (PassValidation::IsEnabled())
                     {
                         // return false directly if the current output color attachment has different multi-sample state then previous ones
-                        if (outputMultiSampleState != binding.GetAttachment()->m_descriptor.m_image.m_multisampleState)
+                        if (outputMultiSampleState != binding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image.m_multisampleState)
                         {
                             AZ_Error("RPI", false, "Pass %s has different multi-sample states within its color attachments", GetPathName().GetCStr());
                             break;
@@ -356,7 +356,7 @@ namespace AZ
 
                     if (binding.m_shaderImageDimensionsNameIndex.HasName())
                     {
-                        RHI::Size size = attachment->m_descriptor.m_image.m_size;
+                        RHI::Size size = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
                         AZ::Vector4 imageDimensions;
                         imageDimensions.SetX(float(size.m_width));

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleMipChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleMipChainPass.cpp
@@ -72,17 +72,18 @@ namespace AZ
             if (attachment != nullptr)
             {
                 // Check if we need to rebuild children because the number of mips has changed
-                m_needToRebuildChildren = m_needToRebuildChildren || (m_mipLevels != attachment->m_descriptor.m_image.m_mipLevels);
+                const auto& imageDesc = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
+                m_needToRebuildChildren = m_needToRebuildChildren || (m_mipLevels != imageDesc.m_mipLevels);
 
                 // Check if we need to update children because the image dimensions have changed
-                m_needToUpdateChildren |= (m_inputWidth != attachment->m_descriptor.m_image.m_size.m_width);
-                m_needToUpdateChildren |= (m_inputHeight != attachment->m_descriptor.m_image.m_size.m_height);
+                m_needToUpdateChildren |= (m_inputWidth != imageDesc.m_size.m_width);
+                m_needToUpdateChildren |= (m_inputHeight != imageDesc.m_size.m_height);
                 m_needToUpdateChildren |= m_needToRebuildChildren;
 
                 // Get parameters from the image descriptor
-                m_mipLevels = attachment->m_descriptor.m_image.m_mipLevels;
-                m_inputWidth = attachment->m_descriptor.m_image.m_size.m_width;
-                m_inputHeight = attachment->m_descriptor.m_image.m_size.m_height;
+                m_mipLevels = imageDesc.m_mipLevels;
+                m_inputWidth = imageDesc.m_size.m_width;
+                m_inputHeight = imageDesc.m_size.m_height;
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleSinglePassLuminancePass.cpp
@@ -76,7 +76,7 @@ namespace AZ::RPI
         {
             return;
         }
-        const uint32_t mipLevelCount = attachment->m_descriptor.m_image.m_mipLevels;
+        const uint32_t mipLevelCount = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_mipLevels;
         RHI::AttachmentId attachmentId = attachment->GetAttachmentId();
         const RHI::Image* rhiImage = context.GetImage(attachmentId);
         if (!rhiImage)
@@ -148,8 +148,8 @@ namespace AZ::RPI
 
         if (attachment)
         {
-            m_destinationImageSize[0] = attachment->m_descriptor.m_image.m_size.m_width;
-            m_destinationImageSize[1] = attachment->m_descriptor.m_image.m_size.m_height;
+            m_destinationImageSize[0] = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_width;
+            m_destinationImageSize[1] = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size.m_height;
 
             // m_mipLevels of the attachment has not been initialized yet, so it is calculated below:
             const uint32_t maxDimension = GetMax(m_destinationImageSize[0], m_destinationImageSize[1]);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -43,7 +43,7 @@ namespace AZ
         {
             if (m_swapChainAttachment)
             {
-                return m_swapChainAttachment->m_descriptor.m_image.m_format;
+                return m_swapChainAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_format;
             }
             return RHI::Format::Unknown;
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -199,7 +199,7 @@ namespace AZ
                         }
                         else
                         {
-                            imageDesc = attachment->m_descriptor.m_image;
+                            imageDesc = attachment->m_descriptor.get<RHI::ImageAttachment>().m_image;
                         }
                         m_viewport = RHI::Viewport(0, (float)imageDesc.m_size.m_width, 0, (float)imageDesc.m_size.m_height);
                         m_scissor = RHI::Scissor(0, 0, imageDesc.m_size.m_width, imageDesc.m_size.m_height);

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.inl
@@ -230,7 +230,7 @@ namespace AZ::Render
                     }
                     else
                     {
-                        descriptor = binding.GetAttachment()->m_descriptor.m_image;
+                        descriptor = binding.GetAttachment()->m_descriptor.get<RHI::ImageAttachment>().m_image;
                     }
                     auto format = descriptor.m_format;
                     auto size = descriptor.m_size;
@@ -251,7 +251,7 @@ namespace AZ::Render
                 else if (type == AZ::RHI::AttachmentType::Buffer)
                 {
                     // Append buffer info: [size]
-                    auto size = binding.GetAttachment()->m_descriptor.m_buffer.m_byteCount;
+                    auto size = binding.GetAttachment()->m_descriptor.get<RHI::BufferAttachment>().m_buffer.m_byteCount;
                     label += AZStd::string::format(" [%llu]", size);
                 }
 

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridQueryFullscreenPass.cpp
@@ -219,7 +219,7 @@ namespace AZ
                 AZ_Assert(outputAttachment != nullptr, "[DiffuseProbeGridQueryFullscreenPass '%s']: A fullscreen DiffuseProbeGridQuery pass must have a valid output or input/output.", GetPathName().GetCStr());
                 AZ_Assert(outputAttachment->GetAttachmentType() == RHI::AttachmentType::Image, "[DiffuseProbeGridQueryFullscreenPass '%s']: The output of a fullscreen DiffuseProbeGridQuery pass must be an image.", GetPathName().GetCStr());
 
-                RHI::Size imageSize = outputAttachment->m_descriptor.m_image.m_size;
+                RHI::Size imageSize = outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
 
                 // submit DispatchItem
                 const uint8_t srgCount = 3;

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridRenderPass.cpp
@@ -83,7 +83,7 @@ namespace AZ
             RPI::PassAttachment* m_outputAttachment = GetInputOutputBinding(0).GetAttachment().get();
             AZ_Assert(m_outputAttachment, "DiffuseProbeGridRenderPass: Output binding has no attachment!");
             
-            RHI::Size size = m_outputAttachment->m_descriptor.m_image.m_size;
+            RHI::Size size = m_outputAttachment->m_descriptor.get<RHI::ImageAttachment>().m_image.m_size;
             RHI::Viewport viewport(0.f, aznumeric_cast<float>(size.m_width), 0.f, aznumeric_cast<float>(size.m_height));
             RHI::Scissor scissor(0, 0, size.m_width, size.m_height);
             


### PR DESCRIPTION
## What does this PR do?

Types that require a constructor call cannot be hidden in layers of anonymous unions or anonymous structs. To make this standard conforming we need to be able to name a constructor to initialize at least one path into the data structures. So the union itself would have to be named, and then select a member to construct. 

I first tried to remove any types that require construction, but once I found an optional in one of the paths I reconsidered and switched to this solution instead. I interpreted that as a canary that told me that this part of the code base is on a modernization path. 

Still I am puzzled why this works in clang at all.

This change avoids the trouble by using a variant. This does change the interface! Hence the impact. Please let me know if you would prefer an alternative route!

_Please add links to any issues, RFCs or other items that are relevant to this PR._

## How was this PR tested?

I built with clang and gcc. This is part of a longer work stream to make it build with gcc
