### PR TITLE
Fix tabwidgets

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
@@ -272,15 +272,6 @@ namespace AzQtComponents
                 }
                 break;
             }
-            case QStyle::CT_TabBarTab:
-            {
-                const auto tabSize = TabBar::sizeFromContents(this, type, option, size, widget, m_data->tabWidgetConfig);
-                if (tabSize.isValid())
-                {
-                    return tabSize;
-                }
-                break;
-            }
             case QStyle::CT_HeaderSection:
             {
                 const auto headerSize = TableView::sizeFromContents(this, type, option, size, widget, m_data->tableViewConfig);
@@ -370,24 +361,6 @@ namespace AzQtComponents
                 if (qobject_cast<const QRadioButton*>(widget))
                 {
                     if (RadioButton::drawRadioButtonLabel(this, option, painter, widget, m_data->radioButtonConfig))
-                    {
-                        return;
-                    }
-                }
-            }
-            break;
-
-            case CE_TabBarTabLabel:
-            {
-                if (qobject_cast<const QTabBar*>(widget))
-                {
-                    // Qt lacks a textAlignment variable in QStyleOptionTab, which is used for drawing QTabWidget and QTabBar.
-                    // Text alignment for tab labels is hardcoded to horizontal center. For this reason, there is no way to customize
-                    // text alignment if not creating a new member variable for QStyleOptionTab (or to subclass QStyleOptionTab) on Qt
-                    // side. To avoid doing either, we set a new variable to be used from Style::drawItemText, with a scope limited to
-                    // the drawing of this specific control element (the tab label).
-                    QScopedValueRollback<QVariant> rollbackTabBarTabLabel(m_drawItemTextAlignmentOverride, {(int)(Qt::AlignLeft | Qt::AlignVCenter)});
-                    if (TabBar::drawTabBarTabLabel(this, option, painter, widget, m_data->tabWidgetConfig))
                     {
                         return;
                     }
@@ -687,15 +660,6 @@ namespace AzQtComponents
         }
 
         return QProxyStyle::drawComplexControl(element, option, painter, widget);
-    }
-
-    void Style::drawItemText(QPainter* painter, const QRect& rectangle, int alignment, const QPalette& palette, bool enabled, const QString& text, QPalette::ColorRole textRole) const
-    {
-        if (m_drawItemTextAlignmentOverride.isValid())
-        {
-            alignment = m_drawItemTextAlignmentOverride.value<Qt::Alignment>();
-        }
-        QProxyStyle::drawItemText(painter, rectangle, alignment, palette, enabled, text, textRole);
     }
 
     void Style::drawDragIndicator(const QStyleOption* option, QPainter* painter, const QWidget* widget) const

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.h
@@ -124,7 +124,6 @@ namespace AzQtComponents
         void drawControl(QStyle::ControlElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const override;
         void drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const override;
         void drawComplexControl(QStyle::ComplexControl element, const QStyleOptionComplex* option, QPainter* painter, const QWidget* widget) const override;
-        void drawItemText(QPainter* painter, const QRect& rectangle, int alignment, const QPalette& palette, bool enabled, const QString& text, QPalette::ColorRole textRole) const override;
 
         void drawDragIndicator(const QStyleOption* option, QPainter* painter, const QWidget* widget) const;
 
@@ -182,9 +181,6 @@ namespace AzQtComponents
         AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // needs to have dll-interface to be used by clients of class 'AzQtComponents::LineEdit'
         QScopedPointer<Data> m_data;
         AZ_POP_DISABLE_WARNING
-
-        // To be used when text alignment has to be forced from outside Qt
-        mutable QVariant m_drawItemTextAlignmentOverride;
 
         mutable const QWidget* m_drawControlWidget = nullptr;
     };

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.cpp
@@ -38,8 +38,6 @@ namespace AzQtComponents
     static int g_borderWidth = 1;
     static int g_releaseTabMaxAnimationDuration = 250; // Copied from qtabbar_p.h
     // Will be initialized by TabWidget::loadConfig
-    static int g_closeButtonWidth = -1;
-    static int g_closeButtonPadding = -1;
     static int g_closeButtonMinTabWidth = -1;
     static int g_toolTipTabWidthThreshold = -1;
     static int g_overflowSpacing = -1;
@@ -96,17 +94,12 @@ namespace AzQtComponents
         ConfigHelpers::read<QPixmap>(settings, QStringLiteral("TearIcon"), config.tearIcon);
         ConfigHelpers::read<int>(settings, QStringLiteral("TearIconLeftPadding"), config.tearIconLeftPadding);
         ConfigHelpers::read<int>(settings, QStringLiteral("TabHeight"), config.tabHeight);
-        ConfigHelpers::read<int>(settings, QStringLiteral("MinimumTabWidth"), config.minimumTabWidth);
         ConfigHelpers::read<int>(settings, QStringLiteral("CloseButtonSize"), config.closeButtonSize);
-        ConfigHelpers::read<int>(settings, QStringLiteral("TextRightPadding"), config.textRightPadding);
-        ConfigHelpers::read<int>(settings, QStringLiteral("CloseButtonRightPadding"), config.closeButtonRightPadding);
         ConfigHelpers::read<int>(settings, QStringLiteral("CloseButtonMinTabWidth"), config.closeButtonMinTabWidth);
         ConfigHelpers::read<int>(settings, QStringLiteral("ToolTipTabWidthThreshold"), config.toolTipTabWidthThreshold);
         ConfigHelpers::read<bool>(settings, QStringLiteral("ShowOverflowMenu"), config.showOverflowMenu);
         ConfigHelpers::read<int>(settings, QStringLiteral("OverflowSpacing"), config.overflowSpacing);
 
-        g_closeButtonPadding = config.closeButtonRightPadding;
-        g_closeButtonWidth = config.closeButtonSize;
         g_closeButtonMinTabWidth = config.closeButtonMinTabWidth;
         g_toolTipTabWidthThreshold = config.toolTipTabWidthThreshold;
         g_overflowSpacing = config.overflowSpacing;
@@ -120,10 +113,7 @@ namespace AzQtComponents
             QPixmap(),  // TearIcon
             3,          // TearIconLeftPadding
             30,         // TabHeight 28 + 1 (top margin) + 1 (bottom margin)
-            16,         // MinimumTabWidth
             16,         // CloseButtonSize
-            40,         // TextRightPadding
-            4,          // CloseButtonRightPadding
             32,         // CloseButtonMinTabWidth
             96,         // ToolTipTabWidthThreshold
             true,       // ShowOverflowMenu
@@ -529,6 +519,19 @@ namespace AzQtComponents
         setToolTipIfNeeded(m_hoveredTab);
 
         QTabBar::paintEvent(paintEvent);
+
+        // Draw the tear icon (3 vertical dots on draggable tabs)
+        if (isMovable() && !m_movingTab && m_hoveredTab >= 0 && !m_tearIcon.isNull())
+        {
+            const QRect hoveredTabRect = tabRect(m_hoveredTab);
+            const QRect tearIconRectangle(
+                hoveredTabRect.left() + m_tearIconLeftPadding + g_borderWidth,
+                hoveredTabRect.top() + (hoveredTabRect.height() - m_tearIcon.height()) / 2,
+                m_tearIcon.width(),
+                m_tearIcon.height());
+            QPainter painter(this);
+            painter.drawPixmap(tearIconRectangle, m_tearIcon);
+        }
     }
 
     QSize TabBar::minimumSizeHint() const
@@ -541,6 +544,37 @@ namespace AzQtComponents
         minSizeHint.setWidth(0);
 
         return minSizeHint;
+    }
+
+    QSize TabBar::tabSizeHint(int index) const
+    {
+        // Handle tabs shrinking when overflowing
+        QSize size = QTabBar::tabSizeHint(index);
+
+        if (m_overflowing == Overflowing && index != currentIndex())
+        {
+            auto tabWidget = qobject_cast<TabWidget*>(parent());
+            if (!tabWidget)
+            {
+                return size;
+            }
+
+            int availableWidth = tabWidget->width() - tabWidget->count() + 1;
+            if (tabWidget->isActionToolBarVisible())
+            {
+                auto toolBarContainer = qobject_cast<QWidget*>(tabWidget->actionToolBar()->parent());
+                if (toolBarContainer != nullptr)
+                {
+                    availableWidth -= toolBarContainer->size().width();
+                }
+            }
+
+            // The selected tab keeps its full size, the others share the remaining width
+            availableWidth -= tabSizeHint(currentIndex()).width();
+            size.setWidth(availableWidth / (count() - 1));
+        }
+
+        return size;
     }
 
     void TabBar::tabInserted(int /*index*/)
@@ -644,17 +678,6 @@ namespace AzQtComponents
                 int tabWidth = tabRect(i).width();
                 shouldShow &= tabWidth >= g_closeButtonMinTabWidth;
 
-                // Need to explicitly move the button if we want to customize its position
-                // Don't bother moving it if it won't be shown
-                if (shouldShow)
-                {
-                    QPoint p = tabRect(i).topLeft();
-
-                    p.setX(p.x() + tabRect(i).width() - g_closeButtonPadding - g_closeButtonWidth);
-                    p.setY(p.y() + 1 + (tabRect(i).height() - g_closeButtonWidth) / 2);
-                    tabBtn->move(p);
-                }
-
                 tabBtn->setVisible(shouldShow);
 
                 // Remove tooltips from close buttons so we can see the tab ones
@@ -689,10 +712,11 @@ namespace AzQtComponents
     bool TabBar::polish(Style* style, QWidget* widget, const TabWidget::Config& config)
     {
         Q_UNUSED(style);
-        Q_UNUSED(config);
 
         if (auto tabBar = qobject_cast<TabBar*>(widget))
         {
+            tabBar->m_tearIcon = config.tearIcon;
+            tabBar->m_tearIconLeftPadding = config.tearIconLeftPadding;
             tabBar->setUsesScrollButtons(false);
             return true;
         }
@@ -721,116 +745,6 @@ namespace AzQtComponents
         Q_UNUSED(widget);
 
         return config.closeButtonSize;
-    }
-
-    bool TabBar::drawTabBarTabLabel(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const TabWidget::Config& config)
-    {
-        const QStyleOptionTab* tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
-
-        if (!tabOption)
-        {
-            return false;
-        }
-
-        const TabBar* tabBar = qobject_cast<const TabBar*>(widget);
-        if (!tabBar)
-        {
-            return false;
-        }
-
-        // Tear icon drawing can't be done properly using QSS only because text and image can't be positioned differently
-        if (tabBar->isMovable() && (option->state & (QStyle::State_MouseOver | QStyle::State_Sunken)))
-        {
-            painter->save();
-            const QRect tearIconRectangle(
-                option->rect.left() + config.tearIconLeftPadding + g_borderWidth,
-                option->rect.top() + (option->rect.height() - config.tearIcon.height()) / 2,
-                config.tearIcon.width(),
-                config.tearIcon.height());
-            style->baseStyle()->drawItemPixmap(painter, tearIconRectangle, 0, config.tearIcon);
-            painter->restore();
-        }
-
-        painter->save();
-        if (tabBar->m_useMaxWidth)
-        {
-            QRect textRect = style->subElementRect(QStyle::SE_TabBarTabText, option, widget);
-
-            // Extend the label to cover more of the tab width
-            QSize widthExtension = QSize(config.closeButtonSize, 0);
-
-            if (option->state & QStyle::State_MouseOver)
-            {
-                widthExtension /= 4;
-            }
-
-            textRect.setSize(textRect.size() + widthExtension);
-            
-            QString labelText = painter->fontMetrics().elidedText(tabOption->text, Qt::ElideRight, textRect.width());
-            painter->drawText(textRect, Qt::AlignLeft | Qt::AlignVCenter, labelText);
-        }
-        else
-        {
-            style->baseStyle()->drawControl(QStyle::CE_TabBarTabLabel, option, painter, widget);
-        }
-        painter->restore();
-
-        return true;
-    }
-
-    QSize TabBar::sizeFromContents(const Style* style, QStyle::ContentsType type, const QStyleOption* option, const QSize& contentsSize, const QWidget* widget, const TabWidget::Config& config)
-    {
-        const QStyleOptionTab* tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
-
-        if (!tabOption)
-        {
-            return QSize();
-        }
-
-        const TabBar* tabBar = qobject_cast<const TabBar*>(widget);
-        if (!tabBar)
-        {
-            return QSize();
-        }
-
-        QSize size = style->baseStyle()->sizeFromContents(type, tabOption, contentsSize, widget);
-
-        size.setHeight(config.tabHeight);
-
-        if (tabBar->m_overflowing != Overflowing || (tabOption->state & QStyle::State_Selected))
-        {
-            size.setWidth(size.width() + config.textRightPadding);
-            if (!tabBar->tabsClosable())
-            {
-                size -= QSize(config.closeButtonSize + 1, 0);
-            }
-        }
-        else
-        {
-            auto tabWidget = qobject_cast<TabWidget*>(tabBar->parent());
-            if (!tabWidget)
-            {
-                return {};
-            }
-
-            int availableWidth = tabWidget->width() - tabWidget->count() + 1;
-            if (tabWidget->isActionToolBarVisible())
-            {
-                auto toolBarContainer = qobject_cast<QWidget*>(tabWidget->actionToolBar()->parent());
-                if (toolBarContainer != nullptr)
-                {
-                    availableWidth -= toolBarContainer->size().width();
-                }
-            }
-
-            QStyleOptionTab selectedOptions;
-            tabBar->initStyleOption(&selectedOptions, tabBar->currentIndex());
-            QSize selectedSize = sizeFromContents(style, type, &selectedOptions, contentsSize, tabBar, config);
-            availableWidth -= selectedSize.width();
-            size.setWidth(availableWidth / (tabBar->count() - 1));
-        }
-
-        return size;
     }
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.cpp
@@ -551,7 +551,7 @@ namespace AzQtComponents
         // Handle tabs shrinking when overflowing
         QSize size = QTabBar::tabSizeHint(index);
 
-        if (m_overflowing == Overflowing && index != currentIndex())
+        if (m_overflowing == Overflowing)
         {
             auto tabWidget = qobject_cast<TabWidget*>(parent());
             if (!tabWidget)
@@ -560,18 +560,26 @@ namespace AzQtComponents
             }
 
             int availableWidth = tabWidget->width() - tabWidget->count() + 1;
-            if (tabWidget->isActionToolBarVisible())
+
+            // Reserve the space taken by the top-right corner widget, which holds the
+            // action toolbar and/or the overflow button
+            if (auto* corner = tabWidget->cornerWidget(Qt::TopRightCorner))
             {
-                auto toolBarContainer = qobject_cast<QWidget*>(tabWidget->actionToolBar()->parent());
-                if (toolBarContainer != nullptr)
-                {
-                    availableWidth -= toolBarContainer->size().width();
-                }
+                availableWidth -= corner->width();
             }
 
-            // The selected tab keeps its full size, the others share the remaining width
-            availableWidth -= tabSizeHint(currentIndex()).width();
-            size.setWidth(availableWidth / (count() - 1));
+            if (index == currentIndex())
+            {
+                // The selected tab keeps its full size, but is never wider than the whole
+                // tab bar region.
+                size.setWidth(qMax(0, qMin(size.width(), availableWidth)));
+            }
+            else
+            {
+                // The other tabs share whatever width is left after the selected tab
+                const int remainingWidth = availableWidth - tabSizeHint(currentIndex()).width();
+                size.setWidth(qMax(0, remainingWidth / (count() - 1)));
+            }
         }
 
         return size;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.h
@@ -45,10 +45,7 @@ namespace AzQtComponents
             QPixmap tearIcon;               //!< The icon shown on the left side of a tab to show it can be dragged. Must be an svg image.
             int tearIconLeftPadding;        //!< Padding between the tear icon and the left side of the tab, in pixels.
             int tabHeight;                  //!< Height of a tab, in pixels.
-            int minimumTabWidth;            //!< Minimum size of tabs when shrunk, in pixels.
             int closeButtonSize;            //!< Size of the close button, both width and height, in pixels.
-            int textRightPadding;           //!< Padding between the tab text and the close button, in pixels.
-            int closeButtonRightPadding;    //!< Padding between the close button and the right side of the tab, in pixels.
             int closeButtonMinTabWidth;     //!< Width threshold below which the close button is not shown, in pixels.
             int toolTipTabWidthThreshold;   //!< Width threshold below which a tooltip is displayed, in pixels.
             bool showOverflowMenu;          //!< Whether an overflow dropdown menu listing the tabs should be displayed on resize.
@@ -177,6 +174,7 @@ namespace AzQtComponents
         void mouseReleaseEvent(QMouseEvent* mouseEvent) override;
         void paintEvent(QPaintEvent* paintEvent) override;
         QSize minimumSizeHint() const override;
+        QSize tabSizeHint(int index) const override;
         void SetUseMaxWidth(bool use) { m_useMaxWidth = use; }
 
 
@@ -196,6 +194,8 @@ namespace AzQtComponents
         int m_hoveredTab = -1;
         bool m_movingTab = false;
         QPoint m_lastMousePress;
+        QPixmap m_tearIcon;
+        int m_tearIconLeftPadding = 0;
 
         QCursor m_dragCursor;
         QCursor m_hoverCursor;
@@ -209,8 +209,6 @@ namespace AzQtComponents
         static bool polish(Style* style, QWidget* widget, const TabWidget::Config& config);
         static bool unpolish(Style* style, QWidget* widget, const TabWidget::Config& config);
         static int closeButtonSize(const Style* style, const QStyleOption* option, const QWidget* widget, const TabWidget::Config& config);
-        static bool drawTabBarTabLabel(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const TabWidget::Config& config);
-        static QSize sizeFromContents(const Style* style, QStyle::ContentsType type, const QStyleOption* option, const QSize& contentsSize, const QWidget* widget, const TabWidget::Config& config);
     };
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TabWidget.qss
@@ -28,6 +28,11 @@ AzQtComponents--TabWidget > QWidget
     background-color: #444444;
 }
 
+AzQtComponents--TabWidget QMenu
+{
+    background-color: #222222;
+}
+
 AzQtComponents--TabWidget:pane
 {
     border: 0 none;
@@ -44,15 +49,28 @@ AzQtComponents--TabBar
     background-color: #111111;
     margin-bottom: 0;
     min-height: 28px;
+
+    /* Disable the tab slide animation as the text is not animated */
+    widget-animation-duration: 0;
 }
 
 AzQtComponents--TabBar:tab
 {
     border: 1px solid #111111;
     background-color: #333333;
+    padding: 6px 21px 6px 9px; /* top, right, bottom, left */
+}
 
-    text-align: left;
-    padding: 6px -2px 6px 9px; /* top, right, bottom, left */
+AzQtComponents--TabBar::close-button
+{
+    image: url(":/stylesheet/img/close_small.svg");
+    margin-right: 4px;
+}
+
+AzQtComponents--TabBar::close-button:hover
+{
+    background-color: rgba(255, 255, 255, 0.2);
+    border-radius: 2px;
 }
 
 AzQtComponents--TabBar::tab:text
@@ -120,14 +138,8 @@ AzQtComponents--TabBar.Secondary::tab
     background-color: #444444;
     border: 0 none;
     border-bottom: 3px solid #333333;
-    text-align: center;
-    padding: 7px 0 5px 14px;
+    padding: 7px 14px 5px 14px;
     color: #959595;
-}
-
-AzQtComponents--TabBar.Secondary::close-button
-{
-    image: url(":/stylesheet/img/close_small.svg");
 }
 
 AzQtComponents--TabBar.Secondary::tab:hover
@@ -140,7 +152,7 @@ AzQtComponents--TabBar.Secondary::tab:hover
 AzQtComponents--TabBar.Secondary.Bordered::tab
 {
     border-top: 1px solid #111111;
-    padding: 6px 0 6px 14px;
+    padding: 6px 14px 6px 14px;
 }
 
 AzQtComponents--TabBar.Secondary::tab:selected

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TitleBar.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TitleBar.qss
@@ -84,6 +84,7 @@ AzQtComponents--TabBar AzQtComponents--DockBarButton
     max-width: 14px;
     min-height: 14px;
     max-height: 14px;
+    margin-right: 4px;
 }
 
 QToolButton#minimizeButton,


### PR DESCRIPTION
## What does this PR do?

Fix item 4 of https://github.com/o3de/o3de/issues/19855.

| Qt5 | Qt6 without PR | Qt6 with PR |
| --- | --- | --- |
| <img width="628" height="555" alt="qt5" src="https://github.com/user-attachments/assets/0dc42685-24ba-420b-a456-aa2fca4b0c9b" />| <img width="588" height="565" alt="qt6-nofix" src="https://github.com/user-attachments/assets/106ba6e1-070d-4813-b29f-88b1b2218ada" /> | <img width="646" height="562" alt="qt6" src="https://github.com/user-attachments/assets/fa271f32-781e-45d2-8669-cb288ad9bd95" /> |

**Drag behavior :**

Compared to vanilla QT, with have the 3 vertical dot and instant move.

https://github.com/user-attachments/assets/4677c1d2-ad4f-47f9-97c6-e216b15c4985

**Overflow behavior :**

Compared to vanilla QT, we resize tabs on overflow of the main container to allow shrinking the main container as much as we want

https://github.com/user-attachments/assets/559c2799-a68b-479b-8e0f-de489341f6b4

## How was this PR tested?

Local windows build, testing various setup in the ControlGalleryApp and in the Editor (ScriptCanvas, Animation editor, etc)