### PR TITLE
Upgrade Android NDK to r27d (LTS)

### DIFF
--- a/.github/workflows/ar.yml
+++ b/.github/workflows/ar.yml
@@ -48,6 +48,10 @@ on:
 
 env:
   CMAKE_VERSION: &cmake_version "4.2.3"
+  GRADLE_VERSION: &gradle_version "8.12"
+  MSVC_PLATFORM_TOOLSET: &msvc_platform_toolset "v143"
+  MSVC_TOOLSET_VERSION: &msvc_toolset_version "14.44"
+  NDK_VERSION: &ndk_version "27.3.13750724"
 
 jobs:
   # The following jobs are used to build the project for the different platforms.
@@ -78,8 +82,8 @@ jobs:
       platform: Android
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
-      ndk_version: "25.1.8937393"
-      gradle_version: "8.12"
+      ndk_version: *ndk_version
+      gradle_version: *gradle_version
       cmake_version: *cmake_version
 
   Android-Asset:
@@ -92,8 +96,8 @@ jobs:
       image: ubuntu-22.04
       platform: Android
       type: asset_profile
-      ndk_version: "25.1.8937393"
-      gradle_version: "8.12"
+      ndk_version: *ndk_version
+      gradle_version: *gradle_version
       cmake_version: *cmake_version
 
   Android-Gradle:
@@ -106,8 +110,8 @@ jobs:
       image: ubuntu-22.04
       platform: Android
       type: gradle
-      ndk_version: "25.1.8937393"
-      gradle_version: "8.12"
+      ndk_version: *ndk_version
+      gradle_version: *gradle_version
       cmake_version: *cmake_version
 
 #### iOS Build ####
@@ -221,8 +225,8 @@ jobs:
       platform: Windows
       type: profile
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }} # If CLEAN_ARTIFACTS is false, then this returns true
-      msvc_toolset_version: "14.44"
-      msvc_platform_toolset: "v143"
+      msvc_toolset_version: *msvc_toolset_version
+      msvc_platform_toolset: *msvc_platform_toolset
       cmake_version: *cmake_version
 
   Windows-Asset:
@@ -235,8 +239,8 @@ jobs:
       image: windows-2022
       platform: Windows
       type: asset_profile
-      msvc_toolset_version: "14.44"
-      msvc_platform_toolset: "v143"
+      msvc_toolset_version: *msvc_toolset_version
+      msvc_platform_toolset: *msvc_platform_toolset
       cmake_version: *cmake_version
 
   Windows-Test:
@@ -249,8 +253,8 @@ jobs:
       image: windows-2022
       platform: Windows
       type: test_cpu_profile
-      msvc_toolset_version: "14.44"
-      msvc_platform_toolset: "v143"
+      msvc_toolset_version: *msvc_toolset_version
+      msvc_platform_toolset: *msvc_platform_toolset
       cmake_version: *cmake_version
 
   Windows-Release:
@@ -263,6 +267,6 @@ jobs:
       platform: Windows
       type: release
       last_artifact: ${{ !inputs.CLEAN_ARTIFACTS }}
-      msvc_toolset_version: "14.44"
-      msvc_platform_toolset: "v143"
+      msvc_toolset_version: *msvc_toolset_version
+      msvc_platform_toolset: *msvc_platform_toolset
       cmake_version: *cmake_version

--- a/Code/Tools/Android/ProjectGenerator/config_data.py
+++ b/Code/Tools/Android/ProjectGenerator/config_data.py
@@ -18,7 +18,7 @@ class ConfigData:
     data that is required to create an android project for O3DE.
     """
     ASSET_MODE_LOOSE = "LOOSE"
-    DEFAULT_NDK_VERSION = "25*"
+    DEFAULT_NDK_VERSION = "27*"
     DEFAULT_API_LEVEL = "31" # The API level for Android 12.
     def __init__(self):
         self.engine_path = "" # Not serialized.

--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -41,7 +41,7 @@ ANDROID_GRADLE_PLUGIN_COMPATIBILITY_MAP = {
               'min_cmake_version': '3.20'},
     '7.3.1': {'min_gradle_version': '7.5.1',
               'sdk_build': '33.0.0',
-              'default_ndk': '25.1.8937393',
+              'default_ndk': '27.3.13750724',
               'min_cmake_version': '3.24'},
 }
 

--- a/scripts/build/Platform/Android/gradle_linux.sh
+++ b/scripts/build/Platform/Android/gradle_linux.sh
@@ -57,8 +57,8 @@ ANDROID_GRADLE_PLUGIN="${ANDROID_GRADLE_PLUGIN:-8.1.4}"
 echo "Using Android gradle plugin version $ANDROID_GRADLE_PLUGIN"
 "$O3DE_PATH/scripts/o3de.sh" android-configure --set-value android.gradle.plugin="$ANDROID_GRADLE_PLUGIN" --global
 
-# Optionally override the version of the android NDK to use, otherwise default to 25
-ANDROID_NDK_VERSION="${ANDROID_NDK_VERSION:-25}"
+# Optionally override the version of the android NDK to use, otherwise default to 27
+ANDROID_NDK_VERSION="${ANDROID_NDK_VERSION:-27}"
 echo "Using Android NDK Version $ANDROID_NDK_VERSION"
 "$O3DE_PATH/scripts/o3de.sh" android-configure --set-value ndk.version="$ANDROID_NDK_VERSION.*"
 

--- a/scripts/build/Platform/Android/gradle_windows.cmd
+++ b/scripts/build/Platform/Android/gradle_windows.cmd
@@ -71,10 +71,10 @@ IF "%ANDROID_GRADLE_PLUGIN%" == "" (
 )
 
 
-REM Optionally override the version of the android NDK to use, otherwise default to 25
+REM Optionally override the version of the android NDK to use, otherwise default to 27
 IF "%ANDROID_NDK_VERSION%" == "" (
-    ECHO Using [default] Android NDK Version 25
-    CALL %O3DE_PATH%\scripts\o3de.bat android-configure --set-value ndk.version=25.*
+    ECHO Using [default] Android NDK Version 27
+    CALL %O3DE_PATH%\scripts\o3de.bat android-configure --set-value ndk.version=27.*
 ) else (
     ECHO Using [default] Android NDK Version %ANDROID_NDK_VERSION%
     CALL %O3DE_PATH%\scripts\o3de.bat android-configure --set-value ndk.version=%ANDROID_NDK_VERSION%

--- a/scripts/build/Platform/Android/pipeline.json
+++ b/scripts/build/Platform/Android/pipeline.json
@@ -3,7 +3,7 @@
         "GRADLE_HOME": "C:/Gradle/gradle-7.0",
         "NODE_LABEL": "windows-2024-07",
         "LY_3RDPARTY_PATH": "D:\\workspace\\3rdParty",
-        "LY_NDK_DIR": "C:/AndroidSdk/ndk/25.1.8937393",
+        "LY_NDK_DIR": "C:/AndroidSdk/ndk/27.3.13750724",
         "TIMEOUT": 30,
         "WORKSPACE": "D:/workspace",
         "MOUNT_VOLUME": true

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -591,7 +591,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "release",
       "OUTPUT_DIRECTORY": "build\\android_api_mono",
-      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DLY_MONOLITHIC_GAME=TRUE -DLY_DISABLE_TEST_MODULES=TRUE -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"C:/AndroidSdk/ndk/25.1.8937393\"",
+      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DLY_MONOLITHIC_GAME=TRUE -DLY_DISABLE_TEST_MODULES=TRUE -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"C:/AndroidSdk/ndk/27.3.13750724\"",
       "CMAKE_TARGET": "install",
       "CMAKE_BUILD_ARGS":"-j!NUMBER_OF_PROCESSORS!"
     }
@@ -605,7 +605,7 @@
     "PARAMETERS": {
       "CONFIGURATION": "profile",
       "OUTPUT_DIRECTORY": "build\\android_api_mono",
-      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DLY_MONOLITHIC_GAME=TRUE -DLY_DISABLE_TEST_MODULES=TRUE -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"C:/AndroidSdk/ndk/25.1.8937393\"",
+      "CMAKE_OPTIONS":"-G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=cmake\\Platform\\Android\\Toolchain_android.cmake -DLY_MONOLITHIC_GAME=TRUE -DLY_DISABLE_TEST_MODULES=TRUE -DANDROID_NATIVE_API_LEVEL=24 -DLY_NDK_DIR=\"C:/AndroidSdk/ndk/27.3.13750724\"",
       "CMAKE_TARGET": "install",
       "CMAKE_BUILD_ARGS":"-j!NUMBER_OF_PROCESSORS!"
     }

--- a/scripts/build/build_node/Platform/Linux/install-ubuntu-android-tools.sh
+++ b/scripts/build/build_node/Platform/Linux/install-ubuntu-android-tools.sh
@@ -44,7 +44,7 @@ then
 fi
 rm -f /tmp/commandlinetools-linux.zip
 
-for i in "cmdline-tools;latest" "build-tools;30.0.2" "platform-tools" "platforms;android-24" "ndk;25.2.9519653"
+for i in "cmdline-tools;latest" "build-tools;30.0.2" "platform-tools" "platforms;android-24" "ndk;25.2.9519653" "ndk;27.3.13750724"
 do
     echo "Installing official $i"
     yes | /opt/android-sdk-linux/cmdline-tools/tools/bin/sdkmanager --install "$i"
@@ -55,11 +55,11 @@ do
     fi
 done
 
-# Add the path and necessary environment variable to build android based on NDK 25.2.9519653
+# Add the path and necessary environment variable to build android based on NDK 27.3.13750724
 if [[ -d /etc/profile.d ]]; then
     mkdir /etc/profile.d
 fi
 echo 'export PATH="$PATH:/opt/android-sdk-linux/cmdline-tools/latest/bin/"' > /etc/profile.d/android-env.sh
-echo "export LY_NDK_DIR=/opt/android-sdk-linux/ndk/25.2.9519653" >> /etc/profile.d/android-env.sh
+echo "export LY_NDK_DIR=/opt/android-sdk-linux/ndk/27.3.13750724" >> /etc/profile.d/android-env.sh
 chmod a+x /etc/profile.d/android-env.sh
 

--- a/scripts/build/build_node/Platform/Windows/install-windows-android.ps1
+++ b/scripts/build/build_node/Platform/Windows/install-windows-android.ps1
@@ -22,7 +22,7 @@ Rename-Item -Path "$androidSdkInstallDir\cmdline-tools" "$androidSdkLatestDir"
 $android_packages = '"platforms;android-28" "platforms;android-29" "platforms;android-30"'
 $googleplay_packages = '"extras;google;market_apk_expansion" "extras;google;market_licensing"'
 $build_tools = '"build-tools;30.0.2" "build-tools;34.0.0" "tools"'
-$ndk = '"ndk;21.4.7075529" "ndk;23.1.7779620" "ndk;25.1.8937393" "ndk;25.2.9519653"'
+$ndk = '"ndk;21.4.7075529" "ndk;23.1.7779620" "ndk;25.1.8937393" "ndk;25.2.9519653" "ndk;27.3.13750724"'
 
 Write-Host "Installing Android SDK packages..."
 $sdkmanager = "$androidSdkLatestDir\bin\sdkmanager.bat"
@@ -35,7 +35,7 @@ Start-Process -FilePath $sdkmanager -ArgumentList $build_tools -RedirectStandard
 Write-Host "Installing Android NDK packages: $ndk"
 Start-Process -FilePath $sdkmanager -ArgumentList $ndk -NoNewWindow -Wait
 # Set the NDK environment
-Install-ChocolateyEnvironmentVariable "LY_NDK_DIR" "C:\AndroidSdk\ndk\25.1.8937393" -VariableType 'Machine'
+Install-ChocolateyEnvironmentVariable "LY_NDK_DIR" "C:\AndroidSdk\ndk\27.3.13750724" -VariableType 'Machine'
 
 $gradle_version = '8.7'
 $gradle_checksum = '194717442575a6f96e1c1befa2c30e9a4fc90f701d7aee33eb879b79e7ff05c0'

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -116,8 +116,8 @@ SETTINGS_PLATFORM_SDK_API      = register_setting(key='platform.sdk.api',
                                                   default='31')
 
 SETTINGS_NDK_VERSION           = register_setting(key='ndk.version',
-                                                  description='The version of the android NDK (ref https://developer.android.com/ndk/downloads). File matching patterns can be used (i.e. 25.* will search for the most update to date major version 25)',
-                                                  default='25.*')
+                                                  description='The version of the android NDK (ref https://developer.android.com/ndk/downloads). File matching patterns can be used (i.e. 27.* will search for the most update to date major version 27)',
+                                                  default='27.*')
 
 SETTINGS_GRADLE_PLUGIN_VERSION = register_setting(key='android.gradle.plugin',
                                                   description='The version of the android gradle plugin to use for the build (ref https://developer.android.com/reference/tools/gradle-api)',

--- a/scripts/o3de/tests/test_android.py
+++ b/scripts/o3de/tests/test_android.py
@@ -720,7 +720,7 @@ def test_generate_android_project_success(tmpdir):
     test_platform_api_level = '31'
     test_asset_mode = 'LOOSE'
     test_bundle_subpath = f'AssetBundling{os.sep}Bundles'
-    test_ndk_version = '25.*'
+    test_ndk_version = '27.*'
 
     tmpdir.ensure(test_sc_store_file, dir=False)
     test_key_store_path = tmpdir.join(test_sc_store_file).realpath()


### PR DESCRIPTION
## What does this PR do?

Updates the Android NDK used across the engines build tooling and CI from r25 (`25.1.8937393`, Clang 14) to r27d (`27.3.13750724`, Clang 18).

r25 ships Clang14, which is holding back in-progress AZStd modernization (newer C++/concepts and libc++ features that require a more recent Clang). r27d brings Clang18 and an updated libc++, which unblocks that work. r27 is the current LTS, so it's the conservative landing spot (rather than jumping to r28/r29).

### What changed
- NDK defaults bumped to r27 in the o3de CLI, the legacy project generators AGP compatibility map, the ProjectGenerator GUI default, and the CI Gradle wrappers. I'm not sure if anyone still uses these, but I updated them just to be safe.
- Build-node provisioning: r27.3 is added alongside the existing NDKs (21.4 / 23.1 / 25.x) rather than replacing them, and `LY_NDK_DIR` is repointed to r27.3. Branches sharing a build node continue to work, and the rollback is a one-line config change.
- ar.yml: the Android `profile` / `asset_profile` / `gradle` lanes now build against r27.3. I added a new `&ndk_version` anchor that makes sure they are consistent (like how cmake_version is set).

### Why this is a safe update
Android NDK upgrades are designed to preserve runtime/ABI backward compatibility. Native code built with a newer NDK runs on the same range of devices, provided the target/min API is unchanged:

- **Device support is unchanged.** We keep `ANDROID_NATIVE_API_LEVEL=24` and platform API 31. The r27 minimum supported API is 21 (Lollipop), so we stay comfortably in range.
- **No packaging orruntime change by default.** The r27 16 KB page-size support is **opt-in** (default stays 4 KB, gated behind `ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES`). Binaries still run on existing 4 KB devices. ([Changelog r27](https://github.com/android/ndk/wiki/Changelog-r27))
- **LTS release.** r27 is the 2024 Long-Term-Support NDK.
- **The real change is compile-time, not runtime.** The substantive difference is Clang14 to Clang18 (`clang-r450784d` → `clang-r522817`). The risk surface is therefore new compiler diagnostics on non-conforming code, which are build-time-visible and caught by CI, rather than fun silent runtime regressions we need to hunt down. ([r25](https://github.com/android/ndk/wiki/Changelog-r25) / [r27](https://github.com/android/ndk/wiki/Changelog-r27) changelogs)
- **Trivial rollback.** Older NDKs remain installed on the build nodes, so reverting is a config/version change with no node re-imaging. For anyone using the Jenkins node provisioning scripts...

## How was this PR tested?

- The AR Android lanes (`profile`, `asset_profile`, `gradle`) build against r27.3/Clang18 via the updated `ar.yml`, so CI on this PR exercises the new toolchain end-to-end. Any ABI/compat issue would surface as a build failure in those lanes.
