### PR TITLE
Fix Graph Canvas search by actually checking if there's a match.

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -148,7 +148,7 @@ namespace GraphCanvas
         
         bool showRow = false;
         QRegularExpressionMatch match = m_filterRegex.match(test);
-        if (match.isValid())
+        if (match.isValid() && match.hasMatch())
         {
             showRow = true;
             


### PR DESCRIPTION
## What does this PR do?

This PR fixes #19843, by calling QRegularExpressionMatch's [hasMatch](https://doc.qt.io/qt-6/qregularexpressionmatch.html#hasMatch) method.

Currently, it only checks if the match object is valid:

https://github.com/o3de/o3de/blob/112b6122f6c768216b9eafebd75dbdaa7f5694a1/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp#L151

This adds a `hasMatch` call, that checks for a match on `test` string.

### Before

<img width="328" height="832" alt="Captura de tela de 2026-06-12 23-17-12" src="https://github.com/user-attachments/assets/ecbdef6d-a405-4fd0-9743-5fa931875cb1" />
<br>

<img width="399" height="599" alt="Captura de tela de 2026-06-12 00-30-16" src="https://github.com/user-attachments/assets/ae969ec7-2a27-4668-9dd2-8fd335a92311" />
<br>

<img width="432" height="741" alt="Captura de tela de 2026-06-12 00-29-57-1" src="https://github.com/user-attachments/assets/3e3236f9-ce61-4a32-a11f-d085d585be0d" />
<br>

### Now

<img width="327" height="272" alt="Captura de tela de 2026-06-12 23-18-51" src="https://github.com/user-attachments/assets/68de6c28-48a5-4d13-96a5-6236bd8373c6" />
<br>

<img width="457" height="766" alt="Captura de tela de 2026-06-12 00-41-40" src="https://github.com/user-attachments/assets/3dbd242e-4d74-4c9c-a46e-d1cd879bd573" />
<br>

<img width="399" height="599" alt="Captura de tela de 2026-06-12 00-41-32" src="https://github.com/user-attachments/assets/b68c8a06-3f2e-4a08-ad50-b0d792aa0819" />
<br>

## How was this PR tested?

By doing the steps described on the original issue.

Tested on same environment: Fedora Linux 44.