### PR TITLE
Ctrl state lock in Viewport when saving fix.

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -413,15 +413,27 @@ void EditorActionsHandler::OnActionRegistrationHook()
                 // window holding keyboard focus, so editor shortcuts (e.g. Ctrl+Z) are not delivered until the
                 // user clicks back into the interface. Focusing the viewport both commits the edit and keeps
                 // keyboard focus inside the editor's shortcut scope.
+                //
+                // Only redirect focus when it is currently OUTSIDE the viewport. GetActiveViewport() returns the
+                // outer EditorViewportWidget, but keyboard input is owned by its child render viewport (the input
+                // mapper's source widget). If focus is already inside the viewport, moving it to the wrapper
+                // strands the in-flight modifier-key release (e.g. the Ctrl of Ctrl+S) on the wrong widget,
+                // leaving the viewport's Ctrl state latched on. There is also no field edit to commit in that case.
                 if (QWidget* focusWidget = QApplication::focusWidget())
                 {
-                    if (QtViewport* viewport = mainWindow ? mainWindow->GetActiveViewport() : nullptr)
+                    QtViewport* viewport = mainWindow ? mainWindow->GetActiveViewport() : nullptr;
+                    const bool focusInViewport =
+                        viewport && (focusWidget == viewport || viewport->isAncestorOf(focusWidget));
+                    if (!focusInViewport)
                     {
-                        viewport->setFocus(Qt::OtherFocusReason);
-                    }
-                    else
-                    {
-                        focusWidget->clearFocus();
+                        if (viewport)
+                        {
+                            viewport->setFocus(Qt::OtherFocusReason);
+                        }
+                        else
+                        {
+                            focusWidget->clearFocus();
+                        }
                     }
                 }
                 cryEdit->OnFileSave();


### PR DESCRIPTION
Fixing regression in: http://github.com/o3de/o3de/pull/19688

There was a focus guard to commit inspector changes before saving which landed on 'nothing' in the viewport, causing a focus change that failed to point back to the viewport. Half-interrupting the keypress despite successfully saving

Inspector change commits still work!

---

Tested as an issue in fresh dev branch. Tested as fixed afterwards.

Tested the inspector commit before saving, and it still works. Scoping seems to be resolved.