### PR TITLE
Various fixes for Qt6 regressions

### DIFF
--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.cpp
@@ -11,18 +11,19 @@
 #include "WelcomeScreenDialog.h"
 
 // Qt
-#include <QTableWidget>
-#include <QTableWidgetItem>
-#include <QToolTip>
-#include <QMenu>
+#include <QDateTime>
 #include <QDesktopServices>
 #include <QFileDialog>
+#include <QHeaderView>
+#include <QMenu>
 #include <QMessageBox>
-#include <QScreen>
-#include <QTimer>
-#include <QDateTime>
 #include <QRegularExpression>
 #include <QRegularExpressionValidator>
+#include <QScreen>
+#include <QTimer>
+#include <QToolTip>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
 
 #include <AzCore/Utils/Utils.h>
 
@@ -92,8 +93,11 @@ WelcomeScreenDialog::WelcomeScreenDialog(QWidget* pParent)
     ui->recentLevelTable->setColumnCount(3);
     ui->recentLevelTable->setMouseTracking(true);
     ui->recentLevelTable->setContextMenuPolicy(Qt::CustomContextMenu);
-    ui->recentLevelTable->horizontalHeader()->hide();
-    ui->recentLevelTable->verticalHeader()->hide();
+    ui->recentLevelTable->setHeaderHidden(true);
+    ui->recentLevelTable->setRootIsDecorated(false);
+    ui->recentLevelTable->setIndentation(0);
+    ui->recentLevelTable->setUniformRowHeights(true);
+    ui->recentLevelTable->setAllColumnsShowFocus(true);
     ui->recentLevelTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     ui->recentLevelTable->setSelectionMode(QAbstractItemView::SingleSelection);
     ui->recentLevelTable->setIconSize(QSize(20, 20));
@@ -111,8 +115,8 @@ WelcomeScreenDialog::WelcomeScreenDialog(QWidget* pParent)
 
     connect(ui->recentLevelTable, &QWidget::customContextMenuRequested, this, &WelcomeScreenDialog::OnShowContextMenu);
 
-    connect(ui->recentLevelTable, &QTableWidget::entered, this, &WelcomeScreenDialog::OnShowToolTip);
-    connect(ui->recentLevelTable, &QTableWidget::clicked, this, &WelcomeScreenDialog::OnRecentLevelTableItemClicked);
+    connect(ui->recentLevelTable, &QTreeWidget::entered, this, &WelcomeScreenDialog::OnShowToolTip);
+    connect(ui->recentLevelTable, &QTreeWidget::clicked, this, &WelcomeScreenDialog::OnRecentLevelTableItemClicked);
 
     connect(ui->newLevelButton, &QPushButton::clicked, this, &WelcomeScreenDialog::OnNewLevelBtnClicked);
     connect(ui->levelFileLabel, &QLabel::linkActivated, this, &WelcomeScreenDialog::OnNewLevelLabelClicked);
@@ -154,9 +158,9 @@ bool WelcomeScreenDialog::eventFilter(QObject *watched, QEvent *event)
 {
     if (event->type() == QEvent::Show)
     {
-        ui->recentLevelTable->horizontalHeader()->resizeSection(0, ui->nameLabel->width());
-        ui->recentLevelTable->horizontalHeader()->resizeSection(1, ui->modifiedLabel->width());
-        ui->recentLevelTable->horizontalHeader()->resizeSection(2, ui->typeLabel->width());
+        ui->recentLevelTable->header()->resizeSection(0, ui->nameLabel->width());
+        ui->recentLevelTable->header()->resizeSection(1, ui->modifiedLabel->width());
+        ui->recentLevelTable->header()->resizeSection(2, ui->typeLabel->width());
     }
 
     return QDialog::eventFilter(watched, event);
@@ -200,8 +204,10 @@ void WelcomeScreenDialog::SetRecentFileList(RecentFileList* pList)
 
     int recentListSize = pList->GetSize();
     int currentRow = 0;
-    ui->recentLevelTable->setRowCount(recentListSize);
-     for (int i = 0; i < recentListSize; ++i)
+
+    constexpr int rowHeight = 48;
+    ui->recentLevelTable->clear();
+    for (int i = 0; i < recentListSize; ++i)
     {
         const QString& recentFile = pList->m_arrNames[i];
         if (recentFile.endsWith(m_levelExtension) && IsValidLevelName(recentFile))
@@ -228,32 +234,31 @@ void WelcomeScreenDialog::SetRecentFileList(RecentFileList* pList)
                     // the active-source check above and skip it.
                     if (isGemRooted || fullPath.contains(gamePath))
                     {
+                        auto* item = new QTreeWidgetItem(ui->recentLevelTable);
+                        item->setText(0, name);
                         if (gSettings.prefabSystem)
                         {
                             QIcon icon;
                             icon.addFile(QString::fromUtf8(":/Level/level.svg"), QSize(), QIcon::Normal, QIcon::Off);
-                            ui->recentLevelTable->setItem(currentRow, 0, new QTableWidgetItem(icon, name));
-                        }
-                        else
-                        {
-                            ui->recentLevelTable->setItem(currentRow, 0, new QTableWidgetItem(name));
+                            item->setIcon(0, icon);
                         }
                         QFileInfo file(recentFile);
                         QString date = QLocale::system().toString(file.lastModified(), QLocale::ShortFormat);
-                        ui->recentLevelTable->setItem(currentRow, 1, new QTableWidgetItem(date));
-                        ui->recentLevelTable->setItem(currentRow++, 2, new QTableWidgetItem(tr("Level")));
+                        item->setText(1, date);
+                        item->setText(2, tr("Level"));
+                        item->setSizeHint(0, QSize(0, rowHeight));
+                        ++currentRow;
                         m_levels.push_back(std::make_pair(name, recentFile));
                     }
                 }
             }
         }
     }
-    ui->recentLevelTable->setRowCount(currentRow);
-    ui->recentLevelTable->setMinimumHeight(currentRow * ui->recentLevelTable->verticalHeader()->defaultSectionSize());
-    ui->recentLevelTable->setMaximumHeight(currentRow * ui->recentLevelTable->verticalHeader()->defaultSectionSize());
+    ui->recentLevelTable->setMinimumHeight(currentRow * rowHeight);
+    ui->recentLevelTable->setMaximumHeight(currentRow * rowHeight);
     ui->levelFileLabel->setVisible(currentRow ? false : true);
 
-    ui->recentLevelTable->setCurrentIndex(QModelIndex());
+    ui->recentLevelTable->setCurrentItem(nullptr);
 }
 
 
@@ -261,7 +266,7 @@ void WelcomeScreenDialog::RemoveLevelEntry(int index)
 {
     TNamePathPair levelPath = m_levels[index];
 
-    ui->recentLevelTable->removeRow(index);
+    delete ui->recentLevelTable->takeTopLevelItem(index);
     m_levels.erase(m_levels.begin() + index);
 
 
@@ -309,7 +314,7 @@ void WelcomeScreenDialog::OnShowContextMenu(const QPoint& pos)
     QModelIndex index = ui->recentLevelTable->indexAt(pos);
     if (index.isValid())
     {
-        QString level = ui->recentLevelTable->itemAt(pos)->text();
+        QString level = ui->recentLevelTable->itemAt(pos)->text(0);
 
         QPoint globalPos = ui->recentLevelTable->viewport()->mapToGlobal(pos);
 

--- a/Code/Editor/WelcomeScreen/WelcomeScreenDialog.ui
+++ b/Code/Editor/WelcomeScreen/WelcomeScreenDialog.ui
@@ -538,7 +538,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QTableWidget" name="recentLevelTable">
+           <widget class="QTreeWidget" name="recentLevelTable">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -554,33 +554,36 @@
             <property name="horizontalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOff</enum>
             </property>
+            <property name="rootIsDecorated">
+             <bool>false</bool>
+            </property>
+            <property name="uniformRowHeights">
+             <bool>true</bool>
+            </property>
+            <property name="itemsExpandable">
+             <bool>false</bool>
+            </property>
             <property name="columnCount">
              <number>3</number>
             </property>
-            <attribute name="horizontalHeaderVisible">
+            <attribute name="headerVisible">
              <bool>false</bool>
             </attribute>
-            <attribute name="horizontalHeaderStretchLastSection">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="verticalHeaderVisible">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="verticalHeaderMinimumSectionSize">
-             <number>1</number>
-            </attribute>
-            <attribute name="verticalHeaderDefaultSectionSize">
-             <number>48</number>
-            </attribute>
-            <attribute name="verticalHeaderHighlightSections">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="verticalHeaderStretchLastSection">
-             <bool>false</bool>
-            </attribute>
-            <column/>
-            <column/>
-            <column/>
+            <column>
+             <property name="text">
+              <string notr="true">Name</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string notr="true">Modified</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string notr="true">Type</string>
+             </property>
+            </column>
            </widget>
           </item>
           <item>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -331,7 +331,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     void ViewportUiDisplay::CreateViewportBorder(
         const AZStd::string& borderTitle, AZStd::optional<ViewportUiBackButtonCallback> backButtonCallback)
     {
-        m_uiOverlay.setStyleSheet(QString("border: %1px solid %2; border-top: %3px solid %4;")
+        m_uiOverlay.setStyleSheet(QString("#ViewportUiOverlay { border: %1px solid %2; border-top: %3px solid %4; }")
                                       .arg(
                                           QString::number(HighlightBorderSize), HighlightBorderColor,
                                           QString::number(ViewportUiTopBorderSize), HighlightBorderColor));
@@ -370,7 +370,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     void ViewportUiDisplay::RemoveViewportBorder()
     {
         m_viewportBorderText.hide();
-        m_uiOverlay.setStyleSheet("border: none;");
+        m_uiOverlay.setStyleSheet("#ViewportUiOverlay { border: none; }");
         m_uiOverlayLayout.setContentsMargins(ViewportElementMargins());
         m_viewportBorderBackButtonCallback.reset();
         m_viewportBorderBackButton.hide();
@@ -435,6 +435,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         m_fullScreenLayout.addWidget(&m_viewportBorderText, 0, 0, Qt::AlignTop | Qt::AlignHCenter);
 
         m_viewportBorderBackButton.setAutoRaise(true); // hover highlight
+        m_viewportBorderBackButton.setFixedHeight(ViewportUiTopBorderSize);
         m_viewportBorderBackButton.hide();
 
         QIcon backButtonIcon(QString(":/stylesheet/img/UI20/toolbar/%1").arg(HighlightBorderBackButtonIconFile));

--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -12,11 +12,6 @@ QMainWindow {
     min-height:700px;
 }
 
-QPushButton:focus {
-    outline: none;
-    border:1px solid #1e70eb;
-}
-
 QPushButton[primary="true"] {
     qproperty-flat: true;
     background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,


### PR DESCRIPTION
## What does this PR do?

This fixes 3 low-priority items from https://github.com/o3de/o3de/issues/19855

| Without fix | With fix
| --- | --- |
| <img width="700" height="122" alt="image" src="https://github.com/user-attachments/assets/493011a3-1ebe-4074-ab68-7e137ca7bd45" /> |  <img width="694" height="124" alt="image" src="https://github.com/user-attachments/assets/3ca1ca58-4e64-41b5-ac29-bd312dcce157" />|
| <img width="303" height="216" alt="image" src="https://github.com/user-attachments/assets/564b94aa-e556-49fd-a48c-8f4107be93c7" /> |  <img width="238" height="98" alt="image" src="https://github.com/user-attachments/assets/73aa2cc3-98d8-4fc7-bf95-2a97653ca459" />|
| <img width="692" height="133" alt="image" src="https://github.com/user-attachments/assets/bbca7a15-849f-422c-b0cd-595a73b72480" /> | <img width="944" height="321" alt="image" src="https://github.com/user-attachments/assets/51f6d818-2fb3-4e7d-be43-c685dfeda793" /> |

### 1 - Component edit-mode cross misplaced

The stylesheet applied on the top container was leaking into sub-items and the icon was wrongly resized.

### 2 - Project manager "new project" button styling

The button styling in o3de is highly custom (see Code\Framework\AzQtComponents\AzQtComponents\Components\Widgets\PushButton.h), so we have to prevent any .qss rule from styling them else the custom styling will not be triggered. Checked all pages of the Project Manager, this rule removal don't seems to have side effects

### 3 - Welcome screen row mousehover behavior

Switched from a QTreeWidget to a QTableWidget, the QTreeWidget wasn't falling into our custom styling logic to have the mouse-hover outline the full row. We have a few other occurences of QTreeWidget in the codebase, will try to check them all see how they behave and if further adjustments needs to be done. This Welcome screen fix seemed a low-risk and higher priority.

## How was this PR tested?

Local build on windows