### PR TITLE
Fix assert in InvokeOnDomValue when ChangeNotify contains non-invokable objects

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -574,8 +574,14 @@ namespace AZ::DocumentPropertyEditor
 
                             return CallbackTraits::InvokeOnBoundMessage(boundMessage.value(), marshalledArguments);
                         }
+
+                        return AZ::Failure<ErrorType>("Failed to unmarshal BoundAdapterMessage from DOM value");
                     }
+
+                    return AZ::Failure<ErrorType>("Object has an unrecognized $type for callback invocation");
                 }
+
+                return AZ::Failure<ErrorType>("Object has no $type field for callback invocation");
             }
             else if (value.IsArray())
             {


### PR DESCRIPTION
## What does this PR do?

InvokeOnDomValue in DocumentSchema.h would crash (assert) when encountering unrecognized DOM objects in callback attribute arrays.  The function handles arrays by recursing into each element, but unrecognized objects  would fall through all branches and hit GetOpaqueValue() on a non-opaque value
This happened to me when using the GradientTransformComponent when trying to activate the advanced button. This seem to occur when InheritChangeNotify merged multiple ChangeNotify attribute values into an array. 

Unfortunately I wasn't yet not able to fully pinpoint the real cause but having this "fix, workaround" prevents the assert. 

## How was this PR tested?

On my local Kubuntu 26.04 LTS.


I am not sure if I am the only one having this issue. Maybe someone knows more about this and we can figure out the real issue why the Invoke fails.


Update: I did more tests and figured out that doing this prevents some ui elements not being shown anymore. Needs further investigation.