### PR TITLE
Add FUNDING.yml file to add a Sponsor button on Github

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://o3de.org/donate/']


### PR DESCRIPTION
This adds a button that opens the donate page of O3DE.

Reference:

https://github.com/crownengine/crown/blob/master/.github/FUNDING.yml

Documentation:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository