### PR TITLE
Upgrade meshoptimizer to v1.2

### DIFF
--- a/Code/Tools/SceneAPI/SceneData/Rules/LodRule.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Rules/LodRule.cpp
@@ -26,11 +26,9 @@ namespace AZ
                 if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
                 {
                     serializeContext->Class<LodRule::AutoLodGenerationSettings>()
-                        ->Version(1)
+                        ->Version(2)
                         ->Field("PreserveTopology", &LodRule::AutoLodGenerationSettings::m_preserveTopology)
                         ->Field("LimitError", &LodRule::AutoLodGenerationSettings::m_limitError)
-                        ->Field("LockBorder", &LodRule::AutoLodGenerationSettings::m_lockBorder)
-                        ->Field("Sparse", &LodRule::AutoLodGenerationSettings::m_sparse)
                         ->Field("Prune", &LodRule::AutoLodGenerationSettings::m_prune)
                         ->Field("TargetError", &LodRule::AutoLodGenerationSettings::m_targetError)
                         ->Field("IndexThreshold", &LodRule::AutoLodGenerationSettings::m_indexThreshold);
@@ -41,10 +39,6 @@ namespace AZ
                                 ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                             ->DataElement(AZ::Edit::UIHandlers::Default, &LodRule::AutoLodGenerationSettings::m_preserveTopology, "Preserve Topology", "Preserve the topology of the mesh (slower).")
                                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
-                            ->DataElement(AZ::Edit::UIHandlers::Default, &LodRule::AutoLodGenerationSettings::m_lockBorder, "Lock Border", "Restrict from collapsing edges that are on the border of the mesh.")
-                                ->Attribute(AZ::Edit::Attributes::Visibility, &LodRule::AutoLodGenerationSettings::m_preserveTopology)
-                            ->DataElement(AZ::Edit::UIHandlers::Default, &LodRule::AutoLodGenerationSettings::m_sparse, "Sparse", "Improve simplification performance assuming input indices are a sparse subset of the mesh.")
-                                ->Attribute(AZ::Edit::Attributes::Visibility, &LodRule::AutoLodGenerationSettings::m_preserveTopology)
                             ->DataElement(AZ::Edit::UIHandlers::Default, &LodRule::AutoLodGenerationSettings::m_prune, "Prune", "Allow the simplifier to remove isolated components regardless of the topological restrictions inside the component.")
                                 ->Attribute(AZ::Edit::Attributes::Visibility, &LodRule::AutoLodGenerationSettings::m_preserveTopology)
                             ->DataElement(AZ::Edit::UIHandlers::Default, &LodRule::AutoLodGenerationSettings::m_limitError, "Limit Error", "Enable the error limit for the mesh.")

--- a/Code/Tools/SceneAPI/SceneData/Rules/LodRule.h
+++ b/Code/Tools/SceneAPI/SceneData/Rules/LodRule.h
@@ -34,8 +34,6 @@ namespace AZ
                     static void Reflect(ReflectContext* context);
                     bool m_preserveTopology = false;
                     bool m_limitError = false;
-                    bool m_lockBorder = false;
-                    bool m_sparse = false;
                     bool m_prune = false;
                     float m_targetError = 0.1f; // Default target error for simplification
                     float m_indexThreshold = 0.5f; // Default index threshold for simplification

--- a/Gems/Atom/RPI/3rdParty/Findmeshoptimizer.cmake
+++ b/Gems/Atom/RPI/3rdParty/Findmeshoptimizer.cmake
@@ -10,21 +10,26 @@ set(MESHOPTIMIZER_TARGET meshoptimizer)
 if (TARGET 3rdParty::${MESHOPTIMIZER_TARGET})
     return()
 endif()
+function(Getmeshoptimizer)
+    set(MESHOPTIMIZER_GIT_REPO "https://github.com/zeux/meshoptimizer.git")
+    set(MESHOPTIMIZER_GIT_HASH "9d9890c73011d75920af614485296d1e03e95448")
+    set(MESHOPTIMIZER_GIT_TAG "v1.2")
 
-set(MESHOPTIMIZER_GIT_REPO "https://github.com/zeux/meshoptimizer.git")
-set(MESHOPTIMIZER_GIT_TAG "6daea4695c48338363b08022d2fb15deaef6ac09")   # v0.25
+    include(FetchContent)
+    FetchContent_Declare(
+            ${MESHOPTIMIZER_TARGET}
+            GIT_REPOSITORY ${MESHOPTIMIZER_GIT_REPO}
+            GIT_TAG ${MESHOPTIMIZER_GIT_HASH}
+            GIT_SHALLOW TRUE
+    )
+    set(MESHOPT_INSTALL OFF)
+    FetchContent_MakeAvailable(meshoptimizer)
 
-include(FetchContent)
-FetchContent_Declare(
-        ${MESHOPTIMIZER_TARGET}
-        GIT_REPOSITORY ${MESHOPTIMIZER_GIT_REPO}
-        GIT_TAG ${MESHOPTIMIZER_GIT_TAG}
-        GIT_SHALLOW TRUE
-)
-set(MESHOPT_INSTALL OFF)
-FetchContent_MakeAvailable(meshoptimizer)
+    message(STATUS "Atom Gem uses ${MESHOPTIMIZER_TARGET}-${MESHOPTIMIZER_GIT_TAG} (MIT License) ${MESHOPTIMIZER_GIT_REPO}")
+endfunction()
 
-message(STATUS "Atom Gem uses ${MESHOPTIMIZER_TARGET}-${MESHOPTIMIZER_GIT_TAG} (MIT License) ${MESHOPTIMIZER_GIT_REPO}")
+Getmeshoptimizer()
+unset(Getmeshoptimizer)
 
 get_property(this_gem_root GLOBAL PROPERTY "@GEMROOT:${gem_name}@")
 ly_get_engine_relative_source_dir(${this_gem_root} relative_this_gem_root)
@@ -33,4 +38,4 @@ set_property(TARGET ${MESHOPTIMIZER_TARGET} PROPERTY FOLDER "${relative_this_gem
 add_library(3rdParty::${MESHOPTIMIZER_TARGET} ALIAS ${MESHOPTIMIZER_TARGET})
 ly_install(FILES ${CMAKE_CURRENT_LIST_DIR}/Installer/Findmeshoptimizer.cmake DESTINATION cmake/3rdParty)
 
-set(meshoptimizer_FOUND TRUE)
+set(meshoptimizer_FOUND TRUE PARENT_SCOPE)

--- a/Gems/Atom/RPI/3rdParty/Installer/Findmeshoptimizer.cmake
+++ b/Gems/Atom/RPI/3rdParty/Installer/Findmeshoptimizer.cmake
@@ -12,7 +12,7 @@ if (TARGET 3rdParty::${MESHOPTIMIZER_TARGET})
 endif()
 
 set(MESHOPTIMIZER_GIT_REPO "https://github.com/zeux/meshoptimizer.git")
-set(MESHOPTIMIZER_GIT_TAG "v0.25")
+set(MESHOPTIMIZER_GIT_TAG "v1.2")
 
 message(STATUS "Atom Gem uses ${MESHOPTIMIZER_TARGET}-${MESHOPTIMIZER_GIT_TAG} (MIT License) ${MESHOPTIMIZER_GIT_REPO}")
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -71,6 +71,16 @@ namespace AZ
     {
         static const uint64_t s_invalidMaterialUid = 0;
 
+        static void* MeshOptimizerAllocate(size_t size)
+        {
+            return azmalloc(size);
+        }
+
+        static void MeshOptimizerFree(void* ptr)
+        {
+            azfree(ptr);
+        }
+
         static bool MismatchedVertexLayoutsAreErrors()
         {
             bool mismatchedVertexStreamsAreErrors = false;
@@ -153,16 +163,6 @@ namespace AZ
 
                 AZ::u32 simplifyOption = 0;
 
-                if (settings.m_lockBorder)
-                {
-                    simplifyOption |= meshopt_SimplifyLockBorder;
-                }
-
-                if (settings.m_sparse)
-                {
-                    simplifyOption |= meshopt_SimplifySparse;
-                }
-
                 if (settings.m_prune)
                 {
                     simplifyOption |= meshopt_SimplifyPrune;
@@ -195,6 +195,8 @@ namespace AZ
 
         SceneAPI::Events::ProcessingResult ModelAssetBuilderComponent::BuildModel(ModelAssetBuilderContext& context)
         {
+            meshopt_setAllocator(MeshOptimizerAllocate, MeshOptimizerFree);
+
             {
                 auto assetIdOutcome = RPI::AssetUtils::MakeAssetId(s_defaultVertexBufferPoolSourcePath, 0);
                 if (!assetIdOutcome.IsSuccess())


### PR DESCRIPTION
## What does this PR do?

This PR upgrades meshoptimizer 3p to v1.2
Also removed "sparse" and "lock border" LOD generation options as they are intended for meshlets simplification.

## How was this PR tested?

Tested on Windows 11
