### PR TITLE
Fix lrelease rpath

### DIFF
--- a/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
+++ b/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
@@ -8,4 +8,5 @@
 
 set(lrelease_files
     ${QT_LRELEASE_EXECUTABLE}
+    ${QT_PATH}/lib/libQt6Core.so.6
 )

--- a/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
+++ b/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
@@ -6,6 +6,15 @@
 #
 #
 
+add_custom_command(TARGET LmbrCentral.Editor POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -P "${LY_ROOT_FOLDER}/cmake/Platform/Linux/RPathChange.cmake"
+            "$<TARGET_FILE_DIR:LmbrCentral.Editor>/lrelease"
+            "$ORIGIN/../bin"
+            "$ORIGIN"
+    COMMENT "Patching lrelease..."
+    VERBATIM
+)
+
 set(lrelease_files
     ${QT_LRELEASE_EXECUTABLE}
 )

--- a/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
+++ b/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
@@ -8,5 +8,4 @@
 
 set(lrelease_files
     ${QT_LRELEASE_EXECUTABLE}
-    ${QT_PATH}/lib/libQt6Core.so.6
 )

--- a/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
+++ b/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake
@@ -9,7 +9,7 @@
 add_custom_command(TARGET LmbrCentral.Editor POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -P "${LY_ROOT_FOLDER}/cmake/Platform/Linux/RPathChange.cmake"
             "$<TARGET_FILE_DIR:LmbrCentral.Editor>/lrelease"
-            "$ORIGIN/../bin"
+            "$ORIGIN/../lib"
             "$ORIGIN"
     COMMENT "Patching lrelease..."
     VERBATIM

--- a/Gems/LmbrCentral/Code/Source/Builders/TranslationBuilder/TranslationBuilderComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/TranslationBuilder/TranslationBuilderComponent.cpp
@@ -24,8 +24,6 @@ namespace TranslationBuilder
 {
     void BuilderPluginComponent::Activate()
     {
-        // https://github.com/o3de/o3de/issues/19851 - Disable QT translation building via asset processor as a workaround (it is currently unused)
-        /*
         // activate is where you'd perform registration with other objects and systems.
 
         // since we want to register our builder, we do that here:
@@ -44,7 +42,6 @@ namespace TranslationBuilder
 
         AssetBuilderSDK::AssetBuilderBus::Broadcast(
             &AssetBuilderSDK::AssetBuilderBus::Events::RegisterBuilderInformation, builderDescriptor);
-        */
     }
 
     void BuilderPluginComponent::Deactivate()

--- a/Gems/LmbrCentral/Code/Source/Builders/TranslationBuilder/TranslationBuilderComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/TranslationBuilder/TranslationBuilderComponent.cpp
@@ -24,6 +24,8 @@ namespace TranslationBuilder
 {
     void BuilderPluginComponent::Activate()
     {
+        // https://github.com/o3de/o3de/issues/19851 - Disable QT translation building via asset processor as a workaround (it is currently unused)
+        /*
         // activate is where you'd perform registration with other objects and systems.
 
         // since we want to register our builder, we do that here:
@@ -42,6 +44,7 @@ namespace TranslationBuilder
 
         AssetBuilderSDK::AssetBuilderBus::Broadcast(
             &AssetBuilderSDK::AssetBuilderBus::Events::RegisterBuilderInformation, builderDescriptor);
+        */
     }
 
     void BuilderPluginComponent::Deactivate()


### PR DESCRIPTION
## What does this PR do?

Fix https://github.com/o3de/o3de/issues/19851.

The Asset Processor job fails on linux as libQt6Core.so.6 is not found (it does exist). Reason is that the Qt6 merge removed the rpath change command from the file instead of fixing it (see https://github.com/o3de/o3de/blob/0fb5d654bd5e3e4edbe1517a7c081ddc3531fd52/Gems/LmbrCentral/Code/Platform/Linux/lrelease_linux.cmake). This PR fixes the command.

## How was this PR tested?

Local build on Ubuntu 26.04 (not able to launch the editor yet)