### PR TITLE
Fixes a crash in the inspector when modifying values

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -588,7 +588,8 @@ namespace AZ::DocumentPropertyEditor
                 }
                 return overallResult;
             }
-            else if (!value.IsOpaqueValue())
+
+            if (!value.IsOpaqueValue())
             {
                 // CallbackAttributes that return a value may be bound to a simple value of that type
                 // In that case, ignore our parameters and simply return the value


### PR DESCRIPTION
## What does this PR do?

Fixes a crash related to issue 
https://github.com/o3de/o3de/issues/19894

The message which appears is:
 "Variant does not contain alternative at index 11"

## How was this PR tested?

This was a 100% crash picked up every single time by VS and ASAN, easy to repro.

After the fix, it worked correctly, including all these callbacks that were not working before.
Tested with prefabs, overrides, and also drop downs, enums, changenotifies with functions.

Most likely we got away with this since 2011 due to lucky memory layout.

## Explanation of why this happens

### Background info
When the DPE (Document Property Editor) builds its document tree, it keeps track of any callback functions it needs to call, for example, Change Notify.

It does so by adding additional DOM Nodes (ie, DOMValue type) in the metadata about a particular element.  For example,on an element where a change notify is bound to a function, like this
```cpp
   ->Attribute(AZ::Edit::ChangeNotify, &EditorMeshComponent::SomeFunctionToCall)
```

this is what it looks like in the DOM
```
root:  Object
   member[0] : "$type" : DOMValue("AZ::Attribute") string literal
   member[1] : "attribute" : Object
                    member[0] : "$type" : "pointer" string literal
                    member[1] : "value" : 0xf1231321321 __uintPtr64 literal
   member[2] : "instance" : Object
                    member[0] : "$type" : "pointer" string literal
                    member[1] : "value" : 0xf02313213) __uintPtr64 literal
                    member[2] : "pointerType" : "AZ::Render::EditorMeshComponent" string literal
 ```
 
 As JSON, the above would look like this
``` json
{
   "$type" : "AZ::Attribute",
    "attribute" : {
      "$type" : "pointer",
      "value" : "0xf1231321321"
    }
    "instance" : {
       "$type" : "pointer",
       "value" : "0xf02313213",
       "pointerType" : "AZ::Render::EditorMeshComponent"
       }
}
```

This encodes the function to call's address (attribute) as well as the "this" pointer (instance) to use when calling it.

Another way attributes can be expressed is literal values, for example, you can have an attribute bound to just a literal value like bool, like this in your reflection:
```cpp
   ->Attribute(AZ::EditorAttributes::AutoExpand, true)
```

In that case, the return type in question (true) is a `bool`, a bool is a primitive type in the DOM (think of the various types a json document supports natively).  So the DOM Representation of this is just a literal:
```
root:  DOMValue(true) bool literal
```

the JSON document representation would just be a bool literal (no reason to make a whole tree of objects to represent a bool):
```json
true
````

Another way attributes can be expressed is custom typed values, for example, a struct or class that isn't one of the basic types that you can store directly in a DOM node.  In the case of ChangeNotify, the return type is AZ::Crc32 and AZ::Crc32 is a `class` that has a member `m_value`.  It isn't itself a primitive type.  

In the code, this attribute looks like this
```cpp
 ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
```
Note that `Edit::PropertyRefreshLevels::ValuesOnly` is an AZ::Crc32 object, which is a c++ class, not a primitive type like bool or int.

Because it cannot store an AZ::Crc32 directly into a dom node directly, it uses reflection to write it to a DOM.  The "reflect" function for an AZ::Crc32 is this:
```cpp
void Crc32::Reflect(AZ::SerializeContext& context)
{
    context.Class<Crc32>()
        ->Field("Value", &Crc32::m_value);  // Crc32::m_value is an int
}
```

So written to a DOM it looks like this
```
root:  Object
   member[0] "Value" : literal uint32 1239761296213
```

or json, it looks like this (since an Object is a key-value pair dictionary)
```json
{
    "Value" : 1239761296213
}
```

The final way it can store a callback attribute value is in an opaque type.  It uses opaque types when it cannot serialize the type, its not declared to reflection, etc.  In that case, it internally stores it as an AZ::Any<T>, and the DOM cannot access the value, it an only unwrap it on demand.

e.g.
```cpp
   ->Attribute(SomeAttribute, SomeComplexType(12321, true, false));
```

If "SomeComplexType" is not reflected to the reflection system, the final DOM looks like this
```
root: OpaqueType (typeid is available)
```

It cannot store this to JSON, so there is no JSON equivalent (no serializer).  When the callback function is invoked, it directly marshals the Opaque Type into the return type, using azstd::any's marshalling.

You can also bind multiple different OnChange callbacks to one element in the document (since multiple different things might be interested in being notified).  If this is the case, then the root of the value just turns into an Array instead, and each element in the array is one of the above kinds of DOMValues.

### How the bug happens

When Change Notify happens, the DPE calls `InvokeOnDomValue`, passing it that value we discussed above - that Value is either an `Object` which encodes a function call with a `attribute` and `instance`, members or its a literal `Object` that can be unpacked and returned (like the CRC32 example), or it is an actual Value that is a simple literal (like bool), or it is an Opaque value, or it is an array of the above.

The bug is in the `InvokeOnDomValue` function.

Its pseudocode does this:

```cpp
if (value is an object)
{
     if (it can find the `type` member)
     {
        if (it can find the `attribute` member)
        {
            return (invoke the function given in `attribute` member with `this` pointer in `instance` member);
        }
     }
}
else if (it is an Array)
{
     recurse into self with each array member.
     return the value returned by the last one.
}
else if (its not an opaque object) // so like a crc32 or a simple value
{
    Unpack it and return it
} 

// it must be an opaque value if we get here!
directly cast the OpaqueValue (which is an AZStd::any<T>) into the return value, and return it.
```

The bug is in the "else if" of `else if (its not an opaque object)`

Whats going on here is that it ends up having an object that is serialized as an object, like a AZ::Crc32

```
root:  Object
   member[0] "Value" : literal uint32 1239761296213
```

This causes it to enter the "If its an object" block
but its not a function call.
So it doesn't make the function call.
But because there's an "else if" on the `else if (its not an opaque object)` it does not check if its a deserializable object and *assumes* its a Opaque object, passing right over the block.

Yes, it took several days to figure out the 4 characters to delete (`else`) to fix this.