### PR TITLE
Qt6 fixes: Welcome Screen, New Level Dialog, Entity Inspector

### DIFF
--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -58,10 +58,8 @@ private:
     CNewLevelDialog* m_parentDialog;
 };
 
-// In Qt6, QListWidget icon-mode items render icons in QIcon::Selected mode when
-// selected, applying a white color transformation that makes PNG previews unreadable.
-// This delegate draws the selection background manually, then paints the icon in
-// Normal mode so it remains visible regardless of selection state.
+// QListWidget icon-mode items render icons in white color when selected in Qt6, 
+// which makes PNG previews unreadable. This delegate draws the selection background manually.
 class TemplateItemDelegate : public QStyledItemDelegate
 {
 public:

--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -13,11 +13,14 @@
 #include "NewLevelDialog.h"
 
 // Qt
+#include <QApplication>
 #include <QComboBox>
 #include <QLabel>
+#include <QPainter>
 #include <QPushButton>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QStyledItemDelegate>
 #include <QTimer>
 #include <QToolButton>
 #include <QListWidgetItem>
@@ -53,6 +56,35 @@ public:
 
 private:
     CNewLevelDialog* m_parentDialog;
+};
+
+// In Qt6, QListWidget icon-mode items render icons in QIcon::Selected mode when
+// selected, applying a white color transformation that makes PNG previews unreadable.
+// This delegate draws the selection background manually, then paints the icon in
+// Normal mode so it remains visible regardless of selection state.
+class TemplateItemDelegate : public QStyledItemDelegate
+{
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+    {
+        QStyleOptionViewItem opt = option;
+        initStyleOption(&opt, index);
+
+        QStyle* style = opt.widget ? opt.widget->style() : QApplication::style();
+
+        const bool selected = opt.state & QStyle::State_Selected;
+        if (selected)
+        {
+            painter->fillRect(opt.rect, opt.palette.highlight());
+        }
+
+        // Strip selection/focus flags so Qt doesn't tint the icon white.
+        opt.state &= ~QStyle::State_Selected;
+        opt.state &= ~QStyle::State_HasFocus;
+        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
+    }
 };
 
 static QString ChangeFileExtension(const QString& filePath, const QString& newExtension)
@@ -181,6 +213,7 @@ void CNewLevelDialog::InitTemplateListWidget() const
     ui->listTemplates->setViewMode(QListWidget::IconMode);
     ui->listTemplates->setIconSize(iconSize);
     ui->listTemplates->setDragDropMode(QAbstractItemView::NoDragDrop);
+    ui->listTemplates->setItemDelegate(new TemplateItemDelegate(ui->listTemplates));
     if (ui->listTemplates->count() > 0)
     {
         ui->listTemplates->setCurrentRow(defaultItem);

--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -58,33 +58,6 @@ private:
     CNewLevelDialog* m_parentDialog;
 };
 
-// QListWidget icon-mode items render icons in white color when selected in Qt6, 
-// which makes PNG previews unreadable. This delegate draws the selection background manually.
-class TemplateItemDelegate : public QStyledItemDelegate
-{
-public:
-    using QStyledItemDelegate::QStyledItemDelegate;
-
-    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
-    {
-        QStyleOptionViewItem opt = option;
-        initStyleOption(&opt, index);
-
-        QStyle* style = opt.widget ? opt.widget->style() : QApplication::style();
-
-        const bool selected = opt.state & QStyle::State_Selected;
-        if (selected)
-        {
-            painter->fillRect(opt.rect, opt.palette.highlight());
-        }
-
-        // Strip selection/focus flags so Qt doesn't tint the icon white.
-        opt.state &= ~QStyle::State_Selected;
-        opt.state &= ~QStyle::State_HasFocus;
-        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
-    }
-};
-
 static QString ChangeFileExtension(const QString& filePath, const QString& newExtension)
 {
     QFileInfo fileInfo(filePath);
@@ -211,7 +184,7 @@ void CNewLevelDialog::InitTemplateListWidget() const
     ui->listTemplates->setViewMode(QListWidget::IconMode);
     ui->listTemplates->setIconSize(iconSize);
     ui->listTemplates->setDragDropMode(QAbstractItemView::NoDragDrop);
-    ui->listTemplates->setItemDelegate(new TemplateItemDelegate(ui->listTemplates));
+    ui->listTemplates->setItemDelegate(new DrawIconWithBackgroundDelegate(ui->listTemplates));
     if (ui->listTemplates->count() > 0)
     {
         ui->listTemplates->setCurrentRow(defaultItem);

--- a/Code/Editor/NewLevelDialog.h
+++ b/Code/Editor/NewLevelDialog.h
@@ -9,11 +9,41 @@
 
 #pragma once
 
+#include <QApplication>
+#include <QPainter>
 #include <QScopedPointer>
 #include <QAbstractButton>
 #include <QDialog>
+#include <QStyledItemDelegate>
 
 #include "LevelRoots.h"
+
+// QListWidget icon-mode items render icons in white when selected in Qt6 because
+// QIcon::Selected mode tints the pixmap. This delegate draws the selection background
+// manually and strips State_Selected before Qt renders, keeping the icon readable.
+class DrawIconWithBackgroundDelegate : public QStyledItemDelegate
+{
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+    {
+        QStyleOptionViewItem opt = option;
+        initStyleOption(&opt, index);
+
+        QStyle* style = opt.widget ? opt.widget->style() : QApplication::style();
+
+        const bool selected = opt.state & QStyle::State_Selected;
+        if (selected)
+        {
+            painter->fillRect(opt.rect, opt.palette.highlight());
+        }
+
+        opt.state &= ~QStyle::State_Selected;
+        opt.state &= ~QStyle::State_HasFocus;
+        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
+    }
+};
 
 namespace Ui {
     class CNewLevelDialog;

--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
@@ -217,7 +217,7 @@ void WelcomeScreenDialog::SetRecentFileList(RecentFileList* pList)
                 if (isProjectRooted || isGemRooted)
                 {
                     QString fullPath = recentFile;
-                    const QString name = Path::GetFile(fullPath);
+                    const QString name = Path::GetFileName(fullPath);
 
                     Path::ConvertSlashToBackSlash(fullPath);
                     fullPath = Path::ToUnixPath(fullPath.toLower());
@@ -239,9 +239,7 @@ void WelcomeScreenDialog::SetRecentFileList(RecentFileList* pList)
                             ui->recentLevelTable->setItem(currentRow, 0, new QTableWidgetItem(name));
                         }
                         QFileInfo file(recentFile);
-                        QDateTime dateTime = file.lastModified();
-                        QString date = QLocale::system().toString(dateTime.date(), QLocale::ShortFormat) + " " +
-                            QLocale::system().toString(dateTime.time(), QLocale::LongFormat);
+                        QString date = QLocale::system().toString(file.lastModified(), QLocale::ShortFormat);
                         ui->recentLevelTable->setItem(currentRow, 1, new QTableWidgetItem(date));
                         ui->recentLevelTable->setItem(currentRow++, 2, new QTableWidgetItem(tr("Level")));
                         m_levels.push_back(std::make_pair(name, recentFile));

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
@@ -9,6 +9,8 @@
 
 #include <AzQtComponents/Components/StyleManager.h>
 
+#include <QWidget>
+
 namespace AzQtComponents
 {
     namespace StyleHelpers
@@ -48,11 +50,17 @@ namespace AzQtComponents
 
                 if (QStyle* styleSheet = StyleManager::styleSheetStyle(widget))
                 {
-                    // For the widget and each of its children, QStyleSheetStyle::repolish clears
-                    // the existing render rules, polishes the widget and sends it a StyleChange
-                    // event. This ensure that both render rules which depend on properties, and
-                    // properties that are set in style sheets via qproperty- are correctly updated.
+                    // Qt6: unpolish() clears the cached render rules so polish() re-evaluates
+                    // them with the new property value.
+                    styleSheet->unpolish(widget);
                     styleSheet->polish(widget);
+                    // Qt6: child render rules (e.g. "Card[selected=true] > #contentContainer")
+                    // are cached independently and must be explicitly invalidated.
+                    for (QWidget* child : widget->template findChildren<QWidget*>())
+                    {
+                        styleSheet->unpolish(child);
+                        styleSheet->polish(child);
+                    }
                 }
             });
         }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
@@ -50,12 +50,10 @@ namespace AzQtComponents
 
                 if (QStyle* styleSheet = StyleManager::styleSheetStyle(widget))
                 {
-                    // Qt6: unpolish() clears the cached render rules so polish() re-evaluates
-                    // them with the new property value.
+                    // Qt6: unpolish() clears the cached render rules; polish() re-evaluates
+                    // them with the new property value. Child render rules must be explicitly invalidated.
                     styleSheet->unpolish(widget);
                     styleSheet->polish(widget);
-                    // Qt6: child render rules (e.g. "Card[selected=true] > #contentContainer")
-                    // are cached independently and must be explicitly invalidated.
                     for (QWidget* child : widget->template findChildren<QWidget*>())
                     {
                         styleSheet->unpolish(child);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.cpp
@@ -136,6 +136,7 @@ namespace AzQtComponents
                     case QEvent::DynamicPropertyChange:
                     {
                         auto styleSheet = StyleManager::styleSheetStyle(cbWidget);
+                        styleSheet->unpolish(cbWidget);
                         styleSheet->polish(cbWidget);
                     }
                     break;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ScrollBar.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ScrollBar.cpp
@@ -167,6 +167,7 @@ namespace AzQtComponents
                     {
                         if (auto styleSheet = StyleManager::styleSheetStyle(cornerWidget))
                         {
+                            styleSheet->unpolish(cornerWidget);
                             styleSheet->polish(cornerWidget);
                         }
                     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
@@ -527,6 +527,7 @@ bool SpinBoxWatcher::filterSpinBoxEvents(QAbstractSpinBox* spinBox, QEvent* even
         case QEvent::DynamicPropertyChange:
         {
             auto styleSheet = StyleManager::styleSheetStyle(spinBox);
+            styleSheet->unpolish(spinBox);
             styleSheet->polish(spinBox);
             break;
         }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TreeView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TreeView.cpp
@@ -44,6 +44,7 @@ namespace AzQtComponents
                         auto styleSheet = StyleManager::styleSheetStyle(widget);
                         if (styleSheet)
                         {
+                            styleSheet->unpolish(widget);
                             styleSheet->polish(widget);
                         }
                         widget->update();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -2810,9 +2810,8 @@ namespace AzToolsFramework
         ToolsApplicationRequests::Bus::BroadcastResult(areEntitiesEditable, &ToolsApplicationRequests::AreEntitiesEditable, m_selectedEntityIds);
         if (areEntitiesEditable)
         {
-            componentPalette->Populate(m_serializeContext, m_selectedEntityIds, m_componentFilter, serviceFilter, incompatibleServiceFilter);
-            componentPalette->Present();
             componentPalette->setGeometry(QRect(position, size));
+            componentPalette->Populate(m_serializeContext, m_selectedEntityIds, m_componentFilter, serviceFilter, incompatibleServiceFilter);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes various issues found when testing Qt6:

-  **New Level Dialog**: Qt6 `QIcon::Selected` mode tints icons white in dark background (it is tailored to svg files). Added a custom `TemplateItemDelegate` that draws the selection highlight manually and strips `State_Selected` before Qt renders the icon.
-  **Welcome screen**: recent level name shows an extra slash before the extension, e.g., `asdf/.prefab`; changed to stem only as in _New Level Dialog_; last modified date format simplified
- **Entity Inspector**: selected component not highlighted, as Qt6 no longer propagates stylesheet render rule cache invalidation to children when `polish()` is called on a parent, added calls to all children
- **Entity Inspector**: add Component palette opens too small on first use, fixed method order

## How was this PR tested?

Before on the left, after on the righ.
<img width="1810" height="678" alt="qt6_1" src="https://github.com/user-attachments/assets/2835b4f5-29a1-4ede-839e-e2d410d8fb72" />
<img width="1200" height="800" alt="qt6_2" src="https://github.com/user-attachments/assets/7a97e4c4-6836-4103-ae74-6179bca39386" />
<img width="886" height="510" alt="qt6_3" src="https://github.com/user-attachments/assets/82939bd8-09a2-47f7-a0e9-4c0d50548cdc" />
