### PR TITLE
Fix build: missing header

### DIFF
--- a/Code/Tools/AssetProcessor/CMakeLists.txt
+++ b/Code/Tools/AssetProcessor/CMakeLists.txt
@@ -157,7 +157,6 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         NAME AssetProcessor.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
         NAMESPACE AZ
         AUTOMOC
-        AUTORCC
         FILES_CMAKE
             assetprocessor_test_files.cmake
         INCLUDE_DIRECTORIES

--- a/Code/Tools/AssetProcessor/CMakeLists.txt
+++ b/Code/Tools/AssetProcessor/CMakeLists.txt
@@ -115,7 +115,6 @@ ly_add_target(
 ly_add_target(
     NAME AssetProcessorBatch EXECUTABLE
     NAMESPACE AZ
-    AUTOMOC
     FILES_CMAKE
         assetprocessor_batch_files.cmake
     INCLUDE_DIRECTORIES

--- a/Code/Tools/ProjectManager/CMakeLists.txt
+++ b/Code/Tools/ProjectManager/CMakeLists.txt
@@ -79,7 +79,6 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     ly_add_target(
         NAME ProjectManager.Tests EXECUTABLE
         NAMESPACE AZ
-        AUTORCC
         FILES_CMAKE
             project_manager_tests_files.cmake
             Platform/${PAL_PLATFORM_NAME}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}_tests_files.cmake

--- a/Gems/LyShine/Code/Editor/Widgets/UiComponentPaletteWidget.cpp
+++ b/Gems/LyShine/Code/Editor/Widgets/UiComponentPaletteWidget.cpp
@@ -10,6 +10,8 @@
 
 #include "UiEditorInternalBus.h"
 
+#include <QModelIndex>
+
 #include <AzCore/Component/ComponentBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 

--- a/Gems/PhysX/Core/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX5/CMakeLists.txt
@@ -157,7 +157,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
         OUTPUT_NAME ${gem_name}.Editor.Gem
-        AUTOMOC
         FILES_CMAKE
             ${physx_module_files}
         COMPILE_DEFINITIONS

--- a/Gems/SkyAtmosphere/Code/CMakeLists.txt
+++ b/Gems/SkyAtmosphere/Code/CMakeLists.txt
@@ -157,7 +157,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             skyatmosphere_editor_shared_files.cmake
         INCLUDE_DIRECTORIES


### PR DESCRIPTION
## What does this PR do?

This PR fixes build on Ubuntu 2404 with Clang 18 and cmake 3.28.3:
- add missing header that prevented build on my machine
- remove AUTOMOC warnings
- remove AUTORCC warnings

Missing header:
Qt 6 no longer auto-includes `QModelIndex` through `qmetatype.h` (it's only forward-declared there now), so any .cpp that calls methods on `QModelIndex` needs the explicit include.

Sample warnings that were removed (it was checked that no qrc files and no Q_OBJECT macros are called):
```
[cmake]   Target PhysX5.Editor contains AUTOMOC but doesn't have any Q_OBJECT macro in a .h or .hxx file
[cmake]   Target AssetProcessor.Tests contains AUTORCC but doesnt have any .qrc file
```

## How was this PR tested?

The code builds correctly now with no warnings.
