### PR TITLE
Fixes the autogen cmake script to not trigger a full cmake regenerate…

### DIFF
--- a/cmake/LyAutoGen.cmake
+++ b/cmake/LyAutoGen.cmake
@@ -49,8 +49,12 @@ function(ly_add_autogen)
         unset(AUTOGEN_ERROR)
         string(STRIP "${AUTOGEN_OUTPUTS}" AUTOGEN_OUTPUTS)
         set(AZCG_DEPENDENCIES ${AZCG_INPUTFILES})
-        list(APPEND AZCG_DEPENDENCIES "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py")
-        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${AZCG_DEPENDENCIES})
+        list(APPEND AZCG_DEPENDENCIES "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py" "${input_files_path}")
+
+        # The configure-time dry run only needs to be repeated when the generator
+        # logic changes. XML/Jinja content changes are handled by the build rule
+        # below so ordinary data/template edits avoid a full CMake regeneration.
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py")
         add_custom_command(
             OUTPUT ${AUTOGEN_OUTPUTS}
             DEPENDS ${AZCG_DEPENDENCIES}


### PR DESCRIPTION
The fix separates autogen content dependencies from CMake configure dependencies: XML/Jinja files still trigger the fast build-time autogen command, but they no longer trigger CMake’s full regenerate path. The generated input list file is also included in the build rule dependencies so list changes stay wired correctly after configure.

Tested locally, edit an autocomponent.xml file and build, not that the autogen script executes and unity build rebuilds the expected source files only. Add a NEW autocomponent.xml file (thus changing the generated file list created by the dryrun pass) and note that the full regenerate pass still properly executes.