### PR TITLE
Define TIFF_DISABLE_DEPRECATED ahead of every tiffio.h include

### DIFF
--- a/Code/Editor/Util/ImageTIF.cpp
+++ b/Code/Editor/Util/ImageTIF.cpp
@@ -12,6 +12,13 @@
 #include "ImageTIF.h"
 
 /// libTiff
+// libtiff 4.5+ still emits its legacy non-prefixed typedefs (uint8 ...
+// uint64) by default; the int64/uint64 pair collides with the
+// CryCommon/BaseTypes.h definitions in any TU that includes both, which
+// blocks building against a modern system libtiff. Every O3DE tiffio.h
+// consumer uses the C99 names, so opt out of the legacy ones entirely.
+// No-op for older libtiff (the guard is simply not consulted).
+#define TIFF_DISABLE_DEPRECATED
 #include <tiffio.h>  // TIFF library
 
 // Function prototypes

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/TIFFLoader.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/TIFFLoader.cpp
@@ -16,6 +16,13 @@
 
 #include <QString>
 
+// libtiff 4.5+ still emits its legacy non-prefixed typedefs (uint8 ...
+// uint64) by default; the int64/uint64 pair collides with the
+// CryCommon/BaseTypes.h definitions in any TU that includes both, which
+// blocks building against a modern system libtiff. Every O3DE tiffio.h
+// consumer uses the C99 names, so opt out of the legacy ones entirely.
+// No-op for older libtiff (the guard is simply not consulted).
+#define TIFF_DISABLE_DEPRECATED
 #include <tiffio.h>  // TIFF library
 
 namespace ImageProcessingAtom

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -39,6 +39,13 @@
 #include <AzCore/Preprocessor/EnumReflectUtils.h>
 #include <AzCore/Console/Console.h>
 
+// libtiff 4.5+ still emits its legacy non-prefixed typedefs (uint8 ...
+// uint64) by default; the int64/uint64 pair collides with the
+// CryCommon/BaseTypes.h definitions in any TU that includes both, which
+// blocks building against a modern system libtiff. Every O3DE tiffio.h
+// consumer uses the C99 names, so opt out of the legacy ones entirely.
+// No-op for older libtiff (the guard is simply not consulted).
+#define TIFF_DISABLE_DEPRECATED
 #include <tiffio.h>
 
 namespace AZ


### PR DESCRIPTION
## What does this PR do?

Defines `TIFF_DISABLE_DEPRECATED` above the `<tiffio.h>` include in the three TUs that consume it, so the engine can build against a modern system libtiff (4.5+). Full analysis in #19824.

libtiff 4.5+ still emits its legacy non-prefixed typedefs by default, and the `int64`/`uint64` pair collides with `Code/Legacy/CryCommon/BaseTypes.h` (`int64_t` is `long` on LP64 Linux, CryCommon's is `long long`), failing any TU that includes both. The engine no longer uses any of the legacy names (#19734 migrated `TIFFLoader.cpp` and `ImageTIF.cpp`; `FrameCaptureSystemComponent.cpp` never used them), so opting out of them entirely is free.

## How was this PR tested?

- The define is not consulted by the bundled tiff 4.2 headers (the guard postdates 4.2), so bundled-package builds compile exactly as before on every platform; AR on this PR is the direct verification of that.
- Against system libtiff, validated downstream in the Fedora packaging with the bundled package swapped for `libtiff-devel`: engine builds green on Fedora 44, Fedora rawhide (libtiff 4.7.1) and CentOS Stream 10 (https://copr.fedorainfracloud.org/coprs/build/10568964, https://copr.fedorainfracloud.org/coprs/build/10570032), and the installed-engine test suite confirms the system `libtiff.so.6` is linked with zero bundled tiff in the payload (https://github.com/nickschuetz/o3de-rpm/actions/runs/27017382939).
