### PR TITLE
Fixes potential AssetProcessor job freeze issue, and adds more debug logging

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCQueueSortModel.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCQueueSortModel.cpp
@@ -51,15 +51,16 @@ namespace AssetProcessor
         {
             AZ_Printf(
                 AssetProcessor::ConsoleChannel,
-                "    Job %04i: (Escalation: %i) (Priority: %3i) (Status: %10s) (Crit? %s) (Plat: %s) (MissingDeps? %s) - %s\n",
+                "    Job %04i: (Escalation: %i) (Priority: %3i) (Status: %10s) (Crit? %s) (MissingDeps? %s) - %s %s %s\n",
                 idx,
                 actualJob->JobEscalation(),
                 actualJob->GetPriority(),
                 RCJob::GetStateDescription(actualJob->GetState()).toUtf8().constData(),
                 actualJob->IsCritical() ? "Y" : "N",
-                actualJob->GetPlatformInfo().m_identifier.c_str(),
                 actualJob->HasMissingSourceDependency() ? "Y" : "N",
-                actualJob->GetJobEntry().GetAbsoluteSourcePath().toUtf8().constData());
+                actualJob->GetJobEntry().GetAbsoluteSourcePath().toUtf8().constData(),
+                actualJob->GetJobEntry().m_jobKey.toUtf8().constData(),
+                actualJob->GetPlatformInfo().m_identifier.c_str());
 
             for (const JobDependencyInternal& jobDependencyInternal : actualJob->GetJobDependencies())
             {

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
@@ -136,7 +136,7 @@ namespace AssetProcessor
         m_RCJobListModel.markAsStarted(rcJob);
         Q_EMIT JobStatusChanged(rcJob->GetJobEntry(), AzToolsFramework::AssetSystem::JobStatus::InProgress);
         rcJob->Start();
-        Q_EMIT JobStarted(rcJob->GetJobEntry().m_sourceAssetReference.RelativePath().c_str(), QString::fromUtf8(rcJob->GetPlatformInfo().m_identifier.c_str()));
+        Q_EMIT JobStarted(rcJob->GetJobEntry().m_sourceAssetReference.RelativePath().c_str(), rcJob->GetJobEntry().m_jobKey, QString::fromUtf8(rcJob->GetPlatformInfo().m_identifier.c_str()));
     }
 
     void RCController::QuitRequested()

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
@@ -258,8 +258,8 @@ namespace AssetProcessor
                 // The job status has changed
                 if (existingJob->HasMissingSourceDependency() != hasMissingDependency)
                 {
-                    AZ_TracePrintf(
-                        AssetProcessor::DebugChannel,
+                    AZ_Printf(
+                        AssetProcessor::ConsoleChannel,
                         "Cancelling Job [%s, %s, %s] missing source dependency status has changed.\n",
                         checkFile.GetSourceAssetReference().AbsolutePath().c_str(),
                         checkFile.GetPlatform().toUtf8().data(),
@@ -271,8 +271,8 @@ namespace AssetProcessor
 
             if (!cancelJob)
             {
-                AZ_TracePrintf(
-                    AssetProcessor::DebugChannel,
+                AZ_Printf(
+                    AssetProcessor::ConsoleChannel,
                     "Job is already in queue and has not started yet - ignored [%s, %s, %s]\n",
                     checkFile.GetSourceAssetReference().AbsolutePath().c_str(),
                     checkFile.GetPlatform().toUtf8().data(),
@@ -299,8 +299,8 @@ namespace AssetProcessor
                 // have FinishJob called once through the callback in RCController::StartJob. FinishJob should not be called more than once.
                 if (existingJob->GetJobEntry().m_computedFingerprint != details.m_jobEntry.m_computedFingerprint)
                 {
-                    AZ_TracePrintf(
-                        AssetProcessor::DebugChannel,
+                    AZ_Printf(
+                        AssetProcessor::ConsoleChannel,
                         "Cancelling Job [%s, %s, %s] with old FP %u, replacing with new FP %u \n",
                         checkFile.GetSourceAssetReference().AbsolutePath().c_str(),
                         checkFile.GetPlatform().toUtf8().data(),
@@ -314,7 +314,7 @@ namespace AssetProcessor
                     // If a job has dependencies, it's very likely it was re-queued as a result of a dependency being changed
                     // The in-flight job is probably going to fail at best, or use old data at worst, so cancel the in-flight job
 
-                    AZ_TracePrintf(AssetProcessor::DebugChannel, "Cancelling Job with dependencies [%s, %s, %s], replacing with re-queued job\n",
+                    AZ_Printf(AssetProcessor::ConsoleChannel, "Cancelling Job with dependencies [%s, %s, %s], replacing with re-queued job\n",
                         checkFile.GetSourceAssetReference().AbsolutePath().c_str(), checkFile.GetPlatform().toUtf8().data(), checkFile.GetJobDescriptor().toUtf8().data());
                     cancelJob = true;
                 }

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.h
@@ -63,7 +63,7 @@ namespace AssetProcessor
         void ReadyToQuit(QObject* source); //After receiving QuitRequested, you must send this when its safe
 
         ///! JobStarted will notify with a path name relative to the watch folder it was found in (not the database sourcename column)
-        void JobStarted(QString inputFile, QString platform);
+        void JobStarted(QString inputFile, QString jobKey, QString platform);
         void JobStatusChanged(JobEntry entry, AzToolsFramework::AssetSystem::JobStatus status);
         void JobsInQueuePerPlatform(QString platform, int jobs);
         void ActiveJobsCountChanged(unsigned int jobs); // This is the count of jobs which are either queued or inflight

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rcjoblistmodel.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rcjoblistmodel.cpp
@@ -425,8 +425,8 @@ namespace AssetProcessor
                 if ((isInQueue(target)) || (isInFlight(target)))
                 {
                     // Its important that this still follows the 'cancelled' flow, so that other parts of the code can update their "in progress" and other maps.
-                    AZ_TracePrintf(
-                        AssetProcessor::DebugChannel,
+                    AZ_Printf(
+                        AssetProcessor::ConsoleChannel,
                         "Cancelling Job [%s, %s, %s] because the source file no longer exists.\n",
                         target.GetSourceAssetReference().AbsolutePath().c_str(),
                         target.GetPlatform().toUtf8().data(),

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManager.cpp
@@ -88,6 +88,16 @@ namespace AssetProcessor
                 // we are in a job thread - return early to make it so that the global log file does not get this message
                 // there will also be a log listener in the actual job log thread which will get the message too, and that one
                 // will write it to the individual log.
+
+                // you can "punch through" this filter by using a window of the console channel (AssetProcessor).
+                // mainly used to show debug.
+                if (window)
+                {
+                    if (strcmp(window, ConsoleChannel) == 0)
+                    {
+                        AzFramework::LogComponent::OutputMessage(severity, window, message);
+                    }
+                }
                 return;
             }
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -608,9 +608,9 @@ void ApplicationManagerBase::InitConnectionManager()
     AZ_Assert(result, "Failed to connect to RCController signal");
 
     result = QObject::connect(GetRCController(), &AssetProcessor::RCController::JobStarted, this,
-            [](QString inputFile, QString platform)
+            [](QString inputFile, QString jobKey, QString platform)
             {
-                QString msg = QCoreApplication::translate("O3DE Asset Processor", "Processing %1 (%2)...\n", "%1 is the name of the file, and %2 is the platform to process it for").arg(inputFile, platform);
+                QString msg = QCoreApplication::translate("O3DE Asset Processor", "Processing %1 \"%2\" (%3)...\n", "%1 is the name of the file, %2 is the job type, %3 is the platform to process it for").arg(inputFile, jobKey, platform);
                 AZ_Printf(AssetProcessor::ConsoleChannel, "%s", msg.toUtf8().constData());
                 AssetNotificationMessage message(inputFile.toUtf8().constData(), AssetNotificationMessage::JobStarted, AZ::Data::s_invalidAssetType, platform.toUtf8().constData());
                 AssetProcessor::ConnectionBus::Broadcast(&AssetProcessor::ConnectionBus::Events::SendPerPlatform, 0, message, platform);

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -1702,7 +1702,8 @@ static void HandleConditionalRetry(const AssetProcessor::BuilderRunJobOutcome& r
     // If a lost connection occured or the process was terminated before a response can be read, and there is another retry to get the
     // response from a Builder, then handle the logic to log and sleep before attempting the retry of the job
     if ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection ||
-         result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated ) && (retryCount <= AssetProcessor::RetriesForJobLostConnection))
+         result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated ||
+         result == AssetProcessor::BuilderRunJobOutcome::ResponseFailure) && (retryCount <= AssetProcessor::RetriesForJobLostConnection))
     {
         const int delay = 1 << (retryCount-1);
 
@@ -1711,22 +1712,25 @@ static void HandleConditionalRetry(const AssetProcessor::BuilderRunJobOutcome& r
         {
             // If the connection was lost and the process handle is no longer valid, then we need to request a new builder to reprocess the job
             AZStd::string oldBuilderId = builderRef->GetUuid().ToString<AZStd::string>();
+            AZ::u32 oldConnId = builderRef->GetConnectionId();
             builderRef.release();
-
             AssetProcessor::BuilderManagerBus::BroadcastResult(builderRef, &AssetProcessor::BuilderManagerBusTraits::GetBuilder, purpose);
 
             if (builderRef)
             {
-                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Lost connection to builder %s. Retrying with a new builder %s (Attempt %d with %d second delay)",
+                AZ_Printf(AssetProcessor::ConsoleChannel, "Lost connection to builder %s - %i. Retrying with a new builder %s - %i (Attempt %d with %d second delay)",
                                 oldBuilderId.c_str(),
+                                oldConnId,
                                 builderRef->GetUuid().ToString<AZStd::string>().c_str(),
+                                builderRef->GetConnectionId(),
                                 retryCount+1,
                                 delay);
             }
             else
             {
-                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Lost connection to builder %s and no further builders are available. Job will not retry.\n",
-                               oldBuilderId.c_str());
+                AZ_Printf(AssetProcessor::ConsoleChannel, "Lost connection to builder %s - %i and no further builders are available. Job will not retry.\n",
+                    oldBuilderId.c_str(),
+                    oldConnId);
                 // if we failed to get a builder ref, it means we're probably
                 // shutting down, in which case we do not want to do an exponential
                 // backoff delay and need to return immediately.
@@ -1795,10 +1799,16 @@ void ApplicationManagerBase::RegisterBuilderInformation(const AssetBuilderSDK::A
                     result = builderRef->RunJob<AssetBuilder::CreateJobsNetRequest, AssetBuilder::CreateJobsNetResponse>(
                         request, response, s_MaximumCreateJobsTimeSeconds, "create", "", nullptr);
 
+                    if (JobOutcomeIsTerminal(result))
+                    {
+                        builderRef.MarkAsDefunct(); // prevent reuse immediately, within the same thread, etc, before we try anything else.
+                    }
+
                     HandleConditionalRetry(result, retryCount, builderRef, AssetProcessor::BuilderPurpose::CreateJobs);
 
                 } while ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection ||
-                          result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated) &&
+                          result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated ||
+                          result == AssetProcessor::BuilderRunJobOutcome::ResponseFailure) &&
                           retryCount <= AssetProcessor::RetriesForJobLostConnection);
             }
             else
@@ -1850,7 +1860,8 @@ void ApplicationManagerBase::RegisterBuilderInformation(const AssetBuilderSDK::A
                     HandleConditionalRetry(result, retryCount, builderRef, AssetProcessor::BuilderPurpose::ProcessJob);
 
                 } while ((result == AssetProcessor::BuilderRunJobOutcome::LostConnection ||
-                          result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated) &&
+                          result == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated ||
+                          result == AssetProcessor::BuilderRunJobOutcome::ResponseFailure) &&
                           retryCount <= AssetProcessor::RetriesForJobLostConnection);
             }
             else

--- a/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/Builder.cpp
@@ -171,12 +171,17 @@ namespace AssetProcessor
 
     bool Builder::IsValid() const
     {
-        return m_connectionId != 0 && IsRunning();
+        return m_connectionId != 0 && IsRunning() && !m_defunct;
     }
 
     bool Builder::IsRunning(AZ::u32* exitCode) const
     {
         return !m_processWatcher || (m_processWatcher && m_processWatcher->IsProcessRunning(exitCode));
+    }
+
+    bool Builder::IsReadyToWork() const
+    {
+        return !(m_busy || m_defunct);
     }
 
     AZStd::vector<AZStd::string> Builder::BuildParams(
@@ -299,26 +304,26 @@ namespace AssetProcessor
         }
         else if (!IsConnected())
         {
-            AZ_Error("Builder", false, "Lost connection to asset builder %s", UuidString().c_str());
+            AZ_Error("Builder", false, "BuildLost connection to asset builder %s - %i", UuidString().c_str(), GetConnectionId());
             return BuilderRunJobOutcome::LostConnection;
         }
         else if (!IsRunning(&exitCode))
         {
             // these are written to the debug channel because other messages are given for when asset builders die
             // that are more appropriate
-            AZ_Error("Builder", false, "AssetBuilder %s terminated with exit code %d", UuidString().c_str(), exitCode);
+            AZ_Error("Builder", false, "AssetBuilder %s - %i terminated with exit code %d", UuidString().c_str(), GetConnectionId(), exitCode);
             return BuilderRunJobOutcome::ProcessTerminated;
         }
         else if (jobCancelListener && jobCancelListener->IsCancelled())
         {
-            AZ_Error("Builder", false, "Job request was canceled");
+            AZ_Error("Builder", false, "Job request was canceled - terminating process builder %s - %i", UuidString().c_str(), GetConnectionId());
             TerminateProcess(
                 AZ::u32(-1)); // Terminate the builder. Even if it isn't deadlocked, we can't put it back in the pool while it's busy.
             return BuilderRunJobOutcome::JobCancelled;
         }
         else
         {
-            AZ_Error("Builder", false, "AssetBuilder %s failed to respond within %d seconds", UuidString().c_str(), processTimeoutLimitInSeconds);
+            AZ_Error("Builder", false, "AssetBuilder %s - %i failed to respond within %d seconds", UuidString().c_str(), GetConnectionId(), processTimeoutLimitInSeconds);
             TerminateProcess(
                 AZ::u32(-1)); // Terminate the builder. Even if it isn't deadlocked, we can't put it back in the pool while it's busy.
             return BuilderRunJobOutcome::ResponseFailure;
@@ -360,6 +365,14 @@ namespace AssetProcessor
     BuilderRef::operator bool() const
     {
         return m_builder != nullptr;
+    }
+
+    void BuilderRef::MarkAsDefunct()
+    {
+        if (m_builder)
+        {
+            m_builder->m_defunct = true;
+        }
     }
 
     void BuilderRef::release()

--- a/Code/Tools/AssetProcessor/native/utilities/Builder.h
+++ b/Code/Tools/AssetProcessor/native/utilities/Builder.h
@@ -25,14 +25,26 @@ namespace AssetProcessor
 
     enum class BuilderRunJobOutcome
     {
-        Ok,
-        LostConnection,
-        ProcessTerminated,
-        JobCancelled,
-        ResponseFailure,
-        FailedToDecodeResponse,
-        FailedToWriteDebugRequest
+        Ok,                         // the builder completed the job.  This does not mean the job succeeded, just that it began, processed, ended, responded.
+        LostConnection,             // the network socket was closed.
+        ProcessTerminated,          // the process was terminated by some outside source (not us).
+        JobCancelled,               // we cancelled the job, and will terminate the process ourselves.
+        ResponseFailure,            // we asked it to do work and after a very long time it did not respond.
+        FailedToDecodeResponse,     // response was garbled
+        FailedToWriteDebugRequest   // in debug mode, we couldn't write the file to disk (disk full?  permissions?  serialization fail?)
     };
+
+    // the following outcomes are all the kind of outcomes where the builder is in a terminal state, and is unusable from this point on.
+    // it has either already been terminated, or will be soon.
+    static constexpr bool JobOutcomeIsTerminal(BuilderRunJobOutcome outcome)
+    {
+        return (
+            outcome == AssetProcessor::BuilderRunJobOutcome::LostConnection ||
+            outcome == AssetProcessor::BuilderRunJobOutcome::ProcessTerminated ||
+            outcome == AssetProcessor::BuilderRunJobOutcome::JobCancelled ||
+            outcome == AssetProcessor::BuilderRunJobOutcome::ResponseFailure
+            );
+    }
 
     //! Wrapper for managing a single builder process and sending job requests to it
     class Builder
@@ -72,6 +84,7 @@ namespace AssetProcessor
         void PumpCommunicator() const;
         void FlushCommunicator() const;
         void TerminateProcess(AZ::u32 exitCode) const;
+        bool IsReadyToWork() const;
 
         //! Sends the job over to the builder and blocks until the response is received or the builder crashes/times out
         template<typename TNetRequest, typename TNetResponse, typename TRequest, typename TResponse>
@@ -105,7 +118,7 @@ namespace AssetProcessor
         BuilderRunJobOutcome WaitForBuilderResponse(
             AssetBuilderSDK::JobCancelListener* jobCancelListener,
             AZ::u32 processTimeoutLimitInSeconds,
-            AZStd::binary_semaphore* waitEvent) const;
+            AZStd::binary_semaphore* waitEvent) const; // non-const since it can set itself as defunct
 
         //! Writes the request out to disk for debug purposes and logs info on how to manually run the asset builder
         template<typename TRequest>
@@ -120,6 +133,8 @@ namespace AssetProcessor
 
         //! Indicates if the builder is currently in use
         bool m_busy = false;
+
+        bool m_defunct = false; // becomes true if the builder process has terminated, but before cleanup, so we don't reuse it.
 
         AZStd::atomic<AZ::u32> m_connectionId = 0;
 
@@ -156,6 +171,8 @@ namespace AssetProcessor
         const Builder* operator->() const;
 
         explicit operator bool() const;
+
+        void MarkAsDefunct();
 
         void release();
 

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderList.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderList.cpp
@@ -48,7 +48,7 @@ namespace AssetProcessor
         {
             if (m_createJobsBuilder)
             {
-                if (!m_createJobsBuilder->m_busy)
+                if (m_createJobsBuilder->IsReadyToWork())
                 {
                     m_createJobsBuilder->PumpCommunicator();
 
@@ -76,7 +76,7 @@ namespace AssetProcessor
         {
             auto& builder = itr->second;
 
-            if (!builder->m_busy)
+            if (builder->IsReadyToWork())
             {
                 builder->PumpCommunicator();
 
@@ -147,7 +147,9 @@ namespace AssetProcessor
 
     void BuilderList::PumpIdleBuilders()
     {
-        if (m_createJobsBuilder && !m_createJobsBuilder->m_busy)
+        // idle builders will not have their event pump run inside the job that they are performing, so we need to pump them here.
+        // these are all the builders that are "ready to work" ie aren't currently working.
+        if (m_createJobsBuilder && m_createJobsBuilder->IsReadyToWork())
         {
             m_createJobsBuilder->PumpCommunicator();
         }
@@ -156,7 +158,7 @@ namespace AssetProcessor
         {
             auto builder = pair.second;
 
-            if (!builder->m_busy)
+            if (builder->IsReadyToWork())
             {
                 builder->PumpCommunicator();
             }

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -62,7 +62,7 @@ namespace AssetProcessor
 
         if(auto uuidString = m_builderList.RemoveByConnectionId(connId); !uuidString.empty())
         {
-            AZ_TracePrintf("BuilderManager", "Lost connection to builder %s\n", uuidString.c_str());
+            AZ_Printf(AssetProcessor::ConsoleChannel, "BuilderManager: Lost connection to builder %s, index %u, removed from pool\n", uuidString.c_str(), connId);
         }
     }
 
@@ -111,7 +111,7 @@ namespace AssetProcessor
                 }
                 else
                 {
-                    AZ_TracePrintf("BuilderManager", "Builder %s connected, connId: %d\n", builder->UuidString().c_str(), connId);
+                    AZ_Printf(AssetProcessor::ConsoleChannel, "BuilderManager: Builder %s connected, connId: %d\n", builder->UuidString().c_str(), connId);
                     builder->SetConnection(connId);
                     responsePing.m_accepted = true;
                     responsePing.m_uuid = builder->GetUuid();

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
@@ -26,14 +26,14 @@ namespace AssetProcessor
                 , m_sourceFile(sourceFile)
                 , m_task(task)
             {
-                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request started builder [%s] task (%s) %s \n",
-                    m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
+                AZ_Printf(AssetProcessor::ConsoleChannel, "Builder::RunJob - Request started builder [%s - %u] task (%s) %s \n",
+                    m_builder.UuidString().c_str(), m_builder.GetConnectionId(), m_task.c_str(), m_sourceFile.c_str());
             }
 
             ~BuildTracker()
             {
-                AZ_TracePrintf(AssetProcessor::ConsoleChannel, "Request stopped builder [%s] task (%s) %s \n",
-                    m_builder.UuidString().c_str(), m_task.c_str(), m_sourceFile.c_str());
+                AZ_Printf(AssetProcessor::ConsoleChannel, "Builder::RunJob - Request stopped builder [%s - %u] task (%s) %s \n",
+                    m_builder.UuidString().c_str(), m_builder.GetConnectionId(), m_task.c_str(), m_sourceFile.c_str());
             }
 
             const Builder& m_builder;

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
@@ -26,13 +26,16 @@ namespace AssetProcessor
                 , m_sourceFile(sourceFile)
                 , m_task(task)
             {
-                AZ_Printf(AssetProcessor::ConsoleChannel, "Builder::RunJob - Request started builder [%s - %u] task (%s) %s \n",
+                // Note that this message and the following message may be useful in debugging job runs and builder timeouts
+                // but spew before and after every single job, cluttering the log.  Send to AssetProcessor::ConsoleChannel if you want
+                // to debug, but otherwise, leave as-is to avoid STDOUT clutter.  (They still end up in the log)
+                AZ_TracePrintf("Builder::RunJob", "Request started builder [%s - %u] task (%s) %s \n",
                     m_builder.UuidString().c_str(), m_builder.GetConnectionId(), m_task.c_str(), m_sourceFile.c_str());
             }
 
             ~BuildTracker()
             {
-                AZ_Printf(AssetProcessor::ConsoleChannel, "Builder::RunJob - Request stopped builder [%s - %u] task (%s) %s \n",
+                AZ_TracePrintf("Builder::RunJob", "Request stopped builder [%s - %u] task (%s) %s \n",
                     m_builder.UuidString().c_str(), m_builder.GetConnectionId(), m_task.c_str(), m_sourceFile.c_str());
             }
 

--- a/Code/Tools/AssetProcessor/native/utilities/LogPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/LogPanel.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "LogPanel.h"
+#include <native/assetprocessor.h> // for consolechannel
 #include <native/utilities/ThreadHelper.h>
 
 namespace AssetProcessor
@@ -57,6 +58,15 @@ namespace AssetProcessor
     {
         if (AssetProcessor::GetThreadLocalJobId())
         {
+            // you can "punch through" this filter by using a window of the console channel (AssetProcessor).
+            // mainly used to show debug.
+            if (window)
+            {
+                if (strcmp(window, AssetProcessor::ConsoleChannel) == 0)
+                {
+                    return true; // allow it to print.
+                }
+            }
             return false; // we are in a job thread
         }
 

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -1743,6 +1743,15 @@ namespace AssetUtilities
                 AppendLog(m_inException ? AzFramework::LogFile::SEV_EXCEPTION : AzFramework::LogFile::SEV_NORMAL, window, message);
             }
 
+            // allow "AssetProcessor" log to escape builder threads for debugging
+            if (window)
+            {
+                if (strcmp(window, AssetProcessor::ConsoleChannel) == 0)
+                {
+                    return false;
+                }
+            }
+
             return true;
         }
 


### PR DESCRIPTION
## What does this PR do?

* Fixes a potential crash / deadlock that can occur when a job fails (due to crashing) or is cancelled (for example, it is already running, and a file it needs changes, so it has to restart).

This crash/deadlock can occur if a builder becomes **defunct**, that is, its in the middle of crashing, being told to shut down, has frozen, socket died, is cancelled, etc.  Once that happens, the builder is in a terminal state, and either is already dead, or will terminate soon.  The problem condition is that when that happens, the builder is returned to the pool briefly, in this defunct state, because the system that owns the pool and manages it is not on the same thread and event loop that the system which monitors the subprocess or sockets lives in.  This means that there was a possibility a defunct builder would get picked up and used before the other system got around to cleaning it up.

* Adds the builder connection ID to debug output for future debugging
* Adds the ability for log messages emitted during a build job to punch through the filter and appear in the STDOUT console in AP.  Previously, all messages emitted during a build job were filtered out of the AP's STDOUT, making it impossible to emit debug info if we need it.  Note that build messages from the builder subprocess are still filtered into the log, this just applies to locally emitted messages from the AP process, inside a thread it spawned to do a job.
* Adds the Job Key of a job to the console output for the CLI version of AssetProcessor. 

Old output:
```
Processing (FILENAME) (PLATFORM) ...
```

New Output
```
Processing (FILENAME) "(Job Key)" (PLATFORM) ...
```

For example, now would emit something like 
```
Processing /projects/o3de/AutomatedTesting/blank.material "Material Builder (Initial)" (PC) ...
Processing /projects/o3de/AutomatedTesting/blank.material "Material Builder (Final Pass)" (PC) ...
```

instead of the ambiguous seemingly duplicate job:
```
Processing /projects/o3de/AutomatedTesting/blank.material (PC) ...
Processing /projects/o3de/AutomatedTesting/blank.material (PC) ...
```

* Adds missing information like the job key to the debug spam that happens when we encounter a job deadlock

## How was this PR tested?

Lots of local testing on Windows/PC with full and partial rebuilds of Automated Testing (killing AP, deleting assets, etc)
Testing with AR.
