### PR TITLE
Do not populate recent files menu too early

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -1693,8 +1693,7 @@ void EditorActionsHandler::OnMenuRegistrationHook()
             menuProperties.m_name = "Open Recent";
             m_menuManagerInterface->RegisterMenu(EditorIdentifiers::RecentFilesMenuIdentifier, menuProperties);
 
-            // Legacy - the menu should update when the files list is changed.
-            QMenu* menu = m_menuManagerInternalInterface->GetMenu(EditorIdentifiers::FileMenuIdentifier);
+            QMenu* menu = m_menuManagerInternalInterface->GetMenu(EditorIdentifiers::RecentFilesMenuIdentifier);
             QObject::connect(
                 menu,
                 &QMenu::aboutToShow,


### PR DESCRIPTION
## What does this PR do?

On some platforms clicking the main "File" menu in the Editor seem to be a bit slow in some cases.  The population of the Recent File Menu was updated (connected by the event) when the "File" menu was about to shown which is not necessary and it enough to connect the Recent File menu itself and populate before its about to shown. 

## How was this PR tested?

On my Kubuntu 26.04 LTS.
