### PR TITLE
Adds the ability to provide a functor callback to autocomplete AZ console command arguments

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -242,6 +242,61 @@ namespace AZ
             return command;
         }
 
+        constexpr AZStd::string_view commandSeparators = " \t\n\r";
+        const size_t argumentSeparator = command.find_first_of(commandSeparators);
+        if (argumentSeparator != AZStd::string_view::npos)
+        {
+            const AZStd::string_view commandName = command.substr(0, argumentSeparator);
+            const AZStd::string_view arguments = command.substr(argumentSeparator + 1);
+            if (!commandName.empty())
+            {
+                if (ConsoleFunctorBase* functor = FindCommand(commandName); functor != nullptr && functor->HasArgumentAutoCompleteCallback())
+                {
+                    AZStd::vector<AZStd::string> argumentMatches;
+                    functor->AutoCompleteArguments(arguments, argumentMatches);
+
+                    AZStd::vector<AZStd::string> commandMatches;
+                    commandMatches.reserve(argumentMatches.size());
+                    ConsoleCommandContainer commandMatchViews;
+                    commandMatchViews.reserve(argumentMatches.size());
+                    const AZStd::string commandPrefix(command.substr(0, argumentSeparator + 1));
+                    for (const AZStd::string& argumentMatch : argumentMatches)
+                    {
+                        AZStd::string commandMatch = commandPrefix + argumentMatch;
+                        AZLOG_INFO("- %s", commandMatch.c_str());
+                        commandMatches.push_back(AZStd::move(commandMatch));
+                        commandMatchViews.push_back(commandMatches.back());
+                    }
+
+                    if (matches != nullptr)
+                    {
+                        matches->insert(matches->end(), commandMatches.begin(), commandMatches.end());
+                    }
+
+                    AZStd::string largestSubstring = command;
+                    if (!largestSubstring.empty() && !commandMatches.empty())
+                    {
+                        const uint32_t totalCount = CountMatchingPrefixes(command, commandMatchViews);
+
+                        for (size_t index = largestSubstring.length(); index < commandMatches.front().length(); ++index)
+                        {
+                            const AZStd::string nextSubstring = largestSubstring + commandMatches.front()[index];
+                            const uint32_t count = CountMatchingPrefixes(nextSubstring, commandMatchViews);
+
+                            if (count < totalCount)
+                            {
+                                break;
+                            }
+
+                            largestSubstring = nextSubstring;
+                        }
+                    }
+
+                    return largestSubstring;
+                }
+            }
+        }
+
         ConsoleCommandContainer commandSubset;
 
         for (const auto& functor : m_commands)

--- a/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.cpp
@@ -80,7 +80,9 @@ namespace AZ
         : m_name(other.m_name)
         , m_desc(other.m_desc)
         , m_flags(other.m_flags)
+        , m_typeId(other.m_typeId)
         , m_console(other.m_console)
+        , m_argumentAutoCompleteCallback(AZStd::move(other.m_argumentAutoCompleteCallback))
         , m_isDeferred(other.m_isDeferred)
     {
         if (m_console)
@@ -101,7 +103,9 @@ namespace AZ
         m_name = other.m_name;
         m_desc = other.m_desc;
         m_flags = other.m_flags;
+        m_typeId = other.m_typeId;
         m_console = other.m_console;
+        m_argumentAutoCompleteCallback = AZStd::move(other.m_argumentAutoCompleteCallback);
         m_isDeferred = other.m_isDeferred;
 
         if (m_console)
@@ -171,5 +175,23 @@ namespace AZ
     GetValueResult ConsoleFunctorBase::GetValueAsString(CVarFixedString&) const
     {
         return GetValueResult::NotImplemented;
+    }
+
+    void ConsoleFunctorBase::SetArgumentAutoCompleteCallback(ArgumentAutoCompleteCallback callback)
+    {
+        m_argumentAutoCompleteCallback = AZStd::move(callback);
+    }
+
+    bool ConsoleFunctorBase::HasArgumentAutoCompleteCallback() const
+    {
+        return static_cast<bool>(m_argumentAutoCompleteCallback);
+    }
+
+    void ConsoleFunctorBase::AutoCompleteArguments(AZStd::string_view arguments, AZStd::vector<AZStd::string>& matches) const
+    {
+        if (m_argumentAutoCompleteCallback)
+        {
+            m_argumentAutoCompleteCallback(arguments, matches);
+        }
     }
 }

--- a/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.h
+++ b/Code/Framework/AzCore/AzCore/Console/ConsoleFunctor.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <AzCore/base.h>
 #include <AzCore/Console/IConsoleTypes.h>
+#include <AzCore/std/functional.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/variant.h>
@@ -34,6 +35,7 @@ namespace AZ
     class AZCORE_API ConsoleFunctorBase
     {
     public:
+        using ArgumentAutoCompleteCallback = AZStd::function<void(AZStd::string_view arguments, AZStd::vector<AZStd::string>& matches)>;
 
         //! Constructor.
         //! @param name   the string name of the functor, used to identify and invoke the functor through the console interface
@@ -75,6 +77,16 @@ namespace AZ
         //! @return the TypeId of the bound type if one exists
         const TypeId& GetTypeId() const;
 
+        //! Sets the callback used to autocomplete arguments after this functor name.
+        //! The callback receives the raw argument substring after the command name and should append complete argument strings to matches.
+        void SetArgumentAutoCompleteCallback(ArgumentAutoCompleteCallback callback);
+
+        //! Returns whether this functor has an argument autocomplete callback.
+        bool HasArgumentAutoCompleteCallback() const;
+
+        //! Appends autocomplete matches for arguments after this functor name.
+        void AutoCompleteArguments(AZStd::string_view arguments, AZStd::vector<AZStd::string>& matches) const;
+
         //! Execute operator, calling this executes the functor.
         //! @param arguments set of string inputs to the functor
         virtual void operator()(const ConsoleCommandContainer& arguments) = 0;
@@ -107,6 +119,7 @@ namespace AZ
         TypeId m_typeId;
 
         IConsole* m_console = nullptr;
+        ArgumentAutoCompleteCallback m_argumentAutoCompleteCallback;
 
         ConsoleFunctorBase* m_prev = nullptr;
         ConsoleFunctorBase* m_next = nullptr;

--- a/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
+++ b/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Console/Console.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/Utils/Utils.h>
 
 namespace AZ
@@ -344,6 +345,46 @@ namespace AZ
             AZStd::vector<AZStd::string> matches;
             AZStd::string completeCommand = console->AutoCompleteCommand("testAutoCompleteD", &matches);
             AZ_TEST_ASSERT(matches.size() == 1 && completeCommand == "testAutoCompleteDuplication");
+        }
+
+        // Argument autocomplete callback
+        {
+            auto id = AZ::TypeId();
+            auto flag = AZ::ConsoleFunctorFlags::Null;
+            auto signature = AZ::ConsoleFunctor<void, false>::FunctorSignature();
+            AZ::ConsoleFunctor<void, false> commandWithArgumentAutocomplete(
+                *console,
+                "testArgumentAutocomplete",
+                "",
+                flag,
+                id,
+                signature);
+
+            commandWithArgumentAutocomplete.SetArgumentAutoCompleteCallback(
+                [](AZStd::string_view arguments, AZStd::vector<AZStd::string>& matches)
+                {
+                    constexpr AZStd::string_view choices[] = { "apple", "apricot", "banana" };
+                    for (AZStd::string_view choice : choices)
+                    {
+                        if (AZ::StringFunc::StartsWith(choice, arguments, false))
+                        {
+                            matches.push_back(choice);
+                        }
+                    }
+                });
+
+            AZStd::vector<AZStd::string> matches;
+            AZStd::string completeCommand = console->AutoCompleteCommand("testArgumentAutocomplete ap", &matches);
+            AZ_TEST_ASSERT(completeCommand == "testArgumentAutocomplete ap");
+            AZ_TEST_ASSERT(matches.size() == 2);
+            AZ_TEST_ASSERT(matches[0] == "testArgumentAutocomplete apple");
+            AZ_TEST_ASSERT(matches[1] == "testArgumentAutocomplete apricot");
+
+            matches.clear();
+            completeCommand = console->AutoCompleteCommand("testArgumentAutocomplete app", &matches);
+            AZ_TEST_ASSERT(completeCommand == "testArgumentAutocomplete apple");
+            AZ_TEST_ASSERT(matches.size() == 1);
+            AZ_TEST_ASSERT(matches[0] == "testArgumentAutocomplete apple");
         }
     }
 


### PR DESCRIPTION
As per the title. Allows you to set a callback functor on autocomplete (<tab>) in the console so you can autocomplete arguments. Not added to the macros themselves to avoid modifying existing interfaces, this just adds the new interface.

`FunctorGiveItem.SetArgumentAutoCompleteCallback(&CompleteGiveItemArguments);`

Where the callback signature should be something like:

`void CompleteGiveItemArguments(AZStd::string_view arguments, AZStd::vector<AZStd::string>& matches)`

Push back whatever matches you want into the matches vector and away you go. Right now the console just logs the matches because its easy, but we could also make the console itself smarter in future..

Adds unit tests. Unit tests ran and passed.

`OKAY Library loaded: C:/Users/kberg/o3de/bin/bin/profile/AzCore.Tests.dll
OKAY Symbol found: AzRunUnitTests
Note: Google Test filter = ConsoleTests.*
[==========] Running 28 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 28 tests from ConsoleTests
[ RUN      ] ConsoleTests.CVar_GetSetTest_Bool
[       OK ] ConsoleTests.CVar_GetSetTest_Bool (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Char
[       OK ] ConsoleTests.CVar_GetSetTest_Char (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Int8
[       OK ] ConsoleTests.CVar_GetSetTest_Int8 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Int16
[       OK ] ConsoleTests.CVar_GetSetTest_Int16 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Int32
[       OK ] ConsoleTests.CVar_GetSetTest_Int32 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Int64
[       OK ] ConsoleTests.CVar_GetSetTest_Int64 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_UInt8
[       OK ] ConsoleTests.CVar_GetSetTest_UInt8 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_UInt16
[       OK ] ConsoleTests.CVar_GetSetTest_UInt16 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_UInt32
[       OK ] ConsoleTests.CVar_GetSetTest_UInt32 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_UInt64
[       OK ] ConsoleTests.CVar_GetSetTest_UInt64 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Float
[       OK ] ConsoleTests.CVar_GetSetTest_Float (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Double
[       OK ] ConsoleTests.CVar_GetSetTest_Double (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_String
[       OK ] ConsoleTests.CVar_GetSetTest_String (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Vector2
[       OK ] ConsoleTests.CVar_GetSetTest_Vector2 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Vector3
[       OK ] ConsoleTests.CVar_GetSetTest_Vector3 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Vector4
[       OK ] ConsoleTests.CVar_GetSetTest_Vector4 (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Quaternion
[       OK ] ConsoleTests.CVar_GetSetTest_Quaternion (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Color_Normalized
[       OK ] ConsoleTests.CVar_GetSetTest_Color_Normalized (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Color_Normalized_Mixed
[       OK ] ConsoleTests.CVar_GetSetTest_Color_Normalized_Mixed (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_Color_Rgba
[       OK ] ConsoleTests.CVar_GetSetTest_Color_Rgba (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_EnumType_SupportsNumericValue
[       OK ] ConsoleTests.CVar_GetSetTest_EnumType_SupportsNumericValue (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_EnumType_SupportsEnumOptionString
[       OK ] ConsoleTests.CVar_GetSetTest_EnumType_SupportsEnumOptionString (0 ms)
[ RUN      ] ConsoleTests.CVar_ConstructAfterDeferredInit
[       OK ] ConsoleTests.CVar_ConstructAfterDeferredInit (0 ms)
[ RUN      ] ConsoleTests.CVar_GetSetTest_FormatConversion
[       OK ] ConsoleTests.CVar_GetSetTest_FormatConversion (0 ms)
[ RUN      ] ConsoleTests.CVar_Autocomplete
[       OK ] ConsoleTests.CVar_Autocomplete (0 ms)
[ RUN      ] ConsoleTests.ConsoleFunctor_FreeFunctorExecutionTest
[       OK ] ConsoleTests.ConsoleFunctor_FreeFunctorExecutionTest (0 ms)
[ RUN      ] ConsoleTests.ConsoleFunctor_ClassFunctorExecutionTest
[       OK ] ConsoleTests.ConsoleFunctor_ClassFunctorExecutionTest (0 ms)
[ RUN      ] ConsoleTests.ConsoleFunctor_MultiInstanceClassFunctorExecutionTest
[       OK ] ConsoleTests.ConsoleFunctor_MultiInstanceClassFunctorExecutionTest (0 ms)
[----------] 28 tests from ConsoleTests (9 ms total)

[----------] Global test environment tear-down
[==========] 28 tests from 1 test suite ran. (10 ms total)
[  PASSED  ] 28 tests.
OKAY AzRunUnitTests() returned 0
Returning code: 0`
