### PR TITLE
Developing Category symbol dumps for better Lua Palette displaying.

### DIFF
--- a/Gems/EditorPythonBindings/Editor/Scripts/dump_lua_symbol_categories.py
+++ b/Gems/EditorPythonBindings/Editor/Scripts/dump_lua_symbol_categories.py
@@ -1,0 +1,95 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Dumps the FINAL resolved Script Canvas category path for every reflected class,
+# global and EBus into a JSON file that a remote tool (e.g. the VS Code "O3DE
+# Development Tools" extension) can JOIN onto the symbol set it scrapes over the
+# Script Debug bridge.
+#
+# The category for each symbol is resolved editor-side by the
+# LuaSymbolCategoryReporter (ScriptCanvasEditor gem) using the same three tiers
+# the Node Palette uses: translation override -> reflection Category attribute ->
+# default bucket. The extension does no resolution; it looks up each scraped
+# symbol by identity and uses the path verbatim. A miss = uncategorized.
+#
+# Run from the Editor:
+#   Tools -> Other -> Python Scripts, or from the console:
+#   pyRunFile <o3de>/Gems/EditorPythonBindings/Editor/Scripts/dump_lua_symbol_categories.py
+# Produces <game_project>\lua_symbol_categories.json (override with --outfile).
+#
+# Join keys the extension uses:
+#   classes           -> typeId   (normalize brace/case on both sides)
+#   globalMethods     -> name
+#   globalProperties  -> name
+#   ebuses            -> name      (senderCategory for Event/Broadcast, handlerCategory for Notification)
+
+import sys
+import os
+import json
+import argparse
+
+import azlmbr.bus as azbus
+import azlmbr.script as azscript
+import azlmbr.legacy.general as azgeneral
+
+
+def _dump_class_categories():
+    rows = azscript.LuaSymbolCategoryReporterBus(azbus.Broadcast, "GetClassCategories")
+    return [
+        {"typeId": str(row.typeId), "name": row.name, "category": row.category}
+        for row in rows
+    ]
+
+
+def _dump_global_method_categories():
+    rows = azscript.LuaSymbolCategoryReporterBus(azbus.Broadcast, "GetGlobalMethodCategories")
+    return [{"name": row.name, "category": row.category} for row in rows]
+
+
+def _dump_global_property_categories():
+    rows = azscript.LuaSymbolCategoryReporterBus(azbus.Broadcast, "GetGlobalPropertyCategories")
+    return [{"name": row.name, "category": row.category} for row in rows]
+
+
+def _dump_ebus_categories():
+    rows = azscript.LuaSymbolCategoryReporterBus(azbus.Broadcast, "GetEBusCategories")
+    return [
+        {"name": row.name, "senderCategory": row.senderCategory, "handlerCategory": row.handlerCategory}
+        for row in rows
+    ]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Dumps the resolved Script Canvas category path for all classes, globals and EBuses to JSON.")
+    parser.add_argument('--outfile', '--o', default='lua_symbol_categories.json',
+                        help='Output JSON file. If relative, written under the game project folder.')
+    args = parser.parse_args()
+
+    output_file_name = args.outfile
+    if not os.path.isabs(output_file_name):
+        game_root_path = os.path.normpath(azgeneral.get_game_folder())
+        output_file_name = os.path.join(game_root_path, output_file_name)
+
+    payload = {
+        "classes": _dump_class_categories(),
+        "globalMethods": _dump_global_method_categories(),
+        "globalProperties": _dump_global_property_categories(),
+        "ebuses": _dump_ebus_categories(),
+    }
+
+    try:
+        with open(output_file_name, 'wt') as file_obj:
+            json.dump(payload, file_obj, indent=2, sort_keys=True)
+    except Exception as e:
+        print(f"Failed to write {output_file_name}: {e}")
+        sys.exit(-1)
+
+    print(f"Lua symbol categories written to: {output_file_name}")
+    print(f"  classes={len(payload['classes'])} globalMethods={len(payload['globalMethods'])} "
+          f"globalProperties={len(payload['globalProperties'])} ebuses={len(payload['ebuses'])}")

--- a/Gems/ScriptCanvas/Code/Editor/LuaSymbolCategoryReporter.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/LuaSymbolCategoryReporter.cpp
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/RTTI/AttributeReader.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContextAttributes.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/StringFunc/StringFunc.h>
+
+#include <Editor/LuaSymbolCategoryReporter.h>
+#include <Editor/Translation/TranslationHelper.h>   // pulls GraphCanvas TranslationBus + AssetContext keys
+
+namespace ScriptCanvasEditor
+{
+    //////////////////////////////////////////////////////////////////////////
+    // Category resolution — a faithful, UI-free copy of the Node Palette's
+    // per-kind rules (NodePaletteModel.cpp). Keep these in step if that file
+    // changes. Each rule is: translation override -> reflection Category
+    // attribute -> default bucket, with the same leaf/append behavior per kind.
+    //////////////////////////////////////////////////////////////////////////
+
+    namespace
+    {
+        // Default buckets — must match NodePaletteModel's constants exactly.
+        constexpr char DefaultClassMethodCategory[]    = "Class Methods";
+        constexpr char DefaultGlobalMethodCategory[]   = "Global Methods";
+        constexpr char DefaultGlobalConstantCategory[] = "Global Constants";
+        constexpr char DefaultEbusHandlerCategory[]    = "Event Handlers";
+        constexpr char DefaultEbusEventCategory[]      = "Events";
+
+        // Reads the reflection Category attribute (path form, e.g. "Gameplay/Camera").
+        // Empty when unspecified — the correct "uncategorized" signal.
+        AZStd::string GetCategoryAttribute(const AZ::AttributeArray& attributes, const AZ::BehaviorContext& behaviorContext)
+        {
+            AZStd::string retVal;
+            if (AZ::Attribute* categoryAttribute = AZ::FindAttribute(AZ::Script::Attributes::Category, attributes))
+            {
+                AZ::AttributeReader(nullptr, categoryAttribute).Read<AZStd::string>(retVal, behaviorContext);
+            }
+            return retVal;
+        }
+
+        // Looks up the "<context>.<name>.details" translation entry, the tier-1 override source.
+        GraphCanvas::TranslationRequests::Details GetTranslationDetails(const char* assetContext, const AZStd::string& name)
+        {
+            GraphCanvas::TranslationKey key;
+            key << assetContext << name << "details";
+
+            GraphCanvas::TranslationRequests::Details details;
+            GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
+            return details;
+        }
+
+        // Classes: translation ?: attribute ?: (prettyName | "Class Methods"), then "/" + leaf.
+        AZStd::string ResolveClassCategory(const AZStd::string& className, const AZ::BehaviorClass& behaviorClass, const AZ::BehaviorContext& behaviorContext)
+        {
+            const GraphCanvas::TranslationRequests::Details details =
+                GetTranslationDetails(TranslationHelper::AssetContext::BehaviorClassContext, behaviorClass.m_name);
+
+            AZStd::string categoryPath = details.m_category;
+            if (categoryPath.empty())
+            {
+                categoryPath = GetCategoryAttribute(behaviorClass.m_attributes, behaviorContext);
+            }
+
+            AZStd::string classNamePretty(className);
+            if (AZ::Attribute* prettyNameAttribute = AZ::FindAttribute(AZ::ScriptCanvasAttributes::PrettyName, behaviorClass.m_attributes))
+            {
+                AZ::AttributeReader(nullptr, prettyNameAttribute).Read<AZStd::string>(classNamePretty, behaviorContext);
+            }
+
+            if (categoryPath.empty())
+            {
+                categoryPath = classNamePretty.empty() ? DefaultClassMethodCategory : classNamePretty;
+            }
+
+            categoryPath.append("/");
+            categoryPath.append(details.m_name.empty() ? classNamePretty : details.m_name);
+            return categoryPath;
+        }
+
+        // Global methods: translation ?: attribute ?: "Global Methods". No leaf.
+        AZStd::string ResolveGlobalMethodCategory(const AZ::BehaviorMethod& behaviorMethod, const AZ::BehaviorContext& behaviorContext)
+        {
+            const GraphCanvas::TranslationRequests::Details details =
+                GetTranslationDetails(TranslationHelper::AssetContext::BehaviorGlobalMethodContext, behaviorMethod.m_name);
+
+            if (!details.m_category.empty())
+            {
+                return details.m_category;
+            }
+
+            const AZStd::string categoryPath = GetCategoryAttribute(behaviorMethod.m_attributes, behaviorContext);
+            return categoryPath.empty() ? DefaultGlobalMethodCategory : categoryPath;
+        }
+
+        // Global constants: translation ?: "Global Constants". Note: no attribute fallback,
+        // matching the Node Palette (RegisterGlobalConstant).
+        AZStd::string ResolveGlobalPropertyCategory(const AZStd::string& propertyName)
+        {
+            AZStd::string name = propertyName;
+            AZ::StringFunc::Replace(name, "::Getter", "");
+            AZ::StringFunc::Replace(name, "::Setter", "");
+
+            const GraphCanvas::TranslationRequests::Details details =
+                GetTranslationDetails(TranslationHelper::AssetContext::BehaviorGlobalPropertyContext, name);
+
+            return details.m_category.empty() ? DefaultGlobalConstantCategory : details.m_category;
+        }
+
+        // Shared EBus rule (sender + handler differ only by context key and default bucket).
+        AZStd::string ResolveEBusCategory(const AZ::BehaviorEBus& behaviorEbus, const AZ::BehaviorContext& behaviorContext,
+            const char* assetContext, const char* defaultCategory)
+        {
+            const GraphCanvas::TranslationRequests::Details details = GetTranslationDetails(assetContext, behaviorEbus.m_name);
+
+            AZStd::string categoryPath = details.m_category.empty()
+                ? GetCategoryAttribute(behaviorEbus.m_attributes, behaviorContext)
+                : details.m_category;
+
+            if (!categoryPath.empty())
+            {
+                categoryPath.append("/");
+            }
+            else
+            {
+                categoryPath = AZStd::string::format("%s/", defaultCategory);
+            }
+
+            if (!details.m_name.empty())
+            {
+                categoryPath.append(details.m_name);
+            }
+            else if (categoryPath.contains(defaultCategory))
+            {
+                categoryPath.append(behaviorEbus.m_name);
+            }
+
+            return categoryPath;
+        }
+    } // namespace
+
+    //////////////////////////////////////////////////////////////////////////
+    // Reflected result rows
+    //////////////////////////////////////////////////////////////////////////
+
+    AZStd::string LuaClassCategory::ToString() const
+    {
+        return AZStd::string::format("%s [%s] -> %s", m_name.c_str(), m_typeId.ToString<AZStd::string>().c_str(), m_category.c_str());
+    }
+
+    void LuaClassCategory::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<LuaClassCategory>()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Module, "script")
+                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
+                ->Property("typeId", BehaviorValueProperty(&LuaClassCategory::m_typeId))
+                ->Property("name", BehaviorValueProperty(&LuaClassCategory::m_name))
+                ->Property("category", BehaviorValueProperty(&LuaClassCategory::m_category))
+                ->Method("ToString", &LuaClassCategory::ToString)
+                    ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
+                ;
+        }
+    }
+
+    AZStd::string LuaGlobalCategory::ToString() const
+    {
+        return AZStd::string::format("%s -> %s", m_name.c_str(), m_category.c_str());
+    }
+
+    void LuaGlobalCategory::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<LuaGlobalCategory>()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Module, "script")
+                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
+                ->Property("name", BehaviorValueProperty(&LuaGlobalCategory::m_name))
+                ->Property("category", BehaviorValueProperty(&LuaGlobalCategory::m_category))
+                ->Method("ToString", &LuaGlobalCategory::ToString)
+                    ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
+                ;
+        }
+    }
+
+    AZStd::string LuaEBusCategory::ToString() const
+    {
+        return AZStd::string::format("%s -> sender[%s] handler[%s]", m_name.c_str(), m_senderCategory.c_str(), m_handlerCategory.c_str());
+    }
+
+    void LuaEBusCategory::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<LuaEBusCategory>()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Module, "script")
+                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
+                ->Property("name", BehaviorValueProperty(&LuaEBusCategory::m_name))
+                ->Property("senderCategory", BehaviorValueProperty(&LuaEBusCategory::m_senderCategory))
+                ->Property("handlerCategory", BehaviorValueProperty(&LuaEBusCategory::m_handlerCategory))
+                ->Method("ToString", &LuaEBusCategory::ToString)
+                    ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
+                ;
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // System component
+    //////////////////////////////////////////////////////////////////////////
+
+    void LuaSymbolCategoryReporterSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        LuaClassCategory::Reflect(context);
+        LuaGlobalCategory::Reflect(context);
+        LuaEBusCategory::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<LuaSymbolCategoryReporterSystemComponent, AZ::Component>()
+                ->Version(0);
+
+            serializeContext->RegisterGenericType<AZStd::vector<LuaClassCategory>>();
+            serializeContext->RegisterGenericType<AZStd::vector<LuaGlobalCategory>>();
+            serializeContext->RegisterGenericType<AZStd::vector<LuaEBusCategory>>();
+        }
+
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<LuaSymbolCategoryReporterRequestBus>("LuaSymbolCategoryReporterBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ->Attribute(AZ::Script::Attributes::Module, "script")
+                ->Event("GetClassCategories", &LuaSymbolCategoryReporterRequests::GetClassCategories)
+                ->Event("GetGlobalMethodCategories", &LuaSymbolCategoryReporterRequests::GetGlobalMethodCategories)
+                ->Event("GetGlobalPropertyCategories", &LuaSymbolCategoryReporterRequests::GetGlobalPropertyCategories)
+                ->Event("GetEBusCategories", &LuaSymbolCategoryReporterRequests::GetEBusCategories)
+                ;
+        }
+    }
+
+    void LuaSymbolCategoryReporterSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("LuaSymbolCategoryReporterService"));
+    }
+
+    void LuaSymbolCategoryReporterSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("LuaSymbolCategoryReporterService"));
+    }
+
+    void LuaSymbolCategoryReporterSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        // The BehaviorContext and translation database are queried lazily on first request, by which
+        // point the editor is fully loaded; no hard service dependency is required.
+    }
+
+    void LuaSymbolCategoryReporterSystemComponent::Activate()
+    {
+        LuaSymbolCategoryReporterRequestBus::Handler::BusConnect();
+    }
+
+    void LuaSymbolCategoryReporterSystemComponent::Deactivate()
+    {
+        LuaSymbolCategoryReporterRequestBus::Handler::BusDisconnect();
+    }
+
+    void LuaSymbolCategoryReporterSystemComponent::BuildCategoriesIfNeeded()
+    {
+        if (m_built)
+        {
+            return;
+        }
+
+        AZ::BehaviorContext* behaviorContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationRequests::GetBehaviorContext);
+        if (!behaviorContext)
+        {
+            return;
+        }
+
+        for (const auto& [className, behaviorClass] : behaviorContext->m_classes)
+        {
+            if (!behaviorClass)
+            {
+                continue;
+            }
+
+            LuaClassCategory row;
+            row.m_typeId = behaviorClass->m_typeId;
+            row.m_name = className;
+            row.m_category = ResolveClassCategory(className, *behaviorClass, *behaviorContext);
+            m_classCategories.push_back(AZStd::move(row));
+        }
+
+        for (const auto& [methodName, behaviorMethod] : behaviorContext->m_methods)
+        {
+            if (!behaviorMethod)
+            {
+                continue;
+            }
+
+            LuaGlobalCategory row;
+            row.m_name = methodName;
+            row.m_category = ResolveGlobalMethodCategory(*behaviorMethod, *behaviorContext);
+            m_globalMethodCategories.push_back(AZStd::move(row));
+        }
+
+        for (const auto& [propertyName, behaviorProperty] : behaviorContext->m_properties)
+        {
+            if (!behaviorProperty)
+            {
+                continue;
+            }
+
+            LuaGlobalCategory row;
+            row.m_name = propertyName;
+            row.m_category = ResolveGlobalPropertyCategory(propertyName);
+            m_globalPropertyCategories.push_back(AZStd::move(row));
+        }
+
+        for (const auto& [ebusName, behaviorEbus] : behaviorContext->m_ebuses)
+        {
+            if (!behaviorEbus)
+            {
+                continue;
+            }
+
+            LuaEBusCategory row;
+            row.m_name = ebusName;
+            row.m_senderCategory = ResolveEBusCategory(*behaviorEbus, *behaviorContext, TranslationHelper::AssetContext::EBusSenderContext, DefaultEbusEventCategory);
+            row.m_handlerCategory = ResolveEBusCategory(*behaviorEbus, *behaviorContext, TranslationHelper::AssetContext::EBusHandlerContext, DefaultEbusHandlerCategory);
+            m_ebusCategories.push_back(AZStd::move(row));
+        }
+
+        m_built = true;
+    }
+
+    const AZStd::vector<LuaClassCategory>& LuaSymbolCategoryReporterSystemComponent::GetClassCategories()
+    {
+        BuildCategoriesIfNeeded();
+        return m_classCategories;
+    }
+
+    const AZStd::vector<LuaGlobalCategory>& LuaSymbolCategoryReporterSystemComponent::GetGlobalMethodCategories()
+    {
+        BuildCategoriesIfNeeded();
+        return m_globalMethodCategories;
+    }
+
+    const AZStd::vector<LuaGlobalCategory>& LuaSymbolCategoryReporterSystemComponent::GetGlobalPropertyCategories()
+    {
+        BuildCategoriesIfNeeded();
+        return m_globalPropertyCategories;
+    }
+
+    const AZStd::vector<LuaEBusCategory>& LuaSymbolCategoryReporterSystemComponent::GetEBusCategories()
+    {
+        BuildCategoriesIfNeeded();
+        return m_ebusCategories;
+    }
+}

--- a/Gems/ScriptCanvas/Code/Editor/LuaSymbolCategoryReporter.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/LuaSymbolCategoryReporter.cpp
@@ -20,7 +20,7 @@
 namespace ScriptCanvasEditor
 {
     //////////////////////////////////////////////////////////////////////////
-    // Category resolution — a faithful, UI-free copy of the Node Palette's
+    // Category resolution - a faithful, UI-free copy of the Node Palette's
     // per-kind rules (NodePaletteModel.cpp). Keep these in step if that file
     // changes. Each rule is: translation override -> reflection Category
     // attribute -> default bucket, with the same leaf/append behavior per kind.
@@ -28,7 +28,7 @@ namespace ScriptCanvasEditor
 
     namespace
     {
-        // Default buckets — must match NodePaletteModel's constants exactly.
+        // Default buckets - must match NodePaletteModel's constants exactly.
         constexpr char DefaultClassMethodCategory[]    = "Class Methods";
         constexpr char DefaultGlobalMethodCategory[]   = "Global Methods";
         constexpr char DefaultGlobalConstantCategory[] = "Global Constants";
@@ -36,7 +36,7 @@ namespace ScriptCanvasEditor
         constexpr char DefaultEbusEventCategory[]      = "Events";
 
         // Reads the reflection Category attribute (path form, e.g. "Gameplay/Camera").
-        // Empty when unspecified — the correct "uncategorized" signal.
+        // Empty when unspecified - the correct "uncategorized" signal.
         AZStd::string GetCategoryAttribute(const AZ::AttributeArray& attributes, const AZ::BehaviorContext& behaviorContext)
         {
             AZStd::string retVal;

--- a/Gems/ScriptCanvas/Code/Editor/LuaSymbolCategoryReporter.h
+++ b/Gems/ScriptCanvas/Code/Editor/LuaSymbolCategoryReporter.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Uuid.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
+
+namespace ScriptCanvasEditor
+{
+    //////////////////////////////////////////////////////////////////////////
+    // Reflected result rows
+    //
+    // Each row carries the FINAL resolved Script Canvas category path for one
+    // reflected symbol (translation override -> reflection Category attribute ->
+    // default bucket, exactly as the Node Palette computes it). A remote tool
+    // joins these onto the symbol set it already scrapes, keyed by the identity
+    // it already has: typeId for classes, name for globals and EBuses. A miss
+    // means "uncategorized" and the tool keeps its flat layout for that symbol.
+    //////////////////////////////////////////////////////////////////////////
+
+    struct LuaClassCategory
+    {
+        AZ_TYPE_INFO(LuaClassCategory, "{A1E8C4D2-3F6B-4A19-9C2E-1B7D5E0F8A34}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::Uuid      m_typeId;     // join key
+        AZStd::string m_name;       // behavior class name (reference / debugging)
+        AZStd::string m_category;   // final resolved category path
+
+        AZStd::string ToString() const;
+    };
+
+    struct LuaGlobalCategory
+    {
+        AZ_TYPE_INFO(LuaGlobalCategory, "{B2F9D5E3-4A7C-4B2A-8D3F-2C8E6F1A9B45}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZStd::string m_name;       // join key (global method or property name)
+        AZStd::string m_category;   // final resolved category path
+
+        AZStd::string ToString() const;
+    };
+
+    struct LuaEBusCategory
+    {
+        AZ_TYPE_INFO(LuaEBusCategory, "{C3A0E6F4-5B8D-4C3B-9E4A-3D9F7A2B0C56}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZStd::string m_name;              // join key (EBus name)
+        AZStd::string m_senderCategory;    // path for Event / Broadcast senders
+        AZStd::string m_handlerCategory;   // path for Notification handler events
+
+        AZStd::string ToString() const;
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // Request bus
+    //////////////////////////////////////////////////////////////////////////
+
+    class LuaSymbolCategoryReporterRequests
+    {
+    public:
+        AZ_RTTI(LuaSymbolCategoryReporterRequests, "{D4B1F7A5-6C9E-4D4C-AF5B-4E0A8B3C1D67}");
+        virtual ~LuaSymbolCategoryReporterRequests() = default;
+
+        virtual const AZStd::vector<LuaClassCategory>& GetClassCategories() = 0;
+        virtual const AZStd::vector<LuaGlobalCategory>& GetGlobalMethodCategories() = 0;
+        virtual const AZStd::vector<LuaGlobalCategory>& GetGlobalPropertyCategories() = 0;
+        virtual const AZStd::vector<LuaEBusCategory>& GetEBusCategories() = 0;
+    };
+
+    class LuaSymbolCategoryReporterBusTraits
+        : public AZ::EBusTraits
+    {
+    public:
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+    };
+
+    using LuaSymbolCategoryReporterRequestBus = AZ::EBus<LuaSymbolCategoryReporterRequests, LuaSymbolCategoryReporterBusTraits>;
+
+    //////////////////////////////////////////////////////////////////////////
+    // System component
+    //
+    // Editor-only. Iterates the BehaviorContext and, using the GraphCanvas
+    // translation database, resolves the final category path for every class,
+    // global and EBus, then serves the results over a behavior-reflected bus so
+    // the offline Python dumper can emit lua_symbol_categories.json.
+    //////////////////////////////////////////////////////////////////////////
+
+    class LuaSymbolCategoryReporterSystemComponent
+        : public AZ::Component
+        , protected LuaSymbolCategoryReporterRequestBus::Handler
+    {
+    public:
+        AZ_COMPONENT(LuaSymbolCategoryReporterSystemComponent, "{E5C2A8B6-7D0F-4E5D-B06C-5F1B9C4D2E78}");
+
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+
+        // LuaSymbolCategoryReporterRequestBus
+        const AZStd::vector<LuaClassCategory>& GetClassCategories() override;
+        const AZStd::vector<LuaGlobalCategory>& GetGlobalMethodCategories() override;
+        const AZStd::vector<LuaGlobalCategory>& GetGlobalPropertyCategories() override;
+        const AZStd::vector<LuaEBusCategory>& GetEBusCategories() override;
+
+    private:
+        // Resolves every symbol's category once, on first request, and caches it.
+        void BuildCategoriesIfNeeded();
+
+        AZStd::vector<LuaClassCategory>  m_classCategories;
+        AZStd::vector<LuaGlobalCategory> m_globalMethodCategories;
+        AZStd::vector<LuaGlobalCategory> m_globalPropertyCategories;
+        AZStd::vector<LuaEBusCategory>   m_ebusCategories;
+        bool m_built = false;
+    };
+}

--- a/Gems/ScriptCanvas/Code/Editor/ScriptCanvasEditorGem.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/ScriptCanvasEditorGem.cpp
@@ -27,6 +27,7 @@
 
 #include <Editor/ReflectComponent.h>
 #include <Editor/SystemComponent.h>
+#include <Editor/LuaSymbolCategoryReporter.h>
 
 #include <Editor/Components/IconComponent.h>
 #include <Editor/Model/EntityMimeDataHandler.h>
@@ -82,6 +83,7 @@ namespace ScriptCanvas
             ScriptCanvasEditor::IconComponent::CreateDescriptor(),
             ScriptCanvasEditor::ReflectComponent::CreateDescriptor(),
             ScriptCanvasEditor::SystemComponent::CreateDescriptor(),
+            ScriptCanvasEditor::LuaSymbolCategoryReporterSystemComponent::CreateDescriptor(),
             ScriptCanvasEditor::EditorGraphVariableManagerComponent::CreateDescriptor(),
             ScriptCanvasEditor::VariablePropertiesComponent::CreateDescriptor(),
             ScriptCanvasEditor::SlotMappingComponent::CreateDescriptor(),
@@ -120,7 +122,8 @@ namespace ScriptCanvas
         components.insert(components.end(), std::initializer_list<AZ::Uuid> {
                 azrtti_typeid<ScriptCanvasEditor::EditorAssetSystemComponent>(),
                 azrtti_typeid<ScriptCanvasEditor::ReflectComponent>(),
-                azrtti_typeid<ScriptCanvasEditor::SystemComponent>()
+                azrtti_typeid<ScriptCanvasEditor::SystemComponent>(),
+                azrtti_typeid<ScriptCanvasEditor::LuaSymbolCategoryReporterSystemComponent>()
         });
 
         return components;

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
@@ -15,6 +15,8 @@ set(FILES
     Editor/ReflectComponent.cpp
     Editor/SystemComponent.h
     Editor/SystemComponent.cpp
+    Editor/LuaSymbolCategoryReporter.h
+    Editor/LuaSymbolCategoryReporter.cpp
     Editor/QtMetaTypes.h
     Editor/Assets/ScriptCanvasAssetHelpers.h
     Editor/Assets/ScriptCanvasAssetHelpers.cpp


### PR DESCRIPTION
## What does this PR do?

This adds a non-destructive small interface addition to allow external remote tools to query the script canvas system to output the entire categories processing hierarchy 

<img width="452" height="1093" alt="image" src="https://github.com/user-attachments/assets/03030db3-f5d2-4b71-8d85-770a6afeacce" />

## How was this PR tested?

Using my new O3DE Development Tools vscode extension, the Generate Lua Intellisense both accesses the base data normally accessed from Remote Tools, but now with this new exposure can match the raw data to a dictionary of category data and print out the tree in the SAME ordering available in Script Canvas.

Built into our inhouse engine.