### PR TITLE
Cherry pick translation tr and macro changes in the core module

### DIFF
--- a/Code/Editor/AssetEditor/AssetEditorWindow.cpp
+++ b/Code/Editor/AssetEditor/AssetEditorWindow.cpp
@@ -141,7 +141,7 @@ void AssetEditorWindow::OnAssetOpened(const AZ::Data::Asset<AZ::Data::AssetData>
 
         AZStd::string windowTitle = asset.GetHint();
 
-        qobject_cast<QWidget*>(parent())->setWindowTitle(tr(windowTitle.c_str()));
+        qobject_cast<QWidget*>(parent())->setWindowTitle(QString::fromUtf8(windowTitle.c_str()));
     }
     else
     {
@@ -160,5 +160,5 @@ void AssetEditorWindow::closeEvent(QCloseEvent* event)
 void AssetEditorWindow::OnAssetSaveFailed(const AZStd::string& error)
 {
     QMessageBox::warning(this, tr("Unable to Save Asset"),
-        tr(error.c_str()), QMessageBox::Ok, QMessageBox::Ok);
+        QString::fromUtf8(error.c_str()), QMessageBox::Ok, QMessageBox::Ok);
 }

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserMultiWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserMultiWindow.cpp
@@ -39,7 +39,7 @@ AzAssetBrowserWindow* AzAssetBrowserMultiWindow::OpenNewAssetBrowserWindow()
             AzToolsFramework::ViewPaneOptions options;
             options.preferedDockingArea = Qt::BottomDockWidgetArea;
             options.showInMenu = false;
-            AzToolsFramework::RegisterViewPane<AzAssetBrowserWindow>(qPrintable(candidateName), LyViewPane::CategoryTools, options);
+            AzToolsFramework::RegisterViewPane<AzAssetBrowserWindow>(qUtf8Printable(candidateName), LyViewPane::CategoryTools, options);
             return qobject_cast<AzAssetBrowserWindow*>(QtViewPaneManager::instance()->OpenPane(candidateName)->Widget());
         }
 

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -517,7 +517,7 @@ void AzAssetBrowserWindow::RegisterViewClass()
 
     options.showInMenu = false;
     const QString name = QString("%1 (2)").arg(LyViewPane::AssetBrowser);
-    AzToolsFramework::RegisterViewPane<AzAssetBrowserWindow>(qPrintable(name), LyViewPane::CategoryTools, options);
+    AzToolsFramework::RegisterViewPane<AzAssetBrowserWindow>(qUtf8Printable(name), LyViewPane::CategoryTools, options);
 }
 
 QObject* AzAssetBrowserWindow::createListenerForShowAssetEditorEvent(QObject* parent)

--- a/Code/Editor/Controls/FolderTreeCtrl.cpp
+++ b/Code/Editor/Controls/FolderTreeCtrl.cpp
@@ -244,7 +244,7 @@ void CFolderTreeCtrl::AddItem(const QString& path)
     AZ::IO::FixedMaxPath fileNameWithoutExtension = folder.Stem();
     folder = folder.ParentPath();
 
-    if (AZStd::wildcard_match(qPrintable(m_fileNameSpec), qPrintable(path)))
+    if (AZStd::wildcard_match(qUtf8Printable(m_fileNameSpec), qUtf8Printable(path)))
     {
         CTreeItem* folderTreeItem = CreateFolderItems(QString::fromUtf8(folder.c_str(), static_cast<int>(folder.Native().size())));
         if(folderTreeItem)

--- a/Code/Editor/Core/Widgets/PrefabEditVisualModeWidget.cpp
+++ b/Code/Editor/Core/Widgets/PrefabEditVisualModeWidget.cpp
@@ -18,15 +18,15 @@ PrefabEditVisualModeWidget::PrefabEditVisualModeWidget()
 {
     // Create Label
     m_label = new QLabel(this);
-    m_label->setText("Prefab Edit:");
+    m_label->setText(tr("Prefab Edit:"));
 
     // Create ComboBox
     m_comboBox = new QComboBox(this);
     m_comboBox->setMinimumWidth(120);
 
     // Follow the same order as the PrefabEditModeUXSetting enum.
-    m_comboBox->addItem(QObject::tr("Normal"));
-    m_comboBox->addItem(QObject::tr("Monochromatic"));
+    m_comboBox->addItem(tr("Normal"));
+    m_comboBox->addItem(tr("Monochromatic"));
 
     m_prefabEditMode =
         AzToolsFramework::PrefabEditModeEffectEnabled() ? PrefabEditModeUXSetting::Monochromatic : PrefabEditModeUXSetting::Normal;

--- a/Code/Editor/Core/Widgets/PrefabEditVisualModeWidget.h
+++ b/Code/Editor/Core/Widgets/PrefabEditVisualModeWidget.h
@@ -12,6 +12,7 @@
 #include <AzQtComponents/Components/Widgets/ComboBox.h>
 
 #include <QComboBox>
+#include <QCoreApplication>
 #include <QLabel>
 #include <QWidget>
 
@@ -19,6 +20,8 @@
 class PrefabEditVisualModeWidget
     : public QWidget
 {
+    Q_DECLARE_TR_FUNCTIONS(PrefabEditVisualModeWidget)
+
 public:
     PrefabEditVisualModeWidget();
     ~PrefabEditVisualModeWidget();

--- a/Code/Editor/Core/Widgets/ViewportSettingsWidgets.cpp
+++ b/Code/Editor/Core/Widgets/ViewportSettingsWidgets.cpp
@@ -12,7 +12,7 @@
 ViewportFieldOfViewPropertyWidget::ViewportFieldOfViewPropertyWidget()
 {
     // Set label name.
-    m_label->setText("Field of View");
+    m_label->setText(tr("Field of View"));
 
     // Set suffix on SpinBox
     m_spinBox->setSuffix(" deg");
@@ -52,7 +52,7 @@ void ViewportFieldOfViewPropertyWidget::OnCameraFovChanged(float fovRadians)
 ViewportCameraSpeedScalePropertyWidget::ViewportCameraSpeedScalePropertyWidget()
 {
     // Set label name.
-    m_label->setText("Camera Speed Scale");
+    m_label->setText(tr("Camera Speed Scale"));
 
     // Set starting value.
     m_spinBox->setValue(SandboxEditor::CameraSpeedScale());
@@ -82,7 +82,7 @@ void ViewportCameraSpeedScalePropertyWidget::OnCameraSpeedScaleChanged(float val
 ViewportGridSnappingSizePropertyWidget::ViewportGridSnappingSizePropertyWidget()
 {
     // Set label name.
-    m_label->setText("Grid Snapping Size");
+    m_label->setText(tr("Grid Snapping Size"));
 
     // Set suffix on SpinBox
     m_spinBox->setSuffix(" m");
@@ -99,7 +99,7 @@ void ViewportGridSnappingSizePropertyWidget::OnSpinBoxValueChanged(double newVal
 ViewportAngleSnappingSizePropertyWidget::ViewportAngleSnappingSizePropertyWidget()
 {
     // Set label name.
-    m_label->setText("Angle Snapping Size");
+    m_label->setText(tr("Angle Snapping Size"));
 
     // Set suffix on SpinBox
     m_spinBox->setSuffix(" deg");

--- a/Code/Editor/Core/Widgets/ViewportSettingsWidgets.h
+++ b/Code/Editor/Core/Widgets/ViewportSettingsWidgets.h
@@ -12,11 +12,15 @@
 
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
+#include <QCoreApplication>
+
 // Field of View Widget
 class ViewportFieldOfViewPropertyWidget
     : public AzQtComponents::PropertyInputDoubleWidget
     , private AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler
 {
+    Q_DECLARE_TR_FUNCTIONS(ViewportFieldOfViewPropertyWidget)
+
 public:
     ViewportFieldOfViewPropertyWidget();
     ~ViewportFieldOfViewPropertyWidget();
@@ -33,6 +37,8 @@ class ViewportCameraSpeedScalePropertyWidget
     : public AzQtComponents::PropertyInputDoubleWidget
     , private AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler
 {
+    Q_DECLARE_TR_FUNCTIONS(ViewportCameraSpeedScalePropertyWidget)
+
 public:
     ViewportCameraSpeedScalePropertyWidget();
     ~ViewportCameraSpeedScalePropertyWidget();
@@ -48,6 +54,8 @@ private:
 class ViewportGridSnappingSizePropertyWidget
     : public AzQtComponents::PropertyInputDoubleWidget
 {
+    Q_DECLARE_TR_FUNCTIONS(ViewportGridSnappingSizePropertyWidget)
+
 public:
     ViewportGridSnappingSizePropertyWidget();
 
@@ -59,6 +67,8 @@ private:
 class ViewportAngleSnappingSizePropertyWidget
     : public AzQtComponents::PropertyInputDoubleWidget
 {
+    Q_DECLARE_TR_FUNCTIONS(ViewportAngleSnappingSizePropertyWidget)
+
 public:
     ViewportAngleSnappingSizePropertyWidget();
 

--- a/Code/Editor/EditorFileMonitor.cpp
+++ b/Code/Editor/EditorFileMonitor.cpp
@@ -201,7 +201,7 @@ void CEditorFileMonitor::OnFileMonitorChange(const SFileChangeInfo& rChange)
                 {
                     if (AZ::IO::PathView(sCallback.item.toUtf8().constData()) == projectRelativeFilePath)
                     {
-                        sCallback.pListener->OnFileChange(qPrintable(projectRelativeFilePath.c_str()), IFileChangeListener::EChangeType(rChange.changeType));
+                        sCallback.pListener->OnFileChange(qUtf8Printable(projectRelativeFilePath.c_str()), IFileChangeListener::EChangeType(rChange.changeType));
                     }
                 }
             }

--- a/Code/Editor/EditorPreferencesPageAWS.cpp
+++ b/Code/Editor/EditorPreferencesPageAWS.cpp
@@ -14,6 +14,15 @@
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Jobs/JobFunction.h>
+#include <AzFramework/Translation/TranslationDef.h>
+
+namespace EditorPreferencesAWSStrings
+{
+    static const char* OptionsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageAWS", "Options");
+    static const char* AWSAttributionEnabledName = QT_TRANSLATE_NOOP("EditorPreferencesPageAWS", "Allow <a href=\"https://aws.amazon.com/privacy/\">O3DE</a> to send information about your use of AWS Core Gem to AWS");
+    static const char* AWSPreferencesClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageAWS", "AWS Preferences");
+    static const char* AWSDataCollectionName = QT_TRANSLATE_NOOP("EditorPreferencesPageAWS", "AWS Data Collection and Use");
+}
 
 void CEditorPreferencesPage_AWS::Reflect(AZ::SerializeContext& serialize)
 {
@@ -28,14 +37,15 @@ void CEditorPreferencesPage_AWS::Reflect(AZ::SerializeContext& serialize)
     AZ::EditContext* editContext = serialize.GetEditContext();
     if (editContext)
     {
-        editContext->Class<UsageOptions>("Options", "")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &UsageOptions::m_awsAttributionEnabled, "Allow <a href=\"https://aws.amazon.com/privacy/\">O3DE</a> to send information about your use of AWS Core Gem to AWS",
-            "");
+        using namespace EditorPreferencesAWSStrings;
 
-        editContext->Class<CEditorPreferencesPage_AWS>("AWS Preferences", "AWS Preferences")
+        editContext->Class<UsageOptions>(OptionsClassName, "")
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &UsageOptions::m_awsAttributionEnabled, AWSAttributionEnabledName, "");
+
+        editContext->Class<CEditorPreferencesPage_AWS>(AWSPreferencesClassName, AWSPreferencesClassName)
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC_CE("PropertyVisibility_ShowChildrenOnly"))
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_AWS::m_usageOptions, "AWS Data Collection and Use", "AWS Data Collection and Use");
+            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_AWS::m_usageOptions, AWSDataCollectionName, AWSDataCollectionName);
     }
 }
 
@@ -54,7 +64,7 @@ CEditorPreferencesPage_AWS::~CEditorPreferencesPage_AWS()
 
 const char* CEditorPreferencesPage_AWS::GetTitle()
 {
-    return "Cloud";
+    return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Cloud");
 }
 
 QIcon& CEditorPreferencesPage_AWS::GetIcon()

--- a/Code/Editor/EditorPreferencesPageAWS.h
+++ b/Code/Editor/EditorPreferencesPageAWS.h
@@ -30,7 +30,7 @@ public:
     virtual ~CEditorPreferencesPage_AWS();
 
     // IPreferencesPage interface methods.
-    virtual const char* GetCategory() override { return "AWS"; }
+    virtual const char* GetCategory() override { return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "AWS"); }
     virtual const char* GetTitle() override;
     virtual QIcon& GetIcon() override;
     virtual void OnApply() override;

--- a/Code/Editor/EditorPreferencesPageFiles.cpp
+++ b/Code/Editor/EditorPreferencesPageFiles.cpp
@@ -13,12 +13,52 @@
 
 // AzToolsFramework
 #include <AzToolsFramework/Slice/SliceUtilities.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 // Editor
 #include "Settings.h"
 #include "EditorViewportSettings.h"
 
+namespace EditorPreferencesFilesStrings
+{
+    static const char* FilesClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Files");
+    static const char* FilesClassDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "File Preferences");
+    static const char* AutoNumberSlicesName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Append numeric value to slices");
+    static const char* AutoNumberSlicesDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Should the name of the slice file be automatically numbered. e.g SliceName_001.slice vs. SliceName.slice");
+    static const char* BackupOnSaveName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Backup on Save");
+    static const char* MaxSaveBackupsName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Maximum Save Backups");
+    static const char* TempDirectoryName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Standard Temporary Directory");
+    static const char* UISliceSaveLocationName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "UI Slice Save location");
+    static const char* UISliceSaveLocationDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Specify the default location to save new UI slices");
 
+    static const char* ExternalEditorsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "External Editors");
+    static const char* ScriptsEditorName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Scripts Editor");
+    static const char* ScriptsEditorDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Scripts Text Editor (Default to O3DE internal tool when empty)");
+    static const char* ScriptsEditorPlaceholder = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Default to O3DE internal tool when empty");
+    static const char* ShadersEditorName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Shaders Editor");
+    static const char* ShadersEditorDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Shaders Text Editor");
+    static const char* BSpaceEditorName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "BSpace Editor");
+    static const char* BSpaceEditorDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Bspace Text Editor");
+    static const char* TextureEditorName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Texture Editor");
+    static const char* AnimationEditorName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Animation Editor");
+
+    static const char* AutoBackupClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Auto Backup");
+    static const char* EnableName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Enable");
+    static const char* EnableDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Enable Auto Backup");
+    static const char* TimeIntervalName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Time Interval");
+    static const char* TimeIntervalDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Auto Backup Interval (Minutes)");
+    static const char* MaxBackupsName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Maximum Backups");
+    static const char* MaxBackupsDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Maximum Auto Backups");
+    static const char* RemindTimeName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Remind Time");
+    static const char* RemindTimeDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Auto Remind Every (Minutes)");
+
+    static const char* AssetBrowserSettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Asset Browser Settings");
+    static const char* MaxItemsDisplayedName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Maximum number of displayed items");
+    static const char* MaxItemsDisplayedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Maximum number of items to display in the Search View.");
+
+    static const char* FilePreferencesClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "File Preferences");
+    static const char* FilePreferencesClassDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageFiles", "Class for handling File Preferences");
+}
 
 void CEditorPreferencesPage_Files::Reflect(AZ::SerializeContext& serialize)
 {
@@ -59,47 +99,48 @@ void CEditorPreferencesPage_Files::Reflect(AZ::SerializeContext& serialize)
     AZ::EditContext* editContext = serialize.GetEditContext();
     if (editContext)
     {
-        editContext->Class<Files>("Files", "File Preferences")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Files::m_autoNumberSlices, "Append numeric value to slices", "Should the name of the slice file be automatically numbered. e.g SliceName_001.slice vs. SliceName.slice")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Files::m_backupOnSave, "Backup on Save", "Backup on Save")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Files::m_backupOnSaveMaxCount, "Maximum Save Backups", "Maximum Save Backups")
+        using namespace EditorPreferencesFilesStrings;
+
+        editContext->Class<Files>(FilesClassName, FilesClassDesc)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Files::m_autoNumberSlices, AutoNumberSlicesName, AutoNumberSlicesDesc)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Files::m_backupOnSave, BackupOnSaveName, BackupOnSaveName)
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Files::m_backupOnSaveMaxCount, MaxSaveBackupsName, MaxSaveBackupsName)
             ->Attribute(AZ::Edit::Attributes::Min, 1)
             ->Attribute(AZ::Edit::Attributes::Max, 100)
-            ->DataElement(AZ::Edit::UIHandlers::LineEdit, &Files::m_standardTempDirectory, "Standard Temporary Directory", "Standard Temporary Directory")
-            ->DataElement(AZ::Edit::UIHandlers::LineEdit, &Files::m_saveLocation, "UI Slice Save location", "Specify the default location to save new UI slices");
+            ->DataElement(AZ::Edit::UIHandlers::LineEdit, &Files::m_standardTempDirectory, TempDirectoryName, TempDirectoryName)
+            ->DataElement(AZ::Edit::UIHandlers::LineEdit, &Files::m_saveLocation, UISliceSaveLocationName, UISliceSaveLocationDesc);
 
-        editContext->Class<ExternalEditors>("External Editors", "External Editors")
-            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_scripts, "Scripts Editor", "Scripts Text Editor (Default to O3DE internal tool when empty)")
-            ->Attribute(AZ::Edit::Attributes::PlaceholderText, "Default to O3DE internal tool when empty")
-            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_shaders, "Shaders Editor", "Shaders Text Editor")
-            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_BSpaces, "BSpace Editor", "Bspace Text Editor")
-            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_textures, "Texture Editor", "Texture Editor")
-            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_animations, "Animation Editor", "Animation Editor");
+        editContext->Class<ExternalEditors>(ExternalEditorsClassName, ExternalEditorsClassName)
+            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_scripts, ScriptsEditorName, ScriptsEditorDesc)
+            ->Attribute(AZ::Edit::Attributes::PlaceholderText, ScriptsEditorPlaceholder)
+            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_shaders, ShadersEditorName, ShadersEditorDesc)
+            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_BSpaces, BSpaceEditorName, BSpaceEditorDesc)
+            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_textures, TextureEditorName, TextureEditorName)
+            ->DataElement(AZ::Edit::UIHandlers::ExeSelectBrowseEdit, &ExternalEditors::m_animations, AnimationEditorName, AnimationEditorName);
 
-        editContext->Class<AutoBackup>("Auto Backup", "Auto Backup")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &AutoBackup::m_enabled, "Enable", "Enable Auto Backup")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AutoBackup::m_timeInterval, "Time Interval", "Auto Backup Interval (Minutes)")
+        editContext->Class<AutoBackup>(AutoBackupClassName, AutoBackupClassName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &AutoBackup::m_enabled, EnableName, EnableDesc)
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AutoBackup::m_timeInterval, TimeIntervalName, TimeIntervalDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 2)
             ->Attribute(AZ::Edit::Attributes::Max, 10000)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AutoBackup::m_maxCount, "Maximum Backups", "Maximum Auto Backups")
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AutoBackup::m_maxCount, MaxBackupsName, MaxBackupsDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 1)
             ->Attribute(AZ::Edit::Attributes::Max, 100)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AutoBackup::m_remindTime, "Remind Time", "Auto Remind Every (Minutes)");
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AutoBackup::m_remindTime, RemindTimeName, RemindTimeDesc);
 
-         editContext->Class<AssetBrowserSettings>("Asset Browser Settings", "Asset Browser Settings")
+        editContext->Class<AssetBrowserSettings>(AssetBrowserSettingsClassName, AssetBrowserSettingsClassName)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &AssetBrowserSettings::m_maxNumberOfItemsShownInSearch, "Maximum number of displayed items",
-                "Maximum number of items to display in the Search View.")
+                AZ::Edit::UIHandlers::SpinBox, &AssetBrowserSettings::m_maxNumberOfItemsShownInSearch, MaxItemsDisplayedName, MaxItemsDisplayedDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 50)
             ->Attribute(AZ::Edit::Attributes::Max, 5000);
 
-        editContext->Class<CEditorPreferencesPage_Files>("File Preferences", "Class for handling File Preferences")
+        editContext->Class<CEditorPreferencesPage_Files>(FilePreferencesClassName, FilePreferencesClassDesc)
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC_CE("PropertyVisibility_ShowChildrenOnly"))
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_files, "Files", "File Preferences")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_editors, "External Editors", "External Editors")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_autoBackup, "Auto Backup", "Auto Backup")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_assetBrowserSettings, "Asset Browser Settings","Asset Browser Settings");
+            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_files, FilesClassName, FilesClassDesc)
+            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_editors, ExternalEditorsClassName, ExternalEditorsClassName)
+            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_autoBackup, AutoBackupClassName, AutoBackupClassName)
+            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_Files::m_assetBrowserSettings, AssetBrowserSettingsClassName, AssetBrowserSettingsClassName);
     }
 }
 

--- a/Code/Editor/EditorPreferencesPageFiles.h
+++ b/Code/Editor/EditorPreferencesPageFiles.h
@@ -11,6 +11,7 @@
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <QIcon>
 
 
@@ -29,8 +30,8 @@ public:
     CEditorPreferencesPage_Files();
     virtual ~CEditorPreferencesPage_Files() = default;
 
-    virtual const char* GetCategory() override { return "General Settings"; }
-    virtual const char* GetTitle() override { return "Files"; }
+    virtual const char* GetCategory() override { return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "General Settings"); }
+    virtual const char* GetTitle() override { return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Files"); }
     virtual QIcon& GetIcon() override;
     virtual void OnApply() override;
     virtual void OnCancel() override {}

--- a/Code/Editor/EditorPreferencesPageViewportCamera.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportCamera.cpp
@@ -15,11 +15,94 @@
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzQtComponents/Components/StyleManager.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <EditorModularViewportCameraComposerBus.h>
 
 // Editor
 #include "EditorViewportSettings.h"
 #include "Settings.h"
+
+namespace EditorPreferencesViewportCameraStrings
+{
+    static const char* CameraMovementSettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Movement Settings");
+    static const char* CameraSpeedScaleName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Speed Scale");
+    static const char* CameraSpeedScaleDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Overall scale applied to all camera movements");
+    static const char* CameraMovementSpeedName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Movement Speed");
+    static const char* CameraMovementSpeedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera movement speed");
+    static const char* CameraRotationSpeedName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Rotation Speed");
+    static const char* CameraRotationSpeedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera rotation speed");
+    static const char* CameraBoostMultiplierName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Boost Multiplier");
+    static const char* CameraBoostMultiplierDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera boost multiplier to apply to movement speed");
+    static const char* CameraScrollSpeedName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Scroll Speed");
+    static const char* CameraScrollSpeedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera movement speed while using scroll/wheel input");
+    static const char* CameraDollySpeedName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Dolly Speed");
+    static const char* CameraDollySpeedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera movement speed while using mouse motion to move in and out");
+    static const char* CameraPanSpeedName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Pan Speed");
+    static const char* CameraPanSpeedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera movement speed while panning using the mouse");
+    static const char* CameraRotateSmoothingName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Rotate Smoothing");
+    static const char* CameraRotateSmoothingDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Is camera rotation smoothing enabled or disabled");
+    static const char* CameraRotateSmoothnessName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Rotate Smoothness");
+    static const char* CameraRotateSmoothnessDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Amount of camera smoothing to apply while rotating the camera");
+    static const char* CameraTranslateSmoothingName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Translate Smoothing");
+    static const char* CameraTranslateSmoothingDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Is camera translation smoothing enabled or disabled");
+    static const char* CameraTranslateSmoothnessName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Translate Smoothness");
+    static const char* CameraTranslateSmoothnessDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Amount of camera smoothing to apply while translating the camera");
+    static const char* CameraOrbitYawInvertedName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Orbit Yaw Inverted");
+    static const char* CameraOrbitYawInvertedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Inverted yaw rotation while orbiting");
+    static const char* InvertPanXName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Invert Pan X");
+    static const char* InvertPanXDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Invert direction of pan in local X axis");
+    static const char* InvertPanYName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Invert Pan Y");
+    static const char* InvertPanYDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Invert direction of pan in local Y axis");
+    static const char* InvertZoomName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Invert Zoom Direction");
+    static const char* InvertZoomDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Invert Mouse Wheel Zoom direction");
+    static const char* CameraCaptureLookCursorName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Capture Look Cursor");
+    static const char* CameraCaptureLookCursorDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Should the cursor be captured (hidden) while performing free look");
+    static const char* DefaultCameraPositionName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Default Camera Position");
+    static const char* DefaultCameraPositionDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Default Camera Position when a level is first opened");
+    static const char* DefaultCameraOrientationName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Default Camera Orientation");
+    static const char* DefaultCameraOrientationDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Default Camera Orientation when a level is first opened (X - Pitch value (degrees), Y - Yaw value (degrees)");
+    static const char* DefaultOrbitDistanceName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Default Orbit Distance");
+    static const char* DefaultOrbitDistanceDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "The default distance to orbit about when there is no entity selected");
+    static const char* CameraGoToPositionDurationName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Go To Position Duration");
+    static const char* CameraGoToPositionDurationDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Time it takes for the camera to interpolate to a given position");
+    static const char* CameraGoToPositionInstantlyName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Go To Position Instantly");
+    static const char* CameraGoToPositionInstantlyDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera will instantly go to the set position and won't interpolate there");
+    static const char* RestoreDefaultsMovementDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Restore camera movement settings to defaults");
+    static const char* RestoreDefaultsButtonText = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Restore defaults");
+
+    static const char* CameraInputSettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Camera Input Settings");
+    static const char* TranslateForwardName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Translate Forward");
+    static const char* TranslateForwardDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to move the camera forward");
+    static const char* TranslateBackwardName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Translate Backward");
+    static const char* TranslateBackwardDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to move the camera backward");
+    static const char* TranslateLeftName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Translate Left");
+    static const char* TranslateLeftDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to move the camera left");
+    static const char* TranslateRightName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Translate Right");
+    static const char* TranslateRightDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to move the camera right");
+    static const char* TranslateUpName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Translate Up");
+    static const char* TranslateUpDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to move the camera up");
+    static const char* TranslateDownName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Translate Down");
+    static const char* TranslateDownDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to move the camera down");
+    static const char* BoostName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Boost");
+    static const char* BoostDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to move the camera more quickly");
+    static const char* OrbitName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Orbit");
+    static const char* OrbitDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to begin the camera orbit behavior");
+    static const char* FreeLookName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Free Look");
+    static const char* FreeLookDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to begin camera free look");
+    static const char* FreePanName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Free Pan");
+    static const char* FreePanDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to begin camera free pan");
+    static const char* OrbitLookName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Orbit Look");
+    static const char* OrbitLookDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to begin camera orbit look");
+    static const char* OrbitDollyName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Orbit Dolly");
+    static const char* OrbitDollyDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to begin camera orbit dolly");
+    static const char* OrbitPanName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Orbit Pan");
+    static const char* OrbitPanDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to begin camera orbit pan");
+    static const char* FocusName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Focus");
+    static const char* FocusDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Key/button to focus camera orbit");
+    static const char* RestoreDefaultsInputDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Restore camera input settings to defaults");
+
+    static const char* ViewportPreferencesClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportCamera", "Viewport Preferences");
+}
 
 static AZStd::vector<AZStd::string> GetInputNamesByDevice(const AzFramework::InputDeviceId inputDeviceId)
 {
@@ -87,128 +170,129 @@ void CEditorPreferencesPage_ViewportCamera::CameraMovementSettings::Reflect(AZ::
 
     if (AZ::EditContext* editContext = serialize.GetEditContext())
     {
+        using namespace EditorPreferencesViewportCameraStrings;
         const float minValue = 0.0001f;
-        editContext->Class<CameraMovementSettings>("Camera Movement Settings", "")
+        editContext->Class<CameraMovementSettings>(CameraMovementSettingsClassName, "")
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_speedScale,
-                "Camera Speed Scale",
-                "Overall scale applied to all camera movements")
+                CameraSpeedScaleName,
+                CameraSpeedScaleDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_translateSpeed, "Camera Movement Speed", "Camera movement speed")
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_translateSpeed, CameraMovementSpeedName, CameraMovementSpeedDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSpeed, "Camera Rotation Speed", "Camera rotation speed")
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSpeed, CameraRotationSpeedName, CameraRotationSpeedDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_boostMultiplier,
-                "Camera Boost Multiplier",
-                "Camera boost multiplier to apply to movement speed")
+                CameraBoostMultiplierName,
+                CameraBoostMultiplierDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_scrollSpeed,
-                "Camera Scroll Speed",
-                "Camera movement speed while using scroll/wheel input")
+                CameraScrollSpeedName,
+                CameraScrollSpeedDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_dollySpeed,
-                "Camera Dolly Speed",
-                "Camera movement speed while using mouse motion to move in and out")
+                CameraDollySpeedName,
+                CameraDollySpeedDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_panSpeed,
-                "Camera Pan Speed",
-                "Camera movement speed while panning using the mouse")
+                CameraPanSpeedName,
+                CameraPanSpeedDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_rotateSmoothing,
-                "Camera Rotate Smoothing",
-                "Is camera rotation smoothing enabled or disabled")
+                CameraRotateSmoothingName,
+                CameraRotateSmoothingDesc)
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_rotateSmoothness,
-                "Camera Rotate Smoothness",
-                "Amount of camera smoothing to apply while rotating the camera")
+                CameraRotateSmoothnessName,
+                CameraRotateSmoothnessDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->Attribute(AZ::Edit::Attributes::ReadOnly, &CameraMovementSettings::RotateSmoothingReadOnly)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_translateSmoothing,
-                "Camera Translate Smoothing",
-                "Is camera translation smoothing enabled or disabled")
+                CameraTranslateSmoothingName,
+                CameraTranslateSmoothingDesc)
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_translateSmoothness,
-                "Camera Translate Smoothness",
-                "Amount of camera smoothing to apply while translating the camera")
+                CameraTranslateSmoothnessName,
+                CameraTranslateSmoothnessDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->Attribute(AZ::Edit::Attributes::ReadOnly, &CameraMovementSettings::TranslateSmoothingReadOnly)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_orbitYawRotationInverted,
-                "Camera Orbit Yaw Inverted",
-                "Inverted yaw rotation while orbiting")
+                CameraOrbitYawInvertedName,
+                CameraOrbitYawInvertedDesc)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_panInvertedX,
-                "Invert Pan X",
-                "Invert direction of pan in local X axis")
+                InvertPanXName,
+                InvertPanXDesc)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_panInvertedY,
-                "Invert Pan Y",
-                "Invert direction of pan in local Y axis")
+                InvertPanYName,
+                InvertPanYDesc)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_zoomInverted,
-                "Invert Zoom Direction",
-                "Invert Mouse Wheel Zoom direction")
+                InvertZoomName,
+                InvertZoomDesc)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_captureCursorLook,
-                "Camera Capture Look Cursor",
-                "Should the cursor be captured (hidden) while performing free look")
+                CameraCaptureLookCursorName,
+                CameraCaptureLookCursorDesc)
             ->DataElement(
                 AZ::Edit::UIHandlers::Vector3,
                 &CameraMovementSettings::m_defaultPosition,
-                "Default Camera Position",
-                "Default Camera Position when a level is first opened")
+                DefaultCameraPositionName,
+                DefaultCameraPositionDesc)
             ->DataElement(
                 AZ::Edit::UIHandlers::Vector2,
                 &CameraMovementSettings::m_defaultPitchYaw,
-                "Default Camera Orientation",
-                "Default Camera Orientation when a level is first opened (X - Pitch value (degrees), Y - Yaw value (degrees)")
+                DefaultCameraOrientationName,
+                DefaultCameraOrientationDesc)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_defaultOrbitDistance,
-                "Default Orbit Distance",
-                "The default distance to orbit about when there is no entity selected")
+                DefaultOrbitDistanceName,
+                DefaultOrbitDistanceDesc)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox,
                 &CameraMovementSettings::m_goToPositionDuration,
-                "Camera Go To Position Duration",
-                "Time it takes for the camera to interpolate to a given position")
+                CameraGoToPositionDurationName,
+                CameraGoToPositionDurationDesc)
             ->Attribute(AZ::Edit::Attributes::ReadOnly, &CameraMovementSettings::GoToPositionDurationReadOnly)
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox,
                 &CameraMovementSettings::m_goToPositionInstantly,
-                "Camera Go To Position Instantly",
-                "Camera will instantly go to the set position and won't interpolate there")
+                CameraGoToPositionInstantlyName,
+                CameraGoToPositionInstantlyDesc)
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
             ->DataElement(
-                AZ::Edit::UIHandlers::Button, &CameraMovementSettings::m_resetButton, "", "Restore camera movement settings to defaults")
+                AZ::Edit::UIHandlers::Button, &CameraMovementSettings::m_resetButton, "", RestoreDefaultsMovementDesc)
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CameraMovementSettings::Reset)
-            ->Attribute(AZ::Edit::Attributes::ButtonText, "Restore defaults")
+            ->Attribute(AZ::Edit::Attributes::ButtonText, RestoreDefaultsButtonText)
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues);
     }
 }
@@ -235,89 +319,90 @@ void CEditorPreferencesPage_ViewportCamera::CameraInputSettings::Reflect(AZ::Ser
 
     if (AZ::EditContext* editContext = serialize.GetEditContext())
     {
-        editContext->Class<CameraInputSettings>("Camera Input Settings", "")
+        using namespace EditorPreferencesViewportCameraStrings;
+        editContext->Class<CameraInputSettings>(CameraInputSettingsClassName, "")
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_translateForwardChannelId,
-                "Translate Forward",
-                "Key/button to move the camera forward")
+                TranslateForwardName,
+                TranslateForwardDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_translateBackwardChannelId,
-                "Translate Backward",
-                "Key/button to move the camera backward")
+                TranslateBackwardName,
+                TranslateBackwardDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_translateLeftChannelId,
-                "Translate Left",
-                "Key/button to move the camera left")
+                TranslateLeftName,
+                TranslateLeftDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_translateRightChannelId,
-                "Translate Right",
-                "Key/button to move the camera right")
+                TranslateRightName,
+                TranslateRightDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_translateUpChannelId,
-                "Translate Up",
-                "Key/button to move the camera up")
+                TranslateUpName,
+                TranslateUpDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_translateDownChannelId,
-                "Translate Down",
-                "Key/button to move the camera down")
+                TranslateDownName,
+                TranslateDownDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_boostChannelId,
-                "Boost",
-                "Key/button to move the camera more quickly")
+                BoostName,
+                BoostDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_orbitChannelId,
-                "Orbit",
-                "Key/button to begin the camera orbit behavior")
+                OrbitName,
+                OrbitDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_freeLookChannelId,
-                "Free Look",
-                "Key/button to begin camera free look")
+                FreeLookName,
+                FreeLookDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_freePanChannelId, "Free Pan", "Key/button to begin camera free pan")
+                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_freePanChannelId, FreePanName, FreePanDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_orbitLookChannelId,
-                "Orbit Look",
-                "Key/button to begin camera orbit look")
+                OrbitLookName,
+                OrbitLookDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_orbitDollyChannelId,
-                "Orbit Dolly",
-                "Key/button to begin camera orbit dolly")
+                OrbitDollyName,
+                OrbitDollyDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox,
                 &CameraInputSettings::m_orbitPanChannelId,
-                "Orbit Pan",
-                "Key/button to begin camera orbit pan")
+                OrbitPanName,
+                OrbitPanDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_focusChannelId, "Focus", "Key/button to focus camera orbit")
+                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_focusChannelId, FocusName, FocusDesc)
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::Button, &CameraInputSettings::m_resetButton, "", "Restore camera input settings to defaults")
+                AZ::Edit::UIHandlers::Button, &CameraInputSettings::m_resetButton, "", RestoreDefaultsInputDesc)
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CameraInputSettings::Reset)
-            ->Attribute(AZ::Edit::Attributes::ButtonText, "Restore defaults")
+            ->Attribute(AZ::Edit::Attributes::ButtonText, RestoreDefaultsButtonText)
             ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues);
     }
 }
@@ -334,19 +419,20 @@ void CEditorPreferencesPage_ViewportCamera::Reflect(AZ::SerializeContext& serial
 
     if (AZ::EditContext* editContext = serialize.GetEditContext())
     {
-        editContext->Class<CEditorPreferencesPage_ViewportCamera>("Viewport Preferences", "Viewport Preferences")
+        using namespace EditorPreferencesViewportCameraStrings;
+        editContext->Class<CEditorPreferencesPage_ViewportCamera>(ViewportPreferencesClassName, ViewportPreferencesClassName)
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC_CE("PropertyVisibility_ShowChildrenOnly"))
             ->DataElement(
                 AZ::Edit::UIHandlers::Default,
                 &CEditorPreferencesPage_ViewportCamera::m_cameraMovementSettings,
-                "Camera Movement Settings",
-                "Camera Movement Settings")
+                CameraMovementSettingsClassName,
+                CameraMovementSettingsClassName)
             ->DataElement(
                 AZ::Edit::UIHandlers::Default,
                 &CEditorPreferencesPage_ViewportCamera::m_cameraInputSettings,
-                "Camera Input Settings",
-                "Camera Input Settings");
+                CameraInputSettingsClassName,
+                CameraInputSettingsClassName);
     }
 }
 
@@ -358,12 +444,12 @@ CEditorPreferencesPage_ViewportCamera::CEditorPreferencesPage_ViewportCamera()
 
 const char* CEditorPreferencesPage_ViewportCamera::GetCategory()
 {
-    return "Viewports";
+    return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Viewports");
 }
 
 const char* CEditorPreferencesPage_ViewportCamera::GetTitle()
 {
-    return "Camera";
+    return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Camera");
 }
 
 QIcon& CEditorPreferencesPage_ViewportCamera::GetIcon()

--- a/Code/Editor/EditorPreferencesPageViewportDebug.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportDebug.cpp
@@ -11,9 +11,24 @@
 
 // AzCore
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 // Editor
 #include "Settings.h"
+
+namespace EditorPreferencesViewportDebugStrings
+{
+    static const char* ProfilingClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Profiling");
+    static const char* ShowMeshStatsName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Show Mesh Statistics");
+    static const char* ShowMeshStatsDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Show Mesh Statistics on Mouse Over");
+
+    static const char* ViewportWarningSettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Viewport Warning Settings");
+    static const char* WarningIconsDistanceName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Warning Icons Draw Distance");
+    static const char* ShowScaleWarningsName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Show Scale Warnings");
+    static const char* ShowRotationWarningsName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Show Rotation Warnings");
+
+    static const char* ViewportDebugPreferencesClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportDebug", "Viewport Debug Preferences");
+}
 
 void CEditorPreferencesPage_ViewportDebug::Reflect(AZ::SerializeContext& serialize)
 {
@@ -36,19 +51,21 @@ void CEditorPreferencesPage_ViewportDebug::Reflect(AZ::SerializeContext& seriali
     AZ::EditContext* editContext = serialize.GetEditContext();
     if (editContext)
     {
-        editContext->Class<Profiling>("Profiling", "Profiling")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Profiling::m_showMeshStatsOnMouseOver, "Show Mesh Statistics", "Show Mesh Statistics on Mouse Over");
+        using namespace EditorPreferencesViewportDebugStrings;
 
-        editContext->Class<Warnings>("Viewport Warning Settings", "")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Warnings::m_warningIconsDrawDistance, "Warning Icons Draw Distance", "Warning Icons Draw Distance")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Warnings::m_showScaleWarnings, "Show Scale Warnings", "Show Scale Warnings")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Warnings::m_showRotationWarnings, "Show Rotation Warnings", "Show Rotation Warnings");
+        editContext->Class<Profiling>(ProfilingClassName, ProfilingClassName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Profiling::m_showMeshStatsOnMouseOver, ShowMeshStatsName, ShowMeshStatsDesc);
 
-        editContext->Class<CEditorPreferencesPage_ViewportDebug>("Viewport Debug Preferences", "Viewport Debug Preferences")
+        editContext->Class<Warnings>(ViewportWarningSettingsClassName, "")
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Warnings::m_warningIconsDrawDistance, WarningIconsDistanceName, WarningIconsDistanceName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Warnings::m_showScaleWarnings, ShowScaleWarningsName, ShowScaleWarningsName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Warnings::m_showRotationWarnings, ShowRotationWarningsName, ShowRotationWarningsName);
+
+        editContext->Class<CEditorPreferencesPage_ViewportDebug>(ViewportDebugPreferencesClassName, ViewportDebugPreferencesClassName)
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC_CE("PropertyVisibility_ShowChildrenOnly"))
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportDebug::m_profiling, "Profiling", "Profiling")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportDebug::m_warnings, "Viewport Warning Settings", "Viewport Warning Settings");
+            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportDebug::m_profiling, ProfilingClassName, ProfilingClassName)
+            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportDebug::m_warnings, ViewportWarningSettingsClassName, ViewportWarningSettingsClassName);
     }
 }
 

--- a/Code/Editor/EditorPreferencesPageViewportDebug.h
+++ b/Code/Editor/EditorPreferencesPageViewportDebug.h
@@ -10,6 +10,7 @@
 #include "Include/IPreferencesPage.h"
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/RTTI/RTTIMacros.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <QIcon>
 
 namespace AZ
@@ -28,8 +29,8 @@ public:
     CEditorPreferencesPage_ViewportDebug();
     virtual ~CEditorPreferencesPage_ViewportDebug() = default;
 
-    virtual const char* GetCategory() override { return "Viewports"; }
-    virtual const char* GetTitle() override { return "Debug"; }
+    virtual const char* GetCategory() override { return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Viewports"); }
+    virtual const char* GetTitle() override { return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Debug"); }
     virtual QIcon& GetIcon() override;
     virtual void OnApply() override;
     virtual void OnCancel() override {}

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -14,10 +14,60 @@
 #include <AzCore/Serialization/EditContext.h>
 
 #include <AzQtComponents/Components/StyleManager.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 // Editor
 #include "DisplaySettings.h"
 #include "Settings.h"
+
+namespace EditorPreferencesViewportGeneralStrings
+{
+    static const char* GeneralViewportSettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "General Viewport Settings");
+    static const char* Sync2DViewportsName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Synchronize 2D Viewports");
+    static const char* PerspectiveViewFOVName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Perspective View FOV");
+    static const char* PerspectiveNearPlaneName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Perspective Near Plane");
+    static const char* PerspectiveFarPlaneName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Perspective Far Plane");
+    static const char* PerspectiveAspectRatioName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Perspective View Aspect Ratio");
+    static const char* EnableContextMenuName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Enable Right-Click Context Menu");
+    static const char* EnableStickySelectName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Enable Sticky Select");
+
+    static const char* ViewportDisplaySettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Viewport Display Settings");
+    static const char* HighlightSelectedGeometryName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Highlight Selected Geometry");
+    static const char* HighlightSelectedVegetationName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Highlight Selected Vegetation");
+    static const char* HighlightOnMouseOverName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Highlight Geometry On Mouse Over");
+    static const char* HideCursorWhenCapturedName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Hide Cursor When Captured");
+    static const char* HideCursorWhenCapturedDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Hide Mouse Cursor When Captured");
+    static const char* DragSquareSizeName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Drag Square Size");
+    static const char* DisplayObjectLinksName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Display Object Links");
+    static const char* DisplayAnimationTracksName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Display Animation Tracks");
+    static const char* AlwaysShowRadiiName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Always Show Radii");
+    static const char* ShowBoundingBoxesName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Show Bounding Boxes");
+    static const char* AlwaysDrawEntityLabelsName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Always Draw Entity Labels");
+    static const char* AlwaysShowTriggerBoundsName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Always Show Trigger Bounds");
+    static const char* ShowFrozenHelpersName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Show Helpers of Frozen Objects");
+    static const char* FillSelectedShapesName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Fill Selected Shapes");
+    static const char* ShowSnappingGridGuideName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Show Snapping Grid Guide");
+    static const char* DisplayDimensionFiguresName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Display Dimension Figures");
+
+    static const char* MapViewportSettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Map Viewport Settings");
+    static const char* SwapXYAxisName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Swap X/Y Axis");
+    static const char* MapTextureResolutionName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Map Texture Resolution");
+
+    static const char* TextLabelSettingsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Text Label Settings");
+    static const char* EnabledName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Enabled");
+    static const char* DistanceName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Distance");
+
+    static const char* SelectionPreviewColorClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Selection Preview Color Settings");
+    static const char* GroupBoundingBoxName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Group Bounding Box");
+    static const char* EntityBoundingBoxName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Entity Bounding Box");
+    static const char* BBoxHighlightAlphaName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Bounding Box Highlight Alpha");
+    static const char* GeometryColorName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Geometry Color");
+    static const char* SolidBrushGeometryColorName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Solid Brush Geometry Color");
+    static const char* GeometryHighlightAlphaName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Geometry Highlight Alpha");
+    static const char* ChildGeometryHighlightAlphaName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "Child Geometry Highlight Alpha");
+
+    static const char* GeneralViewportPreferencesClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportGeneral", "General Viewport Preferences");
+}
 
 void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& serialize)
 {
@@ -82,101 +132,89 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
     AZ::EditContext* editContext = serialize.GetEditContext();
     if (editContext)
     {
-        editContext->Class<General>("General Viewport Settings", "")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_sync2DViews, "Synchronize 2D Viewports", "Synchronize 2D Viewports")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultFOV, "Perspective View FOV", "Perspective View FOV")
+        using namespace EditorPreferencesViewportGeneralStrings;
+
+        editContext->Class<General>(GeneralViewportSettingsClassName, "")
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_sync2DViews, Sync2DViewportsName, Sync2DViewportsName)
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultFOV, PerspectiveViewFOVName, PerspectiveViewFOVName)
             ->Attribute(AZ::Edit::Attributes::Min, 1.0f)
             ->Attribute(AZ::Edit::Attributes::Max, 120.0f)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultNearPlane, "Perspective Near Plane", "Perspective Near Plane")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultFarPlane, "Perspective Far Plane", "Perspective Far Plane")
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultNearPlane, PerspectiveNearPlaneName, PerspectiveNearPlaneName)
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultFarPlane, PerspectiveFarPlaneName, PerspectiveFarPlaneName)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &General::m_defaultAspectRatio, "Perspective View Aspect Ratio",
-                "Perspective View Aspect Ratio")
+                AZ::Edit::UIHandlers::SpinBox, &General::m_defaultAspectRatio, PerspectiveAspectRatioName, PerspectiveAspectRatioName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &General::m_contextMenuEnabled, "Enable Right-Click Context Menu",
-                "Enable Right-Click Context Menu")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_stickySelectEnabled, "Enable Sticky Select", "Enable Sticky Select");
+                AZ::Edit::UIHandlers::CheckBox, &General::m_contextMenuEnabled, EnableContextMenuName, EnableContextMenuName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_stickySelectEnabled, EnableStickySelectName, EnableStickySelectName);
 
-        editContext->Class<Display>("Viewport Display Settings", "")
+        editContext->Class<Display>(ViewportDisplaySettingsClassName, "")
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelGeom, "Highlight Selected Geometry", "Highlight Selected Geometry")
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelGeom, HighlightSelectedGeometryName, HighlightSelectedGeometryName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelVegetation, "Highlight Selected Vegetation",
-                "Highlight Selected Vegetation")
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelVegetation, HighlightSelectedVegetationName, HighlightSelectedVegetationName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightOnMouseOver, "Highlight Geometry On Mouse Over",
-                "Highlight Geometry On Mouse Over")
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightOnMouseOver, HighlightOnMouseOverName, HighlightOnMouseOverName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_hideMouseCursorWhenCaptured, "Hide Cursor When Captured",
-                "Hide Mouse Cursor When Captured")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Display::m_dragSquareSize, "Drag Square Size", "Drag Square Size")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_displayLinks, "Display Object Links", "Display Object Links")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_displayTracks, "Display Animation Tracks", "Display Animation Tracks")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_alwaysShowRadii, "Always Show Radii", "Always Show Radii")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showBBoxes, "Show Bounding Boxes", "Show Bounding Boxes")
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_hideMouseCursorWhenCaptured, HideCursorWhenCapturedName, HideCursorWhenCapturedDesc)
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Display::m_dragSquareSize, DragSquareSizeName, DragSquareSizeName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_displayLinks, DisplayObjectLinksName, DisplayObjectLinksName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_displayTracks, DisplayAnimationTracksName, DisplayAnimationTracksName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_alwaysShowRadii, AlwaysShowRadiiName, AlwaysShowRadiiName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showBBoxes, ShowBoundingBoxesName, ShowBoundingBoxesName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_drawEntityLabels, "Always Draw Entity Labels", "Always Draw Entity Labels")
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_drawEntityLabels, AlwaysDrawEntityLabelsName, AlwaysDrawEntityLabelsName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_showTriggerBounds, "Always Show Trigger Bounds", "Always Show Trigger Bounds")
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_showTriggerBounds, AlwaysShowTriggerBoundsName, AlwaysShowTriggerBoundsName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_showFrozenHelpers, "Show Helpers of Frozen Objects",
-                "Show Helpers of Frozen Objects")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_fillSelectedShapes, "Fill Selected Shapes", "Fill Selected Shapes")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showGridGuide, "Show Snapping Grid Guide", "Show Snapping Grid Guide")
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_showFrozenHelpers, ShowFrozenHelpersName, ShowFrozenHelpersName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_fillSelectedShapes, FillSelectedShapesName, FillSelectedShapesName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showGridGuide, ShowSnappingGridGuideName, ShowSnappingGridGuideName)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Display::m_displayDimension, "Display Dimension Figures", "Display Dimension Figures");
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_displayDimension, DisplayDimensionFiguresName, DisplayDimensionFiguresName);
 
-        editContext->Class<MapViewport>("Map Viewport Settings", "")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MapViewport::m_swapXY, "Swap X/Y Axis", "Swap X/Y Axis")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &MapViewport::m_resolution, "Map Texture Resolution", "Map Texture Resolution");
+        editContext->Class<MapViewport>(MapViewportSettingsClassName, "")
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MapViewport::m_swapXY, SwapXYAxisName, SwapXYAxisName)
+            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &MapViewport::m_resolution, MapTextureResolutionName, MapTextureResolutionName);
 
-        editContext->Class<TextLabels>("Text Label Settings", "")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &TextLabels::m_labelsOn, "Enabled", "Enabled")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &TextLabels::m_labelsDistance, "Distance", "Distance")
+        editContext->Class<TextLabels>(TextLabelSettingsClassName, "")
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &TextLabels::m_labelsOn, EnabledName, EnabledName)
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &TextLabels::m_labelsDistance, DistanceName, DistanceName)
             ->Attribute(AZ::Edit::Attributes::Min, 0.f)
             ->Attribute(AZ::Edit::Attributes::Max, 100000.f);
 
-        editContext->Class<SelectionPreviewColor>("Selection Preview Color Settings", "")
-            ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_colorGroupBBox, "Group Bounding Box", "Group Bounding Box")
+        editContext->Class<SelectionPreviewColor>(SelectionPreviewColorClassName, "")
+            ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_colorGroupBBox, GroupBoundingBoxName, GroupBoundingBoxName)
             ->DataElement(
-                AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_colorEntityBBox, "Entity Bounding Box", "Entity Bounding Box")
+                AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_colorEntityBBox, EntityBoundingBoxName, EntityBoundingBoxName)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fBBoxAlpha, "Bounding Box Highlight Alpha",
-                "Bounding Box Highlight Alpha")
+                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fBBoxAlpha, BBoxHighlightAlphaName, BBoxHighlightAlphaName)
             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
-            ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_geometryHighlightColor, "Geometry Color", "Geometry Color")
+            ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_geometryHighlightColor, GeometryColorName, GeometryColorName)
             ->DataElement(
-                AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_solidBrushGeometryColor, "Solid Brush Geometry Color",
-                "Solid Brush Geometry Color")
+                AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_solidBrushGeometryColor, SolidBrushGeometryColorName, SolidBrushGeometryColorName)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fgeomAlpha, "Geometry Highlight Alpha", "Geometry Highlight Alpha")
+                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fgeomAlpha, GeometryHighlightAlphaName, GeometryHighlightAlphaName)
             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_childObjectGeomAlpha, "Child Geometry Highlight Alpha",
-                "Child Geometry Highlight Alpha")
+                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_childObjectGeomAlpha, ChildGeometryHighlightAlphaName, ChildGeometryHighlightAlphaName)
             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
             ->Attribute(AZ::Edit::Attributes::Max, 1.0f);
 
-        editContext->Class<CEditorPreferencesPage_ViewportGeneral>("General Viewport Preferences", "General Viewport Preferences")
+        editContext->Class<CEditorPreferencesPage_ViewportGeneral>(GeneralViewportPreferencesClassName, GeneralViewportPreferencesClassName)
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC_CE("PropertyVisibility_ShowChildrenOnly"))
             ->DataElement(
-                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_general, "General Viewport Settings",
-                "General Viewport Settings")
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_general, GeneralViewportSettingsClassName, GeneralViewportSettingsClassName)
             ->DataElement(
-                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_display, "Viewport Display Settings",
-                "Viewport Display Settings")
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_display, ViewportDisplaySettingsClassName, ViewportDisplaySettingsClassName)
             ->DataElement(
-                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_map, "Map Viewport Settings",
-                "Map Viewport Settings")
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_map, MapViewportSettingsClassName, MapViewportSettingsClassName)
             ->DataElement(
-                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_textLabels, "Text Label Settings",
-                "Text Label Settings")
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_textLabels, TextLabelSettingsClassName, TextLabelSettingsClassName)
             ->DataElement(
-                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_selectionPreviewColor,
-                "Selection Preview Color Settings", "Selection Preview Color Settings");
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_selectionPreviewColor, SelectionPreviewColorClassName, SelectionPreviewColorClassName);
     }
 }
 
@@ -188,12 +226,12 @@ CEditorPreferencesPage_ViewportGeneral::CEditorPreferencesPage_ViewportGeneral()
 
 const char* CEditorPreferencesPage_ViewportGeneral::GetCategory()
 {
-    return "Viewports";
+    return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Viewports");
 }
 
 const char* CEditorPreferencesPage_ViewportGeneral::GetTitle()
 {
-    return "Viewport";
+    return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Viewport");
 }
 
 QIcon& CEditorPreferencesPage_ViewportGeneral::GetIcon()

--- a/Code/Editor/EditorPreferencesPageViewportManipulator.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportManipulator.cpp
@@ -13,10 +13,42 @@
 #include <AzCore/Serialization/EditContext.h>
 
 #include <AzToolsFramework/Viewport/ViewportSettings.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 // Editor
 #include "EditorViewportSettings.h"
 #include "Settings.h"
+
+namespace EditorPreferencesViewportManipulatorStrings
+{
+    static const char* ManipulatorsClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Manipulators");
+    static const char* LineBoundWidthName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Line Bound Width");
+    static const char* LineBoundWidthDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Manipulator Line Bound Width");
+    static const char* CircleBoundWidthName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Circle Bound Width");
+    static const char* CircleBoundWidthDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Manipulator Circle Bound Width");
+    static const char* LinearAxisLengthName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Linear Manipulator Axis Length");
+    static const char* LinearAxisLengthDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Length of default Linear Manipulator (for Translation and Scale Manipulators)");
+    static const char* PlanarAxisLengthName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Planar Manipulator Axis Length");
+    static const char* PlanarAxisLengthDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Length of default Planar Manipulator (for Translation Manipulators)");
+    static const char* SurfaceRadiusName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Surface Manipulator Radius");
+    static const char* SurfaceRadiusDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Radius of default Surface Manipulator (for Translation Manipulators)");
+    static const char* SurfaceOpacityName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Surface Manipulator Opacity");
+    static const char* SurfaceOpacityDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Opacity of default Surface Manipulator (for Translation Manipulators)");
+    static const char* LinearConeLengthName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Linear Manipulator Cone Length");
+    static const char* LinearConeLengthDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Length of cone for default Linear Manipulator (for Translation Manipulators)");
+    static const char* LinearConeRadiusName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Linear Manipulator Cone Radius");
+    static const char* LinearConeRadiusDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Radius of cone for default Linear Manipulator (for Translation Manipulators)");
+    static const char* ScaleBoxHalfExtentName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Scale Manipulator Box Half Extent");
+    static const char* ScaleBoxHalfExtentDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Half extent of box for default Scale Manipulator");
+    static const char* RotationRadiusName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Rotation Manipulator Radius");
+    static const char* RotationRadiusDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Radius of default Angular Manipulators (for Rotation Manipulators)");
+    static const char* ViewBaseScaleName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Manipulator View Base Scale");
+    static const char* ViewBaseScaleDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "The base scale to apply to all Manipulator Views (default is 1.0)");
+    static const char* FlipAxesTowardsViewName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Flip Manipulator Axes Towards View");
+    static const char* FlipAxesTowardsViewDesc = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Determines whether Planar and Linear Manipulators should switch to face the view (camera) in the Editor");
+
+    static const char* ManipulatorViewportPreferencesClassName = QT_TRANSLATE_NOOP("EditorPreferencesPageViewportManipulator", "Manipulator Viewport Preferences");
+}
 
 void CEditorPreferencesPage_ViewportManipulator::Reflect(AZ::SerializeContext& serialize)
 {
@@ -40,72 +72,62 @@ void CEditorPreferencesPage_ViewportManipulator::Reflect(AZ::SerializeContext& s
 
     if (AZ::EditContext* editContext = serialize.GetEditContext())
     {
-        editContext->Class<Manipulators>("Manipulators", "")
+        using namespace EditorPreferencesViewportManipulatorStrings;
+
+        editContext->Class<Manipulators>(ManipulatorsClassName, "")
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorLineBoundWidth, "Line Bound Width",
-                "Manipulator Line Bound Width")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorLineBoundWidth, LineBoundWidthName, LineBoundWidthDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
             ->Attribute(AZ::Edit::Attributes::Max, 2.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorCircleBoundWidth, "Circle Bound Width",
-                "Manipulator Circle Bound Width")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorCircleBoundWidth, CircleBoundWidthName, CircleBoundWidthDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
             ->Attribute(AZ::Edit::Attributes::Max, 2.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_linearManipulatorAxisLength, "Linear Manipulator Axis Length",
-                "Length of default Linear Manipulator (for Translation and Scale Manipulators)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_linearManipulatorAxisLength, LinearAxisLengthName, LinearAxisLengthDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.1f)
             ->Attribute(AZ::Edit::Attributes::Max, 5.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_planarManipulatorAxisLength, "Planar Manipulator Axis Length",
-                "Length of default Planar Manipulator (for Translation Manipulators)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_planarManipulatorAxisLength, PlanarAxisLengthName, PlanarAxisLengthDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.1f)
             ->Attribute(AZ::Edit::Attributes::Max, 5.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_surfaceManipulatorRadius, "Surface Manipulator Radius",
-                "Radius of default Surface Manipulator (for Translation Manipulators)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_surfaceManipulatorRadius, SurfaceRadiusName, SurfaceRadiusDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.05f)
             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_surfaceManipulatorOpacity, "Surface Manipulator Opacity",
-                "Opacity of default Surface Manipulator (for Translation Manipulators)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_surfaceManipulatorOpacity, SurfaceOpacityName, SurfaceOpacityDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_linearManipulatorConeLength, "Linear Manipulator Cone Length",
-                "Length of cone for default Linear Manipulator (for Translation Manipulators)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_linearManipulatorConeLength, LinearConeLengthName, LinearConeLengthDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.05f)
             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_linearManipulatorConeRadius, "Linear Manipulator Cone Radius",
-                "Radius of cone for default Linear Manipulator (for Translation Manipulators)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_linearManipulatorConeRadius, LinearConeRadiusName, LinearConeRadiusDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.05f)
             ->Attribute(AZ::Edit::Attributes::Max, 0.5f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_scaleManipulatorBoxHalfExtent, "Scale Manipulator Box Half Extent",
-                "Half extent of box for default Scale Manipulator")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_scaleManipulatorBoxHalfExtent, ScaleBoxHalfExtentName, ScaleBoxHalfExtentDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.05f)
             ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_rotationManipulatorRadius, "Rotation Manipulator Radius",
-                "Radius of default Angular Manipulators (for Rotation Manipulators)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_rotationManipulatorRadius, RotationRadiusName, RotationRadiusDesc)
             ->Attribute(AZ::Edit::Attributes::Min, 0.5f)
             ->Attribute(AZ::Edit::Attributes::Max, 5.0f)
             ->DataElement(
-                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorViewBaseScale, "Manipulator View Base Scale",
-                "The base scale to apply to all Manipulator Views (default is 1.0)")
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorViewBaseScale, ViewBaseScaleName, ViewBaseScaleDesc)
             ->Attribute(AZ::Edit::Attributes::Min, AzToolsFramework::MinManipulatorViewBaseScale)
             ->Attribute(AZ::Edit::Attributes::Max, AzToolsFramework::MaxManipulatorViewBaseScale)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &Manipulators::m_flipManipulatorAxesTowardsView, "Flip Manipulator Axes Towards View",
-                "Determines whether Planar and Linear Manipulators should switch to face the view (camera) in the Editor");
+                AZ::Edit::UIHandlers::CheckBox, &Manipulators::m_flipManipulatorAxesTowardsView, FlipAxesTowardsViewName, FlipAxesTowardsViewDesc);
 
         editContext
-            ->Class<CEditorPreferencesPage_ViewportManipulator>("Manipulator Viewport Preferences", "Manipulator Viewport Preferences")
+            ->Class<CEditorPreferencesPage_ViewportManipulator>(ManipulatorViewportPreferencesClassName, ManipulatorViewportPreferencesClassName)
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC_CE("PropertyVisibility_ShowChildrenOnly"))
             ->DataElement(
-                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportManipulator::m_manipulators, "Manipulators", "Manipulators");
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportManipulator::m_manipulators, ManipulatorsClassName, ManipulatorsClassName);
     }
 }
 
@@ -117,12 +139,12 @@ CEditorPreferencesPage_ViewportManipulator::CEditorPreferencesPage_ViewportManip
 
 const char* CEditorPreferencesPage_ViewportManipulator::GetCategory()
 {
-    return "Viewports";
+    return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Viewports");
 }
 
 const char* CEditorPreferencesPage_ViewportManipulator::GetTitle()
 {
-    return "Manipulators";
+    return QT_TRANSLATE_NOOP("EditorPreferencesDialog", "Manipulators");
 }
 
 QIcon& CEditorPreferencesPage_ViewportManipulator::GetIcon()

--- a/Code/Editor/LogFile.cpp
+++ b/Code/Editor/LogFile.cpp
@@ -445,7 +445,7 @@ void CLogFile::AboutSystem()
     Gestalt(gestaltSystemVersionMinor, &minorVersion);
     AZ_POP_DISABLE_WARNING
 
-    CryLog("%s - %d.%d", qPrintable(operatingSystemName), majorVersion, minorVersion);
+    CryLog("%s - %d.%d", qUtf8Printable(operatingSystemName), majorVersion, minorVersion);
 #else
     CryLog("Unknown Operating System");
 #endif
@@ -476,7 +476,7 @@ void CLogFile::AboutSystem()
 #else
     clock_gettime(CLOCK_MONOTONIC, &ts);
 #endif
-    CryLog("Local time is %s, system running for %ld minutes", qPrintable(QTime::currentTime().toString("hh:mm:ss")), ts.tv_sec / 60);
+    CryLog("Local time is %s, system running for %ld minutes", qUtf8Printable(QTime::currentTime().toString("hh:mm:ss")), ts.tv_sec / 60);
 #endif
 
     //////////////////////////////////////////////////////////////////////
@@ -505,7 +505,7 @@ void CLogFile::AboutSystem()
     auto screen = QGuiApplication::primaryScreen();
     if (screen)
     {
-        CryLog("Current display mode is %dx%dx%d, %s", screen->size().width(), screen->size().height(), screen->depth(), qPrintable(screen->name()));
+        CryLog("Current display mode is %dx%dx%d, %s", screen->size().width(), screen->size().height(), screen->depth(), qUtf8Printable(screen->name()));
     }
 #endif
 

--- a/Code/Editor/LyViewPaneNames.h
+++ b/Code/Editor/LyViewPaneNames.h
@@ -8,41 +8,49 @@
 
 #pragma once
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace LyViewPane
 {
-    static const char* const CategoryTools = "Tools";
-    static const char* const CategoryOther = "Other";
+    // Note: QT_TRANSLATE_NOOP marks these strings for translation extraction by lupdate,
+    // but does NOT change their runtime values. The constants remain plain English strings
+    // and continue to serve as pane identifiers for registration, lookup, and layout persistence.
+    // To display the translated version, use:
+    //   QCoreApplication::translate("LyViewPane", LyViewPane::XXX)
+
+    static const char* const CategoryTools = QT_TRANSLATE_NOOP("LyViewPane", "Tools");
+    static const char* const CategoryOther = QT_TRANSLATE_NOOP("LyViewPane", "Other");
     //----
-    static const char* const CategoryEditor = "Editor";
-    static const char* const CategoryViewport = "Viewport";
+    static const char* const CategoryEditor = QT_TRANSLATE_NOOP("LyViewPane", "Editor");
+    static const char* const CategoryViewport = QT_TRANSLATE_NOOP("LyViewPane", "Viewport");
 
 
     // Putting these names here so that when view panes are opened
     // from other areas of Editor code, they still work when the name changes.
-    static const char* const AssetBrowser = "Asset Browser";
-    static const char* const AssetEditor = "Asset Editor";
-    static const char* const AssetBrowserInspector = "Asset Browser Inspector";
-    static const char* const EntityOutliner = "Entity Outliner";
-    static const char* const Inspector = "Inspector";
-    static const char* const EntityInspectorPinned = "Pinned Entity Inspector";
-    static const char* const LevelInspector = "Level Inspector";
-    static const char* const ProjectSettingsTool = "Edit Platform Settings...";
-    static const char* const ErrorReport = "Error Report";
-    static const char* const Console = "Console";
-    static const char* const ConsoleMenuName = "&Console";
-    static const char* const ConsoleVariables = "Console Variables";
-    static const char* const TrackView = "Track View";
-    static const char* const ScriptCanvas = "Script Canvas";
-    static const char* const UiEditor = "UI Editor";
+    static const char* const AssetBrowser = QT_TRANSLATE_NOOP("LyViewPane", "Asset Browser");
+    static const char* const AssetEditor = QT_TRANSLATE_NOOP("LyViewPane", "Asset Editor");
+    static const char* const AssetBrowserInspector = QT_TRANSLATE_NOOP("LyViewPane", "Asset Browser Inspector");
+    static const char* const EntityOutliner = QT_TRANSLATE_NOOP("LyViewPane", "Entity Outliner");
+    static const char* const Inspector = QT_TRANSLATE_NOOP("LyViewPane", "Inspector");
+    static const char* const EntityInspectorPinned = QT_TRANSLATE_NOOP("LyViewPane", "Pinned Entity Inspector");
+    static const char* const LevelInspector = QT_TRANSLATE_NOOP("LyViewPane", "Level Inspector");
+    static const char* const ProjectSettingsTool = QT_TRANSLATE_NOOP("LyViewPane", "Edit Platform Settings...");
+    static const char* const ErrorReport = QT_TRANSLATE_NOOP("LyViewPane", "Error Report");
+    static const char* const Console = QT_TRANSLATE_NOOP("LyViewPane", "Console");
+    static const char* const ConsoleMenuName = QT_TRANSLATE_NOOP("LyViewPane", "&Console");
+    static const char* const ConsoleVariables = QT_TRANSLATE_NOOP("LyViewPane", "Console Variables");
+    static const char* const TrackView = QT_TRANSLATE_NOOP("LyViewPane", "Track View");
+    static const char* const ScriptCanvas = QT_TRANSLATE_NOOP("LyViewPane", "Script Canvas");
+    static const char* const UiEditor = QT_TRANSLATE_NOOP("LyViewPane", "UI Editor");
 
-    static const char* const EditorSettingsManager = "Editor Settings Manager";
-    static const char* const AudioControlsEditor = "Audio Controls Editor";
-    static const char* const SubstanceEditor = "Substance Editor";
-    static const char* const LandscapeCanvas = "Landscape Canvas";
-    static const char* const AnimationEditor = "EMotion FX Animation Editor";
-    static const char* const PhysXConfigurationEditor = "PhysX Configuration";
+    static const char* const EditorSettingsManager = QT_TRANSLATE_NOOP("LyViewPane", "Editor Settings Manager");
+    static const char* const AudioControlsEditor = QT_TRANSLATE_NOOP("LyViewPane", "Audio Controls Editor");
+    static const char* const SubstanceEditor = QT_TRANSLATE_NOOP("LyViewPane", "Substance Editor");
+    static const char* const LandscapeCanvas = QT_TRANSLATE_NOOP("LyViewPane", "Landscape Canvas");
+    static const char* const AnimationEditor = QT_TRANSLATE_NOOP("LyViewPane", "EMotion FX Animation Editor");
+    static const char* const PhysXConfigurationEditor = QT_TRANSLATE_NOOP("LyViewPane", "PhysX Configuration");
 
-    static const char* const SliceRelationships = "Slice Relationship View";
+    static const char* const SliceRelationships = QT_TRANSLATE_NOOP("LyViewPane", "Slice Relationship View");
 
     const int NO_BUILTIN_ACTION = -1;
 }

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/ContextMenuHandlers.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/ContextMenuHandlers.cpp
@@ -59,8 +59,9 @@ void EditorContextMenuHandler::OnActionRegistrationHook()
     {
         const AZStd::string_view actionIdentifier = "o3de.action.entity.openPinnedInspector";
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_name = "Open Pinned Inspector";
-        actionProperties.m_description = "Open a new instance of the Entity Inspector for the current selection.";
+        actionProperties.m_name = qUtf8Printable(QObject::tr("Open Pinned Inspector"));
+        actionProperties.m_description =
+            qUtf8Printable(QObject::tr("Open a new instance of the Entity Inspector for the current selection."));
         actionProperties.m_category = "Edit";
 
         actionManagerInterface->RegisterAction(

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -515,8 +515,8 @@ void SandboxIntegrationManager::OnActionRegistrationHook()
     {
         const AZStd::string_view actionIdentifier = "o3de.action.sandbox.createEntity";
         AzToolsFramework::ActionProperties actionProperties;
-        actionProperties.m_name = "Create entity";
-        actionProperties.m_description = "Creates an entity under the current selection";
+        actionProperties.m_name = QObject::tr("Create entity").toUtf8().constData();
+        actionProperties.m_description = QObject::tr("Creates an entity under the current selection").toUtf8().constData();
         actionProperties.m_category = "Entity";
         actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::HideWhenDisabled;
 

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Android.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Android.cpp
@@ -11,9 +11,11 @@
 #include "PlatformSettings_common.h"
 #include "Validators.h"
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace ProjectSettingsTool
 {
-    static const char* defaultImageTooltip = "Default image used if a specific DPI override is not given.";
+    static const char* defaultImageTooltip = QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Default image used if a specific DPI override is not given.");
     static void* xmlFunctor = reinterpret_cast<void*>(&SelectXmlFromFileDialog);
 
     void AndroidIcons::Reflect(AZ::ReflectContext* context)
@@ -34,27 +36,35 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<AndroidIcons>("Icons", "All icon overrides for android.")
-                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_default, "Default", defaultImageTooltip)
+                editContext->Class<AndroidIcons>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Icons"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All icon overrides for android."))
+                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_default,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Default"), defaultImageTooltip)
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::AndroidIconDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_mdpi, "Medium Dpi (48px)", "")
+                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_mdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Medium Dpi (48px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<48>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidIcons, "mdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidIconDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_hdpi, "High Dpi (72px)", "")
+                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_hdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "High Dpi (72px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<72>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidIcons, "hdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidIconDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_xhdpi, "XHigh Dpi (96px)", "")
+                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_xhdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "XHigh Dpi (96px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<96>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidIcons, "xhdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidIconDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_xxhdpi, "XXHigh Dpi (144px)", "")
+                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_xxhdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "XXHigh Dpi (144px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<144>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidIcons, "xxhdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidIconDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_xxxhdpi, "XXXHigh Dpi (192px)", "")
+                    ->DataElement(Handlers::ImagePreview, &AndroidIcons::m_xxxhdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "XXXHigh Dpi (192px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<192>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidIcons, "xxxhdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidIconDefault)
@@ -80,23 +90,34 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<AndroidLandscapeSplashscreens>("Landscape", "All landscape splashscreen overrides for Android.")
-                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_default, "Default", defaultImageTooltip)
+                editContext->Class<AndroidLandscapeSplashscreens>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Landscape"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All landscape splashscreen overrides for Android."))
+                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_default,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Default"), defaultImageTooltip)
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::AndroidLandDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_mdpi, "Medium Dpi", "Suggested 1024 x 640 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_mdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Medium Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 1024 x 640 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidLandscape, "mdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidLandDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_hdpi, "High Dpi", "Suggested 1280 x 800 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_hdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "High Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 1280 x 800 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidLandscape, "hdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidLandDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_xhdpi, "XHigh Dpi", "Suggested 1920 x 1200 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_xhdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "XHigh Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 1920 x 1200 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidLandscape, "xhdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidLandDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_xxhdpi, "XXHigh Dpi", "Suggested 2560 x 1600 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidLandscapeSplashscreens::m_xxhdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "XXHigh Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 2560 x 1600 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidLandscape, "xxhdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidLandDefault)
@@ -122,23 +143,34 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<AndroidPortraitSplashscreens>("Portrait", "All portrait splashscreen overrides for Android.")
-                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_default, "Default", defaultImageTooltip)
+                editContext->Class<AndroidPortraitSplashscreens>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Portrait"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All portrait splashscreen overrides for Android."))
+                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_default,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Default"), defaultImageTooltip)
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::AndroidPortDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_mdpi, "Medium Dpi", "Suggested 640 x 1024 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_mdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Medium Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 640 x 1024 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidPortrait, "mdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidPortDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_hdpi, "High Dpi", "Suggested 800 x 1280 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_hdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "High Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 800 x 1280 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidPortrait, "hdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidPortDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_xhdpi, "XHigh Dpi", "Suggested 1200 x 1920 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_xhdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "XHigh Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 1200 x 1920 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidPortrait, "xhdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidPortDefault)
-                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_xxhdpi, "XXHigh Dpi", "Suggested 1600 x 2560 png.")
+                    ->DataElement(Handlers::ImagePreview, &AndroidPortraitSplashscreens::m_xxhdpi,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "XXHigh Dpi"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Suggested 1600 x 2560 png."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidPngOrEmpty))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::AndroidPortrait, "xxhdpi"))
                         ->Attribute(Attributes::DefaultImagePreview, Identfiers::AndroidPortDefault)
@@ -164,7 +196,9 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<AndroidSplashscreens>("Splashscreens", "All splashscreen overrides for Android.")
+                editContext->Class<AndroidSplashscreens>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Splashscreens"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All splashscreen overrides for Android."))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSplashscreens::m_landscapeSplashscreens)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSplashscreens::m_portraitSplashscreens)
                 ;
@@ -201,22 +235,32 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<AndroidSettings>("Android Settings", "All settings related to Android not already defined by base settings.")
+                editContext->Class<AndroidSettings>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Android Settings"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All settings related to Android not already defined by base settings."))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_packageName, "Package Name", "Android application package identifier. Used for generating the project specific Java activity class and in the AndroidManifest.xml. Must be in dot separated format.")
+                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_packageName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Package Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Android application package identifier. Used for generating the project specific Java activity class and in the AndroidManifest.xml. Must be in dot separated format."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PackageName))
                         ->Attribute(Attributes::LinkOptional, true)
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::AndroidPackageName)
-                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_versionName, "Version Name", "Human readable version number. Used to set the \"android: versionName\" tag in the AndroidManifest.xml and ultimately what will be displayed in the App Store.")
+                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_versionName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Version Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Human readable version number. Used to set the \"android: versionName\" tag in the AndroidManifest.xml and ultimately what will be displayed in the App Store."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::IOSVersionNumber))
                         ->Attribute(Attributes::LinkOptional, true)
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::AndroidVersionName)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_versionNumber, "Version Number", "Internal application version number. Used to set the \"android:versionCode\" tag in the AndroidManifest.xml.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_versionNumber,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Version Number"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Internal application version number. Used to set the \"android:versionCode\" tag in the AndroidManifest.xml."))
                         ->Attribute(AZ::Edit::Attributes::Min, 1)
                         ->Attribute(AZ::Edit::Attributes::Max, Validators::maxAndroidVersion)
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &AndroidSettings::m_orientation, "Orientation", "Desired orientation of the Android application. Used to set the \"android:screenOrientation\" tag in the AndroidManifest.xml.")
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &AndroidSettings::m_orientation,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Orientation"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Desired orientation of the Android application. Used to set the \"android:screenOrientation\" tag in the AndroidManifest.xml."))
                         ->Attribute(AZ::Edit::Attributes::StringList, AZStd::vector<AZStd::string>
                         {
                             "landscape",
@@ -236,21 +280,37 @@ namespace ProjectSettingsTool
                             "behind",
                             "unspecified"
                         })
-                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_appPublicKey, "Public App Key", "The application license key provided by Google Play. Required for using APK expansion files or other Google Play Services.")
+                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_appPublicKey,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Public App Key"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The application license key provided by Google Play. Required for using APK expansion files or other Google Play Services."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PublicAppKeyOrEmpty))
                         ->Attribute(Attributes::Obfuscated, true)
-                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_appObfuscatorSalt, "App Obfuscation Salt", "Application specific salt value for (un)obfuscation when using APK expansion files.")
+                    ->DataElement(Handlers::LinkedLineEdit, &AndroidSettings::m_appObfuscatorSalt,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "App Obfuscation Salt"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Application specific salt value for (un)obfuscation when using APK expansion files."))
                         ->Attribute(Attributes::Obfuscated, true)
-                    ->DataElement(Handlers::FileSelect, &AndroidSettings::m_rcPakJob, "Rc Job PAK Override", "Path to the RC job XML file used to override the normal PAK files generation used in release builds. Path must be relative to <build dir>.")
+                    ->DataElement(Handlers::FileSelect, &AndroidSettings::m_rcPakJob,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Rc Job PAK Override"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Path to the RC job XML file used to override the normal PAK files generation used in release builds. Path must be relative to <build dir>."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidXmlOrEmpty))
                         ->Attribute(Attributes::SelectFunction, xmlFunctor)
-                    ->DataElement(Handlers::FileSelect, &AndroidSettings::m_rcObbJob, "Rc Job APK Override", "Path to the RC job XML file used to override the normal APK Expansion file(s) generation used in release builds. Path must be relative to <build dir>.")
+                    ->DataElement(Handlers::FileSelect, &AndroidSettings::m_rcObbJob,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Rc Job APK Override"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Path to the RC job XML file used to override the normal APK Expansion file(s) generation used in release builds. Path must be relative to <build dir>."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::ValidXmlOrEmpty))
                         ->Attribute(Attributes::SelectFunction, xmlFunctor)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_useMainObb, "Use Main APK", "Specify if the \"Main\" APK Expansion file should be used.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_usePatchObb, "Use Patch APK", "Specify if the \"Patch\" APK Expansion file should be used.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_enableKeyScreenOn, "Enable Screen Wake Lock", "Enabled or disable the screen wake lock (device won't go to sleep while the application is running).")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_disableImmersiveMode, "Disable Immersive Mode", "Disable hiding of top and bottom system bars.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_useMainObb,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Use Main APK"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Specify if the \"Main\" APK Expansion file should be used."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_usePatchObb,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Use Patch APK"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Specify if the \"Patch\" APK Expansion file should be used."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_enableKeyScreenOn,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable Screen Wake Lock"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable or disable the screen wake lock (device won't go to sleep while the application is running)."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_disableImmersiveMode,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Disable Immersive Mode"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Disable hiding of top and bottom system bars."))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_icons)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSettings::m_splashscreens)
                 ;

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Base.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Base.cpp
@@ -11,6 +11,8 @@
 #include "PlatformSettings_common.h"
 #include "Validators.h"
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace ProjectSettingsTool
 {
     void BaseSettings::Reflect(AZ::ReflectContext* context)
@@ -31,22 +33,36 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<BaseSettings>("Project Settings", "All core settings for the game project and package and deployment.")
+                editContext->Class<BaseSettings>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Project Settings"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All core settings for the game project and package and deployment."))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                    ->DataElement(Handlers::LinkedLineEdit, &BaseSettings::m_projectName, "Project Name", "The name of the project.")
+                    ->DataElement(Handlers::LinkedLineEdit, &BaseSettings::m_projectName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Project Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The name of the project."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::FileName))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::ProjectName)
-                    ->DataElement(Handlers::LinkedLineEdit, &BaseSettings::m_productName, "Product Name", "The project's user facing name.")
+                    ->DataElement(Handlers::LinkedLineEdit, &BaseSettings::m_productName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Product Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The project's user facing name."))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::ProductName)
-                    ->DataElement(Handlers::LinkedLineEdit, &BaseSettings::m_executableName, "Executable Name", "The project launcher's name.")
+                    ->DataElement(Handlers::LinkedLineEdit, &BaseSettings::m_executableName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Executable Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The project launcher's name."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::FileNameOrEmpty))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::ExecutableName)
-                    ->DataElement(Handlers::QValidatedLineEdit, &BaseSettings::m_projectPath, "Project Path", "The project root folder path .")
+                    ->DataElement(Handlers::QValidatedLineEdit, &BaseSettings::m_projectPath,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Project Path"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The project root folder path."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::FileNameOrEmpty))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::ProductName)
-                    ->DataElement(Handlers::QValidatedLineEdit, &BaseSettings::m_projectOutputFolder, "Output Folder", "The folder the packed project will be exported to.")
-                    ->DataElement(Handlers::QValidatedLineEdit, &BaseSettings::m_codeFolder, "Code Folder (legacy)", "A legacy setting specifing the folder for this project's code.")
+                    ->DataElement(Handlers::QValidatedLineEdit, &BaseSettings::m_projectOutputFolder,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Output Folder"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The folder the packed project will be exported to."))
+                    ->DataElement(Handlers::QValidatedLineEdit, &BaseSettings::m_codeFolder,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Code Folder (legacy)"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "A legacy setting specifying the folder for this project's code."))
                 ;
             }
         }

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Ios.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Ios.cpp
@@ -11,6 +11,8 @@
 #include "PlatformSettings_common.h"
 #include "Validators.h"
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace ProjectSettingsTool
 {
     namespace Icons
@@ -65,59 +67,79 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<IosIcons>("Icons", "All png icon overrides for iOS.")
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_appStore, "App Store (1024px)", "")
+                editContext->Class<IosIcons>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Icons"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All png icon overrides for iOS."))
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_appStore,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "App Store (1024px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<1024>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::appStore))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneApp120, "iPhone App (120px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneApp120,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone App (120px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<120>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneApp120))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneApp180, "iPhone App (180px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneApp180,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone App (180px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<180>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneApp180))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneNotification40, "iPhone Notification (40px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneNotification40,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone Notification (40px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<40>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneNotification40))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneNotification60, "iPhone Notification (60px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneNotification60,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone Notification (60px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<60>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneNotification60))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSettings58, "iPhone Settings (58px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSettings58,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone Settings (58px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<58>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneSettings58))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSettings87, "iPhone Settings (87px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSettings87,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone Settings (87px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<87>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneSettings87))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSpotlight80, "iPhone Spotlight (80px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSpotlight80,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone Spotlight (80px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<80>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneSpotlight80))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSpotlight120, "iPhone Spotlight (120px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_iphoneSpotlight120,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone Spotlight (120px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<120>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::iphoneSpotlight120))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadApp76, "iPad App (76px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadApp76,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad App (76px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<76>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadApp76))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadApp152, "iPad App (152px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadApp152,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad App (152px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<152>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadApp152))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadProApp, "iPad Pro App (167px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadProApp,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Pro App (167px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<167>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadProApp))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadNotification20, "iPad Notification (20px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadNotification20,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Notification (20px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<20>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadNotification20))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadNotification40, "iPad Notification (40px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadNotification40,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Notification (40px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<40>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadNotification40))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSettings29, "iPad Settings (29px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSettings29,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Settings (29px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<29>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadSettings29))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSettings58, "iPad Settings (58px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSettings58,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Settings (58px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<58>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadSettings58))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSpotlight40, "iPad Spotlight (40px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSpotlight40,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Spotlight (40px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<40>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadSpotlight40))
-                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSpotlight80, "iPad Spotlight (80px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosIcons::m_ipadSpotlight80,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Spotlight (80px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<80>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosIcons, Icons::ipadSpotlight80))
                 ;
@@ -163,38 +185,51 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<IosLaunchscreens>("Launchscreens", "All png launchscreen overrides for iOS.")
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone640x960, "iPhone (640x960px)", "")
+                editContext->Class<IosLaunchscreens>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Launchscreens"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All png launchscreen overrides for iOS."))
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone640x960,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone (640x960px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<640, 960>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::iphone640x960))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone640x1136, "iPhone (640x1136px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone640x1136,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone (640x1136px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<640, 1136>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::iphone640x1136))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone750x1334, "iPhone (750x1334px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone750x1334,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone (750x1334px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<750, 1334>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::iphone750x1334))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone1125x2436, "iPhone (1125x2436px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone1125x2436,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone (1125x2436px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<1125, 2436>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::iphone1125x2436))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone2436x1125, "iPhone (2436x1125px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone2436x1125,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone (2436x1125px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<2436, 1125>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::iphone2436x1125))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone1242x2208, "iPhone (1242x2208px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone1242x2208,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone (1242x2208px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<1242, 2208>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::iphone1242x2208))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone2208x1242, "iPhone (2208x1242px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_iphone2208x1242,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone (2208x1242px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<2208, 1242>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::iphone2208x1242))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad768x1024, "iPad (768x1024px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad768x1024,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad (768x1024px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<768, 1024>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::ipad768x1024))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad1024x768, "iPad (1024x768px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad1024x768,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad (1024x768px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<1024, 768>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::ipad1024x768))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad1536x2048, "iPad (1536x2048px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad1536x2048,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad (1536x2048px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<1536, 2048>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::ipad1536x2048))
-                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad2048x1536, "iPad (2048x1536px)", "")
+                    ->DataElement(Handlers::ImagePreview, &IosLaunchscreens::m_ipad2048x1536,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad (2048x1536px)"), "")
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PngImageSetSizeOrEmpty<2048, 1536>))
                         ->Attribute(Attributes::DefaultPath, GenDefaultImagePath(ImageGroup::IosLaunchScreens, Launchscreens::ipad2048x1536))
                 ;
@@ -218,11 +253,21 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<IosOrientations>("Orientations", "All supported orientations for iOS.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_landscapeRight, "Landscape (right home button)", "Enable landscape orientation with home button on right side of device.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_landscapeLeft, "Landscape (left home button)", "Enable landscape orientation with home button on left side of device.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_portraitBottom, "Portrait (bottom home button)", "Enable portrait orientation with home button on bottom of device.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_portraitTop, "Portrait (top home button)", "Enable portrait orientation with home button on top of device.")
+                editContext->Class<IosOrientations>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Orientations"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All supported orientations for iOS."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_landscapeRight,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Landscape (right home button)"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable landscape orientation with home button on right side of device."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_landscapeLeft,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Landscape (left home button)"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable landscape orientation with home button on left side of device."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_portraitBottom,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Portrait (bottom home button)"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable portrait orientation with home button on bottom of device."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosOrientations::m_portraitTop,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Portrait (top home button)"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable portrait orientation with home button on top of device."))
                 ;
             }
         }
@@ -257,30 +302,46 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<IosSettings>("Ios Settings", "All settings iOS settings.")
+                editContext->Class<IosSettings>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iOS Settings"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "All iOS settings."))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_bundleName, "Bundle Name", "The name of the bundle.")
+                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_bundleName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Bundle Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The name of the bundle."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::IOSFileName))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::IosBundleName)
-                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_bundleDisplayName, "Display Name", "The user visible name of the bundle.")
+                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_bundleDisplayName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Display Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The user visible name of the bundle."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::IsNotEmpty))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::IosDisplayName)
-                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_executableName, "Executable Name", "Name of the bundle's executable file.")
+                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_executableName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Executable Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Name of the bundle's executable file."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::IOSFileName))
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::IosExecutableName)
-                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_bundleIdentifier, "Bundle Identifier", "Uniquely identifies the bundle. Should be in reverse-DNS format.")
+                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_bundleIdentifier,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Bundle Identifier"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Uniquely identifies the bundle. Should be in reverse-DNS format."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::PackageName))
                         ->Attribute(Attributes::LinkOptional, true)
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::IosBundleIdentifer)
-                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_versionName, "Version Name", "The release version number string for the app. Displayed in the app store.")
+                    ->DataElement(Handlers::LinkedLineEdit, &IosSettings::m_versionName,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Version Name"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The release version number string for the app. Displayed in the app store."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::IOSVersionNumber))
                         ->Attribute(Attributes::LinkOptional, true)
                         ->Attribute(Attributes::PropertyIdentfier, Identfiers::IosVersionName)
-                    ->DataElement(Handlers::QValidatedLineEdit, &IosSettings::m_versionNumber, "Version Number", "The build version number string for the bundle.")
+                    ->DataElement(Handlers::QValidatedLineEdit, &IosSettings::m_versionNumber,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Version Number"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The build version number string for the bundle."))
                         ->Attribute(Attributes::FuncValidator, ConvertFunctorToVoid(&Validators::IOSVersionNumber))
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &IosSettings::m_developmentRegion, "Development Region", "The default language and region for the app.")
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &IosSettings::m_developmentRegion,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Development Region"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "The default language and region for the app."))
                         ->Attribute(AZ::Edit::Attributes::StringList, AZStd::vector<AZStd::string>
                         {
                             "en_US",
@@ -295,10 +356,18 @@ namespace ProjectSettingsTool
                             "zh_TW",
                             "en_GB"
                         })
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_requiresFullscreen, "Requires Fullscreen", "Specifies whether the app is required to run in fullscreen mode.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_hideStatusBar, "Hide Status Bar", "Specifies whether the status bar is initially hidden when the app launches.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_iphoneOrientations, "iPhone Orientations", "Enable support for iPhone orientations.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_ipadOrientations, "iPad Orientations", "Enable support for iPad orientations.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_requiresFullscreen,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Requires Fullscreen"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Specifies whether the app is required to run in fullscreen mode."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_hideStatusBar,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Hide Status Bar"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Specifies whether the status bar is initially hidden when the app launches."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_iphoneOrientations,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPhone Orientations"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable support for iPhone orientations."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_ipadOrientations,
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "iPad Orientations"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enable support for iPad orientations."))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_icons)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &IosSettings::m_launchscreens)
                 ;

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Windows.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Windows.cpp
@@ -12,6 +12,7 @@
 #include "Validators.h"
 
 #include <AzCore/IO/FileIO.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 namespace ProjectSettingsTool
 {
@@ -35,7 +36,8 @@ namespace ProjectSettingsTool
                     ->DataElement(
                         AZ::Edit::UIHandlers::ComboBox,
                         &WindowsGraphics::m_graphicsAPI,
-                        "Graphics API", "Select the primary graphics API")
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Graphics API"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Select the primary graphics API"))
                     ->Attribute(
                         AZ::Edit::Attributes::StringList,
                         []()
@@ -45,16 +47,20 @@ namespace ProjectSettingsTool
                     ->DataElement(
                         AZ::Edit::UIHandlers::ComboBox,
                         &WindowsGraphics::m_validationMode,
-                        "Validation Layers", "Set the validation mode for the RHI.")
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Validation Layers"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Set the validation mode for the RHI."))
                     ->Attribute(
                         AZ::Edit::Attributes::EnumValues,
                         AZStd::vector<AZ::Edit::EnumConstant<ValidationMode>>{
                             AZ::Edit::EnumConstant<ValidationMode>(
-                                ValidationMode::Disabled, "Disabled"),
+                                ValidationMode::Disabled,
+                                QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Disabled")),
                             AZ::Edit::EnumConstant<ValidationMode>(
-                                ValidationMode::Enabled, "Enabled  (Shows warnings and error messages)"),
+                                ValidationMode::Enabled,
+                                QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Enabled  (Shows warnings and error messages)")),
                             AZ::Edit::EnumConstant<ValidationMode>(
-                                ValidationMode::Verbose, "Verbose  (Shows warnings, errors, and informational messages)"),
+                                ValidationMode::Verbose,
+                                QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Verbose  (Shows warnings, errors, and informational messages)")),
                             AZ::Edit::EnumConstant<ValidationMode>(
                                 ValidationMode::GPU, "GPU"),
                         });
@@ -123,15 +129,17 @@ namespace ProjectSettingsTool
             AZ::EditContext* editContext = serialize->GetEditContext();
             if (editContext)
             {
-                editContext->Class<WindowsSettings>("Windows Settings", "Configure settings for Windows platform")
+                editContext->Class<WindowsSettings>(
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Windows Settings"),
+                    QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Configure settings for Windows platform"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &WindowsSettings::m_graphics,
-                        "Graphics Settings",
-                        "Configure Graphics settings for Windows platform");
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Graphics Settings"),
+                        QT_TRANSLATE_NOOP("ReflectedPropertyEditor", "Configure Graphics settings for Windows platform"));
             }
         }
     }

--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.cpp
@@ -485,8 +485,8 @@ namespace ProjectSettingsTool
                 QMessageBox::critical
                 (
                     this,
-                    "Critical",
-                    "Android settings is invalid. Project Settings Tool must close.",
+                    tr("Critical"),
+                    tr("Android settings is invalid. Project Settings Tool must close."),
                     QMessageBox::Abort
                 );
                 ForceClose();
@@ -512,8 +512,8 @@ namespace ProjectSettingsTool
                 QMessageBox::critical
                 (
                     this,
-                    "Critical",
-                    "Ios pList is invalid. Project Settings Tool must close.",
+                    tr("Critical"),
+                    tr("iOS pList is invalid. Project Settings Tool must close."),
                     QMessageBox::Abort
                 );
                 ForceClose();
@@ -539,8 +539,8 @@ namespace ProjectSettingsTool
                 QMessageBox::critical
                 (
                     this,
-                    "Critical",
-                    "Windows settings is invalid. Project Settings Tool must close.",
+                    tr("Critical"),
+                    tr("Windows settings is invalid. Project Settings Tool must close."),
                     QMessageBox::Abort
                 );
                 ForceClose();

--- a/Code/Editor/TrackView/CharacterKeyUIControls.cpp
+++ b/Code/Editor/TrackView/CharacterKeyUIControls.cpp
@@ -34,14 +34,14 @@ public:
 
     void OnCreateVars() override
     {
-        AddVariable(mv_table, "Key Properties");
-        AddVariable(mv_table, mv_animation, "Animation", IVariable::DT_ANIMATION);
-        AddVariable(mv_table, mv_loop, "Loop");
-        AddVariable(mv_table, mv_blendGap, "Blend Gap");
-        AddVariable(mv_table, mv_inplace, "In Place");
-        AddVariable(mv_table, mv_startTime, "Start Time");
-        AddVariable(mv_table, mv_endTime, "End Time");
-        AddVariable(mv_table, mv_timeScale, "Time Scale");
+        AddVariable(mv_table, tr("Key Properties"));
+        AddVariable(mv_table, mv_animation, tr("Animation"), IVariable::DT_ANIMATION);
+        AddVariable(mv_table, mv_loop, tr("Loop"));
+        AddVariable(mv_table, mv_blendGap, tr("Blend Gap"));
+        AddVariable(mv_table, mv_inplace, tr("In Place"));
+        AddVariable(mv_table, mv_startTime, tr("Start Time"));
+        AddVariable(mv_table, mv_endTime, tr("End Time"));
+        AddVariable(mv_table, mv_timeScale, tr("Time Scale"));
         mv_timeScale->SetLimits(0.001f, 100.f);
     }
     bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -232,7 +232,7 @@ void CSequenceBatchRenderDialog::OnInitDialog()
     // Fill the FPS combo box.
     for (int i = 0; i < AZStd::size(fpsOptions); ++i)
     {
-        m_ui->m_fpsCombo->addItem(fpsOptions[i].fpsDesc);
+        m_ui->m_fpsCombo->addItem(tr(fpsOptions[i].fpsDesc));
     }
     m_ui->m_fpsCombo->setCurrentIndex(0);
 
@@ -243,10 +243,10 @@ void CSequenceBatchRenderDialog::OnInitDialog()
     }
     m_ui->m_imageFormatCombo->setCurrentIndex(0);
 
-    m_ui->BATCH_RENDER_FILE_PREFIX->setText("Frame");
+    m_ui->BATCH_RENDER_FILE_PREFIX->setText(tr("Frame"));
     m_ui->BATCH_RENDER_FILE_PREFIX->setValidator(m_prefixValidator.data());
 
-    m_ui->m_progressStatusMsg->setText("Not running");
+    m_ui->m_progressStatusMsg->setText(tr("Not running"));
 
     m_ui->BATCH_RENDER_REMOVE_SEQ->setEnabled(false);
     m_ui->m_pGoBtn->setEnabled(false);
@@ -497,7 +497,7 @@ void CSequenceBatchRenderDialog::OnUpdateRenderItem()
 void CSequenceBatchRenderDialog::OnLoadPreset()
 {
     QString loadPath;
-    if (CFileUtil::SelectFile("Preset Files (*.preset)", Path::GetUserSandboxFolder(), loadPath))
+    if (CFileUtil::SelectFile(tr("Preset Files (*.preset)"), Path::GetUserSandboxFolder(), loadPath))
     {
         if (LoadOutputOptions(loadPath) == false)
         {
@@ -509,7 +509,7 @@ void CSequenceBatchRenderDialog::OnLoadPreset()
 void CSequenceBatchRenderDialog::OnSavePreset()
 {
     QString savePath;
-    if (CFileUtil::SelectSaveFile("Preset Files (*.preset)", "preset", Path::GetUserSandboxFolder(), savePath))
+    if (CFileUtil::SelectSaveFile(tr("Preset Files (*.preset)"), "preset", Path::GetUserSandboxFolder(), savePath))
     {
         SaveOutputOptions(savePath);
     }
@@ -536,7 +536,7 @@ void CSequenceBatchRenderDialog::OnGo()
     else
     {
         // Start a new batch.
-        m_ui->m_pGoBtn->setText("Cancel");
+        m_ui->m_pGoBtn->setText(tr("Cancel"));
         m_ui->m_pGoBtn->setIcon(QPixmap(":/Trackview/clapperboard_cancel.png"));
         // Inform the movie system that it soon will be in a batch-rendering mode.
 
@@ -928,7 +928,7 @@ void CSequenceBatchRenderDialog::CaptureItemStart()
     QString probeName = finalFolder;
     while (QFileInfo::exists(probeName))
     {
-        probeName = QObject::tr("%1_v%2").arg(finalFolder).arg(numProbeIndex++);
+        probeName = tr("%1_v%2").arg(finalFolder).arg(numProbeIndex++);
     }
     finalFolder = probeName;
 
@@ -939,7 +939,7 @@ void CSequenceBatchRenderDialog::CaptureItemStart()
         TrackViewMessageBox::Critical(
             AzToolsFramework::GetActiveWindow(),
             QString(),
-            QObject::tr("Cannot create directory %1 for output frames").arg(finalFolder));
+            tr("Cannot create directory %1 for output frames").arg(finalFolder));
 
         OnUpdateFinalize();
         return;
@@ -1015,7 +1015,7 @@ void CSequenceBatchRenderDialog::CaptureItemStart()
 
 void CSequenceBatchRenderDialog::OnUpdateWarmingUpAfterResChange()
 {
-    UpdateSpinnerProgressMessage("Warming up");
+    UpdateSpinnerProgressMessage(qUtf8Printable(tr("Warming up")));
 
     // Spend the given frames warming up after frame buffer resolution change
     if (m_renderContext.framesSpentInCurrentPhase++ >= TrackView::tv_SkipFramesCount)
@@ -1031,7 +1031,7 @@ void CSequenceBatchRenderDialog::OnUpdateWarmingUpAfterResChange()
 
 void CSequenceBatchRenderDialog::OnUpdateEnteringGameMode()
 {
-    UpdateSpinnerProgressMessage("Entering game mode");
+    UpdateSpinnerProgressMessage(qUtf8Printable(tr("Entering game mode")));
 
     GetIEditor()->GetGameEngine()->Update();
 
@@ -1053,7 +1053,7 @@ void CSequenceBatchRenderDialog::OnUpdateEnteringGameMode()
 
 void CSequenceBatchRenderDialog::OnUpdateBeginPlayingSequence()
 {
-    UpdateSpinnerProgressMessage("Begin Playing Sequence");
+    UpdateSpinnerProgressMessage(qUtf8Printable(tr("Begin Playing Sequence")));
 
     SRenderItem& renderItem = m_renderItems[m_renderContext.currentItemIndex];
     const AZStd::string seqName = renderItem.seqName.toUtf8().data();
@@ -1131,7 +1131,7 @@ void CSequenceBatchRenderDialog::OnUpdateCapturing()
     // Progress message
     const QString itemText = m_ui->m_renderList->model()->index(m_renderContext.currentItemIndex, 0).data().toString();
     const QString msg = tr("Rendering '%1'...(%2%)").arg(itemText).arg(static_cast<int>(100.0f * elapsedTime / (rng.end - rng.start)));
-    UpdateSpinnerProgressMessage(msg.toLatin1().data());
+    UpdateSpinnerProgressMessage(qUtf8Printable(msg));
 
     m_renderContext.framesSpentInCurrentPhase++;
 }
@@ -1223,7 +1223,7 @@ void CSequenceBatchRenderDialog::OnUpdateEnd(IAnimSequence* sequence)
 
 void CSequenceBatchRenderDialog::OnUpdateFFMPEGProcessing()
 {
-    UpdateSpinnerProgressMessage("FFMPEG processing");
+    UpdateSpinnerProgressMessage(qUtf8Printable(tr("FFMPEG processing")));
 
     if (!m_renderContext.processingFFMPEG)
     {
@@ -1511,7 +1511,7 @@ void CSequenceBatchRenderDialog::OnCreateVideoChange()
 void CSequenceBatchRenderDialog::OnLoadBatch()
 {
     QString loadPath;
-    if (CFileUtil::SelectFile("Render Batch Files (*.batch)",
+    if (CFileUtil::SelectFile(tr("Render Batch Files (*.batch)"),
             Path::GetUserSandboxFolder(), loadPath))
     {
         XmlNodeRef batchRenderListNode = XmlHelpers::LoadXmlFromFile(loadPath.toStdString().c_str());
@@ -1602,7 +1602,7 @@ void CSequenceBatchRenderDialog::OnLoadBatch()
 void CSequenceBatchRenderDialog::OnSaveBatch()
 {
     QString savePath;
-    if (CFileUtil::SelectSaveFile("Render Batch Files (*.batch)", "batch",
+    if (CFileUtil::SelectSaveFile(tr("Render Batch Files (*.batch)"), "batch",
             Path::GetUserSandboxFolder(), savePath))
     {
         XmlNodeRef batchRenderListNode = XmlHelpers::CreateXmlNode("batchrenderlist");
@@ -1688,7 +1688,7 @@ bool CSequenceBatchRenderDialog::SetUpNewRenderItem(SRenderItem& item)
     item.frameRange = Range(m_ui->m_startFrame->value() / m_fpsForTimeToFrameConversion,
             m_ui->m_endFrame->value() / m_fpsForTimeToFrameConversion);
     // fps
-    if (m_ui->m_fpsCombo->currentIndex() == -1 || m_ui->m_fpsCombo->currentText() != fpsOptions[m_ui->m_fpsCombo->currentIndex()].fpsDesc)
+    if (m_ui->m_fpsCombo->currentIndex() == -1 || m_ui->m_fpsCombo->currentText() != tr(fpsOptions[m_ui->m_fpsCombo->currentIndex()].fpsDesc))
     {
         item.fps = m_customFPS;
     }

--- a/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
+++ b/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
@@ -39,7 +39,7 @@
 struct STrackEntry
 {
     CAnimParamType paramType;
-    QString name;
+    const char* name;
     QColor defaultColor;
 };
 
@@ -47,62 +47,62 @@ namespace
 {
     const STrackEntry g_trackEntries[] = {
         // Color for tracks
-        { AnimParamType::Position, "Pos", QColor(90, 150, 90) },
-        { AnimParamType::Rotation, "Rot", QColor(90, 150, 90) },
-        { AnimParamType::Scale, "Scale", QColor(90, 150, 90) },
-        { AnimParamType::Event, "Event", QColor(220, 220, 220) },
-        { AnimParamType::Visibility, "Visibility", QColor(220, 220, 220) },
-        { AnimParamType::Camera, "Camera", QColor(220, 220, 220) },
-        { AnimParamType::Sound, "Sound", QColor(220, 220, 220) },
-        { AnimParamType::Animation, "Animation", QColor(220, 220, 220) },
-        { AnimParamType::Sequence, "Sequence", QColor(220, 220, 220) },
-        { AnimParamType::Console, "Console", QColor(220, 220, 220) },
-        { AnimParamType::LookAt, "LookAt", QColor(220, 220, 220) },
-        { AnimParamType::TrackEvent, "TrackEvent", QColor(220, 220, 220) },
-        { AnimParamType::ShakeMultiplier, "ShakeMult", QColor(90, 150, 90) },
-        { AnimParamType::TransformNoise, "Noise", QColor(90, 150, 90) },
-        { AnimParamType::TimeWarp, "Timewarp", QColor(220, 220, 220) },
-        { AnimParamType::FixedTimeStep, "FixedTimeStep", QColor(220, 220, 220) },
-        { AnimParamType::DepthOfField, "DepthOfField", QColor(90, 150, 90) },
-        { AnimParamType::CommentText, "CommentText", QColor(220, 220, 220) },
-        { AnimParamType::ScreenFader, "ScreenFader", QColor(220, 220, 220) },
-        { AnimParamType::LightDiffuse, "LightDiffuseColor", QColor(90, 150, 90) },
-        { AnimParamType::LightRadius, "LightRadius", QColor(220, 220, 220) },
-        { AnimParamType::LightDiffuseMult, "LightDiffuseMult", QColor(220, 220, 220) },
-        { AnimParamType::LightHDRDynamic, "LightHDRDynamic", QColor(220, 220, 220) },
-        { AnimParamType::LightSpecularMult, "LightSpecularMult", QColor(220, 220, 220) },
-        { AnimParamType::LightSpecPercentage, "LightSpecularPercent", QColor(220, 220, 220) },
-        { AnimParamType::FocusDistance, "FocusDistance", QColor(220, 220, 220) },
-        { AnimParamType::FocusRange, "FocusRange", QColor(220, 220, 220) },
-        { AnimParamType::BlurAmount, "BlurAmount", QColor(220, 220, 220) },
-        { AnimParamType::PositionX, "PosX", QColor(220, 220, 220) },
-        { AnimParamType::PositionY, "PosY", QColor(220, 220, 220) },
-        { AnimParamType::PositionZ, "PosZ", QColor(220, 220, 220) },
-        { AnimParamType::RotationX, "RotX", QColor(220, 220, 220) },
-        { AnimParamType::RotationY, "RotY", QColor(220, 220, 220) },
-        { AnimParamType::RotationZ, "RotZ", QColor(220, 220, 220) },
-        { AnimParamType::ScaleX, "ScaleX", QColor(220, 220, 220) },
-        { AnimParamType::ScaleY, "ScaleY", QColor(220, 220, 220) },
-        { AnimParamType::ScaleZ, "ScaleZ", QColor(220, 220, 220) },
-        { AnimParamType::ShakeAmpAMult, "ShakeMultAmpA", QColor(220, 220, 220) },
-        { AnimParamType::ShakeAmpBMult, "ShakeMultAmpB", QColor(220, 220, 220) },
-        { AnimParamType::ShakeFreqAMult, "ShakeMultFreqA", QColor(220, 220, 220) },
-        { AnimParamType::ShakeFreqBMult, "ShakeMultFreqB", QColor(220, 220, 220) },
-        { AnimParamType::ColorR, "ColorR", QColor(220, 220, 220) },
-        { AnimParamType::ColorG, "ColorG", QColor(220, 220, 220) },
-        { AnimParamType::ColorB, "ColorB", QColor(220, 220, 220) },
-        { AnimParamType::MaterialOpacity, "MaterialOpacity", QColor(220, 220, 220) },
-        { AnimParamType::MaterialSmoothness, "MaterialGlossiness", QColor(220, 220, 220) },
-        { AnimParamType::MaterialEmissive, "MaterialEmission", QColor(220, 220, 220) },
-        { AnimParamType::MaterialEmissiveIntensity, "MaterialEmissionIntensity", QColor(220, 220, 220) },
-        { AnimParamType::NearZ, "NearZ", QColor(220, 220, 220) },
+        { AnimParamType::Position, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Pos"), QColor(90, 150, 90) },
+        { AnimParamType::Rotation, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Rot"), QColor(90, 150, 90) },
+        { AnimParamType::Scale, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Scale"), QColor(90, 150, 90) },
+        { AnimParamType::Event, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Event"), QColor(220, 220, 220) },
+        { AnimParamType::Visibility, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Visibility"), QColor(220, 220, 220) },
+        { AnimParamType::Camera, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Camera"), QColor(220, 220, 220) },
+        { AnimParamType::Sound, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Sound"), QColor(220, 220, 220) },
+        { AnimParamType::Animation, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Animation"), QColor(220, 220, 220) },
+        { AnimParamType::Sequence, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Sequence"), QColor(220, 220, 220) },
+        { AnimParamType::Console, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Console"), QColor(220, 220, 220) },
+        { AnimParamType::LookAt, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "LookAt"), QColor(220, 220, 220) },
+        { AnimParamType::TrackEvent, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "TrackEvent"), QColor(220, 220, 220) },
+        { AnimParamType::ShakeMultiplier, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ShakeMult"), QColor(90, 150, 90) },
+        { AnimParamType::TransformNoise, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Noise"), QColor(90, 150, 90) },
+        { AnimParamType::TimeWarp, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Timewarp"), QColor(220, 220, 220) },
+        { AnimParamType::FixedTimeStep, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "FixedTimeStep"), QColor(220, 220, 220) },
+        { AnimParamType::DepthOfField, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "DepthOfField"), QColor(90, 150, 90) },
+        { AnimParamType::CommentText, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "CommentText"), QColor(220, 220, 220) },
+        { AnimParamType::ScreenFader, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ScreenFader"), QColor(220, 220, 220) },
+        { AnimParamType::LightDiffuse, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "LightDiffuseColor"), QColor(90, 150, 90) },
+        { AnimParamType::LightRadius, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "LightRadius"), QColor(220, 220, 220) },
+        { AnimParamType::LightDiffuseMult, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "LightDiffuseMult"), QColor(220, 220, 220) },
+        { AnimParamType::LightHDRDynamic, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "LightHDRDynamic"), QColor(220, 220, 220) },
+        { AnimParamType::LightSpecularMult, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "LightSpecularMult"), QColor(220, 220, 220) },
+        { AnimParamType::LightSpecPercentage, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "LightSpecularPercent"), QColor(220, 220, 220) },
+        { AnimParamType::FocusDistance, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "FocusDistance"), QColor(220, 220, 220) },
+        { AnimParamType::FocusRange, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "FocusRange"), QColor(220, 220, 220) },
+        { AnimParamType::BlurAmount, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "BlurAmount"), QColor(220, 220, 220) },
+        { AnimParamType::PositionX, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "PosX"), QColor(220, 220, 220) },
+        { AnimParamType::PositionY, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "PosY"), QColor(220, 220, 220) },
+        { AnimParamType::PositionZ, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "PosZ"), QColor(220, 220, 220) },
+        { AnimParamType::RotationX, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "RotX"), QColor(220, 220, 220) },
+        { AnimParamType::RotationY, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "RotY"), QColor(220, 220, 220) },
+        { AnimParamType::RotationZ, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "RotZ"), QColor(220, 220, 220) },
+        { AnimParamType::ScaleX, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ScaleX"), QColor(220, 220, 220) },
+        { AnimParamType::ScaleY, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ScaleY"), QColor(220, 220, 220) },
+        { AnimParamType::ScaleZ, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ScaleZ"), QColor(220, 220, 220) },
+        { AnimParamType::ShakeAmpAMult, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ShakeMultAmpA"), QColor(220, 220, 220) },
+        { AnimParamType::ShakeAmpBMult, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ShakeMultAmpB"), QColor(220, 220, 220) },
+        { AnimParamType::ShakeFreqAMult, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ShakeMultFreqA"), QColor(220, 220, 220) },
+        { AnimParamType::ShakeFreqBMult, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ShakeMultFreqB"), QColor(220, 220, 220) },
+        { AnimParamType::ColorR, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ColorR"), QColor(220, 220, 220) },
+        { AnimParamType::ColorG, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ColorG"), QColor(220, 220, 220) },
+        { AnimParamType::ColorB, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "ColorB"), QColor(220, 220, 220) },
+        { AnimParamType::MaterialOpacity, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "MaterialOpacity"), QColor(220, 220, 220) },
+        { AnimParamType::MaterialSmoothness, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "MaterialGlossiness"), QColor(220, 220, 220) },
+        { AnimParamType::MaterialEmissive, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "MaterialEmission"), QColor(220, 220, 220) },
+        { AnimParamType::MaterialEmissiveIntensity, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "MaterialEmissionIntensity"), QColor(220, 220, 220) },
+        { AnimParamType::NearZ, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "NearZ"), QColor(220, 220, 220) },
 
         { AnimParamType::User, "", QColor(0, 0, 0) }, // An empty string means a separator row.
 
         // Misc colors for special states of a track
-        { AnimParamType::User, "Others", QColor(220, 220, 220) },
-        { AnimParamType::User, "Disabled/Inactive", QColor(255, 224, 224) },
-        { AnimParamType::User, "Muted", QColor(255, 224, 224) },
+        { AnimParamType::User, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Others"), QColor(220, 220, 220) },
+        { AnimParamType::User, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Disabled/Inactive"), QColor(255, 224, 224) },
+        { AnimParamType::User, QT_TRANSLATE_NOOP("CTVCustomizeTrackColorsDlg", "Muted"), QColor(255, 224, 224) },
     };
 
     const int kMaxRows = 20;
@@ -156,7 +156,7 @@ void CTVCustomizeTrackColorsDlg::OnInitDialog()
         {
             m_aLabels[i] = new QLabel(m_ui->frame);
             m_aLabels[i]->setGeometry(labelRect);
-            m_aLabels[i]->setText(labelText);
+            m_aLabels[i]->setText(tr(entry.name));
 
             m_colorButtons[i] = new ColorButton(m_ui->frame);
             m_colorButtons[i]->setGeometry(buttonRect);
@@ -284,7 +284,7 @@ void CTVCustomizeTrackColorsDlg::LoadColors(const char* sectionName)
 void CTVCustomizeTrackColorsDlg::OnExport()
 {
     QString savePath;
-    if (CFileUtil::SelectSaveFile("Custom Track Colors Files (*.ctc)", "ctc",
+    if (CFileUtil::SelectSaveFile(tr("Custom Track Colors Files (*.ctc)"), "ctc",
             Path::GetUserSandboxFolder(), savePath))
     {
         Export(savePath);
@@ -294,7 +294,7 @@ void CTVCustomizeTrackColorsDlg::OnExport()
 void CTVCustomizeTrackColorsDlg::OnImport()
 {
     QString loadPath;
-    if (CFileUtil::SelectFile("Custom Track Colors Files (*.ctc)",
+    if (CFileUtil::SelectFile(tr("Custom Track Colors Files (*.ctc)"),
             Path::GetUserSandboxFolder(), loadPath))
     {
         if (Import(loadPath))

--- a/Code/Editor/TrackView/TVEventsDialog.cpp
+++ b/Code/Editor/TrackView/TVEventsDialog.cpp
@@ -76,7 +76,7 @@ public:
                 remove = QMessageBox::warning(
                              nullptr,
                              tr("Remove Event"),
-                             tr("Remove \"") + eventName + tr("\" event might cause some link breakages in Flow Graph.\nStill continue?"),
+                             tr("Remove \"%1\" event might cause some link breakages in Flow Graph.\nStill continue?").arg(eventName),
                              QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes;
             }
 

--- a/Code/Editor/TrackView/TVSequenceProps.cpp
+++ b/Code/Editor/TrackView/TVSequenceProps.cpp
@@ -253,13 +253,13 @@ void CTVSequenceProps::OnOK()
     QString name = ui->NAME->text();
     if (name.isEmpty())
     {
-        QMessageBox::warning(this, "Sequence Properties", "A sequence name cannot be empty!");
+        QMessageBox::warning(this, tr("Sequence Properties"), tr("A sequence name cannot be empty!"));
         return;
     }
 
     if (name.contains('/'))
     {
-        QMessageBox::warning(this, "Sequence Properties", "A sequence name cannot contain a '/' character!");
+        QMessageBox::warning(this, tr("Sequence Properties"), tr("A sequence name cannot contain a '/' character!"));
         return;
     }
 

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -73,7 +73,7 @@ inline namespace TrackViewInternal
     const char* s_kRebarVersionEntry = "TrackViewReBarVersion";
     const char* s_kRebarBandEntryPrefix = "ReBarBand";
 
-    const char* s_kNoSequenceComboBoxEntry = "--- No Sequence ---";
+    const char* s_kNoSequenceComboBoxEntry = QT_TRANSLATE_NOOP("CTrackViewDialog", "--- No Sequence ---");
 
     const int s_kMinimumFrameSnappingFPS = 1;
     const int s_kMaximumFrameSnappingFPS = 120;
@@ -240,7 +240,7 @@ bool CTrackViewDialog::OnInitDialog()
     m_wndKeyProperties = new CTrackViewKeyPropertiesDlg(this);
     QDockWidget* dw = new AzQtComponents::StyledDockWidget(this);
     dw->setObjectName("m_wndKeyProperties");
-    dw->setWindowTitle("Key");
+    dw->setWindowTitle(tr("Key"));
     dw->setWidget(m_wndKeyProperties);
     addDockWidget(Qt::RightDockWidgetArea, dw);
     m_wndKeyProperties->PopulateVariables();
@@ -248,7 +248,7 @@ bool CTrackViewDialog::OnInitDialog()
 
     m_wndCurveEditorDock = new AzQtComponents::StyledDockWidget(this);
     m_wndCurveEditorDock->setObjectName("m_wndCurveEditorDock");
-    m_wndCurveEditorDock->setWindowTitle("Curve Editor");
+    m_wndCurveEditorDock->setWindowTitle(tr("Curve Editor"));
     m_wndCurveEditor = new TrackViewCurveEditorDialog(this);
     m_wndCurveEditorDock->setWidget(m_wndCurveEditor);
     addDockWidget(Qt::BottomDockWidgetArea, m_wndCurveEditorDock);
@@ -282,9 +282,9 @@ void CTrackViewDialog::FillAddSelectedEntityMenu()
     };
 
     AZStd::map<AnimParamType, QString> paramNames;
-    paramNames[AnimParamType::Position] = "Position";
-    paramNames[AnimParamType::Rotation] = "Rotation",
-    paramNames[AnimParamType::Scale] = "Scale";
+    paramNames[AnimParamType::Position] = tr("Position");
+    paramNames[AnimParamType::Rotation] = tr("Rotation"),
+    paramNames[AnimParamType::Scale] = tr("Scale");
 
     for (AnimParamType track : allTracks)
     {
@@ -302,32 +302,32 @@ void CTrackViewDialog::FillAddSelectedEntityMenu()
 
 void CTrackViewDialog::InitToolbar()
 {
-    m_mainToolBar = addToolBar("Sequence/Node Toolbar");
+    m_mainToolBar = addToolBar(tr("Sequence/Node Toolbar"));
     m_mainToolBar->setObjectName("m_mainToolBar");
     m_mainToolBar->setFloatable(false);
-    m_mainToolBar->addWidget(new QLabel("Sequence/Node:"));
-    QAction* qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-00.png"), "Add Sequence");
+    m_mainToolBar->addWidget(new QLabel(tr("Sequence/Node:")));
+    QAction* qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-00.png"), tr("Add Sequence"));
     qaction->setData(ID_TV_ADD_SEQUENCE);
     m_actions[ID_TV_ADD_SEQUENCE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnAddSequence);
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-01.png"), "Delete Sequence");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-01.png"), tr("Delete Sequence"));
     qaction->setData(ID_TV_DEL_SEQUENCE);
     m_actions[ID_TV_DEL_SEQUENCE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnDelSequence);
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-02.png"), "Edit Sequence Properties");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-02.png"), tr("Edit Sequence Properties"));
     qaction->setData(ID_TV_EDIT_SEQUENCE);
     m_actions[ID_TV_EDIT_SEQUENCE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnEditSequence);
     m_sequencesComboBox = new QComboBox(this);
     m_sequencesComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    m_sequencesComboBox->setToolTip("Select the sequence");
+    m_sequencesComboBox->setToolTip(tr("Select the sequence"));
     connect(m_sequencesComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(OnSequenceComboBox()));
     m_mainToolBar->addWidget(m_sequencesComboBox);
     m_mainToolBar->addSeparator();
 
     QToolButton* toolButton = new QToolButton(m_mainToolBar);
     toolButton->setPopupMode(QToolButton::MenuButtonPopup);
-    qaction = new QAction(QIcon(":/Trackview/main/tvmain-03.png"), "Add Selected Node", this);
+    qaction = new QAction(QIcon(":/Trackview/main/tvmain-03.png"), tr("Add Selected Node"), this);
     qaction->setData(ID_ADDNODE);
     m_actions[ID_ADDNODE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnAddSelectedNode);
@@ -339,69 +339,69 @@ void CTrackViewDialog::InitToolbar()
     }
     m_mainToolBar->addWidget(toolButton);
 
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-04.png"), "Add Director Node");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-04.png"), tr("Add Director Node"));
     qaction->setData(ID_ADDSCENETRACK);
     m_actions[ID_ADDSCENETRACK] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnAddDirectorNode);
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-05.png"), "Find");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-05.png"), tr("Find"));
     qaction->setData(ID_FIND);
     m_actions[ID_FIND] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnFindNode);
     m_mainToolBar->addSeparator();
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-06.png"), "Toggle Disable");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-06.png"), tr("Toggle Disable"));
     qaction->setCheckable(true);
     qaction->setData(ID_TRACKVIEW_TOGGLE_DISABLE);
     m_actions[ID_TRACKVIEW_TOGGLE_DISABLE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnToggleDisable);
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-07.png"), "Toggle Mute");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-07.png"), tr("Toggle Mute"));
     qaction->setCheckable(true);
     qaction->setData(ID_TRACKVIEW_TOGGLE_MUTE);
     m_actions[ID_TRACKVIEW_TOGGLE_MUTE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnToggleMute);
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-08.png"), "Mute Selected Tracks");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-08.png"), tr("Mute Selected Tracks"));
     qaction->setData(ID_TRACKVIEW_MUTE_ALL);
     m_actions[ID_TRACKVIEW_MUTE_ALL] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnMuteAll);
-    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-09.png"), "Unmute Selected Tracks");
+    qaction = m_mainToolBar->addAction(QIcon(":/Trackview/main/tvmain-09.png"), tr("Unmute Selected Tracks"));
     qaction->setData(ID_TRACKVIEW_UNMUTE_ALL);
     m_actions[ID_TRACKVIEW_UNMUTE_ALL] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnUnmuteAll);
 
-    m_viewToolBar = addToolBar("View Toolbar");
+    m_viewToolBar = addToolBar(tr("View Toolbar"));
     m_viewToolBar->setObjectName("m_viewToolBar");
     m_viewToolBar->setFloatable(false);
-    m_viewToolBar->addWidget(new QLabel("View:"));
-    qaction = m_viewToolBar->addAction(QIcon(":/Trackview/view/tvview-00.png"), "Track Editor");
+    m_viewToolBar->addWidget(new QLabel(tr("View:")));
+    qaction = m_viewToolBar->addAction(QIcon(":/Trackview/view/tvview-00.png"), tr("Track Editor"));
     qaction->setData(ID_TV_MODE_DOPESHEET);
     qaction->setShortcut(QKeySequence("Ctrl+D"));
     qaction->setCheckable(true);
     qaction->setChecked(true);
     m_actions[ID_TV_MODE_DOPESHEET] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnModeDopeSheet);
-    qaction = m_viewToolBar->addAction(QIcon(":/Trackview/view/tvview-01.png"), "Curve Editor");
+    qaction = m_viewToolBar->addAction(QIcon(":/Trackview/view/tvview-01.png"), tr("Curve Editor"));
     qaction->setData(ID_TV_MODE_CURVEEDITOR);
     qaction->setShortcut(QKeySequence("Ctrl+R"));
     qaction->setCheckable(true);
     m_actions[ID_TV_MODE_CURVEEDITOR] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnModeCurveEditor);
-    qaction = m_viewToolBar->addAction(QIcon(":/Trackview/view/tvview-02.png"), "Both");
+    qaction = m_viewToolBar->addAction(QIcon(":/Trackview/view/tvview-02.png"), tr("Both"));
     qaction->setData(ID_TV_MODE_OPENCURVEEDITOR);
     qaction->setShortcut(QKeySequence("Ctrl+B"));
     m_actions[ID_TV_MODE_OPENCURVEEDITOR] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnOpenCurveEditor);
 
-    m_playToolBar = addToolBar("Play Toolbar");
+    m_playToolBar = addToolBar(tr("Play Toolbar"));
     m_playToolBar->setObjectName("m_playToolBar");
     m_playToolBar->setFloatable(false);
-    m_playToolBar->addWidget(new QLabel("Play:"));
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/SequenceStart.svg"), "Go to start of sequence");
+    m_playToolBar->addWidget(new QLabel(tr("Play:")));
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/SequenceStart.svg"), tr("Go to start of sequence"));
     qaction->setData(ID_TV_JUMPSTART);
     m_actions[ID_TV_JUMPSTART] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnGoToStart);
 
     toolButton = new QToolButton(m_playToolBar);
     toolButton->setPopupMode(QToolButton::MenuButtonPopup);
-    qaction = new QAction(QIcon(":/Trackview/PlayForward.svg"), "Play Animation", this);
+    qaction = new QAction(QIcon(":/Trackview/PlayForward.svg"), tr("Play Animation"), this);
     qaction->setData(ID_TV_PLAY);
     qaction->setCheckable(true);
     m_actions[ID_TV_PLAY] = qaction;
@@ -438,7 +438,7 @@ void CTrackViewDialog::InitToolbar()
 
     toolButton = new QToolButton(m_playToolBar);
     toolButton->setPopupMode(QToolButton::MenuButtonPopup);
-    qaction = new QAction(QIcon(":/Trackview/Stop.svg"), "Stop", this);
+    qaction = new QAction(QIcon(":/Trackview/Stop.svg"), tr("Stop"), this);
     qaction->setData(ID_TV_STOP);
     m_actions[ID_TV_STOP] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnStop);
@@ -448,7 +448,7 @@ void CTrackViewDialog::InitToolbar()
         toolButton->setMenu(buttonMenu);
 
         buttonMenu->addAction(qaction);
-        qaction = buttonMenu->addAction("Stop with Hard Reset");
+        qaction = buttonMenu->addAction(tr("Stop with Hard Reset"));
         qaction->setData(ID_TV_STOP_HARD_RESET);
         m_actions[ID_TV_STOP_HARD_RESET] = qaction;
         connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnStopHardReset);
@@ -456,17 +456,17 @@ void CTrackViewDialog::InitToolbar()
     m_playToolBar->addWidget(toolButton);
 
     m_playToolBar->addSeparator();
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/Pause.svg"), "Pause");
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/Pause.svg"), tr("Pause"));
     qaction->setData(ID_TV_PAUSE);
     qaction->setCheckable(true);
     m_actions[ID_TV_PAUSE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnPause);
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/SequenceEnd.svg"), "Go to end of sequence");
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/SequenceEnd.svg"), tr("Go to end of sequence"));
     qaction->setData(ID_TV_JUMPEND);
     m_actions[ID_TV_JUMPEND] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnGoToEnd);
 
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/RecordButton.svg"), "Start Animation Recording");
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/RecordButton.svg"), tr("Start Animation Recording"));
     qaction->setData(ID_TV_RECORD);
     qaction->setCheckable(true);
     m_actions[ID_TV_RECORD] = qaction;
@@ -474,7 +474,7 @@ void CTrackViewDialog::InitToolbar()
 
     toolButton = new QToolButton(m_playToolBar);
     toolButton->setPopupMode(QToolButton::MenuButtonPopup);
-    qaction = new QAction(QIcon(":/Trackview/AutoRecord.svg"), "Start Auto Recording", this);
+    qaction = new QAction(QIcon(":/Trackview/AutoRecord.svg"), tr("Start Auto Recording"), this);
     toolButton->addAction(qaction);
     toolButton->setDefaultAction(qaction);
     qaction->setData(ID_TV_RECORD_AUTO);
@@ -489,11 +489,11 @@ void CTrackViewDialog::InitToolbar()
         {
             if (i == 1)
             {
-                qaction = buttonMenu->addAction(" 1 sec");
+                qaction = buttonMenu->addAction(tr(" 1 sec"));
             }
             else
             {
-                qaction = buttonMenu->addAction(QString("1/%1 sec").arg(i));
+                qaction = buttonMenu->addAction(tr("1/%1 sec").arg(i));
             }
             qaction->setData(i);
             connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnAutoRecordStep);
@@ -506,7 +506,7 @@ void CTrackViewDialog::InitToolbar()
     m_playToolBar->addWidget(toolButton);
 
     m_playToolBar->addSeparator();
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/Loop.svg"), "Loop");
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/Loop.svg"), tr("Loop"));
     qaction->setData(ID_PLAY_LOOP);
     qaction->setCheckable(true);
     m_actions[ID_PLAY_LOOP] = qaction;
@@ -514,7 +514,7 @@ void CTrackViewDialog::InitToolbar()
     m_playToolBar->addSeparator();
     m_cursorPos = new QLabel(this);
     m_playToolBar->addWidget(m_cursorPos);
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/play/tvplay-08.png"), "Frame Rate");
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/play/tvplay-08.png"), tr("Frame Rate"));
     qaction->setData(ID_TV_SNAP_FPS);
     qaction->setCheckable(true);
     m_actions[ID_TV_SNAP_FPS] = qaction;
@@ -522,14 +522,14 @@ void CTrackViewDialog::InitToolbar()
     m_activeCamStatic = new QLabel(this);
     m_playToolBar->addWidget(m_activeCamStatic);
     m_playToolBar->addSeparator();
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/play/tvplay-09.png"), "Undo");
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/play/tvplay-09.png"), tr("Undo"));
     qaction->setData(ID_UNDO);
     m_actions[ID_UNDO] = qaction;
     connect(qaction, &QAction::triggered, this, []()
     {
         GetIEditor()->Undo();
     });
-    qaction = m_playToolBar->addAction(QIcon(":/Trackview/play/tvplay-10.png"), "Redo");
+    qaction = m_playToolBar->addAction(QIcon(":/Trackview/play/tvplay-10.png"), tr("Redo"));
     qaction->setData(ID_REDO);
     m_actions[ID_REDO] = qaction;
     connect(qaction, &QAction::triggered, this, []()
@@ -539,53 +539,53 @@ void CTrackViewDialog::InitToolbar()
 
     addToolBarBreak(Qt::TopToolBarArea);
 
-    m_keysToolBar = addToolBar("Keys Toolbar");
+    m_keysToolBar = addToolBar(tr("Keys Toolbar"));
     m_keysToolBar->setObjectName("m_keysToolBar");
     m_keysToolBar->setFloatable(false);
-    m_keysToolBar->addWidget(new QLabel("Keys:"));
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-00.png"), "Go to previous key");
+    m_keysToolBar->addWidget(new QLabel(tr("Keys:")));
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-00.png"), tr("Go to previous key"));
     qaction->setData(ID_TV_PREVKEY);
     m_actions[ID_TV_PREVKEY] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnGoToPrevKey);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-01.png"), "Go to next key");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-01.png"), tr("Go to next key"));
     qaction->setData(ID_TV_NEXTKEY);
     m_actions[ID_TV_NEXTKEY] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnGoToNextKey);
     m_keysToolBar->addSeparator();
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-02.png"), "Move Keys");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-02.png"), tr("Move Keys"));
     qaction->setData(ID_TV_MOVEKEY);
     m_actions[ID_TV_MOVEKEY] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnMoveKey);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-03.png"), "Slide Keys");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-03.png"), tr("Slide Keys"));
     qaction->setData(ID_TV_SLIDEKEY);
     m_actions[ID_TV_SLIDEKEY] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnSlideKey);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-04.png"), "Scale Keys");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-04.png"), tr("Scale Keys"));
     qaction->setData(ID_TV_SCALEKEY);
     m_actions[ID_TV_SCALEKEY] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnScaleKey);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-05.png"), "Add Keys");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-05.png"), tr("Add Keys"));
     qaction->setData(ID_TV_ADDKEY);
     m_actions[ID_TV_ADDKEY] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnAddKey);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-06.png"), "Delete Keys");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-06.png"), tr("Delete Keys"));
     qaction->setData(ID_TV_DELKEY);
     m_actions[ID_TV_DELKEY] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnDelKey);
     m_keysToolBar->addSeparator();
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-07.png"), "No Snapping");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-07.png"), tr("No Snapping"));
     qaction->setData(ID_TV_SNAP_NONE);
     m_actions[ID_TV_SNAP_NONE] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnSnapNone);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-08.png"), "Magnet Snapping");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-08.png"), tr("Magnet Snapping"));
     qaction->setData(ID_TV_SNAP_MAGNET);
     m_actions[ID_TV_SNAP_MAGNET] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnSnapMagnet);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-09.png"), "Frame Snapping");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-09.png"), tr("Frame Snapping"));
     qaction->setData(ID_TV_SNAP_FRAME);
     m_actions[ID_TV_SNAP_FRAME] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnSnapFrame);
-    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-10.png"), "Tick Snapping");
+    qaction = m_keysToolBar->addAction(QIcon(":/Trackview/keys/tvkeys-10.png"), tr("Tick Snapping"));
     qaction->setData(ID_TV_SNAP_TICK);
     m_actions[ID_TV_SNAP_TICK] = qaction;
     connect(qaction, &QAction::triggered, this, &CTrackViewDialog::OnSnapTick);
@@ -612,7 +612,7 @@ void CTrackViewDialog::InitToolbar()
 
     m_actions[ID_TV_SNAP_NONE]->setChecked(true);
 
-    m_tracksToolBar = addToolBar("Tracks Toolbar");
+    m_tracksToolBar = addToolBar(tr("Tracks Toolbar"));
     m_tracksToolBar->setObjectName("m_tracksToolBar");
     m_tracksToolBar->setFloatable(false);
     ClearTracksToolBar();
@@ -626,34 +626,34 @@ void CTrackViewDialog::InitMenu()
 {
     QMenuBar* mb = this->menuBar();
 
-    QMenu* m = mb->addMenu("&Sequence");
-    QAction* a = m->addAction("New Sequence...");
+    QMenu* m = mb->addMenu(tr("&Sequence"));
+    QAction* a = m->addAction(tr("New Sequence..."));
     a->setData(ID_TV_SEQUENCE_NEW);
     m_actions[ID_TV_SEQUENCE_NEW] = a;
     connect(a, &QAction::triggered, this, &CTrackViewDialog::OnAddSequence);
 
-    m = mb->addMenu("&View");
+    m = mb->addMenu(tr("&View"));
     m->addAction(m_actions[ID_TV_MODE_DOPESHEET]);
     m->addAction(m_actions[ID_TV_MODE_CURVEEDITOR]);
     m->addAction(m_actions[ID_TV_MODE_OPENCURVEEDITOR]);
     m->addSeparator();
-    a = m->addAction("Tick in Seconds");
+    a = m->addAction(tr("Tick in Seconds"));
     a->setData(ID_VIEW_TICKINSECONDS);
     a->setCheckable(true);
     m_actions[ID_VIEW_TICKINSECONDS] = a;
     connect(a, &QAction::triggered, this, &CTrackViewDialog::OnViewTickInSeconds);
-    a = m->addAction("Tick in Frames");
+    a = m->addAction(tr("Tick in Frames"));
     a->setData(ID_VIEW_TICKINFRAMES);
     a->setCheckable(true);
     m_actions[ID_VIEW_TICKINFRAMES] = a;
     connect(a, &QAction::triggered, this, &CTrackViewDialog::OnViewTickInFrames);
 
-    m = mb->addMenu("T&ools");
-    a = m->addAction("Render Output...");
+    m = mb->addMenu(tr("T&ools"));
+    a = m->addAction(tr("Render Output..."));
     a->setData(ID_TOOLS_BATCH_RENDER);
     m_actions[ID_TOOLS_BATCH_RENDER] = a;
     connect(a, &QAction::triggered, this, &CTrackViewDialog::OnBatchRender);
-    a = m->addAction("Customize &Track Colors...");
+    a = m->addAction(tr("Customize &Track Colors..."));
     a->setData(ID_TV_TOOLS_CUSTOMIZETRACKCOLORS);
     m_actions[ID_TV_TOOLS_CUSTOMIZETRACKCOLORS] = a;
     connect(a, &QAction::triggered, this, &CTrackViewDialog::OnCustomizeTrackColors);
@@ -865,7 +865,7 @@ void CTrackViewDialog::Update()
         }
     }
 
-    constexpr const auto noMovieCameraName = "Active Camera";
+    const auto noMovieCameraName = tr("Active Camera");
     const auto sequence = pAnimationContext->GetSequence();
     if (!sequence)  // Nothing to update ?
     {
@@ -1091,7 +1091,7 @@ void CTrackViewDialog::ReloadSequencesComboBox()
 {
     m_sequencesComboBox->blockSignals(true);
     m_sequencesComboBox->clear();
-    m_sequencesComboBox->addItem(QString(s_kNoSequenceComboBoxEntry));
+    m_sequencesComboBox->addItem(tr(s_kNoSequenceComboBoxEntry));
 
     AZ::EntityId lastSequenceComponentEntityId;
     int lastIndex = -1;
@@ -1195,7 +1195,7 @@ void CTrackViewDialog::OnDelSequence()
         return;
     }
 
-    if (QMessageBox::question(this, LyViewPane::TrackView, "Delete current sequence?") == QMessageBox::Yes)
+    if (QMessageBox::question(this, LyViewPane::TrackView, tr("Delete current sequence?")) == QMessageBox::Yes)
     {
         int sel = m_sequencesComboBox->currentIndex();
         if (sel != -1)
@@ -1592,7 +1592,7 @@ void CTrackViewDialog::OnFindNode()
 {
     if (!m_findDlg)
     {
-        m_findDlg = new CTrackViewFindDlg("Find Node in Track View", this);
+        m_findDlg = new CTrackViewFindDlg(tr("Find Node in Track View").toUtf8().constData(), this);
         m_findDlg->Init(this);
         connect(m_findDlg, SIGNAL(finished(int)), m_wndNodesCtrl->findChild<QTreeView*>(), SLOT(setFocus()), Qt::QueuedConnection);
     }
@@ -2014,7 +2014,7 @@ void CTrackViewDialog::UpdateTracksToolBar()
 
                 name = QString::fromUtf8(pAnimNode->GetParamName(paramType).c_str());
 
-                QString sToolTipText("Add " + name + " Track");
+                QString sToolTipText(tr("Add %1 Track").arg(name));
                 QIcon hIcon = m_wndNodesCtrl->GetIconForTrack(pTrack);
                 AddButtonToTracksToolBar(paramType, hIcon, sToolTipText);
             }
@@ -2025,7 +2025,7 @@ void CTrackViewDialog::UpdateTracksToolBar()
 void CTrackViewDialog::ClearTracksToolBar()
 {
     m_tracksToolBar->clear();
-    m_tracksToolBar->addWidget(new QLabel("Tracks:"));
+    m_tracksToolBar->addWidget(new QLabel(tr("Tracks:")));
 
     m_pNodeForTracksToolBar = nullptr;
     m_toolBarParamTypes.clear();

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
@@ -419,8 +419,8 @@ void CTrackViewTrackPropsDlg::OnUpdateTime()
                     // so work around it by blocking signal before we do it.
 
                     ui->TIME->blockSignals(true);
-                    QString msgBody = "There is an existing key at the specified time. If you continue, the existing key will be removed.";
-                    if (QMessageBox::warning(this, "Overwrite Existing Key?", msgBody, QMessageBox::Cancel | QMessageBox::Yes) ==
+                    QString msgBody = tr("There is an existing key at the specified time. If you continue, the existing key will be removed.");
+                    if (QMessageBox::warning(this, tr("Overwrite Existing Key?"), msgBody, QMessageBox::Cancel | QMessageBox::Yes) ==
                         QMessageBox::Cancel)
                     {
                         // Restore the old value and return.

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -913,7 +913,7 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                                 break;
                             }
                         }
-                        shortMessages += "Message truncated, please see console for a full list of warnings.\n";
+                        shortMessages += tr("Message truncated, please see console for a full list of warnings.\n").toUtf8().constData();
                     }
                     else
                     {
@@ -1353,7 +1353,7 @@ struct SContextMenu
 
 void CTrackViewNodesCtrl::AddGroupNodeAddItems(SContextMenu& contextMenu, CTrackViewAnimNode* animNode)
 {
-    contextMenu.main.addAction("Create Folder")->setData(eMI_CreateFolder);
+    contextMenu.main.addAction(tr("Create Folder"))->setData(eMI_CreateFolder);
 
     AzToolsFramework::EntityIdList entityIds;
     AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
@@ -1361,7 +1361,7 @@ void CTrackViewNodesCtrl::AddGroupNodeAddItems(SContextMenu& contextMenu, CTrack
 
     if (!entityIds.empty())
     {
-        const char* msg = entityIds.size() == 1 ? "Add Selected Entity" : "Add Selected Entities";
+        QString msg = entityIds.size() == 1 ? tr("Add Selected Entity") : tr("Add Selected Entities");
         contextMenu.main.addAction(msg)->setData(eMI_AddSelectedEntities);
     }
 
@@ -1370,39 +1370,39 @@ void CTrackViewNodesCtrl::AddGroupNodeAddItems(SContextMenu& contextMenu, CTrack
 
     if (pDirector->GetAnimNodesByType(AnimNodeType::RadialBlur).GetCount() == 0)
     {
-        contextMenu.main.addAction("Add Radial Blur Node")->setData(eMI_AddRadialBlur);
+        contextMenu.main.addAction(tr("Add Radial Blur Node"))->setData(eMI_AddRadialBlur);
     }
 
     if (pDirector->GetAnimNodesByType(AnimNodeType::ColorCorrection).GetCount() == 0)
     {
-        contextMenu.main.addAction("Add Color Correction Node")->setData(eMI_AddColorCorrection);
+        contextMenu.main.addAction(tr("Add Color Correction Node"))->setData(eMI_AddColorCorrection);
     }
 
     if (pDirector->GetAnimNodesByType(AnimNodeType::DepthOfField).GetCount() == 0)
     {
-        contextMenu.main.addAction("Add Depth of Field Node")->setData(eMI_AddDOF);
+        contextMenu.main.addAction(tr("Add Depth of Field Node"))->setData(eMI_AddDOF);
     }
 
     if (pDirector->GetAnimNodesByType(AnimNodeType::ScreenFader).GetCount() == 0)
     {
-        contextMenu.main.addAction("Add Screen Fader")->setData(eMI_AddScreenfader);
+        contextMenu.main.addAction(tr("Add Screen Fader"))->setData(eMI_AddScreenfader);
     }
 
     if (pDirector->GetAnimNodesByType(AnimNodeType::ShadowSetup).GetCount() == 0)
     {
-        contextMenu.main.addAction("Add Shadows Setup Node")->setData(eMI_AddShadowSetup);
+        contextMenu.main.addAction(tr("Add Shadows Setup Node"))->setData(eMI_AddShadowSetup);
     }
 
     // A director node cannot have another director node as a child.
     if (animNode->GetType() != AnimNodeType::Director)
     {
-        contextMenu.main.addAction("Add Director(Scene) Node")->setData(eMI_AddDirectorNode);
+        contextMenu.main.addAction(tr("Add Director(Scene) Node"))->setData(eMI_AddDirectorNode);
     }
 
-    contextMenu.main.addAction("Add Comment Node")->setData(eMI_AddCommentNode);
-    contextMenu.main.addAction("Add Console Variable Node")->setData(eMI_AddConsoleVariable);
-    contextMenu.main.addAction("Add Script Variable Node")->setData(eMI_AddScriptVariable);
-    contextMenu.main.addAction("Add Event Node")->setData(eMI_AddEvent);
+    contextMenu.main.addAction(tr("Add Comment Node"))->setData(eMI_AddCommentNode);
+    contextMenu.main.addAction(tr("Add Console Variable Node"))->setData(eMI_AddConsoleVariable);
+    contextMenu.main.addAction(tr("Add Script Variable Node"))->setData(eMI_AddScriptVariable);
+    contextMenu.main.addAction(tr("Add Event Node"))->setData(eMI_AddEvent);
 }
 
 void CTrackViewNodesCtrl::AddMenuSeperatorConditional(QMenu& menu, bool& bAppended)
@@ -1459,7 +1459,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
 
     if (isOnSequence)
     {
-        contextMenu.main.addAction("Select In Viewport")->setData(eMI_SelectInViewport);
+        contextMenu.main.addAction(tr("Select In Viewport"))->setData(eMI_SelectInViewport);
         contextMenu.main.addSeparator();
     }
 
@@ -1468,7 +1468,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
 
-        contextMenu.main.addAction("Select In Viewport")->setData(eMI_SelectInViewport);
+        contextMenu.main.addAction(tr("Select In Viewport"))->setData(eMI_SelectInViewport);
 
         bAppended = true;
     }
@@ -1480,19 +1480,19 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
         if ((bOnNode || bOnSequence) && !isOnComponentNode)
         {
             AddMenuSeperatorConditional(contextMenu.main, bAppended);
-            contextMenu.main.addAction("Copy")->setData(eMI_CopyNodes);
+            contextMenu.main.addAction(tr("Copy"))->setData(eMI_CopyNodes);
             bCopyPasteRenameAppended = true;
         }
 
         if (pNode->IsGroupNode() && !isOnAzEntity)
         {
-            contextMenu.main.addAction("Paste")->setData(eMI_PasteNodes);
+            contextMenu.main.addAction(tr("Paste"))->setData(eMI_PasteNodes);
             bCopyPasteRenameAppended = true;
         }
 
         if ((bOnNode || bOnSequence || bOnTrackNotSub) && !isOnComponentNode)
         {
-            contextMenu.main.addAction("Delete")->setData(bOnTrackNotSub ? eMI_RemoveTrack : eMI_RemoveSelected);
+            contextMenu.main.addAction(tr("Delete"))->setData(bOnTrackNotSub ? eMI_RemoveTrack : eMI_RemoveSelected);
             bCopyPasteRenameAppended = true;
         }
 
@@ -1500,7 +1500,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
         if (pNode->CanBeRenamed())
         {
             AddMenuSeperatorConditional(contextMenu.main, bAppended);
-            contextMenu.main.addAction("Rename")->setData(eMI_Rename);
+            contextMenu.main.addAction(tr("Rename"))->setData(eMI_Rename);
             bCopyPasteRenameAppended = true;
         }
 
@@ -1511,9 +1511,9 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     {
         // Copy & paste keys
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
-        contextMenu.main.addAction("Copy Keys")->setData(eMI_CopyKeys);
-        contextMenu.main.addAction("Copy Selected Keys")->setData(eMI_CopySelectedKeys);
-        contextMenu.main.addAction("Paste Keys")->setData(eMI_PasteKeys);
+        contextMenu.main.addAction(tr("Copy Keys"))->setData(eMI_CopyKeys);
+        contextMenu.main.addAction(tr("Copy Selected Keys"))->setData(eMI_CopySelectedKeys);
+        contextMenu.main.addAction(tr("Paste Keys"))->setData(eMI_PasteKeys);
         bAppended = true;
     }
 
@@ -1524,7 +1524,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
         if (!bOnSequence)
         {
             AddMenuSeperatorConditional(contextMenu.main, bAppended);
-            QAction* a = contextMenu.main.addAction("Disabled");
+            QAction* a = contextMenu.main.addAction(tr("Disabled"));
             a->setData(eMI_Disable);
             a->setCheckable(true);
             a->setChecked(pNode->IsDisabled());
@@ -1542,7 +1542,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
             {
                 AddMenuSeperatorConditional(contextMenu.main, bAppended);
                 bool bMuted = pTrack->GetFlags() & IAnimTrack::eAnimTrackFlags_Muted;
-                QAction* a = contextMenu.main.addAction("Muted");
+                QAction* a = contextMenu.main.addAction(tr("Muted"));
                 a->setData(eMI_Mute);
                 a->setCheckable(true);
                 a->setChecked(bMuted);
@@ -1554,7 +1554,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
         if (bOnNode && animNode->GetType() == AnimNodeType::Director)
         {
             AddMenuSeperatorConditional(contextMenu.main, bAppended);
-            QAction* a = contextMenu.main.addAction("Active Director");
+            QAction* a = contextMenu.main.addAction(tr("Active Director"));
             a->setData(eMI_SetAsActiveDirector);
             a->setCheckable(true);
             a->setChecked(animNode->IsActiveDirector());
@@ -1569,20 +1569,20 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
 
-        contextMenu.expandSub.addAction("Expand all")->setData(eMI_ExpandAll);
-        contextMenu.collapseSub.addAction("Collapse all")->setData(eMI_CollapseAll);
+        contextMenu.expandSub.addAction(tr("Expand all"))->setData(eMI_ExpandAll);
+        contextMenu.collapseSub.addAction(tr("Collapse all"))->setData(eMI_CollapseAll);
         if (!isOnAzEntity)
         {
-            contextMenu.expandSub.addAction("Expand Folders")->setData(eMI_ExpandFolders);
-            contextMenu.collapseSub.addAction("Collapse Folders")->setData(eMI_CollapseFolders);
-            contextMenu.expandSub.addAction("Expand Entities")->setData(eMI_ExpandEntities);
-            contextMenu.collapseSub.addAction("Collapse Entities")->setData(eMI_CollapseEntities);
-            contextMenu.expandSub.addAction("Expand Events")->setData(eMI_ExpandEvents);
-            contextMenu.collapseSub.addAction("Collapse Events")->setData(eMI_CollapseEvents);
+            contextMenu.expandSub.addAction(tr("Expand Folders"))->setData(eMI_ExpandFolders);
+            contextMenu.collapseSub.addAction(tr("Collapse Folders"))->setData(eMI_CollapseFolders);
+            contextMenu.expandSub.addAction(tr("Expand Entities"))->setData(eMI_ExpandEntities);
+            contextMenu.collapseSub.addAction(tr("Collapse Entities"))->setData(eMI_CollapseEntities);
+            contextMenu.expandSub.addAction(tr("Expand Events"))->setData(eMI_ExpandEvents);
+            contextMenu.collapseSub.addAction(tr("Collapse Events"))->setData(eMI_CollapseEvents);
         }
-        contextMenu.expandSub.setTitle("Expand");
+        contextMenu.expandSub.setTitle(tr("Expand"));
         contextMenu.main.addMenu(&contextMenu.expandSub);
-        contextMenu.collapseSub.setTitle("Collapse");
+        contextMenu.collapseSub.setTitle(tr("Collapse"));
         contextMenu.main.addMenu(&contextMenu.collapseSub);
 
         bAppended = true;
@@ -1606,7 +1606,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
                 // Create 'Add Tracks' submenu
                 m_menuParamTypeMap.clear();
 
-                const QString addTracksMenuName = "Add Tracks";
+                const QString addTracksMenuName = tr("Add Tracks");
                 if (FillAddTrackMenu(contextMenu.addTrackSub, animNode))
                 {
                     // add script table properties -> tracks available for adding
@@ -1629,8 +1629,8 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     if (isLegacySequence && bOnNode && !bIsLightAnimationSet && !isOnDirector && !isOnComponentNode && !isOnAzEntityNode)
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
-        contextMenu.main.addAction("Import FBX File...")->setData(eMI_ImportFromFBX);
-        contextMenu.main.addAction("Export FBX File...")->setData(eMI_SaveToFBX);
+        contextMenu.main.addAction(tr("Import FBX File..."))->setData(eMI_ImportFromFBX);
+        contextMenu.main.addAction(tr("Export FBX File..."))->setData(eMI_SaveToFBX);
         bAppended = true;
     }
 
@@ -1638,7 +1638,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     if (bOnSequence || pNode->IsGroupNode() && !bIsLightAnimationSet && !isOnAzEntity)
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
-        contextMenu.main.addAction("Edit Events...")->setData(eMI_EditEvents);
+        contextMenu.main.addAction(tr("Edit Events..."))->setData(eMI_EditEvents);
         bAppended = true;
     }
 
@@ -1650,7 +1650,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
             // Add the set-animation-layer pop-up menu.
             AddMenuSeperatorConditional(contextMenu.main, bAppended);
             CreateSetAnimationLayerPopupMenu(contextMenu.setLayerSub, pTrack);
-            contextMenu.setLayerSub.setTitle("Set Animation Layer");
+            contextMenu.setLayerSub.setTitle(tr("Set Animation Layer"));
             contextMenu.main.addMenu(&contextMenu.setLayerSub);
             bAppended = true;
         }
@@ -1660,10 +1660,10 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     if (bOnTrack)
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
-        contextMenu.main.addAction("Customize Track Color...")->setData(eMI_CustomizeTrackColor);
+        contextMenu.main.addAction(tr("Customize Track Color..."))->setData(eMI_CustomizeTrackColor);
         if (pTrack->HasCustomColor())
         {
-            contextMenu.main.addAction("Clear Custom Track Color")->setData(eMI_ClearCustomTrackColor);
+            contextMenu.main.addAction(tr("Clear Custom Track Color"))->setData(eMI_ClearCustomTrackColor);
         }
         bAppended = true;
     }
@@ -1673,7 +1673,7 @@ int CTrackViewNodesCtrl::ShowPopupMenuSingleSelection(SContextMenu& contextMenu,
     {
         AddMenuSeperatorConditional(contextMenu.main, bAppended);
 
-        const QString manageTracksMenuName = "Toggle Tracks";
+        const QString manageTracksMenuName = tr("Toggle Tracks");
         auto manageTracksAction = contextMenu.main.addAction(manageTracksMenuName);
 
         bool bAppendedTrackFlag = false;
@@ -1724,15 +1724,15 @@ int CTrackViewNodesCtrl::ShowPopupMenuMultiSelection(SContextMenu& contextMenu)
 
     if (bNodeSelected)
     {
-        contextMenu.main.addAction("Copy Selected Nodes")->setData(eMI_CopySelectedNodes);
+        contextMenu.main.addAction(tr("Copy Selected Nodes"))->setData(eMI_CopySelectedNodes);
     }
 
-    contextMenu.main.addAction("Remove Selected Nodes/Tracks")->setData(eMI_RemoveSelected);
+    contextMenu.main.addAction(tr("Remove Selected Nodes/Tracks"))->setData(eMI_RemoveSelected);
 
     if (bNodeSelected)
     {
         contextMenu.main.addSeparator();
-        contextMenu.main.addAction("Select In Viewport")->setData(eMI_SelectInViewport);
+        contextMenu.main.addAction(tr("Select In Viewport"))->setData(eMI_SelectInViewport);
 
         // Importing FBX is currently only supported on legacy entities. Legacy
         // sequences contain only legacy Cry entities and no AZ component entities.
@@ -1743,8 +1743,8 @@ int CTrackViewNodesCtrl::ShowPopupMenuMultiSelection(SContextMenu& contextMenu)
             CTrackViewSequence* sequence = context->GetSequence();
             if (sequence && sequence->GetSequenceType() == SequenceType::Legacy)
             {
-                contextMenu.main.addAction("Import From FBX File")->setData(eMI_ImportFromFBX);
-                contextMenu.main.addAction("Save To FBX File")->setData(eMI_SaveToFBX);
+                contextMenu.main.addAction(tr("Import From FBX File"))->setData(eMI_ImportFromFBX);
+                contextMenu.main.addAction(tr("Save To FBX File"))->setData(eMI_SaveToFBX);
             }
         }
     }
@@ -1924,7 +1924,7 @@ void CTrackViewNodesCtrl::SetPopupMenuLock(QMenu* menu)
         QAction* a = menu->actions()[i];
         QString menuString = a->text();
 
-        if (menuString != "Expand" && menuString != "Collapse")
+        if (menuString != tr("Expand") && menuString != tr("Collapse"))
         {
             a->setEnabled(false);
         }
@@ -2166,7 +2166,7 @@ void CTrackViewNodesCtrl::CreateSetAnimationLayerPopupMenu(QMenu& menuSetLayer, 
     // Add layer items.
     for (int i = 0; i < 16; ++i)
     {
-        QString layerText = QString("Layer #%1").arg(i);
+        QString layerText = tr("Layer #%1").arg(i);
 
         QAction* a = menuSetLayer.addAction(layerText);
         a->setData(eMI_SetAnimationLayerBase + i);

--- a/Code/Editor/TrackView/TrackViewSplineCtrl.cpp
+++ b/Code/Editor/TrackView/TrackViewSplineCtrl.cpp
@@ -726,7 +726,7 @@ void CTrackViewSplineCtrl::mouseMoveEvent(QMouseEvent* event)
                         {
                             ITcbKey key;
                             keyHandle.GetKey(&key);
-                            tipText = QStringLiteral("t=%1  v=%2 / T=%3  C=%4  B=%5")
+                            tipText = tr("t=%1  v=%2 / T=%3  C=%4  B=%5")
                                 .arg(time * m_fTooltipScaleX, 3, 'f').arg(afValue[nCurrentDimension] * m_fTooltipScaleY, 3, 'f', 2)
                                 .arg(key.tens, 3, 'f').arg(key.cont, 3, 'f').arg(key.bias, 3, 'f');
                         }
@@ -736,7 +736,7 @@ void CTrackViewSplineCtrl::mouseMoveEvent(QMouseEvent* event)
 
                             ISplineInterpolator::ValueType tin, tout;
                             pSpline->GetKeyTangents(i, tin, tout);
-                            tipText = QStringLiteral("t=%1  v=%2 / tin=(%3,%4)  tout=(%5,%6)")
+                            tipText = tr("t=%1  v=%2 / tin=(%3,%4)  tout=(%5,%6)")
                                 .arg(time * m_fTooltipScaleX, 3, 'f').arg(afValue[0] * m_fTooltipScaleY, 3, 'f', 2)
                                 .arg(tin[0], 3, 'f').arg(tin[1], 3, 'f', 2).arg(tout[0], 3, 'f').arg(tout[1], 3, 'f', 2);
                         }

--- a/Code/Editor/Util/FileChangeMonitor.cpp
+++ b/Code/Editor/Util/FileChangeMonitor.cpp
@@ -195,7 +195,7 @@ void CFileChangeMonitor::NotifyListeners(const QString &path, SFileChangeInfo::E
 {
     for (const auto &glob : m_ignoreMasks)
     {
-        if (AZStd::wildcard_match(qPrintable(glob), qPrintable(path)))
+        if (AZStd::wildcard_match(qUtf8Printable(glob), qUtf8Printable(path)))
         {
             return; // mask matches, ignore event
         }

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManagerComponent.cpp
@@ -13,6 +13,8 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Asset/AssetManager.h>
+
+#include <AzCore/i18n/TranslationMacros.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Slice/SliceAssetHandler.h>
@@ -180,7 +182,8 @@ namespace AZ
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<AssetManagerComponent>(
-                    "Asset Database", "Asset database system functionality")
+                    QT_TRANSLATE_NOOP("AzCore", "Asset Database"),
+                    QT_TRANSLATE_NOOP("AzCore", "Asset database system functionality"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
                     ;

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -28,6 +28,8 @@
 
 #include <AzCore/NativeUI/NativeUIRequests.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/Utils.h>
@@ -384,21 +386,38 @@ namespace AZ
 
             if (EditContext* ec = serializeContext->GetEditContext())
             {
-                ec->Enum<Debug::AllocationRecords::Mode>("Debug::AllocationRecords::Mode", "Allocator recording mode")
-                    ->Value("No records", Debug::AllocationRecords::Mode::RECORD_NO_RECORDS)
-                    ->Value("No stack trace", Debug::AllocationRecords::Mode::RECORD_STACK_NEVER)
-                    ->Value("Stack trace when file/line missing", Debug::AllocationRecords::Mode::RECORD_STACK_IF_NO_FILE_LINE)
-                    ->Value("Stack trace always", Debug::AllocationRecords::Mode::RECORD_FULL);
-                ec->Class<Descriptor>("System memory settings", "Settings for managing application memory usage")
+                ec->Enum<Debug::AllocationRecords::Mode>("Debug::AllocationRecords::Mode",
+                    QT_TRANSLATE_NOOP("AzCore", "Allocator recording mode"))
+                    ->Value(QT_TRANSLATE_NOOP("AzCore", "No records"), Debug::AllocationRecords::Mode::RECORD_NO_RECORDS)
+                    ->Value(QT_TRANSLATE_NOOP("AzCore", "No stack trace"), Debug::AllocationRecords::Mode::RECORD_STACK_NEVER)
+                    ->Value(QT_TRANSLATE_NOOP("AzCore", "Stack trace when file/line missing"), Debug::AllocationRecords::Mode::RECORD_STACK_IF_NO_FILE_LINE)
+                    ->Value(QT_TRANSLATE_NOOP("AzCore", "Stack trace always"), Debug::AllocationRecords::Mode::RECORD_FULL);
+                ec->Class<Descriptor>(
+                    QT_TRANSLATE_NOOP("AzCore", "System memory settings"),
+                    QT_TRANSLATE_NOOP("AzCore", "Settings for managing application memory usage"))
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                         ->Attribute(Edit::Attributes::AutoExpand, true)
-                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_allocationRecordsSaveNames, "Record allocations with name saving", "Saves names/filenames information on each allocation made, useful for tracking down leaks in dynamic modules (ignored in Release builds)")
-                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_allocationRecordsAttemptDecodeImmediately, "Record allocations and attempt immediate decode", "Decode callstacks for each allocation when they occur, used for tracking allocations that fail decoding. Very expensive. (ignored in Release builds)")
-                    ->DataElement(Edit::UIHandlers::ComboBox, &Descriptor::m_recordingMode, "Stack recording mode", "Stack record mode. (Ignored in final builds)")
-                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_autoIntegrityCheck, "Validate allocations", "Check allocations for integrity on each allocation/free (ignored in Release builds)")
-                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_markUnallocatedMemory, "Mark freed memory", "Set memory to 0xcd when a block is freed for debugging (ignored in Release builds)")
-                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_doNotUsePools, "Don't pool allocations", "Pipe pool allocations in system/tree heap (ignored in Release builds)")
-                    ->DataElement(Edit::UIHandlers::SpinBox, &Descriptor::m_memoryBlocksByteSize, "Block size", "Memory block size in bytes (must be multiple of the page size)")
+                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_allocationRecordsSaveNames,
+                        QT_TRANSLATE_NOOP("AzCore", "Record allocations with name saving"),
+                        QT_TRANSLATE_NOOP("AzCore", "Saves names/filenames information on each allocation made, useful for tracking down leaks in dynamic modules (ignored in Release builds)"))
+                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_allocationRecordsAttemptDecodeImmediately,
+                        QT_TRANSLATE_NOOP("AzCore", "Record allocations and attempt immediate decode"),
+                        QT_TRANSLATE_NOOP("AzCore", "Decode callstacks for each allocation when they occur, used for tracking allocations that fail decoding. Very expensive. (ignored in Release builds)"))
+                    ->DataElement(Edit::UIHandlers::ComboBox, &Descriptor::m_recordingMode,
+                        QT_TRANSLATE_NOOP("AzCore", "Stack recording mode"),
+                        QT_TRANSLATE_NOOP("AzCore", "Stack record mode. (Ignored in final builds)"))
+                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_autoIntegrityCheck,
+                        QT_TRANSLATE_NOOP("AzCore", "Validate allocations"),
+                        QT_TRANSLATE_NOOP("AzCore", "Check allocations for integrity on each allocation/free (ignored in Release builds)"))
+                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_markUnallocatedMemory,
+                        QT_TRANSLATE_NOOP("AzCore", "Mark freed memory"),
+                        QT_TRANSLATE_NOOP("AzCore", "Set memory to 0xcd when a block is freed for debugging (ignored in Release builds)"))
+                    ->DataElement(Edit::UIHandlers::CheckBox, &Descriptor::m_doNotUsePools,
+                        QT_TRANSLATE_NOOP("AzCore", "Don't pool allocations"),
+                        QT_TRANSLATE_NOOP("AzCore", "Pipe pool allocations in system/tree heap (ignored in Release builds)"))
+                    ->DataElement(Edit::UIHandlers::SpinBox, &Descriptor::m_memoryBlocksByteSize,
+                        QT_TRANSLATE_NOOP("AzCore", "Block size"),
+                        QT_TRANSLATE_NOOP("AzCore", "Memory block size in bytes (must be multiple of the page size)"))
                     ;
             }
         }
@@ -865,21 +884,22 @@ namespace AZ
 
     void ComponentApplication::ReportBadEngineRoot()
     {
-        AZStd::string errorMessage = {"Unable to determine a valid path to the engine.\n"
-                                      "Check parameters such as --project-path and --engine-path and make sure they are valid.\n"};
+        AZStd::string errorMessage = {QT_TRANSLATE_NOOP("AzCore",
+            "Unable to determine a valid path to the engine.\n"
+            "Check parameters such as --project-path and --engine-path and make sure they are valid.\n")};
         if (auto registry = AZ::SettingsRegistry::Get(); registry != nullptr)
         {
             AZ::SettingsRegistryInterface::FixedValueString filePathErrorStr;
             if (registry->Get(filePathErrorStr, AZ::SettingsRegistryMergeUtils::FilePathKey_ErrorText); !filePathErrorStr.empty())
             {
-                errorMessage += "Additional Info:\n";
+                errorMessage += QT_TRANSLATE_NOOP("AzCore", "Additional Info:\n");
                 errorMessage += filePathErrorStr.c_str();
             }
         }
 
         if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
         {
-            nativeUI->DisplayOkDialog("O3DE Fatal Error", errorMessage.c_str(), false);
+            nativeUI->DisplayOkDialog(QT_TRANSLATE_NOOP("AzCore", "O3DE Fatal Error"), errorMessage.c_str(), false);
         }
         else
         {

--- a/Code/Framework/AzCore/AzCore/Component/Entity.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/Entity.cpp
@@ -25,6 +25,9 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 
 #include <AzCore/Math/Crc.h>
+
+#include <AzCore/i18n/TranslationMacros.h>
+
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/chrono/chrono.h>
 #include <AzCore/std/parallel/thread.h>
@@ -893,19 +896,27 @@ namespace AZ
             EditContext* ec = serializeContext->GetEditContext();
             if (ec)
             {
-                ec->Class<Entity>("Entity", "Base entity class")->
+                ec->Class<Entity>(
+                    QT_TRANSLATE_NOOP("AzCore", "Entity"),
+                    QT_TRANSLATE_NOOP("AzCore", "Base entity class"))->
                     DataElement(AZ::Edit::UIHandlers::Default, &Entity::m_id, "Id", "")->
                         Attribute(Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)->
                         Attribute(Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::NotPushable)->
                     DataElement(AZ::Edit::UIHandlers::Default, &Entity::m_isDependencyReady, "IsDependencyReady", "")->
                         Attribute(Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)->
                         Attribute(Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::NotPushable)->
-                    DataElement(AZ::Edit::UIHandlers::Default, &Entity::m_isRuntimeActiveByDefault, "StartActive", "")->
-                    DataElement("String", &Entity::m_name, "Name", "Unique name of the entity")->
+                    DataElement(AZ::Edit::UIHandlers::Default, &Entity::m_isRuntimeActiveByDefault,
+                        QT_TRANSLATE_NOOP("AzCore", "StartActive"), "")->
+                    DataElement("String", &Entity::m_name,
+                        QT_TRANSLATE_NOOP("AzCore", "Name"),
+                        QT_TRANSLATE_NOOP("AzCore", "Unique name of the entity"))->
                         Attribute(Edit::Attributes::ChangeNotify, &Entity::OnNameChanged)->
-                    DataElement("Components", &Entity::m_components, "Components", "");
+                    DataElement("Components", &Entity::m_components,
+                        QT_TRANSLATE_NOOP("AzCore", "Components"), "");
 
-                ec->Class<EntityId>("EntityId", "Entity Unique Id");
+                ec->Class<EntityId>(
+                    QT_TRANSLATE_NOOP("AzCore", "EntityId"),
+                    QT_TRANSLATE_NOOP("AzCore", "Entity Unique Id"));
             }
         }
 
@@ -1372,7 +1383,7 @@ namespace AZ
         if (sortedComponents.size() != componentInfos.size())
         {
             // Format message like: "Cycle exists amongst: ComponentA, ComponentB, ComponentC, ..."
-            AZStd::string message = "Infinite loop of service dependencies amongst components: ";
+            AZStd::string message = QT_TRANSLATE_NOOP("AzCore", "Infinite loop of service dependencies amongst components: ");
             size_t foundUnsorted = 0;
             for (ComponentInfo& componentInfo : componentInfos)
             {

--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -20,6 +20,8 @@
 #include <AzCore/NativeUI/NativeUIRequests.h>
 #include <AzCore/Debug/TraceMessageBus.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 // Used to keep a set of ignored asserts for CRC checking
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/Module/Environment.h>
@@ -375,7 +377,8 @@ namespace AZ::Debug
             Output(g_dbgSystemWnd, "==================================================================\n");
 
             char dialogBoxText[g_maxMessageLength];
-            azsnprintf(dialogBoxText, g_maxMessageLength, "Assert \n\n %s(%d) \n %s \n\n %s", fileName, line, funcName, message);
+            azsnprintf(dialogBoxText, g_maxMessageLength,
+                QT_TRANSLATE_NOOP("AzCore", "Assert \n\n %s(%d) \n %s \n\n %s"), fileName, line, funcName, message);
 
             // If we are logging only then ignore the assert after it logs once in order to prevent spam
             if (currentLevel == 1 && !IsDebuggerPresent())

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
@@ -12,6 +12,8 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 #include <AzCore/Jobs/JobManager.h>
 #include <AzCore/Jobs/JobContext.h>
 
@@ -134,13 +136,18 @@ namespace AZ
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<JobManagerComponent>(
-                    "Job Manager", "Provides fine grained job system and worker threads")
+                    QT_TRANSLATE_NOOP("AzCore", "Job Manager"),
+                    QT_TRANSLATE_NOOP("AzCore", "Provides fine grained job system and worker threads"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
-                    ->DataElement(AZ::Edit::UIHandlers::SpinBox, &JobManagerComponent::m_numberOfWorkerThreads, "Worker threads", "Number of worked threads for this job manager.")
+                    ->DataElement(AZ::Edit::UIHandlers::SpinBox, &JobManagerComponent::m_numberOfWorkerThreads,
+                        QT_TRANSLATE_NOOP("AzCore", "Worker threads"),
+                        QT_TRANSLATE_NOOP("AzCore", "Number of worker threads for this job manager."))
                         ->Attribute(AZ::Edit::Attributes::Min, 0)
                         ->Attribute(AZ::Edit::Attributes::Max, 16)
-                    ->DataElement(AZ::Edit::UIHandlers::SpinBox, &JobManagerComponent::m_firstThreadCPU, "CPU ID", "First CPU ID for a worker thread, each consecutive thread will use the next CPU ID. -1 Will not assign CPU Ids")
+                    ->DataElement(AZ::Edit::UIHandlers::SpinBox, &JobManagerComponent::m_firstThreadCPU,
+                        QT_TRANSLATE_NOOP("AzCore", "CPU ID"),
+                        QT_TRANSLATE_NOOP("AzCore", "First CPU ID for a worker thread, each consecutive thread will use the next CPU ID. -1 Will not assign CPU Ids"))
                         ->Attribute(AZ::Edit::Attributes::Min, -1)
                         ->Attribute(AZ::Edit::Attributes::Max, 16)
                     ;

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.cpp
@@ -13,6 +13,8 @@
 #include <AzCore/Math/MathScriptHelpers.h>
 #include <AzCore/Math/ShapeIntersection.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
     void ViewFrustumAttributes::Reflect(ReflectContext* context)
@@ -30,23 +32,28 @@ namespace AZ
 
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<ViewFrustumAttributes>("ViewFrustumAttributes", "")
+                editContext->Class<ViewFrustumAttributes>(QT_TRANSLATE_NOOP("AzCore", "ViewFrustumAttributes"), "")
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                     ->DataElement(
-                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_worldTransform, "WorldTransform",
-                        "The world transform used to construct the frustum")
+                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_worldTransform,
+                        QT_TRANSLATE_NOOP("AzCore", "WorldTransform"),
+                        QT_TRANSLATE_NOOP("AzCore", "The world transform used to construct the frustum"))
                     ->DataElement(
-                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_aspectRatio, "AspectRatio",
-                        "The aspect ratio of the frustum")
+                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_aspectRatio,
+                        QT_TRANSLATE_NOOP("AzCore", "AspectRatio"),
+                        QT_TRANSLATE_NOOP("AzCore", "The aspect ratio of the frustum"))
                     ->DataElement(
-                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_verticalFovRadians, "FovRadians",
-                        "The vertical field of view of the frustum in radians")
+                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_verticalFovRadians,
+                        QT_TRANSLATE_NOOP("AzCore", "FovRadians"),
+                        QT_TRANSLATE_NOOP("AzCore", "The vertical field of view of the frustum in radians"))
                     ->DataElement(
-                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_nearClip, "NearClip",
-                        "Distance to the frustums near clip plane")
+                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_nearClip,
+                        QT_TRANSLATE_NOOP("AzCore", "NearClip"),
+                        QT_TRANSLATE_NOOP("AzCore", "Distance to the frustums near clip plane"))
                     ->DataElement(
-                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_farClip, "FarClip",
-                        "Distance to the frustums far clip plane")
+                        Edit::UIHandlers::Default, &ViewFrustumAttributes::m_farClip,
+                        QT_TRANSLATE_NOOP("AzCore", "FarClip"),
+                        QT_TRANSLATE_NOOP("AzCore", "Distance to the frustums far clip plane"))
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MatrixMxN.cpp
@@ -10,6 +10,8 @@
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
     void MatrixMxN::Reflect([[maybe_unused]] ReflectContext* context)
@@ -27,11 +29,16 @@ namespace AZ
 
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<MatrixMxN>("MxN-Dimensional Matrix", "")
+                editContext->Class<MatrixMxN>(
+                    QT_TRANSLATE_NOOP("AzCore", "MxN-Dimensional Matrix"), "")
                     ->ClassElement(Edit::ClassElements::EditorData, "")
-                    ->DataElement(Edit::UIHandlers::Default, &MatrixMxN::m_rowCount, "Total Rows", "The total number of rows in the matrix")
+                    ->DataElement(Edit::UIHandlers::Default, &MatrixMxN::m_rowCount,
+                        QT_TRANSLATE_NOOP("AzCore", "Total Rows"),
+                        QT_TRANSLATE_NOOP("AzCore", "The total number of rows in the matrix"))
                         ->Attribute(Edit::Attributes::ChangeNotify, &MatrixMxN::OnSizeChanged)
-                    ->DataElement(Edit::UIHandlers::Default, &MatrixMxN::m_colCount, "Total Columns", "The total number of columns in the matrix")
+                    ->DataElement(Edit::UIHandlers::Default, &MatrixMxN::m_colCount,
+                        QT_TRANSLATE_NOOP("AzCore", "Total Columns"),
+                        QT_TRANSLATE_NOOP("AzCore", "The total number of columns in the matrix"))
                         ->Attribute(Edit::Attributes::ChangeNotify, &MatrixMxN::OnSizeChanged)
                     ;
             }

--- a/Code/Framework/AzCore/AzCore/Math/PolygonPrism.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/PolygonPrism.cpp
@@ -12,6 +12,8 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
     void PolygonPrismReflect(ReflectContext* context)
@@ -31,15 +33,21 @@ namespace AZ
 
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<PolygonPrism>("PolygonPrism", "Polygon prism shape")
+                editContext->Class<PolygonPrism>(
+                    QT_TRANSLATE_NOOP("AzCore", "PolygonPrism"),
+                    QT_TRANSLATE_NOOP("AzCore", "Polygon prism shape"))
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                     ->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::ShowChildrenOnly)
-                    ->DataElement(Edit::UIHandlers::Default, &PolygonPrism::m_height, "Height", "Shape Height")
+                    ->DataElement(Edit::UIHandlers::Default, &PolygonPrism::m_height,
+                        QT_TRANSLATE_NOOP("AzCore", "Height"),
+                        QT_TRANSLATE_NOOP("AzCore", "Shape Height"))
                         ->Attribute(Edit::Attributes::Suffix, " m")
                         ->Attribute(Edit::Attributes::Step, 0.05f)
                         ->Attribute(Edit::Attributes::Min, 0.0f)
                         ->Attribute(Edit::Attributes::ChangeNotify, &PolygonPrism::OnChangeHeight)
-                    ->DataElement(Edit::UIHandlers::Default, &PolygonPrism::m_vertexContainer, "Vertices", "Data representing the polygon, in the entity's local coordinate space")
+                    ->DataElement(Edit::UIHandlers::Default, &PolygonPrism::m_vertexContainer,
+                        QT_TRANSLATE_NOOP("AzCore", "Vertices"),
+                        QT_TRANSLATE_NOOP("AzCore", "Data representing the polygon, in the entity's local coordinate space"))
                         ->Attribute(Edit::Attributes::ContainerCanBeModified, false)
                         ->Attribute(Edit::Attributes::AutoExpand, true)
                         ;

--- a/Code/Framework/AzCore/AzCore/Math/Spline.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Spline.cpp
@@ -15,6 +15,8 @@
 #include <AzCore/Script/ScriptContextAttributes.h>
 #include <AzCore/Serialization/EditContext.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
     const float Spline::s_splineEpsilon = 0.00001f;
@@ -549,14 +551,20 @@ namespace AZ
 
         if (EditContext* editContext = context.GetEditContext())
         {
-            editContext->Class<Spline>("Spline", "Spline Data")
+            editContext->Class<Spline>(
+                QT_TRANSLATE_NOOP("AzCore", "Spline"),
+                QT_TRANSLATE_NOOP("AzCore", "Spline Data"))
                 ->ClassElement(Edit::ClassElements::EditorData, "")
                     //->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::ShowChildrenOnly) // disabled - prevents ChangeNotify attribute firing correctly
                     ->Attribute(Edit::Attributes::AutoExpand, true)
                     ->Attribute(Edit::Attributes::ContainerCanBeModified, false)
-                ->DataElement(Edit::UIHandlers::Default, &Spline::m_vertexContainer, "Vertices", "Data representing the spline, in the entity's local coordinate space")
+                ->DataElement(Edit::UIHandlers::Default, &Spline::m_vertexContainer,
+                    QT_TRANSLATE_NOOP("AzCore", "Vertices"),
+                    QT_TRANSLATE_NOOP("AzCore", "Data representing the spline, in the entity's local coordinate space"))
                     ->Attribute(Edit::Attributes::AutoExpand, true)
-                ->DataElement(Edit::UIHandlers::CheckBox, &Spline::m_closed, "Closed", "Determine whether a spline is self closing (looping) or not")
+                ->DataElement(Edit::UIHandlers::CheckBox, &Spline::m_closed,
+                    QT_TRANSLATE_NOOP("AzCore", "Closed"),
+                    QT_TRANSLATE_NOOP("AzCore", "Determine whether a spline is self closing (looping) or not"))
                     ->Attribute(Edit::Attributes::ChangeNotify, &Spline::OnOpenCloseChanged)
                 ;
         }
@@ -799,7 +807,9 @@ namespace AZ
 
         if (EditContext* editContext = context.GetEditContext())
         {
-            editContext->Class<LinearSpline>("Linear Spline", "Spline data")
+            editContext->Class<LinearSpline>(
+                QT_TRANSLATE_NOOP("AzCore", "Linear Spline"),
+                QT_TRANSLATE_NOOP("AzCore", "Spline data"))
                 ->ClassElement(Edit::ClassElements::EditorData, "")
                 ->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::ShowChildrenOnly)
                 ->Attribute(Edit::Attributes::AutoExpand, true)
@@ -1286,14 +1296,20 @@ namespace AZ
 
         if (EditContext* editContext = context.GetEditContext())
         {
-            editContext->Class<BezierSpline>("Bezier Spline", "Spline data")
+            editContext->Class<BezierSpline>(
+                QT_TRANSLATE_NOOP("AzCore", "Bezier Spline"),
+                QT_TRANSLATE_NOOP("AzCore", "Spline data"))
                 ->ClassElement(Edit::ClassElements::EditorData, "")
                     //->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::ShowChildrenOnly) // disabled - prevents ChangeNotify attribute firing correctly
                     ->Attribute(Edit::Attributes::AutoExpand, true)
                     ->Attribute(Edit::Attributes::ContainerCanBeModified, false)
-                ->DataElement(Edit::UIHandlers::Default, &BezierSpline::m_bezierData, "Bezier Data", "Data defining the bezier curve")
+                ->DataElement(Edit::UIHandlers::Default, &BezierSpline::m_bezierData,
+                    QT_TRANSLATE_NOOP("AzCore", "Bezier Data"),
+                    QT_TRANSLATE_NOOP("AzCore", "Data defining the bezier curve"))
                     ->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::Hide)
-                ->DataElement(Edit::UIHandlers::Slider, &BezierSpline::m_granularity, "Granularity", "Parameter specifying the granularity of each segment in the spline")
+                ->DataElement(Edit::UIHandlers::Slider, &BezierSpline::m_granularity,
+                    QT_TRANSLATE_NOOP("AzCore", "Granularity"),
+                    QT_TRANSLATE_NOOP("AzCore", "Parameter specifying the granularity of each segment in the spline"))
                     ->Attribute(Edit::Attributes::Min, s_minGranularity)
                     ->Attribute(Edit::Attributes::Max, s_maxGranularity)
                     ;
@@ -1542,15 +1558,21 @@ namespace AZ
 
         if (EditContext* editContext = context.GetEditContext())
         {
-            editContext->Class<CatmullRomSpline>("Catmull Rom Spline", "Spline data")
+            editContext->Class<CatmullRomSpline>(
+                QT_TRANSLATE_NOOP("AzCore", "Catmull Rom Spline"),
+                QT_TRANSLATE_NOOP("AzCore", "Spline data"))
                 ->ClassElement(Edit::ClassElements::EditorData, "")
                     //->Attribute(Edit::Attributes::Visibility, Edit::PropertyVisibility::ShowChildrenOnly) // disabled - prevents ChangeNotify attribute firing correctly
                     ->Attribute(Edit::Attributes::AutoExpand, true)
                     ->Attribute(Edit::Attributes::ContainerCanBeModified, false)
-                ->DataElement(Edit::UIHandlers::Slider, &CatmullRomSpline::m_knotParameterization, "Knot Parameterization", "Parameter specifying interpolation of the spline")
+                ->DataElement(Edit::UIHandlers::Slider, &CatmullRomSpline::m_knotParameterization,
+                    QT_TRANSLATE_NOOP("AzCore", "Knot Parameterization"),
+                    QT_TRANSLATE_NOOP("AzCore", "Parameter specifying interpolation of the spline"))
                     ->Attribute(Edit::Attributes::Min, 0.0f)
                     ->Attribute(Edit::Attributes::Max, 1.0f)
-                ->DataElement(Edit::UIHandlers::Slider, &CatmullRomSpline::m_granularity, "Granularity", "Parameter specifying the granularity of each segment in the spline")
+                ->DataElement(Edit::UIHandlers::Slider, &CatmullRomSpline::m_granularity,
+                    QT_TRANSLATE_NOOP("AzCore", "Granularity"),
+                    QT_TRANSLATE_NOOP("AzCore", "Parameter specifying the granularity of each segment in the spline"))
                     ->Attribute(Edit::Attributes::Min, s_minGranularity)
                     ->Attribute(Edit::Attributes::Max, s_maxGranularity)
                     ;

--- a/Code/Framework/AzCore/AzCore/Math/VectorN.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/VectorN.cpp
@@ -10,6 +10,8 @@
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
     void VectorN::Reflect([[maybe_unused]] ReflectContext* context)
@@ -24,10 +26,13 @@ namespace AZ
 
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<VectorN>("N-Dimensional Vector", "")
+                editContext->Class<VectorN>(
+                    QT_TRANSLATE_NOOP("AzCore", "N-Dimensional Vector"), "")
                     ->ClassElement(Edit::ClassElements::EditorData, "")
                     ->DataElement(
-                        Edit::UIHandlers::Default, &VectorN::m_numElements, "Total Elements", "The total number of elements in the vector")
+                        Edit::UIHandlers::Default, &VectorN::m_numElements,
+                        QT_TRANSLATE_NOOP("AzCore", "Total Elements"),
+                        QT_TRANSLATE_NOOP("AzCore", "The total number of elements in the vector"))
                             ->Attribute(Edit::Attributes::ChangeNotify, &VectorN::OnSizeChanged)
                     ;
             }

--- a/Code/Framework/AzCore/AzCore/Module/ModuleManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/ModuleManager.cpp
@@ -21,6 +21,8 @@
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace
 {
     static const char* s_moduleLoggingScope = "Module Manager";
@@ -56,8 +58,11 @@ namespace AZ
             if (EditContext* ec = serializeContext->GetEditContext())
             {
                 ec->Class<DynamicModuleDescriptor>(
-                    "Dynamic Module descriptor", "Describes a dynamic module (DLL) used by the application")
-                    ->DataElement(Edit::UIHandlers::Default, &DynamicModuleDescriptor::m_dynamicLibraryPath, "Dynamic library path", "Path to DLL.")
+                    QT_TRANSLATE_NOOP("AzCore", "Dynamic Module descriptor"),
+                    QT_TRANSLATE_NOOP("AzCore", "Describes a dynamic module (DLL) used by the application"))
+                    ->DataElement(Edit::UIHandlers::Default, &DynamicModuleDescriptor::m_dynamicLibraryPath,
+                        QT_TRANSLATE_NOOP("AzCore", "Dynamic library path"),
+                        QT_TRANSLATE_NOOP("AzCore", "Path to DLL."))
                     ;
             }
         }
@@ -632,8 +637,10 @@ namespace AZ
         {
             errorMessage.append("\n\n");
             errorMessage.append(outcome.GetError().m_extendedMessage);
-            auto choice = nativeUI->DisplayBlockingDialog(s_moduleLoggingScope, errorMessage, { "Quit", "Ignore" });
-            m_quitRequested = (choice == "Quit");
+            static const char* quitButton = QT_TRANSLATE_NOOP("AzCore", "Quit");
+            static const char* ignoreButton = QT_TRANSLATE_NOOP("AzCore", "Ignore");
+            auto choice = nativeUI->DisplayBlockingDialog(s_moduleLoggingScope, errorMessage, { quitButton, ignoreButton });
+            m_quitRequested = (choice == quitButton);
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
+++ b/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
@@ -13,6 +13,8 @@
 #include <AzCore/ScriptCanvas/ScriptCanvasOnDemandNames.h>
 #include <AzCore/RTTI/AzStdOnDemandPrettyName.inl>
 #include <AzCore/RTTI/AzStdOnDemandReflectionLuaFunctions.inl>
+
+#include <AzCore/i18n/TranslationMacros.h>
 #include <AzCore/std/optional.h>
 #include <AzCore/std/typetraits/has_member_function.h>
 
@@ -352,13 +354,13 @@ namespace AZ
             {
                 BranchOnResultInfo emptyBranchInfo;
                 emptyBranchInfo.m_returnResultInBranches = true;
-                emptyBranchInfo.m_trueToolTip = "The container is empty";
-                emptyBranchInfo.m_falseToolTip = "The container is not empty";
+                emptyBranchInfo.m_trueToolTip = QT_TRANSLATE_NOOP("AzCore", "The container is empty");
+                emptyBranchInfo.m_falseToolTip = QT_TRANSLATE_NOOP("AzCore", "The container is not empty");
 
                 BranchOnResultInfo hasElementsBranchInfo;
                 hasElementsBranchInfo.m_returnResultInBranches = true;
-                hasElementsBranchInfo.m_trueToolTip = "The container has elements";
-                hasElementsBranchInfo.m_falseToolTip = "The container has no elements";
+                hasElementsBranchInfo.m_trueToolTip = QT_TRANSLATE_NOOP("AzCore", "The container has elements");
+                hasElementsBranchInfo.m_falseToolTip = QT_TRANSLATE_NOOP("AzCore", "The container has no elements");
 
                 behaviorContext->Class<ContainerType>()
                     ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::ListOnly)
@@ -819,8 +821,8 @@ namespace AZ
             {
                 BranchOnResultInfo emptyBranchInfo;
                 emptyBranchInfo.m_returnResultInBranches = true;
-                emptyBranchInfo.m_trueToolTip = "The container is empty";
-                emptyBranchInfo.m_falseToolTip = "The container is not empty";
+                emptyBranchInfo.m_trueToolTip = QT_TRANSLATE_NOOP("AzCore", "The container is empty");
+                emptyBranchInfo.m_falseToolTip = QT_TRANSLATE_NOOP("AzCore", "The container is not empty");
 
                 auto ContainsTransparent = [](const ContainerType& containerType, typename ContainerType::key_type& key)->bool
                 {
@@ -974,8 +976,8 @@ namespace AZ
             {
                 BranchOnResultInfo emptyBranchInfo;
                 emptyBranchInfo.m_returnResultInBranches = true;
-                emptyBranchInfo.m_trueToolTip = "The container is empty";
-                emptyBranchInfo.m_falseToolTip = "The container is not empty";
+                emptyBranchInfo.m_trueToolTip = QT_TRANSLATE_NOOP("AzCore", "The container is empty");
+                emptyBranchInfo.m_falseToolTip = QT_TRANSLATE_NOOP("AzCore", "The container is not empty");
 
                 auto ContainsTransparent = [](const ContainerType& containerType, typename ContainerType::key_type& key)->bool
                 {

--- a/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.cpp
@@ -33,6 +33,8 @@
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/std/string/conversions.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
 
@@ -876,7 +878,8 @@ void ScriptSystemComponent::Reflect(ReflectContext* reflection)
         if (EditContext* editContext = serializeContext->GetEditContext())
         {
             editContext->Class<ScriptSystemComponent>(
-                "Script System", "Initializes and maintains script contexts")
+                QT_TRANSLATE_NOOP("AzCore", "Script System"),
+                QT_TRANSLATE_NOOP("AzCore", "Initializes and maintains script contexts"))
                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Engine")
                 ;

--- a/Code/Framework/AzCore/AzCore/Slice/SliceMetadataInfoComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceMetadataInfoComponent.cpp
@@ -8,6 +8,8 @@
 
 #include <AzCore/Slice/SliceMetadataInfoComponent.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
 
@@ -186,7 +188,8 @@ namespace AZ
             if (editContext)
             {
                 editContext->Class<SliceMetadataInfoComponent>(
-                    "Slice Metadata Info", "The Slice Metadata Info Component maintains a list of all of the entities that are associated with a slice metadata entity.")
+                    QT_TRANSLATE_NOOP("AzCore", "Slice Metadata Info"),
+                    QT_TRANSLATE_NOOP("AzCore", "The Slice Metadata Info Component maintains a list of all of the entities that are associated with a slice metadata entity."))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                     ->Attribute(AZ::Edit::Attributes::RuntimeExportCallback, &SliceMetadataInfoComponent::ExportComponent)

--- a/Code/Framework/AzCore/AzCore/Slice/SliceSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceSystemComponent.cpp
@@ -10,6 +10,8 @@
 #include "SliceAsset.h"
 #include <AzCore/Serialization/EditContext.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
     void SliceSystemComponent::Reflect(ReflectContext* context)
@@ -21,7 +23,8 @@ namespace AZ
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<SliceSystemComponent>(
-                    "Slice System", "Manages the Slice system")
+                    QT_TRANSLATE_NOOP("AzCore", "Slice System"),
+                    QT_TRANSLATE_NOOP("AzCore", "Manages the Slice system"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
                     ;

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraphSystemComponent.cpp
@@ -15,6 +15,8 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Threading/ThreadUtils.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
  // PERFORMANCE NOTE & TODO
  // Profiling Ros Con demo, Task Graph was 2-3ms slower than Jobs
  // Time for Jobs was ~5.5ms, maxing out at ~6.3ms
@@ -100,7 +102,8 @@ namespace AZ
             if (AZ::EditContext* ec = serializeContext->GetEditContext())
             {
                 ec->Class<TaskGraphSystemComponent>
-                    ("TaskGraph", "System component to create the default executor")
+                    (QT_TRANSLATE_NOOP("AzCore", "TaskGraph"),
+                    QT_TRANSLATE_NOOP("AzCore", "System component to create the default executor"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Engine")
                     ;

--- a/Code/Framework/AzCore/AzCore/UserSettings/UserSettingsComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/UserSettings/UserSettingsComponent.cpp
@@ -12,6 +12,8 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Math/Crc.h>
 
+#include <AzCore/i18n/TranslationMacros.h>
+
 namespace AZ
 {
     //-----------------------------------------------------------------------------
@@ -105,12 +107,15 @@ namespace AZ
             if (EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<UserSettingsComponent>(
-                    "User Settings", "Provides userdata storage for all system components")
+                    QT_TRANSLATE_NOOP("AzCore", "User Settings"),
+                    QT_TRANSLATE_NOOP("AzCore", "Provides userdata storage for all system components"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Editor")
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &UserSettingsComponent::m_providerId, "ProviderId", "The settings group this provider with handle.")
-                        ->EnumAttribute(UserSettings::CT_LOCAL, "Local")
-                        ->EnumAttribute(UserSettings::CT_GLOBAL, "Global")
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &UserSettingsComponent::m_providerId,
+                        QT_TRANSLATE_NOOP("AzCore", "ProviderId"),
+                        QT_TRANSLATE_NOOP("AzCore", "The settings group this provider will handle."))
+                        ->EnumAttribute(UserSettings::CT_LOCAL, QT_TRANSLATE_NOOP("AzCore", "Local"))
+                        ->EnumAttribute(UserSettings::CT_GLOBAL, QT_TRANSLATE_NOOP("AzCore", "Global"))
                     ;
             }
         }

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -492,6 +492,7 @@ set(FILES
     NativeUI/NativeUISystemComponent.h
     NativeUI/NativeUIRequests.cpp
     NativeUI/NativeUIRequests.h
+    i18n/TranslationMacros.h
     Outcome/Outcome.h
     Outcome/Internal/OutcomeImpl.h
     Platform.cpp

--- a/Code/Framework/AzCore/AzCore/i18n/TranslationMacros.h
+++ b/Code/Framework/AzCore/AzCore/i18n/TranslationMacros.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// QT_TRANSLATE_NOOP is a Qt macro that marks strings for extraction by lupdate
+// but does NOT perform runtime translation. It simply returns the string as-is.
+// This header provides a no-op fallback definition for modules that don't depend on Qt
+// (such as AzCore), allowing them to mark strings for translation without pulling in Qt headers.
+//
+// When Qt headers are included (e.g., in AzToolsFramework or Editor), Qt's own definition takes precedence.
+#ifndef QT_TRANSLATE_NOOP
+    #define QT_TRANSLATE_NOOP(scope, x) (x)
+#endif

--- a/Code/Framework/AzFramework/AzFramework/Asset/Benchmark/BenchmarkSettingsAsset.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/Benchmark/BenchmarkSettingsAsset.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzFramework/Asset/Benchmark/BenchmarkSettingsAsset.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 namespace AzFramework
 {
@@ -29,15 +30,26 @@ namespace AzFramework
             if (edit)
             {
                 edit->Class<BenchmarkSettingsAsset>(
-                    "Benchmark Settings Asset", "Settings file for generating assets for benchmark purposes")
+                    QT_TRANSLATE_NOOP("AzFramework", "Benchmark Settings Asset"),
+                    QT_TRANSLATE_NOOP("AzFramework", "Settings file for generating assets for benchmark purposes"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
 
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_primaryAssetByteSize, "Asset Buffer Size", "Size of the test buffer in the primary asset in bytes")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_dependentAssetByteSize, "Dependent Asset Buffer Size", "Size of the test buffer in each dependent asset in bytes")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_dependencyDepth, "Dependency Depth", "Depth of the asset dependency tree")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_numAssetsPerDependency, "Assets Per Dependency", "Number of assets to generate for each dependency in the tree")
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &BenchmarkSettingsAsset::m_assetStorageType, "Asset Storage", "Serializaton format to use for each asset (binary, text)")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_primaryAssetByteSize,
+                        QT_TRANSLATE_NOOP("AzFramework", "Asset Buffer Size"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Size of the test buffer in the primary asset in bytes"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_dependentAssetByteSize,
+                        QT_TRANSLATE_NOOP("AzFramework", "Dependent Asset Buffer Size"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Size of the test buffer in each dependent asset in bytes"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_dependencyDepth,
+                        QT_TRANSLATE_NOOP("AzFramework", "Dependency Depth"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Depth of the asset dependency tree"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &BenchmarkSettingsAsset::m_numAssetsPerDependency,
+                        QT_TRANSLATE_NOOP("AzFramework", "Assets Per Dependency"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Number of assets to generate for each dependency in the tree"))
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &BenchmarkSettingsAsset::m_assetStorageType,
+                        QT_TRANSLATE_NOOP("AzFramework", "Asset Storage"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Serializaton format to use for each asset (binary, text)"))
                         ->EnumAttribute(AZ::DataStream::StreamType::ST_BINARY, "Binary")
                         ->EnumAttribute(AZ::DataStream::StreamType::ST_XML, "XML")
                         ->EnumAttribute(AZ::DataStream::StreamType::ST_JSON, "JSON")

--- a/Code/Framework/AzFramework/AzFramework/Asset/FileTagAsset.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/FileTagAsset.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 namespace AzFramework
 {
@@ -34,19 +35,29 @@ namespace AzFramework
 
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Class<FileTagData>("Definition", "Files/Patterns and their associated tags.")
+                    editContext->Class<FileTagData>(
+                        QT_TRANSLATE_NOOP("AzFramework", "Definition"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Files/Patterns and their associated tags."))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->DataElement(AZ::Edit::UIHandlers::ComboBox, &FileTagData::m_filePatternType,
-                            "File Pattern", "File Pattern can either be an exact value, a regex or a wildcard.")
+                            QT_TRANSLATE_NOOP("AzFramework", "File Pattern"),
+                            QT_TRANSLATE_NOOP("AzFramework", "File Pattern can either be an exact value, a regex or a wildcard."))
                         ->Attribute(AZ::Edit::Attributes::EnumValues,
                             AZStd::vector<AZ::Edit::EnumConstant<FilePatternType>>
                     {
-                        AZ::Edit::EnumConstant<FilePatternType>(FilePatternType::Exact, "Exact"),
-                        AZ::Edit::EnumConstant<FilePatternType>(FilePatternType::Wildcard, "Wildcard"),
-                        AZ::Edit::EnumConstant<FilePatternType>(FilePatternType::Regex, "Regex")
+                        AZ::Edit::EnumConstant<FilePatternType>(FilePatternType::Exact,
+                            QT_TRANSLATE_NOOP("AzFramework", "Exact")),
+                        AZ::Edit::EnumConstant<FilePatternType>(FilePatternType::Wildcard,
+                            QT_TRANSLATE_NOOP("AzFramework", "Wildcard")),
+                        AZ::Edit::EnumConstant<FilePatternType>(FilePatternType::Regex,
+                            QT_TRANSLATE_NOOP("AzFramework", "Regex"))
                     })
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &FileTagData::m_fileTags, "File Tags", "List of tags associated with the file/pattern.")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &FileTagData::m_comment, "Comment", "Comment for the file tag definition");
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &FileTagData::m_fileTags,
+                            QT_TRANSLATE_NOOP("AzFramework", "File Tags"),
+                            QT_TRANSLATE_NOOP("AzFramework", "List of tags associated with the file/pattern."))
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &FileTagData::m_comment,
+                            QT_TRANSLATE_NOOP("AzFramework", "Comment"),
+                            QT_TRANSLATE_NOOP("AzFramework", "Comment for the file tag definition"));
                 }
             }
         }
@@ -63,9 +74,13 @@ namespace AzFramework
                     ->Field("FileTagMap", &FileTagAsset::m_fileTagMap);
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Class<FileTagAsset>("Definition", "Asset storing all the file/pattern tagging information.")
+                    editContext->Class<FileTagAsset>(
+                        QT_TRANSLATE_NOOP("AzFramework", "Definition"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Asset storing all the file/pattern tagging information."))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &FileTagAsset::m_fileTagMap, "File Tag Map", "Container for storing file tagging information.");
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &FileTagAsset::m_fileTagMap,
+                            QT_TRANSLATE_NOOP("AzFramework", "File Tag Map"),
+                            QT_TRANSLATE_NOOP("AzFramework", "Container for storing file tagging information."));
                 }
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Asset/XmlSchemaAsset.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/XmlSchemaAsset.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "XmlSchemaAsset.h"
+#include <AzFramework/Translation/TranslationDef.h>
 
 namespace AzFramework
 {
@@ -20,9 +21,13 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<VersionSearchRule>("Version Search Rule", "Rule for getting the attribute of the root node which specifies the version")
+                editContext->Class<VersionSearchRule>(
+                    QT_TRANSLATE_NOOP("AzFramework", "Version Search Rule"),
+                    QT_TRANSLATE_NOOP("AzFramework", "Rule for getting the attribute of the root node which specifies the version"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &VersionSearchRule::m_rootNodeAttributeName, "Root Node Attribute Name", "Attribute name of the root node which specifies the version. Example: versionnumber");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &VersionSearchRule::m_rootNodeAttributeName,
+                        QT_TRANSLATE_NOOP("AzFramework", "Root Node Attribute Name"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Attribute name of the root node which specifies the version. Example: versionnumber"));
             }
         }
     }
@@ -44,11 +49,19 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<MatchingRule>("Matching Rules", "Rules for matchup")
+                editContext->Class<MatchingRule>(
+                    QT_TRANSLATE_NOOP("AzFramework", "Matching Rules"),
+                    QT_TRANSLATE_NOOP("AzFramework", "Rules for matchup"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &MatchingRule::m_filePathPattern, "File Path Pattern", "Pattern of the file path. Example: *Fonts/*.xml")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &MatchingRule::m_excludedFilePathPattern, "Excluded File Path Pattern", "Pattern of the excluded file path. Example: *Fonts/*.xml")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &MatchingRule::m_versionConstraints, "Version Constraints", "Data file versions these rules adapt to. These constraints follow the rules of Semantic Versioning. Example: >=1.2.3, ~>1.2.3");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MatchingRule::m_filePathPattern,
+                        QT_TRANSLATE_NOOP("AzFramework", "File Path Pattern"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Pattern of the file path. Example: *Fonts/*.xml"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MatchingRule::m_excludedFilePathPattern,
+                        QT_TRANSLATE_NOOP("AzFramework", "Excluded File Path Pattern"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Pattern of the excluded file path. Example: *Fonts/*.xml"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MatchingRule::m_versionConstraints,
+                        QT_TRANSLATE_NOOP("AzFramework", "Version Constraints"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Data file versions these rules adapt to. These constraints follow the rules of Semantic Versioning. Example: >=1.2.3, ~>1.2.3"));
             }
         }
     }
@@ -92,23 +105,45 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<XmlSchemaAttribute>("XmlSchemaAttribute", "XML Schema attribute")
+                editContext->Class<XmlSchemaAttribute>(
+                    QT_TRANSLATE_NOOP("AzFramework", "XmlSchemaAttribute"),
+                    QT_TRANSLATE_NOOP("AzFramework", "XML Schema attribute"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_name, "Name", "Name of the attribute")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_expectedExtension, "Expected Extension", "Expected extension for the file name.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_matchPattern, "Match Pattern", "(Optional) Values that don't match this regex pattern will be rejected.  Case-insensitive.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_findPattern, "Find Pattern", "(Optional) Regex pattern to use to match against the value for replacing.  Case-insensitive.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_replacePattern, "Replace Pattern", "(Optional) Regex pattern to use to replace the value.")
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &XmlSchemaAttribute::m_type, "Type", "Type of the attribute. Select from RelativePath, AssetId, etc.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_name,
+                        QT_TRANSLATE_NOOP("AzFramework", "Name"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Name of the attribute"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_expectedExtension,
+                        QT_TRANSLATE_NOOP("AzFramework", "Expected Extension"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Expected extension for the file name."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_matchPattern,
+                        QT_TRANSLATE_NOOP("AzFramework", "Match Pattern"),
+                        QT_TRANSLATE_NOOP("AzFramework", "(Optional) Values that don't match this regex pattern will be rejected.  Case-insensitive."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_findPattern,
+                        QT_TRANSLATE_NOOP("AzFramework", "Find Pattern"),
+                        QT_TRANSLATE_NOOP("AzFramework", "(Optional) Regex pattern to use to match against the value for replacing.  Case-insensitive."))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_replacePattern,
+                        QT_TRANSLATE_NOOP("AzFramework", "Replace Pattern"),
+                        QT_TRANSLATE_NOOP("AzFramework", "(Optional) Regex pattern to use to replace the value."))
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &XmlSchemaAttribute::m_type,
+                        QT_TRANSLATE_NOOP("AzFramework", "Type"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Type of the attribute. Select from RelativePath, AssetId, etc."))
                     ->EnumAttribute(AttributeType::RelativePath, "RelativePath")
                     ->EnumAttribute(AttributeType::Asset, "Asset")
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &XmlSchemaAttribute::m_pathDependencyType, "Path Dependency Type", "Path dependency type of the attribute. Select from SourceFile and ProductFile")
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &XmlSchemaAttribute::m_pathDependencyType,
+                        QT_TRANSLATE_NOOP("AzFramework", "Path Dependency Type"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Path dependency type of the attribute. Select from SourceFile and ProductFile"))
                     ->Attribute(AZ::Edit::Attributes::Visibility, &XmlSchemaAttribute::GetVisibilityProperty)
                     ->EnumAttribute(AttributePathDependencyType::SourceFile, "SourceFile")
                     ->EnumAttribute(AttributePathDependencyType::ProductFile, "ProductFile")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_relativeToSourceAssetFolder, "RelativeToSourceAssetFolder", "Whether the file path is relative to the source asset folder")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_optional, "Optional", "Whether the attribute is optional")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_cacheRelativePath, "CacheRelativePath", "CacheRelative allows dependent assets to be from other scan folders.");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_relativeToSourceAssetFolder,
+                        QT_TRANSLATE_NOOP("AzFramework", "RelativeToSourceAssetFolder"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Whether the file path is relative to the source asset folder"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_optional,
+                        QT_TRANSLATE_NOOP("AzFramework", "Optional"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Whether the attribute is optional"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAttribute::m_cacheRelativePath,
+                        QT_TRANSLATE_NOOP("AzFramework", "CacheRelativePath"),
+                        QT_TRANSLATE_NOOP("AzFramework", "CacheRelative allows dependent assets to be from other scan folders."));
 
             }
         }
@@ -182,12 +217,22 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<XmlSchemaElement>("XmlSchemaElement", "XML Schema Element")
+                editContext->Class<XmlSchemaElement>(
+                    QT_TRANSLATE_NOOP("AzFramework", "XmlSchemaElement"),
+                    QT_TRANSLATE_NOOP("AzFramework", "XML Schema Element"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_name, "Name", "Name of the element")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_childElements, "Child Elements", "Children of the element")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_attributes, "Attributes", "Attributes of the element")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_optional, "Optional", "Whether the element is optional");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_name,
+                        QT_TRANSLATE_NOOP("AzFramework", "Name"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Name of the element"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_childElements,
+                        QT_TRANSLATE_NOOP("AzFramework", "Child Elements"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Children of the element"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_attributes,
+                        QT_TRANSLATE_NOOP("AzFramework", "Attributes"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Attributes of the element"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaElement::m_optional,
+                        QT_TRANSLATE_NOOP("AzFramework", "Optional"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Whether the element is optional"));
             }
         }
     }
@@ -240,10 +285,16 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<SearchRuleDefinition>("SearchRuleDefinition", "Definition for the dependency search rule")
+                editContext->Class<SearchRuleDefinition>(
+                    QT_TRANSLATE_NOOP("AzFramework", "SearchRuleDefinition"),
+                    QT_TRANSLATE_NOOP("AzFramework", "Definition for the dependency search rule"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SearchRuleDefinition::m_searchRuleStructure, "Search Rule Structure", "Search rule structure which contain element and attribute nodes")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SearchRuleDefinition::m_relativeToXmlRoot, "Relative to XML Root", "Whether the element is relative to XML root");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SearchRuleDefinition::m_searchRuleStructure,
+                        QT_TRANSLATE_NOOP("AzFramework", "Search Rule Structure"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Search rule structure which contain element and attribute nodes"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SearchRuleDefinition::m_relativeToXmlRoot,
+                        QT_TRANSLATE_NOOP("AzFramework", "Relative to XML Root"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Whether the element is relative to XML root"));
             }
         }
     }
@@ -269,10 +320,16 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<DependencySearchRule>("DependencySearchRule", "Dependency search rules")
+                editContext->Class<DependencySearchRule>(
+                    QT_TRANSLATE_NOOP("AzFramework", "DependencySearchRule"),
+                    QT_TRANSLATE_NOOP("AzFramework", "Dependency search rules"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DependencySearchRule::m_searchRuleDefinitions, "Search Rule Definitions", "A list of Definitions for dependency search rules")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &DependencySearchRule::m_versionConstraints, "Version Constraints", "Data file versions these rules adapt to. These constraints follow the rules of Semantic Versioning. Example: >=1.2.3: Minimum: 1.2.3 Maximum: None");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DependencySearchRule::m_searchRuleDefinitions,
+                        QT_TRANSLATE_NOOP("AzFramework", "Search Rule Definitions"),
+                        QT_TRANSLATE_NOOP("AzFramework", "A list of Definitions for dependency search rules"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DependencySearchRule::m_versionConstraints,
+                        QT_TRANSLATE_NOOP("AzFramework", "Version Constraints"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Data file versions these rules adapt to. These constraints follow the rules of Semantic Versioning. Example: >=1.2.3: Minimum: 1.2.3 Maximum: None"));
             }
         }
     }
@@ -314,12 +371,22 @@ namespace AzFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<XmlSchemaAsset>("Definition", "Definition of the schema asset")
+                editContext->Class<XmlSchemaAsset>(
+                    QT_TRANSLATE_NOOP("AzFramework", "Definition"),
+                    QT_TRANSLATE_NOOP("AzFramework", "Definition of the schema asset"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_versionSearchRule, "Version Search Rule", "VersionSearchRule")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_matchingRules, "Matching Rules", "A list of matching rules defined by the current schema")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_useAZSerialization, "Use AZ Serialization for dependencies", "Use AZ serialization to extract dependencies from matching files")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_dependencySearchRules, "Dependency Search Rules", "A list of dependency search rules defined by the current schema");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_versionSearchRule,
+                        QT_TRANSLATE_NOOP("AzFramework", "Version Search Rule"),
+                        QT_TRANSLATE_NOOP("AzFramework", "VersionSearchRule"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_matchingRules,
+                        QT_TRANSLATE_NOOP("AzFramework", "Matching Rules"),
+                        QT_TRANSLATE_NOOP("AzFramework", "A list of matching rules defined by the current schema"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_useAZSerialization,
+                        QT_TRANSLATE_NOOP("AzFramework", "Use AZ Serialization for dependencies"),
+                        QT_TRANSLATE_NOOP("AzFramework", "Use AZ serialization to extract dependencies from matching files"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &XmlSchemaAsset::m_dependencySearchRules,
+                        QT_TRANSLATE_NOOP("AzFramework", "Dependency Search Rules"),
+                        QT_TRANSLATE_NOOP("AzFramework", "A list of dependency search rules defined by the current schema"));
             }
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionLayers.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionLayers.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/i18n/TranslationMacros.h>
 
 #include <AzFramework/Physics/CollisionBus.h>
 
@@ -84,10 +85,14 @@ namespace AzPhysics
 
             if (auto* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<CollisionLayers>("Collision Layers", "List of defined collision layers")
+                editContext->Class<CollisionLayers>(
+                        QT_TRANSLATE_NOOP("PhysX", "Collision Layers"),
+                        QT_TRANSLATE_NOOP("PhysX", "List of defined collision layers"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &CollisionLayers::m_names, "Layers", "Names of each collision layer")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CollisionLayers::m_names,
+                        QT_TRANSLATE_NOOP("PhysX", "Layers"),
+                        QT_TRANSLATE_NOOP("PhysX", "Names of each collision layer"))
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ;
             }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SceneConfiguration.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/i18n/TranslationMacros.h>
 
 namespace AzPhysics
 {
@@ -36,29 +37,38 @@ namespace AzPhysics
 
             if (auto* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<SceneConfiguration>("Scene Configuration", "Default scene configuration")
+                editContext->Class<SceneConfiguration>(
+                    QT_TRANSLATE_NOOP("PhysX", "Scene Configuration"), QT_TRANSLATE_NOOP("PhysX", "Default scene configuration"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_worldBounds, "World Bounds", "World bounds")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_gravity, "Gravity", "Gravity")
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "Continuous Collision Detection")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_worldBounds,
+                        QT_TRANSLATE_NOOP("PhysX", "World Bounds"), QT_TRANSLATE_NOOP("PhysX", "World bounds"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_gravity,
+                        QT_TRANSLATE_NOOP("PhysX", "Gravity"), QT_TRANSLATE_NOOP("PhysX", "Gravity"))
+                    ->ClassElement(AZ::Edit::ClassElements::Group, QT_TRANSLATE_NOOP("PhysX", "Continuous Collision Detection"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_enableCcd, "Enable CCD", "Enabled continuous collision detection in the world")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_enableCcd,
+                        QT_TRANSLATE_NOOP("PhysX", "Enable CCD"), QT_TRANSLATE_NOOP("PhysX", "Enabled continuous collision detection in the world"))
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_maxCcdPasses,
-                        "Max CCD Passes", "Maximum number of continuous collision detection passes")
+                        QT_TRANSLATE_NOOP("PhysX", "Max CCD Passes"), QT_TRANSLATE_NOOP("PhysX", "Maximum number of continuous collision detection passes"))
                     ->Attribute(AZ::Edit::Attributes::Visibility, &SceneConfiguration::GetCcdVisibility)
                     ->Attribute(AZ::Edit::Attributes::Min, 1u)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_enableCcdResweep,
-                        "Enable CCD Resweep", "Enable a more accurate but more expensive continuous collision detection method")
+                        QT_TRANSLATE_NOOP("PhysX", "Enable CCD Resweep"), QT_TRANSLATE_NOOP("PhysX", "Enable a more accurate but more expensive continuous collision detection method"))
                     ->Attribute(AZ::Edit::Attributes::Visibility, &SceneConfiguration::GetCcdVisibility)
                     ->EndGroup()
 
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_enablePcm, "Persistent Contact Manifold", "Enabled the persistent contact manifold narrow-phase algorithm")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SceneConfiguration::m_enablePcm,
+                        QT_TRANSLATE_NOOP("PhysX", "Persistent Contact Manifold"),
+                        QT_TRANSLATE_NOOP("PhysX", "Enabled the persistent contact manifold narrow-phase algorithm"))
                     ->DataElement(AZ::Edit::UIHandlers::Default,&SceneConfiguration::m_enableEnhancedDeterminism,
-                        "Enhanced Determinism", "Improves determinism at a performance cost. Applied at scene creation.")
+                        QT_TRANSLATE_NOOP("PhysX", "Enhanced Determinism"),
+                        QT_TRANSLATE_NOOP("PhysX", "Improves determinism at a performance cost. Applied at scene creation."))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_bounceThresholdVelocity,
-                        "Bounce Threshold Velocity", "Relative velocity below which colliding objects will not bounce")
+                        QT_TRANSLATE_NOOP("PhysX", "Bounce Threshold Velocity"), QT_TRANSLATE_NOOP("PhysX", "Relative velocity below which colliding objects will not bounce"))
                     ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
                     ;
             }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/i18n/TranslationMacros.h>
 
 namespace AzPhysics
 {
@@ -43,25 +44,27 @@ namespace AzPhysics
                 editContext->Class<AzPhysics::SystemConfiguration>("", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_maxTimestep, "Max Time Step (sec)", "Max time step in seconds")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_maxTimestep,
+                        QT_TRANSLATE_NOOP("PhysX", "Max Time Step (sec)"), QT_TRANSLATE_NOOP("PhysX", "Max time step in seconds"))
                         ->Attribute(AZ::Edit::Attributes::Min, TimestepMin)
                         ->Attribute(AZ::Edit::Attributes::Max, TimestepMax)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &SystemConfiguration::OnMaxTimeStepChanged)//need to clamp m_fixedTimeStep if this value changes
                         ->Attribute(AZ::Edit::Attributes::Decimals, 8)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 8)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_fixedTimestep, "Fixed Time Step (sec)", "Fixed time step in seconds. Limited by 'Max Time Step'")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_fixedTimestep,
+                        QT_TRANSLATE_NOOP("PhysX", "Fixed Time Step (sec)"), QT_TRANSLATE_NOOP("PhysX", "Fixed time step in seconds. Limited by 'Max Time Step'"))
                         ->Attribute(AZ::Edit::Attributes::Min, TimestepMin)
                         ->Attribute(AZ::Edit::Attributes::Max, &SystemConfiguration::GetFixedTimeStepMax)
                         ->Attribute(AZ::Edit::Attributes::Decimals, 8)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 8)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_raycastBufferSize,
-                        "Raycast Buffer Size", "Maximum number of hits from a raycast")
+                        QT_TRANSLATE_NOOP("PhysX", "Raycast Buffer Size"), QT_TRANSLATE_NOOP("PhysX", "Maximum number of hits from a raycast"))
                         ->Attribute(AZ::Edit::Attributes::Min, 1u)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_shapecastBufferSize,
-                        "Shapecast Buffer Size", "Maximum number of hits from a shapecast")
+                        QT_TRANSLATE_NOOP("PhysX", "Shapecast Buffer Size"), QT_TRANSLATE_NOOP("PhysX", "Maximum number of hits from a shapecast"))
                         ->Attribute(AZ::Edit::Attributes::Min, 1u)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_overlapBufferSize,
-                        "Overlap Query Buffer Size", "Maximum number of hits from a overlap query")
+                        QT_TRANSLATE_NOOP("PhysX", "Overlap Query Buffer Size"), QT_TRANSLATE_NOOP("PhysX", "Maximum number of hits from a overlap query"))
                         ->Attribute(AZ::Edit::Attributes::Min, 1u)
                     ;
             }

--- a/Code/Framework/AzFramework/AzFramework/Translation/TranslationDef.h
+++ b/Code/Framework/AzFramework/AzFramework/Translation/TranslationDef.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Forward to the canonical definition in AzCore.
+// AzFramework modules should include this header for QT_TRANSLATE_NOOP support.
+// AzCore modules should include <AzCore/i18n/TranslationMacros.h> directly.
+#include <AzCore/i18n/TranslationMacros.h>

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -421,6 +421,7 @@ set(FILES
     Terrain/TerrainDataRequestBus.cpp
     Thermal/ThermalInfo.cpp
     Thermal/ThermalInfo.h
+    Translation/TranslationDef.h
     Platform/PlatformDefaults.h
     Windowing/WindowBus.cpp
     Windowing/WindowBus.h

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker.cpp
@@ -505,7 +505,7 @@ ColorPicker::ColorPicker(ColorPicker::Configuration configuration, const QString
     m_toggleHueGridButton->setAutoRaise(true);
     m_toggleHueGridButton->setCheckable(true);
     m_toggleHueGridButton->setChecked(true);
-    m_toggleHueGridButton->setToolTip("Click this to toggle the color grid between Saturation/Value mode and Hue/Saturation mode");
+    m_toggleHueGridButton->setToolTip(tr("Click this to toggle the color grid between Saturation/Value mode and Hue/Saturation mode"));
     m_hsvPickerLayout->addWidget(m_toggleHueGridButton, 1, 2);
 
     connect(m_toggleHueGridButton, &QAbstractButton::toggled, this, [this](bool checked) {
@@ -597,9 +597,9 @@ ColorPicker::ColorPicker(ColorPicker::Configuration configuration, const QString
     containerLayout->addWidget(tabWidgetSeparator);
 
     m_slidersTabWidget = new TabWidget(this);
-    m_slidersTabWidget->addTab(m_rgbSliders, QObject::tr("RGB"));
-    m_slidersTabWidget->addTab(m_hslSliders, QObject::tr("HSL"));
-    m_slidersTabWidget->addTab(m_hsvSliders, QObject::tr("HSV"));
+    m_slidersTabWidget->addTab(m_rgbSliders, tr("RGB"));
+    m_slidersTabWidget->addTab(m_hslSliders, tr("HSL"));
+    m_slidersTabWidget->addTab(m_hsvSliders, tr("HSV"));
 
     TabWidget::applySecondaryStyle(m_slidersTabWidget, false);
     containerLayout->addWidget(m_slidersTabWidget);
@@ -667,16 +667,16 @@ ColorPicker::ColorPicker(ColorPicker::Configuration configuration, const QString
     // Final color space comment
     m_commentSeparator = makePaddedSeparator(this);
     containerLayout->addWidget(m_commentSeparator);
-    m_commentLabel = new QLabel(QObject::tr("Color space: sRGB"), this);
+    m_commentLabel = new QLabel(tr("Color space: sRGB"), this);
     containerLayout->addWidget(m_commentLabel);
 
     // Alternate color space info
 
     // These widgets will be updated as needed in setAlternateColorspace* functions
-    m_alternateColorSpaceIntLabel = new QLabel(QObject::tr("Alternate Int"), this);
-    m_alternateColorSpaceFloatLabel = new QLabel(QObject::tr("Alternate Float"), this);
-    m_alternateColorSpaceIntValue = new QLineEdit(QObject::tr("Unspecified"), this);
-    m_alternateColorSpaceFloatValue = new QLineEdit(QObject::tr("Unspecified"), this);
+    m_alternateColorSpaceIntLabel = new QLabel(tr("Alternate Int"), this);
+    m_alternateColorSpaceFloatLabel = new QLabel(tr("Alternate Float"), this);
+    m_alternateColorSpaceIntValue = new QLineEdit(tr("Unspecified"), this);
+    m_alternateColorSpaceFloatValue = new QLineEdit(tr("Unspecified"), this);
     m_alternateColorSpaceIntValue->setDisabled(true);
     m_alternateColorSpaceFloatValue->setDisabled(true);
 
@@ -703,7 +703,7 @@ ColorPicker::ColorPicker(ColorPicker::Configuration configuration, const QString
     initContextMenu(configuration);
 
     // Add a settings menu button on the slider tab widget
-    QAction* settingsMenuAction = new QAction(QIcon(":/stylesheet/img/UI20/menu-centered.svg"), QObject::tr("Settings"), this);
+    QAction* settingsMenuAction = new QAction(QIcon(":/stylesheet/img/UI20/menu-centered.svg"), tr("Settings"), this);
     settingsMenuAction->setMenu(m_menu);
     m_slidersTabWidget->setActionToolBarVisible();
     m_slidersTabWidget->addAction(settingsMenuAction);
@@ -1283,7 +1283,7 @@ void ColorPicker::setQuickPaletteVisibility(bool show)
     m_quickPaletteCard->setVisible(show);
     m_quickPaletteSeparator->setVisible(show);
 
-    m_toggleQuickPaletteAction->setText(tr(show ? "Hide Quick Palette" : "Show Quick Palette"));
+    m_toggleQuickPaletteAction->setText(show ? tr("Hide Quick Palette") : tr("Show Quick Palette"));
 }
 
 void ColorPicker::paletteContextMenuRequested(QSharedPointer<PaletteCard> paletteCard, const QPoint& point)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCard.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCard.cpp
@@ -195,7 +195,7 @@ QuickPaletteCard::QuickPaletteCard(QSharedPointer<Palette> palette, Internal::Co
 {
     m_paletteView->addDefaultRGBColors();
     
-    m_header->setTitle("Quick Palette");
+    m_header->setTitle(tr("Quick Palette"));
 
     connect(m_paletteView, &PaletteView::selectedColorsChanged, this, &QuickPaletteCard::selectedColorsChanged);
 }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/BrowseEditPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/BrowseEditPage.cpp
@@ -24,17 +24,17 @@ BrowseEditPage::BrowseEditPage(QWidget* parent)
 
     ui->browseEditEnabled->setAttachedButtonIcon(icon);
     ui->browseEditEnabled->setLineEditReadOnly(true);
-    ui->browseEditEnabled->setPlaceholderText("Some placeholder");
+    ui->browseEditEnabled->setPlaceholderText(tr("Some placeholder"));
     connect(ui->browseEditEnabled, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, [this]() {
-        QString text = QInputDialog::getText(this, "Text Entry", "Enter a number, or some invalid text");
+        QString text = QInputDialog::getText(this, tr("Text Entry"), tr("Enter a number, or some invalid text"));
         ui->browseEditEnabled->setText(text);
     });
 
     ui->browseEditReadOnlyClearButton->setLineEditReadOnly(true);
     ui->browseEditReadOnlyClearButton->setClearButtonEnabled(true);
-    ui->browseEditReadOnlyClearButton->setText(QStringLiteral("Text to clear"));
+    ui->browseEditReadOnlyClearButton->setText(tr("Text to clear"));
     connect(ui->browseEditReadOnlyClearButton, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, [this]() {
-        QString text = QInputDialog::getText(this, "Text Entry", "Enter some text");
+        QString text = QInputDialog::getText(this, tr("Text Entry"), tr("Enter some text"));
         ui->browseEditReadOnlyClearButton->setText(text);
     });
 
@@ -43,9 +43,9 @@ BrowseEditPage::BrowseEditPage(QWidget* parent)
     ui->browseEditDisabled->setLineEditReadOnly(true);
     ui->browseEditDisabled->setEnabled(false);
     ui->browseEditDisabled->setAttachedButtonIcon(icon);
-    ui->browseEditDisabled->setText("Text");
+    ui->browseEditDisabled->setText(tr("Text"));
     connect(ui->browseEditDisabled, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, [this]() {
-        QString text = QInputDialog::getText(this, "Text Entry", "Enter a number, or some invalid text");
+        QString text = QInputDialog::getText(this, tr("Text Entry"), tr("Enter a number, or some invalid text"));
         ui->browseEditDisabled->setText(text);
     });
 
@@ -55,22 +55,22 @@ BrowseEditPage::BrowseEditPage(QWidget* parent)
     ui->browseEditNumberReadOnly->setLineEditReadOnly(true);
     ui->browseEditNumberReadOnly->setValidator(new QIntValidator(this));
     ui->browseEditNumberReadOnly->setAttachedButtonIcon(icon);
-    ui->browseEditNumberReadOnly->setToolTip("Click the attached button to enter a number. Put random characters in to put the control into error state.");
-    ui->browseEditNumberReadOnly->setErrorToolTip("The control only accepts numbers!");
-    ui->browseEditNumberReadOnly->setText("Nan");
+    ui->browseEditNumberReadOnly->setToolTip(tr("Click the attached button to enter a number. Put random characters in to put the control into error state."));
+    ui->browseEditNumberReadOnly->setErrorToolTip(tr("The control only accepts numbers!"));
+    ui->browseEditNumberReadOnly->setText(tr("Nan"));
     connect(ui->browseEditNumberReadOnly, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, [this]() {
         // pop up a dialog box and set the line edit based on the user's input
-        QString text = QInputDialog::getText(this, "Text Entry", "Enter a number, or some invalid text");
+        QString text = QInputDialog::getText(this, tr("Text Entry"), tr("Enter a number, or some invalid text"));
         ui->browseEditNumberReadOnly->setText(text);
     });
 
     ui->browseEditNumberNonReadOnly->setValidator(new QIntValidator(this));
     ui->browseEditNumberNonReadOnly->setAttachedButtonIcon(icon);
-    ui->browseEditNumberNonReadOnly->setToolTip("Click the attached button to enter a number. Put random characters in to put the control into error state.");
-    ui->browseEditNumberNonReadOnly->setErrorToolTip("The control only accepts numbers!");
+    ui->browseEditNumberNonReadOnly->setToolTip(tr("Click the attached button to enter a number. Put random characters in to put the control into error state."));
+    ui->browseEditNumberNonReadOnly->setErrorToolTip(tr("The control only accepts numbers!"));
     connect(ui->browseEditNumberNonReadOnly, &AzQtComponents::BrowseEdit::attachedButtonTriggered, this, [this]() {
         // pop up a dialog box and set the line edit based on the user's input
-        QMessageBox::critical(this, "title", "Button attach worked!");
+        QMessageBox::critical(this, tr("title"), tr("Button attach worked!"));
     });
 
     QString exampleText = R"(

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/CardPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/CardPage.cpp
@@ -104,34 +104,34 @@ card->mockDisabledState(true);
 
     ui->exampleText->setHtml(exampleText);
 
-    ui->basicCard->setTitle("Example Card");
+    ui->basicCard->setTitle(tr("Example Card"));
     addContentWidget(ui->basicCard, 30);
 
-    ui->warningCard->setTitle("Card With Warning");
+    ui->warningCard->setTitle(tr("Card With Warning"));
     ui->warningCard->header()->setWarning(true);
     addContentWidget(ui->warningCard, 30);
 
-    ui->disabledCard->setTitle("Actually Disabled Card");
+    ui->disabledCard->setTitle(tr("Actually Disabled Card"));
     ui->disabledCard->setContentWidget(new QWidget());
     ui->disabledCard->header()->setIcon(QIcon(QStringLiteral(":/stylesheet/img/search.svg")));
     ui->disabledCard->header()->setHelpURL("https://o3de.org/docs/");
-    ui->disabledCard->setSecondaryTitle("Secondary Title");
+    ui->disabledCard->setSecondaryTitle(tr("Secondary Title"));
     ui->disabledCard->setSecondaryContentWidget(new QWidget());
     ui->disabledCard->setEnabled(false);
     
-    ui->disabledCard2->setTitle("Mock Disabled Card");
+    ui->disabledCard2->setTitle(tr("Mock Disabled Card"));
     ui->disabledCard2->setContentWidget(new QWidget());
     ui->disabledCard2->header()->setIcon(QIcon(QStringLiteral(":/stylesheet/img/search.svg")));
     ui->disabledCard2->header()->setHelpURL("https://o3de.org/docs/");
-    ui->disabledCard2->setSecondaryTitle("Secondary Title");
+    ui->disabledCard2->setSecondaryTitle(tr("Secondary Title"));
     ui->disabledCard2->setSecondaryContentWidget(new QWidget());
     ui->disabledCard2->mockDisabledState(true);
 
-    ui->functionalCard->setTitle("Card With Secondary Section");
+    ui->functionalCard->setTitle(tr("Card With Secondary Section"));
     addContentWidget(ui->functionalCard, 60);
 
     AzQtComponents::Card::applyContainerStyle(ui->containerCard);
-    ui->containerCard->setTitle("Container card");
+    ui->containerCard->setTitle(tr("Container card"));
     ui->containerCard->header()->setUnderlineColor(QColor("#a675ff"));
 
     auto* contentWidget = new QWidget;
@@ -139,11 +139,11 @@ card->mockDisabledState(true);
     ui->containerCard->setContentWidget(contentWidget);
 
     auto* nestedCard = new AzQtComponents::Card();
-    nestedCard->setTitle("Nested card");
+    nestedCard->setTitle(tr("Nested card"));
     addContentWidget(nestedCard, 30);
     nestedLayout->addWidget(nestedCard);
 
-    auto* button = new QPushButton("Nested button");
+    auto* button = new QPushButton(tr("Nested button"));
     nestedLayout->addWidget(button);
 
     // put in an example icon
@@ -159,29 +159,29 @@ card->mockDisabledState(true);
     connect(ui->disabledCard, &AzQtComponents::Card::contextMenuRequested, this, &CardPage::showContextMenu);
     connect(ui->disabledCard2, &AzQtComponents::Card::contextMenuRequested, this, &CardPage::showContextMenu);
 
-    m_addNotification = new QAction("Add Notification", this);
+    m_addNotification = new QAction(tr("Add Notification"), this);
     addAction(m_addNotification);
     connect(m_addNotification, &QAction::triggered, this, &CardPage::addNotification);
 
-    m_clearNotification = new QAction("Clear Notifications", this);
+    m_clearNotification = new QAction(tr("Clear Notifications"), this);
     addAction(m_clearNotification);
     connect(m_clearNotification, &QAction::triggered, ui->functionalCard, &AzQtComponents::Card::clearNotifications);
 
-    m_warningAction = new QAction("Show Warning Icon", this);
+    m_warningAction = new QAction(tr("Show Warning Icon"), this);
     m_warningAction->setCheckable(true);
     addAction(m_warningAction);
     connect(m_warningAction, &QAction::toggled, this, &CardPage::toggleWarning);
 
-    m_contentChangedAction = new QAction("Set content changed", this);
+    m_contentChangedAction = new QAction(tr("Set content changed"), this);
     m_contentChangedAction->setCheckable(true);
     connect(m_contentChangedAction, &QAction::toggled, this, &CardPage::toggleContentChanged);
 
-    m_selectedChangedAction = new QAction("Toggle selected", this);
+    m_selectedChangedAction = new QAction(tr("Toggle selected"), this);
     m_selectedChangedAction->setCheckable(true);
     connect(m_selectedChangedAction, &QAction::toggled, this, &CardPage::toggleSelectedChanged);
 
     auto card = ui->functionalCard;
-    card->setSecondaryTitle("Advanced Options");
+    card->setSecondaryTitle(tr("Advanced Options"));
 
     QWidget* testWidget2 = new QWidget(card);
     testWidget2->setMaximumHeight(30);
@@ -195,8 +195,8 @@ CardPage::~CardPage()
 
 void CardPage::addNotification()
 {
-    AzQtComponents::CardNotification* notification = ui->functionalCard->addNotification("A warning message indicating a conflict or problem.");
-    QPushButton* button = notification->addButtonFeature("Clear Warnings");
+    AzQtComponents::CardNotification* notification = ui->functionalCard->addNotification(tr("A warning message indicating a conflict or problem."));
+    QPushButton* button = notification->addButtonFeature(tr("Clear Warnings"));
     connect(button, &QPushButton::clicked, ui->functionalCard, &AzQtComponents::Card::clearNotifications);
 }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComboBoxPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComboBoxPage.cpp
@@ -34,23 +34,23 @@ ComboBoxPage::ComboBoxPage(QWidget* parent)
     ui->setupUi(this);
 
     // Add some sample items to the combo box
-    ui->m_data->addItem("Selected value", 0);
+    ui->m_data->addItem(tr("Selected value"), 0);
     for (int i = 1; i < 5; i++)
     {
-        ui->m_data->addItem(QString("Option %1").arg(i), i);
+        ui->m_data->addItem(tr("Option %1").arg(i), i);
     }
     ui->m_data->setCurrentIndex(0);
 
     ui->m_disabled->setDisabled(true);
-    ui->m_disabled->addItem("Disabled dropdown");
+    ui->m_disabled->addItem(tr("Disabled dropdown"));
     ui->m_disabled->setCurrentIndex(0);
 
     // Add a custom validator to the combo box
     auto validator = new FirstIsErrorComboBoxValidator();
     AzQtComponents::ComboBox::setValidator(ui->m_error, validator);
 
-    ui->m_error->addItem(QString("Item 0"));
-    ui->m_error->addItem(QString("Item 1"));
+    ui->m_error->addItem(tr("Item 0"));
+    ui->m_error->addItem(tr("Item 1"));
 
     auto* model = new QStandardItemModel(0, 1, this);
     const auto addItem = [model](const QString& text, Qt::CheckState checkState)
@@ -60,9 +60,9 @@ ComboBoxPage::ComboBoxPage(QWidget* parent)
         item->setCheckState(checkState);
         model->appendRow(item);
     };
-    addItem(QStringLiteral("Orange"), Qt::Unchecked);
-    addItem(QStringLiteral("Apple"), Qt::Checked);
-    addItem(QStringLiteral("Banana"), Qt::PartiallyChecked);
+    addItem(tr("Orange"), Qt::Unchecked);
+    addItem(tr("Apple"), Qt::Checked);
+    addItem(tr("Banana"), Qt::PartiallyChecked);
 
     ui->m_customCheckState->setModel(model);
     AzQtComponents::ComboBox::addCustomCheckStateStyle(ui->m_customCheckState);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/LineEditPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/LineEditPage.cpp
@@ -41,9 +41,9 @@ LineEditPage::LineEditPage(QWidget* parent)
     AzQtComponents::LineEdit::applyDropTargetStyle(ui->validDropTargetLineEdit, true);
     AzQtComponents::LineEdit::applyDropTargetStyle(ui->invalidDropTargetLineEdit, false);
 
-    ui->withData->setToolTip("<b></b>This will be a very very long sentence with an end but not for a long time, spanning an entire screen. I said, spanning an entire screen. No really. An entire screen. A very long, very wide screen.");
+    ui->withData->setToolTip(tr("<b></b>This will be a very very long sentence with an end but not for a long time, spanning an entire screen. I said, spanning an entire screen. No really. An entire screen. A very long, very wide screen."));
 
-    ui->error->setText("Error");
+    ui->error->setText(tr("Error"));
     ui->error->setValidator(new ErrorValidator(ui->error));
 
     auto validator = new QDoubleValidator(ui->longNumber);
@@ -51,14 +51,14 @@ LineEditPage::LineEditPage(QWidget* parent)
     validator->setTop(4.0);
     validator->setBottom(3.0);
     ui->longNumber->setValidator(validator);
-    AzQtComponents::LineEdit::setErrorMessage(ui->longNumber, QStringLiteral("Value must be between 3.0 and 4.0"));
+    AzQtComponents::LineEdit::setErrorMessage(ui->longNumber, tr("Value must be between 3.0 and 4.0"));
     ui->longNumber->setClearButtonEnabled(true);
 
     const auto searchBoxes = {ui->searchBox, ui->emptySearchBox};
     for (auto searchBox : searchBoxes)
     {
         AzQtComponents::LineEdit::applySearchStyle(searchBox);
-        searchBox->setPlaceholderText("Search...");
+        searchBox->setPlaceholderText(tr("Search..."));
     }
 
     QString exampleText = R"(

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ReflectedPropertyEditorPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ReflectedPropertyEditorPage.cpp
@@ -276,7 +276,7 @@ ReflectedPropertyEditorPage::ReflectedPropertyEditorPage(QWidget* parent)
 
     // ReflectedPropertyEditor by in a Card
     AzQtComponents::Card* card = new AzQtComponents::Card(this);
-    card->setTitle(QStringLiteral("Card"));
+    card->setTitle(tr("Card"));
     card->header()->setIcon(QIcon(QStringLiteral(":/Gallery/Grid-small.svg")));
 
     auto cardPropertyEditor = aznew AzToolsFramework::ReflectedPropertyEditor(card);
@@ -293,7 +293,7 @@ ReflectedPropertyEditorPage::ReflectedPropertyEditorPage(QWidget* parent)
 
     // ReflectedPropertyEditor by in a disabled Card
     AzQtComponents::Card* disabledCard = new AzQtComponents::Card(this);
-    disabledCard->setTitle(QStringLiteral("Disabled card"));
+    disabledCard->setTitle(tr("Disabled card"));
     disabledCard->setEnabled(false);
 
     auto disabledCardPropertyEditor = aznew AzToolsFramework::ReflectedPropertyEditor(disabledCard);
@@ -325,7 +325,7 @@ See the documentation linked above for more details.
 )";
 
     ui->exampleText->setHtml(exampleText);
-    ui->hyperlinkLabel->setText(QStringLiteral(R"(<a href="https://o3de.org/docs/user-guide/components/development/reflection/">Reflected Property Editor docs</a>)"));
+    ui->hyperlinkLabel->setText(QStringLiteral(R"(<a href="https://o3de.org/docs/user-guide/components/development/reflection/">)") + tr("Reflected Property Editor docs") + QStringLiteral("</a>"));
 }
 
 ReflectedPropertyEditorPage::~ReflectedPropertyEditorPage()

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/SegmentControlPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/SegmentControlPage.cpp
@@ -60,7 +60,7 @@ SegmentControlPage::SegmentControlPage(QWidget* parent)
     {
         for (int i = 0; i < 4; i++)
         {
-            sb->addTab(QStringLiteral("Segment Bar %1").arg(i));
+            sb->addTab(tr("Segment Bar %1").arg(i));
         }
     }
 
@@ -69,9 +69,9 @@ SegmentControlPage::SegmentControlPage(QWidget* parent)
                                                              ui->segmentControlVertical };
     for (AzQtComponents::SegmentControl* sc : controls)
     {
-        sc->addTab(new SampleColorSwatch(QColor("#690000"), sc), "Red");
-        sc->addTab(new SampleColorSwatch(QColor("#006900"), sc), "Green");
-        sc->addTab(new SampleColorSwatch(QColor("#000069"), sc), "Blue");
+        sc->addTab(new SampleColorSwatch(QColor("#690000"), sc), tr("Red"));
+        sc->addTab(new SampleColorSwatch(QColor("#006900"), sc), tr("Green"));
+        sc->addTab(new SampleColorSwatch(QColor("#000069"), sc), tr("Blue"));
     }
 
     QString exampleText = R"(

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/SpinBoxPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/SpinBoxPage.cpp
@@ -22,7 +22,7 @@ class SpinBoxChangedCommand : public QUndoCommand
 {
 public:
     SpinBoxChangedCommand(Spinbox* objectChanging, ValueType oldValue, ValueType newValue)
-        : QUndoCommand(QStringLiteral("Change %1 to %2").arg(oldValue).arg(newValue))
+        : QUndoCommand(QObject::tr("Change %1 to %2").arg(oldValue).arg(newValue))
         , m_spinBox(objectChanging)
         , m_oldValue(oldValue)
         , m_newValue(newValue)
@@ -83,7 +83,7 @@ SpinBoxPage::SpinBoxPage(QWidget* parent)
     ui->metersVectorInput->setSuffix(" m");
 
     {
-        const QStringList labels = {"Top", "Right", "Bottom", "Left"};
+        const QStringList labels = {tr("Top"), tr("Right"), tr("Bottom"), tr("Left")};
         const int size = ui->labelsVectorInput->getSize();
         for (int i = 0; i < size; ++i)
         {
@@ -144,7 +144,7 @@ AzQtComponents::SpinBox::setHasError(doubleSpinBox, true);
     track<AzQtComponents::DoubleSpinBox, double>(ui->focusDoubleSpinBox);
 
     {
-        QAction* action = new QAction("Up", this);
+        QAction* action = new QAction(tr("Up"), this);
         action->setShortcut(QKeySequence(Qt::Key_Up));
         connect(action, &QAction::triggered, []()
         {
@@ -153,7 +153,7 @@ AzQtComponents::SpinBox::setHasError(doubleSpinBox, true);
         addAction(action);
     }
     {
-        QAction* action = new QAction("Down", this);
+        QAction* action = new QAction(tr("Down"), this);
         action->setShortcut(QKeySequence(Qt::Key_Down));
         connect(action, &QAction::triggered, []()
         {

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/StyleSheetPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/StyleSheetPage.cpp
@@ -67,21 +67,21 @@ StyleSheetPage::StyleSheetPage(QWidget* parent)
     , ui(new Ui::StyleSheetPage)
 {
     ui->setupUi(this);
-    ui->qrcLabel->setText("Styled using qrc: \":/Gallery/StyleSheetPage.qss\"");
-    ui->absolutePathLabel->setText("Style using: \"<path/to>/StyleSheetPage.qss\"");
-    ui->noPrefixLabel->setText("Styled without a prefix: \"StyleSheetPage.qss\"");
-    ui->exampleLabel->setText("Styled using a prefix: \"gallery:StyleSheetPage.qss\"");
+    ui->qrcLabel->setText(tr("Styled using qrc: \":/Gallery/StyleSheetPage.qss\""));
+    ui->absolutePathLabel->setText(tr("Style using: \"<path/to>/StyleSheetPage.qss\""));
+    ui->noPrefixLabel->setText(tr("Styled without a prefix: \"StyleSheetPage.qss\""));
+    ui->exampleLabel->setText(tr("Styled using a prefix: \"gallery:StyleSheetPage.qss\""));
 
     // Add demo tabs to segmentBar
     for (int i = 0; i < 4; i++)
     {
-        ui->segmentBar->addTab(QStringLiteral("Segment Bar %1").arg(i));
+        ui->segmentBar->addTab(tr("Segment Bar %1").arg(i));
     }
 
     // Add demo filters to filteredSearchWidget
-    const auto fruitList = {"Apple", "Orange", "Pear", "Banana"};
+    const auto fruitList = {tr("Apple"), tr("Orange"), tr("Pear"), tr("Banana")};
     const auto category = tr("Fruit");
-    for (const auto fruit : fruitList)
+    for (const auto& fruit : fruitList)
     {
         ui->filteredSearchWidget->AddTypeFilter(category, fruit);
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/StyledDockWidgetPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/StyledDockWidgetPage.cpp
@@ -171,17 +171,17 @@ void StyledDockWidgetPage::showMainWindow()
     m_mainWindow->addToolBar(toolBar);
 
     auto statusBar = new QStatusBar(m_mainWindow);
-    statusBar->showMessage(QStringLiteral("Status Bar..."));
+    statusBar->showMessage(tr("Status Bar..."));
     m_mainWindow->setStatusBar(statusBar);
 
     QWidget* centralWidget = new QWidget;
-    QPushButton* load = new QPushButton("Restore layout");
-    QPushButton* save = new QPushButton("Save layout");
-    QPushButton* split = new QPushButton("Split docks");
-    QPushButton* tabs = new QPushButton("Tabs docks");
+    QPushButton* load = new QPushButton(tr("Restore layout"));
+    QPushButton* save = new QPushButton(tr("Save layout"));
+    QPushButton* split = new QPushButton(tr("Split docks"));
+    QPushButton* tabs = new QPushButton(tr("Tabs docks"));
     QVBoxLayout* vl = new QVBoxLayout(centralWidget);
 
-    vl->addWidget(new QLabel("Central Widget"));
+    vl->addWidget(new QLabel(tr("Central Widget")));
     vl->addWidget(load);
     vl->addWidget(save);
     vl->addWidget(split);
@@ -189,24 +189,24 @@ void StyledDockWidgetPage::showMainWindow()
 
     m_mainWindow->setCentralWidget(centralWidget);
 
-    auto leftDockWidget = new AzQtComponents::StyledDockWidget("Left Dock Widget", m_mainWindow);
+    auto leftDockWidget = new AzQtComponents::StyledDockWidget(tr("Left Dock Widget"), m_mainWindow);
     leftDockWidget->setObjectName(leftDockWidget->windowTitle());
-    leftDockWidget->setWidget(new QLabel("StyledDockWidget"));
+    leftDockWidget->setWidget(new QLabel(tr("StyledDockWidget")));
     m_mainWindow->addDockWidget(Qt::LeftDockWidgetArea, leftDockWidget);
 
-    auto topDockWidget = new AzQtComponents::StyledDockWidget("Top Dock Widget", m_mainWindow);
+    auto topDockWidget = new AzQtComponents::StyledDockWidget(tr("Top Dock Widget"), m_mainWindow);
     topDockWidget->setObjectName(topDockWidget->windowTitle());
-    topDockWidget->setWidget(new QLabel("StyledDockWidget"));
+    topDockWidget->setWidget(new QLabel(tr("StyledDockWidget")));
     m_mainWindow->addDockWidget(Qt::TopDockWidgetArea, topDockWidget);
 
-    auto rightDockWidget = new AzQtComponents::StyledDockWidget("Right Dock Widget", m_mainWindow);
+    auto rightDockWidget = new AzQtComponents::StyledDockWidget(tr("Right Dock Widget"), m_mainWindow);
     rightDockWidget->setObjectName(rightDockWidget->windowTitle());
-    rightDockWidget->setWidget(new QLabel("StyledDockWidget"));
+    rightDockWidget->setWidget(new QLabel(tr("StyledDockWidget")));
     m_mainWindow->addDockWidget(Qt::RightDockWidgetArea, rightDockWidget);
 
-    auto bottomDockWidget = new AzQtComponents::StyledDockWidget("Bottom Dock Widget", m_mainWindow);
+    auto bottomDockWidget = new AzQtComponents::StyledDockWidget(tr("Bottom Dock Widget"), m_mainWindow);
     bottomDockWidget->setObjectName(bottomDockWidget->windowTitle());
-    bottomDockWidget->setWidget(new QLabel("StyledDockWidget"));
+    bottomDockWidget->setWidget(new QLabel(tr("StyledDockWidget")));
     m_mainWindow->addDockWidget(Qt::BottomDockWidgetArea, bottomDockWidget);
 
     auto galleryCenter = mapToGlobal(frameGeometry().center());

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/TabWidgetPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/TabWidgetPage.cpp
@@ -22,37 +22,37 @@ TabWidgetPage::TabWidgetPage(QWidget* parent)
 {
     ui->setupUi(this);
 
-    QAction* action1 = new QAction(QIcon(":/stylesheet/img/table_error.png"), "Action 1", this);
-    QAction* action2 = new QAction(QIcon(":/stylesheet/img/table_error.png"), "Action 2", this);
-    QAction* action3 = new QAction(QIcon(":/stylesheet/img/table_error.png"), "Action 3", this);
+    QAction* action1 = new QAction(QIcon(":/stylesheet/img/table_error.png"), tr("Action 1"), this);
+    QAction* action2 = new QAction(QIcon(":/stylesheet/img/table_error.png"), tr("Action 2"), this);
+    QAction* action3 = new QAction(QIcon(":/stylesheet/img/table_error.png"), tr("Action 3"), this);
     QAction* actionAddTab = new QAction(QIcon(QStringLiteral(":/stylesheet/img/logging/add-filter.svg")), "", this);
-    QAction* actionMenu = new QAction(QIcon(":/stylesheet/img/UI20/menu-centered.svg"), "Action Menu", this);
+    QAction* actionMenu = new QAction(QIcon(":/stylesheet/img/UI20/menu-centered.svg"), tr("Action Menu"), this);
 
     // Menu for the action button, including a no-op action to show without icon as well
     QMenu * menu = new QMenu(this);
     menu->addAction(action1);
     menu->addAction(action2);
     menu->addAction(action3);
-    menu->addAction("Action 4 (No-op)");
+    menu->addAction(tr("Action 4 (No-op)"));
     actionMenu->setMenu(menu);
 
     connect(action1, &QAction::triggered, this, []() {
-        QMessageBox messageBox({}, "Action 1 triggered", "Action 1 has been triggered", QMessageBox::Ok);
+        QMessageBox messageBox({}, tr("Action 1 triggered"), tr("Action 1 has been triggered"), QMessageBox::Ok);
         messageBox.exec();
     });
 
     connect(action2, &QAction::triggered, this, []() {
-        QMessageBox messageBox({}, "Action 2 triggered", "Action 2 has been triggered", QMessageBox::Ok);
+        QMessageBox messageBox({}, tr("Action 2 triggered"), tr("Action 2 has been triggered"), QMessageBox::Ok);
         messageBox.exec();
     });
 
     connect(action3, &QAction::triggered, this, []() {
-        QMessageBox messageBox({}, "Action 3 triggered", "Action 3 has been triggered", QMessageBox::Ok);
+        QMessageBox messageBox({}, tr("Action 3 triggered"), tr("Action 3 has been triggered"), QMessageBox::Ok);
         messageBox.exec();
     });
 
     connect(actionAddTab, &QAction::triggered, this, [this]() {
-        ui->tabWidgetBig->addTab(new QWidget(), "New tab");
+        ui->tabWidgetBig->addTab(new QWidget(), tr("New tab"));
     });
 
     ui->tabWidget->setActionToolBarVisible();
@@ -92,10 +92,10 @@ TabWidgetPage::TabWidgetPage(QWidget* parent)
     ui->tabWidgetSecondaryBorderless->addAction(action3);
     ui->tabWidgetSecondaryBorderless->addAction(actionMenu);
 
-    auto* removeFirstAction = new QPushButton("Remove first action");
-    auto* removeLastAction = new QPushButton("Remove last action");
-    auto* changeActions = new QPushButton("Change actions");
-    auto* toggleActionToolBars = new QPushButton("Toggle action toolbars");
+    auto* removeFirstAction = new QPushButton(tr("Remove first action"));
+    auto* removeLastAction = new QPushButton(tr("Remove last action"));
+    auto* changeActions = new QPushButton(tr("Change actions"));
+    auto* toggleActionToolBars = new QPushButton(tr("Toggle action toolbars"));
     int* changeIdx = new int(0);
 
     connect(ui->tabWidgetBig, &QTabWidget::tabCloseRequested, ui->tabWidgetBig, &QTabWidget::removeTab);
@@ -157,9 +157,9 @@ TabWidgetPage::TabWidgetPage(QWidget* parent)
     connect(changeActions, &QPushButton::clicked, this, [action1, action2, action3, changeIdx]() {
         if (*changeIdx)
         {
-            action1->setText("Action 1");
-            action2->setText("Action 2");
-            action3->setText("Action 3");
+            action1->setText(tr("Action 1"));
+            action2->setText(tr("Action 2"));
+            action3->setText(tr("Action 3"));
 
             action1->setIcon(QIcon(":/stylesheet/img/table_error.png"));
             action2->setIcon(QIcon(":/stylesheet/img/table_error.png"));
@@ -167,9 +167,9 @@ TabWidgetPage::TabWidgetPage(QWidget* parent)
         }
         else
         {
-            action1->setText("Action A");
-            action2->setText("Action B");
-            action3->setText("Action C");
+            action1->setText(tr("Action A"));
+            action2->setText(tr("Action B"));
+            action3->setText(tr("Action C"));
 
             action1->setIcon(QIcon(":/stylesheet/img/table_success.png"));
             action2->setIcon(QIcon(":/stylesheet/img/table_success.png"));

--- a/Code/Framework/AzQtComponents/Platform/Windows/AzQtComponents/Utilities/DesktopUtilities_Windows.cpp
+++ b/Code/Framework/AzQtComponents/Platform/Windows/AzQtComponents/Utilities/DesktopUtilities_Windows.cpp
@@ -29,7 +29,6 @@ namespace AzQtComponents
 
     QString fileBrowserActionName()
     {
-        const char* exploreActionName = "Open in Explorer";
-        return QObject::tr(exploreActionName);
+        return QObject::tr("Open in Explorer");
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Archive/ArchiveComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 #include <AzFramework/Archive/INestedArchive.h>
 #include <AzFramework/Archive/ZipDirStructures.h>
@@ -112,9 +113,10 @@ namespace AzToolsFramework
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<ArchiveComponent>(
-                    "Archive", "Handles creation and extraction of zip archives.")
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Archive"),
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Handles creation and extraction of zip archives."))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                    ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "Editor"))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorWidget.cpp
@@ -311,24 +311,24 @@ namespace AzToolsFramework
                 );
             }
 
-            QAction* openAssetAction = fileMenu->addAction("&Open...");
+            QAction* openAssetAction = fileMenu->addAction(tr("&Open..."));
             connect(openAssetAction, &QAction::triggered, this, &AssetEditorWidget::OpenAssetWithDialog);
 
-            m_recentFileMenu = fileMenu->addMenu("Open Recent");
+            m_recentFileMenu = fileMenu->addMenu(tr("Open Recent"));
 
             fileMenu->addSeparator();
 
-            m_saveAssetAction = fileMenu->addAction("&Save");
+            m_saveAssetAction = fileMenu->addAction(tr("&Save"));
             m_saveAssetAction->setShortcut(QKeySequence::Save);
             m_saveAssetAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
             connect(m_saveAssetAction, &QAction::triggered, this, &AssetEditorWidget::SaveAsset);
 
-            m_saveAsAssetAction = fileMenu->addAction("&Save As");
+            m_saveAsAssetAction = fileMenu->addAction(tr("&Save As"));
             m_saveAsAssetAction->setShortcut(QKeySequence::SaveAs);
             m_saveAsAssetAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
             connect(m_saveAsAssetAction, &QAction::triggered, this, &AssetEditorWidget::SaveAssetAs);
 
-            m_saveAllAssetsAction = fileMenu->addAction("Save All");
+            m_saveAllAssetsAction = fileMenu->addAction(tr("Save All"));
             connect(m_saveAllAssetsAction, &QAction::triggered, this, &AssetEditorWidget::SaveAll);
 
             // The Save actions are disabled by default.
@@ -358,10 +358,10 @@ namespace AzToolsFramework
 
             QMenu* viewMenu = mainMenu->addMenu(tr("&View"));
 
-            QAction* expandAll = viewMenu->addAction("&Expand All");
+            QAction* expandAll = viewMenu->addAction(tr("&Expand All"));
             connect(expandAll, &QAction::triggered, this, &AssetEditorWidget::ExpandAll);
 
-            QAction* collapseAll = viewMenu->addAction("&Collapse All");
+            QAction* collapseAll = viewMenu->addAction(tr("&Collapse All"));
             connect(collapseAll, &QAction::triggered, this, &AssetEditorWidget::CollapseAll);
 
             mainLayout->setMenuBar(mainMenu);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeDelegate.cpp
@@ -10,6 +10,8 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 #include <AzToolsFramework/Application/ToolsApplication.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
@@ -36,11 +38,12 @@ namespace AzToolsFramework
         }
 
         static const char* const s_componentModeEnterDescription =
+            QT_TRANSLATE_NOOP("AzToolsFramework",
             "In this mode, you can only edit properties for this component. "
-            "All other components on the entity are locked.";
+            "All other components on the entity are locked.");
 
         static const char* const s_componentModeLeaveDescription =
-            "Return to normal viewport editing";
+            QT_TRANSLATE_NOOP("AzToolsFramework", "Return to normal viewport editing");
 
         // was the double click on the component or off it (select/deselect)
         enum class DoubleClickOutcome
@@ -131,16 +134,17 @@ namespace AzToolsFramework
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
                 {
                     editContext->Class<ComponentModeDelegate>(
-                        "Component Mode", "Provides advanced editing of Components.")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Component Mode"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Provides advanced editing of Components."))
                         ->UIElement(AZ::Edit::UIHandlers::Button, "", s_componentModeEnterDescription)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ComponentModeDelegate::OnComponentModeEnterButtonPressed)
-                            ->Attribute(AZ::Edit::Attributes::ButtonText, "Edit")
+                            ->Attribute(AZ::Edit::Attributes::ButtonText, QT_TRANSLATE_NOOP("AzToolsFramework", "Edit"))
                             ->Attribute(AZ::Edit::Attributes::Visibility, &EnterComponentModeButtonVisible)
                             ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true)
                             ->Attribute(AZ::Edit::Attributes::ReadOnly, &ComponentModeDelegate::ComponentModeButtonInactive)
                         ->UIElement(AZ::Edit::UIHandlers::Button, "", s_componentModeLeaveDescription)
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ComponentModeDelegate::OnComponentModeLeaveButtonPressed)
-                            ->Attribute(AZ::Edit::Attributes::ButtonText, "Done")
+                            ->Attribute(AZ::Edit::Attributes::ButtonText, QT_TRANSLATE_NOOP("AzToolsFramework", "Done"))
                             ->Attribute(AZ::Edit::Attributes::Visibility, &LeaveComponentModeButtonVisible)
                             ->Attribute(AZ::Edit::Attributes::AcceptsMultiEdit, true)
                             ;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -9,6 +9,8 @@
 
 #include <AzToolsFramework/Entity/EditorEntityContextComponent.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityUtils.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
@@ -83,9 +85,10 @@ namespace AzToolsFramework
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<EditorEntityContextComponent>(
-                    "Editor Entity Context", "System component responsible for owning the edit-time entity context")
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Editor Entity Context"),
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "System component responsible for owning the edit-time entity context"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                    ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "Editor"))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
@@ -9,6 +9,7 @@
 #include "EditorEntityInfoBus.h"
 #include "EditorEntityHelpers.h"
 #include <AzCore/Component/TransformBus.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
@@ -48,7 +49,8 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<EditorEntitySortComponent>("Child Entity Sort Order", "")
+                    editContext->Class<EditorEntitySortComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Child Entity Sort Order"), "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                         ->Attribute(AZ::Edit::Attributes::HideIcon, true)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/GlobalPaintBrushSettings.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PaintBrush/GlobalPaintBrushSettings.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/PaintBrush/GlobalPaintBrushSettings.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <AzToolsFramework/PaintBrush/GlobalPaintBrushSettingsNotificationBus.h>
 #include <AzToolsFramework/PaintBrush/GlobalPaintBrushSettingsRequestBus.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx>
@@ -30,22 +31,26 @@ namespace AzToolsFramework
                 // we want to use the ColorEditorConfiguration to control the Color Picker widget for the Color field.
                 // The ColorEditorConfiguration and the Color picker widget are defined at the AzToolsFramework level, so the
                 // EditContext needs to be at this level as well to be able to refer to them.
-                editContext->Class<PaintBrushSettings>("Paint Brush", "")
+                editContext->Class<PaintBrushSettings>(
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Paint Brush"), "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         // There's no special meaning to 100, we just want the PaintBrushSettings to display after the GlobalPaintBrushSettings
                         ->Attribute(AZ::Edit::Attributes::DisplayOrder, 100)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_size, "Size",
-                        "Size/diameter of the brush stamp in meters.")
+                        AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_size,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Size"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Size/diameter of the brush stamp in meters."))
                         ->Attribute(AZ::Edit::Attributes::Min, &PaintBrushSettings::GetSizeMin)
                         ->Attribute(AZ::Edit::Attributes::Max, &PaintBrushSettings::GetSizeMax)
                         ->Attribute(AZ::Edit::Attributes::Step, &PaintBrushSettings::GetSizeStep)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 2)
-                        ->Attribute(AZ::Edit::Attributes::Suffix, " m")
+                        ->Attribute(AZ::Edit::Attributes::Suffix, QT_TRANSLATE_NOOP("AzToolsFramework", " m"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetSizeVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &PaintBrushSettings::m_brushColor, "Color", "Color of the paint brush.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &PaintBrushSettings::m_brushColor,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Color"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Color of the paint brush."))
                     ->Attribute(
                         "ColorEditorConfiguration",
                         []([[maybe_unused]] void* voidHandler) -> AzToolsFramework::ColorEditorConfiguration
@@ -96,94 +101,103 @@ namespace AzToolsFramework
                     ->DataElement(
                         AZ::Edit::UIHandlers::Slider,
                         &PaintBrushSettings::m_intensityPercent,
-                        "Intensity",
-                        "Intensity/color percent of the paint brush. 0% = black, 100% = white.")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Intensity"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Intensity/color percent of the paint brush. 0% = black, 100% = white."))
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
-                        ->Attribute(AZ::Edit::Attributes::Suffix, " %")
+                        ->Attribute(AZ::Edit::Attributes::Suffix, QT_TRANSLATE_NOOP("AzToolsFramework", " %"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetIntensityVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnIntensityChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Slider,
                         &PaintBrushSettings::m_opacityPercent,
-                        "Opacity",
-                        "Opacity percent of each paint brush stroke. 0% = transparent, 100% = opaque.")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Opacity"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Opacity percent of each paint brush stroke. 0% = transparent, 100% = opaque."))
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
-                        ->Attribute(AZ::Edit::Attributes::Suffix, " %")
+                        ->Attribute(AZ::Edit::Attributes::Suffix, QT_TRANSLATE_NOOP("AzToolsFramework", " %"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetOpacityVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnOpacityChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Slider,
                         &PaintBrushSettings::m_hardnessPercent,
-                        "Hardness",
-                        "Falloff percent around the edges of each paint brush stamp. 0% = soft falloff, 100% = hard edges.")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Hardness"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Falloff percent around the edges of each paint brush stamp. 0% = soft falloff, 100% = hard edges."))
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
-                        ->Attribute(AZ::Edit::Attributes::Suffix, " %")
+                        ->Attribute(AZ::Edit::Attributes::Suffix, QT_TRANSLATE_NOOP("AzToolsFramework", " %"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetHardnessVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
-                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_flowPercent, "Flow",
-                        "The opacity percent of each paint brush stamp. 0% = transparent, 100% = opaque.")
+                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_flowPercent,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Flow"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "The opacity percent of each paint brush stamp. 0% = transparent, 100% = opaque."))
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
-                        ->Attribute(AZ::Edit::Attributes::Suffix, " %")
+                        ->Attribute(AZ::Edit::Attributes::Suffix, QT_TRANSLATE_NOOP("AzToolsFramework", " %"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetFlowVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
-                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_distancePercent, "Distance",
-                        "Brush distance to move between stamps in % of brush size. 1% = high overlap, 100% = non-overlapping stamps.")
+                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_distancePercent,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Distance"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Brush distance to move between stamps in % of brush size. 1% = high overlap, 100% = non-overlapping stamps."))
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::SoftMin, 1.0f)
                         ->Attribute(AZ::Edit::Attributes::SoftMax, 100.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 300.0f)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.5f)
                         ->Attribute(AZ::Edit::Attributes::DisplayDecimals, 1)
-                        ->Attribute(AZ::Edit::Attributes::Suffix, " %")
+                        ->Attribute(AZ::Edit::Attributes::Suffix, QT_TRANSLATE_NOOP("AzToolsFramework", " %"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetDistanceVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::ComboBox, &PaintBrushSettings::m_blendMode, "Blend Mode", "Blend mode of the brush stroke.")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Normal, "Normal")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Multiply, "Multiply")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Screen, "Screen")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Add, "Linear Dodge (Add)")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Subtract, "Subtract")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Darken, "Darken (Min)")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Lighten, "Lighten (Max)")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Average, "Average")
-                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Overlay, "Overlay")
+                        AZ::Edit::UIHandlers::ComboBox, &PaintBrushSettings::m_blendMode,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Blend Mode"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Blend mode of the brush stroke."))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Normal, QT_TRANSLATE_NOOP("AzToolsFramework", "Normal"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Multiply, QT_TRANSLATE_NOOP("AzToolsFramework", "Multiply"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Screen, QT_TRANSLATE_NOOP("AzToolsFramework", "Screen"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Add, QT_TRANSLATE_NOOP("AzToolsFramework", "Linear Dodge (Add)"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Subtract, QT_TRANSLATE_NOOP("AzToolsFramework", "Subtract"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Darken, QT_TRANSLATE_NOOP("AzToolsFramework", "Darken (Min)"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Lighten, QT_TRANSLATE_NOOP("AzToolsFramework", "Lighten (Max)"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Average, QT_TRANSLATE_NOOP("AzToolsFramework", "Average"))
+                        ->EnumAttribute(AzFramework::PaintBrushBlendMode::Overlay, QT_TRANSLATE_NOOP("AzToolsFramework", "Overlay"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetBlendModeVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::ComboBox, &PaintBrushSettings::m_smoothMode,
-                        "Smooth Mode", "Smooth mode of the brush stroke.")
-                        ->EnumAttribute(AzFramework::PaintBrushSmoothMode::Gaussian, "Weighted Average (Gaussian)")
-                        ->EnumAttribute(AzFramework::PaintBrushSmoothMode::Mean, "Average (Mean)")
-                        ->EnumAttribute(AzFramework::PaintBrushSmoothMode::Median, "Middle Value (Median)")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Smooth Mode"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Smooth mode of the brush stroke."))
+                        ->EnumAttribute(AzFramework::PaintBrushSmoothMode::Gaussian, QT_TRANSLATE_NOOP("AzToolsFramework", "Weighted Average (Gaussian)"))
+                        ->EnumAttribute(AzFramework::PaintBrushSmoothMode::Mean, QT_TRANSLATE_NOOP("AzToolsFramework", "Average (Mean)"))
+                        ->EnumAttribute(AzFramework::PaintBrushSmoothMode::Median, QT_TRANSLATE_NOOP("AzToolsFramework", "Middle Value (Median)"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetSmoothModeVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
-                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_smoothingRadius, "Smoothing Radius",
-                        "The number of values in each direction to use for smoothing (a radius of 1 = 3x3 smoothing kernel).")
+                    ->DataElement(AZ::Edit::UIHandlers::Slider, &PaintBrushSettings::m_smoothingRadius,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Smoothing Radius"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "The number of values in each direction to use for smoothing (a radius of 1 = 3x3 smoothing kernel)."))
                         ->Attribute(AZ::Edit::Attributes::Min, MinSmoothingRadius)
                         ->Attribute(AZ::Edit::Attributes::Max, MaxSmoothingRadius)
                         ->Attribute(AZ::Edit::Attributes::Visibility, &PaintBrushSettings::GetSmoothingRadiusVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PaintBrushSettings::OnSettingsChanged)
                     ;
 
-                editContext->Class<GlobalPaintBrushSettings>("Global Paint Brush Settings", "")
+                editContext->Class<GlobalPaintBrushSettings>(
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Global Paint Brush Settings"), "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::ComboBox, &GlobalPaintBrushSettings::m_brushMode, "Brush Mode", "Brush functionality.")
+                        AZ::Edit::UIHandlers::ComboBox, &GlobalPaintBrushSettings::m_brushMode,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Brush Mode"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Brush functionality."))
                     ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<AzToolsFramework::PaintBrushMode>())
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GlobalPaintBrushSettings::OnBrushModeChanged)
                     ;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/EditorPrefabComponent.cpp
@@ -9,6 +9,7 @@
 #include <AzToolsFramework/Prefab/EditorPrefabComponent.h>
 
 #include <AzCore/Interface/Interface.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -30,7 +31,8 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<EditorPrefabComponent>("Prefab Component", "")
+                    editContext->Class<EditorPrefabComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Prefab Component"), "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                         ->Attribute(AZ::Edit::Attributes::HideIcon, true)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceMetadataEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceMetadataEntityContextComponent.cpp
@@ -9,6 +9,7 @@
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Slice/SliceMetadataInfoBus.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 #include <AzToolsFramework/Entity/EditorEntitySortComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.h>
@@ -48,9 +49,10 @@ namespace AzToolsFramework
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<SliceMetadataEntityContextComponent>(
-                    "Slice Metadata Entity Context", "System component responsible for owning the slice metadata entity context")
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Slice Metadata Entity Context"),
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "System component responsible for owning the slice metadata entity context"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                    ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "Editor"))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/std/parallel/lock.h>
 
@@ -123,9 +124,10 @@ namespace AzToolsFramework
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<PerforceComponent>(
-                    "Perforce Connectivity", "Manages Perforce connectivity and executes Perforce commands.")
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Perforce Connectivity"),
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "Manages Perforce connectivity and executes Perforce commands."))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                    ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "Editor"))
                 ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/AzToolsFrameworkConfigurationSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/AzToolsFrameworkConfigurationSystemComponent.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 #include <AzFramework/Scene/Scene.h>
 #include <AzFramework/Scene/SceneSystemInterface.h>
@@ -28,9 +29,10 @@ namespace AzToolsFramework
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
                 editContext->Class<AzToolsFrameworkConfigurationSystemComponent>(
-                    "AzToolsFramework Configuration Component", "System component responsible for configuring AzToolsFramework")
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "AzToolsFramework Configuration Component"),
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "System component responsible for configuring AzToolsFramework"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                    ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "Editor"))
                     ;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
@@ -12,6 +12,8 @@
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     namespace Components
@@ -105,7 +107,8 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<EditorDisabledCompositionComponent>("Disabled Components", "")
+                    editContext->Class<EditorDisabledCompositionComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Disabled Components"), "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::HideIcon, true)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/Asset/AssetManagerBus.h>
+#include <AzFramework/Translation/TranslationDef.h>
 
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/EditorViewportIconDisplayInterface.h>
@@ -35,7 +36,9 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<EditorEntityIconComponent>("Entity Icon", "Edit-time entity icon in entity-inspector and viewport")
+                    editContext->Class<EditorEntityIconComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Entity Icon"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Edit-time entity icon in entity-inspector and viewport"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::HideIcon, true)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorInspectorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorInspectorComponent.cpp
@@ -10,6 +10,8 @@
 #include <AzCore/std/sort.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     namespace Components
@@ -36,7 +38,9 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<EditorInspectorComponent>("Inspector Component Order", "Edit-time entity inspector state")
+                    editContext->Class<EditorInspectorComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Inspector Component Order"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Edit-time entity inspector state"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::HideOnAdd | AZ::Edit::SliceFlags::PushWhenHidden)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorLockComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorLockComponent.cpp
@@ -11,6 +11,8 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     namespace Components
@@ -25,7 +27,9 @@ namespace AzToolsFramework
 
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Class<EditorLockComponent>("Lock", "Edit-time entity lock state")
+                    editContext->Class<EditorLockComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Lock"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Edit-time entity lock state"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::NotPushable)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.cpp
@@ -13,6 +13,8 @@
 #include <AzFramework/Components/NonUniformScaleComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     namespace Components
@@ -37,22 +39,25 @@ namespace AzToolsFramework
                 {
                     editContext
                         ->Class<EditorNonUniformScaleComponent>(
-                            "Non-uniform Scale", "Non-uniform scale for this entity only (does not propagate through hierarchy)")
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Non-uniform Scale"),
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Non-uniform scale for this entity only (does not propagate through hierarchy)"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::FixedComponentListIndex, 1)
                         ->Attribute(AZ::Edit::Attributes::RemoveableByUser, true)
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/NonUniformScale.svg")
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/NonUniformScale.svg")
                         ->DataElement(
-                            AZ::Edit::UIHandlers::Default, &EditorNonUniformScaleComponent::m_scale, "Non-uniform Scale",
-                            "Non-uniform scale for this entity only (does not propagate through hierarchy)")
+                            AZ::Edit::UIHandlers::Default, &EditorNonUniformScaleComponent::m_scale,
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Non-uniform Scale"),
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Non-uniform scale for this entity only (does not propagate through hierarchy)"))
                         ->Attribute(AZ::Edit::Attributes::Min, AZ::MinTransformScale)
                         ->Attribute(AZ::Edit::Attributes::Max, AZ::MaxTransformScale)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.1f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorNonUniformScaleComponent::OnScaleChanged)
                         ->DataElement(
-                            AZ::Edit::UIHandlers::Default, &EditorNonUniformScaleComponent::m_componentModeDelegate, "Component Mode",
-                            "Non-uniform Scale Component Mode")
+                            AZ::Edit::UIHandlers::Default, &EditorNonUniformScaleComponent::m_componentModeDelegate,
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Component Mode"),
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Non-uniform Scale Component Mode"))
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorOnlyEntityComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorOnlyEntityComponent.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     namespace Components
@@ -26,13 +28,14 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<EditorOnlyEntityComponent>("Editor-Only Flag Handler", "")
+                    editContext->Class<EditorOnlyEntityComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Editor-Only Flag Handler"), "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::HideIcon, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &EditorOnlyEntityComponent::m_isEditorOnly, 
-                            "Editor Only", 
-                            "Marks the entity for editor-use only. If true, the entity will not be exported for use in runtime contexts (including dynamic slices).")
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Editor Only"), 
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Marks the entity for editor-use only. If true, the entity will not be exported for use in runtime contexts (including dynamic slices)."))
                         ;
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
@@ -13,6 +13,8 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     namespace Components
@@ -106,7 +108,8 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<EditorPendingCompositionComponent>("Pending Components", "")
+                    editContext->Class<EditorPendingCompositionComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Pending Components"), "")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::HideIcon, true)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorSelectionAccentSystemComponent.cpp
@@ -8,6 +8,7 @@
 #include "EditorSelectionAccentSystemComponent.h"
 
 #include <AzCore/Debug/Profiler.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Component/TransformBus.h>
@@ -29,7 +30,9 @@ namespace AzToolsFramework
 
                 if (AZ::EditContext* ec = serialize->GetEditContext())
                 {
-                    ec->Class<EditorSelectionAccentSystemComponent>("EditorSelectionAccenting", "Used for selection accenting behavior in the viewport")
+                    ec->Class<EditorSelectionAccentSystemComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "EditorSelectionAccenting"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Used for selection accenting behavior in the viewport"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorVisibilityComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorVisibilityComponent.cpp
@@ -12,6 +12,8 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     namespace Components
@@ -26,7 +28,9 @@ namespace AzToolsFramework
 
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Class<EditorVisibilityComponent>("Visibility", "Edit-time entity visibility")
+                    editContext->Class<EditorVisibilityComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Visibility"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Edit-time entity visibility"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::NotPushable)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/GenericComponentWrapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/GenericComponentWrapper.cpp
@@ -15,6 +15,8 @@
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 
 namespace AzToolsFramework
 {
@@ -45,7 +47,9 @@ namespace AzToolsFramework
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
-                    editContext->Class<GenericComponentWrapper>("GenericComponentWrapper", "This should be hidden!")
+                    editContext->Class<GenericComponentWrapper>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "GenericComponentWrapper"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "This should be hidden!"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &GenericComponentWrapper::GetDisplayName)
                             ->Attribute(AZ::Edit::Attributes::DescriptionTextOverride, &GenericComponentWrapper::GetDisplayDescription)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
@@ -9,6 +9,7 @@
 
 #include <AzToolsFramework/ToolsComponents/ScriptEditorComponent.h>
 #include <AzCore/Script/ScriptSystemBus.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <AzCore/EBus/Results.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetSerializer.h>
@@ -1090,99 +1091,140 @@ namespace AzToolsFramework
                 AZ::EditContext* ec = serializeContext->GetEditContext();
                 if (ec)
                 {
-                    ec->Class<ScriptEditorComponent>("Lua Script", "The Lua Script component allows you to add arbitrary Lua logic to an entity in the form of a Lua script")
+                    ec->Class<ScriptEditorComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Lua Script"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "The Lua Script component allows you to add arbitrary Lua logic to an entity in the form of a Lua script"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("UI"))
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("CanvasUI"))
                         ->Attribute(AZ::Edit::Attributes::NameLabelOverride, &ScriptEditorComponent::m_customName)
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                        ->Attribute(AZ::Edit::Attributes::Category, "Scripting")
+                        ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "Scripting"))
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/LuaScript.svg")
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/LuaScript.svg")
                         ->Attribute(AZ::Edit::Attributes::PrimaryAssetType, AZ::AzTypeInfo<AZ::ScriptAsset>::Uuid())
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Script.png")
                         ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/scripting/lua-script/")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &ScriptEditorComponent::m_scriptAsset, "Script", "Which script to use")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &ScriptEditorComponent::m_scriptAsset,
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Script"),
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Which script to use"))
                             ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ScriptEditorComponent::ScriptHasChanged)
                             ->Attribute("BrowseIcon", ":/stylesheet/img/UI20/browse-edit-select-files.svg")
                             ->Attribute("EditButton", "")
-                            ->Attribute("EditDescription", "Open in Lua Editor")
+                            ->Attribute("EditDescription", QT_TRANSLATE_NOOP("AzToolsFramework", "Open in Lua Editor"))
                             ->Attribute("EditCallback", &ScriptEditorComponent::LaunchLuaEditor)
-                        ->DataElement(nullptr, &ScriptEditorComponent::m_scriptComponent, "Script properties", "The script template")
+                        ->DataElement(nullptr, &ScriptEditorComponent::m_scriptComponent,
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Script properties"),
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "The script template"))
                         ->SetDynamicEditDataProvider(&ScriptEditorComponent::GetScriptPropertyEditData)
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ;
 
-                    ec->Class<AzFramework::ScriptComponent>("Script Component", "Adding scripting functionality to the entity!")
-                        ->DataElement(nullptr, &AzFramework::ScriptComponent::m_properties, "Properties", "Lua script properties")
+                    ec->Class<AzFramework::ScriptComponent>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Component"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Adding scripting functionality to the entity!"))
+                        ->DataElement(nullptr, &AzFramework::ScriptComponent::m_properties,
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Properties"),
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Lua script properties"))
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                        ->DataElement(nullptr, &AzFramework::ScriptComponent::m_script, "Asset", "")
+                        ->DataElement(nullptr, &AzFramework::ScriptComponent::m_script,
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Asset"), "")
                             ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::Hide)
                             ->Attribute(AZ::Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::NotPushable) // Only the editor-component's script asset needs to be slice-pushable.
                         ;
 
-                    ec->Class<AzFramework::ScriptPropertyGroup>("Script Property group", "This is a script property group")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyGroup's class attributes.")->
+                    ec->Class<AzFramework::ScriptPropertyGroup>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property group"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "This is a script property group"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AzFramework::ScriptPropertyGroup::m_name)->
                             Attribute(AZ::Edit::Attributes::AutoExpand, true)->
-                        DataElement(nullptr, &AzFramework::ScriptPropertyGroup::m_properties, "m_properties", "Properties in this property group")->
+                        DataElement(nullptr, &AzFramework::ScriptPropertyGroup::m_properties, "m_properties",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Properties in this property group"))->
                             Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AzFramework::ScriptPropertyGroup::m_groups, "m_groups", "Subgroups in this property group")->
+                        DataElement(nullptr, &AzFramework::ScriptPropertyGroup::m_groups, "m_groups",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "Subgroups in this property group"))->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
 
-                    ec->Class<AZ::ScriptProperty>("Script Property", "Base class for script properties")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyGroup's class attributes.")->
+                    ec->Class<AZ::ScriptProperty>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Base class for script properties"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
 
-                    ec->Class<AZ::ScriptPropertyBoolean>("Script Property (bool)", "A script boolean property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyGroup's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyBoolean>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property (bool)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script boolean property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AZ::ScriptPropertyBoolean::m_value, "m_value", "A boolean")->
+                        DataElement(nullptr, &AZ::ScriptPropertyBoolean::m_value, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "A boolean"))->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AZ::ScriptProperty::m_name);
 
-                    ec->Class<AZ::ScriptPropertyNumber>("Script Property (number)", "A script number property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyGroup's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyNumber>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property (number)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script number property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AZ::ScriptPropertyNumber::m_value, "m_value", "A number")->
+                        DataElement(nullptr, &AZ::ScriptPropertyNumber::m_value, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "A number"))->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AZ::ScriptProperty::m_name);
 
-                    ec->Class<AZ::ScriptPropertyString>("Script Property (string)", "A script string property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyGroup's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyString>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property (string)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script string property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AZ::ScriptPropertyString::m_value, "m_value", "A string")->
+                        DataElement(nullptr, &AZ::ScriptPropertyString::m_value, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "A string"))->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AZ::ScriptProperty::m_name);
 
-                    ec->Class<AZ::ScriptPropertyGenericClass>("Script Property (object)", "A script object property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyGroup's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyGenericClass>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property (object)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script object property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AZ::ScriptPropertyGenericClass::m_value, "m_value", "An object")->
+                        DataElement(nullptr, &AZ::ScriptPropertyGenericClass::m_value, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "An object"))->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
 
-                    ec->Class<AZ::ScriptPropertyBooleanArray>("Script Property Array(bool)", "A script bool array property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyBooleanArray's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyBooleanArray>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property Array(bool)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script bool array property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AZ::ScriptPropertyBooleanArray::m_values, "m_value", "An object")->
+                        DataElement(nullptr, &AZ::ScriptPropertyBooleanArray::m_values, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "An object"))->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AZ::ScriptProperty::m_name);
 
-                    ec->Class<AZ::ScriptPropertyNumberArray>("Script Property Array(number)", "A script number array property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyNumberArray's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyNumberArray>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property Array(number)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script number array property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AZ::ScriptPropertyNumberArray::m_values, "m_value", "An object")->
+                        DataElement(nullptr, &AZ::ScriptPropertyNumberArray::m_values, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "An object"))->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AZ::ScriptProperty::m_name);
 
-                    ec->Class<AZ::ScriptPropertyStringArray>("Script Property Array(string)", "A script string array property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyStringArray's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyStringArray>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property Array(string)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script string array property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
-                        DataElement(nullptr, &AZ::ScriptPropertyStringArray::m_values, "m_value", "An object")->
+                        DataElement(nullptr, &AZ::ScriptPropertyStringArray::m_values, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "An object"))->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AZ::ScriptProperty::m_name);
 
-                    ec->Class<AZ::ScriptPropertyGenericClassArray>("Script Property Array(object)", "A script object array property")->
-                        ClassElement(AZ::Edit::ClassElements::EditorData, "ScriptPropertyGenericClassArray's class attributes.")->
+                    ec->Class<AZ::ScriptPropertyGenericClassArray>(
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Script Property Array(object)"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "A script object array property"))->
+                        ClassElement(AZ::Edit::ClassElements::EditorData, "")->
                             Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
                             Attribute(AZ::Edit::Attributes::DynamicElementType, &AZ::ScriptPropertyGenericClassArray::GetElementTypeUuid)->
-                        DataElement(nullptr, &AZ::ScriptPropertyGenericClassArray::m_values, "m_value", "An object")->
+                        DataElement(nullptr, &AZ::ScriptPropertyGenericClassArray::m_values, "m_value",
+                            QT_TRANSLATE_NOOP("AzToolsFramework", "An object"))->
                             ElementAttribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)->
                             Attribute(AZ::Edit::Attributes::NameLabelOverride, &AZ::ScriptProperty::m_name);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAudioCtrl.cpp
@@ -38,7 +38,9 @@ namespace AzToolsFramework
 
             if (auto editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<CReflectedVarAudioControl>("VarAudioControl", "AudioControl")
+                editContext->Class<CReflectedVarAudioControl>(
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "VarAudioControl"),
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "AudioControl"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ;
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -7,6 +7,7 @@
  */
 #include "PropertyManagerComponent.h"
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ToolsComponents/EditorEntityIdContainer.h>
@@ -343,9 +344,10 @@ namespace AzToolsFramework
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
                 {
                     editContext->Class<PropertyManagerComponent>(
-                        "Property Manager", "Provides services for registration of property editors")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Property Manager"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Provides services for registration of property editors"))
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                            ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                            ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "Editor"))
                         ;
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/LocalViewBookmarkComponent.cpp
@@ -12,6 +12,8 @@
 #include <AzToolsFramework/Viewport/LocalViewBookmarkComponent.h>
 #include <Viewport/ViewBookmarkLoaderInterface.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     void ViewBookmark::Reflect(AZ::ReflectContext* context)
@@ -25,11 +27,15 @@ namespace AzToolsFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<ViewBookmark>("ViewBookmark Data", "")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "ViewBookmark")
+                editContext->Class<ViewBookmark>(
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "ViewBookmark Data"), "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "ViewBookmark"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Vector3, &ViewBookmark::m_position, "Position", "")
-                    ->DataElement(AZ::Edit::UIHandlers::Vector3, &ViewBookmark::m_rotation, "Rotation", "");
+                    ->DataElement(AZ::Edit::UIHandlers::Vector3, &ViewBookmark::m_position,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Position"), "")
+                    ->DataElement(AZ::Edit::UIHandlers::Vector3, &ViewBookmark::m_rotation,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Rotation"), "");
             }
         }
     }
@@ -49,16 +55,18 @@ namespace AzToolsFramework
             {
                 editContext
                     ->Class<LocalViewBookmarkComponent>(
-                        "Local View Bookmark Component",
-                        "The Local View Bookmark Component allows the user to store bookmarks in a custom setreg file.")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Local View Bookmarks")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Local View Bookmark Component"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "The Local View Bookmark Component allows the user to store bookmarks in a custom setreg file."))
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Local View Bookmarks"))
                     ->Attribute(AZ::Edit::Attributes::AddableByUser, false)
                     ->Attribute(AZ::Edit::Attributes::RemoveableByUser, false)
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Level"))
-                    ->Attribute(AZ::Edit::Attributes::Category, "View Bookmarks")
+                    ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "View Bookmarks"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &LocalViewBookmarkComponent::m_localBookmarksFileName, "Local Bookmarks File Name",
+                        AZ::Edit::UIHandlers::Default, &LocalViewBookmarkComponent::m_localBookmarksFileName,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Local Bookmarks File Name"),
                         "");
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/SharedViewBookmarkComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/SharedViewBookmarkComponent.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/Utils/Utils.h>
 #include <AzToolsFramework/Viewport/SharedViewBookmarkComponent.h>
 
+#include <AzFramework/Translation/TranslationDef.h>
+
 namespace AzToolsFramework
 {
     void EditorViewBookmarks::Reflect(AZ::ReflectContext* context)
@@ -21,9 +23,12 @@ namespace AzToolsFramework
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<EditorViewBookmarks>("EditorViewBookmarks", "")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Editor View Bookmarks")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorViewBookmarks::m_viewBookmarks, "View Bookmarks", "")
+                editContext->Class<EditorViewBookmarks>(
+                    QT_TRANSLATE_NOOP("AzToolsFramework", "EditorViewBookmarks"), "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Editor View Bookmarks"))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorViewBookmarks::m_viewBookmarks,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "View Bookmarks"), "")
                     ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, true)
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::IndexedChildNameLabelOverride, &EditorViewBookmarks::GetBookmarkLabel);
@@ -51,13 +56,16 @@ namespace AzToolsFramework
             {
                 editContext
                     ->Class<SharedViewBookmarkComponent>(
-                        "Shared View Bookmark Component", "The ViewBookmark Component allows to store bookmarks for a prefab")
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "Shared View Bookmark Component"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "The ViewBookmark Component allows to store bookmarks for a prefab"))
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AddableByUser, false)
-                    ->Attribute(AZ::Edit::Attributes::Category, "View Bookmarks")
+                    ->Attribute(AZ::Edit::Attributes::Category, QT_TRANSLATE_NOOP("AzToolsFramework", "View Bookmarks"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &SharedViewBookmarkComponent::m_viewBookmark, "ViewBookmarks", "ViewBookmarks")
+                        AZ::Edit::UIHandlers::Default, &SharedViewBookmarkComponent::m_viewBookmark,
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "ViewBookmarks"),
+                        QT_TRANSLATE_NOOP("AzToolsFramework", "ViewBookmarks"))
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, false);
             }
         }

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1176,7 +1176,7 @@ namespace AssetProcessor
                 auto scanFolderMatch = [watchFolderQt = QString::fromUtf8(scanFolderEntry.m_watchPath.c_str(),
                     aznumeric_cast<int>(scanFolderEntry.m_watchPath.Native().size()))](const QString& scanFolderPattern)
                 {
-                    const bool match = AZStd::wildcard_match(qPrintable(scanFolderPattern), qPrintable(watchFolderQt));
+                    const bool match = AZStd::wildcard_match(qUtf8Printable(scanFolderPattern), qUtf8Printable(watchFolderQt));
                     return match;
                 };
                 if (!scanFolderPatterns.empty() && AZStd::none_of(scanFolderPatterns.begin(), scanFolderPatterns.end(), scanFolderMatch))
@@ -1702,7 +1702,7 @@ namespace AssetProcessor
                 continue;
             }
             QString pathMatch{ sourceFolderDir.relativeFilePath(dirIterator.filePath()) };
-            if (AZStd::wildcard_match(qPrintable(posixRelativeName), qPrintable(pathMatch)))
+            if (AZStd::wildcard_match(qUtf8Printable(posixRelativeName), qUtf8Printable(pathMatch)))
             {
                 returnList.append(QDir::fromNativeSeparators(dirIterator.filePath()));
             }
@@ -1761,7 +1761,7 @@ namespace AssetProcessor
                 }
 
                 QString pathMatch{ sourceFolderDir.relativeFilePath(dirIterator.filePath()) };
-                if (AZStd::wildcard_match(qPrintable(posixRelativeName), qPrintable(pathMatch)))
+                if (AZStd::wildcard_match(qUtf8Printable(posixRelativeName), qUtf8Printable(pathMatch)))
                 {
                     returnList.append(QDir::fromNativeSeparators(dirIterator.filePath()));
                 }

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorFindDialog.cpp
@@ -245,11 +245,11 @@ namespace LUAEditor
 
         if (m_bWasFindInAll)
         {
-            this->setWindowTitle("Find in files...");
+            this->setWindowTitle(tr("Find in files..."));
         }
         else
         {
-            this->setWindowTitle("Find...");
+            this->setWindowTitle(tr("Find..."));
         }
     }
 
@@ -348,12 +348,12 @@ namespace LUAEditor
         }
         else
         {
-            QMessageBox::warning(this, "Error!", "You may not search for an empty string!");
+            QMessageBox::warning(this, tr("Error!"), tr("You may not search for an empty string!"));
         }
 
         if (!m_findOperation)
         {
-            QMessageBox::warning(this, "Search failed!", tr("Could not find \"%1\" within/further this context.").arg(m_gui->txtFind->text()));
+            QMessageBox::warning(this, tr("Search failed!"), tr("Could not find \"%1\" within/further this context.").arg(m_gui->txtFind->text()));
         }
     }
 
@@ -424,7 +424,7 @@ namespace LUAEditor
     {
         if (m_bReplaceThreadRunning)
         {
-            QMessageBox::warning(this, "Error!", "You may not run Find ALL while a Replace All is running!");
+            QMessageBox::warning(this, tr("Error!"), tr("You may not run Find ALL while a Replace All is running!"));
             return;
         }
 
@@ -491,7 +491,7 @@ namespace LUAEditor
         }
         else
         {
-            QMessageBox::warning(this, "Error!", "You may not search for an empty string!");
+            QMessageBox::warning(this, tr("Error!"), tr("You may not search for an empty string!"));
         }
     }
 
@@ -841,28 +841,15 @@ namespace LUAEditor
 
         int currentLine = 0;
         m_FIFData.m_resultsWidget->Clear();
-        QString hits;
-        if (m_FIFData.m_TotalMatchesFound == 1)
-        {
-            hits.append("hit");
-        }
-        else
-        {
-            hits.append("hits");
-        }
+        // Use Qt's %n plural forms for proper internationalization.
+        // Languages like Russian, Arabic, etc. have more than 2 plural forms.
+        //: %n is the number of search matches found
+        QString hits = tr("%n hit(s)", "", m_FIFData.m_TotalMatchesFound);
+        //: %n is the number of files containing matches
+        QString files = tr("%n file(s)", "", static_cast<int>(m_resultList.size()));
 
-        QString files;
-        if (m_resultList.size() == 1)
-        {
-            files.append("file");
-        }
-        else
-        {
-            files.append("files");
-        }
-
-        QString header("Find \"%1\" (%2 %4 in %3 %5)");
-        header = header.arg(m_FIFData.m_SearchText).arg(m_FIFData.m_TotalMatchesFound).arg(m_resultList.size()).arg(hits).arg(files);
+        QString header = tr("Find \"%1\" (%2 in %3)")
+            .arg(m_FIFData.m_SearchText, hits, files);
         m_FIFData.m_resultsWidget->AppendPlainText(header);
         setFoldLevel(currentLine, 0, 0);
 
@@ -974,7 +961,7 @@ namespace LUAEditor
             }
             else if (!pLUAViewWidget->m_Info.m_bSourceControl_CanWrite)
             {
-                QMessageBox::warning(this, "Error!", "Can not check out file for replace!");
+                QMessageBox::warning(this, tr("Error!"), tr("Can not check out file for replace!"));
             }
             else
             {
@@ -1300,7 +1287,7 @@ namespace LUAEditor
         }
         else if (!pLUAViewWidget->m_Info.m_bSourceControl_CanWrite)
         {
-            QMessageBox::warning(this, "Can not check out file!", (pLUAViewWidget->m_Info.m_assetName + ".lua").c_str());
+            QMessageBox::warning(this, tr("Can not check out file!"), (pLUAViewWidget->m_Info.m_assetName + ".lua").c_str());
             return -1;
         }
 
@@ -1351,7 +1338,7 @@ namespace LUAEditor
     {
         if (m_bFindThreadRunning)
         {
-            QMessageBox::warning(this, "Error!", "You may not run Replace ALL while a Find All is running!");
+            QMessageBox::warning(this, tr("Error!"), tr("You may not run Replace ALL while a Find All is running!"));
             return;
         }
 
@@ -1391,24 +1378,24 @@ namespace LUAEditor
         }
         else
         {
-            QMessageBox::warning(this, "Error!", "You may not replace an empty string!");
+            QMessageBox::warning(this, tr("Error!"), tr("You may not replace an empty string!"));
         }
     }
 
     void LUAEditorFindDialog::BusyOn()
     {
         m_gui->cancelButton->setEnabled(true);
-        m_gui->busyLabel->setText("Working");
+        m_gui->busyLabel->setText(tr("Working"));
     }
     void LUAEditorFindDialog::BusyOff()
     {
         m_gui->cancelButton->setEnabled(false);
-        m_gui->busyLabel->setText("Idle");
+        m_gui->busyLabel->setText(tr("Idle"));
     }
     void LUAEditorFindDialog::PostProcessOn()
     {
         m_gui->cancelButton->setEnabled(false);
-        m_gui->busyLabel->setText("List Prep");
+        m_gui->busyLabel->setText(tr("List Prep"));
     }
     void LUAEditorFindDialog::PostReplaceOn()
     {
@@ -1416,7 +1403,7 @@ namespace LUAEditor
         m_bReplaceThreadRunning = false;
 
         m_gui->cancelButton->setEnabled(true);
-        m_gui->busyLabel->setText("Replacing");
+        m_gui->busyLabel->setText(tr("Replacing"));
     }
 
     void LUAEditorFindDialog::showEvent(QShowEvent* event)

--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorView.cpp
@@ -671,7 +671,7 @@ namespace LUAEditor
             if ((!isModified) && (isascii(ev->key()) || isUseful))
             {
                 QMessageBox msgBox;
-                msgBox.setText("Checkout This File To Edit?");
+                msgBox.setText(tr("Checkout This File To Edit?"));
                 msgBox.setInformativeText(m_Info.m_assetName.c_str());
                 msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
                 msgBox.setDefaultButton(QMessageBox::Ok);

--- a/Code/Tools/LuaIDE/Source/LUA/TargetContextButton.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/TargetContextButton.cpp
@@ -23,7 +23,7 @@ namespace LUA
         AZStd::string context("Default");
         LUAEditor::LUATargetContextRequestMessages::Bus::Broadcast(
             &LUAEditor::LUATargetContextRequestMessages::Bus::Events::SetCurrentTargetContext, context);
-        this->setText("Context: Default");
+        this->setText(tr("Context: Default"));
 
         QSizePolicy sizePolicy1(QSizePolicy::Preferred, QSizePolicy::Preferred);
         sizePolicy1.setHorizontalStretch(0);
@@ -61,7 +61,7 @@ namespace LUA
         if (resultAction)
         {
             AZStd::string context = resultAction->property("context").toString().toUtf8().data();
-            this->setText("Context: None"); // prepare for failure
+            this->setText(tr("Context: None")); // prepare for failure
             LUAEditor::LUATargetContextRequestMessages::Bus::Broadcast(
                 &LUAEditor::LUATargetContextRequestMessages::Bus::Events::SetCurrentTargetContext, context);
         }
@@ -69,7 +69,7 @@ namespace LUA
 
     void TargetContextButton::OnTargetContextPrepared(AZStd::string& contextName)
     {
-        QString qstr = QString("Context: %1").arg(contextName.c_str());
+        QString qstr = tr("Context: %1").arg(contextName.c_str());
         this->setText(qstr); // plan for success
     }
 

--- a/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateAGemScreen.cpp
@@ -227,7 +227,7 @@ namespace O3DE::ProjectManager
 
         LoadButtonsFromGemTemplatePaths(gemSetupLayout);
 
-        m_formFolderRadioButton = new QRadioButton("Choose existing template");
+        m_formFolderRadioButton = new QRadioButton(tr("Choose existing template"));
         m_formFolderRadioButton->setObjectName("createAGem");
         m_radioButtonGroup->addButton(m_formFolderRadioButton);
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogHeaderWidget.cpp
@@ -192,7 +192,7 @@ namespace O3DE::ProjectManager
         gemDownloadLayout->setContentsMargins(0, 0, 0, 0);
         gemDownloadLayout->setAlignment(Qt::AlignTop);
         downloadingGemsWidget->setLayout(gemDownloadLayout);
-        QLabel* processingQueueLabel = new QLabel("Processing Queue");
+        QLabel* processingQueueLabel = new QLabel(tr("Processing Queue"));
         gemDownloadLayout->addWidget(processingQueueLabel);
 
         m_downloadingListWidget = new QWidget();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -815,7 +815,7 @@ namespace O3DE::ProjectManager
 
     QString GemCatalogScreen::GetTabText()
     {
-        return "Gems";
+        return tr("Gems");
     }
 
     bool GemCatalogScreen::IsTab()

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
@@ -301,7 +301,7 @@ namespace O3DE::ProjectManager
         mainLayout->setAlignment(Qt::AlignTop);
         mainWidget->setLayout(mainLayout);
 
-        QLabel* filterByLabel = new QLabel("Filter by");
+        QLabel* filterByLabel = new QLabel(tr("Filter by"));
         filterByLabel->setObjectName("FilterByLabel");
         mainLayout->addWidget(filterByLabel);
 
@@ -313,22 +313,22 @@ namespace O3DE::ProjectManager
         filterLayout->setContentsMargins(0, 0, 0, 0);
         filterSection->setLayout(filterLayout);
 
-        m_statusFilter = new FilterCategoryWidget("Status");
+        m_statusFilter = new FilterCategoryWidget(tr("Status"));
         connect(m_statusFilter->GetButtonGroup(), QOverload<QAbstractButton *, bool>::of(&QButtonGroup::buttonToggled), this, &GemFilterWidget::OnStatusFilterToggled);
 
-        m_versionsFilter = new FilterCategoryWidget("Versions");
+        m_versionsFilter = new FilterCategoryWidget(tr("Versions"));
         connect(m_versionsFilter->GetButtonGroup(), QOverload<QAbstractButton *, bool>::of(&QButtonGroup::buttonToggled), this, &GemFilterWidget::OnUpdateFilterToggled);
 
-        m_featureFilter = new FilterCategoryWidget("Feature", /*showAllLessButton=*/true, /*collapsed*/false, /*defaultShowCount=*/5);
+        m_featureFilter = new FilterCategoryWidget(tr("Feature"), /*showAllLessButton=*/true, /*collapsed*/false, /*defaultShowCount=*/5);
         connect(m_featureFilter->GetButtonGroup(), QOverload<QAbstractButton *, bool>::of(&QButtonGroup::buttonToggled), this, &GemFilterWidget::OnFeatureFilterToggled);
 
-        m_platformFilter = new OrFilterCategoryWidget("Platform", GemInfo::NumPlatforms, m_gemModel);
+        m_platformFilter = new OrFilterCategoryWidget(tr("Platform"), GemInfo::NumPlatforms, m_gemModel);
         connect(m_platformFilter, &OrFilterCategoryWidget::FilterToggled, m_filterProxyModel, &GemSortFilterProxyModel::SetPlatformFilterFlag);
 
-        m_originFilter = new OrFilterCategoryWidget("Provider", GemInfo::NumGemOrigins, m_gemModel);
+        m_originFilter = new OrFilterCategoryWidget(tr("Provider"), GemInfo::NumGemOrigins, m_gemModel);
         connect(m_originFilter, &OrFilterCategoryWidget::FilterToggled, m_filterProxyModel, &GemSortFilterProxyModel::SetOriginFilterFlag);
 
-        m_typeFilter = new OrFilterCategoryWidget("Type", GemInfo::NumTypes, m_gemModel);
+        m_typeFilter = new OrFilterCategoryWidget(tr("Type"), GemInfo::NumTypes, m_gemModel);
         connect(m_typeFilter, &OrFilterCategoryWidget::FilterToggled, m_filterProxyModel, &GemSortFilterProxyModel::SetTypeFilterFlag);
 
         // add filters in the order they appear
@@ -393,7 +393,7 @@ namespace O3DE::ProjectManager
             numCompatibleGems += GemModel::IsCompatible(m_gemModel->index(i, 0)) ? 1 : 0;
         }
 
-        m_versionsFilter->SetElements({ "Update Available", "Compatible" }, { numGemsWithUpdates, numCompatibleGems });
+        m_versionsFilter->SetElements({ tr("Update Available"), tr("Compatible") }, { numGemsWithUpdates, numCompatibleGems });
 
         if (buttons.isEmpty())
         {

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -274,7 +274,7 @@ namespace O3DE::ProjectManager
                     gemInfo.m_name = gemName;
                     gemInfo.m_displayName = gemName;
                     gemInfo.m_version = gemVersion;
-                    gemInfo.m_summary = QString("This project uses %1 but a compatible gem was not found, or has not been registered yet.")
+                    gemInfo.m_summary = QString(tr("This project uses %1 but a compatible gem was not found, or has not been registered yet."))
                                             .arg(gemNameWithSpecifier);
                     gemInfo.m_isAdded = true;
 
@@ -298,7 +298,7 @@ namespace O3DE::ProjectManager
             gemInfo.m_name = gemName;
             gemInfo.m_displayName = gemName;
             gemInfo.m_version = gemVersion;
-            gemInfo.m_summary = QString("This project uses %1 but a compatible gem was not found, or has not been registered yet.").arg(gemNameWithSpecifier);
+            gemInfo.m_summary = QString(tr("This project uses %1 but a compatible gem was not found, or has not been registered yet.")).arg(gemNameWithSpecifier);
             gemInfo.m_isAdded = true;
 
             QStandardItem* gemItem = new QStandardItem();

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemSortFilterProxyModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemSortFilterProxyModel.cpp
@@ -197,11 +197,11 @@ namespace O3DE::ProjectManager
         switch (status)
         {
         case GemSelected::Unselected:
-            return "Unselected";
+            return tr("Unselected");
         case GemSelected::Selected:
-            return "Selected";
+            return tr("Selected");
         default:
-            return "<Unknown Selection Status>";
+            return tr("<Unknown Selection Status>");
         }
     }
 
@@ -210,11 +210,11 @@ namespace O3DE::ProjectManager
         switch (status)
         {
         case GemActive::Inactive:
-            return "Inactive";
+            return tr("Inactive");
         case GemActive::Active:
-            return "Active";
+            return tr("Active");
         default:
-            return "<Unknown Active Status>";
+            return tr("<Unknown Active Status>");
         }
     }
     void GemSortFilterProxyModel::InvalidateFilter()

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
@@ -205,7 +205,7 @@ namespace O3DE::ProjectManager
             }
             else
             {
-                emit ShowToastNotification("Failed to copy URL to clipboard");
+                emit ShowToastNotification(tr("Failed to copy URL to clipboard"));
             }
         }
     }

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
@@ -195,7 +195,7 @@ namespace O3DE::ProjectManager
         else
         {
             QMessageBox::critical(
-                this, tr("Operation failed"), QString("Some repos failed to refresh."));
+                this, tr("Operation failed"), QString(tr("Some repos failed to refresh.")));
         }
     }
 
@@ -218,7 +218,7 @@ namespace O3DE::ProjectManager
         {
             QMessageBox::critical(
                 this, tr("Operation failed"),
-                QString("Failed to refresh gem repo %1<br>Error:<br>%2")
+                QString(tr("Failed to refresh gem repo %1<br>Error:<br>%2"))
                     .arg(m_gemRepoModel->GetName(modelIndex), refreshResult.GetError().c_str()));
         }
     }
@@ -267,7 +267,7 @@ namespace O3DE::ProjectManager
         }
         else
         {
-            QMessageBox::critical(this, tr("Operation failed"), QString("Cannot retrieve gem repos for engine.<br>Error:<br>%2").arg(allGemRepoInfosResult.GetError().c_str()));
+            QMessageBox::critical(this, tr("Operation failed"), QString(tr("Cannot retrieve gem repos for engine.<br>Error:<br>%2")).arg(allGemRepoInfosResult.GetError().c_str()));
         }
     }
 

--- a/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectExportController.cpp
@@ -122,7 +122,7 @@ namespace O3DE::ProjectManager
                 if (logFilePathQuery.IsSuccess())
                 {
                     QMessageBox::critical(m_parent,
-                                      QString("%1\nYou can check the logs in the following directory:\n%2")
+                                      QString(tr("%1\nYou can check the logs in the following directory:\n%2"))
                                         .arg(LauncherExportFailedMessage)
                                         .arg(logFilePathQuery.GetValue()),
                                       result);
@@ -130,7 +130,7 @@ namespace O3DE::ProjectManager
                 else
                 {
                     QMessageBox::critical(m_parent,
-                                      QString("%1\nNo logs are available at this time. Unable to create the folders to hold the logs.\n%2")
+                                      QString(tr("%1\nNo logs are available at this time. Unable to create the folders to hold the logs.\n%2"))
                                         .arg(LauncherExportFailedMessage)
                                         .arg(logFilePathQuery.GetError()),
                                       result);

--- a/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectGemCatalogScreen.cpp
@@ -75,7 +75,7 @@ namespace O3DE::ProjectManager
                 {
                     QMessageBox::critical(
                         nullptr,
-                        "Cannot add gem that isn't downloaded",
+                        tr("Cannot add gem that isn't downloaded"),
                         tr("Cannot add gem %1 to project because it isn't downloaded yet or failed to download.")
                             .arg(GemModel::GetDisplayName(modelIndex)));
 
@@ -150,7 +150,7 @@ namespace O3DE::ProjectManager
             if (!result.IsSuccess())
             {
                 QMessageBox::critical(
-                    nullptr, "Failed to remove gem from project",
+                    nullptr, tr("Failed to remove gem from project"),
                     tr("Cannot remove gem %1 from project.<br><br>Error:<br>%2")
                         .arg(GemModel::GetDisplayName(modelIndex), result.GetError().c_str()));
 

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -150,9 +150,9 @@ namespace O3DE::ProjectManager
                 headerLayout->addWidget(titleLabel);
 
                 QMenu* newProjectMenu = new QMenu(this);
-                m_createNewProjectAction = newProjectMenu->addAction("Create New Project");
-                m_addExistingProjectAction = newProjectMenu->addAction("Open Existing Project");
-                m_addRemoteProjectAction = newProjectMenu->addAction("Add a Remote Project");
+                m_createNewProjectAction = newProjectMenu->addAction(tr("Create New Project"));
+                m_addExistingProjectAction = newProjectMenu->addAction(tr("Open Existing Project"));
+                m_addRemoteProjectAction = newProjectMenu->addAction(tr("Add a Remote Project"));
 
                 connect(m_createNewProjectAction, &QAction::triggered, this, &ProjectsScreen::HandleNewProjectButton);
                 connect(m_addExistingProjectAction, &QAction::triggered, this, &ProjectsScreen::HandleAddProjectButton);
@@ -488,7 +488,7 @@ namespace O3DE::ProjectManager
 
     void ProjectsScreen::HandleAddProjectButton()
     {
-        QString title{ QObject::tr("Select Project File") };
+        QString title{ tr("Select Project File") };
         QString defaultPath;
 
         // get the default path to look for new projects in

--- a/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/SceneWidgets/SceneGraphWidget.cpp
@@ -416,12 +416,12 @@ namespace AZ
                 QSignalBlocker blocker(ui->m_selectAllCheckBox);
                 if (m_selectedCount == m_totalCount)
                 {
-                    ui->m_selectAllCheckBox->setText("Unselect all");
+                    ui->m_selectAllCheckBox->setText(tr("Unselect all"));
                     ui->m_selectAllCheckBox->setCheckState(Qt::CheckState::Checked);
                 }
                 else
                 {
-                    ui->m_selectAllCheckBox->setText("Select all");
+                    ui->m_selectAllCheckBox->setText(tr("Select all"));
                     ui->m_selectAllCheckBox->setCheckState(Qt::CheckState::Unchecked);
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Cherry pick the `tr` and `QT_TRANSLATE_NOOP` additions from the #19554 PR.

This should have 0 impact for the users. A follow-up PR will do the same for all gems.

## How was this PR tested?

Local windows build
