### PR TITLE
Remove `engines_path` from registration flow.

### DIFF
--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -225,60 +225,6 @@ def register_all_repos_in_folder(repos_path: pathlib.Path,
     return register_all_o3de_objects_of_type_in_folder(repos_path, 'repo', remove, force, None, engine_path=engine_path)
 
 
-def remove_engine_name_to_path(json_data: dict,
-                               engine_path: pathlib.Path) -> int:
-    """
-    Remove the engine at the specified path if it exist in the o3de manifest
-    :param json_data in-memory json view of the o3de_manifest.json data
-    :param engine_path path to engine to remove from the manifest data
-    returns 0 to indicate no issues has occurred with removal
-    """
-    if engine_path.is_dir() and validation.valid_o3de_engine_json(pathlib.Path(engine_path).resolve() / 'engine.json'):
-        engine_json_data = manifest.get_engine_json_data(engine_path=engine_path)
-        if 'engine_name' in engine_json_data and 'engines_path' in json_data:
-            engine_name = engine_json_data['engine_name']
-            try:
-                del json_data['engines_path'][engine_name]
-            except KeyError:
-                # Attempting to remove a non-existent engine_name is fine
-                pass
-
-    return 0
-
-
-def add_engine_name_to_path(json_data: dict, engine_path: pathlib.Path, force: bool):
-    # This functionality is deprecated and exists to allow older projects
-    # to find newer versions of the engine which no longer require the engine name
-    # exist in "engines_path"
-
-    # Add an engine path JSON object which maps the "engine_name" -> "engine_path"
-    engine_json_data = manifest.get_engine_json_data(engine_path=engine_path)
-    if not engine_json_data:
-        logger.error(f'Unable to retrieve json data from engine.json at path {engine_path.as_posix()}')
-        return 1
-    engines_path_json = json_data.setdefault('engines_path', {})
-    if 'engine_name' not in engine_json_data:
-        logger.error(f'engine.json at path {engine_path.as_posix()} is missing "engine_name" key')
-        return 1
-
-    engine_name = engine_json_data['engine_name']
-    if not force and engine_name in engines_path_json and \
-            pathlib.PurePath(engines_path_json[engine_name]) != engine_path:
-        logger.info(f'Engine successfully registered.')
-        logger.warning(
-            f'Important notice regarding older projects created with engine version 22.10 or earlier:\n'
-            f'An engine named "{engine_name}" is already registered at "{pathlib.Path(engines_path_json[engine_name]).as_posix()}"\n'
-            f'If you have projects created with engine version 22.10 or earlier, and you want them to use this engine'
-            f' you will need to:\n'
-            f'  1. backup the project\'s existing "cmake/EngineFinder.cmake" file\n'
-            f'  2. copy the "Templates/DefaultProject/Template/cmake/EngineFinder.cmake" from this engine into the project.\n'
-            f' Alternately, to force all older projects that use "{engine_name}" to use this engine path, specify the -f/--force option.')
-        return 0
-
-    engines_path_json[engine_name] = engine_path.as_posix()
-    return 0
-
-
 def register_o3de_object_path(json_data: dict,
                               o3de_object_path: str or pathlib.Path,
                               o3de_object_key: str,
@@ -377,24 +323,15 @@ def register_o3de_object_path(json_data: dict,
 
 def register_engine_path(json_data: dict,
                          engine_path: pathlib.Path,
-                         remove: bool = False,
-                         force: bool = False) -> int:
+                         remove: bool = False) -> int:
     # If the o3de_manifest.json 'engines' key is list containing dictionary entries, transform it to a list of strings
     engine_list = json_data.get('engines', [])
 
     def transform_engine_dict_to_string(engine): return engine.get('path', '') if isinstance(engine, dict) else engine
     json_data['engines'] = list(map(transform_engine_dict_to_string, engine_list))
 
-    result = register_o3de_object_path(json_data, engine_path, 'engines', 'engine.json',
-                                       validation.valid_o3de_engine_json, remove)
-    if result != 0:
-        return result
-
-    # Backwards compatibility to allow older projects to find newer engines
-    if remove:
-        return remove_engine_name_to_path(json_data, engine_path)
-    else:
-        return add_engine_name_to_path(json_data, engine_path, force)
+    return register_o3de_object_path(json_data, engine_path, 'engines', 'engine.json',
+                                     validation.valid_o3de_engine_json, remove)
 
 
 def register_external_subdirectory(json_data: dict,
@@ -834,7 +771,7 @@ def register(engine_path: pathlib.Path = None,
     :param external_subdir_gem_path: Path to the gem to use when registering an external subdirectory.
      The registrations occurs in the gem.json in this case
     :param remove: add/remove the entries
-    :param force: force update of the engine_path for specified "engine_name" from the engine.json file
+    :param force: force the registration to bypass compatibility checks (e.g. for gems/projects)
 
     :return: 0 for success or non 0 failure code
     """
@@ -923,7 +860,7 @@ def register(engine_path: pathlib.Path = None,
         if not engine_path:
             logger.error(f'Engine path cannot be empty.')
             return 1
-        result = result or register_engine_path(json_data, engine_path, remove, force)
+        result = result or register_engine_path(json_data, engine_path, remove)
 
     if not result and not dry_run:
         manifest.save_o3de_manifest(json_data)


### PR DESCRIPTION
## What does this PR do?

`engines_path` was deprecated as of 22.10. There had remained some residual backwards compatibility code to accommodate engines prior to 22.10, which still relied on `engines_path`. However, this compatibility code also had a bug where registering an engine with a name that already existed in `engines_path`, but at a different path, silently failed.

This PR removes that compatibility code and, by extension, fixes the silent failure.

## How was this PR tested?

1. Remove `engines_path` from o3de_manifest (this PR does not remove the field from the manifest, only thoroughly ignores it). Remove the engine at this one's path from `engines`. Optionally, remove other engines, too.
2. Register this engine using this engine's registration script. Optionally, register other engines using this engine's registration script.
3. Open Project Manager, view engines in a Project's settings.
4. Open the o3de_manifest, view `engines` list properly populated, and `engines_path` absent.


## References

- It was decided at the [TSC meeting on 6/30/2026](https://github.com/o3de/tsc/blob/main/meetings/notes/tsc-meeting-20260630.md) to fix several of the items related to engine names and registration.
- This is part of the changes for addressing #19885 