### PR TITLE
fix(gcc): usage of a dangling temporary by reference

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/EditorCommon.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/EditorCommon.cpp
@@ -333,7 +333,7 @@ namespace ImageProcessingAtomEditor
         }
 
         TextureSettings& texSetting = GetMultiplatformTextureSetting();
-        for (auto& it = ++ m_settingsMap.begin(); it != m_settingsMap.end(); ++it)
+        for (auto it = ++ m_settingsMap.begin(); it != m_settingsMap.end(); ++it)
         {
             const PlatformName defaultPlatform = BuilderSettingManager::s_defaultPlatform;
             if (it->first != defaultPlatform)


### PR DESCRIPTION
## What does this PR do?

`begin()` returns a temporary, that one gets modified by op++, then captured in a reference. Afterwards it is out of scope. 
Any further attempts to increment should go into the void.. 

## How was this PR tested?

_Please describe any testing performed._
