### PR TITLE
Move combobox open drawing fully to a delegate + remove dead code

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
@@ -636,15 +636,6 @@ namespace AzQtComponents
             }
             break;
 
-            case PE_IndicatorItemViewItemCheck:
-            {
-                if (ComboBox::drawItemCheckIndicator(this, option, painter, widget, m_data->comboBoxConfig))
-                {
-                    return;
-                }
-            }
-            break;
-
             case PE_PanelStatusBar:
             {
                 if (StatusBar::drawPanelStatusBar(this, option, painter, widget, m_data->statusBarConfig))

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.cpp
@@ -173,12 +173,12 @@ namespace AzQtComponents
         m_autoCustomWindowDecorations = new AutoCustomWindowDecorations(this);
         m_autoCustomWindowDecorations->setMode(AutoCustomWindowDecorations::Mode_AnyWindow);
 
-        // Order matters, need to setStylesheet() first, then when we call setStyle()
-        // QT 6.8.3 implementation will create a (private) QStyleSheetStyle with our stylesheet, and use our custom QStyle class below.
+        // Order matters: set the .qss stylesheet first so that Qt creates a (private) QStyleSheetStyle
         const auto globalStyleSheet = m_stylesheetCache->loadStyleSheet(g_globalStyleSheetName.toString());
         application->setStyleSheet(globalStyleSheet);
 
-        // Style is chained as: Style -> QStyleSheetStyle -> native, meaning any CSS limitation can be tackled in Style.cpp
+        // The resulting style chain is: QStyleSheetStyle -> Style (our custom class) -> native base.
+        // Anything not handled in via QStyleSheetStyle will be able to fallback in our custom Style class.
         m_style = new Style(createBaseStyle());
 
         QApplication::setStyle(m_style);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.cpp
@@ -11,23 +11,32 @@
 #include <AzQtComponents/Components/StyleManager.h>
 #include <AzQtComponents/Components/ConfigHelpers.h>
 
-AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option")
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QComboBox>
-#include <QDebug>
 #include <QGraphicsDropShadowEffect>
+#include <QIcon>
 #include <QLineEdit>
+#include <QPainter>
 #include <QSettings>
 #include <QStyledItemDelegate>
 #include <QToolButton>
-AZ_POP_DISABLE_WARNING
 
 namespace AzQtComponents
 {
     const int g_errorBorderWidth = 1;
 
     static const QString g_customCheckStateClass = QStringLiteral("CustomCheckState");
+
+    // (options below can be moved to the config file later if needed)
+    // Size, in pixels, of the check / indeterminate mark drawn at the left of each dropdown item.
+    static constexpr int g_checkMarkSize = 16;
+    // Horizontal inset, in pixels, of that mark from the left edge of the item. The left padding
+    // reserved for the mark is set in ComboBox.qss (QAbstractItemView::item) and must stay in sync.
+    static constexpr int g_checkMarkLeftMargin = 4;
+    // Minimum height, in pixels, of a dropdown item. Drives the popup row geometry from the delegate
+    // so it stays in sync with the rendered item regardless of the combo box font size.
+    static constexpr int g_minItemHeight = 24;
 
     ComboBoxValidator::ComboBoxValidator(QObject* parent)
         : QValidator(parent)
@@ -213,23 +222,51 @@ namespace AzQtComponents
         {
             QStyledItemDelegate::initStyleOption(option, index);
 
-            // The default usage of combobox only allow one selection,
-            // then we have to tweak it a bit so it show a check mark in this case.
-            if (option && m_combo && m_combo->view()->selectionMode() == QAbstractItemView::SingleSelection)
+            // Prevent QT from drawing the checkbox as we do it ourself
+            option->features &= ~QStyleOptionViewItem::HasCheckIndicator;
+        }
+
+        QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
+        {
+            QSize size = QStyledItemDelegate::sizeHint(option, index);
+            size.setHeight(qMax(size.height(), g_minItemHeight));
+            return size;
+        }
+
+        Qt::CheckState itemCheckState(const QModelIndex& index) const
+        {
+            if (Style::hasClass(m_combo, g_customCheckStateClass))
             {
-                option->features |= QStyleOptionViewItem::HasCheckIndicator;
-                auto *style = qobject_cast<Style *>(m_combo->style());
-                Qt::CheckState checkState;
-                if (style && style->hasClass(m_combo, g_customCheckStateClass))
-                {
-                    checkState = index.data(Qt::CheckStateRole).value<Qt::CheckState>();
-                }
-                else
-                {
-                    checkState = m_combo->currentIndex() == index.row() ? Qt::Checked : Qt::Unchecked;
-                }
-                option->checkState = checkState;
+                return index.data(Qt::CheckStateRole).value<Qt::CheckState>();
             }
+            return (m_combo && m_combo->currentIndex() == index.row()) ? Qt::Checked : Qt::Unchecked;
+        }
+
+        void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+        {
+            QStyledItemDelegate::paint(painter, option, index);
+
+            if (!m_combo || m_combo->view()->selectionMode() != QAbstractItemView::SingleSelection)
+            {
+                return;
+            }
+
+            const Qt::CheckState checkState = itemCheckState(index);
+            if (checkState == Qt::Unchecked)
+            {
+                return;
+            }
+
+            static const QIcon s_checkMark(QStringLiteral(":/stylesheet/img/UI20/checkmark.svg"));
+            static const QIcon s_indeterminateMark(QStringLiteral(":/stylesheet/img/UI20/indeterminate.svg"));
+            const QIcon& mark = (checkState == Qt::PartiallyChecked) ? s_indeterminateMark : s_checkMark;
+
+            const QRect markRect(
+                option.rect.left() + g_checkMarkLeftMargin,
+                option.rect.top() + (option.rect.height() - g_checkMarkSize) / 2,
+                g_checkMarkSize,
+                g_checkMarkSize);
+            mark.paint(painter, markRect, Qt::AlignCenter);
         }
 
     private:
@@ -437,29 +474,6 @@ namespace AzQtComponents
         cb.rect = downArrowRect;
         cb.palette.setColor(QPalette::ButtonText, config.framelessTextColor);
         style->QCommonStyle::drawPrimitive(QStyle::PE_IndicatorArrowDown, &cb, painter, widget);
-        return true;
-    }
-
-    bool ComboBox::drawItemCheckIndicator(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config)
-    {
-        Q_UNUSED(config);
-
-        if (strcmp(widget->metaObject()->className(), "QComboBoxListView") != 0)
-        {
-            return false;
-        }
-
-        auto opt = qstyleoption_cast<const QStyleOptionViewItem*>(option);
-        if (!opt)
-        {
-            return false;
-        }
-
-        if (opt->checkState != Qt::Unchecked)
-        {
-            style->QProxyStyle::drawPrimitive(QStyle::PE_IndicatorItemViewItemCheck, opt, painter, widget);
-        }
-
         return true;
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.h
@@ -92,7 +92,6 @@ namespace AzQtComponents
         static bool drawComboBox(const Style* style, const QStyleOptionComplex* option, QPainter* painter, const QWidget* widget, const Config& config);
         static bool drawComboBoxLabel(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config);
         static bool drawIndicatorArrow(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config);
-        static bool drawItemCheckIndicator(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config);
 
         static void addErrorButton(QComboBox* cb, const Config& config);
     };

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.qss
@@ -88,7 +88,8 @@ QComboBox QAbstractItemView::item
 {
     color: #FFFFFF;
     padding-right: 24px;
-    padding-left: 2px; /* There is already 22px from the check mark */
+    /* We draw the checkbox via a delegate, need to reserve space for it  */
+    padding-left: 24px;
 
     /* Without that the padding don't apply */
     border: 0px solid transparent;
@@ -113,24 +114,6 @@ QComboBox QAbstractItemView::separator
 {
     height: 1px;
     background: #444444;
-}
-
-QComboBox QAbstractItemView::indicator
-{
-    /* Keep in sync with the check mark image size */
-    width: 16px;
-    height: 16px;
-    image: none;
-}
-
-QComboBox QAbstractItemView::indicator:checked
-{
-    image: url(:/stylesheet/img/UI20/checkmark.svg);
-}
-
-QComboBox QAbstractItemView::indicator:indeterminate
-{
-    image: url(:/stylesheet/img/UI20/indeterminate.svg);
 }
 
 QMenu QComboBox


### PR DESCRIPTION
## What does this PR do?

Fix several items in https://github.com/o3de/o3de/issues/19855, used https://github.com/o3de/o3de/pull/19872 as a starting point, related to the ComboBox visual when we click on it.

## Explanation

With the move of Qt5 to Qt6, the style chaining was changed such as that the internal QStyleSheetStyle class is taking precedence over our internal Style class. This is not something we can change without touching the Qt internals.

In partice its not so much of an issue, as .qss styling is powerful, and we can use ItemDelegates whenever we need custom styling.

This is what is occuring in this PR, a codepath previously driven by our custom Style class is now handled by QStyleSheetStyle, leading to dead code in our styling logic. This PR removes this dead code, and adapt it into a simple ItemDelegate.

## In Action

Visual are the same as in Qt5 branch

<img width="269" height="135" alt="image" src="https://github.com/user-attachments/assets/cad1d7ee-7f9a-4f01-a860-48429b32b943" />

<img width="220" height="199" alt="image" src="https://github.com/user-attachments/assets/d2e4d79e-8df8-4826-bc19-aa6b3a217bf5" />

<img width="350" height="220" alt="image" src="https://github.com/user-attachments/assets/18d505c7-03b4-4032-8332-9df59c38dcbf" />

<img width="375" height="213" alt="image" src="https://github.com/user-attachments/assets/c1cb5300-1e88-4589-af55-3f69c3cdb80c" />

## How was this PR tested?

Local build on windows