### PR TITLE
Removes the negative lookahead regex from AssetProcessor config (PAK)

### DIFF
--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -431,9 +431,8 @@
                     "glob": "*.ext",
                     "params": "copy"
                 },
-                // Copy all pak files except level.pak, level.pak has its own builder.
                 "RC pak": {
-                    "pattern": "^((?!\\\\/level\\\\.pak).)*\\\\.pak$",
+                    "glob": "*.pak",
                     "params": "copy"
                 },
                 "RC ctc": {


### PR DESCRIPTION
## What does this PR do?

The AssetProcessor config file was attempting to copy "All Pak Files except for level.pak" into the cache.

This is a holdover from Crytek - we no longer do anything special about "level.pak" or generate any pak files into the source folder.  The regex was extremely expensive, costing over 1000 steps for a fairly normal string.  This slowed AP startup time.

Instead, I use a simple file pattern, *.pak, to ensure backwards compatibility for the case where a user has manually placed some pak file in their source folder for some reason.  We don't do this by default - when we generate paks, we do it to a completely different installation folder.

## How was this PR tested?

Running through AP, checking that the startup still works, paks still copy.
Note that in debug mode, some file paths actually crash due to stack overflow if your path is long enough.  Regexes with negative look-ahead recurse.

