### PR TITLE
Fix LuaIDE crash on exit (double free).

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.cpp
@@ -144,7 +144,6 @@ namespace AzQtComponents
 
         if (m_style)
         {
-            delete m_style.data();
             m_style.clear();
         }
     }


### PR DESCRIPTION
## What does this PR do?

I noticed when I started debugging LuaIDE when starting without the Editor. I had crashes when trying to exit the application. If am not wrong we lneed to remove manual deletion of m_style to prevent a double-free crash, as QApplication already takes ownership. This also is even mentioned in the comment of the variable itself.
Hope I don't miss here something.

## Reproduction (Linux)

On Linux, I just started LuaIDE and hit the close button and saw the crash.

## How was this PR tested?

On my local Kubuntu 26.04.

