### PR TITLE
(DO NOT SUBMIT) Revert "AssetBuilder: add child-side parent-death watchdog"

### DIFF
--- a/Code/Tools/AssetProcessor/AssetBuilder/main.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilder/main.cpp
@@ -14,57 +14,8 @@
 // so it can be always running in the culture-invariant locale.
 #include <locale.h>
 
-#if defined(AZ_PLATFORM_LINUX) || defined(AZ_PLATFORM_MAC)
-#include <unistd.h>
-#include <thread>
-#include <chrono>
-
-namespace
-{
-    // Child-side parent-death watchdog. Polls getppid(); if the parent
-    // process dies (we get reparented to init / systemd-user), exit
-    // cleanly so we don't accumulate as an orphan across AP restarts.
-    //
-    // This replaces ProcessLauncher's m_tetherLifetime path
-    // (prctl(PR_SET_PDEATHSIG, SIGTERM)) which is unsafe to use from
-    // short-lived forking threads. The kernel binds PDEATHSIG to the
-    // THREAD that called fork(), not the parent PROCESS; AssetProcessor's
-    // BuilderManager forks builders from short-lived TaskWorker threads,
-    // so the prctl approach gets every spawned builder SIGTERM'd within
-    // milliseconds. Child-side polling is independent of the launching
-    // thread's lifetime.
-    //
-    // 2s polling = negligible CPU, max orphan-lifetime of 2 seconds.
-    void StartParentDeathWatchdog()
-    {
-        const pid_t parentAtStartup = getppid();
-        if (parentAtStartup <= 1)
-        {
-            // Launched without a meaningful parent (already init's child);
-            // no watchdog needed.
-            return;
-        }
-        std::thread([parentAtStartup]()
-        {
-            for (;;)
-            {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-                if (::getppid() != parentAtStartup)
-                {
-                    _exit(0);
-                }
-            }
-        }).detach();
-    }
-}
-#endif
-
 int main(int argc, char** argv)
 {
-#if defined(AZ_PLATFORM_LINUX) || defined(AZ_PLATFORM_MAC)
-    StartParentDeathWatchdog();
-#endif
-
     // globally set the application locale to the culture-invariant locale.
     // This should cause all reading and writing under all threads to use the invariant locale
     // So that the application can be run in any locale and still produce the same output.


### PR DESCRIPTION
(DO NOT SUBMIT) 

## What does this PR do?
This reverts commit 62fdd36ee8626a046ed58c1cadb4a6c15776057b

I don't actually intend to submit this, but we have been experiencing stuck child processes in assetbuilder in linux only roughly since this PR was added.  I'm going to run AR on this a bunch of times, and see if the AR ever gets stuck on it.  In development ARs, its not a 100% repo, but its close to 100%.

