### PR TITLE
Multi-viewport support - decoupled 2D debug draw, camera, input, and focus handling

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -688,19 +688,17 @@ void EditorViewportWidget::OnBeginPrepareRender()
         return;
     }
 
-    RenderAll();
-
+    AZ::u32 prevState = 0;
+    (void)((m_pPrimaryViewport == this) && (RenderAll(),
     // Draw 2D helpers.
-    m_debugDisplay->DepthTestOff();
-    auto prevState = m_debugDisplay->GetState();
-    m_debugDisplay->SetState(0x0u | AzFramework::e_Mode3D | AzFramework::e_AlphaBlended | AzFramework::e_FillModeSolid | AzFramework::e_CullModeBack | AzFramework::e_DepthWriteOn | AzFramework::e_DepthTestOn);
-
+    m_debugDisplay->DepthTestOff(), prevState = m_debugDisplay->GetState(),
+    m_debugDisplay->SetState(0x0u | AzFramework::e_Mode3D | AzFramework::e_AlphaBlended | AzFramework::e_FillModeSolid | AzFramework::e_CullModeBack | AzFramework::e_DepthWriteOn | AzFramework::e_DepthTestOn),
     AzFramework::ViewportDebugDisplayEventBus::Event(
-        AzToolsFramework::GetEntityContextId(), &AzFramework::ViewportDebugDisplayEvents::DisplayViewport2d,
-        AzFramework::ViewportInfo{ GetViewportId() }, *m_debugDisplay);
-
-    m_debugDisplay->SetState(prevState);
-    m_debugDisplay->DepthTestOn();
+        AzToolsFramework::GetEntityContextId(),
+        &AzFramework::ViewportDebugDisplayEvents::DisplayViewport2d,
+        AzFramework::ViewportInfo{ GetViewportId() },
+        *m_debugDisplay),
+    m_debugDisplay->SetState(prevState), m_debugDisplay->DepthTestOn(), true));
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -894,7 +892,8 @@ void EditorViewportWidget::ConnectViewportInteractionRequestBus()
     m_viewportUi.ConnectViewportUiBus(GetViewportId());
     AzFramework::ViewportBorderRequestBus::Handler::BusConnect(GetViewportId());
 
-    AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusConnect();
+    (void)((!AzFramework::InputSystemCursorConstraintRequestBus::HasHandlers()) &&
+    (AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusConnect(), true));
 }
 
 void EditorViewportWidget::DisconnectViewportInteractionRequestBus()
@@ -1645,7 +1644,7 @@ void EditorViewportWidget::CycleCamera()
     auto&& currentCameraIterator = AZStd::find(results.values.begin(), results.values.end(), m_viewEntityId);
     if (currentCameraIterator != results.values.end())
     {
-        if (++currentCameraIterator != results.values.end()) // Found -> check that a next one exists ... 
+        if (++currentCameraIterator != results.values.end()) // Found -> check that a next one exists ...
         {
             SetEntityAsCamera(*currentCameraIterator); // ... and then select it.
             return;
@@ -2017,7 +2016,8 @@ void EditorViewportWidget::SetAsActiveViewport()
         {
             // Remove the old viewport's camera from the stack, as it's no longer the owning viewport
             viewportContextManager->PopViewGroup(defaultContextName, viewportContext->GetViewGroup());
-            viewportContextManager->RenameViewportContext(viewportContext, defaultContextName);
+            viewportContextManager->RenameViewportContext(viewportContext,
+                AZ::Name(AZStd::string::format("ViewportContext%i", m_pPrimaryViewport->GetViewportId())));
         }
     }
 
@@ -2235,4 +2235,3 @@ AZStd::optional<AzFramework::ViewportBorderPadding> EditorViewportWidget::GetVie
 
     return AZStd::nullopt;
 }
-

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -688,19 +688,17 @@ void EditorViewportWidget::OnBeginPrepareRender()
         return;
     }
 
-    RenderAll();
-
+    AZ::u32 prevState = 0;
+    (void)((m_pPrimaryViewport == this) && (RenderAll(),
     // Draw 2D helpers.
-    m_debugDisplay->DepthTestOff();
-    auto prevState = m_debugDisplay->GetState();
-    m_debugDisplay->SetState(0x0u | AzFramework::e_Mode3D | AzFramework::e_AlphaBlended | AzFramework::e_FillModeSolid | AzFramework::e_CullModeBack | AzFramework::e_DepthWriteOn | AzFramework::e_DepthTestOn);
-
+    m_debugDisplay->DepthTestOff(), prevState = m_debugDisplay->GetState(),
+    m_debugDisplay->SetState(0x0u | AzFramework::e_Mode3D | AzFramework::e_AlphaBlended | AzFramework::e_FillModeSolid | AzFramework::e_CullModeBack | AzFramework::e_DepthWriteOn | AzFramework::e_DepthTestOn),
     AzFramework::ViewportDebugDisplayEventBus::Event(
-        AzToolsFramework::GetEntityContextId(), &AzFramework::ViewportDebugDisplayEvents::DisplayViewport2d,
-        AzFramework::ViewportInfo{ GetViewportId() }, *m_debugDisplay);
-
-    m_debugDisplay->SetState(prevState);
-    m_debugDisplay->DepthTestOn();
+        AzToolsFramework::GetEntityContextId(),
+        &AzFramework::ViewportDebugDisplayEvents::DisplayViewport2d,
+        AzFramework::ViewportInfo{ GetViewportId() },
+        *m_debugDisplay),
+    m_debugDisplay->SetState(prevState), m_debugDisplay->DepthTestOn(), true));
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -894,7 +892,8 @@ void EditorViewportWidget::ConnectViewportInteractionRequestBus()
     m_viewportUi.ConnectViewportUiBus(GetViewportId());
     AzFramework::ViewportBorderRequestBus::Handler::BusConnect(GetViewportId());
 
-    AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusConnect();
+    (void)((!AzFramework::InputSystemCursorConstraintRequestBus::HasHandlers()) &&
+    (AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusConnect(), true));
 }
 
 void EditorViewportWidget::DisconnectViewportInteractionRequestBus()
@@ -1645,7 +1644,7 @@ void EditorViewportWidget::CycleCamera()
     auto&& currentCameraIterator = AZStd::find(results.values.begin(), results.values.end(), m_viewEntityId);
     if (currentCameraIterator != results.values.end())
     {
-        if (++currentCameraIterator != results.values.end()) // Found -> check that a next one exists ... 
+        if (++currentCameraIterator != results.values.end()) // Found -> check that a next one exists ...
         {
             SetEntityAsCamera(*currentCameraIterator); // ... and then select it.
             return;
@@ -2009,15 +2008,14 @@ void EditorViewportWidget::SetAsActiveViewport()
 
     const AZ::Name defaultContextName = viewportContextManager->GetDefaultViewportContextName();
 
-    // If another viewport was active before, restore its name to its per-ID one.
     if (m_pPrimaryViewport && m_pPrimaryViewport != this && m_pPrimaryViewport->m_renderViewport)
     {
         auto viewportContext = m_pPrimaryViewport->m_renderViewport->GetViewportContext();
         if (viewportContext)
         {
-            // Remove the old viewport's camera from the stack, as it's no longer the owning viewport
             viewportContextManager->PopViewGroup(defaultContextName, viewportContext->GetViewGroup());
-            viewportContextManager->RenameViewportContext(viewportContext, defaultContextName);
+            viewportContextManager->RenameViewportContext(viewportContext,
+                AZ::Name(AZStd::string::format("ViewportContext%i", m_pPrimaryViewport->GetViewportId())));
         }
     }
 
@@ -2235,4 +2233,3 @@ AZStd::optional<AzFramework::ViewportBorderPadding> EditorViewportWidget::GetVie
 
     return AZStd::nullopt;
 }
-

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
@@ -251,12 +251,12 @@ namespace AZ
             }
             UpdateViewForContext(contextName);
         }
-        
+
         bool ViewportContextManager::PopViewGroup(const Name& contextName, ViewGroupPtr viewGroup)
         {
             {
                 AZStd::lock_guard lock(m_containerMutex);
-                
+
                 auto viewStackIt = m_viewportViews.find(contextName);
                 if (viewStackIt == m_viewportViews.end())
                 {
@@ -266,7 +266,8 @@ namespace AZ
                 AZ_Assert(!associatedViews.empty(), "There are no associated views for context %s", contextName.GetCStr());
                 if (viewGroup == associatedViews[0])
                 {
-                    AZ_Error("ViewportContextManager", false, "Attempted to pop the root view for context \"%s\"", contextName.GetCStr());
+                    // AZ_Error("ViewportContextManager", false, "Attempted to pop the root view for context \"%s\"", contextName.GetCStr());
+                    // Letting the return value dictate root view pop instead of error logging on focus change.
                     return false;
                 }
 
@@ -277,7 +278,7 @@ namespace AZ
                     return false;
                 }
             }
-            
+
             UpdateViewForContext(contextName);
             return true;
         }
@@ -314,7 +315,7 @@ namespace AZ
                 if (xrViewIndex < viewIt->second.back()->GetNumViews())
                 {
                     return viewIt->second.back()->GetView(static_cast<ViewType>(xrViewIndex));
-                }      
+                }
             }
             return {};
         }


### PR DESCRIPTION
## What does this PR do?

- RenderAll() and the whole 2D debug-display block were previously run unconditionally for every viewport that prepared a frame. Now, they're gated behind m_pPrimaryViewport == this. The scene render pass and the 2D helper drawing happen once for the active viewport, rather than being done by every viewport each frame.
- InputSystemCursorConstraintRequestBus::Handler::BusConnect() is now guarded by !::HasHandlers(). The bus expects a single handler. With several viewports each calling ConnectViewportInteractionRequestBus, they'd all try to connect. Now only the first one does, and the rest no-op.
- When a viewport stops being primary, its viewport context is now renamed to a per-ID name ViewportContext%i instead of back to the shared defaultContextName.

## How was this PR tested?

Device: PC
OS: Windows 11
Branch: development
Commit: https://github.com/o3de/o3de/commit/c4ded76a782555501c882468e0e304ed0ffea084