### PR TITLE
Fixes the inspector not updating when ChangeNotify says they should

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/CrcSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/CrcSerializer.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/Math/Crc.h>
+#include <AzCore/Math/CrcSerializer.h>
+#include <AzCore/Serialization/Json/JsonSerialization.h>
+#include <AzCore/Serialization/Json/StackedString.h>
+#include <AzCore/std/algorithm.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+
+namespace AZ
+{
+    AZ_CLASS_ALLOCATOR_IMPL(JsonCrcSerializer, SystemAllocator);
+
+    JsonSerializationResult::Result JsonCrcSerializer::Load(void* outputValue, const Uuid& outputValueTypeId,
+        const rapidjson::Value& inputValue, JsonDeserializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult; // Used remove name conflicts in AzCore in uber builds.
+
+        AZ_Assert(azrtti_typeid<Crc32>() == outputValueTypeId,
+            "Unable to deserialize Crc to json because the provided type is %s",
+            outputValueTypeId.ToString<AZStd::string>().c_str());
+        AZ_UNUSED(outputValueTypeId);
+
+        Crc32* Crc = reinterpret_cast<Crc32*>(outputValue);
+        AZ_Assert(Crc, "Output value for JsonCrcSerializer can't be null.");
+
+        if (IsExplicitDefault(inputValue))
+        {
+            *Crc = Crc32();
+            return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::DefaultsUsed, "Crc32 value set to default of zero.");
+        }
+
+        switch (inputValue.GetType())
+        {
+        case rapidjson::kObjectType:
+            return LoadObject(*Crc, inputValue, context);
+        case rapidjson::kNumberType:
+            return LoadNumber(*Crc, inputValue, context);
+        case rapidjson::kNullType:
+            [[fallthrough]];
+        case rapidjson::kStringType:
+            [[fallthrough]];
+        case rapidjson::kFalseType:
+            [[fallthrough]];
+        case rapidjson::kArrayType:
+            [[fallthrough]];
+        case rapidjson::kTrueType:
+            return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::Unsupported,
+                "Unsupported type. Crc32s can only be read from numbers, or objects");
+        
+        default:
+            return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::Unknown,
+                "Unknown json type encountered in Crc.");
+        }
+    }
+
+    JsonSerializationResult::Result JsonCrcSerializer::Store(rapidjson::Value& outputValue, const void* inputValue, const void* defaultValue,
+        const Uuid& valueTypeId, JsonSerializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult; // Used remove name conflicts in AzCore in uber builds.
+
+        AZ_Assert(azrtti_typeid<Crc32>() == valueTypeId, "Unable to serialize Crc to json because the provided type is %s",
+            valueTypeId.ToString<AZStd::string>().c_str());
+        AZ_UNUSED(valueTypeId);
+
+        const Crc32* Crc = reinterpret_cast<const Crc32*>(inputValue);
+        AZ_Assert(Crc, "Input value for JsonCrcSerializer can't be null.");
+        const Crc32* defaultCrc = reinterpret_cast<const Crc32*>(defaultValue);
+
+        if (!context.ShouldKeepDefaults() && defaultCrc && *Crc == *defaultCrc)
+        {
+            return context.Report(JSR::Tasks::WriteValue, JSR::Outcomes::DefaultsUsed, "Default Crc32 used.");
+        }
+
+        outputValue.SetUint(Crc->GetValue());
+        return context.Report(JSR::Tasks::WriteValue, JSR::Outcomes::Success, "Crc32 successfully stored.");
+    }
+
+    auto JsonCrcSerializer::GetOperationsFlags() const -> OperationFlags
+    {
+        return OperationFlags::InitializeNewInstance;
+    }
+
+    JsonSerializationResult::Result JsonCrcSerializer::LoadObject(Crc32& output, const rapidjson::Value& inputValue, 
+        JsonDeserializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult; // Used remove name conflicts in AzCore in uber builds.
+
+        if (IsExplicitDefault(inputValue))
+        {
+            return context.Report(JSR::Tasks::ReadField, JSR::Outcomes::DefaultsUsed,
+                "Default value for Crc provided so no change was made.");
+        }
+
+        JSR::ResultCode result = JSR::ResultCode(JSR::Tasks::ReadField, JSR::Outcomes::Unsupported);
+        auto idMember = inputValue.FindMember("Value");
+        if (idMember != inputValue.MemberEnd())
+        {
+            if (idMember->value.IsNumber())
+            {
+                result = LoadNumber(output, idMember->value, context);
+            }
+        }
+        return context.Report(result, result.GetProcessing() != JSR::Processing::Halted ?
+            "Successfully read Crc." : "Problem encountered while reading Crc.");
+    }
+
+    JsonSerializationResult::Result JsonCrcSerializer::LoadNumber(Crc32& output, const rapidjson::Value& inputValue, JsonDeserializerContext& context)
+    {
+        namespace JSR = JsonSerializationResult; // Used remove name conflicts in AzCore in uber builds.
+        
+        JSR::ResultCode result(JSR::Tasks::ReadField);
+        AZ::u32 crcValue = 0;
+        result.Combine(ContinueLoading(&crcValue, azrtti_typeid<AZ::u32>(), inputValue, context));
+        output = AZ::Crc32(crcValue);
+
+        return context.Report(
+                result,
+                result.GetProcessing() != JSR::Processing::Halted ? "Successfully loaded data AZ::Crc32."
+                       : "Failed to load data into AZ::Crc32.");
+    }
+}

--- a/Code/Framework/AzCore/AzCore/Math/CrcSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Math/CrcSerializer.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
+namespace AZ
+{
+    class Crc32;
+
+    class AZCORE_API JsonCrcSerializer
+        : public BaseJsonSerializer
+    {
+    public:
+        AZ_RTTI(JsonCrcSerializer, "{31480ADE-2EA3-407D-8E04-920EA20AACB4}", BaseJsonSerializer);
+        AZ_CLASS_ALLOCATOR_DECL;
+        JsonSerializationResult::Result Load(void* outputValue, const Uuid& outputValueTypeId, const rapidjson::Value& inputValue,
+            JsonDeserializerContext& context) override;
+        JsonSerializationResult::Result Store(rapidjson::Value& outputValue, const void* inputValue, const void* defaultValue,
+            const Uuid& valueTypeId, JsonSerializerContext& context) override;
+
+        OperationFlags GetOperationsFlags() const override;
+
+    private:
+        JsonSerializationResult::Result LoadObject(Crc32& output, const rapidjson::Value& inputValue, JsonDeserializerContext& context);
+        JsonSerializationResult::Result LoadNumber(Crc32& output, const rapidjson::Value& inputValue, JsonDeserializerContext& context);
+    };
+}

--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/Math/VectorN.h>
 #include <AzCore/Math/MathMatrixSerializer.h>
 #include <AzCore/Math/MathVectorSerializer.h>
+#include <AzCore/Math/CrcSerializer.h>
 #include <AzCore/Math/Color.h>
 #include <AzCore/Math/ColorGradient.h>
 #include <AzCore/Math/ColorSerializer.h>
@@ -352,6 +353,7 @@ namespace AZ
 
     void MathReflect(JsonRegistrationContext& context)
     {
+        context.Serializer<JsonCrcSerializer>()->HandlesType<Crc32>();
         context.Serializer<JsonColorSerializer>()->HandlesType<Color>();
         context.Serializer<JsonUuidSerializer>()->HandlesType<Uuid>();
         context.Serializer<JsonMatrix3x3Serializer>()->HandlesType<Matrix3x3>();

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -296,6 +296,8 @@ set(FILES
     Math/Crc.inl
     Math/Crc.h
     Math/CrcInternal.h
+    Math/CrcSerializer.h
+    Math/CrcSerializer.cpp
     Math/DocsMath.h
     Math/Frustum.cpp
     Math/Frustum.h

--- a/Code/Framework/AzCore/Tests/Serialization/Json/CrcSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/CrcSerializerTests.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Math/CrcSerializer.h>
+#include <Tests/Serialization/Json/BaseJsonSerializerFixture.h>
+#include <Tests/Serialization/Json/JsonSerializerConformityTests.h>
+
+namespace JsonSerializationTests
+{
+    class CrcSerializerTestDescription :
+        public JsonSerializerConformityTestDescriptor<AZ::Crc32>
+    {
+    public:
+        AZStd::shared_ptr<AZ::BaseJsonSerializer> CreateSerializer() override
+        {
+            return AZStd::make_shared<AZ::JsonCrcSerializer>();
+        }
+
+        AZStd::shared_ptr<AZ::Crc32> CreateDefaultInstance() override
+        {
+            return AZStd::make_shared<AZ::Crc32>();
+        }
+
+        AZStd::shared_ptr<AZ::Crc32> CreateFullySetInstance() override
+        {
+            return AZStd::make_shared<AZ::Crc32>(12345678);
+        }
+
+        AZStd::string_view GetJsonForFullySetInstance() override
+        {
+            return "12345678";
+        }
+
+        void ConfigureFeatures(JsonSerializerConformityTestDescriptorFeatures& features) override
+        {
+            features.EnableJsonType(rapidjson::kNumberType);
+            features.EnableJsonType(rapidjson::kObjectType);
+            features.m_supportsPartialInitialization = false;
+            features.m_supportsInjection = false;
+        }
+
+        bool AreEqual(const AZ::Crc32& lhs, const AZ::Crc32& rhs) override
+        {
+            return lhs == rhs;
+        }
+    };
+
+    using CrcSerializerConformityTestTypes = ::testing::Types<CrcSerializerTestDescription>;
+    IF_JSON_CONFORMITY_ENABLED(INSTANTIATE_TYPED_TEST_SUITE_P(JsonCrcSerializer, JsonSerializerConformityTests, CrcSerializerConformityTestTypes));
+
+    class JsonCrcSerializerTests
+        : public BaseJsonSerializerFixture
+    {
+    public:
+        void SetUp() override
+        {
+            BaseJsonSerializerFixture::SetUp();
+            m_CrcSerializer = AZStd::make_unique<AZ::JsonCrcSerializer>();
+        }
+
+        void TearDown() override
+        {
+            m_CrcSerializer.reset();
+            BaseJsonSerializerFixture::TearDown();
+        }
+
+        void Load(rapidjson::Value& testVal, const AZ::Crc32& expectedCrc, AZ::JsonSerializationResult::Outcomes expectedOutcome)
+        {
+            using namespace AZ::JsonSerializationResult;
+
+            AZ::Crc32 testCrc = AZ::Crc32();
+            ResultCode result = m_CrcSerializer->Load(&testCrc, azrtti_typeid<AZ::Crc32>(), testVal, *m_jsonDeserializationContext);
+            EXPECT_EQ(expectedOutcome, result.GetOutcome());
+            if (expectedOutcome == AZ::JsonSerializationResult::Outcomes::Success)
+            {
+                EXPECT_EQ(testCrc, expectedCrc);
+            }
+            else
+            {
+                EXPECT_NE(testCrc, expectedCrc);
+            }
+        }
+
+    protected:
+        AZStd::unique_ptr<AZ::JsonCrcSerializer> m_CrcSerializer;
+    };
+
+    TEST_F(JsonCrcSerializerTests, Load_u32Value_ReturnsSuccess)
+    {
+        rapidjson::Document jsonDocument;
+        jsonDocument.SetUint(64);
+
+        Load(jsonDocument.SetUint(64), AZ::Crc32(64), AZ::JsonSerializationResult::Outcomes::Success);
+        Load(jsonDocument.SetUint(0xFFFFFFFF), AZ::Crc32(0xFFFFFFFF), AZ::JsonSerializationResult::Outcomes::Success);
+    }
+
+    TEST_F(JsonCrcSerializerTests, Load_Object_ValidValue_ReturnsSuccess)
+    {
+        rapidjson::Document jsonDocument;
+        jsonDocument.SetObject();
+        jsonDocument.AddMember("Value", 0x12345678, jsonDocument.GetAllocator());
+        Load(jsonDocument, AZ::Crc32(0x12345678), AZ::JsonSerializationResult::Outcomes::Success);
+    }
+
+    TEST_F(JsonCrcSerializerTests, Load_EmptyString_ReturnsUnsupportedAndValueIsUnchanged)
+    {
+        rapidjson::Document jsonDocument;
+        jsonDocument.SetString("");
+        Load(jsonDocument, AZ::Crc32(123), AZ::JsonSerializationResult::Outcomes::Unsupported);
+    }
+} // namespace JsonSerializationTests

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -197,6 +197,7 @@ set(FILES
     Serialization/Json/BoolSerializerTests.cpp
     Serialization/Json/ByteStreamSerializerTests.cpp
     Serialization/Json/ColorSerializerTests.cpp
+    Serialization/Json/CrcSerializerTests.cpp
     Serialization/Json/DoubleSerializerTests.cpp
     Serialization/Json/IntSerializerTests.cpp
     Serialization/Json/JsonRegistrationContextTests.cpp

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -10,6 +10,7 @@
 
 #include <AzFramework/DocumentPropertyEditor/DocumentSchema.h>
 #include <AzFramework/AzFrameworkAPI.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
 
 namespace AZ::DocumentPropertyEditor
 {
@@ -84,14 +85,18 @@ namespace AZ::DocumentPropertyEditor::Nodes
 
     //! PropertyRefreshLevel: Determines the amount of a property tree that needs to be rebuilt
     //! based on a change to a reflected property.
-    enum class PropertyRefreshLevel : AZ::u32
+    using PropertyRefreshLevel = AZ::Crc32;
+    namespace PropertyRefreshLevels
     {
+        using namespace AZ::Edit::PropertyRefreshLevels;
+    };
+    /*{
         Undefined = 0,
         None = static_cast<AZ::u32>(AZ_CRC_CE("RefreshNone")),
         ValuesOnly = static_cast<AZ::u32>(AZ_CRC_CE("RefreshValues")),
         AttributesAndValues = static_cast<AZ::u32>(AZ_CRC_CE("RefreshAttributesAndValues")),
         EntireTree = static_cast<AZ::u32>(AZ_CRC_CE("RefreshEntireTree")),
-    };
+    }*/
 
     //! Label: A textual label that shall render its contents as part of a Row.
     struct AZF_API Label : NodeWithVisiblityControl

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -90,13 +90,6 @@ namespace AZ::DocumentPropertyEditor::Nodes
     {
         using namespace AZ::Edit::PropertyRefreshLevels;
     };
-    /*{
-        Undefined = 0,
-        None = static_cast<AZ::u32>(AZ_CRC_CE("RefreshNone")),
-        ValuesOnly = static_cast<AZ::u32>(AZ_CRC_CE("RefreshValues")),
-        AttributesAndValues = static_cast<AZ::u32>(AZ_CRC_CE("RefreshAttributesAndValues")),
-        EntireTree = static_cast<AZ::u32>(AZ_CRC_CE("RefreshEntireTree")),
-    }*/
 
     //! Label: A textual label that shall render its contents as part of a Row.
     struct AZF_API Label : NodeWithVisiblityControl

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -1309,14 +1309,13 @@ namespace AZ::DocumentPropertyEditor
     {
         using Nodes::PropertyEditor;
         using Nodes::PropertyRefreshLevel;
-
         // Trigger ChangeNotify
         auto changeNotify = PropertyEditor::ChangeNotify.InvokeOnDomNode(domNode);
         if (changeNotify.IsSuccess())
         {
             // If we were told to issue a property refresh, notify our adapter via RequestTreeUpdate
             PropertyRefreshLevel level = changeNotify.GetValue();
-            if (level != PropertyRefreshLevel::Undefined && level != PropertyRefreshLevel::None)
+            if (level != Nodes::PropertyRefreshLevels::None)
             {
                 PropertyEditor::RequestTreeUpdate.InvokeOnDomNode(domNode, level);
             }


### PR DESCRIPTION
## What does this PR do?

One of the identified qt6 regressions in #19855 is that the inspector doesn't refresh when it should.

Cherry-picking this would depend also on https://github.com/o3de/o3de/pull/19895

I don't think this is an actual regression from qt6, its probably been around for much longer.

Basically, when the DPE invokes one of these attribute handlers, the resulting type can either be a function call or a literal value.

If its a function call, it invokes the function and coerces the return type.
If its a literal value, it uses the JSON serializer to write/read the result returned into the DOM.  

The problem is that the underlying type of this particular attribute (on the reflection side) is AZ::Crc32, not AZ::u32, and it was trying to read it into an `enum class PropertyRefreshLevel : u32` which is a completely unrelated type (a u32).

The u32 serializer is  given the following json:
```json
{
   "Value" : 4123123
}
```
which is the JSON encoding of an Az::Crc32.  

We can't really change u32 serialize to also accept this wonky format, as its a native type in rapidjson.

But we *can* make a custom AZ::Crc32 serializer that accepts a u32 in addition to the above.

The fix is to change it so that the **expected** type of this attribute in DocumentPropertyEditor matches the actual type of attribute from AZ::Serialize (which is AZ::Crc32) and then make a custom Json Crc Serializer that can *also* accept u32 naked values, in the case where the attribute is bound to a function that returns u32 instead of AZ::Crc32.

## How was this PR tested?

The camera component has a ChangeNotify on its "orthographic mode" checkbox that illustrates this problem
Fixing this makes it work as intended, the field updates.

In addition, I tried with the cubemap probe baker (adds/removes a button) as well as the diffuse probe selector.

In addition, I tested with the Transform Component "Static" checkbox, which returns a u32 value, instead of an AZ::Crc32 value.  In all cases, the DOM receives the appropriate value.
