### PR TITLE
Add collapse all button

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -608,6 +608,7 @@ namespace AzToolsFramework
         connect(m_gui->m_entitySearchBox, &QLineEdit::textChanged, this, &EntityPropertyEditor::OnSearchTextChanged);
         connect(m_gui->m_entitySearchBox, &QWidget::customContextMenuRequested, this, &EntityPropertyEditor::OnSearchContextMenu);
         connect(m_gui->m_pinButton, &QToolButton::clicked, this, &EntityPropertyEditor::OpenPinnedInspector);
+        connect(m_gui->m_collapseAllButton, &QToolButton::clicked, this, &EntityPropertyEditor::OnCollapseAll);
 
         m_componentPalette = new ComponentPaletteWidget(this, true);
         connect(m_componentPalette, &ComponentPaletteWidget::OnAddComponentEnd, this, [this]()
@@ -1364,6 +1365,7 @@ namespace AzToolsFramework
 
         m_gui->m_darkBox->setVisible(displayComponentSearchBox && !m_isSystemEntityEditor && !isLevelLayout || isPrefabLayout);
         m_gui->m_entitySearchBox->setVisible(displayComponentSearchBox);
+        m_gui->m_collapseAllButton->setVisible(displayComponentSearchBox);
 
         bool isEditingPrefabContainer = isContainerOfFocusedPrefabLayout;
 
@@ -2836,9 +2838,9 @@ namespace AzToolsFramework
         addAction(m_actionToDeleteComponents);
         m_entityComponentActions.push_back(m_actionToDeleteComponents);
 
-        QAction* seperator1 = new QAction(this);
-        seperator1->setSeparator(true);
-        addAction(seperator1);
+        auto* separator1 = new QAction(this);
+        separator1->setSeparator(true);
+        addAction(separator1);
 
         m_actionToCutComponents = new QAction(tr("Cut component"), this);
         m_actionToCutComponents->setShortcut(QKeySequence::Cut);
@@ -2871,9 +2873,9 @@ namespace AzToolsFramework
         addAction(m_actionToDuplicateComponents);
         m_entityComponentActions.push_back(m_actionToDuplicateComponents);
 
-        QAction* seperator2 = new QAction(this);
-        seperator2->setSeparator(true);
-        addAction(seperator2);
+        auto* separator2 = new QAction(this);
+        separator2->setSeparator(true);
+        addAction(separator2);
 
         m_actionToEnableComponents = new QAction(tr("Enable component"), this);
         m_actionToEnableComponents->setShortcutContext(Qt::WidgetWithChildrenShortcut);
@@ -2914,6 +2916,15 @@ namespace AzToolsFramework
         connect(m_actionToMoveComponentsBottom, &QAction::triggered, this, &EntityPropertyEditor::MoveComponentsBottom);
         addAction(m_actionToMoveComponentsBottom);
         m_entityComponentActions.push_back(m_actionToMoveComponentsBottom);
+
+        auto* separator3 = new QAction(this);
+        separator3->setSeparator(true);
+        addAction(separator3);
+
+        m_actionToCollapseAll = new QAction(tr("Collapse All"), this);
+        connect(m_actionToCollapseAll, &QAction::triggered, this, &EntityPropertyEditor::OnCollapseAll);
+        addAction(m_actionToCollapseAll);
+        m_entityComponentActions.push_back(m_actionToCollapseAll);
 
         UpdateInternalState();
     }
@@ -2988,6 +2999,27 @@ namespace AzToolsFramework
         //additional request to hide actions when not allowed so enable and disable aren't shown at the same time
         m_actionToEnableComponents->setVisible(allowRemove && allowEnable);
         m_actionToDisableComponents->setVisible(allowRemove && allowDisable);
+
+        if (hasComponents)
+        {
+            bool anyExpanded = false;
+            for (auto componentEditor : m_componentEditors)
+            {
+                if (componentEditor->IsExpanded())
+                {
+                    anyExpanded = true;
+                    break;
+                }
+            }
+
+            m_actionToCollapseAll->setEnabled(anyExpanded);
+        }
+        else
+        {
+            m_actionToCollapseAll->setEnabled(false);
+        }
+
+        m_actionToCollapseAll->setVisible(hasComponents);
     }
 
     bool EntityPropertyEditor::CanPasteComponentsOnSelectedEntities() const
@@ -5286,6 +5318,14 @@ namespace AzToolsFramework
 
         AzToolsFramework::EntityIdSet pinnedEntities(selectedEntities.begin(), selectedEntities.end());
         AzToolsFramework::EditorRequestBus::Broadcast(&AzToolsFramework::EditorRequests::OpenPinnedInspector, pinnedEntities);
+    }
+
+    void EntityPropertyEditor::OnCollapseAll()
+    {
+        for (auto componentEditor : m_componentEditors)
+        {
+            componentEditor->SetExpanded(false);
+        }
     }
 
     void EntityPropertyEditor::OnPrepareForContextReset()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -388,6 +388,7 @@ namespace AzToolsFramework
         QAction* m_actionToMoveComponentsDown = nullptr;
         QAction* m_actionToMoveComponentsTop = nullptr;
         QAction* m_actionToMoveComponentsBottom = nullptr;
+        QAction* m_actionToCollapseAll = nullptr;
 
         AzToolsFramework::MenuManagerInterface* m_menuManagerInterface = nullptr;
 
@@ -685,6 +686,7 @@ namespace AzToolsFramework
         void ClearSearchFilter();
 
         void OpenPinnedInspector();
+        void OnCollapseAll();
 
         void DragStopped();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.ui
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.ui
@@ -1219,6 +1219,29 @@ p, li { white-space: pre-wrap; }
         <number>4</number>
        </property>
        <item>
+        <widget class="QToolButton" name="m_collapseAllButton">
+         <property name="minimumSize">
+          <size>
+           <width>24</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Collapse all components</string>
+         </property>
+         <property name="icon">
+          <iconset>
+           <normaloff>:/PropertyEditor/Resources/collapse_all.svg</normaloff>:/PropertyEditor/Resources/collapse_all.svg</iconset>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <property name="autoRaise">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLineEdit" name="m_entitySearchBox">
          <property name="placeholderText">
           <string>Search...</string>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Resources/Icons.qrc
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Resources/Icons.qrc
@@ -38,6 +38,7 @@
         <file>locked.png</file>
         <file>hidden.png</file>
         <file>Slice_Entity.svg</file>
+        <file>collapse_all.svg</file>
         <file>trash-small.png</file>
         <file>reset_icon.png</file>
     </qresource>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Resources/collapse_all.svg
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Resources/collapse_all.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" id="svg2" xmlns="http://www.w3.org/2000/svg">
+    <g >
+    <path
+         id="path1"
+         style="fill:#ffffff;stroke:none;stroke-width:1.24726"
+         d="M 15.366626,0.01461612 12.099879,3.2789282 8.8940321,0.06333732 8.8842861,7.1205848 15.939096,7.1303308 12.733252,3.9147382 16,0.65042621 Z" />
+        <path
+         id="path2"
+         style="fill:#ffffff;stroke:none;stroke-width:1.24726"
+         d="M 0.0609013,8.8696713 3.2667479,12.085263 0,15.349574 0.63337392,15.985385 3.900122,12.721072 l 3.2058466,3.215591 0.00975,-7.0572475 z" />
+    </g>
+</svg>


### PR DESCRIPTION
## What does this PR do?

Add a collapse all button feature to the inspector. I find always myself to want to collapse all components, to focus on one component or not have to use the side scroller. So its a personal preference but might be helpful for other people as well?

<img width="418" height="430" alt="image" src="https://github.com/user-attachments/assets/862e2cef-493d-4d86-afef-b457d5dbf156" />


I'll close if this is something not wanted.

## How was this PR tested?

On my Kubuntu 26.04 LTS
