### PR TITLE
Fix QMenu spacing and hover behaviors

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.ui
@@ -564,7 +564,7 @@
           </property>
              <widget class="AzToolsFramework::AssetBrowser::AssetBrowserThumbnailView" name="m_thumbnailView">
                  <property name="styleSheet">
-                     <string notr="true">background-color: #333333</string>
+                     <string notr="true">AzToolsFramework--AssetBrowser--AssetBrowserThumbnailView, AzQtComponents--AssetFolderThumbnailView { background-color: #333333; }</string>
                  </property>
              </widget>
           <widget class="AzToolsFramework::AssetBrowser::AssetBrowserTableView" name="m_tableView">

--- a/Code/Editor/Style/NewEditorStylesheet.qss
+++ b/Code/Editor/Style/NewEditorStylesheet.qss
@@ -1497,42 +1497,6 @@ QSlider::handle:disabled {
     image: url(:/stylesheet/img/slider-handle-disabled.png);
 }
 
-QMenu {
-    background-color: #333333;
-    margin: 3 5 5 5;
-}
-
-/* Setting padding-left explicitly only pads the text,
- * without taking into account the action icon, so it
- * may result in text and icon overlapping. */
-QMenu::item {
-    color: white;
-    font-size: 12px;
-    padding-right: 25px;
-    padding-top: 2px;
-    padding-bottom: 2px;
-}
-
-QMenu::item:selected {
-    color: #4285F4;
-}
-
-QMenu::item:disabled {
-    color: #555555;
-}
-
-QMenu::separator
-{
-    height: 0px;
-    margin: 2px 6px 2px 6px;
-    border-top-width: 1px;
-    border-top-style: solid;
-    border-top-color: #303030;
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
-    border-bottom-color: #222222;
-}
-
 QComboBox {
     height: 17px;
     border-radius: 1px;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
@@ -473,43 +473,6 @@ namespace AzQtComponents
                 }
             }
             break;
-            case CE_MenuItem:
-            {
-                const QMenu* menu = qobject_cast<const QMenu*>(widget);
-                QAction* action = menu->activeAction();
-                if (action)
-                {
-                    QMenu* subMenu = action->menu();
-                    if (subMenu)
-                    {
-                        QVariant noHover = subMenu->property("noHover");
-                        if (noHover.isValid() && noHover.toBool())
-                        {
-                            // First draw as standard to get the correct hover background for the complete control.
-                            QProxyStyle::drawControl(element, option, painter, widget);
-                            // Now draw the icon as non-hovered so control behaves as designed.
-                            QStyleOptionMenuItem myOpt = *qstyleoption_cast<const QStyleOptionMenuItem*>(option);
-                            myOpt.state &= ~QStyle::State_Selected;
-                            return QProxyStyle::drawControl(element, &myOpt, painter, widget);
-                        }
-                    }
-                }
-                // Implement checkmark with icon in menu.
-                QStyleOptionMenuItem myOpt = *qstyleoption_cast<const QStyleOptionMenuItem*>(option);
-                bool checkable = myOpt.checkType != QStyleOptionMenuItem::NotCheckable;
-                bool checked = checkable ? myOpt.checked : false;
-
-                if (!myOpt.icon.isNull() && checked)
-                {
-                    const int iconSize{ 18 };
-                    int topPadding{ AZStd::max( 0 , (myOpt.rect.height() - iconSize) / 2) - 1};
-
-                    QProxyStyle::drawControl(element, &myOpt, painter, widget);
-                    myOpt.rect.adjust(0, topPadding, iconSize - myOpt.rect.width(), iconSize - myOpt.rect.height());
-                    return drawPrimitive(PE_IndicatorMenuCheckMark, &myOpt, painter, widget);
-                }
-            }
-            break;
         }
 
         return QProxyStyle::drawControl(element, option, painter, widget);
@@ -621,15 +584,6 @@ namespace AzQtComponents
             case PE_IndicatorBranch:
             {
                 if (TreeView::drawBranchIndicator(this, option, painter, widget, m_data->treeViewConfig))
-                {
-                    return;
-                }
-            }
-            break;
-
-            case PE_PanelMenu:
-            {
-                if (Menu::drawFrame(this, option, painter, widget, m_data->menuConfig))
                 {
                     return;
                 }
@@ -1041,26 +995,6 @@ namespace AzQtComponents
             case QStyle::PM_TabCloseIndicatorHeight:
             {
                 return TabBar::closeButtonSize(this, option, widget, m_data->tabWidgetConfig);
-                break;
-            }
-
-            case QStyle::PM_MenuHMargin:
-            {
-                const int margin = Menu::horizontalMargin(this, option, widget, m_data->menuConfig);
-                if (margin != -1)
-                {
-                    return margin;
-                }
-                break;
-            }
-
-            case QStyle::PM_MenuVMargin:
-            {
-                const int margin = Menu::verticalMargin(this, option, widget, m_data->menuConfig);
-                if (margin != -1)
-                {
-                    return margin;
-                }
                 break;
             }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.cpp
@@ -10,42 +10,18 @@
 #include <AzQtComponents/Components/Style.h>
 #include <AzQtComponents/Components/ConfigHelpers.h>
 
-#include <QApplication>
 #include <QMenu>
-#include <QPainter>
 #include <QSettings>
 #include <QStyleOption>
-#include <QWindow>
-#include <QSurfaceFormat>
-#include <QTimer>
-
-#include <qdrawutil.h>
 
 #include <limits>
 
 namespace AzQtComponents
 {
-    static void ReadMargins(QSettings& settings, const QString& name, Menu::Margins& margins)
-    {
-        ConfigHelpers::GroupGuard guard(&settings, name);
-        ConfigHelpers::read<int>(settings, QStringLiteral("Top"), margins.top);
-        ConfigHelpers::read<int>(settings, QStringLiteral("Right"), margins.right);
-        ConfigHelpers::read<int>(settings, QStringLiteral("Bottom"), margins.bottom);
-        ConfigHelpers::read<int>(settings, QStringLiteral("Left"), margins.left);
-    }
-
     Menu::Config Menu::loadConfig(QSettings& settings)
     {
         Config config = defaultConfig();
 
-        ConfigHelpers::read<QPixmap>(settings, QStringLiteral("PixmapPath"), config.shadowPixmap);
-        ReadMargins(settings, QStringLiteral("PixmapMargins"), config.shadowMargins);
-        ConfigHelpers::read<QColor>(settings, QStringLiteral("BackgroundColor"), config.backgroundColor);
-        ConfigHelpers::read<int>(settings, QStringLiteral("Radius"), config.radius);
-        ConfigHelpers::read<int>(settings, QStringLiteral("HorizontalMargin"), config.horizontalMargin);
-        ConfigHelpers::read<int>(settings, QStringLiteral("VerticalMargin"), config.verticalMargin);
-        ConfigHelpers::read<int>(settings, QStringLiteral("HorizontalPadding"), config.horizontalPadding);
-        ConfigHelpers::read<int>(settings, QStringLiteral("VerticalPadding"), config.verticalPadding);
         ConfigHelpers::read<int>(settings, QStringLiteral("SubMenuOverlap"), config.subMenuOverlap);
 
         return config;
@@ -55,18 +31,6 @@ namespace AzQtComponents
     {
         Config config;
 
-        config.shadowPixmap = QPixmap(QStringLiteral(":/stylesheet/img/UI20/shadows/menu-shadow.png"));
-        // 5px margin + 2px radius = 7px
-        config.shadowMargins.top = 7;
-        config.shadowMargins.right = 7;
-        config.shadowMargins.bottom = 7;
-        config.shadowMargins.left = 7;
-        config.backgroundColor = QStringLiteral("#222222");
-        config.radius = 2;
-        config.horizontalMargin = 5;
-        config.verticalMargin = 5;
-        config.horizontalPadding = 0;
-        config.verticalPadding = 4;
         config.subMenuOverlap = 0;
 
         return config;
@@ -84,23 +48,6 @@ namespace AzQtComponents
 
         style->repolishOnSettingsChange(widget);
 
-        // QMenu::popup results in the QWindow being created before polish is called. If the QWindow
-        // is created with the wrong flags, window tranparency does not work. Check if the window
-        // surface format supports an alpha. If not, destroy it.
-        if (QWindow* window = menu->windowHandle())
-        {
-            if (!window->format().hasAlpha())
-            {
-                window->destroy();
-            }
-        }
-
-        // Set the widget attributes we need to enable window transparency. Do this before calling
-        // QWidget::setWindowFlags as the QWindow is created there if it does not exist.
-        menu->setAttribute(Qt::WA_TranslucentBackground, true);
-        menu->setAttribute(Qt::WA_OpaquePaintEvent, true);
-        menu->setWindowFlags(menu->windowFlags() | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint);
-
         return true;
     }
 
@@ -109,43 +56,7 @@ namespace AzQtComponents
         Q_UNUSED(style);
         Q_UNUSED(config);
 
-        auto menu = qobject_cast<QMenu*>(widget);
-        if (!menu)
-        {
-            return false;
-        }
-
-        menu->setWindowFlags(menu->windowFlags());
-        menu->setAttribute(Qt::WA_TranslucentBackground, false);
-        menu->setAttribute(Qt::WA_OpaquePaintEvent, false);
-
-        return true;
-    }
-
-    int Menu::horizontalMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config)
-    {
-        Q_UNUSED(style);
-        Q_UNUSED(option);
-
-        if (qobject_cast<const QMenu*>(widget))
-        {
-            return config.horizontalMargin + config.horizontalPadding;
-        }
-
-        return -1;
-    }
-
-    int Menu::verticalMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config)
-    {
-        Q_UNUSED(style);
-        Q_UNUSED(option);
-
-        if (qobject_cast<const QMenu*>(widget))
-        {
-            return config.verticalMargin + config.verticalPadding;
-        }
-
-        return -1;
+        return qobject_cast<QMenu*>(widget) != nullptr;
     }
 
     int Menu::subMenuOverlap(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config)
@@ -161,53 +72,4 @@ namespace AzQtComponents
         return std::numeric_limits<int>::lowest();
     }
 
-    int Menu::verticalShadowMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config)
-    {
-        Q_UNUSED(style);
-        Q_UNUSED(option);
-
-        if (qobject_cast<const QMenu*>(widget))
-        {
-            return -config.verticalMargin;
-        }
-
-        return std::numeric_limits<int>::lowest();
-    }
-
-    int Menu::horizontalShadowMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config)
-    {
-        Q_UNUSED(style);
-        Q_UNUSED(option);
-
-        if (qobject_cast<const QMenu*>(widget))
-        {
-            return -config.horizontalMargin;
-        }
-
-        return std::numeric_limits<int>::lowest();
-    }
-
-    bool Menu::drawFrame(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Menu::Config& config)
-    {
-        Q_UNUSED(style);
-
-        auto menu = qobject_cast<const QMenu*>(widget);
-        if (!menu)
-        {
-            return false;
-        }
-
-        const auto& m = config.shadowMargins;
-        const QMargins shadowMargins(m.left, m.top, m.right, m.bottom);
-
-        qDrawBorderPixmap(painter, option->rect, shadowMargins, config.shadowPixmap);
-
-        painter->setPen(Qt::NoPen);
-        painter->setBrush(config.backgroundColor);
-        const auto hMargin = config.horizontalMargin;
-        const auto vMargin = config.verticalMargin;
-        painter->drawRoundedRect(option->rect.adjusted(hMargin, vMargin, -hMargin, -vMargin), config.radius, config.radius);
-
-        return true;
-    }
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.h
@@ -9,10 +9,7 @@
 
 #include <AzQtComponents/AzQtComponentsAPI.h>
 
-#include <QPixmap>
-
 class QLineEdit;
-class QPainter;
 class QSettings;
 class QStyleOption;
 
@@ -24,27 +21,10 @@ namespace AzQtComponents
     class AZ_QT_COMPONENTS_API Menu
     {
     public:
-        //! Settings for margins around the menu.
-        struct Margins
-        {
-            int top;
-            int right;
-            int bottom;
-            int left;
-        };
-
         //! Style configuration for the Menu class.
         struct Config
         {
-            QPixmap shadowPixmap;       //!< Pixmap for the shadow shown around the Menu.
-            Margins shadowMargins;      //!< Margins for drop shadow around the Menu.
-            QColor backgroundColor;     //!< Background color for the Menu.
-            int radius;                 //!< Corner radius for the Menu rect.
-            int horizontalMargin;       //!< Margin for the Menu on the horizontal directions (left, right).
-            int verticalMargin;         //!< Margin for the Menu on the vertical directions (top, bottom).
-            int horizontalPadding;      //!< Padding for the Menu on the horizontal directions (left, right).
-            int verticalPadding;        //!< Padding for the Menu on the vertical directions (top, bottom).
-            int subMenuOverlap;         //!< Amount of pixels submenus overlap with their parent Menu.
+            int subMenuOverlap; //!< Amount of pixels submenus overlap with their parent Menu.
         };
 
         //! Sets the Menu style configuration.
@@ -60,13 +40,7 @@ namespace AzQtComponents
         static bool polish(Style* style, QWidget* widget, const Config& config);
         static bool unpolish(Style* style, QWidget* widget, const Config& config);
 
-        static int horizontalMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config);
-        static int verticalMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config);
         static int subMenuOverlap(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config);
-        static int verticalShadowMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config);
-        static int horizontalShadowMargin(const Style* style, const QStyleOption* option, const QWidget* widget, const Config& config);
-
-        static bool drawFrame(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config);
     };
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.qss
@@ -10,21 +10,7 @@
 QMenu
 {
     background-color: #222222;
-}
-
-QMenu::item
-{
-    color: #FFFFFF;
-    font-size: 12px;
-    font-family: "Open Sans";
-
-    /* default height is 18px */
-    /* target height is 24px */
-    /* 24 - 18 = 6 */
-    /* 6 / 2 = 3 */
-    /* top, right, bottom, left */
-    padding: 2px auto 4px 20px;
-    height: 18px;
+    padding: 4px 2px;
 }
 
 /* Hover */
@@ -32,33 +18,6 @@ QMenu::item:selected,
 QMenu::item .WidgetAction:hover
 {
     background-color: #444444;
-}
-
-QMenu::icon,
-QMenu::right-arrow
-{
-    width: 16px;
-    height: 16px;
-
-    subcontrol-position: right center;
-}
-
-QMenu::right-arrow
-{
-    right: 4px;
-}
-
-QMenu::icon
-{
-    right: 20px;
-}
-
-QMenu::indicator:checked
-{
-    width: 16px;
-    height: 16px;
-    margin-left: 2px;
-    image: url(:/stylesheet/img/UI20/checkmark-menu.svg);
 }
 
 QMenu::item:disabled
@@ -82,5 +41,5 @@ QMenu.SourceControlMenu
 
 QMenu.SourceControlMenu::item
 {
-    margin-left: 22px;
+    margin-left: 41px;
 }

--- a/Code/Framework/AzQtComponents/AzQtComponents/PropertyInput/PropertyInputWidgets.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/PropertyInput/PropertyInputWidgets.cpp
@@ -8,20 +8,28 @@
 
 #include <AzQtComponents/PropertyInput/PropertyInputWidgets.h>
 
+#include <AzQtComponents/Components/Style.h>
+
 #include <QEvent>
-#include <QKeyEvent>
 #include <QHBoxLayout>
+#include <QKeyEvent>
 
 constexpr int FieldMargins = 17;
 constexpr int SpinBoxWidth = 64;
+constexpr int MenuItemTextLeftMargin = 22;
 
 namespace AzQtComponents
 {
     PropertyInputDoubleWidget::PropertyInputDoubleWidget()
     {
+        Style::addClass(this, "WidgetAction");
+        setAttribute(Qt::WA_StyledBackground, true);
+        setAttribute(Qt::WA_Hover, true);
+
         // Create Label.
         m_label = new QLabel(this);
         m_label->setContentsMargins(QMargins(0, 0, FieldMargins / 2, 0));
+        m_label->setAttribute(Qt::WA_TransparentForMouseEvents, true);
 
         // Create SpinBox.
         m_spinBox = new AzQtComponents::DoubleSpinBox(this);
@@ -43,7 +51,7 @@ namespace AzQtComponents
 
         // Add to Layout.
         QHBoxLayout* layout = new QHBoxLayout(this);
-        layout->setContentsMargins(QMargins(FieldMargins, 0, FieldMargins, 0));
+        layout->setContentsMargins(QMargins(MenuItemTextLeftMargin, 0, FieldMargins, 0));
         layout->addWidget(m_label);
         layout->addWidget(m_spinBox);
     }
@@ -66,7 +74,7 @@ namespace AzQtComponents
             }
         }
 
-        return false;
+        return QWidget::event(event);
     }
 
 } // namespace AzQtComponents


### PR DESCRIPTION
## What does this PR do?

Fix item 3 of https://github.com/o3de/o3de/issues/19855. All the item and icon alignments got broken with the move to QT6. This fixes all of these behaviors for all variations of QMenu we have.

Current Q6 without the fix
<img width="442" height="337" alt="image" src="https://github.com/user-attachments/assets/d49a8cea-4569-4e85-a8f6-40426b0dcd7f" />

| Qt5 | Qt6 with the fix |
| --- | --- |
|  <img width="349" height="537" alt="qt5-2" src="https://github.com/user-attachments/assets/3551d3c9-41b2-452b-b8cb-3a748278fd65" />| <img width="329" height="589" alt="change1" src="https://github.com/user-attachments/assets/9031cb53-676c-4a1c-b39c-68646b779edf" />|
| <img width="436" height="313" alt="qt5-3" src="https://github.com/user-attachments/assets/efe3dc85-4959-4850-9e69-8ab894352026" />|<img width="436" height="335" alt="change2" src="https://github.com/user-attachments/assets/3dabf1b5-c4de-4ac7-b09b-6bd69e322299" /> |
| <img width="216" height="375" alt="qt5-1" src="https://github.com/user-attachments/assets/a83b6baf-ae9a-4d5c-9a76-4d154c2383a4" /> | <img width="244" height="394" alt="change3" src="https://github.com/user-attachments/assets/0227502c-3e0b-4b3c-998d-b3054216d951" />|

## Known regression

The QAction icon is now always on the left side instead of being on the right side. This means that if the QAction is ticked and have an icon, the icon will be used instead of the checkmark.

What I propose to fix this regression is to use a different set of icon based on if the item is ticked or not. This can be done procedurally, so that we just append something to an existing loaded svg.

```cpp
QIcon icon;
icon.addPixmap(QPixmap(":/normal.svg"),  QIcon::Normal, QIcon::Off);
icon.addPixmap(QPixmap(":/checked.svg"), QIcon::Normal, QIcon::On);   // e.g. a tinted variant, can be procedural with QPainter
action->setIcon(icon);
action->setCheckable(true);
```

This is not part of this PR as it would be part of a bigger styling change, since it would impact the icons on the Toolbars as well (which currently have a blue background when ticked).

It is not currently possible in vanilla Qt6 to have the icon on the right side looking correct.
- In our custom Style.cpp, `CE_MenuItem` will never be triggered, even if no .qss rule for QMenu and its items
- Forcing `QMenu::icon { subcontrol-position: right center; }` move it to the right but without padding or margin, it does not look nice
- Forcing padding via `QMenu::item` will remove the base spacing. Menus with no tickable items will not have any padding, leading to visual inconsistencies between menus

## How was this PR tested?

Local build on windows
