### PR TITLE
Modify the way import os, and remove useless return

### DIFF
--- a/Gems/Atom/RPI/Tools/atom_rpi_tools/utils.py
+++ b/Gems/Atom/RPI/Tools/atom_rpi_tools/utils.py
@@ -4,7 +4,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
-import os.path
+import os
 from os import path
 import shutil
 import json
@@ -15,7 +15,6 @@ def find_or_copy_file(destFilePath, sourceFilePath):
         return
     if not path.exists(sourceFilePath):
         raise ValueError('find_or_copy_file: source file [', sourceFilePath, '] doesn\'t exist')
-        return
     
     dstDir = path.dirname(destFilePath)
     if not path.isdir(dstDir):


### PR DESCRIPTION
## What does this PR do?

Modify the way import os, and remove useless return.

An confusing thing in Python:
You import os.path, and then you use the name os instead if os.path

I modified the way the util import os
And removed a really useless return statement right after a raise 

## How was this PR tested?

This time I didn't just use linter to check program. I ran the python -m build to build the util, and it succeeded. 
Below is the successful build output:

(o3de) PS D:\MyWorks\o3de\Gems\Atom\RPI\Tools> python -m build
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for sdist...
running egg_info
writing atom_rpi_tools.egg-info\PKG-INFO
writing dependency_links to atom_rpi_tools.egg-info\dependency_links.txt
writing top-level names to atom_rpi_tools.egg-info\top_level.txt
reading manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
writing manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
* Building sdist...
running sdist
running egg_info
writing atom_rpi_tools.egg-info\PKG-INFO
writing dependency_links to atom_rpi_tools.egg-info\dependency_links.txt
writing top-level names to atom_rpi_tools.egg-info\top_level.txt
reading manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
writing manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
running check
creating atom_rpi_tools-1.0.0
creating atom_rpi_tools-1.0.0\atom_rpi_tools.egg-info
copying files to atom_rpi_tools-1.0.0...
copying README.txt -> atom_rpi_tools-1.0.0
copying setup.py -> atom_rpi_tools-1.0.0
copying atom_rpi_tools.egg-info\PKG-INFO -> atom_rpi_tools-1.0.0\atom_rpi_tools.egg-info
copying atom_rpi_tools.egg-info\SOURCES.txt -> atom_rpi_tools-1.0.0\atom_rpi_tools.egg-info
copying atom_rpi_tools.egg-info\dependency_links.txt -> atom_rpi_tools-1.0.0\atom_rpi_tools.egg-info
copying atom_rpi_tools.egg-info\top_level.txt -> atom_rpi_tools-1.0.0\atom_rpi_tools.egg-info
copying atom_rpi_tools.egg-info\SOURCES.txt -> atom_rpi_tools-1.0.0\atom_rpi_tools.egg-info
Writing atom_rpi_tools-1.0.0\setup.cfg
Creating tar archive
removing 'atom_rpi_tools-1.0.0' (and everything under it)
* Building wheel from sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for wheel...
running egg_info
writing atom_rpi_tools.egg-info\PKG-INFO
writing dependency_links to atom_rpi_tools.egg-info\dependency_links.txt
writing top-level names to atom_rpi_tools.egg-info\top_level.txt
reading manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
writing manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
* Building wheel...
running bdist_wheel
running build
installing to build\bdist.win-amd64\wheel
running install
running install_egg_info
running egg_info
writing atom_rpi_tools.egg-info\PKG-INFO
writing dependency_links to atom_rpi_tools.egg-info\dependency_links.txt
writing top-level names to atom_rpi_tools.egg-info\top_level.txt
reading manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
writing manifest file 'atom_rpi_tools.egg-info\SOURCES.txt'
Copying atom_rpi_tools.egg-info to build\bdist.win-amd64\wheel\.\atom_rpi_tools-1.0.0-py3.10.egg-info
running install_scripts
creating build\bdist.win-amd64\wheel\atom_rpi_tools-1.0.0.dist-info\WHEEL
creating 'D:\\MyWorks\\o3de\\Gems\\Atom\\RPI\\Tools\\dist\\.tmp-v4yj5e20\\atom_rpi_tools-1.0.0-py3-none-any.whl' and adding 'build\\bdist.win-amd64\\wheel' to it
adding 'atom_rpi_tools-1.0.0.dist-info/METADATA'
adding 'atom_rpi_tools-1.0.0.dist-info/WHEEL'
adding 'atom_rpi_tools-1.0.0.dist-info/top_level.txt'
adding 'atom_rpi_tools-1.0.0.dist-info/RECORD'
removing build\bdist.win-amd64\wheel
Successfully built atom_rpi_tools-1.0.0.tar.gz and atom_rpi_tools-1.0.0-py3-none-any.whl
