### PR TITLE
Reflect the system cursor position to gameplay scripts

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Input/Utils/ProcessRawInputEventQueues.h>
 
@@ -50,6 +51,28 @@ namespace AzFramework
                 ->Constant(Movement::X.GetName(), BehaviorConstant(Movement::X.GetName()))
                 ->Constant(Movement::Y.GetName(), BehaviorConstant(Movement::Y.GetName()))
                 ->Constant(Movement::Z.GetName(), BehaviorConstant(Movement::Z.GetName()))
+            ;
+
+            // The system cursor state enum, named so scripts can pass the values to
+            // SetSystemCursorState below.
+            behaviorContext->Enum<static_cast<int>(SystemCursorState::Unknown)>("SystemCursorState_Unknown")
+                ->Enum<static_cast<int>(SystemCursorState::ConstrainedAndHidden)>("SystemCursorState_ConstrainedAndHidden")
+                ->Enum<static_cast<int>(SystemCursorState::ConstrainedAndVisible)>("SystemCursorState_ConstrainedAndVisible")
+                ->Enum<static_cast<int>(SystemCursorState::UnconstrainedAndHidden)>("SystemCursorState_UnconstrainedAndHidden")
+                ->Enum<static_cast<int>(SystemCursorState::UnconstrainedAndVisible)>("SystemCursorState_UnconstrainedAndVisible")
+            ;
+
+            // Make the absolute system cursor position (and state) readable from gameplay
+            // scripts. Input channels only expose mouse deltas, so without this a script
+            // cannot get the cursor's window position, which is what an "aim at the cursor"
+            // scheme needs (feed the normalized position to CameraRequestBus::ScreenNdcToWorld).
+            // Addressed by InputDeviceId, e.g. Event(InputDeviceId("mouse"), ...), or Broadcast.
+            behaviorContext->EBus<InputSystemCursorRequestBus>("InputSystemCursorRequestBus")
+                ->Attribute(AZ::Script::Attributes::Category, "Input")
+                ->Event("GetSystemCursorPositionNormalized", &InputSystemCursorRequests::GetSystemCursorPositionNormalized)
+                ->Event("SetSystemCursorPositionNormalized", &InputSystemCursorRequests::SetSystemCursorPositionNormalized)
+                ->Event("GetSystemCursorState", &InputSystemCursorRequests::GetSystemCursorState)
+                ->Event("SetSystemCursorState", &InputSystemCursorRequests::SetSystemCursorState)
             ;
         }
     }

--- a/Code/Framework/AzFramework/Tests/InputDeviceMouseReflectionTests.cpp
+++ b/Code/Framework/AzFramework/Tests/InputDeviceMouseReflectionTests.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
+#include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
+
+#include <AzFramework/Input/Devices/InputDeviceId.h>
+
+#include <AzCore/Math/MathReflection.h>
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+namespace InputCursorReflectionTests
+{
+    using namespace AzFramework;
+
+    namespace
+    {
+        // Statics bridged to Lua through reflected properties so the script can hand
+        // values back to the test for assertion.
+        float g_capturedCursorX = -1.0f;
+        float g_capturedCursorY = -1.0f;
+        int g_capturedEnum = -1;
+        bool g_busVisibleInLua = false;
+
+        // Reflected so the Lua side can extract scalars from the returned Vector2
+        // without depending on how Vector2 itself is exposed to script.
+        float ExtractVec2X(const AZ::Vector2& v)
+        {
+            return v.GetX();
+        }
+        float ExtractVec2Y(const AZ::Vector2& v)
+        {
+            return v.GetY();
+        }
+
+        // Stand-in for the platform mouse backend: answers the cursor requests with a
+        // known normalized position so the test can assert what the script reads.
+        class StubCursorHandler : public InputSystemCursorRequestBus::Handler
+        {
+        public:
+            void Connect()
+            {
+                InputSystemCursorRequestBus::Handler::BusConnect(InputDeviceMouse::Id);
+            }
+            void Disconnect()
+            {
+                InputSystemCursorRequestBus::Handler::BusDisconnect();
+            }
+
+            void SetSystemCursorState(SystemCursorState state) override
+            {
+                m_state = state;
+            }
+            SystemCursorState GetSystemCursorState() const override
+            {
+                return m_state;
+            }
+            void SetSystemCursorPositionNormalized(AZ::Vector2 positionNormalized) override
+            {
+                m_position = positionNormalized;
+            }
+            AZ::Vector2 GetSystemCursorPositionNormalized() const override
+            {
+                return m_position;
+            }
+
+            AZ::Vector2 m_position = AZ::Vector2(0.7f, 0.3f);
+            SystemCursorState m_state = SystemCursorState::Unknown;
+        };
+    } // namespace
+
+    class InputDeviceMouseReflectionTest : public UnitTest::LeakDetectionFixture
+    {
+    protected:
+        void SetUp() override
+        {
+            UnitTest::LeakDetectionFixture::SetUp();
+
+            g_capturedCursorX = -1.0f;
+            g_capturedCursorY = -1.0f;
+            g_capturedEnum = -1;
+            g_busVisibleInLua = false;
+
+            m_behaviorContext = aznew AZ::BehaviorContext();
+
+            // Dependencies the cursor bus binding needs, reflected app-wide in a real
+            // launcher: Vector2 (the position type) and InputDeviceId (the bus address,
+            // which the Event(id) binding treats as an argument).
+            AZ::MathReflect(m_behaviorContext);
+            InputDeviceId::Reflect(m_behaviorContext);
+
+            // The reflection under test.
+            InputDeviceMouse::Reflect(m_behaviorContext);
+
+            // Test-only helpers/bridges.
+            m_behaviorContext->Method("ExtractVec2X", &ExtractVec2X);
+            m_behaviorContext->Method("ExtractVec2Y", &ExtractVec2Y);
+            m_behaviorContext->Property("g_capturedCursorX", BehaviorValueProperty(&g_capturedCursorX));
+            m_behaviorContext->Property("g_capturedCursorY", BehaviorValueProperty(&g_capturedCursorY));
+            m_behaviorContext->Property("g_capturedEnum", BehaviorValueProperty(&g_capturedEnum));
+            m_behaviorContext->Property("g_busVisibleInLua", BehaviorValueProperty(&g_busVisibleInLua));
+
+            m_scriptContext = aznew AZ::ScriptContext();
+            m_scriptContext->BindTo(m_behaviorContext);
+        }
+
+        void TearDown() override
+        {
+            delete m_scriptContext;
+            m_scriptContext = nullptr;
+            delete m_behaviorContext;
+            m_behaviorContext = nullptr;
+
+            UnitTest::LeakDetectionFixture::TearDown();
+        }
+
+        AZ::BehaviorContext* m_behaviorContext = nullptr;
+        AZ::ScriptContext* m_scriptContext = nullptr;
+    };
+
+    // Tier 1: the cursor request bus, its events, and the cursor-state enum are
+    // registered in the BehaviorContext by InputDeviceMouse::Reflect.
+    TEST_F(InputDeviceMouseReflectionTest, CursorBus_IsReflected_WithEventsAndEnum)
+    {
+        auto ebusIt = m_behaviorContext->m_ebuses.find("InputSystemCursorRequestBus");
+        ASSERT_NE(ebusIt, m_behaviorContext->m_ebuses.end());
+
+        const AZ::BehaviorEBus* ebus = ebusIt->second;
+        EXPECT_NE(ebus->m_events.find("GetSystemCursorPositionNormalized"), ebus->m_events.end());
+        EXPECT_NE(ebus->m_events.find("SetSystemCursorPositionNormalized"), ebus->m_events.end());
+        EXPECT_NE(ebus->m_events.find("GetSystemCursorState"), ebus->m_events.end());
+        EXPECT_NE(ebus->m_events.find("SetSystemCursorState"), ebus->m_events.end());
+
+        // Enum<>() reflects each value as a named global property.
+        EXPECT_NE(
+            m_behaviorContext->m_properties.find("SystemCursorState_ConstrainedAndVisible"),
+            m_behaviorContext->m_properties.end());
+    }
+
+    // Tier 2: a gameplay-style Lua script can see the bus and the enum, and reading
+    // the cursor position dispatches to a connected handler and returns its value.
+    // This is the end-to-end proof that "aim at the cursor" is now possible from a
+    // game script: the normalized position is readable, ready to feed ScreenNdcToWorld.
+    TEST_F(InputDeviceMouseReflectionTest, CursorPosition_ReadableFromLua)
+    {
+        StubCursorHandler stub;
+        stub.Connect();
+
+        const char* script =
+            "g_busVisibleInLua = (InputSystemCursorRequestBus ~= nil)\n"
+            "g_capturedEnum = SystemCursorState_ConstrainedAndVisible\n"
+            "local p = InputSystemCursorRequestBus.Broadcast.GetSystemCursorPositionNormalized()\n"
+            "g_capturedCursorX = ExtractVec2X(p)\n"
+            "g_capturedCursorY = ExtractVec2Y(p)\n";
+
+        const bool executed = m_scriptContext->Execute(script);
+
+        stub.Disconnect();
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_busVisibleInLua);
+        EXPECT_EQ(g_capturedEnum, static_cast<int>(SystemCursorState::ConstrainedAndVisible));
+        EXPECT_NEAR(g_capturedCursorX, 0.7f, 0.0001f);
+        EXPECT_NEAR(g_capturedCursorY, 0.3f, 0.0001f);
+    }
+} // namespace InputCursorReflectionTests

--- a/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
@@ -19,6 +19,7 @@ set(FILES
     CameraInputTests.cpp
     ClickDetectorTests.cpp
     CursorStateTests.cpp
+    InputDeviceMouseReflectionTests.cpp
     EntityContext.cpp
     FileIO.cpp
     FileTagTests.cpp


### PR DESCRIPTION
## What does this PR do?

A GameLauncher script can read mouse **deltas** through input channels, but it cannot read the **absolute** system cursor position: `InputSystemCursorRequests` was never reflected to the BehaviorContext. That makes an "aim at the cursor" scheme (the standard top-down control) impossible from pure game script — you can only integrate deltas.

This reflects `InputSystemCursorRequestBus` (`Get`/`SetSystemCursorPositionNormalized`, `Get`/`SetSystemCursorState`) and the `SystemCursorState` enum in `InputDeviceMouse::Reflect`, alongside the existing channel-name constants, at the default Launcher scope so they are game-callable. The bus is addressed by `InputDeviceId`, e.g. `Event(InputDeviceId("mouse"), ...)`, or `Broadcast`.

It completes the cursor-aim path with no new C++ API: the normalized cursor position feeds directly into the already-reflected `CameraRequestBus::ScreenNdcToWorld` (added in #6903) to unproject to a world ray. `GetSystemCursorPositionNormalized` is a cross-platform pure virtual; on platforms without a system cursor the backend returns zero.

Context: prior closed feature requests asked for the higher-level Script Canvas
nodes this would back (#11894 set cursor position, #6578 cursor position to world)
but the underlying `InputSystemCursorRequests` bus was never reflected to the
BehaviorContext. No open or closed PR was found that reflects it.

## How was this PR tested?

Two new `AzFramework` unit tests (`InputDeviceMouseReflectionTest`):

- `CursorBus_IsReflected_WithEventsAndEnum` asserts the bus, its four events, and the `SystemCursorState` enum are registered in the BehaviorContext.
- `CursorPosition_ReadableFromLua` binds an `AZ::ScriptContext`, connects a stub cursor handler returning a known position, and runs a Lua snippet that reads the position back **through the reflected bus** and resolves the enum constant (end-to-end script proof).

Revert-cycle verified on Linux (clang): both tests FAIL against the un-patched `InputDeviceMouse::Reflect` (bus and enum absent) and PASS with the reflection. `AzFramework.Tests` builds and both tests pass. Not yet runtime-verified from a shipped GameLauncher script; the ScriptContext test exercises the same reflected binding path.
