### PR TITLE
Mac fix lrelease rpath

### DIFF
--- a/Gems/LmbrCentral/Code/Platform/Mac/lrelease_mac.cmake
+++ b/Gems/LmbrCentral/Code/Platform/Mac/lrelease_mac.cmake
@@ -9,7 +9,7 @@
 add_custom_command(TARGET LmbrCentral.Editor POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -P "${LY_ROOT_FOLDER}/cmake/Platform/Mac/RPathChange.cmake"
             "$<TARGET_FILE_DIR:LmbrCentral.Editor>/lrelease"
-            @executable_path/../Frameworks
+            @loader_path/../lib
             @executable_path
     COMMENT "Patching lrelease..."
     VERBATIM


### PR DESCRIPTION
## What does this PR do?

Similar to https://github.com/o3de/o3de/pull/19852, this should allow translation assets to be built by asset processor

## How was this PR tested?

Wasn't able to test, to know which rpath exist, I grabbed the qt6 artifacts for mac and checked the lrelease executable for its current rpath
