### PR TITLE
[Wayland] Force QPA and initial EditorApplication code.

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -3461,6 +3461,18 @@ extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
 
     Editor::EditorQtApplication::InstallQtLogHandler();
 
+#ifdef AZ_PLATFORM_LINUX
+    // Force the QPA platform so Qt does not load a platform plugin that AzFramework doesn't support.
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
+    {
+#if !PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+        qputenv("QT_QPA_PLATFORM", "xcb");
+#elif !PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
+        qputenv("QT_QPA_PLATFORM", "wayland");
+#endif
+    }
+#endif
+
     AzQtComponents::Utilities::HandleDpiAwareness(AzQtComponents::Utilities::SystemDpiAware);
     Editor::EditorQtApplication* app = Editor::EditorQtApplication::newInstance(argc, argv);
 

--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
@@ -18,18 +18,73 @@
 #include <AzFramework/XcbEventHandler.h>
 #endif
 
+#ifdef PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+#include <AzFramework/WaylandInterface.h>
+#include <qpa/qplatformnativeinterface.h>
+#endif
+
 namespace Editor
 {
     EditorQtApplication* EditorQtApplication::newInstance(int& argc, char** argv)
     {
-#ifdef PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
-        return new EditorQtApplicationXcb(argc, argv);
-#endif
-
-        return nullptr;
+        return new EditorQtApplicationLinux(argc, argv);
     }
 
-    xcb_connection_t* EditorQtApplicationXcb::GetXcbConnectionFromQt()
+    EditorQtApplicationLinux::EditorQtApplicationLinux(int& argc, char** argv)
+        : EditorQtApplication(argc, argv)
+    {
+        AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
+
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+        if (platformName() == "wayland")
+        {
+            m_wayland = true;
+            AzFramework::WaylandDisplayProviderInterface::Register(this);
+        }
+#endif
+    }
+
+    int EditorQtApplicationLinux::GetTickOrder()
+    {
+        return AZ::TICK_INPUT;
+    }
+
+    void EditorQtApplicationLinux::OnTick(float deltaTime, AZ::ScriptTimePoint time)
+    {
+        #if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+        if (m_wayland)
+        {
+            AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::PumpSystemEventLoopUntilEmpty);
+        }
+        #endif
+    }
+
+#ifdef PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+    wl_display* EditorQtApplicationLinux::GetWaylandDisplayFromQt() const
+    {
+        auto *waylandApp = nativeInterface<QNativeInterface::QWaylandApplication>();
+        AZ_Warning("EditorQtApplicationWayland", waylandApp, "Unable to retrieve the native platform interface");
+        if (!waylandApp)
+        {
+            return nullptr;
+        }
+
+        return waylandApp->display();
+    }
+
+    wl_display* EditorQtApplicationLinux::GetWaylandDisplay() const
+    {
+        return GetWaylandDisplayFromQt();
+    }
+
+    int EditorQtApplicationLinux::GetDisplayFD() const
+    {
+        return wl_display_get_fd(GetWaylandDisplayFromQt());
+    }
+#endif
+
+#ifdef PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
+    xcb_connection_t* EditorQtApplicationLinux::GetXcbConnectionFromQt()
     {
         QNativeInterface::QX11Application* x11App = QGuiApplication::nativeInterface<QNativeInterface::QX11Application>();
         AZ_Warning("EditorQtApplicationXcb", x11App, "Unable to retrieve the native platform interface");
@@ -39,23 +94,47 @@ namespace Editor
         }
         return x11App->connection();
     }
+#endif
 
-    void EditorQtApplicationXcb::OnStartPlayInEditor()
+    void EditorQtApplicationLinux::OnStartPlayInEditor()
     {
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+        if (m_wayland)
+        {
+            AZ::TickBus::Handler::BusConnect();
+            return;
+        }
+#endif
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
         auto* interface = AzFramework::XcbConnectionManagerInterface::Get();
         interface->SetEnableXInput(GetXcbConnectionFromQt(), true);
+#endif
     }
 
-    void EditorQtApplicationXcb::OnStopPlayInEditor()
+    void EditorQtApplicationLinux::OnStopPlayInEditor()
     {
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+        if (m_wayland)
+        {
+            AZ::TickBus::Handler::BusDisconnect();
+            return;
+        }
+#endif
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
         auto* interface = AzFramework::XcbConnectionManagerInterface::Get();
         interface->SetEnableXInput(GetXcbConnectionFromQt(), false);
 
         AzFramework::XcbEventHandlerBus::Broadcast(&AzFramework::XcbEventHandler::ResetStoredInputStates);
+#endif
     }
 
-    bool EditorQtApplicationXcb::nativeEventFilter([[maybe_unused]] const QByteArray& eventType, void* message, qintptr*)
+    bool EditorQtApplicationLinux::nativeEventFilter([[maybe_unused]] const QByteArray& eventType, void* message, qintptr*)
     {
+        if (m_wayland)
+        {
+            return false;
+        }
+
         if (GetIEditor()->IsInGameMode())
         {
 #ifdef PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
@@ -81,7 +160,7 @@ namespace Editor
             AzFramework::InputSystemCursorRequestBus::EventResult(systemCursorState, AzFramework::InputDeviceMouse::Id, &AzFramework::InputSystemCursorRequestBus::Events::GetSystemCursorState);
             if(systemCursorState == AzFramework::SystemCursorState::UnconstrainedAndVisible)
             {
-                // If the system cursor is visible and unconstrained, the user 
+                // If the system cursor is visible and unconstrained, the user
                 // can interact with the editor so allow all events.
                 return false;
             }

--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
@@ -8,26 +8,45 @@
 
 #pragma once
 
-#include <Editor/Core/QtEditorApplication.h>
+#include <AzCore/Component/TickBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <Editor/Core/QtEditorApplication.h>
 
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
 using xcb_connection_t = struct xcb_connection_t;
+#endif
+
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+#include "AzFramework/WaylandConnectionManager.h"
+#endif
+
 
 namespace Editor
 {
-    class EditorQtApplicationXcb
+    class EditorQtApplicationLinux
         : public EditorQtApplication
         , public AzToolsFramework::EditorEntityContextNotificationBus::Handler
+        , public AZ::TickBus::Handler
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+        , public AzFramework::WaylandDisplayProvider
+#endif
+
     {
     public:
-        EditorQtApplicationXcb(int& argc, char** argv)
-            : EditorQtApplication(argc, argv)
-        {
-            // Connect bus to listen for OnStart/StopPlayInEditor events
-            AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
-        }
+        EditorQtApplicationLinux(int& argc, char** argv);
 
+        int GetTickOrder() override;
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND
+        wl_display* GetWaylandDisplayFromQt() const;
+        wl_display* GetWaylandDisplay() const override;
+        int GetDisplayFD() const override;
+#endif
+
+#if PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
         xcb_connection_t* GetXcbConnectionFromQt();
+#endif
 
         ///////////////////////////////////////////////////////////////////////
         // AzToolsFramework::EditorEntityContextNotificationBus overrides
@@ -36,5 +55,7 @@ namespace Editor
 
         // QAbstractNativeEventFilter:
         bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result) override;
+
+        bool m_wayland = false;
     };
 } // namespace Editor

--- a/Code/Editor/Platform/Linux/editor_lib_linux.cmake
+++ b/Code/Editor/Platform/Linux/editor_lib_linux.cmake
@@ -6,3 +6,10 @@
 #
 #
 
+if(PAL_TRAIT_LINUX_WINDOW_MANAGER_WAYLAND)
+    set(LY_BUILD_DEPENDENCIES
+        PRIVATE
+            Qt6::GuiPrivate
+            Qt6::WaylandClient
+    )
+endif ()


### PR DESCRIPTION
## What does this PR do?
Adds initial editor support for Wayland in Qt6 and adds fallback code so we only use 
QPA's AzFramework can support.

## REQUIRED PR
This needs the following 3p PR to properly build with Wayland enabled: https://github.com/o3de/3p-package-source/pull/383
We also need to add the new rev and hash into this PR when thats done.

## How was this PR tested?
Ran the editor on a new project with and without Wayland enabled.