### PR TITLE
Fixes several issues related to inspector and undo

### DIFF
--- a/Code/Editor/Core/QtEditorApplication.cpp
+++ b/Code/Editor/Core/QtEditorApplication.cpp
@@ -33,6 +33,12 @@
 
 Q_LOGGING_CATEGORY(InputDebugging, "o3de.editor.input")
 
+#if defined(AZ_DEBUG_BUILD)
+// in debug builds we do a constant check of the undo stack each idle tick
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Undo/UndoSystem.h>
+#endif
+
 // internal, private namespace:
 namespace
 {
@@ -324,6 +330,33 @@ namespace Editor
         {
             QTimer::singleShot(1, this, &EditorQtApplication::maybeProcessIdle);
         }
+
+#if defined(AZ_DEBUG_BUILD)
+        AzToolsFramework::UndoSystem::URSequencePoint* currentUndoBatch = nullptr;
+        // in debug builds we do a constant check of the undo stack each idle tick
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::GetCurrentUndoBatch);
+        if (currentUndoBatch)
+        {
+            // Note to developers, if this appears, then someone called "Begin Undo Batch" without calling "End Undo Batch" within the same
+            // callstack, allowing control to pass back to the main loop before the batch was ended.
+            // This is a programming error, and should be fixed.  In order to do multi-frame undos (like dragging an object),
+            // you should use the following pattern
+            // 1. Store a "URSequencePoint*" member variable in your class, initialized to nullptr.  This serves as a HANDLE
+            //    to the undo batch, and can be used to resume the batch in subsequent frames.
+            // 2. When data is modified (and only when data is modified), use the ScopedUndoBatch object and pass in the
+            //    resume handle.  Its okay if its nullptr - it will make a new one, or try to resume the existing one if it can.
+            //    It will return either the same handle, or make a new handle.  Mark the entity dirty using the batch, and
+            //    update/create any data inside it as a child if it needs additional data.
+            // 3. Allow the ScopedUndoBatch object to fall out of scope.
+            // 4. When the user action completes (such as they release the mouse button and editing is over), set your
+            //    remembered handle to nullptr, so the next data change will start a new batch.
+            AZ_Warning(
+                "Undo System",
+                false,
+                "Undo batch '%s' is still open. This may indicate that an undo batch was not properly closed within the same callstack as it was opened.",
+                currentUndoBatch->GetName().c_str());
+        }
+#endif
     }
 
     void EditorQtApplication::InstallQtLogHandler()

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -156,11 +156,8 @@ static void MarkCameraEntityDirty(const AZ::EntityId entityId)
 
     using AzToolsFramework::ToolsApplicationRequests;
 
-    AzToolsFramework::UndoSystem::URSequencePoint* undoBatch = nullptr;
-    ToolsApplicationRequests::Bus::BroadcastResult(
-        undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "EditorCameraComponentEntityChange");
-    ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
-    ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::EndUndoBatch);
+    AzToolsFramework::ScopedUndoBatch undoBatch("EditorCameraComponentEntityChange");
+    undoBatch.MarkEntityDirty(entityId);
 }
 
 static void PopViewGroupForDefaultContext()

--- a/Code/Editor/IEditor.h
+++ b/Code/Editor/IEditor.h
@@ -485,15 +485,6 @@ struct IEditor
     virtual void AcceptUndo(const QString& name) = 0;
     //! Cancel changes and restore undo objects.
     virtual void CancelUndo() = 0;
-    //! Normally this is NOT needed but in special cases this can be useful.
-    //! This allows to group a set of Begin()/Accept() sequences to be undone in one operation.
-    virtual void SuperBeginUndo() = 0;
-    //! When a SuperBegin() used, this method is used to Accept.
-    //! This leaves the undo database in its modified state and registers the IUndoObjects with the undo system.
-    //! This will allow the user to undo the operation.
-    virtual void SuperAcceptUndo(const QString& name) = 0;
-    //! Cancel changes and restore undo objects.
-    virtual void SuperCancelUndo() = 0;
     //! Suspend undo recording.
     virtual void SuspendUndo() = 0;
     //! Resume undo recording.

--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -891,30 +891,6 @@ void CEditorImpl::CancelUndo()
     }
 }
 
-void CEditorImpl::SuperBeginUndo()
-{
-    if (m_pUndoManager)
-    {
-        m_pUndoManager->SuperBegin();
-    }
-}
-
-void CEditorImpl::SuperAcceptUndo(const QString& name)
-{
-    if (m_pUndoManager)
-    {
-        m_pUndoManager->SuperAccept(name);
-    }
-}
-
-void CEditorImpl::SuperCancelUndo()
-{
-    if (m_pUndoManager)
-    {
-        m_pUndoManager->SuperCancel();
-    }
-}
-
 void CEditorImpl::SuspendUndo()
 {
     if (m_pUndoManager)

--- a/Code/Editor/IEditorImpl.h
+++ b/Code/Editor/IEditorImpl.h
@@ -181,9 +181,6 @@ public:
     void RestoreUndo(bool undo) override;
     void AcceptUndo(const QString& name) override;
     void CancelUndo() override;
-    void SuperBeginUndo() override;
-    void SuperAcceptUndo(const QString& name) override;
-    void SuperCancelUndo() override;
     void SuspendUndo() override;
     void ResumeUndo() override;
     void Undo() override;

--- a/Code/Editor/Lib/Tests/IEditorMock.h
+++ b/Code/Editor/Lib/Tests/IEditorMock.h
@@ -103,9 +103,6 @@ public:
     MOCK_METHOD1(RestoreUndo, void(bool));
     MOCK_METHOD1(AcceptUndo, void(const QString& ));
     MOCK_METHOD0(CancelUndo, void());
-    MOCK_METHOD0(SuperBeginUndo, void());
-    MOCK_METHOD1(SuperAcceptUndo, void(const QString&));
-    MOCK_METHOD0(SuperCancelUndo, void());
     MOCK_METHOD0(SuspendUndo, void());
     MOCK_METHOD0(ResumeUndo, void());
     MOCK_METHOD0(Undo, void());

--- a/Code/Editor/Undo/Undo.cpp
+++ b/Code/Editor/Undo/Undo.cpp
@@ -21,49 +21,6 @@
 #define UNDOREDO_MULTIPLE_OBJECTS_TEXT " (Multiple Objects)"
 
 
-//! CSuperUndo objects groups together a block of UndoStepto to allow them to be Undo by single operation.
-class CSuperUndoStep
-    : public CUndoStep
-{
-public:
-    //! Add new undo object to undo step.
-    void AddUndoStep(CUndoStep* step)
-    {
-        m_undoSteps.push_back(step);
-    }
-    int GetSize() const override
-    {
-        int size = 0;
-        for (int i = 0; i < m_undoSteps.size(); i++)
-        {
-            size += m_undoSteps[i]->GetSize();
-        }
-        return size;
-    }
-    bool IsEmpty() const override
-    {
-        return m_undoSteps.empty();
-    }
-    void Undo(bool bUndo) override
-    {
-        for (int i = static_cast<int>(m_undoSteps.size()) - 1; i >= 0; i--)
-        {
-            m_undoSteps[i]->Undo(bUndo);
-        }
-    }
-    void Redo() override
-    {
-        for (int i = 0; i < m_undoSteps.size(); i++)
-        {
-            m_undoSteps[i]->Redo();
-        }
-    }
-
-private:
-    //! Undo steps included in this step.
-    AZStd::vector<CUndoStep*> m_undoSteps;
-};
-
 // Helper class for CUndoManager that monitors the Asset Manager and suspends undo recording while the Asset Manager
 // is processing asset loading events.  The events are processed non-deterministically, so they could accidentally get captured
 // within an undo recording block.
@@ -97,10 +54,8 @@ public:
 CUndoManager::CUndoManager()
 {
     m_bRecording = false;
-    m_bSuperRecording = false;
 
     m_currentUndo = nullptr;
-    m_superUndo = nullptr;
     m_assetManagerUndoInterruptor = new AssetManagerUndoInterruptor();
 
     m_suspendCount = 0;
@@ -117,7 +72,6 @@ CUndoManager::~CUndoManager()
     ClearRedoStack();
     ClearUndoStack();
 
-    delete m_superUndo;
     delete m_currentUndo;
     delete m_assetManagerUndoInterruptor;
 }
@@ -126,8 +80,6 @@ CUndoManager::~CUndoManager()
 void CUndoManager::Begin()
 {
     //CryLog( "<Undo> Begin SuspendCount=%d",m_suspendCount );
-    //if (m_bSuperRecording)
-    //CLogFile::FormatLine( "<Undo> Begin (Inside SuperSuper)" );
     if (m_bUndoing || m_bRedoing) // If Undoing or redoing now, ignore this calls.
     {
         return;
@@ -209,21 +161,14 @@ void CUndoManager::Accept(const QString& name)
         ClearRedoStack();
 
         m_currentUndo->SetName(name);
-        if (m_bSuperRecording)
+        // Normal recording.
+        // Keep max undo steps.
+        while (m_undoStack.size() && (m_undoStack.size() >= GetIEditor()->GetEditorSettings()->undoLevels || GetDatabaseSize() > 100 * 1024 * 1024))
         {
-            m_superUndo->AddUndoStep(m_currentUndo);
+            delete m_undoStack.front();
+            m_undoStack.pop_front();
         }
-        else
-        {
-            // Normal recording.
-            // Keep max undo steps.
-            while (m_undoStack.size() && (m_undoStack.size() >= GetIEditor()->GetEditorSettings()->undoLevels || GetDatabaseSize() > 100 * 1024 * 1024))
-            {
-                delete m_undoStack.front();
-                m_undoStack.pop_front();
-            }
-            m_undoStack.push_back(m_currentUndo);
-        }
+        m_undoStack.push_back(m_currentUndo);
         //CLogFile::FormatLine( "Undo Object Accepted (Undo:%d,Redo:%d, Size=%dKb)",m_undoStack.size(),m_redoStack.size(),GetDatabaseSize()/1024 );
 
         // If undo accepted, document modified.
@@ -303,7 +248,7 @@ void CUndoManager::Redo(int numSteps)
         return;
     }
 
-    if (m_bRecording || m_bSuperRecording)
+    if (m_bRecording)
     {
         AZ_Warning("CUndoManager", false, "Cannot Redo while Recording");
         return;
@@ -363,7 +308,7 @@ void CUndoManager::Undo(int numSteps)
         return;
     }
 
-    if (m_bRecording || m_bSuperRecording)
+    if (m_bRecording)
     {
         AZ_Warning("CUndoManager", false, "Cannot Undo while Recording");
         return;
@@ -525,99 +470,6 @@ void CUndoManager::Resume()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CUndoManager::SuperBegin()
-{
-    //CLogFile::FormatLine( "<Undo> SuperBegin (SuspendCount%d)",m_suspendCount );
-    if (m_bUndoing || m_bRedoing) // If Undoing or redoing now, ignore this calls.
-    {
-        return;
-    }
-
-    m_bSuperRecording = true;
-    m_superUndo = new CSuperUndoStep;
-    //CLogFile::WriteLine( "<Undo> SuperBegin OK" );
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CUndoManager::SuperAccept(const QString& name)
-{
-    //CLogFile::WriteLine( "<Undo> SupperAccept" );
-    if (m_bUndoing || m_bRedoing) // If Undoing or redoing now, ignore this calls.
-    {
-        return;
-    }
-
-    if (!m_bSuperRecording)
-    {
-        return;
-    }
-
-    assert(m_superUndo != 0);
-
-    if (m_bRecording)
-    {
-        Accept(name);
-    }
-
-    if (!m_superUndo->IsEmpty())
-    {
-        m_superUndo->SetName(name);
-        // Keep max undo steps.
-        while (m_undoStack.size() && (m_undoStack.size() >= GetIEditor()->GetEditorSettings()->undoLevels || GetDatabaseSize() > 100 * 1024 * 1024))
-        {
-            delete m_undoStack.front();
-            m_undoStack.pop_front();
-        }
-        m_undoStack.push_back(m_superUndo);
-    }
-    else
-    {
-        // If no any object was recorded, Cancel undo operation.
-        SuperCancel();
-    }
-
-    //CLogFile::FormatLine( "Undo Object Accepted (Undo:%d,Redo:%d)",m_undoStack.size(),m_redoStack.size() );
-    m_bSuperRecording = false;
-    m_superUndo = nullptr;
-    //CLogFile::WriteLine( "<Undo> SupperAccept OK" );
-
-    SignalNumUndoRedoToListeners();
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CUndoManager::SuperCancel()
-{
-    //CLogFile::WriteLine( "<Undo> SuperCancel" );
-    if (m_bUndoing || m_bRedoing) // If Undoing or redoing now, ignore this calls.
-    {
-        return;
-    }
-
-    if (!m_bSuperRecording)
-    {
-        return;
-    }
-
-    assert(m_superUndo != 0);
-
-    if (m_bRecording)
-    {
-        Cancel();
-    }
-
-    Suspend();
-    //! Undo all changes already made.
-    m_superUndo->Undo(false); // Undo not by Undo command (no need to store Redo)
-    Resume();
-
-    m_bSuperRecording = false;
-    delete m_superUndo;
-    m_superUndo = nullptr;
-    //CLogFile::WriteLine( "<Undo> SuperCancel OK" );
-}
-
-
-//////////////////////////////////////////////////////////////////////////
 int CUndoManager::GetUndoStackLen() const
 {
     return static_cast<int>(m_undoStack.size());
@@ -702,9 +554,7 @@ void CUndoManager::Flush()
     ClearRedoStack();
     ClearUndoStack();
 
-    delete m_superUndo;
     delete m_currentUndo;
-    m_superUndo = nullptr;
     m_currentUndo = nullptr;
 
     SignalUndoFlushedToListeners();
@@ -802,7 +652,7 @@ void CUndoManager::SignalUndoFlushedToListeners()
 
 bool CUndoManager::IsUndoRecording() const
 {
-    return (m_bRecording || m_bSuperRecording) && m_suspendCount == 0;
+    return m_bRecording && m_suspendCount == 0;
 }
 
 bool CUndoManager::IsUndoSuspended() const

--- a/Code/Editor/Undo/Undo.h
+++ b/Code/Editor/Undo/Undo.h
@@ -19,7 +19,6 @@
 #include <vector>
 
 struct IUndoObject;
-class CSuperUndoStep;
 class AssetManagerUndoInterruptor;
 
 //! CUndo is a collection of IUndoObjects instances that forms single undo step.
@@ -161,16 +160,6 @@ public:
     //! Cancel changes and restore undo objects.
     void Cancel();
 
-    //! Normally this is NOT needed but in special cases this can be useful.
-    //! This allows to group a set of Begin()/Accept() sequences to be undone in one operation.
-    void SuperBegin();
-    //! When a SuperBegin() used, this method is used to Accept.
-    //! This leaves the undo database in its modified state and registers the IUndoObjects with the undo system.
-    //! This will allow the user to undo the operation.
-    void SuperAccept(const QString& name);
-    //! Cancel changes and restore undo objects.
-    void SuperCancel();
-
     //! Temporarily suspends recording of undo.
     void Suspend();
     //! Resume recording if was suspended.
@@ -243,7 +232,6 @@ private: // ---------------------------------------------------------------
     void SignalUndoFlushedToListeners();
 
     bool                                            m_bRecording;
-    bool                                            m_bSuperRecording;
     int                                             m_suspendCount;
 
     bool                                            m_bUndoing;
@@ -252,8 +240,6 @@ private: // ---------------------------------------------------------------
     bool                                            m_bClearRedoStackQueued;
 
     CUndoStep*                             m_currentUndo;
-    //! Undo step object created by SuperBegin.
-    CSuperUndoStep*                    m_superUndo;
 
     AssetManagerUndoInterruptor* m_assetManagerUndoInterruptor;
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -161,7 +161,6 @@ namespace AZ::DocumentPropertyEditor
                 // notify the new value in the container so that listeners can update dom / store overrides / undo redo
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
-                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
                 impl->m_adapter->NotifyResetDocument();
@@ -176,7 +175,6 @@ namespace AZ::DocumentPropertyEditor
                 // Notify that the document has changed with the new value in the container:
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
-                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
                 // rebuild the view based on the new contents, which could be many rows.
                 // This deletes the 'this' pointer!
@@ -475,7 +473,6 @@ namespace AZ::DocumentPropertyEditor
                 // notify about the new values in the container:
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
-                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
                 impl->m_adapter->NotifyResetDocument();
@@ -489,7 +486,6 @@ namespace AZ::DocumentPropertyEditor
                 //  notify about the new values in the container:
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
-                AZ::DocumentPropertyEditor::ReflectionAdapter::InvokeChangeNotify(containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
                 impl->m_adapter->NotifyResetDocument();

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
@@ -77,6 +77,7 @@ namespace AZ::DocumentPropertyEditor::Tests
         {
             Dom::Value row = GetEntryRow(cvarName);
             ASSERT_FALSE(row.IsNull());
+            auto result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::InProgressEdit);
             auto result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::FinishedEdit);
             EXPECT_TRUE(result.IsSuccess());
             AZ_Error("CvarAdapterDpeTests", result.IsSuccess(), "%s", result.GetError().c_str());

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
@@ -78,8 +78,8 @@ namespace AZ::DocumentPropertyEditor::Tests
             Dom::Value row = GetEntryRow(cvarName);
             ASSERT_FALSE(row.IsNull());
             auto result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::InProgressEdit);
-            auto result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::FinishedEdit);
             EXPECT_TRUE(result.IsSuccess());
+            result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::FinishedEdit);
             AZ_Error("CvarAdapterDpeTests", result.IsSuccess(), "%s", result.GetError().c_str());
         }
 

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/CvarAdapterTests.cpp
@@ -80,6 +80,7 @@ namespace AZ::DocumentPropertyEditor::Tests
             auto result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::InProgressEdit);
             EXPECT_TRUE(result.IsSuccess());
             result = Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(row[1], value, Nodes::ValueChangeType::FinishedEdit);
+            EXPECT_TRUE(result.IsSuccess());
             AZ_Error("CvarAdapterDpeTests", result.IsSuccess(), "%s", result.GetError().c_str());
         }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
@@ -54,11 +54,11 @@ namespace AzQtComponents
                     // them with the new property value. Child render rules must be explicitly invalidated.
                     styleSheet->unpolish(widget);
                     styleSheet->polish(widget);
-                    for (QWidget* child : widget->template findChildren<QWidget*>())
-                    {
-                        styleSheet->unpolish(child);
-                        styleSheet->polish(child);
-                    }
+                    // Note that this specific function is supposed
+                    // to be attached to the actual object itself that
+                    // has the property being observed, and is expected
+                    // to have its style sheet selector based on that property.
+                    // Thus it is not necessary to update the child
                 }
             });
         }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleHelpers.h
@@ -54,11 +54,11 @@ namespace AzQtComponents
                     // them with the new property value. Child render rules must be explicitly invalidated.
                     styleSheet->unpolish(widget);
                     styleSheet->polish(widget);
-                    // Note that this specific function is supposed
-                    // to be attached to the actual object itself that
-                    // has the property being observed, and is expected
-                    // to have its style sheet selector based on that property.
-                    // Thus it is not necessary to update the child
+                    for (QWidget* child : widget->template findChildren<QWidget*>())
+                    {
+                        styleSheet->unpolish(child);
+                        styleSheet->polish(child);
+                    }
                 }
             });
         }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
@@ -11,10 +11,14 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPainter>
+#include <QPaintEvent>
+#include <QResizeEvent>
+#include <QShowEvent>
 #include <QStyle>
 #include <QTextCursor>
 #include <QTextDocument>
-
+#include <QTimer>
+#include <QHideEvent>
 
 namespace AzQtComponents
 {
@@ -29,19 +33,6 @@ namespace AzQtComponents
         setText(text);
     }
 
-    void ElidingLabel::handleElision()
-    {
-        m_elidedText.clear();
-
-        elide();
-
-        if (m_updateGeomentry)
-        {
-            updateGeometry();
-            m_updateGeomentry = false;
-        }
-    }
-
     void ElidingLabel::setText(const QString& text)
     {
         if (text == m_text)
@@ -51,7 +42,7 @@ namespace AzQtComponents
 
         m_text = text;
         m_metricsLabel->setText(m_text);
-
+        updateGeometry();
         requestElide(true);
     }
 
@@ -68,18 +59,61 @@ namespace AzQtComponents
         }
 
         m_elideMode = mode;
-        update();
+        requestElide(true);
     }
 
+    // This event also happens if the label is resized due to a layout update
+    // In that case, we should re-elide the text to fit the new size.
     void ElidingLabel::resizeEvent(QResizeEvent* event)
     {
-        QWidget::resizeEvent(event);
-        requestElide(false);
+        QLabel::resizeEvent(event);
+
+        if (m_elideTimerId == 0)
+        {
+            if (!isHidden())
+            {
+                requestElide(true); // the first 'tick' always updates the elision immediately since its probably a layout change.
+            }
+        }
+        else
+        {
+            requestElide(false);
+        }
+    }
+
+    void ElidingLabel::showEvent([[maybe_unused]] QShowEvent* event)
+    {
+        QLabel::showEvent(event);
+        requestElide(true);
+    }
+
+    void ElidingLabel::hideEvent([[maybe_unused]] QHideEvent* event)
+    {
+        QLabel::hideEvent(event);
+
+        if (m_elideTimerId != 0)
+        {
+            killTimer(m_elideTimerId);
+            m_elideTimerId = 0;
+            m_elideDeferred = false;
+        }
     }
 
     void ElidingLabel::elide()
     {
+        if (isHidden())
+        {
+            return;
+        }
         ensurePolished();
+
+        if (m_text.isEmpty())
+        {
+            m_elidedText.clear();
+            QLabel::setText(QString());
+            setToolTip(m_description);
+            return;
+        }
 
         if (Qt::mightBeRichText(m_text))
         {
@@ -252,13 +286,18 @@ namespace AzQtComponents
         QLabel::paintEvent(event);
     }
 
-    void ElidingLabel::timerEvent([[maybe_unused]] QTimerEvent* event)
+     void ElidingLabel::timerEvent([[maybe_unused]] QTimerEvent* event)
     {
-        if (m_elideDeferred)
+        if (event->timerId() != m_elideTimerId)
         {
-            // do the elision, but keep the timer running in case another request comes in too quickly
-            handleElision();
+            return;
+        }
+
+        if (m_elideDeferred) // a "elide again!" came in during the timer.
+        {
             m_elideDeferred = false;
+            // do the elision, but keep the timer running in case another request comes in too quickly
+            elide();
         }
         else
         {
@@ -268,22 +307,29 @@ namespace AzQtComponents
         }
     }
 
-    void ElidingLabel::requestElide(bool updateGeometry)
+    void ElidingLabel::requestElide(bool immediate)
     {
-        if (!m_updateGeomentry && updateGeometry)
+        if (isHidden())
         {
-            m_updateGeomentry = true;
+            return;
         }
-        if (!m_elideTimerId)
+
+        if (immediate)
         {
-            // do the elision immediately, but start a timer to make sure we don't elide again too quickly
-            handleElision();
-            m_elideTimerId = startTimer(s_minTimeBetweenUpdates);
+            elide();
+            return;
         }
         else
         {
-            // the timer's already running
-            m_elideDeferred = true;
+            if (m_elideTimerId == 0)
+            {
+                m_elideTimerId = startTimer(s_minTimeBetweenUpdates);
+            }
+            else
+            {
+                // if the timer is already running, we got a request to elide when we're already got one queued up.
+                m_elideDeferred = true;  // this will cause the timer to start again.
+            }
         }
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.cpp
@@ -17,9 +17,6 @@
 #include <QStyle>
 #include <QTextCursor>
 #include <QTextDocument>
-#include <QTimer>
-#include <QHideEvent>
-
 namespace AzQtComponents
 {
     ElidingLabel::ElidingLabel(const QString& text, QWidget* parent /* = nullptr */)
@@ -43,7 +40,7 @@ namespace AzQtComponents
         m_text = text;
         m_metricsLabel->setText(m_text);
         updateGeometry();
-        requestElide(true);
+        requestElide();
     }
 
     void ElidingLabel::setDescription(const QString& description)
@@ -59,7 +56,7 @@ namespace AzQtComponents
         }
 
         m_elideMode = mode;
-        requestElide(true);
+        requestElide();
     }
 
     // This event also happens if the label is resized due to a layout update
@@ -67,36 +64,13 @@ namespace AzQtComponents
     void ElidingLabel::resizeEvent(QResizeEvent* event)
     {
         QLabel::resizeEvent(event);
-
-        if (m_elideTimerId == 0)
-        {
-            if (!isHidden())
-            {
-                requestElide(true); // the first 'tick' always updates the elision immediately since its probably a layout change.
-            }
-        }
-        else
-        {
-            requestElide(false);
-        }
+        requestElide();
     }
 
     void ElidingLabel::showEvent([[maybe_unused]] QShowEvent* event)
     {
         QLabel::showEvent(event);
-        requestElide(true);
-    }
-
-    void ElidingLabel::hideEvent([[maybe_unused]] QHideEvent* event)
-    {
-        QLabel::hideEvent(event);
-
-        if (m_elideTimerId != 0)
-        {
-            killTimer(m_elideTimerId);
-            m_elideTimerId = 0;
-            m_elideDeferred = false;
-        }
+        requestElide();
     }
 
     void ElidingLabel::elide()
@@ -286,51 +260,13 @@ namespace AzQtComponents
         QLabel::paintEvent(event);
     }
 
-     void ElidingLabel::timerEvent([[maybe_unused]] QTimerEvent* event)
-    {
-        if (event->timerId() != m_elideTimerId)
-        {
-            return;
-        }
-
-        if (m_elideDeferred) // a "elide again!" came in during the timer.
-        {
-            m_elideDeferred = false;
-            // do the elision, but keep the timer running in case another request comes in too quickly
-            elide();
-        }
-        else
-        {
-            // s_minTimeBetweenUpdates has elapsed since the last elide, and no new requests have come in
-            killTimer(m_elideTimerId);
-            m_elideTimerId = 0;
-        }
-    }
-
-    void ElidingLabel::requestElide(bool immediate)
+    void ElidingLabel::requestElide()
     {
         if (isHidden())
         {
             return;
         }
-
-        if (immediate)
-        {
-            elide();
-            return;
-        }
-        else
-        {
-            if (m_elideTimerId == 0)
-            {
-                m_elideTimerId = startTimer(s_minTimeBetweenUpdates);
-            }
-            else
-            {
-                // if the timer is already running, we got a request to elide when we're already got one queued up.
-                m_elideDeferred = true;  // this will cause the timer to start again.
-            }
-        }
+        elide();
     }
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
@@ -10,6 +10,13 @@
 #include <AzQtComponents/AzQtComponentsAPI.h>
 
 #include <QLabel>
+
+class QShowEvent;
+class QPaintEvent;
+class QResizeEvent;
+class QTimer;
+class QHideEvent;
+
 #include <QRegularExpression>
 
 namespace AzQtComponents
@@ -111,14 +118,13 @@ namespace AzQtComponents
         //! Overrides the QLabel sizeHint function to return the elided text size.
         QSize sizeHint() const override;
 
-        void handleElision();
-
     protected:
         void resizeEvent(QResizeEvent* event) override;
         void paintEvent(QPaintEvent* event) override;
         void timerEvent(QTimerEvent* event) override;
-
-        void requestElide(bool updateGeometry);
+        void showEvent(QShowEvent* event) override;
+        void hideEvent(QHideEvent* event) override;
+        void requestElide(bool immediate);
 
         QString m_filterString;
         QRegularExpression m_filterRegex;
@@ -139,7 +145,6 @@ namespace AzQtComponents
         static constexpr int s_minTimeBetweenUpdates = 200;
         int m_elideTimerId = 0;
         bool m_elideDeferred = false;
-        bool m_updateGeomentry = false;
     };
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
@@ -14,8 +14,6 @@
 class QShowEvent;
 class QPaintEvent;
 class QResizeEvent;
-class QTimer;
-class QHideEvent;
 
 #include <QRegularExpression>
 
@@ -121,10 +119,8 @@ namespace AzQtComponents
     protected:
         void resizeEvent(QResizeEvent* event) override;
         void paintEvent(QPaintEvent* event) override;
-        void timerEvent(QTimerEvent* event) override;
         void showEvent(QShowEvent* event) override;
-        void hideEvent(QHideEvent* event) override;
-        void requestElide(bool immediate);
+        void requestElide();
 
         QString m_filterString;
         QRegularExpression m_filterRegex;
@@ -141,10 +137,6 @@ namespace AzQtComponents
 
         Qt::TextElideMode m_elideMode;
         QLabel* m_metricsLabel;
-        
-        static constexpr int s_minTimeBetweenUpdates = 200;
-        int m_elideTimerId = 0;
-        bool m_elideDeferred = false;
     };
 
 } // namespace AzQtComponents

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ElidingLabel.h
@@ -120,6 +120,8 @@ namespace AzQtComponents
         void resizeEvent(QResizeEvent* event) override;
         void paintEvent(QPaintEvent* event) override;
         void showEvent(QShowEvent* event) override;
+
+        //! Requests that the label re-elide its text.
         void requestElide();
 
         QString m_filterString;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.cpp
@@ -19,10 +19,18 @@ AZ_INSTANTIATE_EBUS_MULTI_ADDRESS(AZTF_API, AzToolsFramework::ViewPaneCallbacks)
 
 namespace AzToolsFramework
 {
-    ScopedUndoBatch::ScopedUndoBatch(const char* batchName)
+    ScopedUndoBatch::ScopedUndoBatch(const char* batchName, UndoSystem::URSequencePoint** resumeHandle)
+        : m_undoBatch(nullptr)
     {
-        ToolsApplicationRequests::Bus::BroadcastResult(
-            m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, batchName);
+        if (resumeHandle)
+        {
+            m_undoBatch = *resumeHandle;
+        }
+        ToolsApplicationRequests::Bus::BroadcastResult(m_undoBatch, &ToolsApplicationRequests::Bus::Events::ResumeUndoBatch, m_undoBatch, batchName);
+        if (resumeHandle)
+        {
+            *resumeHandle = m_undoBatch;
+        }
     }
 
     ScopedUndoBatch::~ScopedUndoBatch()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ToolsApplicationAPI.h
@@ -976,18 +976,30 @@ namespace AzToolsFramework
 
     using ViewPaneCallbackBus = AZ::EBus<ViewPaneCallbacks>;
 
-    /**
-     * RAII Helper class for undo batches.
+    /*! RAII Helper class for undo batches.
      *
-     * AzToolsFramework::ScopedUndoBatch undoBatch("Batch Name");
-     * entity->ChangeData(...);
-     * undoBatch.MarkEntityDirty(entity->GetId());
+     * Usage:  If you are doing a single one-off operation in one frame:
+     * 1. Open a scope.
+     * 2. ScopedUndoBatch batch("Do a thing");
+     * 3. Modify data in entities, set them dirty, and/or add child undo commands for special undo nodes.
+     * 4. Allow the ScopedUndoBatch to leave scope.
+     *
+     * Usage:  If you are doing a multi-frame operation:
+     * 1. Store a UndoSystem::URSequencePoint* resumeHandle = nullptr; in your class to remember your operation handle.
+     * 2. Each time data changes:
+     *    a) ScopedUndoBatch batch("Do a thing", &resumeHandle);
+     *       ResumeHandle will either be reused and be unchanged, or it will be set to a new value if
+     *       resumeHandle was a nullptr, or was not able to be resumed.
+     *    b) Modify the entity data and set them dirty, and/or add child undo commands for special undo nodes.
+     *    c) Allow the scoped undo batch to leave scope.  Retain the resumehandle for next time data changes.
+     * 3. When the operation is complete (as in, logical user operation, like they release the mouse in a drag),
+     *    forget the resume handle (set it to nullptr).  This will cause the next operation to start a new batch.
      */
     class AZTF_API ScopedUndoBatch
     {
     public:
         AZ_CLASS_ALLOCATOR(ScopedUndoBatch, AZ::SystemAllocator);
-        explicit ScopedUndoBatch(const char* batchName);
+        [[nodiscard]] explicit ScopedUndoBatch(const char* batchName, UndoSystem::URSequencePoint** resumeHandle = nullptr);
         ~ScopedUndoBatch();
 
         // utility/convenience function for adding dirty entity

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -1301,9 +1301,17 @@ namespace AzToolsFramework
             searchNode = searchNode->GetParent(); // walk up the tree.
         }
 
-        // note that when resuming an undo batch, we do not pop any values, this allows the node to
-        // continue adding data to nodes without creating new undos.
-        // we only create a new undo node if the one we are trying to resume is not anywhere in the current undo tree.
+        // if we just finished an undo, and its the top operation or contains the resume operation, reopen it.
+        // note that we re-attach the root to the current undo batch, but we return the child found.
+        UndoSystem::URSequencePoint* topOperation = m_undoStack->GetTop();
+        if (topOperation)
+        {
+            if (UndoSystem::URSequencePoint* searcher = topOperation->Find(expected); searcher)
+            {
+                m_currentBatchUndo = m_undoStack->PopTop();
+                return searcher;
+            }
+        }
 
         return BeginUndoBatch(label);
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeViewportEdit.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeViewportEdit.cpp
@@ -119,29 +119,6 @@ namespace AzToolsFramework
         }
     }
 
-    void BaseShapeViewportEdit::BeginUndoBatch(const char* label)
-    {
-        if (!m_entityIds.empty())
-        {
-            ToolsApplicationRequests::Bus::BroadcastResult(
-                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, label);
-
-            for (const AZ::EntityId& entityId : m_entityIds)
-            {
-                ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityId);
-            }
-        }
-    }
-
-    void BaseShapeViewportEdit::EndUndoBatch()
-    {
-        if (m_undoBatch)
-        {
-            ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::EndUndoBatch);
-            m_undoBatch = nullptr;
-        }
-    }
-
     void BaseShapeViewportEdit::OnCameraStateChanged([[maybe_unused]] const AzFramework::CameraState& cameraState)
     {
     }
@@ -150,13 +127,19 @@ namespace AzToolsFramework
     {
         // manipulators handle undo batches for the main viewport themselves, but this function does not work via manipulators
         // so needs its own undo batch
-        BeginUndoBatch("ViewportEdit Reset");
-        // also provide a hook for other viewports to handle undo/redo, UI refresh, etc
-        BeginEditing();
-        ResetValuesImpl();
-        ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_Values);
-        EndEditing();
-        EndUndoBatch();
+        if (!m_entityIds.empty())
+        {
+            AzToolsFramework::ScopedUndoBatch batch("Reset Shape Values");
+            BeginEditing();
+            ResetValuesImpl();
+            ToolsApplicationNotificationBus::Broadcast(&ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplay, Refresh_Values);
+            EndEditing();
+            for (const AZ::EntityId& entityId : m_entityIds)
+            {
+                batch.MarkEntityDirty(entityId);
+            }
+        }
+       
     }
 
     void BaseShapeViewportEdit::AddEntityComponentIdPair(const AZ::EntityComponentIdPair& entityComponentIdPair)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeViewportEdit.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentModes/BaseShapeViewportEdit.h
@@ -79,8 +79,6 @@ namespace AzToolsFramework
 
         void BeginEditing();
         void EndEditing();
-        void BeginUndoBatch(const char* label);
-        void EndUndoBatch();
 
         AZStd::function<AZ::Transform()> m_getManipulatorSpace;
         AZStd::function<AZ::Vector3()> m_getNonUniformScale;
@@ -92,6 +90,5 @@ namespace AzToolsFramework
         AZStd::function<void()> m_endEditing;
 
         AZStd::unordered_set<AZ::EntityId> m_entityIds;
-        UndoSystem::URSequencePoint* m_undoBatch = nullptr;
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
@@ -220,9 +220,9 @@ namespace AzToolsFramework
     {
         if (!PerformingAction())
         {
-            bool m_wasMouseOver = m_mouseOver;
+            bool wasMouseOver = m_mouseOver;
             m_mouseOver = (m_manipulatorId == manipulatorId);
-            if (m_wasMouseOver != m_mouseOver)
+            if (wasMouseOver != m_mouseOver)
             {
                 // the mouse left the current manipulator, clear the undo batch
                 // so we don't try to resume it (for example, wheeling over one manipulator, then

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.cpp
@@ -29,7 +29,6 @@ namespace AzToolsFramework
     BaseManipulator::~BaseManipulator()
     {
         AZ_Assert(!Registered(), "Manipulator must be unregistered before it is destroyed");
-        EndUndoBatch();
     }
 
     bool BaseManipulator::OnLeftMouseDown(const ViewportInteraction::MouseInteraction& interaction, const float rayIntersectionDistance)
@@ -39,19 +38,6 @@ namespace AzToolsFramework
         if (m_onLeftMouseDownImpl)
         {
             BeginAction();
-            ToolsApplicationRequests::Bus::BroadcastResult(
-                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "Manipulator Left Mouse Down");
-
-            for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
-            {
-                ToolsApplicationRequests::Bus::Broadcast(
-                    &ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityComponentId.GetEntityId());
-                ToolsApplicationNotificationBus::Broadcast(
-                    &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
-                    entityComponentId,
-                    Refresh_Values);
-            }
-
             (*this.*m_onLeftMouseDownImpl)(interaction, rayIntersectionDistance);
             return true;
         }
@@ -66,19 +52,6 @@ namespace AzToolsFramework
         if (m_onRightMouseDownImpl)
         {
             BeginAction();
-            ToolsApplicationRequests::Bus::BroadcastResult(
-                m_undoBatch, &ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "Manipulator Right Mouse Down");
-
-            for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
-            {
-                ToolsApplicationRequests::Bus::Broadcast(
-                    &ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entityComponentId.GetEntityId());
-                ToolsApplicationNotificationBus::Broadcast(
-                    &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
-                    entityComponentId,
-                    Refresh_Values);
-
-            }
             (*this.*m_onRightMouseDownImpl)(interaction, rayIntersectionDistance);
             return true;
         }
@@ -90,28 +63,39 @@ namespace AzToolsFramework
     // attached as no active manipulator will have been set in ManipulatorManager.
     void BaseManipulator::OnLeftMouseUp(const ViewportInteraction::MouseInteraction& interaction)
     {
+        // Note that our manipulator system allows for the concept of clicking a thing (like a button)
+        // amongst the manipulators to do things.  However, this usually just changes the mode of a manipulator
+        // without altering entity data.  For the very special case where clicking, without moving the mouse does change
+        // entity data, please ensure that the undo batch is created and the entity is marked dirty in that specific subclass
+        // implementation of OnLeftMouseUpImpl.
         AZ_PROFILE_FUNCTION(AzToolsFramework);
-
         SetBoundsDirty();
 
         EndAction();
         OnLeftMouseUpImpl(interaction);
-        EndUndoBatch();
+        m_undoBatch = nullptr; // mouse up operations end a logical undo op
     }
 
     void BaseManipulator::OnRightMouseUp(const ViewportInteraction::MouseInteraction& interaction)
     {
+        // Note that our manipulator system allows for the concept of clicking a thing (like a button)
+        // amongst the manipulators to do things.  However, this usually just changes the mode of a manipulator
+        // without altering entity data.  For the very special case where clicking, without moving the mouse does change
+        // entity data, please ensure that the undo batch is created and the entity is marked dirty in that specific subclass
+        // implementation of OnRightMouseUpImpl.
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         SetBoundsDirty();
 
         EndAction();
         OnRightMouseUpImpl(interaction);
-        EndUndoBatch();
+        m_undoBatch = nullptr; // mouse up operations end a logical undo op
     }
 
     bool BaseManipulator::OnMouseOver(const ManipulatorId manipulatorId, const ViewportInteraction::MouseInteraction& interaction)
     {
+        // we do nothing with undo here, since mousing over something should never change the actual data state of an entity
+        // and users will get very angry if just moving their mouse over a manipulator causes actual data changes.
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         UpdateMouseOver(manipulatorId);
@@ -121,10 +105,14 @@ namespace AzToolsFramework
 
     void BaseManipulator::OnMouseWheel(const ViewportInteraction::MouseInteraction& interaction)
     {
+        // hovering over a manipulator and rolling the mouse wheel likely modifies entity data, so we create an undo.
+        AzToolsFramework::ScopedUndoBatch undoBatch("Mouse Wheel Manipulator", &m_undoBatch);
+        AZ_PROFILE_FUNCTION(AzToolsFramework);
         OnMouseWheelImpl(interaction);
 
         for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
         {
+            undoBatch.MarkEntityDirty(entityComponentId.GetEntityId());
             ToolsApplicationNotificationBus::Broadcast(
                 &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
                 entityComponentId,
@@ -142,10 +130,12 @@ namespace AzToolsFramework
 
             return;
         }
+        AzToolsFramework::ScopedUndoBatch undoBatch("Drag Manipulator", &m_undoBatch);
 
         // ensure property grid (entity inspector) values are refreshed
         for (const AZ::EntityComponentIdPair& entityComponentId : m_entityComponentIdPairs)
         {
+            undoBatch.MarkEntityDirty(entityComponentId.GetEntityId());
             ToolsApplicationNotificationBus::Broadcast(
                 &ToolsApplicationNotificationBus::Events::InvalidatePropertyDisplayForComponent,
                 entityComponentId,
@@ -230,16 +220,15 @@ namespace AzToolsFramework
     {
         if (!PerformingAction())
         {
+            bool m_wasMouseOver = m_mouseOver;
             m_mouseOver = (m_manipulatorId == manipulatorId);
-        }
-    }
-
-    void BaseManipulator::EndUndoBatch()
-    {
-        if (m_undoBatch != nullptr)
-        {
-            ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::EndUndoBatch);
-            m_undoBatch = nullptr;
+            if (m_wasMouseOver != m_mouseOver)
+            {
+                // the mouse left the current manipulator, clear the undo batch
+                // so we don't try to resume it (for example, wheeling over one manipulator, then
+                // moving the mouse to a new one and wheeling again).
+                m_undoBatch = nullptr;
+            }
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/BaseManipulator.h
@@ -261,9 +261,6 @@ namespace AzToolsFramework
         //! Update the mouseOver state for this manipulator.
         void UpdateMouseOver(ManipulatorId manipulatorId);
 
-        //! Manage correctly ending the undo batch.
-        void EndUndoBatch();
-
         //! Record an action as having started.
         void BeginAction();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -116,26 +116,6 @@ namespace AzToolsFramework::Prefab
     {
         if (propertyChangeInfo.changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::InProgressEdit)
         {
-            // The Begin/ResumeUndoBatch call will come from PropertyManagerComponent::RequestWrite which gets invoked
-            // just before this, so we just need to retrieve the undo batch.
-            AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetCurrentUndoBatch);
-            if (!m_currentUndoBatch)
-            {
-                AZ_Warning(
-                    "Prefab",
-                    false,
-                    "New undo batch is being created in PrefabComponentAdapter. This is unusual. An undo batch should already have "
-                    "existed by this point.");
-                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                    m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Component Property");
-            }
-
-            // But we do need to mark our entity as dirty. In the RPE, this is handled by EntityPropertyEditor::BeforePropertyModified,
-            // but the DPE doesn't use those notification triggers.
-            AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
-                &AzToolsFramework::ToolsApplicationRequests::AddDirtyEntity, m_entityId);
-
             if (auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get())
             {
                 instanceUpdateExecutorInterface->SetShouldPauseInstancePropagation(true);
@@ -147,10 +127,6 @@ namespace AzToolsFramework::Prefab
             {
                 instanceUpdateExecutorInterface->SetShouldPauseInstancePropagation(false);
             }
-
-            // The EndUndoBatch will get called from PropertyManagerComponent::OnEditingFinished, so we can just clear
-            // out our reference to the undo batch here.
-            m_currentUndoBatch = nullptr;
         }
         AZ::Dom::Path serializedPath = propertyChangeInfo.path / AZ::Reflection::DescriptorAttributes::SerializedPath;
 
@@ -234,13 +210,12 @@ namespace AzToolsFramework::Prefab
                 PrefabDom afterValueOfComponentProperty = convertToRapidJsonOutcome.TakeValue();
 
                 ScopedUndoBatch undoBatch("Update component in a prefab template");
-
                 PrefabUndoComponentPropertyEdit* state = aznew PrefabUndoComponentPropertyEdit("Undo Updating Component");
-                state->SetParent(m_currentUndoBatch);
+                state->SetParent(undoBatch.GetUndoBatch());
                 state->Capture(
                     owningInstance->get(), AZ::Dom::Path(relativePathFromOwningPrefab).ToString(), afterValueOfComponentProperty);
                 state->Redo();
-
+                m_currentUndoBatch = nullptr; // do not let this operation be batched with others.
                 return state->Changed();
             }
         }
@@ -279,11 +254,12 @@ namespace AzToolsFramework::Prefab
                     return false;
                 }
 
+                ScopedUndoBatch undoBatch("Override component property in a prefab template");
                 PrefabDom afterValueOfComponentProperty = convertToRapidJsonOutcome.TakeValue();
                 PrefabUndoComponentPropertyOverride* state = aznew PrefabUndoComponentPropertyOverride("Undo overriding Component");
-                state->SetParent(m_currentUndoBatch);
+                state->SetParent(undoBatch.GetUndoBatch());
                 state->CaptureAndRedo(owningInstance->get(), relativePathFromOwningPrefab, afterValueOfComponentProperty);
-
+                m_currentUndoBatch = nullptr; // do not let this operation be batched with others.
                 return state->Changed();
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
@@ -50,9 +50,16 @@ namespace AzToolsFramework::Prefab
         using PrefabPropertyEditorNodes::PrefabOverrideLabel;
 
         m_overridden = PrefabOverrideLabel::IsOverridden.ExtractFromDomNode(domValue).value_or(false);
+        // Cache the node so we can retrieve data when we handle context menu actions. 
+        m_node = domValue;
+    }
+
+    void PrefabOverrideLabelHandler::RefreshUI()
+    {
+        using PrefabPropertyEditorNodes::PrefabOverrideLabel;
 
         // Set up label
-        AZStd::string_view labelText = PrefabOverrideLabel::Value.ExtractFromDomNode(domValue).value_or("");
+        AZStd::string_view labelText = PrefabOverrideLabel::Value.ExtractFromDomNode(m_node).value_or("");
         m_textLabel->setText(QString::fromUtf8(labelText.data(), aznumeric_cast<int>(labelText.size())));
 
         m_textLabel->setProperty(OverriddenPropertyName, QVariant(m_overridden));
@@ -62,8 +69,6 @@ namespace AzToolsFramework::Prefab
         m_iconButton->setIcon(m_overridden ? *m_overrideIcon : *m_emptyIcon);
         m_iconButton->setIconSize(kIconSize);
 
-        // Cache the node so we can retrieve data when we handle context menu actions. 
-        m_node = domValue;
     }
 
     bool PrefabOverrideLabelHandler::ResetToDefaults()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.h
@@ -35,6 +35,8 @@ namespace AzToolsFramework::Prefab
         //! @param value The value holding the override label property in the DPE DOM
         void SetValueFromDom(const AZ::Dom::Value& value) override;
 
+        void RefreshUI() override;
+
         bool ResetToDefaults() override;
 
         void SetFilter(const QString& filter) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
@@ -16,8 +16,10 @@ namespace AzToolsFramework
     {
     }
 
-    void ContainerActionButtonHandler::SetValueFromDom(const AZ::Dom::Value& node)
+    void ContainerActionButtonHandler::RefreshUI()
     {
+        using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
+        using AZ::DocumentPropertyEditor::Nodes::ContainerActionButton;
 
         static const QIcon s_iconAdd(QStringLiteral(":/stylesheet/img/UI20/add-16.svg"));
         static const QIcon s_iconRemove(QStringLiteral(":/stylesheet/img/UI20/delete-16.svg"));
@@ -25,18 +27,13 @@ namespace AzToolsFramework
         static const QIcon s_iconUp(QStringLiteral(":/stylesheet/img/indicator-arrow-up.svg"));
         static const QIcon s_iconDown(QStringLiteral(":/stylesheet/img/indicator-arrow-down.svg"));
 
-        using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
-        using AZ::DocumentPropertyEditor::Nodes::ContainerActionButton;
 
-        GenericButtonHandler::SetValueFromDom(node);
-
-        auto oldAction = m_action;
-        m_action = ContainerActionButton::Action.ExtractFromDomNode(node).value_or(ContainerAction::AddElement);
-
-        if (m_action == oldAction)
+        if (m_action == m_priorAction)
         {
             return;
         }
+
+        m_priorAction = m_action;
 
         switch (m_action)
         {
@@ -79,8 +76,22 @@ namespace AzToolsFramework
         }
     }
 
+    void ContainerActionButtonHandler::SetValueFromDom(const AZ::Dom::Value& node)
+    {
+        using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
+        using AZ::DocumentPropertyEditor::Nodes::ContainerActionButton;
+
+        GenericButtonHandler::SetValueFromDom(node);
+        m_priorAction = m_action;
+        m_action = ContainerActionButton::Action.ExtractFromDomNode(node).value_or(ContainerAction::AddElement);
+    }
+
     bool ContainerActionButtonHandler::ResetToDefaults()
     {
+        using AZ::DocumentPropertyEditor::Nodes::ContainerAction;
+        m_action = ContainerAction::None;
+        m_priorAction = ContainerAction::None;
+
         return GenericButtonHandler::ResetToDefaults();
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.cpp
@@ -74,6 +74,8 @@ namespace AzToolsFramework
                 break;
             }
         }
+
+        GenericButtonHandler::RefreshUI();
     }
 
     void ContainerActionButtonHandler::SetValueFromDom(const AZ::Dom::Value& node)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
@@ -20,6 +20,7 @@ namespace AzToolsFramework
 
         void SetValueFromDom(const AZ::Dom::Value& node) override;
         virtual bool ResetToDefaults() override;
+        void RefreshUI() override;
 
         static constexpr const AZStd::string_view GetHandlerName()
         {
@@ -28,6 +29,7 @@ namespace AzToolsFramework
 
     protected:
         AZ::DocumentPropertyEditor::Nodes::ContainerAction m_action;
+        AZ::DocumentPropertyEditor::Nodes::ContainerAction m_priorAction;
 
         void OnClicked() override;
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/ContainerActionButtonHandler.h
@@ -28,8 +28,8 @@ namespace AzToolsFramework
         }
 
     protected:
-        AZ::DocumentPropertyEditor::Nodes::ContainerAction m_action;
-        AZ::DocumentPropertyEditor::Nodes::ContainerAction m_priorAction;
+        AZ::DocumentPropertyEditor::Nodes::ContainerAction m_action = AZ::DocumentPropertyEditor::Nodes::ContainerAction::None;
+        AZ::DocumentPropertyEditor::Nodes::ContainerAction m_priorAction = AZ::DocumentPropertyEditor::Nodes::ContainerAction::None;
 
         void OnClicked() override;
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <QTimer>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h> // scoped undo batch
 
 namespace AZ::DocumentPropertyEditor
 {
@@ -156,32 +157,30 @@ namespace AZ::DocumentPropertyEditor
             switch (changeType)
             {
             case Nodes::ValueChangeType::InProgressEdit:
+                m_gotInProgressEdit = true;
                 if (m_entityId.IsValid())
                 {
-                    if (m_currentUndoBatch)
-                    {
-                        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                            m_currentUndoBatch,
-                            &AzToolsFramework::ToolsApplicationRequests::ResumeUndoBatch,
-                            m_currentUndoBatch,
-                            "Modify Entity Property");
-                    }
-                    else
-                    {
-                        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                            m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Entity Property");
-                    }
-
-                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
-                        &AzToolsFramework::ToolsApplicationRequests::AddDirtyEntity, m_entityId);
+                    AzToolsFramework::ScopedUndoBatch batch("Modify Component Property", &m_currentUndoBatch);
+                    batch.MarkEntityDirty(m_entityId);
                 }
                 break;
             case Nodes::ValueChangeType::FinishedEdit:
-                if (m_currentUndoBatch)
-                {
-                    AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::EndUndoBatch);
-                    m_currentUndoBatch = nullptr;
-                }
+                // if you find yourself here and the assert triggers, it means someone created some sort of widget or control
+                // that sends only a FinishedEdit, without an InProgressEdit being emitted beforehand.
+                // Controls that have continuous changes like sliders or text boxes (each keystroke) need to issue a
+                // InProgressEdit for each change, then a FinishedEdit when the user is done (arbitrary call to make, could
+                // be something like lost focus, could be hitting return, could be releasing a mouse button).
+                // Instantanous controls like buttons, checkboxes, etc, should issue both an InProgressEdit and FinishedEdit
+                // in the same call, since they are effectively atomic.  Doing so allows this code to deal with the undo
+                // stack up front and not have to do undo/redo capture operations at the end of the change when editing is finished.
+
+                // Note that if you are deep in the UI code for a component or writing a Handler, this means issuing:
+                // AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, gui);
+                // AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, gui);
+                // since those result in InProgressEdit, FinishedEdit being sent to the ComponentAdapter.
+                AZ_Assert(m_gotInProgressEdit, "ComponentAdapter::HandleMessage - Got FinishedEdit without InProgressEdit.");
+                m_gotInProgressEdit = false;
+                m_currentUndoBatch = nullptr;
                 break;
             }
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -158,6 +158,14 @@ namespace AZ::DocumentPropertyEditor
             {
             case Nodes::ValueChangeType::InProgressEdit:
                 m_gotInProgressEdit = true;
+
+                // At this point,  we expect the value to have already been modified in the entity.  In the case of reflected
+                // properties, the RPEPropertyHandlerWrapper<T> class has already validated and then written the value into
+                // the underlying entity component object, before it invokes this message.  In the case of the container buttons
+                // that add/remove container elements, also, this custom handler has already modified the underlying container,
+                // before it invokes this message.
+                // If you make a custom handler, make sure that you either mutate the underlying data first before invoking this
+                // event, or capture a custom undo yourself.
                 if (m_entityId.IsValid())
                 {
                     AzToolsFramework::ScopedUndoBatch batch("Modify Component Property", &m_currentUndoBatch);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -81,6 +81,9 @@ namespace AZ::DocumentPropertyEditor
 
         //! object, used in conjunction with a QPointer, to track if this component is still alive
         QObject m_stillAlive;
+        // for debugging, detect if someone makes a control that sends a "finished edit" without an
+        // in progress edit.
+        bool m_gotInProgressEdit = false;
     };
 
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -455,6 +455,7 @@ namespace AzToolsFramework
                 {
                     childWidget->hide();
                     m_columnLayout->removeWidget(childWidget);
+                    GetDPE()->ClearDirtyHandler(handlerInfo.handlerInterface);
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
                 }
                 else if (auto rowWidget = qobject_cast<DPERowWidget*>(childWidget))
@@ -616,6 +617,7 @@ namespace AzToolsFramework
                 RemoveCachedAttributes(childIndex);
                 if (!newOwner)
                 {
+                    GetDPE()->ClearDirtyHandler(handlerInfo.handlerInterface);
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
                 }
             }
@@ -915,6 +917,7 @@ namespace AzToolsFramework
                                 {
                                     m_domOrderedChildren[childIndex] = replacementWidget;
                                     AddColumnWidget(replacementWidget, childIndex, valueAtSubPath);
+                                    theDPE->AddDirtyHandler(theDPE->GetInfoFromWidget(replacementWidget).handlerInterface);
                                 }
                             }
                             else if (AZ::DocumentPropertyEditor::PropertyEditorSystem::DPEDebugEnabled())
@@ -939,6 +942,7 @@ namespace AzToolsFramework
                         {
                             childWidget->hide();
                             m_columnLayout->removeWidget(childWidget);
+                            theDPE->ClearDirtyHandler(handlerInfo.handlerInterface);
                             DocumentPropertyEditor::ReleaseHandler(handlerInfo);
 
                             // Replace the existing handler widget with one appropriate for the new type
@@ -951,7 +955,7 @@ namespace AzToolsFramework
                             // handler is the same, set the existing handler with the new value
                             RemoveCachedAttributes(childIndex);
                             SetPropertyEditorAttributes(childIndex, valueAtSubPath, childWidget);
-                            handlerInfo.handlerInterface->SetValueFromDom(valueAtSubPath);
+                            handlerInfo.handlerInterface->SetValueFromDom_Internal(valueAtSubPath, theDPE);
                         }
                     }
                     else
@@ -1008,7 +1012,6 @@ namespace AzToolsFramework
         }
 
         SetPropertyEditorAttributes(domIndex, domValue, columnWidget);
-
         // insert after the found index; even if nothing were found and priorIndex is -1,
         // insert one after it, at position 0
         m_columnLayout->insertWidget(priorColumnIndex + 1, columnWidget);
@@ -1248,6 +1251,10 @@ namespace AzToolsFramework
                     AddChildFromDomValue(myValue[valueIndex], valueIndex);
                 }
             }
+            if ((!expandRecursively) || (initialRecursiveExpander))
+            {
+                dpe->UpdateDirtyHandlers(); // this flushes all pending ui updates.
+            }
             if (initialRecursiveExpander)
             {
                 dpe->SetRecursiveExpansionOngoing(false);
@@ -1372,6 +1379,7 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::Clear()
     {
+        m_dirtyHandlers.clear();
         m_rowPool->RecycleInstance(m_rootNode);
         m_rootNode = nullptr;
     }
@@ -1543,6 +1551,15 @@ namespace AzToolsFramework
             applyFilterRecursively(m_rootNode, applyFilterRecursively);
             update(); // Need to redraw for the linting to be applied
         }
+    }
+
+    // this happens when something *outside* of the control of the DPE has changed the underlying data.
+    // for example, clicking a manipulator in the viewport and changing it.  Since the change
+    // does not originate anywhere in the DPE's domain, it cannot know that the value has changed and that the
+    // tree needs to be refreshed, except by listening for this event which is spontaneous.
+    void DocumentPropertyEditor::QueueInvalidation([[maybe_unused]] PropertyModificationRefreshLevel level)
+    {
+        RequestExecuteQueuedReset();
     }
 
     void DocumentPropertyEditor::SetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded)
@@ -1737,6 +1754,7 @@ namespace AzToolsFramework
             }
         }
         m_layout->addStretch();
+        UpdateDirtyHandlers();
         updateGeometry();
         emit RequestSizeUpdate();
     }
@@ -1774,9 +1792,34 @@ namespace AzToolsFramework
             }
             else
             {
+                UpdateDirtyHandlers();
                 updateGeometry();
             }
         }
+        m_dirtyHandlers.clear();
+
+    }
+
+    void DocumentPropertyEditor::AddDirtyHandler(PropertyHandlerWidgetInterface* dirtyHandler)
+    {
+        if (dirtyHandler)
+        {
+            m_dirtyHandlers.insert(dirtyHandler);
+        }
+    }
+
+    void DocumentPropertyEditor::ClearDirtyHandler(PropertyHandlerWidgetInterface* toClear)
+    {
+        m_dirtyHandlers.erase(toClear);
+    }
+
+    void DocumentPropertyEditor::UpdateDirtyHandlers()
+    {
+        for (PropertyHandlerWidgetInterface* dirtyHandler : m_dirtyHandlers)
+        {
+            dirtyHandler->RefreshUI();
+        }
+        m_dirtyHandlers.clear();
     }
 
     void DocumentPropertyEditor::HandleDomMessage(
@@ -1850,14 +1893,7 @@ namespace AzToolsFramework
 
         auto handlePropertyEditorChanged = [&](const AZ::Dom::Value&, AZ::DocumentPropertyEditor::Nodes::ValueChangeType)
         {
-            // When a value changes, we'd like to queue the execution of any property editor tree updates.
-            QTimer::singleShot(
-                0,
-                this,
-                [this]()
-                {
-                    m_adapter->ExecuteQueuedReset();
-                });
+            RequestExecuteQueuedReset();
         };
 
         message.Match(
@@ -1867,6 +1903,25 @@ namespace AzToolsFramework
             showQuerySubclassDialog,
             AZ::DocumentPropertyEditor::Nodes::PropertyEditor::OnChanged,
             handlePropertyEditorChanged);
+    }
+
+    void DocumentPropertyEditor::RequestExecuteQueuedReset()
+    {
+        if (m_executeQueuedResetAlreadyQueued)
+        {
+            return;
+        }
+
+        m_executeQueuedResetAlreadyQueued = true;
+        // When a value changes, we'd like to queue the execution of any property editor tree updates.
+        QTimer::singleShot(
+            1,  // 1 to place it AFTER all other 0 timer or queued events.
+            this,
+            [this]()
+            {
+                m_executeQueuedResetAlreadyQueued = false;
+                m_adapter->ExecuteQueuedReset();
+            });
     }
 
     void DocumentPropertyEditor::RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)
@@ -1937,7 +1992,7 @@ namespace AzToolsFramework
             RegisterHandlerPool(handlerName, handlerPool);
 
             auto handler = handlerPool->GetInstance();
-            handler->SetValueFromDom(domValue);
+            handler->SetValueFromDom_Internal(domValue, this);
             createdWidget = handler->GetWidget();
             createdWidget->setEnabled(true);
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1815,11 +1815,21 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::UpdateDirtyHandlers()
     {
-        for (PropertyHandlerWidgetInterface* dirtyHandler : m_dirtyHandlers)
+        AZStd::unordered_set<PropertyHandlerWidgetInterface*> dirtyHandlers;
+        m_dirtyHandlers.swap(dirtyHandlers);
+
+        for (PropertyHandlerWidgetInterface* dirtyHandler : dirtyHandlers)
         {
             dirtyHandler->RefreshUI();
         }
-        m_dirtyHandlers.clear();
+
+        // additional check - this above loop should not cause any other handlers to be dirty
+        // if it does, it means that someone is setting UI values without blocking signals.
+        AZ_Assert(
+            m_dirtyHandlers.empty(),
+            "DocumentPropertyEditor::UpdateDirtyHandlers - dirty handlers were added during refreshUI."
+            "it means that a handler is setting values without blocking signals.  Ensure that if you "
+            "are calling UI functions like setText / setValue / etc, you are blocking signals.");
     }
 
     void DocumentPropertyEditor::HandleDomMessage(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -231,6 +231,7 @@ namespace AzToolsFramework
         void SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName = {}) override;
         void ClearInstances() override;
         void SetFilterString(AZStd::string str) override; // Only used for linting, filtering is handled by the DocumentAdapter
+        void QueueInvalidation(PropertyModificationRefreshLevel level) override;
         // ~IPropertyEditor overrides
 
         AZ::Dom::Value GetDomValueForRow(DPERowWidget* row) const;
@@ -276,6 +277,8 @@ namespace AzToolsFramework
             }
         };
         static HandlerInfo GetInfoFromWidget(const QWidget* widget);
+        void AddDirtyHandler(PropertyHandlerWidgetInterface* dirtyWidget);
+        void ClearDirtyHandler(PropertyHandlerWidgetInterface* toClear);
 
     signals:
         void ExpanderChangedByUser();
@@ -294,6 +297,9 @@ namespace AzToolsFramework
         void HandleReset();
         void HandleDomChange(const AZ::Dom::Patch& patch);
         void HandleDomMessage(const AZ::DocumentPropertyEditor::AdapterMessage& message, AZ::Dom::Value& value);
+        void RequestExecuteQueuedReset();
+        void UpdateDirtyHandlers();
+        bool m_executeQueuedResetAlreadyQueued = false;
 
         AZ::DocumentPropertyEditor::DocumentAdapterPtr m_adapter;
         AZ::DocumentPropertyEditor::DocumentAdapter::ResetEvent::Handler m_resetHandler;
@@ -324,6 +330,9 @@ namespace AzToolsFramework
 
         // Co-owns the handler pool that is needed in DPE and the ownership would be released when the DPE is deleted
         AZStd::unordered_map<AZ::Name, AZStd::shared_ptr<AZ::InstancePoolBase>> m_handlerPools;
+
+        // Widgets that exist and need to requery their attributes.
+        AZStd::unordered_set<PropertyHandlerWidgetInterface*> m_dirtyHandlers;
     };
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.cpp
@@ -19,10 +19,14 @@ namespace AzToolsFramework
 
     void GenericButtonHandler::SetValueFromDom(const AZ::Dom::Value& node)
     {
-        using AZ::DocumentPropertyEditor::Nodes::GenericButton;
         // Cache the node so we can query OnActivate on it when we're pressed.
         m_node = node;
-        auto buttonText = GenericButton::ButtonText.ExtractFromDomNode(node).value_or("");
+    }
+
+    void GenericButtonHandler::RefreshUI()
+    {
+        using AZ::DocumentPropertyEditor::Nodes::GenericButton;
+        auto buttonText = GenericButton::ButtonText.ExtractFromDomNode(m_node).value_or("");
         setText(QString::fromUtf8(AZStd::string(buttonText).c_str()));
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/GenericButtonHandler.h
@@ -21,8 +21,9 @@ namespace AzToolsFramework
     public:
         GenericButtonHandler();
 
-        virtual void SetValueFromDom(const AZ::Dom::Value& node) override;
-        virtual bool ResetToDefaults() override
+        void SetValueFromDom(const AZ::Dom::Value& node) override;
+        void RefreshUI() override;
+        bool ResetToDefaults() override
         {
             m_node.SetNull();
             return true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.cpp
@@ -8,6 +8,9 @@
 
 #include <AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h>
 
+#include <AzCore/DOM/DomValue.h>
+#include <AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
+
 namespace AzToolsFramework
 {
     QWidget* PropertyHandlerWidgetInterface::GetFirstInTabOrder()
@@ -19,4 +22,14 @@ namespace AzToolsFramework
     {
         return GetWidget();
     }
+
+    void PropertyHandlerWidgetInterface::SetValueFromDom_Internal(const AZ::Dom::Value& node, AzToolsFramework::DocumentPropertyEditor* owningDPE)
+    {
+        SetValueFromDom(node);
+        if (owningDPE)
+        {
+            owningDPE->AddDirtyHandler(this);
+        }
+    }
+
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
@@ -9,16 +9,22 @@
 #pragma once
 
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
-#include <AzCore/DOM/DomUtils.h>
-#include <AzCore/DOM/DomValue.h>
-#include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
-#include <AzFramework/DocumentPropertyEditor/PropertyEditorSystemInterface.h>
+class QWidget;
+class QString;
 
-#include <QPointer>
-#include <QWidget>
+namespace AZ
+{
+    struct Uuid;
+    using TypeId = Uuid;
+    namespace Dom
+    {
+        class Value;
+    }
+}
 
 namespace AzToolsFramework
 {
+    class DocumentPropertyEditor;
     //! Base class for all property editor widgets in the DocumentPropertyEditor.
     //! Property handler widgets are registered to the PropertyEditorToolsSystemInterface and
     //! instantiated as part of the DocumentPropertyEditor, with one handler instance being constructed
@@ -26,6 +32,9 @@ namespace AzToolsFramework
     class AZTF_API PropertyHandlerWidgetInterface
     {
     public:
+        friend class DocumentPropertyEditor;
+        friend class DPERowWidget;
+
         virtual ~PropertyHandlerWidgetInterface() = default;
 
         //! Gets the widget that should be added to the DocumentPropertyEditor.
@@ -34,6 +43,11 @@ namespace AzToolsFramework
         //! This should consume both the property value (if applicable) and any attributes, including OnChange.
         virtual void SetValueFromDom(const AZ::Dom::Value& node) = 0;
 
+        //! The above SetValueFromDom function could be called repeatedly during updates, to set little pieces
+        //! of the node data.  In order to avoid repeatedly updating the widget, avoid setting any widget UI values
+        //! in SetValueFromDom, and instead wait for this function to be called, which will be called after all DOM updates are complete.
+        virtual void RefreshUI() = 0;
+
         //! Attempts to reset the widget handler to default, typically for recycling. Returns true if successful
         virtual bool ResetToDefaults()
         {
@@ -41,9 +55,7 @@ namespace AzToolsFramework
         }
 
         //! Allow the widget to lint its matching text to outline the current search
-        virtual void SetFilter([[maybe_unused]] const QString& filter)
-        {
-        }
+        virtual void SetFilter([[maybe_unused]] const QString& filter) {}; // optional
 
         //! Returns the first widget in the tab order for this property editor, i.e. the widget that should be selected
         //! when the user hits tab on the widget immediately prior to this.
@@ -81,6 +93,12 @@ namespace AzToolsFramework
         {
             return false;
         }
+
+    protected:
+        // The internal code will call this function, which will call the overridable SetValueFromDOM function.
+        // This allows the internal code to perform any necessary setup and teardown and makes it so that implementors
+        // do not have to remember to call the base class.
+        void SetValueFromDom_Internal(const AZ::Dom::Value& node, AzToolsFramework::DocumentPropertyEditor* owningDPE);
     };
 
     //! Helper class, provides a PropertyHandlerWidgetInterface implementation in which

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -45,7 +45,7 @@ namespace AzToolsFramework
     namespace ComponentEditorConstants
     {
         static const int kPropertyLabelWidth = 160; // Width of property label column in property grid.
-        static const char* kUnknownComponentTitle = "-";
+        static const char* kUnknownComponentTitle = "";
 
         // names for widgets so they can be found in stylesheet
         static const char* kPropertyEditorId = "PropertyEditor";

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/MultiLineTextEditHandler.cpp
@@ -17,11 +17,11 @@ namespace AzToolsFramework
         GrowTextEdit* textEdit = aznew GrowTextEdit(parent);
         connect(textEdit, &GrowTextEdit::textChanged, this, [textEdit]()
         {
-                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-                    &AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, textEdit);
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, textEdit);
         });
         connect(textEdit, &GrowTextEdit::EditCompleted, this, [textEdit]()
         {
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::Bus::Events::RequestWrite, textEdit);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, textEdit);
         });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
@@ -289,7 +289,8 @@ namespace AzToolsFramework
             });
         connect(newCtrl, &PropertyDoubleSliderCtrl::editingFinished, this, [newCtrl]()
         {
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 
@@ -308,7 +309,8 @@ namespace AzToolsFramework
             });
         connect(newCtrl, &PropertyDoubleSliderCtrl::editingFinished, this, [newCtrl]()
         {
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.cpp
@@ -342,12 +342,13 @@ namespace AzToolsFramework
     {
         PropertyDoubleSpinCtrl* newCtrl = aznew PropertyDoubleSpinCtrl(pParent);
         connect(newCtrl, &PropertyDoubleSpinCtrl::valueChanged, this, [newCtrl]()
-            {
-                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
-            });
+        {
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+        });
         connect(newCtrl, &PropertyDoubleSpinCtrl::editingFinished, this, [newCtrl]()
         {
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 
@@ -367,7 +368,8 @@ namespace AzToolsFramework
             });
         connect(newCtrl, &PropertyDoubleSpinCtrl::editingFinished, this, [newCtrl]()
         {
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -33,6 +33,9 @@
 #include <AzFramework/DocumentPropertyEditor/PropertyEditorSystemInterface.h>
 
 #include <QMessageBox>
+#include <QTimer>
+#include <QPointer>
+#include <QWidget>
 
 class QWidget;
 class QColor;
@@ -236,6 +239,12 @@ namespace AzToolsFramework
             return m_widget;
         }
 
+        void RefreshUI() override
+        {
+            m_rpeHandler.ConsumeAttributes_Internal(GetWidget(), &m_proxyNode);
+            m_rpeHandler.ReadValuesIntoGUI_Internal(GetWidget(), &m_proxyNode);
+        }
+
         void SetValueFromDom(const AZ::Dom::Value& node)
         {
             using AZ::DocumentPropertyEditor::Nodes::PropertyEditor;
@@ -250,6 +259,7 @@ namespace AzToolsFramework
             }
 
             m_proxyClassElement.m_attributes.clear();
+
             for (auto attributeIt = node.MemberBegin(); attributeIt != node.MemberEnd(); ++attributeIt)
             {
                 const AZ::Name& name = attributeIt->first;
@@ -261,6 +271,11 @@ namespace AzToolsFramework
                 }
                 else if (name == PropertyEditor::ParentValue.GetName())
                 {
+                    // the "ParentValue" attribute contains the entire parent data, so we need to replace it with
+                    // the new data.  Note that this may be an incremental update, so don't assume the existing data is good.
+
+                    m_proxyParentNode.m_instances.clear();
+
                     auto parentValue = PropertyEditor::ParentValue.ExtractFromDomNode(node);
                     if (parentValue.has_value())
                     {
@@ -280,14 +295,14 @@ namespace AzToolsFramework
                         AZ_Assert(parentValuePtr, "Parent instance was nullptr when attempting to add to instance list.");
 
                         // Only add parent instance if it has not been added previously
-                        if (auto foundParentIt = AZStd::find(m_proxyParentNode.m_instances.begin(), m_proxyParentNode.m_instances.end(), parentValuePtr);
-                            foundParentIt == m_proxyParentNode.m_instances.end())
-                        {
-                            m_proxyParentNode.m_instances.push_back(parentValuePtr);
-                        }
+                        m_proxyParentNode.m_instances.push_back(parentValuePtr);
 
                         // Set up the reference to parent node only if a parent value is available.
                         m_proxyNode.m_parent = &m_proxyParentNode;
+                    }
+                    else
+                    {
+                        m_proxyNode.m_parent = nullptr; // clear it out if unavailable.
                     }
                     continue;
                 }
@@ -450,9 +465,6 @@ namespace AzToolsFramework
                 m_proxyClassElement.m_genericClassInfo = serializeContext->FindGenericClassInfo(typeId);
             }
 
-            m_rpeHandler.ConsumeAttributes_Internal(GetWidget(), &m_proxyNode);
-            m_rpeHandler.ReadValuesIntoGUI_Internal(GetWidget(), &m_proxyNode);
-
             m_domNode = node;
         }
 
@@ -527,7 +539,13 @@ namespace AzToolsFramework
                     {
                         if (changeType == AZ::DocumentPropertyEditor::Nodes::ValueChangeType::InProgressEdit)
                         {
-                            QMessageBox::warning(AzToolsFramework::GetActiveWindow(), "Invalid Assignment", outcome.GetError().c_str(), QMessageBox::Ok);
+                            // do not show a message box inside this call stack - instead, queue it for later so that the property editor can finish reverting the value.
+                            auto MessageBoxFn = [outcome]()
+                            {
+                                QMessageBox::warning(AzToolsFramework::GetActiveWindow(), "Invalid Assignment", outcome.GetError().c_str(), QMessageBox::Ok);
+                            };
+
+                            QTimer::singleShot(0, AzToolsFramework::GetActiveWindow(), MessageBoxFn);
 
                             // Force the values to update so that they are correct since something just declined changes and
                             // we want the UI to display the current values and not the invalid ones

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -153,6 +153,7 @@ namespace AzToolsFramework
         });
         this->connect(newCtrl, &PropertyControl::editingFinished, this, [newCtrl]()
         {
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.hxx
@@ -87,8 +87,13 @@ namespace AzToolsFramework
     QWidget* IntSliderHandler<ValueType>::CreateGUI(QWidget* parent)
     {
         PropertyIntSliderCtrl* newCtrl = static_cast<PropertyIntSliderCtrl*>(BaseHandler::CreateGUI(parent));
+        this->connect(newCtrl, &PropertyIntSliderCtrl::valueChanged, this, [newCtrl]()
+        {
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+        });
         this->connect(newCtrl, &PropertyIntSliderCtrl::editingFinished, this, [newCtrl]()
         {
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::RequestWrite, newCtrl);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.cpp
@@ -187,19 +187,7 @@ namespace AzToolsFramework
 
         void PropertyManagerComponent::RequestWrite(QWidget* editorGUI)
         {
-            if (m_currentUndoBatch)
-            {
-                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                    m_currentUndoBatch,
-                    &AzToolsFramework::ToolsApplicationRequests::ResumeUndoBatch,
-                    m_currentUndoBatch,
-                    "Modify Property");
-            }
-            else
-            {
-                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                    m_currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Modify Property");
-            }
+            ScopedUndoBatch undoBatch("Modify Property", &m_currentUndoBatch);
 
             IndividualPropertyHandlerEditNotifications::Bus::Event(
                 editorGUI, &IndividualPropertyHandlerEditNotifications::Bus::Events::OnValueChanged,
@@ -208,15 +196,12 @@ namespace AzToolsFramework
 
         void PropertyManagerComponent::OnEditingFinished(QWidget* editorGUI)
         {
+            ScopedUndoBatch undoBatch("Modify Property", &m_currentUndoBatch);
+
             IndividualPropertyHandlerEditNotifications::Bus::Event(
                 editorGUI, &IndividualPropertyHandlerEditNotifications::Bus::Events::OnValueChanged,
                 AZ::DocumentPropertyEditor::Nodes::ValueChangeType::FinishedEdit);
-
-            if (m_currentUndoBatch)
-            {
-                AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::EndUndoBatch);
-                m_currentUndoBatch = nullptr;
-            }
+            m_currentUndoBatch = nullptr;
         }
 
         void PropertyManagerComponent::RequestPropertyNotify(QWidget* editorGUI)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -14,6 +14,8 @@
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyCheckBoxCtrl.hxx>
 
+#include <QTimer>
+
 AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option") // 4244: conversion from 'int' to 'float', possible loss of data
                                                                     // 4251: class '...' needs to have dll-interface to be used by clients of class 'QInputEvent'
                                                                     // 4800: QTextEngine *const ': forcing value to bool 'true' or 'false' (performance warning)
@@ -1519,7 +1521,13 @@ namespace AzToolsFramework
                         {
                             if (!outcome.IsSuccess())
                             {
-                                QMessageBox::warning(AzToolsFramework::GetActiveWindow(), "Invalid Assignment", outcome.GetError().c_str(), QMessageBox::Ok);
+                                // do not show a message box inside this call stack - instead, queue it for later so that the property editor can finish reverting the value.
+                                auto MessageBoxFn = [outcome]()
+                                {
+                                    QMessageBox::warning(AzToolsFramework::GetActiveWindow(), "Invalid Assignment", outcome.GetError().c_str(), QMessageBox::Ok);
+                                };
+
+                                QTimer::singleShot(0, AzToolsFramework::GetActiveWindow(), MessageBoxFn);
                                 return false;
                             }
                         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyVectorCtrl.cpp
@@ -26,6 +26,7 @@ namespace AzToolsFramework
             });
         newCtrl->connect(newCtrl, &AzQtComponents::VectorInput::editingFinished, [newCtrl]()
         {
+            PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
             PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Undo/UndoSystem.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Undo/UndoSystem.cpp
@@ -74,9 +74,28 @@ namespace AzToolsFramework
                 return this;
             }
 
-            for (ChildVec::iterator it = m_children.begin(); it != m_children.end(); ++it)
+            for (auto &child : m_children)
             {
-                URSequencePoint* cmd = (*it)->Find(id, typeOfCommand);
+                URSequencePoint* cmd = child->Find(id, typeOfCommand);
+                if (cmd)
+                {
+                    return cmd;
+                }
+            }
+
+            return nullptr;
+        }
+
+        URSequencePoint* URSequencePoint::Find(URSequencePoint* expected)
+        {
+            if (this == expected)
+            {
+                return this;
+            }
+
+            for (auto &child : m_children)
+            {
+                URSequencePoint* cmd = child->Find(expected);
                 if (cmd)
                 {
                     return cmd;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Undo/UndoSystem.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Undo/UndoSystem.h
@@ -81,6 +81,11 @@ namespace AzToolsFramework
             */
             URSequencePoint* Find(URCommandID id, const AZ::Uuid& typeOfCommand);
 
+            /*!
+            * Finds the given command in parent-child tree with the matching handle.
+            */
+            URSequencePoint* Find(URSequencePoint* expected);
+
             void SetName(const AZStd::string& friendlyName);
             AZStd::string& GetName();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1850,6 +1850,13 @@ namespace AzToolsFramework
             !UndoRedoOperationInProgress(),
             "ChangeSelectedEntity called from undo/redo operation - this is unexpected and not currently supported");
 
+        if (IsEntitySelectedInternal(entityId, m_selectedEntityIds))
+        {
+            if (m_selectedEntityIds.size() == 1)
+            {
+                return;
+            }
+        }
         // ensure deselect/select is tracked as an atomic undo/redo operation
         ScopedUndoBatch undoBatch(ChangeEntitySelectionUndoRedoDesc);
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -311,9 +311,15 @@ namespace AZ
         void EditorMaterialComponent::UpdateMaterialSlots()
         {
             SetDirty();
+            // cache the old slots until the new ones are updated so that
+            // asset reference counts don't go to 0 temporarily.
+            auto oldDefaultSlot = m_defaultMaterialSlot;
+            EditorMaterialComponentSlotContainer oldSlots;
+            EditorMaterialComponentSlotsByLodContainer oldLODSlots;
+
+            m_materialSlots.swap(oldSlots);
+            m_materialSlotsByLod.swap(oldLODSlots);
             m_defaultMaterialSlot = {};
-            m_materialSlots = {};
-            m_materialSlotsByLod = {};
 
             // Get the known material assignment slots from the associated model or other source
             MaterialAssignmentMap originalMaterials;

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -136,8 +136,6 @@ namespace GradientSignal
 
     EditorImageGradientComponentMode::~EditorImageGradientComponentMode()
     {
-        EndUndoBatch();
-
         m_brushManipulator->Unregister();
         m_brushManipulator.reset();
 
@@ -189,42 +187,19 @@ namespace GradientSignal
     {
     }
 
-    void EditorImageGradientComponentMode::BeginUndoBatch()
-    {
-        AZ_Assert(m_undoBatch == nullptr, "Starting an undo batch while one is already active!");
-
-        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-            m_undoBatch, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "PaintStroke");
-
-        m_paintBrushUndoBuffer = aznew PaintBrushUndoBuffer(GetEntityId());
-        m_paintBrushUndoBuffer->SetParent(m_undoBatch);
-    }
-
-    void EditorImageGradientComponentMode::EndUndoBatch()
-    {
-        if (m_undoBatch != nullptr)
-        {
-            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationRequests::Bus::Events::EndUndoBatch);
-            m_undoBatch = nullptr;
-            m_paintBrushUndoBuffer = nullptr;
-        }
-    }
-
     void EditorImageGradientComponentMode::OnImageGradientBrushStrokeBegin()
     {
-        BeginUndoBatch();
+        // Nothing to do here in terms of undo, because no data has changed yet.
     }
 
     void EditorImageGradientComponentMode::OnImageGradientBrushStrokeEnd(
         AZStd::shared_ptr<ImageTileBuffer> changedDataBuffer, const AZ::Aabb& dirtyRegion)
     {
-        AZ_Assert(m_paintBrushUndoBuffer != nullptr, "Undo batch is expected to exist while painting");
-
+        AzToolsFramework::ScopedUndoBatch undoBatch("Image Gradient Paint Stroke");
         // Hand over ownership of the paint stroke buffer to the undo/redo buffer.
-        m_paintBrushUndoBuffer->SetUndoBufferAndDirtyArea(changedDataBuffer, dirtyRegion);
-
-        EndUndoBatch();
+        auto undoData = aznew PaintBrushUndoBuffer(GetEntityId());
+        undoData->SetParent(undoBatch.GetUndoBatch());
+        undoData->SetUndoBufferAndDirtyArea(changedDataBuffer, dirtyRegion);
     }
 
 } // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.h
@@ -48,17 +48,9 @@ namespace GradientSignal
         // ImageGradientModificationNotificationBus overrides...
         void OnImageGradientBrushStrokeBegin() override;
         void OnImageGradientBrushStrokeEnd(AZStd::shared_ptr<ImageTileBuffer> changedDataBuffer, const AZ::Aabb& dirtyRegion) override;
-
-        void BeginUndoBatch();
-        void EndUndoBatch();
-
     private:
         //! The core paintbrush manipulator and painting logic.
         AZStd::shared_ptr<AzToolsFramework::PaintBrushManipulator> m_brushManipulator;
-
-        //! The undo information for the in-progress painting brush stroke.
-        AzToolsFramework::UndoSystem::URSequencePoint* m_undoBatch = nullptr;
-        PaintBrushUndoBuffer* m_paintBrushUndoBuffer = nullptr;
 
         //! The paint brush cluster that manages switching between paint/smooth/eyedropper modes
         AzToolsFramework::PaintBrushSubModeCluster m_subModeCluster;

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -947,7 +947,7 @@ namespace LandscapeCanvasEditor
 
         if (it != m_dockWidgetsByEntity.end())
         {
-            const AZ::EntityId& rootEntityId = it->first;
+            AZ::EntityId rootEntityId = it->first;
             m_dockWidgetsByEntity.erase(it);
 
             // Save our graph whenever it is closed

--- a/Gems/Terrain/Code/Source/TerrainRenderer/EditorComponents/EditorTerrainMacroMaterialComponentMode.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/EditorComponents/EditorTerrainMacroMaterialComponentMode.cpp
@@ -132,8 +132,6 @@ namespace Terrain
 
     EditorTerrainMacroMaterialComponentMode::~EditorTerrainMacroMaterialComponentMode()
     {
-        EndUndoBatch();
-
         m_brushManipulator->Unregister();
         m_brushManipulator.reset();
 
@@ -165,42 +163,20 @@ namespace Terrain
     {
     }
 
-    void EditorTerrainMacroMaterialComponentMode::BeginUndoBatch()
-    {
-        AZ_Assert(m_undoBatch == nullptr, "Starting an undo batch while one is already active!");
-
-        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-            m_undoBatch, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::BeginUndoBatch, "PaintStroke");
-
-        m_paintBrushUndoBuffer = aznew PaintBrushUndoBuffer(GetEntityId());
-        m_paintBrushUndoBuffer->SetParent(m_undoBatch);
-    }
-
-    void EditorTerrainMacroMaterialComponentMode::EndUndoBatch()
-    {
-        if (m_undoBatch != nullptr)
-        {
-            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
-                &AzToolsFramework::ToolsApplicationRequests::Bus::Events::EndUndoBatch);
-            m_undoBatch = nullptr;
-            m_paintBrushUndoBuffer = nullptr;
-        }
-    }
-
     void EditorTerrainMacroMaterialComponentMode::OnTerrainMacroColorBrushStrokeBegin()
     {
-        BeginUndoBatch();
+        // nothing to do here, since no data changes when the stroke begins.
     }
 
     void EditorTerrainMacroMaterialComponentMode::OnTerrainMacroColorBrushStrokeEnd(
         AZStd::shared_ptr<ImageTileBuffer> changedDataBuffer, const AZ::Aabb& dirtyRegion)
     {
-        AZ_Assert(m_paintBrushUndoBuffer != nullptr, "Undo batch is expected to exist while painting");
+        AzToolsFramework::ScopedUndoBatch undoBatch("PaintStroke");
 
+        PaintBrushUndoBuffer* dataBuffer = aznew PaintBrushUndoBuffer(GetEntityId());
+        dataBuffer->SetParent(undoBatch.GetUndoBatch());
         // Hand over ownership of the paint stroke buffer to the undo/redo buffer.
-        m_paintBrushUndoBuffer->SetUndoBufferAndDirtyArea(changedDataBuffer, dirtyRegion);
-
-        EndUndoBatch();
+        dataBuffer->SetUndoBufferAndDirtyArea(changedDataBuffer, dirtyRegion);
     }
 
 } // namespace Terrain

--- a/Gems/Terrain/Code/Source/TerrainRenderer/EditorComponents/EditorTerrainMacroMaterialComponentMode.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/EditorComponents/EditorTerrainMacroMaterialComponentMode.h
@@ -45,16 +45,9 @@ namespace Terrain
         void OnTerrainMacroColorBrushStrokeEnd(
             AZStd::shared_ptr<ImageTileBuffer> changedDataBuffer, const AZ::Aabb& dirtyRegion) override;
 
-        void BeginUndoBatch();
-        void EndUndoBatch();
-
     private:
         //! The core paintbrush manipulator and painting logic.
         AZStd::shared_ptr<AzToolsFramework::PaintBrushManipulator> m_brushManipulator;
-
-        //! The undo information for the in-progress painting brush stroke.
-        AzToolsFramework::UndoSystem::URSequencePoint* m_undoBatch = nullptr;
-        PaintBrushUndoBuffer* m_paintBrushUndoBuffer = nullptr;
 
         //! The paint brush cluster that manages switching between paint/smooth/eyedropper modes
         AzToolsFramework::PaintBrushSubModeCluster m_subModeCluster;


### PR DESCRIPTION

## What does this PR do?

* (cleanup) Removes an unused Cry-only API related to "Super undos"
* (crash/corruption) Fixes an issue where undo would be leaked or kept open between frames, which can cause a crash if something asynchronous touches the data while the undo is open, like a slice / prefab update.
    * If this happens, suddenly the editor would no longer accept undo or redo or allow any changes in the inspector to save.
* Fixes the inspector not updating visually when you drag handles of shapes (and other manipulators) in the viewport.
* Fixes rendering flicker in the inspector when selecting between entities, where the labels would blank out / flash, flicker.
* Reduces over-refresh in the inspector by only refreshing the property editor guis when the underlying data has finished changing, rather than on every single patch change.
* The delayed UI refresh also fixes a crash issue, where the property editor would still be in the middle of applying patches, and the underlying data is half updated, while the UI is trying to read and update the gui based on that half-formed data.
* Fixed an issue where a property handler would be re-used but didn't clear out its previous proxy node state. This was causing a crash when you checked/unchecked the "USE LOD MATERIALS" checkbox on the material component.
* Hardened the undo system with extra warnings and checks for leaking undo scopes, etc.  And then fixed every instance in the code where it leaked.
* Validation message boxes are queued for the main thread rather than allowing the editor to tick in the middle of a property edit.

### Architectural Changes
* Scoped Undo Batch can now handle batch resumption.  There is even less reason to ever use a regular begin undo / end undo now, when scoped is safer.  It automatically cleans up when it goes out of scope.
* Refactored all meaningful uses of manual begin/end to use scoped undo batches.  There is a LOT less code in most cases, usually a lot of removed housekeeping.
* It is now required to send a "InProgressEdit" notification, and then a "FinishedEditing" notification in any property editor UI that modifies the values.  Just sending a "FinishedEditing" alone is not enough.   This allows optimization (undo and redo can be managed around InProgressEdit and does not have to be dealt with in "FinishedEditing".
* ElidingLabel significantly refactored to avoid over-invoking refresh and to do immediate refreshes when it needs to.  This is the primary reason flicker was reduced in the inspector when changing selection or rebuilding itself.
* Property Handlers for the DPE now split their "update the data" (SetValueFromDom) and "update the GUI" (RefreshUI) functions into two pieces.   This prevents crashes for example, when multiple DOM Changes are being processed, such as changing pointers, by deferring the UI update until all changes are complete.  It also improves the performance of the UI update.
* The Document Property Editor now queues invalidation instead of executes it immediately.  This prevents multiple invalidations for the same event.
* In debug mode, we have extra checks for when someone is using undo and redo to make sure that they haven't messed it up.

## How was this PR tested?

extensive manual testing - I checked the following controls/features
* Inspector
   * Tag components (container addition, removal, reordering)
   * Cube probe component (notably a problem one), drop downs
   * Invalid "validation" error message
   * Painting in the terrain system (macro and regular paint)
   * Mouse wheeling over properties, mouse dragging over properties, sliders
   * Adding / removing components
   * Overriding values
   * Adding overridden component
* Component Mode for shapes, moving handles around, etc.
* Script Canvas inspector
   * Viewing node properties, editing them
* Terrain Canvas inspector
   * Modifying properties, adding/removing nodes
* Asset Editor
   * Modifying, displaying properties, files, etc.
* Material Editor
   * Modifying, displaying properties, etc
* CVAR window

Note that where undo/redo was available in the above, I also performed undo and redo testing, such as setting a value, undoing, redoing, setting a value multiple times, undoing back and forth.

