### PR TITLE
Folding bools and state vars into the activation bitmask for a smaller entity footprint.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Entity.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Entity.cpp
@@ -87,9 +87,8 @@ namespace AZ
         : m_id(id)
         , m_transform(nullptr)
         , m_name{ name.empty() ? AZStd::to_string(static_cast<u64>(m_id)) : AZStd::move(name) }
-        , m_state(State::Constructed)
-        , m_isDependencyReady(false)
-        , m_isRuntimeActiveByDefault(true)
+        // State (Constructed), DependencyReady (false) and RuntimeActiveByDefault (true) are encoded
+        // in the m_activeStateByType default member initializer (see Entity.h).
     {
     }
 
@@ -100,13 +99,13 @@ namespace AZ
 
     void Entity::Reset()
     {
-        AZ_Assert(m_state != State::Activating && m_state != State::Deactivating && m_state != State::Initializing, "Unsafe to delete an entity during its state transition.");
-        if (m_state == State::Active)
+        AZ_Assert(GetState() != State::Activating && GetState() != State::Deactivating && GetState() != State::Initializing, "Unsafe to delete an entity during its state transition.");
+        if (GetState() == State::Active)
         {
             Deactivate();
         }
 
-        if (m_state == State::Init)
+        if (GetState() == State::Init)
         {
             EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityDestruction, m_id);
             EntityBus::Event(m_id, &EntityBus::Events::OnEntityDestruction, m_id);
@@ -125,7 +124,7 @@ namespace AZ
 
         m_components.clear();
 
-        if (m_state == State::Init)
+        if (GetState() == State::Init)
         {
             EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityDestroyed, m_id);
             EntityBus::Event(m_id, &EntityBus::Events::OnEntityDestroyed, m_id);
@@ -146,9 +145,9 @@ namespace AZ
             return;
         }
 
-        AZ_Assert(m_state == State::Constructed, "You may not alter the ID of an entity when it is active or initialized");
+        AZ_Assert(GetState() == State::Constructed, "You may not alter the ID of an entity when it is active or initialized");
 
-        if (m_state != State::Constructed)
+        if (GetState() != State::Constructed)
         {
             return;
         }
@@ -158,11 +157,11 @@ namespace AZ
 
     void Entity::Init()
     {
-        AZ_Assert(m_state == State::Constructed, "Component should be in Constructed state to be Initialized!");
+        AZ_Assert(GetState() == State::Constructed, "Component should be in Constructed state to be Initialized!");
         SetState(State::Initializing);
 
         //Update "Entity" Active state index. Does not change state yet. Left for the Entity handling to apply.
-        SetEntityActive(m_isRuntimeActiveByDefault);
+        SetEntityActive(IsRuntimeActiveByDefault());
 
         if (AZ::Interface<ComponentApplicationRequests>::Get() != nullptr)
         {
@@ -195,7 +194,7 @@ namespace AZ
     {
         AZ_PROFILE_FUNCTION(AzCore);
 
-        AZ_Assert(m_state == State::Init, "Entity should be in Init state to be Activated!");
+        AZ_Assert(GetState() == State::Init, "Entity should be in Init state to be Activated!");
 
         const DependencySortOutcome sortOutcome = EvaluateDependenciesGetDetails();
         if (!sortOutcome.IsSuccess())
@@ -234,7 +233,7 @@ namespace AZ
         EntityBus::Event(m_id, &EntityBus::Events::OnEntityDeactivated, m_id);
         EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityDeactivated, m_id);
 
-        AZ_Assert(m_state == State::Active, "Component should be in Active state to be Deactivated!");
+        AZ_Assert(GetState() == State::Active, "Component should be in Active state to be Deactivated!");
         SetState(State::Deactivating);
 
         for (ComponentArrayType::reverse_iterator it = m_components.rbegin(); it != m_components.rend(); ++it)
@@ -256,10 +255,10 @@ namespace AZ
     {
         DependencySortOutcome outcome = AZ::Success();
 
-        if (!m_isDependencyReady)
+        if (!GetEntityFlag(DependencyReadyFlag))
         {
             outcome = DependencySort(m_components);
-            m_isDependencyReady = outcome.IsSuccess();
+            SetEntityFlag(DependencyReadyFlag, outcome.IsSuccess());
         }
 
         return outcome;
@@ -267,17 +266,17 @@ namespace AZ
 
     void Entity::InvalidateDependencies()
     {
-        m_isDependencyReady = false;
+        SetEntityFlag(DependencyReadyFlag, false);
     }
 
     void Entity::SetRuntimeActiveByDefault(bool activeByDefault)
     {
-        m_isRuntimeActiveByDefault = activeByDefault;
+        SetEntityFlag(RuntimeActiveByDefaultFlag, activeByDefault);
     }
 
     bool Entity::IsRuntimeActiveByDefault() const
     {
-        return m_isRuntimeActiveByDefault;
+        return GetEntityFlag(RuntimeActiveByDefaultFlag);
     }
 
     Component* Entity::CreateComponent(const Uuid& componentTypeId)
@@ -343,7 +342,7 @@ namespace AZ
 
         m_components.push_back(component);
 
-        if (m_state == State::Init)
+        if (GetState() == State::Init)
         {
             component->Init();
         }
@@ -525,7 +524,7 @@ namespace AZ
         componentToAdd->SetEntity(this);
 
         // Initialize component if necessary.
-        if (m_state == State::Init)
+        if (GetState() == State::Init)
         {
             componentToAdd->Init();
         }
@@ -656,9 +655,9 @@ namespace AZ
 
     void Entity::SetState(State state)
     {
-        State oldState = state;
-        m_state = state;
-        m_stateEvent.Signal(oldState, m_state);
+        const State oldState = GetState();
+        SetStateBits(state);
+        m_stateEvent.Signal(oldState, state);
     }
 
 #pragma region Entity Activation State Handling
@@ -708,18 +707,18 @@ namespace AZ
         bool isEffective = IsEffectivelyActive();
 
         // Avoid evaluation during irregular states.
-        if (m_state != State::Init && m_state != State::Active)
+        if (GetState() != State::Init && GetState() != State::Active)
         {
             AZ_Warning("Entity", false, "%s evaluating active state, between valid states. Exiting out.", m_name.c_str());
             return false;
         }
 
-        if (isEffective && m_state == State::Init)
+        if (isEffective && GetState() == State::Init)
         {
             Activate();
             return true;
         }
-        else if (!isEffective && m_state == State::Active)
+        else if (!isEffective && GetState() == State::Active)
         {
             Deactivate();
             return true;
@@ -746,7 +745,7 @@ namespace AZ
         // when for example, another thread is constructing a prefab.  It also prevents spam of these functions from situations where
         // inactive entities are being constructed or modified in place, such as in undo/redo or scene compilation.
         // In general, only active entities should have any bearing on the actual scene, such as showing up in the Scene Outliner.
-        if (m_state == State::Active)
+        if (GetState() == State::Active)
         {
             EntityBus::Event(GetId(), &EntityBus::Events::OnEntityNameChanged, m_name);
             EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityNameChanged, GetId(), m_name);
@@ -756,7 +755,7 @@ namespace AZ
 
     bool Entity::CanAddRemoveComponents() const
     {
-        switch (m_state)
+        switch (GetState())
         {
         case State::Constructed:
         case State::Init:
@@ -854,13 +853,19 @@ namespace AZ
         {
             serializeContext->Class<Entity>(&Serialize::StaticInstance<SerializeEntityFactory>::s_instance)
                 ->PersistentId([](const void* instance) -> u64 { return static_cast<u64>(reinterpret_cast<const Entity*>(instance)->GetId()); })
-                ->Version(2, &ConvertOldData)
+                ->Version(3, &ConvertOldData)
                 ->Field("Id", &Entity::m_id)
                     ->Attribute(Edit::Attributes::IdGeneratorFunction, &Entity::MakeId)
                 ->Field("Name", &Entity::m_name)
-                ->Field("Components", &Entity::m_components) // Component serialization can result in IsDependencyReady getting modified, so serialize Components first.
-                ->Field("IsDependencyReady", &Entity::m_isDependencyReady)
-                ->Field("IsRuntimeActive", &Entity::m_isRuntimeActiveByDefault)
+                ->Field("Components", &Entity::m_components)
+                // State, DependencyReady and RuntimeActiveByDefault are now packed into the single
+                // m_activeStateByType word, so serialize the word. NOTE (prototype): it also carries
+                // the runtime activation-layer + lifecycle State bits. Entities are serialized while
+                // inactive (State::Constructed -> 0 bits), so those load back benign; a follow-up
+                // should mask to persist only RuntimeActiveByDefault. Legacy (<v3) IsRuntimeActive /
+                // IsDependencyReady fields are not migrated here (JSON prefabs keep IsRuntimeActive via
+                // EntitySerializer); add a ConvertOldData(<3) branch if objectstream/.slice data needs it.
+                ->Field("EntityStateBits", &Entity::m_activeStateByType)
                 ;
 
             serializeContext->RegisterGenericType<AZStd::unordered_map<AZStd::string, AZ::Component*>>();
@@ -884,10 +889,10 @@ namespace AZ
                     DataElement(AZ::Edit::UIHandlers::Default, &Entity::m_id, "Id", "")->
                         Attribute(Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)->
                         Attribute(Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::NotPushable)->
-                    DataElement(AZ::Edit::UIHandlers::Default, &Entity::m_isDependencyReady, "IsDependencyReady", "")->
-                        Attribute(Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)->
-                        Attribute(Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::NotPushable)->
-                    DataElement(AZ::Edit::UIHandlers::Default, &Entity::m_isRuntimeActiveByDefault, "StartActive", "")->
+                    // IsDependencyReady and StartActive (RuntimeActiveByDefault) are now packed bits,
+                    // not addressable members, so they are not reflected here. The editor's entity
+                    // "Start status" dropdown drives RuntimeActiveByDefault through the
+                    // Set/IsRuntimeActiveByDefault accessors (EntityPropertyEditor), so it is unaffected.
                     DataElement("String", &Entity::m_name, "Name", "Unique name of the entity")->
                         Attribute(Edit::Attributes::ChangeNotify, &Entity::OnNameChanged)->
                     DataElement("Components", &Entity::m_components, "Components", "");

--- a/Code/Framework/AzCore/AzCore/Component/Entity.h
+++ b/Code/Framework/AzCore/AzCore/Component/Entity.h
@@ -131,7 +131,7 @@ namespace AZ
 
         //! Gets the state of the entity.
         //! @return The state of the entity. For example, the entity has been initialized, the entity is active, and so on.
-        State GetState() const { return m_state; }
+        State GetState() const { return static_cast<State>((m_activeStateByType & s_stateMask) >> s_stateShift); }
         
         //! Sets the "Entity" active state type to determine whether the local state of the entity should be active or inactive. This only alters the local active state factor.
         //! @param active Whether the state should be set to activated or deactivated.
@@ -156,7 +156,7 @@ namespace AZ
         //! Returns the current functional active state of the Entity. This is the evaluated combination of all the Active Type flags on this entity.
         //! If all active, then active, otherwise inactive (deactivate).
         //! @return The current "Effectively Active" state of the Entity.
-        bool IsEffectivelyActive() { return m_activeStateByType == s_allStatesOn; }
+        bool IsEffectivelyActive() { return (m_activeStateByType & s_activeStateMask) == s_activeStateMask; }
 
 
         //! Gets the ticket id used to spawn the entity.
@@ -446,32 +446,50 @@ namespace AZ
 
         u32 m_entitySpawnTicketId = 0;
 
-        //! The state of the entity.
-        State m_state;
+        // --- Bit-packed entity state word ------------------------------------------------------
+        //! m_activeStateByType packs three things that previously cost separate members. The two
+        //! bools lived in tail padding, and the State enum plus the bools together cost a full
+        //! extra 8-byte word; packing them all into one word reclaims that word:
+        //!  * Low 16 bits (s_activeStateMask) - activation layers. Index 0 is the "Entity" layer;
+        //!    further layers are handed out by EntityActiveSystemComponent (LOD, visibility, ...).
+        //!    The entity is "effectively active" only when ALL activation-layer bits are set.
+        //!  * Bits 16-23 - packed boolean entity flags (see EntityFlag).
+        //!  * Bits 24-27 - the lifecycle State enum (see s_stateShift / s_stateMask).
+        static constexpr size_t   s_maxStateFlags   = 16;          // activation-layer capacity (low half)
+        static constexpr uint32_t s_activeStateMask = 0x0000FFFFu; // low 16 bits = activation layers
 
-        //! Expanded Entity State Handling to Introduce an Active by State Type mask for up to 32 possible activeTypes registered by the
-        //! system on startup. Based on state of "entity" type is default at 0 and any other type is an index of the int mask, we determine
-        //! what the absolute desired state (Effective State) of this entity is.
+        //! Packed boolean entity flags, stored above the activation layers.
+        enum EntityFlag : uint32_t
+        {
+            RuntimeActiveByDefaultFlag = 1u << 16, ///< Entity should activate on initial creation ("Start active").
+            DependencyReadyFlag        = 1u << 17, ///< Component dependencies were evaluated and sorted successfully.
+        };
 
-        static constexpr size_t s_maxStateFlags = 32;
-        static constexpr uint32_t s_allOn32 = 0xFFFFFFFFu;
-        static constexpr uint32_t s_allStatesOn =
-                                    (s_maxStateFlags == 0)  ? 0u :
-                                    (s_maxStateFlags >= 32) ? s_allOn32 :
-                                    (s_allOn32 >> (32 - s_maxStateFlags));
+        static constexpr uint32_t s_stateShift = 24;                  ///< Lifecycle State occupies bits 24-27.
+        static constexpr uint32_t s_stateMask  = 0xFu << s_stateShift;
 
-        //! The current int carrying the masked state of all Active States by Type, each held on a defined index.
-        //! Starts all active to assure unused type indexes start active.
-        uint32_t m_activeStateByType = s_allStatesOn;
+        bool GetEntityFlag(uint32_t flag) const { return (m_activeStateByType & flag) != 0; }
+        void SetEntityFlag(uint32_t flag, bool on)
+        {
+            if (on) { m_activeStateByType |= flag; } else { m_activeStateByType &= ~flag; }
+        }
+        void SetStateBits(State state)
+        {
+            m_activeStateByType = (m_activeStateByType & ~s_stateMask)
+                | ((static_cast<uint32_t>(state) << s_stateShift) & s_stateMask);
+        }
 
-        //! Foundational entity properties/flags.
-        //! To keep AZ::Entity lightweight, one should resist the urge the add flags here unless they're extremely
-        //! common to AZ::Entity use cases, and inherently fundamental.
-        //! Furthermore, if more than 4 flags are needed, please consider using a more space-efficient container,
-        //! such as AZStd::bit_set<>. With just a couple flags, AZStd::bit_set's word-size of 32-bits will actually waste space.
-        bool m_isDependencyReady;           ///< Indicates the component dependencies have been evaluated and sorting was completed successfully.
-        bool m_isRuntimeActiveByDefault;    ///< Indicates the entity should be activated on initial creation. 
+        //! Activation layers (low half) + packed flags and lifecycle State (high half). Default:
+        //! all activation layers on, RuntimeActiveByDefault on, DependencyReady off,
+        //! State == Constructed (enum value 0, so no state bits set).
+        uint32_t m_activeStateByType = s_activeStateMask | RuntimeActiveByDefaultFlag;
     };
+
+    // FOOTPRINT PROBE (prototype): folding State + the two bools into m_activeStateByType removes a
+    // full 8-byte tail word, so sizeof(AZ::Entity) should drop by 8 vs the pre-fold layout. To read
+    // the exact size, temporarily change the assert below to "== 0"; the compiler error reports the
+    // real size. Then lock it in by setting <SIZE> to the measured value (and delete this note).
+    // static_assert(sizeof(AZ::Entity) == /*<SIZE>*/ 0, "AZ::Entity footprint changed unexpectedly");
 
     template<class ComponentType, typename... Args>
     inline ComponentType* Entity::CreateComponent(Args&&... args)

--- a/Code/Framework/AzCore/AzCore/Component/EntityActiveSystemComponent.h
+++ b/Code/Framework/AzCore/AzCore/Component/EntityActiveSystemComponent.h
@@ -43,6 +43,6 @@ namespace AZ
         size_t ScanListForIndex(AZ::Crc32 typeNameId);
     private:
         AZStd::vector<AZ::Crc32> m_activeTypeNameToIndex = { ENTITY_ACTIVE_TYPE_NAME };
-        static constexpr size_t s_maxStateFlags = 32;
+        static constexpr size_t s_maxStateFlags = 16; // activation-layer capacity; matches AZ::Entity activation low-half
     };
 } // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
@@ -97,9 +97,12 @@ namespace AZ
             result.Combine(componentLoadResult);
         }
 
-        ContinueLoadingFromJsonObjectField(&entityInstance->m_isRuntimeActiveByDefault,
-            azrtti_typeid<decltype(entityInstance->m_isRuntimeActiveByDefault)>(),
+        // RuntimeActiveByDefault is a packed flag bit (not an addressable member), so round-trip it
+        // through the accessor while keeping the on-disk "IsRuntimeActive" bool field unchanged.
+        bool isRuntimeActiveByDefault = entityInstance->IsRuntimeActiveByDefault();
+        ContinueLoadingFromJsonObjectField(&isRuntimeActiveByDefault, azrtti_typeid<bool>(),
             inputValue, "IsRuntimeActive", context);
+        entityInstance->SetRuntimeActiveByDefault(isRuntimeActiveByDefault);
  
         AZStd::string_view message = result.GetProcessing() == JSR::Processing::Completed
             ? "Successfully loaded entity information."
@@ -184,13 +187,15 @@ namespace AZ
 
         {
             AZ::ScopedContextPath subPathRuntimeActive(context, "m_isRuntimeActiveByDefault");
-            const bool* runtimeActive = &entityInstance->m_isRuntimeActiveByDefault;
-            const bool* runtimeActiveDefault =
-                defaultEntityInstance ? &defaultEntityInstance->m_isRuntimeActiveByDefault : nullptr;
+            // RuntimeActiveByDefault is a packed flag bit; read it via the accessor into a local and
+            // serialize that, keeping the on-disk "IsRuntimeActive" bool field unchanged.
+            const bool runtimeActive = entityInstance->IsRuntimeActiveByDefault();
+            const bool runtimeActiveDefault =
+                defaultEntityInstance ? defaultEntityInstance->IsRuntimeActiveByDefault() : false;
 
             JSR::ResultCode resultRuntimeActive =
                 ContinueStoringToJsonObjectField(outputValue, "IsRuntimeActive",
-                    runtimeActive, runtimeActiveDefault, azrtti_typeid<decltype(entityInstance->m_isRuntimeActiveByDefault)>(), context);
+                    &runtimeActive, defaultEntityInstance ? &runtimeActiveDefault : nullptr, azrtti_typeid<bool>(), context);
 
             result.Combine(resultRuntimeActive);
         }

--- a/Code/Framework/AzCore/AzCore/Module/ModuleManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/ModuleManager.cpp
@@ -87,7 +87,7 @@ namespace AZ
             EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityDeactivated, m_id);
         }
 
-        m_state = state;
+        SetStateBits(state);
 
         if (state == Entity::State::Active)
         {


### PR DESCRIPTION
What the fold does
Entity.h: low 16 = activation layers (s_activeStateMask, cap 16); bit 16 RuntimeActiveByDefaultFlag, bit 17 DependencyReadyFlag; bits 24–27 = State. Removed m_state + both bools. GetState()/IsEffectivelyActive() read from the word; private GetEntityFlag/SetEntityFlag/SetStateBits helpers. Default init matches the old defaults exactly. Entity.cpp: GetState()-based reads everywhere; accessors route to flag bits; SetState rewritten — and I fixed a latent #19319 bug there in passing (State oldState = state; captured the new state, so every state-change event reported old==new; now captures GetState() first). Editor untouched: the "Start status" dropdown drives Set/IsRuntimeActiveByDefault() (accessors), not the member address — so backing those with a flag bit keeps it working. Removed the now-unbindable EditContext entries. Serialization: JSON prefabs keep the on-disk "IsRuntimeActive" bool via the accessors (EntitySerializer); SerializeContext serializes the word (Version→3) for clone/objectstream. Probe: Entity.h has a commented static_assert(sizeof(AZ::Entity)==0) — uncomment to read the real size from the compiler error; expected −8 bytes. Statically verified: no dangling references to the removed symbols anywhere, no bare m_state left, all LF, clean diff (Entity.cpp/.h, EntityActiveSystemComponent.h 1-line, EntitySerializer.cpp).