### PR TITLE
Fixed editor `TransformComponent` not notifying of child add/removal

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -244,6 +244,12 @@ namespace AzToolsFramework
 
         void TransformComponent::Deactivate()
         {
+            AZ::TransformNotificationBus::Event(m_parentEntityId, &AZ::TransformNotificationBus::Events::OnChildRemoved, GetEntityId());
+            if (auto* parentTransform = AZ::TransformBus::FindFirstHandler(m_parentEntityId))
+            {
+                parentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Removed, GetEntityId());
+            }
+
             AZ::EntityBus::Handler::BusDisconnect();
             AZ::SliceEntityHierarchyRequestBus::Handler::BusDisconnect();
             AZ::TransformBus::Handler::BusDisconnect();
@@ -741,6 +747,23 @@ namespace AzToolsFramework
                 GetEntityId(), &AZ::TransformNotificationBus::Events::OnParentChanged, oldParentId, parentId);
             m_parentChangedEvent.Signal(oldParentId, parentId);
 
+            if (oldParentId.IsValid() && oldParentId != parentId)
+            {
+                AZ::TransformNotificationBus::Event(oldParentId, &AZ::TransformNotificationBus::Events::OnChildRemoved, GetEntityId());
+                auto oldParentTransform = AZ::TransformBus::FindFirstHandler(oldParentId);
+                if (oldParentTransform)
+                {
+                    oldParentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Removed, GetEntityId());
+                }
+            }
+
+            AZ::TransformNotificationBus::Event(parentId, &AZ::TransformNotificationBus::Events::OnChildAdded, GetEntityId());
+            auto newParentTransform = AZ::TransformBus::FindFirstHandler(parentId);
+            if (newParentTransform)
+            {
+                newParentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Added, GetEntityId());
+            }
+
             TransformChanged();
         }
 
@@ -790,7 +813,7 @@ namespace AzToolsFramework
         {
             children.push_back(GetEntityId());
         }
-        
+
         bool TransformComponent::IsStaticTransform()
         {
             return m_isStatic;
@@ -821,7 +844,7 @@ namespace AzToolsFramework
             {
                 return nullptr;
             }
-            
+
             AZ::Entity* entity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(otherEntityId);
             if (!entity)
             {
@@ -954,7 +977,7 @@ namespace AzToolsFramework
         AZ::u32 TransformComponent::StaticChangedInspector()
         {
             InvalidatePropertyDisplay(AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
-           
+
             if (GetEntity())
             {
                 SetDirty();


### PR DESCRIPTION
## What does this PR do?
The editor `TransformComponent` in AzToolsFramework had the foundations for sending `NotifyChildChangedEvent` when a child is added or removed from an entity. This already works on the runtime component, but no call to `NotifyChildChangedEvent` existed in the editor variant, likely as an oversight. This PR brings this functionality to the editor.

#13676 discusses OnChildAdded performance with the depracated bus version. This does not modify the deprecated code, but simply mirrors the runtime functionality for consistency until a decision can be made about removing deprecated bus code.

## How was this PR tested?
https://github.com/user-attachments/assets/3cead4e5-1e29-4ce9-91a6-8ee5d9efa086

Using the PhysX editor rigid body, I created a `ChildChangedEvent` handler which filtered for `ChildChangeType` Added and Removed, and connected the entity Id to the `EntityBus` to listen for `OnEntityActivated` and `OnEntityDeactivated`.

It was verified to show the child being added and subsequently activated, removed and deactivated when deleted and when dragged from one parent to another.

I also verified functionality in saved prefab assets.

https://github.com/user-attachments/assets/3cead4e5-1e29-4ce9-91a6-8ee5d9efa086

