### PR TITLE
Fix AutoComponent jinja narrowing conversions for vector properties

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
@@ -71,7 +71,7 @@ const {{ Property.attrib['Type'] }}& {{ ClassName }}::{{ UpperFirst(Property.att
 uint32_t {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}GetSize() const
 {
 {{ ValidateNetworkPropertyGet(ClassName, Property) }}
-    return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.size();
+    return aznumeric_cast<uint32_t>({{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.size());
 }
 
 {%          if Property.attrib['GenerateEventBindings']|booleanTrue %}
@@ -158,7 +158,7 @@ void {{ ClassName }}::Set{{ UpperFirst(Property.attrib['Name']) }}(int32_t index
 bool {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}PushBack(const {{ Property.attrib['Type'] }} &value)
 {
 {{ ValidateNetworkPropertySet(ClassName, Property) }}
-    int32_t indexToSet = GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.size();
+    int32_t indexToSet = aznumeric_cast<int32_t>(GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.size());
     if (indexToSet < {{ Property.attrib['Count'] }})
     {
         GetParent().m_{{ LowerFirst(Property.attrib['Name']) }}.push_back(value);
@@ -718,7 +718,7 @@ void {{ ClassName }}::NotifyChanges{{ AutoComponentMacros.GetNetPropertiesSetNam
 {%         if Property.attrib['Container'] == 'Vector' %}
     if (replicationRecord.m_{{ LowerFirst(AutoComponentMacros.GetNetPropertiesSetName(ReplicateFrom, ReplicateTo)) }}.GetBit(static_cast<int32_t>({{ AutoComponentMacros.GetNetPropertiesQualifiedPropertyDirtyEnum(Component.attrib['Name'], ReplicateFrom, ReplicateTo, Property, 'Size') }})))
     {
-        m_{{ LowerFirst(Property.attrib['Name']) }}SizeChangedEvent.Signal(m_{{ LowerFirst(Property.attrib['Name']) }}.size());
+        m_{{ LowerFirst(Property.attrib['Name']) }}SizeChangedEvent.Signal(aznumeric_cast<uint32_t>(m_{{ LowerFirst(Property.attrib['Name']) }}.size()));
     }
 {%         endif %}
 {%     else %}
@@ -773,7 +773,7 @@ const {{ Property.attrib['Type'] }}& {{ ClassName }}::{{ UpperFirst(Property.att
 
 uint32_t {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}GetSize() const
 {
-    return {{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.size();
+    return aznumeric_cast<uint32_t>({{ Prefix }}m_{{ LowerFirst(Property.attrib['Name']) }}.size());
 }
 
 {%     else %}


### PR DESCRIPTION
The vector container type for network properties on multiplayer autocomponents were generating several narrowing warnings promoted to errors. This is not a commonly used container type, hence why these template issues seem to have gone undetected
for some time. This explicitly downcasts to prevent the warnings as errors.