### PR TITLE
Fix C++26 Compilation

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/utility/tuple_concepts.h
+++ b/Code/Framework/AzCore/AzCore/std/utility/tuple_concepts.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <version>
 #include <AzCore/std/containers/array_fwd.h>
 #include <AzCore/std/ranges/subrange_fwd.h>
 #include <AzCore/std/utility/tuple_fwd.h>
@@ -59,9 +60,12 @@ namespace AZStd
         && tuple_size_v<remove_cvref_t<T>> == 2;
 }
 
-//! common_type and basic_common_reference are from the std namespace.
-//! Their names are brought into the AZStd namespace via a "using" directive.
-//! Therefore they need to be specialized in their original namespace.
+//! common_type/basic_common_reference live in std, so the AZStd fallbacks must be specialized there too.
+//! C++23 adds these same pair/tuple specializations to the stdlib (P2321 "zip", then P2165 tuple-like),
+//! and since AZStd::pair/tuple alias std::pair/tuple, keeping ours would be a duplicate partial specialization.
+//! So only define them when the stdlib doesn't.
+#if !((defined(__cpp_lib_ranges_zip) && __cpp_lib_ranges_zip >= 202110L) \
+    || (defined(__cpp_lib_tuple_like) && __cpp_lib_tuple_like >= 202207L))
 namespace std
 {
     template<class... TTypes, class... UTypes, template<class> class TQual, template<class> class UQual>
@@ -97,3 +101,4 @@ namespace std
         using type = AZStd::pair<common_type_t<T1, U1>, common_type_t<T2, U2>>;
     };
 }
+#endif // stdlib provides pair/tuple common_type/common_reference (P2321 / P2165)

--- a/Gems/WhiteBox/3rdParty/FindManifold.cmake
+++ b/Gems/WhiteBox/3rdParty/FindManifold.cmake
@@ -100,6 +100,22 @@ function(GetManifold)
         target_compile_options(Clipper2 PRIVATE ${O3DE_COMPILE_OPTION_DISABLE_WARNINGS})
     endif()
 
+    # Strip the bogus `-lm` entry from Clipper2 targets on Windows
+    # (doesn't exist on Windows; leaks into link when using clang with MSVC ABI).
+    if (WIN32)
+        foreach (clipper2_target Clipper2 Clipper2Z)
+            if (TARGET ${clipper2_target})
+                foreach (link_prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
+                    get_target_property(clipper2_libs ${clipper2_target} ${link_prop})
+                    if (clipper2_libs)
+                        list(REMOVE_ITEM clipper2_libs "-lm" "m")
+                        set_target_properties(${clipper2_target} PROPERTIES ${link_prop} "${clipper2_libs}")
+                    endif()
+                endforeach()
+            endif()
+        endforeach()
+    endif()
+
     # O3DE promotes some off-by-default MSVC warnings to errors via /weNNNN.
     # /W0 (from O3DE_COMPILE_OPTION_DISABLE_WARNINGS) does NOT cancel per-warning
     # /we flags - only an explicit /wd does. Disable the ones manifold trips over:

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -25,7 +25,8 @@ set(O3DE_COMPILE_OPTION_DISABLE_WARNINGS PRIVATE -w)
 
 # C++20 no longer allows to implicitly convert between enum values of different types or enum values and integral types.
 # This is problematic if 3rd-party libraries use such operations in header files.
-set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE -Wno-deprecated-enum-enum-conversion)
+# C++26 (P2864) makes it a hard error under -Wenum-enum-conversion, so silence both.
+set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE -Wno-deprecated-enum-enum-conversion -Wno-enum-enum-conversion)
 
 # If (USE_FAST_MATH) is set, then enable fast math optimizations.
 # Some targets might need to disable fast math individually (likely 3rd Party libraries)

--- a/cmake/Platform/Common/MSVC/Configurations_clang.cmake
+++ b/cmake/Platform/Common/MSVC/Configurations_clang.cmake
@@ -27,7 +27,8 @@ set(O3DE_COMPILE_OPTION_DISABLE_WARNINGS PRIVATE /W0)
 
 # C++20 no longer allows to implicitly convert between enum values of different types or enum values and integral types.
 # This is problematic if 3rd-party libraries use such operations in header files.
-set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE /Wv:18 -Wno-deprecated-enum-enum-conversion)
+# C++26 (P2864) makes it a hard error under -Wenum-enum-conversion, so silence both.
+set(O3DE_COMPILE_OPTION_DISABLE_DEPRECATED_ENUM_ENUM_CONVERSION PRIVATE /Wv:18 -Wno-deprecated-enum-enum-conversion -Wno-enum-enum-conversion)
 
 # If (USE_FAST_MATH) is set, then enable fast math optimizations.
 # Some targets might need to disable fast math individually (likely 3rd Party libraries)


### PR DESCRIPTION
## What does this PR do?

Fix builds under C++23 and C++26, in addition to the current default. A few small changes were needed to get clean builds:

- AzCore tuple_concepts => C++23s standard library now provides its own common_type/common_reference specializations for pair/tuple, which collide with O3DEs hand-rolled ones (an ambiguity error in clang). Now only defined when the standard library doesnt supply them.
- Clang build config => C++26 turned bitwise operations between different enum types into a hard error under a new warning group. Added it to the flags already silenced for third-party code.
- WhiteBox FindManifold.cmake => dropped a stray Unix-only `-lm` link flag that Clipper2 was adding on Windows, which broke linking under clang.

## How was this PR tested?

Full builds from scratch on Windows, all clean.