### PR TITLE
Preloads the material asset

### DIFF
--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticlePipelineState.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticlePipelineState.cpp
@@ -19,6 +19,13 @@ namespace OpenParticle
     void EmitterInstance::Setup(AZ::Data::Asset<AZ::RPI::MaterialAsset>& mat)
     {
         m_materialAsset = mat;
+        // Preload the material asset so it's ready when Create() needs it.
+        // Without this, material sub-assets from the particle archive may not be
+        // loaded when the particle system activates on level load.
+        if (m_materialAsset.GetId().IsValid() && !m_materialAsset.IsReady())
+        {
+            m_materialAsset.QueueLoad();
+        }
         m_material = AZ::RPI::Material::Create(m_materialAsset);
 
         if (!m_material)


### PR DESCRIPTION
## What does this PR do?
Preloads the material asset so it's ready when Create() needs it.

_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_
Preload the material asset so it's ready when Create() needs it.
Without this, material sub-assets from the particle archive may not be
 loaded when the particle system activates on level load.

_Please add links to any issues, RFCs or other items that are relevant to this PR._
N/A

## How was this PR tested?
Loaded a .material file for a particle saved the .prefab  exited o3de editor reloaded editor made sure .material file still exists

_Please describe any testing performed._
Tested on windows, dx12, vulkan, both pipelines