### PR TITLE
Fixes several (crash and other) issues related to undo and the inspector

### DIFF
--- a/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
+++ b/Code/Editor/Plugins/EditorAssetImporter/AssetImporterWindow.cpp
@@ -74,7 +74,11 @@ AssetImporterWindow::AssetImporterWindow(QWidget* parent)
 
 AssetImporterWindow::~AssetImporterWindow()
 {
-    disconnect();
+    while (QLayoutItem* cardToDelete = ui->m_cardAreaLayout->takeAt(0))
+    {
+        delete cardToDelete->widget();
+        delete cardToDelete;
+    }
 }
 
 void AssetImporterWindow::OpenFile(const AZStd::string& filePath)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -102,8 +102,27 @@ namespace AZ::DocumentPropertyEditor
         return new ExpanderSettings(referenceAdapter, settingsRegistryKey, propertyEditorName);
     }
 
+    void DocumentAdapter::QueueResetDocument(DocumentResetType resetType)
+    {
+        // Implementation for queuing a reset document operation
+        m_queuedResetType = m_queuedResetType == DocumentResetType::HardReset ? DocumentResetType::HardReset : resetType;
+        m_isResetQueued = true;
+    }
+
+    void DocumentAdapter::ExecuteQueuedReset()
+    {
+        if (m_isResetQueued)
+        {
+            NotifyResetDocument(m_queuedResetType);
+        }
+    }
+
     void DocumentAdapter::NotifyResetDocument(DocumentResetType resetType)
     {
+        // this is the actual reset function, which overrides any queuing, so reset it.
+        m_isResetQueued = false;
+        m_queuedResetType = DocumentResetType::SoftReset;
+
         if (resetType == DocumentResetType::HardReset || m_cachedContents.IsNull())
         {
             // If it's a hard reset, or we don't have any lazily cached contents, just send the reset signal.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
@@ -148,6 +148,9 @@ namespace AZ::DocumentPropertyEditor
         //! AdapterMessage provides a Match method to facilitate checking the message against
         //! registered CallbackAttributes.
         Dom::Value SendAdapterMessage(const AdapterMessage& message);
+        
+        //! Subclasses can call this to execute any queued reset operations, if any are present.
+        virtual void ExecuteQueuedReset();
 
         //! If true, debug mode is enabled for all DocumentAdapters.
         //! \see SetDebugModeEnabled
@@ -193,6 +196,12 @@ namespace AZ::DocumentPropertyEditor
         //! Subclasses may call this to trigger a ResetEvent and let the view know that GetContents should be requeried.
         //! Where possible, prefer to use NotifyContentsChanged instead.
         void NotifyResetDocument(DocumentResetType resetType = DocumentResetType::SoftReset);
+
+        //! Subclasses may call this to enqueue a NotifyResetDocument to be executed later when the current call stack unwinds.
+        //! Subclasses should call this one in most cases, except when a true clear is required such as when all data is instantly
+        //! invalid (during a quit / complete reload).
+        void QueueResetDocument(DocumentResetType resetType = DocumentResetType::SoftReset);
+
         //! Subclasses may call this to trigger a ChangedEvent to notify the view that this adapter's contents have changed.
         //! This patch should apply cleanly on the last result GetContents would have returned after any preceding changed
         //! or reset events.
@@ -207,6 +216,8 @@ namespace AZ::DocumentPropertyEditor
         FilterEvent m_filterEvent;
 
         mutable Dom::Value m_cachedContents;
+        DocumentResetType m_queuedResetType = DocumentResetType::SoftReset;
+        bool m_isResetQueued = false;
     };
 } // namespace AZ::DocumentPropertyEditor
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.cpp
@@ -139,6 +139,28 @@ namespace AZ::DocumentPropertyEditor
         return newNode;
     }
 
+    RowFilterAdapter::MatchInfoNode::MatchInfoNode() = default;
+
+    RowFilterAdapter::MatchInfoNode::~MatchInfoNode()
+    {
+        for (auto child : m_childMatchState)
+        {
+            delete child;
+        }
+        m_childMatchState.clear();
+    }
+
+    bool RowFilterAdapter::MatchInfoNode::IncludeInFilter()
+    {
+        return (m_matchesSelf || m_hasMatchingAncestor || !m_matchingDescendants.empty());
+    };
+
+    void RowFilterAdapter::MatchInfoNode::RemoveChildAtIndex(size_t index)
+    {
+        AZ_Assert(m_childMatchState.size() > index, "MatchInfoNode child out of bounds!");
+        m_childMatchState.erase(m_childMatchState.begin() + index);
+    }
+
     void RowFilterAdapter::SetFilterActive(bool activateFilter)
     {
         if (m_filterActive != activateFilter)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/FilterAdapter.h
@@ -28,27 +28,17 @@ namespace AZ::DocumentPropertyEditor
         Dom::Path MapToSourcePath(const Dom::Path& filterPath) const override;
 
     protected:
-        struct MatchInfoNode
+        // If you make a subclass of RowFilterAdapter, you must implement these methods to provide the filtering logic for your adapter.
+        // You can use the MatchInfoNode to store any additional information you need to determine whether a node matches the filter.
+        // Make sure to override NewMatchInfoNode and return your own class, and then CacheDomInfoForNode to populate your node
+        // with any information you'd like to cache, then
+        // MatchesFilter(MatchInfoNode* matchNode) const override to return true if the node matches or not.
+        struct AZF_API MatchInfoNode
         {
-            ~MatchInfoNode()
-            {
-                for (auto child : m_childMatchState)
-                {
-                    delete child;
-                }
-                m_childMatchState.clear();
-            }
+            virtual ~MatchInfoNode();
 
-            bool IncludeInFilter()
-            {
-                return (m_matchesSelf || m_hasMatchingAncestor || !m_matchingDescendants.empty());
-            };
-
-            void RemoveChildAtIndex(size_t index)
-            {
-                AZ_Assert(m_childMatchState.size() > index, "MatchInfoNode child out of bounds!");
-                m_childMatchState.erase(m_childMatchState.begin() + index);
-            }
+            bool IncludeInFilter();
+            void RemoveChildAtIndex(size_t index);
 
             bool m_matchesSelf = false;
 
@@ -64,9 +54,7 @@ namespace AZ::DocumentPropertyEditor
             unsigned int m_lastFilterUpdateFrame = 0; //!< frame that this node's match state last changed
 
         protected:
-            MatchInfoNode()
-            {
-            }
+            MatchInfoNode();
         };
 
         // pure virtual methods for new RowFilterAdapters

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.cpp
@@ -76,4 +76,14 @@ namespace AZ::DocumentPropertyEditor
         return rowPath;
     }
 
+    void MetaAdapter::ExecuteQueuedReset()
+    {
+        DocumentAdapter::ExecuteQueuedReset();
+        // if we're told to execute a queued reset, we need to forward that to our source.
+        if (m_sourceAdapter)
+        {
+            m_sourceAdapter->ExecuteQueuedReset();
+        }
+    }
+
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.h
@@ -27,6 +27,8 @@ namespace AZ::DocumentPropertyEditor
             const AZStd::string& settingsRegistryKey = AZStd::string(),
             const AZStd::string& propertyEditorName = AZStd::string()) override;
 
+        void ExecuteQueuedReset() override;
+
     protected:
         // handlers for source adapter's messages
         void HandleDomMessage(const AZ::DocumentPropertyEditor::AdapterMessage& message, Dom::Value& value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -1616,7 +1616,9 @@ namespace AZ::DocumentPropertyEditor
         {
             // For now just trigger a soft reset but the end goal is to handle granular updates.
             // This will still only send the view patches for what's actually changed.
-            NotifyResetDocument();
+            // Also note, this can happen in the middle of property editing, we do NOT want to actually
+            // reset the document immediately and cause the widgets to potentially be destroyed while still being worked on.
+            QueueResetDocument();
         };
 
         return message.Match(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -79,14 +79,39 @@ namespace AZ::DocumentPropertyEditor
 
     void ComponentAdapter::SetComponent(AZ::Component* componentInstance)
     {
-        m_entityId = componentInstance->GetEntityId();
+        AZ_Assert(componentInstance, "ComponentAdapter::SetComponent - component is null.");
+        if (!componentInstance)
+        {
+            return;
+        }
+
+        AZ::EntityId newEntityId = componentInstance->GetEntityId();
+
+        bool reconnectToSpecificEntityBus = false;
+        if (m_entityId != newEntityId)
+        {
+            if (m_entityId.IsValid())
+            {
+                AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusDisconnect(m_entityId);
+            }
+            reconnectToSpecificEntityBus = true;
+        }
+
+        m_entityId = newEntityId;
         m_componentId = componentInstance->GetId();
-        AZ::EntitySystemBus::Handler::BusConnect();
 
-        AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusConnect(m_entityId);
-        AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusConnect();
-        AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusConnect();
+        if (!AZ::EntitySystemBus::Handler::BusIsConnected())
+        {
+            AZ::EntitySystemBus::Handler::BusConnect(); // listens for "On Entity Destruction" / "On Entity Initialized".
+            AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusConnect();
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusConnect();
+        }
 
+        if (reconnectToSpecificEntityBus)
+        {
+            AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusConnect(m_entityId);
+        }
+        
         AZ::Uuid instanceTypeId = azrtti_typeid(componentInstance);
         SetValue(componentInstance, instanceTypeId);
     }
@@ -115,7 +140,7 @@ namespace AZ::DocumentPropertyEditor
         if (IsComponentValid())
         {
             m_queuedRefreshLevel = AzToolsFramework::PropertyModificationRefreshLevel::Refresh_None;
-            NotifyResetDocument();
+            QueueResetDocument();
         }
     }
 
@@ -123,6 +148,11 @@ namespace AZ::DocumentPropertyEditor
     {
         auto handlePropertyEditorChanged = [&]([[maybe_unused]] const Dom::Value& valueFromEditor, Nodes::ValueChangeType changeType)
         {
+            if (!IsComponentValid())
+            {
+                return;
+            }
+
             switch (changeType)
             {
             case Nodes::ValueChangeType::InProgressEdit:
@@ -172,12 +202,22 @@ namespace AZ::DocumentPropertyEditor
     {
         if (entityId == m_entityId)
         {
+            // stop listening for all events except Entity Initialized, which will be reconnected when the entity is re-initialized
+            // in case its an undo / redo op.
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusDisconnect();
             AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusDisconnect();
             AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusDisconnect(m_entityId);
-            
-            m_entityId.SetInvalid();
-            AZ::EntitySystemBus::Handler::BusDisconnect();
+        }
+    }
+
+    void ComponentAdapter::OnEntityInitialized(const AZ::EntityId& entityId)
+    {
+        if (entityId == m_entityId)
+        {
+            // reconnect to the various busses as our entity has been restored.
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusConnect();
+            AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusConnect();
+            AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusConnect(m_entityId);
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -61,6 +61,7 @@ namespace AZ::DocumentPropertyEditor
 
         //! Gets notification from the EntitySystemBus before destroying an entity.
         void OnEntityDestruction(const AZ::EntityId&) override;
+        void OnEntityInitialized(const AZ::EntityId&) override;
 
     private:
         //! Checks if the component is still valid in the entity.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1848,11 +1848,25 @@ namespace AzToolsFramework
             }
         };
 
+        auto handlePropertyEditorChanged = [&](const AZ::Dom::Value&, AZ::DocumentPropertyEditor::Nodes::ValueChangeType)
+        {
+            // When a value changes, we'd like to queue the execution of any property editor tree updates.
+            QTimer::singleShot(
+                0,
+                this,
+                [this]()
+                {
+                    m_adapter->ExecuteQueuedReset();
+                });
+        };
+
         message.Match(
             AZ::DocumentPropertyEditor::Nodes::Adapter::QueryKey,
             showKeyQueryDialog,
             AZ::DocumentPropertyEditor::Nodes::Adapter::QuerySubclass,
-            showQuerySubclassDialog);
+            showQuerySubclassDialog,
+            AZ::DocumentPropertyEditor::Nodes::PropertyEditor::OnChanged,
+            handlePropertyEditorChanged);
     }
 
     void DocumentPropertyEditor::RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)

--- a/Code/Tools/AssetProcessor/native/FileWatcher/FileWatcher.cpp
+++ b/Code/Tools/AssetProcessor/native/FileWatcher/FileWatcher.cpp
@@ -101,7 +101,7 @@ FileWatcher::FileWatcher()
 
 FileWatcher::~FileWatcher()
 {
-    disconnect();
+    disconnect(this);
     StopWatching();
 }
 

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphInspectWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphInspectWidget.cpp
@@ -48,7 +48,10 @@ namespace AZ
                 connect(m_graphView.data(), &SceneGraphWidget::SelectionChanged, this, &SceneGraphInspectWidget::OnSelectionChanged);
             }
 
-            SceneGraphInspectWidget::~SceneGraphInspectWidget() = default;
+            SceneGraphInspectWidget::~SceneGraphInspectWidget()
+            {
+                QObject::disconnect(this);
+            }
 
             void SceneGraphInspectWidget::OnSelectionChanged(AZStd::shared_ptr<const DataTypes::IGraphObject> item)
             {


### PR DESCRIPTION
## What does this PR do?

Fixes a bunch of issues related to undo and redo and Inspector. 

Note that when "undo" breaks, the editor no longer saves any changes to edited prefabs and cannot update them on disk.  All changes are discarded.

So when undo is broken you may get issue reports like "I can't change this value in my component" or "This value does not save after I change it" when the root cause is that undo/redo has gotten into a bad state.

Fixes https://github.com/o3de/o3de/issues/19842 - turns out to be a bit more severe.  Changing the diffuse probe dropdown actually causes the undo stack and prefab instantiation system to completely break, making all further changes unsaveable and all further undo impossible in that entire session, not just that one change.

Additional problems were found when running this test with ASAN enabled.

The core of the issue boils down to the inspector interacting with the undo system like this:

### Normal Operation
* User starts making an edit (drop down opened)
   * Undo stack opened, "CreateUndoBatch" to hold the change

* User finishes Making an edit (drop down clicked and closed)
   * Undo stack closed, "EndUndoBatch" to hold the change, undo stack is fine

### Operation with this issue in place
* User starts making an edit  (drop down opened)
   * Undo stack opened, "CreateUndoBatch" to hold the change
   * Change Notify called on the component
      * Component requests full tree refresh
      * Tree is immediately refreshed, all widgets deleted and recreated from scratch

* User finishes Making an edit (drop down clicked and closed)
   * The object that would have been listening for ending the undo batch was destroyed already!
   * Undo batch remains open.

### Fix applied
* I defer the refresh of the tree until the call stack returns, by hooking into the ValueChange notification, and posting an event to rebuild the tree, if necessary, at the end of the current message pump.  This means that when it rebuilds the tree, there is no callstack in the middle of editing a value.

### Other Issues Found with ASAN and fixed in this PR
* AssetImporterWindow close with unsaved changes causes a Qt crash.
* Memory Corruption or leak may occur when an inspector with a search bar disappears while a search was present (ie, console vars)
* Crash on close caused by `disconnect()` instead of `disconnect(this)`.  In QT, "Disconnect" is a static function, so not providing it with the `this` pointer does not allow it do anything useful at all.

## How was this PR tested?

* Running the AR tests locally
* Lots of local testing of the inspector
   * Drop downs, normal controls, transform, sliders
   * Probe grid (Issue mentioned this)
   * Tag component, moving objects around, renaming tags, deleting/adding container rows
   * Doing undo and redo repeatedly, including overlapping (before the prior finishes) and repeatedly of all of the above.
