### PR TITLE
Fixes a null pointer dereference in TrackView

### DIFF
--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -524,22 +524,24 @@ void CTrackViewDopeSheetBase::OnLButtonUp(Qt::KeyboardModifiers modifiers, const
         return;
     }
 
+    if (m_rubberBand)
+    {
+        m_rubberBand->deleteLater();
+        m_rubberBand = nullptr;
+    }
+
     if (m_mouseMode == eTVMouseMode_Select)
     {
         // Check if any key are selected.
         m_rcSelect.translate(-m_scrollOffset);
         SelectKeys(m_rcSelect, modifiers & Qt::ControlModifier);
         m_rcSelect = QRect();
-        m_rubberBand->deleteLater();
-        m_rubberBand = nullptr;
     }
     else if (m_mouseMode == eTVMouseMode_SelectWithinTime)
     {
         m_rcSelect.translate(-m_scrollOffset);
         SelectAllKeysWithinTimeFrame(m_rcSelect, modifiers & Qt::ControlModifier);
         m_rcSelect = QRect();
-        m_rubberBand->deleteLater();
-        m_rubberBand = nullptr;
     }
     else if (m_mouseMode == eTVMouseMode_DragTime)
     {
@@ -551,7 +553,6 @@ void CTrackViewDopeSheetBase::OnLButtonUp(Qt::KeyboardModifiers modifiers, const
             GetIEditor()->GetAnimation()->SetRecording(true);   // re-enable recording that was disabled while dragging time
             m_stashedRecordModeWhileTimeDragging = false;       // reset stashed value
         }
-
     }
     else if (m_mouseMode == eTVMouseMode_Paste)
     {
@@ -1424,7 +1425,7 @@ void CTrackViewDopeSheetBase::MouseMoveSelect(const QPoint& point)
     QRect rcClient = rect();
     rc = rc.intersected(rcClient);
 
-    if (m_rubberBand == nullptr)
+    if (!m_rubberBand)
     {
         m_rubberBand = new QRubberBand(QRubberBand::Rectangle, this);
     }

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewDopeSheetBase.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewDopeSheetBase.cpp
@@ -86,7 +86,7 @@ CUiAnimViewDopeSheetBase::CUiAnimViewDopeSheetBase(QWidget* parent)
     m_currentTime = 0.0f;
     m_storedTime = m_currentTime;
     m_rcSelect = QRect(0, 0, 0, 0);
-    m_rubberBand = 0;
+    m_rubberBand = nullptr;
     m_scrollBar = new QScrollBar(Qt::Horizontal, this);
     connect(m_scrollBar, &QScrollBar::valueChanged, this, &CUiAnimViewDopeSheetBase::OnHScroll);
     m_keyTimeOffset = 0;
@@ -529,22 +529,24 @@ void CUiAnimViewDopeSheetBase::OnLButtonUp(Qt::KeyboardModifiers modifiers, [[ma
         return;
     }
 
+    if (m_rubberBand)
+    {
+        m_rubberBand->deleteLater();
+        m_rubberBand = nullptr;
+    }
+
     if (m_mouseMode == eUiAVMouseMode_Select)
     {
         // Check if any key are selected.
         m_rcSelect.translate(-m_scrollOffset);
         SelectKeys(m_rcSelect, modifiers & Qt::ControlModifier);
         m_rcSelect = QRect();
-        m_rubberBand->deleteLater();
-        m_rubberBand = 0;
     }
     else if (m_mouseMode == eUiAVMouseMode_SelectWithinTime)
     {
         m_rcSelect.translate(-m_scrollOffset);
         SelectAllKeysWithinTimeFrame(m_rcSelect, modifiers & Qt::ControlModifier);
         m_rcSelect = QRect();
-        m_rubberBand->deleteLater();
-        m_rubberBand = 0;
     }
     else if (m_mouseMode == eUiAVMouseMode_DragTime)
     {


### PR DESCRIPTION

## What does this PR do?

This fixes a crash in TrackView.  This **Could be** related to https://github.com/o3de/o3de/issues/13893 as it should crash anytime you click anywhere without moving the mouse between pressing and releasing the button.

Qt 5 implements "delete later" like this
```cpp
 QCoreApplication::postEvent(this, new QDeferredDeleteEvent());
 ```

this causes QCoreApplication::postEvent to issue a warning and discard the event.

Qt6 on the other hand, does a bunch of work in `deleteLater` some of which dereference `this` immediately.  This is why it instant crashes on qt6, but just issues a warning on qt5, since this will cause a "later" exec of "delete this" on the main thread, with `this` being uninitialized memory.

## How was this PR tested?

Tested on Qt5 and Qt6 branch.  Transparent-box testing.
