### PR TITLE
Fix button dropdown icon misaligned

### DIFF
--- a/Code/Editor/Style/NewEditorStylesheet.qss
+++ b/Code/Editor/Style/NewEditorStylesheet.qss
@@ -1207,11 +1207,6 @@ QToolButton#assetTypeSelector
     padding: 0 0 0 2;
 }
 
-QToolButton#assetTypeSelector::menu-indicator
-{
-    image : url(none.jpg);
-}
-
 QToolButton#assetTypeSelector:hover
 {
     border: none;
@@ -2346,13 +2341,6 @@ AzQtComponents--FilteredSearchWidget QToolButton#assetTypeSelector
     icon-size: 16px 14px;
     max-height: 24px;
     max-width: 24px;
-}
-
-AzQtComponents--FilteredSearchWidget QToolButton#assetTypeSelector::menu-indicator
-{
-    image: url(none.jpg);
-    subcontrol-position: right center;
-    subcontrol-origin: padding;
 }
 
 AzQtComponents--FilteredSearchWidget QLabel#label

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/PushButton.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/PushButton.qss
@@ -52,16 +52,13 @@ QPushButton:flat
 }
 
 QPushButton.Primary,
-QPushButton:default,
-QToolButton::menu-indicator,
-QToolButton.SmallIcon::menu-indicator
+QPushButton:default
 {
     color: #FFFFFF;
 }
 
 QPushButton.Primary:disabled,
-QPushButton:default:disabled,
-QToolButton.SmallIcon:disabled::menu-indicator
+QPushButton:default:disabled
 {
     color: #BBBBBB;
 }


### PR DESCRIPTION
## What does this PR do?

Fix item 2 of https://github.com/o3de/o3de/issues/19855.

In Qt6 the styling logic changed such that if a .qss rule sets the "menuIndicator" then the QStyleOptionToolButton::HasMenu flag is removed from the item drawing, which means the custom O3DE drawing logic which lies in Code\Framework\AzQtComponents\AzQtComponents\Components\Widgets\ToolButton.cpp was not triggered with the right information.

We strip these .qss rules which were not required, so that we have the right dropdown alignment.

Dropdown arrow with the fix 

<img width="162" height="65" alt="image" src="https://github.com/user-attachments/assets/e13ccad3-87de-4ab5-958f-b91a98019df4" />

## How was this PR tested?

Local build on windows
