### PR TITLE
Fixes network-related crashes during Init of entities and dangling child entities

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Entity.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Entity.cpp
@@ -185,10 +185,11 @@ namespace AZ
             }
         }
 
-        SetState(State::Init);
-
+        // SetState AFTER notifying, so that the entity can check whether it is already in the init state, vs the "Initializing" state.
         EntityBus::Event(m_id, &EntityBus::Events::OnEntityExists, m_id);
         EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityInitialized, m_id);
+
+        SetState(State::Init);
     }
 
     void Entity::Activate()
@@ -211,8 +212,8 @@ namespace AZ
             ActivateComponent(**it);
         }
 
-        SetState(State::Active);
-
+        // alert listeners that the entity is becoming active, do this BEFORE you change its state to Active
+        // so that entities can check if it was already active, vs the "Activating" state.
         EntityBus::Event(m_id, &EntityBus::Events::OnEntityActivated, m_id);
         EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityActivated, m_id);
         AZ::ComponentApplicationRequests* componentApplication = AZ::Interface<AZ::ComponentApplicationRequests>::Get();
@@ -220,11 +221,19 @@ namespace AZ
         {
             componentApplication->SignalEntityActivated(this);
         }
+
+         SetState(State::Active);
     }
 
     void Entity::Deactivate()
     {
         AZ_PROFILE_FUNCTION(AzCore);
+
+        AZ_Assert(m_state == State::Active, "Component should be in Active state to be Deactivated!");
+
+        // To mirror the Init and Activate functions, we set the state Deactivating before we alert listeners,
+        // so that listeners can tell the difference between an entity that is currently deactivating, or one that is already deactivated.
+        SetState(State::Deactivating);
 
         AZ::ComponentApplicationRequests* componentApplication = AZ::Interface<AZ::ComponentApplicationRequests>::Get();
         if (componentApplication != nullptr)
@@ -233,9 +242,6 @@ namespace AZ
         }
         EntityBus::Event(m_id, &EntityBus::Events::OnEntityDeactivated, m_id);
         EntitySystemBus::Broadcast(&EntitySystemBus::Events::OnEntityDeactivated, m_id);
-
-        AZ_Assert(m_state == State::Active, "Component should be in Active state to be Deactivated!");
-        SetState(State::Deactivating);
 
         for (ComponentArrayType::reverse_iterator it = m_components.rbegin(); it != m_components.rend(); ++it)
         {

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -164,11 +164,11 @@ namespace AzFramework
 
     void TransformComponent::Init()
     {
+        // note that during Init() the other components on the entity are not yet init, and should be treated as not-yet-constructed.
+        // This basically means, avoid sending messages out that might cause the other components to do stuff.  Emit in PostInit (aka OnEntityExists) below.
         AZ::TransformBus::Handler::BusConnect(m_entity->GetId());
         AZ::TransformNotificationBus::Bind(m_notificationBus, m_entity->GetId());
-
-        const bool keepWorldTm = (m_parentActivationTransformMode == ParentActivationTransformMode::MaintainCurrentWorldTransform || !m_parentId.IsValid());
-        SetParentImpl(m_parentId, keepWorldTm);
+        AZ::EntityBus::MultiHandler::BusConnect(m_entity->GetId()); // get notifications about when *this* entity is destroyed/activated/etc
     }
 
     void TransformComponent::Activate() 
@@ -181,20 +181,13 @@ namespace AzFramework
     
     TransformComponent ::~TransformComponent()
     {
-        AZ::TransformNotificationBus::Event(m_parentId, &AZ::TransformNotificationBus::Events::OnChildRemoved, m_entityId);
-        auto parentTransform = AZ::TransformBus::FindFirstHandler(m_parentId);
-        if (parentTransform)
-        {
-            parentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Removed, m_entityId);
-        }
-
+       
         m_notificationBus = nullptr;
-        if (m_parentId.IsValid())
-        {
-            AZ::TransformNotificationBus::Handler::BusDisconnect();
-            AZ::TransformHierarchyInformationBus::Handler::BusDisconnect();
-            AZ::EntityBus::Handler::BusDisconnect();
-        }
+
+        // we are being destroyed, disconnect everything, its not valid to keep any connection alive after destructor:
+        AZ::TransformNotificationBus::Handler::BusDisconnect();
+        AZ::TransformHierarchyInformationBus::Handler::BusDisconnect();
+        AZ::EntityBus::MultiHandler::BusDisconnect(); 
         AZ::TransformBus::Handler::BusDisconnect();
     }
 
@@ -565,41 +558,90 @@ namespace AzFramework
         }
     }
 
-    void TransformComponent::OnEntityActivated([[maybe_unused]] const AZ::EntityId& parentEntityId)
+    void TransformComponent::OnEntityExists([[maybe_unused]] const AZ::EntityId& entityId)
     {
-        AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-
-        m_entity->SetEffectiveActiveLayerByTypeIndex(GetParentActiveIndex(), true);
-        if (m_entity->GetState() == AZ::Entity::State::Init || m_entity->GetState() == AZ::Entity::State::Active)
+        if (entityId == m_parentId)
         {
-            m_entity->ApplyEffectiveActiveState();
+            // My Parent popped into existence, OR, we called BusConnect(...parent...) since it has a connection policy that auto-calls it.
+            ProcessParentEntity(entityId);
+        }
+        else if (entityId == GetEntityId())
+        {
+            // This is self.PostInit.
+            // This is our opportunity to notify about hierarchy, 
+            // since the rest of the components on the same entity are now initialized.
+            const bool keepWorldTm = (m_parentActivationTransformMode == ParentActivationTransformMode::MaintainCurrentWorldTransform || !m_parentId.IsValid());
+            SetParentImpl(m_parentId, keepWorldTm);
         }
     }
 
-    void TransformComponent::OnEntityDeactivated([[maybe_unused]] const AZ::EntityId& parentEntityId)
+    void TransformComponent::OnEntityActivated([[maybe_unused]] const AZ::EntityId& entityId)
     {
-        AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-
-        m_entity->SetEffectiveActiveLayerByTypeIndex(GetParentActiveIndex(), false);
-        if (m_entity->GetState() == AZ::Entity::State::Init || m_entity->GetState() == AZ::Entity::State::Active)
+        // did our parent just get activated?  In which case we have to recompute our own state.
+        if (entityId == m_parentId)
         {
-            m_entity->ApplyEffectiveActiveState();
-        }
-    }
-
-    void TransformComponent::OnEntityDestruction([[maybe_unused]] const AZ::EntityId& parentEntityId)
-    {
-        AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-
-        // Catch if the destruction is a false fire from runtime start.
-        if(m_entity->GetState() != AZ::Entity::State::Init && m_entity->GetState() != AZ::Entity::State::Active)
-        {
-            return;
+            m_entity->SetEffectiveActiveLayerByTypeIndex(GetParentActiveIndex(), true);
+            if (m_entity->GetState() == AZ::Entity::State::Init || m_entity->GetState() == AZ::Entity::State::Active)
+            {
+                m_entity->ApplyEffectiveActiveState();
+            }
         }
         
-        m_parentTM = nullptr;
-        m_parentActive = false;
-        SetParentImpl(AZ::EntityId(), true);
+    }
+
+    void TransformComponent::OnEntityDeactivated([[maybe_unused]] const AZ::EntityId& entityId)
+    {
+        if (entityId == m_parentId)
+        {
+            // our parent was deactivated - we must also deactivate if we are active.
+            m_entity->SetEffectiveActiveLayerByTypeIndex(GetParentActiveIndex(), false);
+            if (m_entity->GetState() == AZ::Entity::State::Init || m_entity->GetState() == AZ::Entity::State::Active)
+            {
+                m_entity->ApplyEffectiveActiveState();
+            }
+        }
+    }
+
+    void TransformComponent::OnEntityDestruction([[maybe_unused]] const AZ::EntityId& entityId)
+    {
+        // This call happens before destruction of the entity, with entityId = GetEntityId.
+        // it also happens when the parent is destroyed, with entityId = m_parentId.
+
+        // If our parent is being destroyed, and we are not, it means that the heiarchy is being detached.
+        // on the other hand, if we are being destroyed, and our parent is not, it means we are being removed
+        // from the heirarchy either way, and should notify of child removal.
+
+        if (entityId == m_parentId)
+        {
+            // this can happen if the parent entity is destroyed but we are not.
+            // The default behavior in this case is to unparent and keep the world transform the same
+            // so that entities don't mysteriously teleport to the origin when their parent is deleted.
+
+            // Catch if the destruction is a false fire from runtime start.
+            if (m_entity->GetState() != AZ::Entity::State::Init && m_entity->GetState() != AZ::Entity::State::Active)
+            {
+                return;
+            }
+
+            m_parentTM = nullptr;
+            m_parentActive = false;
+            SetParentImpl(AZ::EntityId(), true);
+        }
+        else if (entityId == GetEntityId())
+        {
+            // for symmetry with EntityExists(), we notify
+            // parent of our removal when we are about to no longer exist.
+            if (m_parentId.IsValid())
+            {
+                AZ::TransformNotificationBus::Event(m_parentId, &AZ::TransformNotificationBus::Events::OnChildRemoved, m_entityId);
+            }
+
+            auto parentTransform = AZ::TransformBus::FindFirstHandler(m_parentId);
+            if (parentTransform)
+            {
+                parentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Removed, m_entityId);
+            }
+        }
     }
 
     void TransformComponent::SetParentImpl(AZ::EntityId parentId, bool isKeepWorldTM)
@@ -610,12 +652,18 @@ namespace AzFramework
             return;
         }
 
+        if (m_parentId == parentId)
+        {
+            // No change, do nothing.
+            return;
+        }
+
         AZ::EntityId oldParent = m_parentId;
         if (oldParent.IsValid())
         {
             AZ::TransformNotificationBus::Handler::BusDisconnect();
             AZ::TransformHierarchyInformationBus::Handler::BusDisconnect();
-            AZ::EntityBus::Handler::BusDisconnect();
+            AZ::EntityBus::MultiHandler::BusDisconnect(oldParent);
             m_parentActive = false;
         }
 
@@ -631,7 +679,7 @@ namespace AzFramework
             AZ::TransformNotificationBus::Handler::BusConnect(m_parentId);
             AZ::TransformHierarchyInformationBus::Handler::BusConnect(m_parentId);
             // Parent (De)Activate handles local entity parent state flag changes.
-            AZ::EntityBus::Handler::BusConnect(m_parentId);
+            AZ::EntityBus::MultiHandler::BusConnect(m_parentId);
 
             // Every parent entity will be processed.
             // Parent active state is applied at parent due to no events firing on connect.

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -506,26 +506,30 @@ namespace AzFramework
     {
         AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
 
-#ifndef _RELEASE
-        AZ::EntityId parentId = m_parentId;
-
-        while (parentId.IsValid())
+#ifndef AZ_RELEASE_BUILD
+        // The following is an error check for cyclic dependencies and can be omitted in shipping builds
+        // Put variables in such a check in their own scope to avoid this kind of code leaking out of scope
         {
-            if (parentId == GetEntityId())
+            AZ::EntityId parentId = m_parentId;
+
+            while (parentId.IsValid())
             {
-                AZ_Error("TransformComponent", false, "Trying to create a circular dependency of parenting. Aborting set parent call.");
-                SetParent(AZ::EntityId());
-                return;
+                if (parentId == GetEntityId())
+                {
+                    AZ_Error("TransformComponent", false, "Trying to create a circular dependency of parenting. Aborting set parent call.");
+                    SetParent(AZ::EntityId());
+                    return;
+                }
+
+                auto handler = AZ::TransformBus::FindFirstHandler(parentId);
+
+                if (handler == nullptr)
+                {
+                    break;
+                }
+
+                parentId = handler->GetParentId();
             }
-
-            auto handler = AZ::TransformBus::FindFirstHandler(parentId);
-
-            if (handler == nullptr)
-            {
-                break;
-            }
-
-            parentId = handler->GetParentId();
         }
 #endif
 
@@ -607,9 +611,17 @@ namespace AzFramework
         // This call happens before destruction of the entity, with entityId = GetEntityId.
         // it also happens when the parent is destroyed, with entityId = m_parentId.
 
-        // If our parent is being destroyed, and we are not, it means that the heiarchy is being detached.
+        // If our parent is being destroyed, and we are not, it means that the hierarchy is being detached.
         // on the other hand, if we are being destroyed, and our parent is not, it means we are being removed
-        // from the heirarchy either way, and should notify of child removal.
+        // from the hierarchy either way, and should notify of child removal.
+
+        // For systems which destroy entire trees of entities, the optimal way would be from the leaves
+        // to the parent, so that none of these cascading transform change notifications happen.  So we
+        // essentially expect only to get into this function in the case where our parent is being destroyed
+        // and we are not.  A future optimization, if this turns out to be a profiler hotspot, would be
+        // to mark entities as being destroyed in a batch, so that elements in here can know whether
+        // its even worth sending out messages at all (ie, if the entire tree is being destroyed, then
+        // only the root, if it has a parent of its own, needs to notify its parent).
 
         if (entityId == m_parentId)
         {
@@ -626,6 +638,14 @@ namespace AzFramework
             m_parentTM = nullptr;
             m_parentActive = false;
             SetParentImpl(AZ::EntityId(), true);
+
+            // The "null" entity is never inactive, so make sure that we update our active state based on this in case we
+            // were inactive before.
+            m_entity->SetEffectiveActiveLayerByTypeIndex(GetParentActiveIndex(), true);
+            if (m_entity->GetState() == AZ::Entity::State::Init || m_entity->GetState() == AZ::Entity::State::Active)
+            {
+                m_entity->ApplyEffectiveActiveState();
+            }
         }
         else if (entityId == GetEntityId())
         {
@@ -649,12 +669,6 @@ namespace AzFramework
         if (GetEntity() && parentId == GetEntityId())
         {
             AZ_Warning("TransformComponent", false, "An entity can not be set as its own parent.");
-            return;
-        }
-
-        if (m_parentId == parentId)
-        {
-            // No change, do nothing.
             return;
         }
 

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -33,7 +33,7 @@ namespace AzFramework
     //! Fundamental component that describes the entity in 3D space.
     class AZF_API TransformComponent
         : public AZ::Component
-        , public AZ::EntityBus::Handler
+        , public AZ::EntityBus::MultiHandler
         , public AZ::TransformBus::Handler
         , public AZ::TransformNotificationBus::Handler
         , private AZ::TransformHierarchyInformationBus::Handler
@@ -151,11 +151,10 @@ namespace AzFramework
         void OnTransformChanged(const AZ::Transform& parentLocalTM, const AZ::Transform& parentWorldTM) override;
 
         // EntityBus
-        //! Called when the parent entity activates.
-        //! Called when the parent entity is going to be destroyed.
-        void OnEntityActivated(const AZ::EntityId& parentEntityId) override;
-        void OnEntityDeactivated(const AZ::EntityId& parentEntityId) override;
-        void OnEntityDestruction(const AZ::EntityId& parentEntityId) override;
+        void OnEntityExists(const AZ::EntityId& entityId) override;
+        void OnEntityActivated(const AZ::EntityId& entityId) override;
+        void OnEntityDeactivated(const AZ::EntityId& entityId) override;
+        void OnEntityDestruction(const AZ::EntityId& entityId) override;
         //! @}
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -310,6 +310,10 @@ namespace AzFramework
                     continue;
                 }
 
+                currentEntity->SetEntityActive(false);
+                // note that the above call makes the entity know that it has been explicitly deactivated,
+                // and will not re-activate itself when its parent is removed.  Since its headed for destruction,
+                // this prevents any kind of ping-ponging.
                 if (currentEntity->GetState() == AZ::Entity::State::Active)
                 {
                     // Deactivate the entity, we'll destroy it as soon as it is safe.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -1816,7 +1816,21 @@ namespace AzToolsFramework
         : QStyledItemDelegate(parent)
         , m_visibilityCheckBoxes(parent, "Visibility", EntityOutlinerListModel::PartiallyVisibleRole, EntityOutlinerListModel::InvisibleAncestorRole)
         , m_lockCheckBoxes(parent, "Lock", EntityOutlinerListModel::PartiallyLockedRole, EntityOutlinerListModel::LockedAncestorRole)
+        , m_cacheRefreshTimer(new QTimer(this))
     {
+        QObject::connect(
+            m_cacheRefreshTimer,
+            &QTimer::timeout,
+            this,
+            [this]()
+            {
+                // periodically clear the cached bounding rect of a tall character
+                // so that if the font changes, we can recalculate it.
+                m_cachedBoundingRectOfTallCharacter = QRect();
+            });
+        m_cacheRefreshTimer->setInterval(200);
+        m_cacheRefreshTimer->start();
+        
         m_editorEntityFrameworkInterface = AZ::Interface<AzToolsFramework::EditorEntityUiInterface>::Get();
         AZ_Assert((m_editorEntityFrameworkInterface != nullptr),
             "EntityOutlinerItemDelegate requires a EditorEntityFrameworkInterface instance on Construction.");
@@ -2187,17 +2201,10 @@ namespace AzToolsFramework
     QSize EntityOutlinerItemDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const
     {
         // Get the height of a tall character...
-        // we do this only once per 'tick'
+
         if (m_cachedBoundingRectOfTallCharacter.isNull())
         {
             m_cachedBoundingRectOfTallCharacter = option.fontMetrics.boundingRect("|");
-            // schedule it to be reset so that if font changes sometime soon, it updates.
-            auto resetFunction = [this]() 
-            { 
-                m_cachedBoundingRectOfTallCharacter = QRect(); 
-            };
-
-            QTimer::singleShot(0, resetFunction);
         }
         
         if (!index.parent().isValid())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx
@@ -30,6 +30,8 @@
 #include <QCheckBox>
 #include <QRect>
 #include <QStyledItemDelegate>
+#include <QTimer>
+
 #include <QWidget>
 
 namespace AzToolsFramework
@@ -379,6 +381,8 @@ namespace AzToolsFramework
 
         EditorEntityUiInterface* m_editorEntityFrameworkInterface = nullptr;
         ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;
+
+        QTimer* m_cacheRefreshTimer = nullptr;
     };
 
 }

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -408,16 +408,24 @@ namespace Multiplayer
         for (NetEntityId entityId : removeList)
         {
             NetworkEntityHandle removeEntity = m_networkEntityTracker.Get(entityId);
-
             if (removeEntity != nullptr)
             {
                 // If we've spawned entities through @NetworkEntityManager::CreateEntitiesImmediate
                 // then we destroy those entities here by processing the removal list.
                 // Note that if we've spawned entities through @NetworkPrefabSpawnerComponent::SpawnPrefab
                 // we should instead use the SpawnableEntitiesManager to destroy them.
-                AzFramework::GameEntityContextRequestBus::Broadcast(
-                    &AzFramework::GameEntityContextRequestBus::Events::DestroyGameEntity, removeEntity.GetEntity()->GetId());
 
+                // Also of note, Deactivating an entity causes its children to also deactivate.
+                // In turn, deactivating a child will cause its NetBindComponent to remove itself from the NetworkEntityTracker.
+                // Which means it won't appear in this loop again.  This means we need to call DestroyGameEntityAndDescendants
+                // here, or we will miss inactive children.  Its either that, or run this loop in reverse order, since children are always
+                // spawned after parents.
+
+                // HOWEVER, working in reverse order would not solve the problem fully, since you can change the parent-child relationships
+                // after spawning, and doing so won't affect their order in this list, which would result in more housekeeping.  Instead,
+                // we just destroy them all here.
+                AzFramework::GameEntityContextRequestBus::Broadcast(
+                    &AzFramework::GameEntityContextRequestBus::Events::DestroyGameEntityAndDescendants, removeEntity.GetEntity()->GetId());
                 m_networkEntityTracker.erase(entityId);
             }
         }

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -403,31 +403,36 @@ namespace Multiplayer
 
     void NetworkEntityManager::RemoveEntities()
     {
-        AZStd::vector<NetEntityId> removeList;
-        removeList.swap(m_removeList);
-        for (NetEntityId entityId : removeList)
+        // this removes entities locally, and from the tracking list in the network entity tracker.
+        // 
+
+        // First collect their entityIds and remove them from the tracker itself.
+        AZStd::vector<AZ::EntityId> removeEntityIds;
+        removeEntityIds.reserve(m_removeList.size());
+        for (const NetEntityId& entityId : m_removeList)
         {
             NetworkEntityHandle removeEntity = m_networkEntityTracker.Get(entityId);
             if (removeEntity != nullptr)
             {
-                // If we've spawned entities through @NetworkEntityManager::CreateEntitiesImmediate
-                // then we destroy those entities here by processing the removal list.
-                // Note that if we've spawned entities through @NetworkPrefabSpawnerComponent::SpawnPrefab
-                // we should instead use the SpawnableEntitiesManager to destroy them.
-
-                // Also of note, Deactivating an entity causes its children to also deactivate.
-                // In turn, deactivating a child will cause its NetBindComponent to remove itself from the NetworkEntityTracker.
-                // Which means it won't appear in this loop again.  This means we need to call DestroyGameEntityAndDescendants
-                // here, or we will miss inactive children.  Its either that, or run this loop in reverse order, since children are always
-                // spawned after parents.
-
-                // HOWEVER, working in reverse order would not solve the problem fully, since you can change the parent-child relationships
-                // after spawning, and doing so won't affect their order in this list, which would result in more housekeeping.  Instead,
-                // we just destroy them all here.
-                AzFramework::GameEntityContextRequestBus::Broadcast(
-                    &AzFramework::GameEntityContextRequestBus::Events::DestroyGameEntityAndDescendants, removeEntity.GetEntity()->GetId());
-                m_networkEntityTracker.erase(entityId);
+                removeEntityIds.push_back(removeEntity.GetEntity()->GetId());
             }
+            m_networkEntityTracker.erase(entityId);
+        }
+        m_removeList.clear();
+
+        // Now, erase them from the "real" entity game local context, using just the cached
+        // entityIds.
+        // iterate over the entityIds in the removeEntityIds vector, in reverse.  The order won't
+        // actually cause problems no matter what order we do it in, but since entities tend to get
+        // added to the tracker from parent first, then child, reversing will more often than not
+        // remove children first, which causes less events to fire.  This is "free" to do, but
+        // actually trying to force this into the order of the children will be more expensive
+        // than actually removing the entities in the wrong order, so don't bother actually searching
+        // first.
+        for (auto it = removeEntityIds.rbegin(); it != removeEntityIds.rend(); ++it)
+        {
+            AzFramework::GameEntityContextRequestBus::Broadcast(
+                &AzFramework::GameEntityContextRequestBus::Events::DestroyGameEntity, *it);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

In version 26.05, O3DE was made more compliant with the same transform behavior as most other engines, namely:
1. Transforms are always available, even for deactivated entities (Unity, Unreal, Godot, etc) to manage hierarchy, pre-position, etc.
2. Deactivating a parent entity also deactivates its children. (All other DCC tools and game engines).    This also helps avoid a big flood of "transform changed!" when activating and deactivating children/parent trees, as the transforms are NOT changed and the entities are not detached when deactivated anymore, as they no longer have to worry about their parent being inactive and themselves being active and relative to an inactive parent.
3. Entities are separately aware of themselves being inactive because they were explicitly requested so, vs them being inactive because their a parent is inactive, allowing them to restore their active state when their parent is reactivated.  Previously, this information was lost.

This change has had a side effect in that it would cause crashes (sometimes) when activating and deactivating entities in hierarchies, over the network, as well as left-over child entities between sessions (https://github.com/o3de/o3de/issues/19823)

The root cause for initialization crashes was that the Initialization of the Transform would cause OnChildAdded messages to propogate during `TransformComponent::Init`.  This means the rest of the components on the entity were not intitialized yet, and would start to process these messages while uninitialized.  This was fixed by making it so that these messages come out post-init instead of during init.  No  new busses had to be added since we already have post-init, post-activate, pre-deactivate, and pre-destroy message buses and the transform component was already listening to those busses anyway.

The root cause for the dangling entity situation was that during network teardown, the client has a list of entities it knows came from the server.  This list of entities is walked through, one by one, and looked up (By entityid) in the map of network managed entities, and told to delete.  The problem is, when a parent is deleted, it is deactivated.  This deactivates its children.  The children's netbind component deactivates, which has a callback which removes it from this map of networked managed entities, which means when the child gets to the front of the list, it cannot be found, and is thus not deleted.

## How was this PR tested?

Testing with the Multiplayer Template - in the "Boxes" level as well as in a custom level set up to reproduce the use case in the issue mentioned above.