### PR TITLE
DPE HIdden-Variables-Shown Issue Fix

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -272,24 +272,6 @@ namespace AZ::Reflection
             return m_keyInstance.IsValid();
         }
 
-        // ---------------------------------------------------------------------
-        // Visibility attribute resolution
-        // ---------------------------------------------------------------------
-        // The legacy "Visibility" attribute is stored as one of three value types:
-        //   1. AZ::Crc32 - the default (e.g. AZ::Edit::PropertyVisibility::Hide)
-        //   2. AZ::u32   - allows the 0/1 shorthand for Hide/Show, or a raw hash
-        //   3. bool      - true/false for Show/Hide
-        //
-        // Reading this through AttributeDefinition<PropertyVisibility> fails for the
-        // common AZ::Crc32 case: PropertyVisibility is an enum, so the AttributeReader
-        // performs an exact AttributeData<PropertyVisibility> match and -- because enums
-        // are not integral -- never falls back to reading the value as an AZ::Crc32.
-        // The DPE then defaulted such fields to Show, leaking properties the author
-        // explicitly marked Hide (e.g. TransformComponent's "Cached World Transform").
-        //
-        // This mirrors AzToolsFramework's ReadVisibilityAttribute, which the legacy RPE
-        // uses, so the DPE resolves visibility identically: read the attribute as its
-        // actual stored type rather than relying on a fragile generic-DOM round-trip.
         bool ReadLegacyVisibility(
             AZ::PointerObject instance, AZ::Attribute* attribute, DocumentPropertyEditor::Nodes::PropertyVisibility& outVisibility)
         {
@@ -1249,8 +1231,6 @@ namespace AZ::Reflection
                 PropertyVisibility visibility = PropertyVisibility::Show;
 
                 // If the stack contains 2 nodes, it means we are now processing the root node. The first node is a dummy parent node.
-                // Hide the root node itself if the visitor is visiting from the instance's root.
-                // Alternatively, hide if forced by the node's property.
                 if ((m_stack.size() == 2 && m_visitFromRoot) || nodeData.m_showChildrenOnly)
                 {
                     visibility = PropertyVisibility::ShowChildrenOnly;
@@ -1294,23 +1274,10 @@ namespace AZ::Reflection
                         visitedAttributes.insert(name);
 
                         // Handle visibility calculations internally, as we calculate and emit an aggregate visibility value.
-                        // We also need to handle special cases here, because the Visibility attribute supports 3 different value types:
-                        //      1. AZ::Crc32 - This is the default
-                        //      2. AZ::u32 - This allows the user to specify a value of 1/0 for Show/Hide, respectively
-                        //      3. bool - This allows the user to specify true/false for Show/Hide, respectively
-                        //
-                        // We need to return out of checkAttribute for Visibility attributes since the attributeValue handling
-                        // below doesn't account for these special cases. The Visibility attribute instead gets cached at
-                        // the end of the CacheAttributes method after it has done further visibility computations.
                         if (name == PropertyEditor::Visibility.GetName())
                         {
                             // Resolve the Visibility attribute by reading it as its actual stored type
-                            // (AZ::Crc32 / AZ::u32 / bool). Reading via AttributeDefinition<PropertyVisibility>
-                            // silently fails for AZ::Crc32 values -- the common case -- which caused fields
-                            // marked Hide to leak into the DPE. See ReadLegacyVisibility for details.
-                            //
-                            // If the attribute is present but unreadable we leave the incoming default
-                            // (Show / ShowChildrenOnly) untouched, matching the legacy RPE's behavior.
+                            
                             PropertyVisibility resolvedVisibility = PropertyVisibility::Show;
                             if (ReadLegacyVisibility(instance, it->second, resolvedVisibility))
                             {
@@ -1319,8 +1286,6 @@ namespace AZ::Reflection
                             return;
                         }
                         // The legacy ReadOnly property needs to be converted into the Disabled node property.
-                        // If our ancestor is disabled we don't need to read the attribute because this node
-                        // will already be disabled as well.
                         else if ((name == PropertyEditor::ReadOnly.GetName()) && !nodeData.m_isAncestorDisabled)
                         {
                             nodeData.m_disableEditor |=
@@ -1363,10 +1328,7 @@ namespace AZ::Reflection
                                 genericValueCache.ArrayPushBack(attributeValue);
                                 return;
                             }
-                            // Collect EnumValueKey attributes unless this node has an EnumValues, GenericValue or GenericValueList
-                            // attribute. If an EnumValues, GenericValue or GenericValueList attribute is present we do not cache
-                            // because such nodes also have internal EnumValueKey attributes that we won't use.
-                            // The cached values will be stored as a GenericValueList attribute.
+                            // Collect EnumValueKey attributes unless this node has an EnumValues, GenericValue or GenericValueList attribute.
                             if (name == enumValueKeyName)
                             {
                                 if (visitedAttributes.contains(enumValuesCrcName) || visitedAttributes.contains(genericValueListName) ||
@@ -1376,10 +1338,7 @@ namespace AZ::Reflection
                                 }
 
                                 genericValueCache.ArrayPushBack(attributeValue);
-                                // Forcing the node's typeId to AZ::u64 so the correct property handler will be chosen
-                                // in the PropertyEditorSystem.
-                                // This is reasonable since the attribute's value is an enum with an underlying integral
-                                // type which is safely convertible to AZ::u64.
+                                // Forcing the node's typeId to AZ::u64 so the correct property handler will be chosen in the PropertyEditorSystem.
                                 nodeData.m_instance.m_typeId = AzTypeInfo<u64>::Uuid();
                                 return;
                             }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -272,6 +272,75 @@ namespace AZ::Reflection
             return m_keyInstance.IsValid();
         }
 
+        // ---------------------------------------------------------------------
+        // Visibility attribute resolution
+        // ---------------------------------------------------------------------
+        // The legacy "Visibility" attribute is stored as one of three value types:
+        //   1. AZ::Crc32 - the default (e.g. AZ::Edit::PropertyVisibility::Hide)
+        //   2. AZ::u32   - allows the 0/1 shorthand for Hide/Show, or a raw hash
+        //   3. bool      - true/false for Show/Hide
+        //
+        // Reading this through AttributeDefinition<PropertyVisibility> fails for the
+        // common AZ::Crc32 case: PropertyVisibility is an enum, so the AttributeReader
+        // performs an exact AttributeData<PropertyVisibility> match and -- because enums
+        // are not integral -- never falls back to reading the value as an AZ::Crc32.
+        // The DPE then defaulted such fields to Show, leaking properties the author
+        // explicitly marked Hide (e.g. TransformComponent's "Cached World Transform").
+        //
+        // This mirrors AzToolsFramework's ReadVisibilityAttribute, which the legacy RPE
+        // uses, so the DPE resolves visibility identically: read the attribute as its
+        // actual stored type rather than relying on a fragile generic-DOM round-trip.
+        bool ReadLegacyVisibility(
+            AZ::PointerObject instance, AZ::Attribute* attribute, DocumentPropertyEditor::Nodes::PropertyVisibility& outVisibility)
+        {
+            using DocumentPropertyEditor::Nodes::PropertyVisibility;
+
+            if (attribute == nullptr)
+            {
+                return false;
+            }
+
+            AZ::AttributeReader reader(instance.m_address, attribute);
+
+            // 1. AZ::Crc32 - holds the PropertyVisibility hash directly.
+            AZ::Crc32 crcValue;
+            if (reader.Read<AZ::Crc32>(crcValue))
+            {
+                outVisibility = static_cast<PropertyVisibility>(static_cast<AZ::u32>(crcValue));
+                return true;
+            }
+
+            // 2. AZ::u32 - a raw hash, or the 0/1 shorthand for Hide/Show. This branch also
+            //    captures bool-returning attributes, which the reader converts to 0/1.
+            AZ::u32 u32Value = 0;
+            if (reader.Read<AZ::u32>(u32Value))
+            {
+                switch (u32Value)
+                {
+                case 0:
+                    outVisibility = PropertyVisibility::Hide;
+                    break;
+                case 1:
+                    outVisibility = PropertyVisibility::Show;
+                    break;
+                default:
+                    outVisibility = static_cast<PropertyVisibility>(u32Value);
+                    break;
+                }
+                return true;
+            }
+
+            // 3. bool - true/false for Show/Hide (safety net for any reader that only matches bool).
+            bool boolValue = false;
+            if (reader.Read<bool>(boolValue))
+            {
+                outVisibility = boolValue ? PropertyVisibility::Show : PropertyVisibility::Hide;
+                return true;
+            }
+
+            return false;
+        }
+
         struct InstanceVisitor
             : IObjectAccess
             , IAttributes
@@ -387,8 +456,6 @@ namespace AZ::Reflection
 
             using HandlerCallback = AZStd::function<bool()>;
             AZStd::unordered_map<AZ::TypeId, HandlerCallback> m_handlers;
-
-            static constexpr auto VisibilityBoolean = AZ::DocumentPropertyEditor::AttributeDefinition<bool>("VisibilityBoolean");
 
             // Specify whether the visit starts from the root of the instance.
             bool m_visitFromRoot = true;
@@ -1237,47 +1304,19 @@ namespace AZ::Reflection
                         // the end of the CacheAttributes method after it has done further visibility computations.
                         if (name == PropertyEditor::Visibility.GetName())
                         {
-                            auto visibilityValue = PropertyEditor::Visibility.DomToValue(
-                                PropertyEditor::Visibility.LegacyAttributeToDomValue(instance, it->second));
-
-                            if (visibilityValue.has_value())
+                            // Resolve the Visibility attribute by reading it as its actual stored type
+                            // (AZ::Crc32 / AZ::u32 / bool). Reading via AttributeDefinition<PropertyVisibility>
+                            // silently fails for AZ::Crc32 values -- the common case -- which caused fields
+                            // marked Hide to leak into the DPE. See ReadLegacyVisibility for details.
+                            //
+                            // If the attribute is present but unreadable we leave the incoming default
+                            // (Show / ShowChildrenOnly) untouched, matching the legacy RPE's behavior.
+                            PropertyVisibility resolvedVisibility = PropertyVisibility::Show;
+                            if (ReadLegacyVisibility(instance, it->second, resolvedVisibility))
                             {
-                                visibility = visibilityValue.value();
-
-                                // The PropertyEditor::Visibility is actually an AZ::u32 enum class, so we need
-                                // to check here if we read in a 0 or 1 instead of a hash so we can handle
-                                // those special cases.
-                                AZ::u32 visibilityNumericValue = static_cast<AZ::u32>(visibility);
-                                switch (visibilityNumericValue)
-                                {
-                                case 0:
-                                    visibility = PropertyVisibility::Hide;
-                                    break;
-                                case 1:
-                                    visibility = PropertyVisibility::Show;
-                                    break;
-                                default:
-                                    break;
-                                }
-                                return;
+                                visibility = resolvedVisibility;
                             }
-                            else if (
-                                auto visibilityBoolValue =
-                                    VisibilityBoolean.DomToValue(VisibilityBoolean.LegacyAttributeToDomValue(instance, it->second)))
-                            {
-                                bool isVisible = visibilityBoolValue.value();
-                                visibility = isVisible ? PropertyVisibility::Show : PropertyVisibility::Hide;
-                                return;
-                            }
-                            else if (auto genericVisibility = ReadGenericAttributeToDomValue(instance, it->second))
-                            {
-                                // Fallback to generic read if LegacyAttributeToDomValue fails
-                                if (auto visibilityOption = PropertyEditor::Visibility.DomToValue(genericVisibility.value()))
-                                {
-                                    visibility = visibilityOption.value();
-                                }
-                                return;
-                            }
+                            return;
                         }
                         // The legacy ReadOnly property needs to be converted into the Disabled node property.
                         // If our ancestor is disabled we don't need to read the attribute because this node


### PR DESCRIPTION
## Diagnosis
This is a long-standing DPE bug exposed by the default flip, not a true Qt6 regression. ed_enableDPEInspector has defaulted to true since Nov 2023; the Qt6 devbranch is just where you're now seeing it.

**Root cause** — a type mismatch in how the DPE reads the Visibility attribute:

- `AZ::Edit::PropertyVisibility::Hide` is a `const static AZ::Crc32` (EditContextConstants.inl:311), so `Attribute(..., PropertyVisibility::Hide)` is stored as `AttributeData<AZ::Crc32>`.
- The DPE bridge read it via` LegacyAttributeToDomValue<PropertyVisibility>`, which does `AttributeReader::Read<PropertyVisibility>(...)`. `PropertyVisibility` is an `enum class : u32`. For an enum dest type, AttributeReader does an exact `AttributeData<PropertyVisibility>` match and — because enums are not `is_integral` — skips the integral fallback chain that would have tried `AZ::Crc32`. So the read fails on every Crc32-typed visibility value.
- It then limped to a generic-DOM fallback that returns `nullopt`, leaving visibility at its default Show. (Commit `9a2e84bb3b` had already band-aided a `.value()` crash there — confirming the fallback fails in the field.) 

The legacy RPE works because `ReadVisibilityAttribute` reads the attribute as its actual stored type: `Crc32` → `u32` (0/1) → `bool`.

## Fix
In LegacyReflectionBridge.cpp:

- Added `ReadLegacyVisibility()` helper that reads visibility the same robust way the RPE does (`Crc32` → `u32` → `bool`). 
- Replaced the fragile three-path Visibility block in `CacheAttributes` with one call to it. 
- Removed the now-dead `VisibilityBoolean` member.

The Crc32 read preserves exact hashes, so `ShowChildrenOnly`/`HideChildren` still resolve correctly downstream.