### PR TITLE
Trust the user when they specify an engine

### DIFF
--- a/cmake/o3deConfigVersion.cmake
+++ b/cmake/o3deConfigVersion.cmake
@@ -27,6 +27,9 @@ if(NOT o3de_project_json)
         if(EXISTS ${O3DE_USER_PROJECT_JSON_PATH})
             file(READ "${O3DE_USER_PROJECT_JSON_PATH}" o3de_user_project_json)
             string(JSON user_project_engine ERROR_VARIABLE json_error GET ${o3de_user_project_json} engine)
+            if(json_error)
+                string(JSON user_project_engine ERROR_VARIABLE json_error GET ${o3de_user_project_json} engine_path)
+            endif()
             if(user_project_engine AND NOT json_error)
                 # The user has taken some action to set what engine to use.
                 # Trust the user that the engine is compatible.

--- a/cmake/o3deConfigVersion.cmake
+++ b/cmake/o3deConfigVersion.cmake
@@ -13,7 +13,7 @@
 set(PACKAGE_VERSION_COMPATIBLE FALSE)
 set(PACKAGE_VERSION_EXACT FALSE)
 
-# Store the project.json with any overrides from <project>/user/project.json 
+# Store the project.json with any overrides from <project>/user/project.json
 # in a global property to avoid the performance hit of loading multiple times
 # The project's CMake will likely have already set this for us, but just in case
 get_property(o3de_project_json GLOBAL PROPERTY O3DE_PROJECT_JSON)
@@ -28,10 +28,14 @@ if(NOT o3de_project_json)
             file(READ "${O3DE_USER_PROJECT_JSON_PATH}" o3de_user_project_json)
             string(JSON user_project_engine ERROR_VARIABLE json_error GET ${o3de_user_project_json} engine)
             if(user_project_engine AND NOT json_error)
-                string(JSON o3de_project_json SET "${o3de_project_json}" engine "\"${user_project_engine}\"" )
+                # The user has taken some action to set what engine to use.
+                # Trust the user that the engine is compatible.
+                message(VERBOSE "The user has specified an engine to use. Trust the user.")
+                set(PACKAGE_VERSION_COMPATIBLE TRUE)
+                return()
             elseif(json_error AND ${user_project_engine} STREQUAL "NOTFOUND")
                 # When the value is just NOTFOUND that means there is a JSON
-                # parsing error, and not simply a missing key 
+                # parsing error, and not simply a missing key
                 message(WARNING "Unable to read 'engine' from '${O3DE_USER_PROJECT_JSON_PATH}'\nError: ${json-error}")
             endif()
         endif()
@@ -65,7 +69,7 @@ string(JSON project_engine ERROR_VARIABLE json_error GET ${o3de_project_json} en
 if(json_error OR NOT project_engine)
     if(NOT project_engine)
         # Check if the project folder is a subdirectory of this engine and would
-        # be found using scan up logic 
+        # be found using scan up logic
         cmake_path(IS_PREFIX this_engine_path "${CMAKE_CURRENT_SOURCE_DIR}" NORMALIZE is_in_engine_tree)
         if(is_in_engine_tree)
             message(VERBOSE "The project folder is a subdirectory of this engine.")
@@ -78,7 +82,7 @@ if(json_error OR NOT project_engine)
     return()
 endif()
 
-# Split the engine field into engine name and version specifier 
+# Split the engine field into engine name and version specifier
 unset(project_engine_name)
 unset(project_engine_op)
 unset(project_engine_version)
@@ -125,13 +129,13 @@ if(project_engine_op AND project_engine_version)
     elseif(op STREQUAL "===" AND version STREQUAL specifier_version)
         set(contains_version TRUE)
     elseif(op STREQUAL "~=")
-        # compatible versions have an equivalent combination of >= and == 
+        # compatible versions have an equivalent combination of >= and ==
         # e.g. ~=2.2 is equivalent to >=2.2,==2.*
         if(version VERSION_GREATER_EQUAL specifier_version)
             string(REPLACE "." ";" specifer_version_part_list ${specifier_version})
             list(LENGTH specifer_version_part_list list_length)
             if(list_length LESS 2)
-                # truncating would leave nothing to compare 
+                # truncating would leave nothing to compare
                 set(contains_version TRUE)
             else()
                 # trim the last version part because CMake doesn't support '*'


### PR DESCRIPTION
## What does this PR do?

Users can specify an engine, creating a `user/project.json` file that holds a path to an engine. Currently, O3DE still runs this engine through the rest of the engine finding checks, which often causes this setup to fail validation in unexpected ways, and requires working around by changing the `engine` field in the main `project.json` file to match the referenced engine, which may not be desirable. (For example, an engine dev working on a custom fork for a specific project.)

Also, the version compatibility check originally looked for `engine` in `user/project.json`, which meant it always failed, because Project Manager sets it as `engine_path`. This PR updates the logic to look first for `engine`, then `engine_path` for before failing, to aid in backwards compatibility while also fixing the bug.

## How was this PR tested?

Manual testing

1. Create a project with this engine
2. Change the project to use a different engine with a different `engine_name` value. This will create a `user/project.json` file
3. Set `user/project.json` manually back to this engine's path, and make sure the `engine` field in `project.json` uses a name that does not match this engine's registered name
4. Build the project. It should build without a compatibility error.

**Note:** Project Manager both adds the `user/project.json` file and sets the main `project.json` file's `engine` field. This is why changing engines via Project Manager always worked. It was masking the `user/project.json`'s failure by falling back to the `project.json` value, which matched the target engine.

## References

- It was decided at the [TSC meeting on 6/30/2026](https://github.com/o3de/tsc/blob/main/meetings/notes/tsc-meeting-20260630.md) that when `user/project.json` is set to a specific engine, o3de should heed it and trust the user.
- This is part of the changes for addressing #19885 
