### PR TITLE
Expose PhysX enhanced-determinism flag via SceneConfiguration.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.cpp
@@ -21,7 +21,7 @@ namespace AzPhysics
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<SceneConfiguration>()
-                ->Version(2)
+                ->Version(3)
                 ->Field("Name", &SceneConfiguration::m_sceneName)
                 ->Field("WorldBounds", &SceneConfiguration::m_worldBounds)
                 ->Field("Gravity", &SceneConfiguration::m_gravity)
@@ -30,6 +30,7 @@ namespace AzPhysics
                 ->Field("EnableCcdResweep", &SceneConfiguration::m_enableCcdResweep)
                 ->Field("EnableActiveActors", &SceneConfiguration::m_enableActiveActors)
                 ->Field("EnablePcm", &SceneConfiguration::m_enablePcm)
+                ->Field("EnableEnhancedDeterminism", &SceneConfiguration::m_enableEnhancedDeterminism)
                 ->Field("BounceThresholdVelocity", &SceneConfiguration::m_bounceThresholdVelocity)
                 ;
 
@@ -54,6 +55,8 @@ namespace AzPhysics
                     ->EndGroup()
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_enablePcm, "Persistent Contact Manifold", "Enabled the persistent contact manifold narrow-phase algorithm")
+                    ->DataElement(AZ::Edit::UIHandlers::Default,&SceneConfiguration::m_enableEnhancedDeterminism,
+                        "Enhanced Determinism", "Improves determinism at a performance cost. Applied at scene creation.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_bounceThresholdVelocity,
                         "Bounce Threshold Velocity", "Relative velocity below which colliding objects will not bounce")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
@@ -74,6 +77,7 @@ namespace AzPhysics
             && m_enableCcdResweep == other.m_enableCcdResweep
             && m_enableActiveActors == other.m_enableActiveActors
             && m_enablePcm == other.m_enablePcm
+            && m_enableEnhancedDeterminism == other.m_enableEnhancedDeterminism
             && m_kinematicFiltering == other.m_kinematicFiltering
             && m_kinematicStaticFiltering == other.m_kinematicStaticFiltering
             && m_customUserData == other.m_customUserData

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.h
@@ -44,6 +44,7 @@ namespace AzPhysics
         //! Enables reporting of changed Simulated bodies on the OnSceneActiveSimulatedBodiesEvent event.
         bool m_enableActiveActors = true; 
         bool m_enablePcm = true; //!< Enables the persistent contact manifold algorithm to be used as the narrow phase algorithm.
+        bool m_enableEnhancedDeterminism = false; //!< Enables improved determinism at a performance cost. Applied at scene creation only.
         bool m_kinematicFiltering = true; //!< Enables filtering between kinematic/kinematic  objects.
         bool m_kinematicStaticFiltering = true; //!< Enables filtering between kinematic/static objects.
         float m_bounceThresholdVelocity = 2.0f; //!< Relative velocity below which colliding objects will not bounce.

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
@@ -105,6 +105,11 @@ namespace PhysX
                 sceneDesc.flags &= ~physx::PxSceneFlag::eENABLE_PCM;
             }
 
+            if (config.m_enableEnhancedDeterminism)
+            {
+                sceneDesc.flags |= physx::PxSceneFlag::eENABLE_ENHANCED_DETERMINISM;
+            }
+
             if (config.m_kinematicFiltering)
             {
                 sceneDesc.kineKineFilteringMode = physx::PxPairFilteringMode::eKEEP;


### PR DESCRIPTION
## What does this PR do?

Adds an `m_enableEnhancedDeterminism` option to `AzPhysics::SceneConfiguration`. This exposes the PhysX enhanced determinism flag which provides additional levels of determinism at a potential performance cost per the PhysX Docs:

https://nvidia-omniverse.github.io/PhysX/physx/5.8.0/docs/Simulation.html#enhanced-determinism 

Default is set to `false` so existing behavior is unchanged. 

Additionally exposes the option as a toggle in the Editor's PhysX Configuration via reflection:

<img width="420" height="313" alt="Enhanced_Determinism_Toggle" src="https://github.com/user-attachments/assets/2fd39bbe-3963-4593-9d3e-42564f85199c" />


## How was this PR tested?

- Built the engine and Editor on Windows 11 (Visual Studio 2022, profile config). 
- Tested in a brand new default project with 1,000+ rigid body sphere objects colliding with one another. No noticeable performance difference when enabled at 240hz physics timestep (mean difference ~0.1 ms).
- Confirmed flag was present by reading `PxScene::getFlags()` and enabling/disabling Editor toggle.