### PR TITLE
Include EBus event argument names in generated Python stubs

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
@@ -979,6 +979,20 @@ namespace EditorPythonBindings
                         continue;
                     }
 
+                    // Emit the reflected argument name (matching the class/global method path in
+                    // MethodDefinition), falling back to a positional argN name when none is reflected.
+                    // The names come from ->Event("Name", &Fn, {{ {"argName", "tooltip"} }}) reflection.
+                    const AZStd::string* argName = behaviorMethod->GetArgumentName(i);
+                    if (!argName || argName->empty())
+                    {
+                        AzFramework::StringFunc::Append(inOutStrBuffer, AZStd::string::format("arg%zu: ", i).c_str());
+                    }
+                    else
+                    {
+                        AzFramework::StringFunc::Append(inOutStrBuffer, argName->c_str());
+                        AzFramework::StringFunc::Append(inOutStrBuffer, ": ");
+                    }
+
                     AZStd::string_view argType = FetchPythonTypeAndTraits(argParam->m_typeId, argParam->m_traits);
                     AzFramework::StringFunc::Append(inOutStrBuffer, argType.data());
 

--- a/Gems/EditorPythonBindings/Code/Tests/PythonLogSymbolsComponentTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonLogSymbolsComponentTests.cpp
@@ -16,9 +16,11 @@
 #include <Source/PythonMarshalComponent.h>
 #include <Source/PythonLogSymbolsComponent.h>
 
+#include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzFramework/StringFunc/StringFunc.h>
+#include <EditorPythonBindings/PythonUtility.h>
 
 
 namespace UnitTest
@@ -84,6 +86,17 @@ namespace UnitTest
     };
 
     //////////////////////////////////////////////////////////////////////////
+    // A request bus with a named-argument event, used to verify the generated
+    // Python stub names the event arguments (width: float) rather than listing
+    // their types only (float). ComponentBus exercises the bus-id-argument skip.
+    class ArgNameTestRequests : public AZ::ComponentBus
+    {
+    public:
+        virtual void SetThing(float width, float height) = 0;
+    };
+    using ArgNameTestRequestBus = AZ::EBus<ArgNameTestRequests>;
+
+    //////////////////////////////////////////////////////////////////////////
     // fixtures
 
     struct PythonLogSymbolsComponentTest
@@ -110,6 +123,27 @@ namespace UnitTest
 
     //////////////////////////////////////////////////////////////////////////
     // tests
+
+    TEST_F(PythonLogSymbolsComponentTest, BusDefinition_IncludesEventArgumentNames)
+    {
+        AZ::BehaviorContext* behaviorContext = m_app.GetBehaviorContext();
+        behaviorContext->EBus<ArgNameTestRequestBus>("ArgNameTestRequestBus")
+            ->Event(
+                "SetThing",
+                &ArgNameTestRequestBus::Events::SetThing,
+                { { { "width", "the width in units" }, { "height", "the height in units" } } });
+
+        auto ebusIt = behaviorContext->m_ebuses.find("ArgNameTestRequestBus");
+        ASSERT_NE(ebusIt, behaviorContext->m_ebuses.end());
+
+        EditorPythonBindings::Text::PythonBehaviorDescription description;
+        const AZStd::string busText = description.BusDefinition("ArgNameTestRequestBus", ebusIt->second);
+
+        // The generated event signature must name the arguments (width: float,
+        // height: float), not just list their types (float, float).
+        EXPECT_NE(busText.find("width: float"), AZStd::string::npos) << busText.c_str();
+        EXPECT_NE(busText.find("height: float"), AZStd::string::npos) << busText.c_str();
+    }
 
     TEST_F(PythonLogSymbolsComponentTest, FetchSupportedTypesByTypeAndTraits_PythonTypeReturned)
     {


### PR DESCRIPTION
## What does this PR do?

`PythonLogSymbolsComponent` writes the `azlmbr/<module>.pyi` Python stubs from the BehaviorContext. Class and global method signatures already emit named arguments (`name: type`), but EBus event signatures were emitted **type-only** — e.g. `'ApplyLinearImpulse', (Vector3) -> None` — dropping the argument names that are reflected via `->Event("Name", &Fn, {{ {"argName","tooltip"} }})` and are readable through `GetArgumentName`.

This mirrors the existing method path in `PythonBehaviorDescription::BusDefinition`: it reads `GetArgumentName` for each event argument and emits `name: type`, with the same positional `argN` fallback the method path uses when no name is reflected. An event now reads `(impulse: Vector3) -> Any` instead of `(Vector3) -> Any`.

The change is editor-only host-tools code (EditorPythonBindings is not built into clients/servers) and affects only the generated stub text — Python dispatch is unchanged and remains positional. It improves scripting-API discoverability for every gem at no per-gem cost.

Context / history: the method and property paths gained named arguments in #5842
("pull argument names from BC when available"), and #17589 refactored the
bus-event formatting into `PythonBehaviorDescription::BusDefinition` but kept it
type-only. This change extends the same naming the method path already does to
EBus events. It also complements #12674 (IDE autocomplete from the `.pyi` files),
but is independent of it. No open or closed PR was found that adds event argument
names to the stubs.

## How was this PR tested?

New unit test `PythonLogSymbolsComponentTest.BusDefinition_IncludesEventArgumentNames` reflects a `ComponentBus` event with named arguments (which also exercises the bus-id-argument skip path) and asserts `BusDefinition` emits `width: float, height: float` rather than `(float, float)`.

Revert-cycle verified on Linux (clang): the test FAILS against the un-patched `BusDefinition` (names absent, `find` returns npos) and PASSES with the change. `EditorPythonBindings.Tests` builds and the new test passes. Not yet runtime-verified by regenerating the stubs in a live editor; the unit test exercises the exact code path that writes them.
