### PR TITLE
fix(gcc): template syntax

### DIFF
--- a/Code/Legacy/CryCommon/Cry_Matrix33.h
+++ b/Code/Legacy/CryCommon/Cry_Matrix33.h
@@ -144,7 +144,7 @@ struct Matrix33_tpl
 
     //CONSTRUCTOR for identical float-types
     //Matrix33 m=m33;
-    ILINE Matrix33_tpl<F>(const Matrix33_tpl<F>&m)
+    ILINE Matrix33_tpl(const Matrix33_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -160,7 +160,7 @@ struct Matrix33_tpl
     //CONSTRUCTOR for different float-types which converts between double/float
     //Matrix33 m=m33r;
     template<class F1>
-    ILINE Matrix33_tpl<F>(const Matrix33_tpl<F1>&m)
+    ILINE Matrix33_tpl(const Matrix33_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -177,7 +177,7 @@ struct Matrix33_tpl
     //CONSTRUCTOR for identical float-types. It converts a Matrix34 into a Matrix33.
     //Needs to be 'explicit' because we loose the translation vector in the conversion process
     //Matrix33(m34);
-    explicit ILINE Matrix33_tpl<F>(const Matrix34_tpl<F>&m)
+    explicit ILINE Matrix33_tpl(const Matrix34_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -194,7 +194,7 @@ struct Matrix33_tpl
     //Needs to be 'explicit' because we loose the translation vector in the conversion process
     //Matrix33(m34r);
     template<class F1>
-    explicit ILINE Matrix33_tpl<F>(const Matrix34_tpl<F1>&m)
+    explicit ILINE Matrix33_tpl(const Matrix34_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -211,7 +211,7 @@ struct Matrix33_tpl
     //CONSTRUCTOR for identical float-types. It converts a Matrix44 into a Matrix33.
     //Needs to be 'explicit' because we loose the translation vector and the 3rd row in the conversion process
     //Matrix33(m44);
-    explicit ILINE Matrix33_tpl<F>(const Matrix44_tpl<F>&m)
+    explicit ILINE Matrix33_tpl(const Matrix44_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -228,7 +228,7 @@ struct Matrix33_tpl
     //Needs to be 'explicit' because we loose the translation vector and the 3rd row in the conversion process
     //Matrix33(m44r);
     template<class F1>
-    explicit ILINE Matrix33_tpl<F>(const Matrix44_tpl<F1>&m)
+    explicit ILINE Matrix33_tpl(const Matrix44_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -245,7 +245,7 @@ struct Matrix33_tpl
     //CONSTRUCTOR for identical float-types. It converts a Quat into a Matrix33.
     //Needs to be 'explicit' because we loose fp-precision in the conversion process
     //Matrix33(quat);
-    explicit ILINE Matrix33_tpl<F>(const Quat_tpl<F>&q)
+    explicit ILINE Matrix33_tpl(const Quat_tpl<F>&q)
     {
         assert(q.IsValid(0.05f));
         Vec3_tpl<F> v2 = q.v + q.v;
@@ -273,7 +273,7 @@ struct Matrix33_tpl
     //Needs to be 'explicit' because we loose fp-precision in the conversion process
     //Matrix33(quatr);
     template<class F1>
-    explicit ILINE Matrix33_tpl<F>(const Quat_tpl<F1>&q)
+    explicit ILINE Matrix33_tpl(const Quat_tpl<F1>&q)
     {
         assert(q.IsValid(0.05f));
         Vec3_tpl<F1> v2 = q.v + q.v;
@@ -301,7 +301,7 @@ struct Matrix33_tpl
     //CONSTRUCTOR for identical float-types. It converts a Euler Angle into a Matrix33.
     //Needs to be 'explicit' because we loose fp-precision in the conversion process
     //Matrix33(Ang3(1,2,3));
-    explicit ILINE Matrix33_tpl<F>(const Ang3_tpl<F>&ang)
+    explicit ILINE Matrix33_tpl(const Ang3_tpl<F>&ang)
     {
         assert(ang.IsValid());
         SetRotationXYZ(ang);
@@ -310,7 +310,7 @@ struct Matrix33_tpl
     //Needs to be 'explicit' because we loose fp-precision in the conversion process
     //Matrix33(Ang3r(1,2,3));
     template<class F1>
-    explicit ILINE Matrix33_tpl<F>(const Ang3_tpl<F1>&ang)
+    explicit ILINE Matrix33_tpl(const Ang3_tpl<F1>&ang)
     {
         assert(ang.IsValid());
         SetRotationXYZ(Ang3_tpl<F>(F(ang.x), F(ang.y), F(ang.z)));

--- a/Code/Legacy/CryCommon/Cry_Matrix34.h
+++ b/Code/Legacy/CryCommon/Cry_Matrix34.h
@@ -129,7 +129,7 @@ struct Matrix34_tpl
 
 
     //CONSTRUCTOR for identical float-types. It initialises a matrix34 with 12 floats.
-    ILINE Matrix34_tpl<F>(F v00, F v01, F v02, F v03, F v10, F v11, F v12, F v13, F v20, F v21, F v22, F v23)
+    ILINE Matrix34_tpl(F v00, F v01, F v02, F v03, F v10, F v11, F v12, F v13, F v20, F v21, F v22, F v23)
     {
         m00 = v00;
         m01 = v01;
@@ -146,7 +146,7 @@ struct Matrix34_tpl
     }
     //CONSTRUCTOR for different float-types. It initialises a matrix34 with 12 floats.
     template<class F1>
-    ILINE Matrix34_tpl<F>(F1 v00, F1 v01, F1 v02, F1 v03, F1 v10, F1 v11, F1 v12, F1 v13, F1 v20, F1 v21, F1 v22, F1 v23)
+    ILINE Matrix34_tpl(F1 v00, F1 v01, F1 v02, F1 v03, F1 v10, F1 v11, F1 v12, F1 v13, F1 v20, F1 v21, F1 v22, F1 v23)
     {
         m00 = F(v00);
         m01 = F(v01);
@@ -165,7 +165,7 @@ struct Matrix34_tpl
 
     //CONSTRUCTOR for identical float-types. It converts a Matrix33 into a Matrix34.
     //Matrix34(m33);
-    ILINE Matrix34_tpl<F>(const Matrix33_tpl<F>&m)
+    ILINE Matrix34_tpl(const Matrix33_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -184,7 +184,7 @@ struct Matrix34_tpl
     //CONSTRUCTOR for different float-types. It converts a Matrix33 into a Matrix34 and also converts between double/float.
     //Matrix34(Matrix33);
     template<class F1>
-    ILINE Matrix34_tpl<F>(const Matrix33_tpl<F1>&m)
+    ILINE Matrix34_tpl(const Matrix33_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -204,7 +204,7 @@ struct Matrix34_tpl
 
     //CONSTRUCTOR for identical float-types. It converts a Matrix33 with a translation-vector into a Matrix34.
     //Matrix34(m33,Vec3(1,2,3));
-    ILINE Matrix34_tpl<F>(const Matrix33_tpl<F>&m, const Vec3_tpl<F>&t)
+    ILINE Matrix34_tpl(const Matrix33_tpl<F>&m, const Vec3_tpl<F>&t)
     {
         assert(m.IsValid());
         assert(t.IsValid());
@@ -224,7 +224,7 @@ struct Matrix34_tpl
     //CONSTRUCTOR for different float-types. It converts a Matrix33 with a translation-vector into a Matrix34 and also converts between double/float.
     //Matrix34(Matrix33r,Vec3d(1,2,3));
     template<class F1>
-    ILINE Matrix34_tpl<F>(const Matrix33_tpl<F1>&m, const Vec3_tpl<F1>&t)
+    ILINE Matrix34_tpl(const Matrix33_tpl<F1>&m, const Vec3_tpl<F1>&t)
     {
         assert(m.IsValid());
         assert(t.IsValid());
@@ -246,7 +246,7 @@ struct Matrix34_tpl
 
     //CONSTRUCTOR for identical float types
     //Matrix34 m=m34;
-    ILINE Matrix34_tpl<F>(const Matrix34_tpl<F>&m)
+    ILINE Matrix34_tpl(const Matrix34_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -265,7 +265,7 @@ struct Matrix34_tpl
     //CONSTRUCTOR for different float-types.
     //Matrix34 m=m34d;
     template<class F1>
-    ILINE Matrix34_tpl<F>(const Matrix34_tpl<F1>&m)
+    ILINE Matrix34_tpl(const Matrix34_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -286,7 +286,7 @@ struct Matrix34_tpl
     //CONSTRUCTOR for identical float-types. It converts a Matrix44 into a Matrix34.
     //Needs to be 'explicit' because we loose the translation vector in the conversion process
     //Matrix34(m44);
-    ILINE explicit Matrix34_tpl<F>(const Matrix44_tpl<F>&m)
+    ILINE explicit Matrix34_tpl(const Matrix44_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -306,7 +306,7 @@ struct Matrix34_tpl
     //Needs to be 'explicit' because we loose the translation vector in the conversion process
     //Matrix34(m44r);
     template<class F1>
-    ILINE explicit Matrix34_tpl<F>(const Matrix44_tpl<F1>&m)
+    ILINE explicit Matrix34_tpl(const Matrix44_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -326,7 +326,7 @@ struct Matrix34_tpl
     //CONSTRUCTOR for identical float-types. It converts a Quat into a Matrix34.
     //Needs to be 'explicit' because we loose float-precision in the conversion process
     //Matrix34(QuatT);
-    explicit ILINE Matrix34_tpl<F>(const Quat_tpl<F>&q)
+    explicit ILINE Matrix34_tpl(const Quat_tpl<F>&q)
     {
         *this = Matrix33_tpl<F>(q);
     }
@@ -334,7 +334,7 @@ struct Matrix34_tpl
     //Needs to be 'explicit' because we loose float-precision in the conversion process
     //Matrix34(QuatTd);
     template<class F1>
-    explicit ILINE Matrix34_tpl<F>(const Quat_tpl<F1>&q)
+    explicit ILINE Matrix34_tpl(const Quat_tpl<F1>&q)
     {
         *this = Matrix33_tpl<F>(q);
     }

--- a/Code/Legacy/CryCommon/Cry_Matrix44.h
+++ b/Code/Legacy/CryCommon/Cry_Matrix44.h
@@ -162,7 +162,7 @@ struct Matrix44_tpl
 
     //CONSTRUCTOR for different types. It converts a Matrix33 into a Matrix44.
     //Matrix44(m33);
-    ILINE Matrix44_tpl<F>(const Matrix33_tpl<F>&m)
+    ILINE Matrix44_tpl(const Matrix33_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -185,7 +185,7 @@ struct Matrix44_tpl
     //CONSTRUCTOR for different types. It converts a Matrix33 into a Matrix44 and also converts between double/float.
     //Matrix44(Matrix33);
     template<class F1>
-    ILINE Matrix44_tpl<F>(const Matrix33_tpl<F1>&m)
+    ILINE Matrix44_tpl(const Matrix33_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -209,7 +209,7 @@ struct Matrix44_tpl
 
     //CONSTRUCTOR for different types. It converts a Matrix34 into a Matrix44.
     //Matrix44(m34);
-    ILINE Matrix44_tpl<F>(const Matrix34_tpl<F>&m)
+    ILINE Matrix44_tpl(const Matrix34_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;
@@ -232,7 +232,7 @@ struct Matrix44_tpl
     //CONSTRUCTOR for different types. It converts a Matrix34 into a Matrix44 and also converts between double/float.
     //Matrix44(Matrix34);
     template<class F1>
-    ILINE Matrix44_tpl<F>(const Matrix34_tpl<F1>&m)
+    ILINE Matrix44_tpl(const Matrix34_tpl<F1>&m)
     {
         assert(m.IsValid());
         m00 = F(m.m00);
@@ -256,7 +256,7 @@ struct Matrix44_tpl
 
     //CONSTRUCTOR for identical types
     //Matrix44 m=m44;
-    ILINE Matrix44_tpl<F>(const Matrix44_tpl<F>&m)
+    ILINE Matrix44_tpl(const Matrix44_tpl<F>&m)
     {
         assert(m.IsValid());
         m00 = m.m00;

--- a/Code/Legacy/CryCommon/Cry_Quat.h
+++ b/Code/Legacy/CryCommon/Cry_Quat.h
@@ -6,7 +6,6 @@
  *
  */
 
-
 // Description : Common quaternion class
 #pragma once
 
@@ -15,7 +14,7 @@
 //----------------------------------------------------------------------
 // Quaternion
 //----------------------------------------------------------------------
-template <typename F>
+template<typename F>
 struct Quat_tpl
 {
     Vec3_tpl<F> v;
@@ -23,7 +22,7 @@ struct Quat_tpl
 
     //-------------------------------
 
-    //constructors
+    // constructors
 #if defined(_DEBUG)
     ILINE Quat_tpl()
     {
@@ -45,10 +44,12 @@ struct Quat_tpl
         }
     }
 #else
-    ILINE Quat_tpl() {}
+    ILINE Quat_tpl()
+    {
+    }
 #endif
 
-    //initialize with zeros
+    // initialize with zeros
     ILINE Quat_tpl(type_zero)
     {
         w = 0, v.x = 0, v.y = 0, v.z = 0;
@@ -58,10 +59,10 @@ struct Quat_tpl
         w = 1, v.x = 0, v.y = 0, v.z = 0;
     }
 
-    //ASSIGNMENT OPERATOR of identical Quat types.
-    //The assignment operator has precedence over assignment constructor
-    //Quat q; q=q0;
-    ILINE Quat_tpl<F>& operator = (const Quat_tpl<F>& src)
+    // ASSIGNMENT OPERATOR of identical Quat types.
+    // The assignment operator has precedence over assignment constructor
+    // Quat q; q=q0;
+    ILINE Quat_tpl<F>& operator=(const Quat_tpl<F>& src)
     {
         v.x = src.v.x;
         v.y = src.v.y;
@@ -71,10 +72,9 @@ struct Quat_tpl
         return *this;
     }
 
-
-    //CONSTRUCTOR to initialize a Quat from 4 floats
-    //Quat q(1,0,0,0);
-    ILINE Quat_tpl<F>(F qw, F qx, F qy, F qz)
+    // CONSTRUCTOR to initialize a Quat from 4 floats
+    // Quat q(1,0,0,0);
+    ILINE Quat_tpl(F qw, F qx, F qy, F qz)
     {
         w = qw;
         v.x = qx;
@@ -82,19 +82,18 @@ struct Quat_tpl
         v.z = qz;
         assert(IsValid());
     }
-    //CONSTRUCTOR to initialize a Quat with a scalar and a vector
-    //Quat q(1,Vec3(0,0,0));
-    ILINE Quat_tpl<F>(F scalar, const Vec3_tpl<F> &vector)
+    // CONSTRUCTOR to initialize a Quat with a scalar and a vector
+    // Quat q(1,Vec3(0,0,0));
+    ILINE Quat_tpl(F scalar, const Vec3_tpl<F>& vector)
     {
         v = vector;
         w = scalar;
         assert(IsValid());
     };
 
-
-    //CONSTRUCTOR for identical types
-    //Quat q=q0;
-    ILINE  Quat_tpl<F>(const Quat_tpl<F>&q)
+    // CONSTRUCTOR for identical types
+    // Quat q=q0;
+    ILINE Quat_tpl(const Quat_tpl<F>& q)
     {
         w = q.w;
         v.x = q.v.x;
@@ -103,8 +102,8 @@ struct Quat_tpl
         assert(IsValid());
     }
 
-    //CONSTRUCTOR for AZ::Quaternion
-    explicit ILINE  Quat_tpl<F>(const AZ::Quaternion& q)
+    // CONSTRUCTOR for AZ::Quaternion
+    explicit ILINE Quat_tpl(const AZ::Quaternion& q)
     {
         w = q.GetW();
         v.x = q.GetX();
@@ -113,11 +112,11 @@ struct Quat_tpl
         assert(IsValid());
     }
 
-    //CONSTRUCTOR for identical types which converts between double/float
-    //Quat q32=q64;
-    //Quatr q64=q32;
-    template <class F1>
-    ILINE  Quat_tpl<F>(const Quat_tpl<F1>&q)
+    // CONSTRUCTOR for identical types which converts between double/float
+    // Quat q32=q64;
+    // Quatr q64=q32;
+    template<class F1>
+    ILINE Quat_tpl(const Quat_tpl<F1>& q)
     {
         assert(q.IsValid());
         w = F(q.w);
@@ -126,130 +125,146 @@ struct Quat_tpl
         v.z = F(q.v.z);
     }
 
-
-
-
-
-
-
-    //CONSTRUCTOR for different types. It converts a Euler Angle into a Quat.
-    //Needs to be 'explicit' because we loose fp-precision in the conversion process
-    //Quat(Ang3(1,2,3));
-    explicit ILINE Quat_tpl<F>(const Ang3_tpl<F>&ang)
+    // CONSTRUCTOR for different types. It converts a Euler Angle into a Quat.
+    // Needs to be 'explicit' because we loose fp-precision in the conversion process
+    // Quat(Ang3(1,2,3));
+    explicit ILINE Quat_tpl(const Ang3_tpl<F>& ang)
     {
         assert(ang.IsValid());
         SetRotationXYZ(ang);
     }
-    //CONSTRUCTOR for different types. It converts a Euler Angle into a Quat and converts between double/float. .
-    //Needs to be 'explicit' because we loose fp-precision in the conversion process
-    //Quat(Ang3r(1,2,3));
+    // CONSTRUCTOR for different types. It converts a Euler Angle into a Quat and converts between double/float. .
+    // Needs to be 'explicit' because we loose fp-precision in the conversion process
+    // Quat(Ang3r(1,2,3));
     template<class F1>
-    explicit ILINE Quat_tpl<F>(const Ang3_tpl<F1>&ang)
+    explicit ILINE Quat_tpl(const Ang3_tpl<F1>& ang)
     {
         assert(ang.IsValid());
         SetRotationXYZ(Ang3_tpl<F>(F(ang.x), F(ang.y), F(ang.z)));
     }
 
-
-    //CONSTRUCTOR for different types. It converts a Matrix33 into a Quat.
-    //Needs to be 'explicit' because we loose fp-precision in the conversion process
-    //Quat(m33);
-    explicit ILINE Quat_tpl<F>(const Matrix33_tpl<F>&m)
+    // CONSTRUCTOR for different types. It converts a Matrix33 into a Quat.
+    // Needs to be 'explicit' because we loose fp-precision in the conversion process
+    // Quat(m33);
+    explicit ILINE Quat_tpl(const Matrix33_tpl<F>& m)
     {
         assert(m.IsOrthonormalRH(0.1f));
         F s, p, tr = m.m00 + m.m11 + m.m22;
         w = 1, v.x = 0, v.y = 0, v.z = 0;
         if (tr > 0)
         {
-            s = sqrt_tpl(tr + 1.0f), p = 0.5f / s, w = s * 0.5f, v.x = (m.m21 - m.m12) * p, v.y = (m.m02 - m.m20) * p, v.z = (m.m10 - m.m01) * p;
+            s = sqrt_tpl(tr + 1.0f), p = 0.5f / s, w = s * 0.5f, v.x = (m.m21 - m.m12) * p, v.y = (m.m02 - m.m20) * p,
+            v.z = (m.m10 - m.m01) * p;
         }
         else if ((m.m00 >= m.m11) && (m.m00 >= m.m22))
         {
-            s = sqrt_tpl(m.m00 - m.m11 - m.m22 + 1.0f), p = 0.5f / s, w = (m.m21 - m.m12) * p, v.x = s * 0.5f, v.y = (m.m10 + m.m01) * p, v.z = (m.m20 + m.m02) * p;
+            s = sqrt_tpl(m.m00 - m.m11 - m.m22 + 1.0f), p = 0.5f / s, w = (m.m21 - m.m12) * p, v.x = s * 0.5f, v.y = (m.m10 + m.m01) * p,
+            v.z = (m.m20 + m.m02) * p;
         }
         else if ((m.m11 >= m.m00) && (m.m11 >= m.m22))
         {
-            s = sqrt_tpl(m.m11 - m.m22 - m.m00 + 1.0f), p = 0.5f / s, w = (m.m02 - m.m20) * p, v.x = (m.m01 + m.m10) * p, v.y = s * 0.5f, v.z = (m.m21 + m.m12) * p;
+            s = sqrt_tpl(m.m11 - m.m22 - m.m00 + 1.0f), p = 0.5f / s, w = (m.m02 - m.m20) * p, v.x = (m.m01 + m.m10) * p, v.y = s * 0.5f,
+            v.z = (m.m21 + m.m12) * p;
         }
         else if ((m.m22 >= m.m00) && (m.m22 >= m.m11))
         {
-            s = sqrt_tpl(m.m22 - m.m00 - m.m11 + 1.0f), p = 0.5f / s, w = (m.m10 - m.m01) * p, v.x = (m.m02 + m.m20) * p, v.y = (m.m12 + m.m21) * p, v.z = s * 0.5f;
+            s = sqrt_tpl(m.m22 - m.m00 - m.m11 + 1.0f), p = 0.5f / s, w = (m.m10 - m.m01) * p, v.x = (m.m02 + m.m20) * p,
+            v.y = (m.m12 + m.m21) * p, v.z = s * 0.5f;
         }
     }
-    //CONSTRUCTOR for different types. It converts a Matrix33 into a Quat and converts between double/float.
-    //Needs to be 'explicit' because we loose fp-precision the conversion process
-    //Quat(m33r);
-    //Quatr(m33);
+    // CONSTRUCTOR for different types. It converts a Matrix33 into a Quat and converts between double/float.
+    // Needs to be 'explicit' because we loose fp-precision the conversion process
+    // Quat(m33r);
+    // Quatr(m33);
     template<class F1>
-    explicit ILINE Quat_tpl<F>(const Matrix33_tpl<F1>&m)
+    explicit ILINE Quat_tpl(const Matrix33_tpl<F1>& m)
     {
         assert(m.IsOrthonormalRH(0.1f));
         F1 s, p, tr = m.m00 + m.m11 + m.m22;
         w = 1, v.x = 0, v.y = 0, v.z = 0;
         if (tr > 0)
         {
-            s = sqrt_tpl(tr + 1.0f), p = 0.5f / s, w = F(s * 0.5), v.x = F((m.m21 - m.m12) * p), v.y = F((m.m02 - m.m20) * p), v.z = F((m.m10 - m.m01) * p);
+            s = sqrt_tpl(tr + 1.0f), p = 0.5f / s, w = F(s * 0.5), v.x = F((m.m21 - m.m12) * p), v.y = F((m.m02 - m.m20) * p),
+            v.z = F((m.m10 - m.m01) * p);
         }
         else if ((m.m00 >= m.m11) && (m.m00 >= m.m22))
         {
-            s = sqrt_tpl(m.m00 - m.m11 - m.m22 + 1.0f), p = 0.5f / s, w = F((m.m21 - m.m12) * p), v.x = F(s * 0.5), v.y = F((m.m10 + m.m01) * p), v.z = F((m.m20 + m.m02) * p);
+            s = sqrt_tpl(m.m00 - m.m11 - m.m22 + 1.0f), p = 0.5f / s, w = F((m.m21 - m.m12) * p), v.x = F(s * 0.5),
+            v.y = F((m.m10 + m.m01) * p), v.z = F((m.m20 + m.m02) * p);
         }
         else if ((m.m11 >= m.m00) && (m.m11 >= m.m22))
         {
-            s = sqrt_tpl(m.m11 - m.m22 - m.m00 + 1.0f), p = 0.5f / s, w = F((m.m02 - m.m20) * p), v.x = F((m.m01 + m.m10) * p), v.y = F(s * 0.5), v.z = F((m.m21 + m.m12) * p);
+            s = sqrt_tpl(m.m11 - m.m22 - m.m00 + 1.0f), p = 0.5f / s, w = F((m.m02 - m.m20) * p), v.x = F((m.m01 + m.m10) * p),
+            v.y = F(s * 0.5), v.z = F((m.m21 + m.m12) * p);
         }
         else if ((m.m22 >= m.m00) && (m.m22 >= m.m11))
         {
-            s = sqrt_tpl(m.m22 - m.m00 - m.m11 + 1.0f), p = 0.5f / s, w = F((m.m10 - m.m01) * p), v.x = F((m.m02 + m.m20) * p), v.y = F((m.m12 + m.m21) * p), v.z = F(s * 0.5);
+            s = sqrt_tpl(m.m22 - m.m00 - m.m11 + 1.0f), p = 0.5f / s, w = F((m.m10 - m.m01) * p), v.x = F((m.m02 + m.m20) * p),
+            v.y = F((m.m12 + m.m21) * p), v.z = F(s * 0.5);
         }
     }
 
-    //CONSTRUCTOR for different types. It converts a Matrix34 into a Quat.
-    //Needs to be 'explicit' because we loose fp-precision in the conversion process
-    //Quat(m34);
-    explicit ILINE Quat_tpl<F>(const Matrix34_tpl<F>&m)
+    // CONSTRUCTOR for different types. It converts a Matrix34 into a Quat.
+    // Needs to be 'explicit' because we loose fp-precision in the conversion process
+    // Quat(m34);
+    explicit ILINE Quat_tpl(const Matrix34_tpl<F>& m)
     {
         *this = Quat_tpl<F>(Matrix33_tpl<F>(m));
     }
-    //CONSTRUCTOR for different types. It converts a Matrix34 into a Quat and converts between double/float.
-    //Needs to be 'explicit' because we loose fp-precision the conversion process
-    //Quat(m34r);
-    //Quatr(m34);
+    // CONSTRUCTOR for different types. It converts a Matrix34 into a Quat and converts between double/float.
+    // Needs to be 'explicit' because we loose fp-precision the conversion process
+    // Quat(m34r);
+    // Quatr(m34);
     template<class F1>
-    explicit ILINE Quat_tpl<F>(const Matrix34_tpl<F1>&m)
+    explicit ILINE Quat_tpl(const Matrix34_tpl<F1>& m)
     {
         *this = Quat_tpl<F>(Matrix33_tpl<F1>(m));
     }
 
-
-
-
-
     /*!
-    * invert quaternion.
-    *
-    * Example 1:
-    *  Quat q=Quat::CreateRotationXYZ(Ang3(1,2,3));
-    *  Quat result = !q;
-    *  Quat result = GetInverted(q);
-    *  q.Invert();
-    */
-    ILINE Quat_tpl<F> operator ! () const { return Quat_tpl(w, -v); }
-    ILINE void Invert(void) { *this = !*this;   }
-    ILINE Quat_tpl<F> GetInverted() const { return !(*this); }
-    //flip quaternion. don't confuse this with quaternion-inversion.
-    ILINE Quat_tpl<F>   operator - () const { return Quat_tpl<F>(-w, -v); };
-    //multiplication by a scalar
-    void operator *= (F op) {   w *= op; v *= op;   }
+     * invert quaternion.
+     *
+     * Example 1:
+     *  Quat q=Quat::CreateRotationXYZ(Ang3(1,2,3));
+     *  Quat result = !q;
+     *  Quat result = GetInverted(q);
+     *  q.Invert();
+     */
+    ILINE Quat_tpl<F> operator!() const
+    {
+        return Quat_tpl(w, -v);
+    }
+    ILINE void Invert(void)
+    {
+        *this = !*this;
+    }
+    ILINE Quat_tpl<F> GetInverted() const
+    {
+        return !(*this);
+    }
+    // flip quaternion. don't confuse this with quaternion-inversion.
+    ILINE Quat_tpl<F> operator-() const
+    {
+        return Quat_tpl<F>(-w, -v);
+    };
+    // multiplication by a scalar
+    void operator*=(F op)
+    {
+        w *= op;
+        v *= op;
+    }
 
     // Exact compare of 2 quats.
-    ILINE bool operator==(const Quat_tpl<F>& q) const { return (v == q.v) && (w == q.w); }
-    ILINE bool operator!=(const Quat_tpl<F>& q) const { return !(*this == q); }
+    ILINE bool operator==(const Quat_tpl<F>& q) const
+    {
+        return (v == q.v) && (w == q.w);
+    }
+    ILINE bool operator!=(const Quat_tpl<F>& q) const
+    {
+        return !(*this == q);
+    }
 
-
-
-
-    //A quaternion is a compressed matrix. Thus there is no problem extracting the rows & columns.
+    // A quaternion is a compressed matrix. Thus there is no problem extracting the rows & columns.
     ILINE Vec3_tpl<F> GetColumn(uint32 i)
     {
         if (i == 0)
@@ -264,35 +279,63 @@ struct Quat_tpl
         {
             return GetColumn2();
         }
-        assert(0); //bad index
+        assert(0); // bad index
         return Vec3(ZERO);
     }
 
-    ILINE Vec3_tpl<F> GetColumn0() const {return Vec3_tpl<F>(2 * (v.x * v.x + w * w) - 1, 2 * (v.y * v.x + v.z * w), 2 * (v.z * v.x - v.y * w)); }
-    ILINE Vec3_tpl<F> GetColumn1() const {return Vec3_tpl<F>(2 * (v.x * v.y - v.z * w), 2 * (v.y * v.y + w * w) - 1, 2 * (v.z * v.y + v.x * w)); }
-    ILINE Vec3_tpl<F> GetColumn2() const {return Vec3_tpl<F>(2 * (v.x * v.z + v.y * w), 2 * (v.y * v.z - v.x * w), 2 * (v.z * v.z + w * w) - 1); }
-    ILINE Vec3_tpl<F> GetRow0() const {return Vec3_tpl<F>(2 * (v.x * v.x + w * w) - 1, 2 * (v.x * v.y - v.z * w), 2 * (v.x * v.z + v.y * w)); }
-    ILINE Vec3_tpl<F> GetRow1() const {return Vec3_tpl<F>(2 * (v.y * v.x + v.z * w), 2 * (v.y * v.y + w * w) - 1, 2 * (v.y * v.z - v.x * w)); }
-    ILINE Vec3_tpl<F> GetRow2() const   {return Vec3_tpl<F>(2 * (v.z * v.x - v.y * w), 2 * (v.z * v.y + v.x * w), 2 * (v.z * v.z + w * w) - 1); }
+    ILINE Vec3_tpl<F> GetColumn0() const
+    {
+        return Vec3_tpl<F>(2 * (v.x * v.x + w * w) - 1, 2 * (v.y * v.x + v.z * w), 2 * (v.z * v.x - v.y * w));
+    }
+    ILINE Vec3_tpl<F> GetColumn1() const
+    {
+        return Vec3_tpl<F>(2 * (v.x * v.y - v.z * w), 2 * (v.y * v.y + w * w) - 1, 2 * (v.z * v.y + v.x * w));
+    }
+    ILINE Vec3_tpl<F> GetColumn2() const
+    {
+        return Vec3_tpl<F>(2 * (v.x * v.z + v.y * w), 2 * (v.y * v.z - v.x * w), 2 * (v.z * v.z + w * w) - 1);
+    }
+    ILINE Vec3_tpl<F> GetRow0() const
+    {
+        return Vec3_tpl<F>(2 * (v.x * v.x + w * w) - 1, 2 * (v.x * v.y - v.z * w), 2 * (v.x * v.z + v.y * w));
+    }
+    ILINE Vec3_tpl<F> GetRow1() const
+    {
+        return Vec3_tpl<F>(2 * (v.y * v.x + v.z * w), 2 * (v.y * v.y + w * w) - 1, 2 * (v.y * v.z - v.x * w));
+    }
+    ILINE Vec3_tpl<F> GetRow2() const
+    {
+        return Vec3_tpl<F>(2 * (v.z * v.x - v.y * w), 2 * (v.z * v.y + v.x * w), 2 * (v.z * v.z + w * w) - 1);
+    }
 
     // These are just copy & pasted components of the GetColumn1() above.
-    ILINE F GetFwdX() const { return (2 * (v.x * v.y - v.z * w)); }
-    ILINE F GetFwdY() const { return (2 * (v.y * v.y + w * w) - 1); }
-    ILINE F GetFwdZ() const { return (2 * (v.z * v.y + v.x * w)); }
-    ILINE F GetRotZ() const { return atan2_tpl(-GetFwdX(), GetFwdY()); }
-
-
+    ILINE F GetFwdX() const
+    {
+        return (2 * (v.x * v.y - v.z * w));
+    }
+    ILINE F GetFwdY() const
+    {
+        return (2 * (v.y * v.y + w * w) - 1);
+    }
+    ILINE F GetFwdZ() const
+    {
+        return (2 * (v.z * v.y + v.x * w));
+    }
+    ILINE F GetRotZ() const
+    {
+        return atan2_tpl(-GetFwdX(), GetFwdY());
+    }
 
     /*!
-    * set identity quaternion
-    *
-    * Example:
-    *       Quat q=Quat::CreateIdentity();
-    *   or
-    *       q.SetIdentity();
-    *   or
-    *       Quat p=Quat(IDENTITY);
-    */
+     * set identity quaternion
+     *
+     * Example:
+     *       Quat q=Quat::CreateIdentity();
+     *   or
+     *       q.SetIdentity();
+     *   or
+     *       Quat p=Quat(IDENTITY);
+     */
     ILINE void SetIdentity(void)
     {
         w = 1;
@@ -304,9 +347,6 @@ struct Quat_tpl
     {
         return Quat_tpl<F>(1, 0, 0, 0);
     }
-
-
-
 
     // Description:
     //    Check if identity quaternion.
@@ -330,11 +370,9 @@ struct Quat_tpl
         {
             return false;
         }
-        //if (!IsUnit(e))   return false;
+        // if (!IsUnit(e))   return false;
         return true;
     }
-
-
 
     ILINE void SetRotationAA(F rad, const Vec3_tpl<F>& axis)
     {
@@ -362,17 +400,14 @@ struct Quat_tpl
         return q;
     }
 
-
-
-
     /*!
-    * Create rotation-quaternion that around the fixed coordinate axes.
-    *
-    * Example:
-    *       Quat q=Quat::CreateRotationXYZ( Ang3(1,2,3) );
-    *   or
-    *       q.SetRotationXYZ( Ang3(1,2,3) );
-    */
+     * Create rotation-quaternion that around the fixed coordinate axes.
+     *
+     * Example:
+     *       Quat q=Quat::CreateRotationXYZ( Ang3(1,2,3) );
+     *   or
+     *       q.SetRotationXYZ( Ang3(1,2,3) );
+     */
     ILINE void SetRotationXYZ(const Ang3_tpl<F>& a)
     {
         assert(a.IsValid());
@@ -382,7 +417,7 @@ struct Quat_tpl
         sincos_tpl(F(a.y * F(0.5)), &sy, &cy);
         F sz, cz;
         sincos_tpl(F(a.z * F(0.5)), &sz, &cz);
-        w       = cx * cy * cz + sx * sy * sz;
+        w = cx * cy * cz + sx * sy * sz;
         v.x = cz * cy * sx - sz * sy * cx;
         v.y = cz * sy * cx + sz * cy * sx;
         v.z = sz * cy * cx - cz * sy * sx;
@@ -420,13 +455,13 @@ struct Quat_tpl
     }
 
     /*!
-    * Create rotation-quaternion that about the x-axis.
-    *
-    * Example:
-    *       Quat q=Quat::CreateRotationX( radiant );
-    *   or
-    *       q.SetRotationX( Ang3(1,2,3) );
-    */
+     * Create rotation-quaternion that about the x-axis.
+     *
+     * Example:
+     *       Quat q=Quat::CreateRotationX( radiant );
+     *   or
+     *       q.SetRotationX( Ang3(1,2,3) );
+     */
     ILINE void SetRotationX(f32 r)
     {
         F s, c;
@@ -443,15 +478,14 @@ struct Quat_tpl
         return q;
     }
 
-
     /*!
-    * Create rotation-quaternion that about the y-axis.
-    *
-    * Example:
-    *       Quat q=Quat::CreateRotationY( radiant );
-    *   or
-    *       q.SetRotationY( radiant );
-    */
+     * Create rotation-quaternion that about the y-axis.
+     *
+     * Example:
+     *       Quat q=Quat::CreateRotationY( radiant );
+     *   or
+     *       q.SetRotationY( radiant );
+     */
     ILINE void SetRotationY(f32 r)
     {
         F s, c;
@@ -468,15 +502,14 @@ struct Quat_tpl
         return q;
     }
 
-
     /*!
-    * Create rotation-quaternion that about the z-axis.
-    *
-    * Example:
-    *       Quat q=Quat::CreateRotationZ( radiant );
-    *   or
-    *       q.SetRotationZ( radiant );
-    */
+     * Create rotation-quaternion that about the z-axis.
+     *
+     * Example:
+     *       Quat q=Quat::CreateRotationZ( radiant );
+     *   or
+     *       q.SetRotationZ( radiant );
+     */
     ILINE void SetRotationZ(f32 r)
     {
         F s, c;
@@ -493,17 +526,15 @@ struct Quat_tpl
         return q;
     }
 
-
-
     /*!
-    *
-    * Create rotation-quaternion that rotates from one vector to another.
-    * Both vectors are assumed to be normalized.
-    *
-    * Example:
-    *       Quat q=Quat::CreateRotationV0V1( v0,v1 );
-    *       q.SetRotationV0V1( v0,v1 );
-    */
+     *
+     * Create rotation-quaternion that rotates from one vector to another.
+     * Both vectors are assumed to be normalized.
+     *
+     * Example:
+     *       Quat q=Quat::CreateRotationV0V1( v0,v1 );
+     *       q.SetRotationV0V1( v0,v1 );
+     */
     ILINE void SetRotationV0V1(const Vec3_tpl<F>& v0, const Vec3_tpl<F>& v1)
     {
         assert(v0.IsUnit(0.01f));
@@ -524,48 +555,48 @@ struct Quat_tpl
         w = 0;
         v = v0.GetOrthogonal().GetNormalized();
     }
-    ILINE static Quat_tpl<F> CreateRotationV0V1(const Vec3_tpl<F>& v0, const Vec3_tpl<F>& v1) { Quat_tpl<F> q;  q.SetRotationV0V1(v0, v1);   return q;   }
-
-
-
-
-
+    ILINE static Quat_tpl<F> CreateRotationV0V1(const Vec3_tpl<F>& v0, const Vec3_tpl<F>& v1)
+    {
+        Quat_tpl<F> q;
+        q.SetRotationV0V1(v0, v1);
+        return q;
+    }
 
     /*!
-    *
-    * \param vdir  normalized view direction.
-    * \param roll  radiant to rotate about Y-axis.
-    *
-    *  Given a view-direction and a radiant to rotate about Y-axis, this function builds a 3x3 look-at quaternion
-    *  using only simple vector arithmetic. This function is always using the implicit up-vector Vec3(0,0,1).
-    *  The view-direction is always stored in column(1).
-    *  IMPORTANT: The view-vector is assumed to be normalized, because all trig-values for the orientation are being
-    *  extracted  directly out of the vector. This function must NOT be called with a view-direction
-    *  that is close to Vec3(0,0,1) or Vec3(0,0,-1). If one of these rules is broken, the function returns a quaternion
-    *  with an undefined rotation about the Z-axis.
-    *
-    *  Rotation order for the look-at-quaternion is Z-X-Y. (Zaxis=YAW / Xaxis=PITCH / Yaxis=ROLL)
-    *
-    *  COORDINATE-SYSTEM
-    *
-    *  z-axis
-    *    ^
-    *    |
-    *    |  y-axis
-    *    |  /
-    *    | /
-    *    |/
-    *    +--------------->   x-axis
-    *
-    *  Example:
-    *       Quat LookAtQuat=Quat::CreateRotationVDir( Vec3(0,1,0) );
-    *   or
-    *       Quat LookAtQuat=Quat::CreateRotationVDir( Vec3(0,1,0), 0.333f );
-    */
+     *
+     * \param vdir  normalized view direction.
+     * \param roll  radiant to rotate about Y-axis.
+     *
+     *  Given a view-direction and a radiant to rotate about Y-axis, this function builds a 3x3 look-at quaternion
+     *  using only simple vector arithmetic. This function is always using the implicit up-vector Vec3(0,0,1).
+     *  The view-direction is always stored in column(1).
+     *  IMPORTANT: The view-vector is assumed to be normalized, because all trig-values for the orientation are being
+     *  extracted  directly out of the vector. This function must NOT be called with a view-direction
+     *  that is close to Vec3(0,0,1) or Vec3(0,0,-1). If one of these rules is broken, the function returns a quaternion
+     *  with an undefined rotation about the Z-axis.
+     *
+     *  Rotation order for the look-at-quaternion is Z-X-Y. (Zaxis=YAW / Xaxis=PITCH / Yaxis=ROLL)
+     *
+     *  COORDINATE-SYSTEM
+     *
+     *  z-axis
+     *    ^
+     *    |
+     *    |  y-axis
+     *    |  /
+     *    | /
+     *    |/
+     *    +--------------->   x-axis
+     *
+     *  Example:
+     *       Quat LookAtQuat=Quat::CreateRotationVDir( Vec3(0,1,0) );
+     *   or
+     *       Quat LookAtQuat=Quat::CreateRotationVDir( Vec3(0,1,0), 0.333f );
+     */
     ILINE void SetRotationVDir(const Vec3_tpl<F>& vdir)
     {
         assert(vdir.IsUnit(0.01f));
-        //set default initialization for up-vector
+        // set default initialization for up-vector
         w = F(0.70710676908493042);
         v.x = F(vdir.z * 0.70710676908493042);
         v.y = F(0.0);
@@ -573,28 +604,32 @@ struct Quat_tpl
         F l = sqrt_tpl(vdir.x * vdir.x + vdir.y * vdir.y);
         if (l > F(0.00001))
         {
-            //calculate LookAt quaternion
-            Vec3_tpl<F> hv  =   Vec3_tpl<F> (vdir.x / l, vdir.y / l + 1.0f, l + 1.0f);
+            // calculate LookAt quaternion
+            Vec3_tpl<F> hv = Vec3_tpl<F>(vdir.x / l, vdir.y / l + 1.0f, l + 1.0f);
             F r = sqrt_tpl(hv.x * hv.x + hv.y * hv.y);
             F s = sqrt_tpl(hv.z * hv.z + vdir.z * vdir.z);
-            //generate the half-angle sine&cosine
+            // generate the half-angle sine&cosine
             F hacos0 = 0.0;
             F hasin0 = -1.0;
             if (r > F(0.00001))
             {
                 hacos0 = hv.y / r;
                 hasin0 = -hv.x / r;
-            }                                                       //yaw
+            } // yaw
             F hacos1 = hv.z / s;
-            F hasin1 = vdir.z / s;                                  //pitch
+            F hasin1 = vdir.z / s; // pitch
             w = F(hacos0 * hacos1);
             v.x = F(hacos0 * hasin1);
             v.y = F(hasin0 * hasin1);
             v.z = F(hasin0 * hacos1);
         }
     }
-    ILINE static Quat_tpl<F> CreateRotationVDir(const Vec3_tpl<F>& vdir) {    Quat_tpl<F> q;  q.SetRotationVDir(vdir); return q;  }
-
+    ILINE static Quat_tpl<F> CreateRotationVDir(const Vec3_tpl<F>& vdir)
+    {
+        Quat_tpl<F> q;
+        q.SetRotationVDir(vdir);
+        return q;
+    }
 
     ILINE void SetRotationVDir(const Vec3_tpl<F>& vdir, F r)
     {
@@ -607,21 +642,23 @@ struct Quat_tpl
         v.z = F(v.z * cy + vx * sy);
         w = F(w * cy - vy * sy);
     }
-    ILINE static Quat_tpl<F> CreateRotationVDir(const Vec3_tpl<F>& vdir, F roll) {    Quat_tpl<F> q; q.SetRotationVDir(vdir, roll);    return q;   }
-
-
-
+    ILINE static Quat_tpl<F> CreateRotationVDir(const Vec3_tpl<F>& vdir, F roll)
+    {
+        Quat_tpl<F> q;
+        q.SetRotationVDir(vdir, roll);
+        return q;
+    }
 
     /*!
-    * normalize quaternion.
-    *
-    * Example 1:
-    *  Quat q; q.Normalize();
-    *
-    * Example 2:
-    *  Quat q=Quat(1,2,3,4);
-    *  Quat qn=q.GetNormalized();
-    */
+     * normalize quaternion.
+     *
+     * Example 1:
+     *  Quat q; q.Normalize();
+     *
+     * Example 2:
+     *  Quat q=Quat(1,2,3,4);
+     *  Quat qn=q.GetNormalized();
+     */
     ILINE void Normalize(void)
     {
         F d = isqrt_tpl(w * w + v.x * v.x + v.y * v.y + v.z * v.z);
@@ -636,7 +673,6 @@ struct Quat_tpl
         t.Normalize();
         return t;
     }
-
 
     ILINE void NormalizeSafe(void)
     {
@@ -661,8 +697,7 @@ struct Quat_tpl
         return t;
     }
 
-
-    ILINE void  NormalizeFast(void)
+    ILINE void NormalizeFast(void)
     {
         assert(this->IsValid());
         F fInvLen = isqrt_fast_tpl(v.x * v.x + v.y * v.y + v.z * v.z + w * w);
@@ -678,13 +713,12 @@ struct Quat_tpl
         return t;
     }
 
-
     /*!
-    * get length of quaternion.
-    *
-    * Example 1:
-    *  f32 l=q.GetLength();
-    */
+     * get length of quaternion.
+     *
+     * Example 1:
+     *  f32 l=q.GetLength();
+     */
     ILINE F GetLength() const
     {
         return sqrt_tpl(w * w + v.x * v.x + v.y * v.y + v.z * v.z);
@@ -699,7 +733,6 @@ struct Quat_tpl
         return qdif;
     }
 
-
     // Exponent of Quaternion.
     ILINE static Quat_tpl<F> exp(const Vec3_tpl<F>& v)
     {
@@ -712,11 +745,11 @@ struct Quat_tpl
             s /= len;
             return Quat_tpl<F>(c, v.x * s, v.y * s, v.z * s);
         }
-        return Quat_tpl<F> (IDENTITY);
+        return Quat_tpl<F>(IDENTITY);
     }
 
     // logarithm of a quaternion, imaginary part (the real part of the logarithm is always 0)
-    ILINE static Vec3_tpl<F> log (const Quat_tpl<F>& q)
+    ILINE static Vec3_tpl<F> log(const Quat_tpl<F>& q)
     {
         assert(q.IsValid());
         F lensqr = q.v.len2();
@@ -730,7 +763,6 @@ struct Quat_tpl
         return Vec3_tpl<F>(0, 0, 0);
     }
 
-
     //////////////////////////////////////////////////////////////////////////
     //! Logarithm of Quaternion difference.
     ILINE static Quat_tpl<F> LnDif(const Quat_tpl<F>& q1, const Quat_tpl<F>& q2)
@@ -738,16 +770,13 @@ struct Quat_tpl
         return Quat_tpl<F>(0, log(q2 / q1));
     }
 
-
-
-
     /*!
-    * linear-interpolation between quaternions (lerp)
-    *
-    * Example:
-    *  CQuaternion result,p,q;
-    *  result=qlerp( p, q, 0.5f );
-    */
+     * linear-interpolation between quaternions (lerp)
+     *
+     * Example:
+     *  CQuaternion result,p,q;
+     *  result=qlerp( p, q, 0.5f );
+     */
     ILINE void SetNlerp(const Quat_tpl<F>& p, const Quat_tpl<F>& tq, F t)
     {
         Quat_tpl<F> q = tq;
@@ -760,7 +789,7 @@ struct Quat_tpl
         v.x = p.v.x * (1.0f - t) + q.v.x * t;
         v.y = p.v.y * (1.0f - t) + q.v.y * t;
         v.z = p.v.z * (1.0f - t) + q.v.z * t;
-        w       = p.w  * (1.0f - t) + q.w  * t;
+        w = p.w * (1.0f - t) + q.w * t;
         Normalize();
     }
 
@@ -772,12 +801,12 @@ struct Quat_tpl
     }
 
     /*!
-    * spherical-interpolation between quaternions (geometrical slerp)
-    *
-    * Example:
-    *  Quat result,p,q;
-    *  result.SetSlerp( p, q, 0.5f );
-    */
+     * spherical-interpolation between quaternions (geometrical slerp)
+     *
+     * Example:
+     *  Quat result,p,q;
+     *  result.SetSlerp( p, q, 0.5f );
+     */
     ILINE void SetSlerp(const Quat_tpl<F>& tp, const Quat_tpl<F>& tq, F t)
     {
         assert(tp.IsValid());
@@ -790,25 +819,25 @@ struct Quat_tpl
         {
             cosine = -cosine;
             q = -q;
-        }                                             //take shortest arc
+        } // take shortest arc
         if (cosine > 0.9999f)
         {
             SetNlerp(p, q, t);
             return;
         }
         // from now on, a division by 0 is not possible any more
-        q2.w        = q.w - p.w * cosine;
-        q2.v.x  = q.v.x - p.v.x * cosine;
-        q2.v.y  = q.v.y - p.v.y * cosine;
-        q2.v.z  = q.v.z - p.v.z * cosine;
-        F sine  = sqrt(q2 | q2);
+        q2.w = q.w - p.w * cosine;
+        q2.v.x = q.v.x - p.v.x * cosine;
+        q2.v.y = q.v.y - p.v.y * cosine;
+        q2.v.z = q.v.z - p.v.z * cosine;
+        F sine = sqrt(q2 | q2);
 
         // Actually you can divide by 0 right here.
         assert(sine != 0.0000f);
 
         F s, c;
         sincos_tpl(atan2_tpl(sine, cosine) * t, &s, &c);
-        w =   F(p.w  * c + q2.w  * s / sine);
+        w = F(p.w * c + q2.w * s / sine);
         v.x = F(p.v.x * c + q2.v.x * s / sine);
         v.y = F(p.v.y * c + q2.v.y * s / sine);
         v.z = F(p.v.z * c + q2.v.z * s / sine);
@@ -834,14 +863,12 @@ struct Quat_tpl
         return d;
     }
 
-
-    //useless, please delete
+    // useless, please delete
     ILINE Quat_tpl<F> GetScaled(F scale) const
     {
         return CreateNlerp(IDENTITY, *this, scale);
     }
 };
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Typedefs                                                                  //
@@ -849,59 +876,56 @@ struct Quat_tpl
 
 // O3DE_DEPRECATION_NOTICE(GHI-19483) - Use AZ::Quaternion
 AZ_DEPRECATED_MESSAGE("Quat is deprecated, use AZ::Quaternion instead.")
-typedef Quat_tpl<f32>  Quat;  //always 32 bit
+typedef Quat_tpl<f32> Quat; // always 32 bit
 
 /*!
-*
-* The "inner product" or "dot product" operation.
-*
-* calculate the "inner product" between two Quaternion.
-* If both Quaternion are unit-quaternions, the result is the cosine: p*q=cos(angle)
-*
-* Example:
-*  Quat p(1,0,0,0),q(1,0,0,0);
-*  f32 cosine = ( p | q );
-*
-*/
+ *
+ * The "inner product" or "dot product" operation.
+ *
+ * calculate the "inner product" between two Quaternion.
+ * If both Quaternion are unit-quaternions, the result is the cosine: p*q=cos(angle)
+ *
+ * Example:
+ *  Quat p(1,0,0,0),q(1,0,0,0);
+ *  f32 cosine = ( p | q );
+ *
+ */
 template<typename F1, typename F2>
-ILINE F1 operator | (const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE F1 operator|(const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     assert(q.v.IsValid());
     assert(p.v.IsValid());
     return (q.v.x * p.v.x + q.v.y * p.v.y + q.v.z * p.v.z + q.w * p.w);
 }
 
-
 /*!
-*
-*  Implements the multiplication operator: Qua=QuatA*QuatB
-*
-*  AxB = operation B followed by operation A.
-*  A multiplication takes 16 muls and 12 adds.
-*
-*  Example 1:
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat result=p*q;
-*
-*  Example 2: (self-multiplication)
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat p*=q;
-*/
+ *
+ *  Implements the multiplication operator: Qua=QuatA*QuatB
+ *
+ *  AxB = operation B followed by operation A.
+ *  A multiplication takes 16 muls and 12 adds.
+ *
+ *  Example 1:
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat result=p*q;
+ *
+ *  Example 2: (self-multiplication)
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat p*=q;
+ */
 template<class F1, class F2>
-Quat_tpl<F1> ILINE operator * (const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+Quat_tpl<F1> ILINE operator*(const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     assert(q.IsValid());
     assert(p.IsValid());
-    return Quat_tpl<F1>
-           (
-        q.w * p.w  - (q.v.x * p.v.x + q.v.y * p.v.y + q.v.z * p.v.z),
+    return Quat_tpl<F1>(
+        q.w * p.w - (q.v.x * p.v.x + q.v.y * p.v.y + q.v.z * p.v.z),
         q.v.y * p.v.z - q.v.z * p.v.y + q.w * p.v.x + q.v.x * p.w,
         q.v.z * p.v.x - q.v.x * p.v.z + q.w * p.v.y + q.v.y * p.w,
-        q.v.x * p.v.y - q.v.y * p.v.x + q.w * p.v.z + q.v.z * p.w
-           );
+        q.v.x * p.v.y - q.v.y * p.v.x + q.w * p.v.z + q.v.z * p.w);
 }
 template<class F1, class F2>
-ILINE void operator *= (Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE void operator*=(Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     assert(q.IsValid());
     assert(p.IsValid());
@@ -910,117 +934,108 @@ ILINE void operator *= (Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
     q.v = p.v * s0 + q.v * p.w + (q.v % p.v);
 }
 
-
-
-
 /*!
-*  division operator
-*
-*  Example 1:
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat result=p/q;
-*
-*  Example 2: (self-division)
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat p/=q;
-*/
+ *  division operator
+ *
+ *  Example 1:
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat result=p/q;
+ *
+ *  Example 2: (self-division)
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat p/=q;
+ */
 template<class F1, class F2>
-ILINE Quat_tpl<F1> operator / (const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE Quat_tpl<F1> operator/(const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     return (!p * q);
 }
 template<class F1, class F2>
-ILINE void operator /= (Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE void operator/=(Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     q = (!p * q);
 }
 
-
 /*!
-*  addition operator
-*
-*  Example:
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat result=p+q;
-*
-*  Example:(self-addition operator)
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat p-=q;
-*/
+ *  addition operator
+ *
+ *  Example:
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat result=p+q;
+ *
+ *  Example:(self-addition operator)
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat p-=q;
+ */
 template<class F1, class F2>
-ILINE Quat_tpl<F1> operator + (const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE Quat_tpl<F1> operator+(const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     return Quat_tpl<F1>(q.w + p.w, q.v + p.v);
 }
 template<class F1, class F2>
-ILINE void operator += (Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE void operator+=(Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     q.w += p.w;
     q.v += p.v;
 }
 
-
-
 /*!
-*  subtraction operator
-*
-*  Example:
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat result=p-q;
-*
-*  Example: (self-subtraction operator)
-*   Quat p(1,0,0,0),q(1,0,0,0);
-*   Quat p-=q;
-*
-*/
+ *  subtraction operator
+ *
+ *  Example:
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat result=p-q;
+ *
+ *  Example: (self-subtraction operator)
+ *   Quat p(1,0,0,0),q(1,0,0,0);
+ *   Quat p-=q;
+ *
+ */
 template<class F1, class F2>
-ILINE Quat_tpl<F1> operator - (const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE Quat_tpl<F1> operator-(const Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     return Quat_tpl<F1>(q.w - p.w, q.v - p.v);
 }
 template<class F1, class F2>
-ILINE void operator -= (Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
+ILINE void operator-=(Quat_tpl<F1>& q, const Quat_tpl<F2>& p)
 {
     q.w -= p.w;
     q.v -= p.v;
 }
 
-
 //! Scale quaternion free function.
-template <typename F>
-ILINE Quat_tpl<F> operator * (F t, const Quat_tpl<F>& q)
+template<typename F>
+ILINE Quat_tpl<F> operator*(F t, const Quat_tpl<F>& q)
 {
     return Quat_tpl<F>(t * q.w, t * q.v);
 };
 
-
-template <typename F1, typename F2>
-ILINE Quat_tpl<F1>   operator * (const Quat_tpl<F1>& q, F2 t)
+template<typename F1, typename F2>
+ILINE Quat_tpl<F1> operator*(const Quat_tpl<F1>& q, F2 t)
 {
     return Quat_tpl<F1>(q.w * t, q.v * t);
 };
-template <typename F1, typename F2>
-ILINE Quat_tpl<F1>   operator / (const Quat_tpl<F1>& q, F2 t)
+template<typename F1, typename F2>
+ILINE Quat_tpl<F1> operator/(const Quat_tpl<F1>& q, F2 t)
 {
     return Quat_tpl<F1>(q.w / t, q.v / t);
 };
 
-
 /*!
-*
-* post-multiply of a quaternion and a Vec3 (3D rotations with quaternions)
-*
-* Example:
-*  Quat q(1,0,0,0);
-*  Vec3 v(33,44,55);
-*    Vec3 result = q*v;
-*/
+ *
+ * post-multiply of a quaternion and a Vec3 (3D rotations with quaternions)
+ *
+ * Example:
+ *  Quat q(1,0,0,0);
+ *  Vec3 v(33,44,55);
+ *    Vec3 result = q*v;
+ */
 template<class F, class F2>
-ILINE Vec3_tpl<F> operator * (const Quat_tpl<F>& q, const Vec3_tpl<F2>& v)
+ILINE Vec3_tpl<F> operator*(const Quat_tpl<F>& q, const Vec3_tpl<F2>& v)
 {
     assert(v.IsValid());
     assert(q.IsValid());
-    //muls=15 / adds=15
+    // muls=15 / adds=15
     Vec3_tpl<F> out, r2;
     r2.x = (q.v.y * v.z - q.v.z * v.y) + q.w * v.x;
     r2.y = (q.v.z * v.x - q.v.x * v.z) + q.w * v.y;
@@ -1034,21 +1049,20 @@ ILINE Vec3_tpl<F> operator * (const Quat_tpl<F>& q, const Vec3_tpl<F2>& v)
     return out;
 }
 
-
 /*!
-* pre-multiply of a quaternion and a Vec3 (3D rotations with quaternions)
-*
-* Example:
-*  Quat q(1,0,0,0);
-*  Vec3 v(33,44,55);
-*    Vec3 result = v*q;
-*/
+ * pre-multiply of a quaternion and a Vec3 (3D rotations with quaternions)
+ *
+ * Example:
+ *  Quat q(1,0,0,0);
+ *  Vec3 v(33,44,55);
+ *    Vec3 result = v*q;
+ */
 template<class F, class F2>
-ILINE Vec3_tpl<F2> operator * (const Vec3_tpl<F>& v, const Quat_tpl<F2>& q)
+ILINE Vec3_tpl<F2> operator*(const Vec3_tpl<F>& v, const Quat_tpl<F2>& q)
 {
     assert(v.IsValid());
     assert(q.IsValid());
-    //muls=15 / adds=15
+    // muls=15 / adds=15
     Vec3_tpl<F> out, r2;
     r2.x = (q.v.z * v.y - q.v.y * v.z) + q.w * v.x;
     r2.y = (q.v.x * v.z - q.v.z * v.x) + q.w * v.y;
@@ -1062,10 +1076,8 @@ ILINE Vec3_tpl<F2> operator * (const Vec3_tpl<F>& v, const Quat_tpl<F2>& q)
     return out;
 }
 
-
-
 template<class F1, class F2>
-ILINE Quat_tpl<F1> operator % (const Quat_tpl<F1>& q, const Quat_tpl<F2>& tp)
+ILINE Quat_tpl<F1> operator%(const Quat_tpl<F1>& q, const Quat_tpl<F2>& tp)
 {
     Quat_tpl<F1> p = tp;
     if ((p | q) < 0)
@@ -1075,7 +1087,7 @@ ILINE Quat_tpl<F1> operator % (const Quat_tpl<F1>& q, const Quat_tpl<F2>& tp)
     return Quat_tpl<F1>(q.w + p.w, q.v + p.v);
 }
 template<class F1, class F2>
-ILINE void operator %= (Quat_tpl<F1>& q, const Quat_tpl<F2>& tp)
+ILINE void operator%=(Quat_tpl<F1>& q, const Quat_tpl<F2>& tp)
 {
     Quat_tpl<F1> p = tp;
     if ((p | q) < 0)

--- a/Code/Legacy/CryCommon/Cry_Vector3.h
+++ b/Code/Legacy/CryCommon/Cry_Vector3.h
@@ -143,35 +143,35 @@ struct Vec3_tpl
     */
     ILINE Vec3_tpl(const Vec3_tpl& v)   {   x = v.x; y = v.y; z = v.z; }
     template<class F1>
-    ILINE  Vec3_tpl<F>(const Vec3_tpl<F1>&v)  {
+    ILINE  Vec3_tpl(const Vec3_tpl<F1>&v)  {
         x = F(v.x);
         y = F(v.y);
         z = F(v.z);
         assert(IsValid());
     }
 
-    ILINE Vec3_tpl<F>(const Vec2_tpl<F>&v) {
+    ILINE Vec3_tpl(const Vec2_tpl<F>&v) {
         x = v.x;
         y = v.y;
         z = 0;
         assert(IsValid());
     }
     template<class T>
-    ILINE Vec3_tpl<F>(const Vec2_tpl<T>&v) {
+    ILINE Vec3_tpl(const Vec2_tpl<T>&v) {
         x = F(v.x);
         y = F(v.y);
         z = 0;
         assert(IsValid());
     }
 
-    explicit ILINE Vec3_tpl<F>(const Ang3_tpl<F>&v) {
+    explicit ILINE Vec3_tpl(const Ang3_tpl<F>&v) {
         x = v.x;
         y = v.y;
         z = v.z;
         assert(IsValid());
     }
     template<class T>
-    explicit ILINE Vec3_tpl<F>(const Ang3_tpl<T>&v) {
+    explicit ILINE Vec3_tpl(const Ang3_tpl<T>&v) {
         x = v.x;
         y = v.y;
         z = v.z;
@@ -975,7 +975,7 @@ struct Ang3_tpl
     Ang3_tpl(type_zero) { x = y = z = 0; }
 
     void operator () (F vx, F vy, F vz) { x = vx; y = vy; z = vz; };
-    ILINE Ang3_tpl<F>(F vx, F vy, F vz)   {
+    ILINE Ang3_tpl(F vx, F vy, F vz)   {
         x = vx;
         y = vy;
         z = vz;

--- a/Gems/Atom/Feature/Common/Code/Source/Material/FallbackPBRMaterial.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/FallbackPBRMaterial.cpp
@@ -48,7 +48,6 @@ namespace AZ::Render
                 return defaultValue;
             }
 
-            template<>
             RHI::Ptr<const RHI::ImageView> GetProperty(const AZ::Name& propertyName, const RHI::Ptr<const RHI::ImageView> defaultValue)
             {
                 auto image = GetProperty<Data::Instance<RPI::Image>>(propertyName, nullptr);
@@ -126,14 +125,14 @@ namespace AZ::Render
             }
 
             convertedMaterial.m_baseColorImageView =
-                util.GetProperty<RHI::Ptr<const RHI::ImageView>>(AZ_NAME_LITERAL("baseColor.textureMap"));
-            convertedMaterial.m_normalImageView = util.GetProperty<RHI::Ptr<const RHI::ImageView>>(AZ_NAME_LITERAL("normal.textureMap"));
+                util.GetProperty(AZ_NAME_LITERAL("baseColor.textureMap"), RHI::Ptr<const RHI::ImageView>{});
+            convertedMaterial.m_normalImageView = util.GetProperty(AZ_NAME_LITERAL("normal.textureMap"), RHI::Ptr<const RHI::ImageView>{});
             convertedMaterial.m_metallicImageView =
-                util.GetProperty<RHI::Ptr<const RHI::ImageView>>(AZ_NAME_LITERAL("metallic.textureMap"));
+                util.GetProperty(AZ_NAME_LITERAL("metallic.textureMap"), RHI::Ptr<const RHI::ImageView>{});
             convertedMaterial.m_roughnessImageView =
-                util.GetProperty<RHI::Ptr<const RHI::ImageView>>(AZ_NAME_LITERAL("roughness.textureMap"));
+                util.GetProperty(AZ_NAME_LITERAL("roughness.textureMap"), RHI::Ptr<const RHI::ImageView>{});
             convertedMaterial.m_emissiveImageView =
-                util.GetProperty<RHI::Ptr<const RHI::ImageView>>(AZ_NAME_LITERAL("emissive.textureMap"));
+                util.GetProperty(AZ_NAME_LITERAL("emissive.textureMap"), RHI::Ptr<const RHI::ImageView>{});
 
             auto irradianceColorSource =
                 util.GetEnumValueName(AZ_NAME_LITERAL("irradiance.irradianceColorSource"), AZ_NAME_LITERAL("Manual"));

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceViewCache.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ResourceViewCache.h
@@ -62,6 +62,22 @@
         };
     } // namespace ResourceViewCacheHelper
 
+    // Forward declare helper trait for ResourceTypeHelper to avoid in-class explicit specialization
+    template<typename ResourceType>
+    struct ResourceTypeHelperTraits;
+
+    template<>
+    struct ResourceTypeHelperTraits<DeviceResource>
+    {
+        using ResourceViewType = DeviceResourceView;
+    };
+
+    template<>
+    struct ResourceTypeHelperTraits<Resource>
+    {
+        using ResourceViewType = ResourceView;
+    };
+
     //! ResourceViewCache is used by both Resource and DeviceResource to cache raw pointers to ResourceView and DeviceResourceView
     //! respectively. As ResourceViewType has a strong dependency (by holding a ConstrPtr) to ResourceType, this cache holds raw pointers to
     //! ensure no circular dependency arises.
@@ -70,23 +86,13 @@
     struct ResourceViewCache
     {
         //! Helper struct to select (Device)ResourceView based on (Device)Resource and the corresponding views for Buffers and Images
-        template <typename Type>
-        struct ResourceTypeHelper;
-
-        template <>
-        struct ResourceTypeHelper<DeviceResource>
+        // Uses external traits to avoid GCC error with in-class explicit specialization
+        template<typename Type>
+        struct ResourceTypeHelper
         {
-            using ResourceViewType = DeviceResourceView;
+            using ResourceViewType = typename ResourceTypeHelperTraits<Type>::ResourceViewType;
             template<typename DescriptorType>
-            using ViewType = typename ResourceViewCacheHelper::ResourceViewTypeHelper<DeviceResource, DescriptorType>::ViewType;
-        };
-
-        template <>
-        struct ResourceTypeHelper<Resource>
-        {
-            using ResourceViewType = ResourceView;
-            template<typename DescriptorType>
-            using ViewType = typename ResourceViewCacheHelper::ResourceViewTypeHelper<Resource, DescriptorType>::ViewType;
+            using ViewType = typename ResourceViewCacheHelper::ResourceViewTypeHelper<Type, DescriptorType>::ViewType;
         };
 
         //! Returns true if the ResourceViewType is in the cache

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialShaderParameter.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialShaderParameter.h
@@ -106,32 +106,6 @@ namespace AZ::RPI
             return result;
         }
 
-        template<>
-        bool GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            auto result = GetShaderParameterData<uint32_t>(index, deviceIndex);
-            AZ_Assert(result == 0 || result == 1, "GetShaderParameterData: GPU Boolean contains illegal value %d", result);
-            if (result == 0)
-            {
-                return false;
-            }
-            return true;
-        }
-
-        template<>
-        Matrix3x3 GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            auto result = GetShaderParameterData<AZStd::array<float, 9>>(index, deviceIndex);
-            return Matrix3x3::CreateFromRowMajorFloat9(result.data());
-        }
-
-        template<>
-        Matrix4x4 GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            auto result = GetShaderParameterData<AZStd::array<float, 16>>(index, deviceIndex);
-            return Matrix4x4::CreateFromRowMajorFloat16(result.data());
-        }
-
         template<typename T, unsigned int N, AZStd::enable_if_t<N <= 4, bool> = true>
         T GetVectorShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex = 0) const
         {
@@ -142,37 +116,6 @@ namespace AZ::RPI
                 vectorResult.SetElement(ele, result[ele]);
             }
             return vectorResult;
-        }
-
-        template<>
-        Vector2 GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            return GetVectorShaderParameterData<Vector2, 2>(index, deviceIndex);
-        }
-
-        template<>
-        Vector3 GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            return GetVectorShaderParameterData<Vector3, 3>(index, deviceIndex);
-        }
-
-        template<>
-        Vector4 GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            return GetVectorShaderParameterData<Vector4, 4>(index, deviceIndex);
-        }
-
-        template<>
-        Color GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            return GetVectorShaderParameterData<Color, 4>(index, deviceIndex);
-        }
-
-        template<>
-        RHI::SamplerState GetShaderParameterData(const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
-        {
-            auto samplerIndex = GetShaderParameterData<uint32_t>(index, deviceIndex);
-            return GetSharedSamplerState(samplerIndex);
         }
 
         AZStd::span<const uint8_t> GetRawBufferParameterData(
@@ -204,5 +147,71 @@ namespace AZ::RPI
         // keep a reference to the registered non-bindless textures, if AZ_TRAIT_REGISTER_TEXTURES_PER_MATERIAL is defined
         AZStd::unordered_map<MaterialShaderParameterLayout::Index, int32_t> m_materialTextureIndices;
     };
+
+    // Template specialization implementations - moved outside class for GCC 14 C++20 compliance
+    template<>
+    inline bool MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        auto result = GetShaderParameterData<uint32_t>(index, deviceIndex);
+        AZ_Assert(result == 0 || result == 1, "GetShaderParameterData: GPU Boolean contains illegal value %d", result);
+        if (result == 0)
+        {
+            return false;
+        }
+        return true;
+    }
+
+    template<>
+    inline Matrix3x3 MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        auto result = GetShaderParameterData<AZStd::array<float, 9>>(index, deviceIndex);
+        return Matrix3x3::CreateFromRowMajorFloat9(result.data());
+    }
+
+    template<>
+    inline Matrix4x4 MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        auto result = GetShaderParameterData<AZStd::array<float, 16>>(index, deviceIndex);
+        return Matrix4x4::CreateFromRowMajorFloat16(result.data());
+    }
+
+    template<>
+    inline Vector2 MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        return GetVectorShaderParameterData<Vector2, 2>(index, deviceIndex);
+    }
+
+    template<>
+    inline Vector3 MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        return GetVectorShaderParameterData<Vector3, 3>(index, deviceIndex);
+    }
+
+    template<>
+    inline Vector4 MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        return GetVectorShaderParameterData<Vector4, 4>(index, deviceIndex);
+    }
+
+    template<>
+    inline Color MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        return GetVectorShaderParameterData<Color, 4>(index, deviceIndex);
+    }
+
+    template<>
+    inline RHI::SamplerState MaterialShaderParameter::GetShaderParameterData(
+        const MaterialShaderParameterLayout::Index& index, const uint32_t deviceIndex) const
+    {
+        auto samplerIndex = GetShaderParameterData<uint32_t>(index, deviceIndex);
+        return GetSharedSamplerState(samplerIndex);
+    }
 
 } // namespace AZ::RPI

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicArray.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicArray.h
@@ -336,7 +336,7 @@ namespace AZ
 
         /// Move constructor that allows converting between handles of different types, as long as they are part of the same inheritance chain
         template<typename OtherType>
-        StableDynamicArrayHandle<ValueType>(StableDynamicArrayHandle<OtherType>&& other);
+        StableDynamicArrayHandle(StableDynamicArrayHandle<OtherType>&& other);
         
         /// Destructor will also destroy its underlying data and free it from the StableDynamicArray
         ~StableDynamicArrayHandle();


### PR DESCRIPTION
## What does this PR do?

This covers a bunch of template syntax related issues that are no longer accepted by gcc:
* appending template parameters in a constructor definition
* creating method and struct specialization at class/struct level

Older gcc used to allow at least the second of the above.. 


## How was this PR tested?

Building with clang and gcc.
