### PR TITLE
Additional performance improvements and fixes for Inspector

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -55,6 +55,11 @@ namespace AZ::DocumentPropertyEditor
         handler.Connect(m_resetEvent);
     }
 
+    void DocumentAdapter::ConnectResetQueuedHandler(ResetQueuedEvent::Handler& handler)
+    {
+        handler.Connect(m_resetQueuedEvent);
+    }
+
     void DocumentAdapter::ConnectChangedHandler(ChangedEvent::Handler& handler)
     {
         handler.Connect(m_changedEvent);
@@ -104,13 +109,34 @@ namespace AZ::DocumentPropertyEditor
 
     void DocumentAdapter::QueueResetDocument(DocumentResetType resetType)
     {
-        // Implementation for queuing a reset document operation
+        // This document needs to refresh itself and may no longer match the underlying data, for example if an outside change has occurred.
+        // It should queue up a reset event, but wait for the views attached to execute it so that it doesn't happen deep in the middle
+        // of some complex callstack.
+
+        // Upgrade the reset type to HardReset in case its already queued as a soft reset.
         m_queuedResetType = m_queuedResetType == DocumentResetType::HardReset ? DocumentResetType::HardReset : resetType;
-        m_isResetQueued = true;
+
+        // De-bounce the reset event.
+        if (!m_isResetQueued)
+        {
+            m_isResetQueued = true;
+            NotifyResetQueued();
+        }
+    }
+
+    void DocumentAdapter::NotifyResetQueued()
+    {
+        // This happens both in the above case (where we are the originator) but also when there is some sort of proxy / meta adapter.
+        // The Document Property Editor (GUI) may have its source adapter set to a filter/proxy/meta adapter.
+        // The filtered adapter may be a proxy on top of the "Real adapter".  There are two Adapters involved, the "underlying" real one
+        // and a filter.  The GUI is watching the filtered one, the filtered one watching the underlying one.
+        // This means that for the document to get these kind of events, the filtered adapter needs to pass any events relevant up the chain
+        m_resetQueuedEvent.Signal();
     }
 
     void DocumentAdapter::ExecuteQueuedReset()
     {
+        // Called by the view when its a good time to execute the queued reset, like when the callstack is short and simple.
         if (m_isResetQueued)
         {
             NotifyResetDocument(m_queuedResetType);
@@ -121,7 +147,6 @@ namespace AZ::DocumentPropertyEditor
     {
         // this is the actual reset function, which overrides any queuing, so reset it.
         m_isResetQueued = false;
-        m_queuedResetType = DocumentResetType::SoftReset;
 
         if (resetType == DocumentResetType::HardReset || m_cachedContents.IsNull())
         {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
@@ -112,6 +112,7 @@ namespace AZ::DocumentPropertyEditor
     public:
         AZ_RTTI(DocumentAdapter, "{8CEFE485-45C2-4ECC-B9D1-BBE75C7B02AB}");
 
+        using ResetQueuedEvent = Event<>;
         using ResetEvent = Event<>;
         using ChangedEvent = Event<const Dom::Patch&>;
         using MessageEvent = Event<const AdapterMessage&, Dom::Value&>;
@@ -128,7 +129,12 @@ namespace AZ::DocumentPropertyEditor
         //! Connects a listener for the reset event, fired when the contents of this adapter have completely changed.
         //! Any views listening to this adapter will need to call GetContents to retrieve the new contents of the adapter.
         void ConnectResetHandler(ResetEvent::Handler& handler);
-        //! Connects a listener for the changed event, fired when the contents of the adapter have changed.
+        //! Connects a listener for when the data in this adapter is dirty and requires a reset to be executed.
+        //! Views listening to this adapter will need to call ExecuteQueuedReset to start the process, and will get
+        //! either ChangedEvent or ResetEvent notifications when the reset processes.  Ideally that call should come
+        //! from as simple of a call stack as possible (ie, not deep inside rendering, responding to ui callbacks, etc).
+        void ConnectResetQueuedHandler(ResetQueuedEvent::Handler& handler);
+         //! Connects a listener for the changed event, fired when the contents of the adapter have changed.
         //! The provided patch contains all the changes provided (i.e. it shall apply cleanly on top of the last
         //! GetContents() result).
         void ConnectChangedHandler(ChangedEvent::Handler& handler);
@@ -149,7 +155,8 @@ namespace AZ::DocumentPropertyEditor
         //! registered CallbackAttributes.
         Dom::Value SendAdapterMessage(const AdapterMessage& message);
         
-        //! Subclasses can call this to execute any queued reset operations, if any are present.
+        //! The document view using this adapter will call this to actually execute any queued reset operations, if any are present.
+        //! Do so on a clean callstack, not during change or UI rebuild operations.
         virtual void ExecuteQueuedReset();
 
         //! If true, debug mode is enabled for all DocumentAdapters.
@@ -197,6 +204,9 @@ namespace AZ::DocumentPropertyEditor
         //! Where possible, prefer to use NotifyContentsChanged instead.
         void NotifyResetDocument(DocumentResetType resetType = DocumentResetType::SoftReset);
 
+        //! Subclasses that are proxying should call this to forward the event up to the view.
+        void NotifyResetQueued();
+
         //! Subclasses may call this to enqueue a NotifyResetDocument to be executed later when the current call stack unwinds.
         //! Subclasses should call this one in most cases, except when a true clear is required such as when all data is instantly
         //! invalid (during a quit / complete reload).
@@ -209,8 +219,10 @@ namespace AZ::DocumentPropertyEditor
         //! Subclasses may call this to notify the view that this adapter's content has been filtered
         void NotifyFilterChanged(const AZStd::string& filter);
 
+
     private:
         ResetEvent m_resetEvent;
+        ResetQueuedEvent m_resetQueuedEvent;
         ChangedEvent m_changedEvent;
         MessageEvent m_messageEvent;
         FilterEvent m_filterEvent;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.cpp
@@ -21,6 +21,14 @@ namespace AZ::DocumentPropertyEditor
             });
         m_sourceAdapter->ConnectResetHandler(m_resetHandler);
 
+        m_resetQueuedHandler = DocumentAdapter::ResetQueuedEvent::Handler(
+            [this]()
+            {
+                // forward this up the chain so that any views above us know that this has happened. 
+                NotifyResetQueued();
+            });
+        m_sourceAdapter->ConnectResetQueuedHandler(m_resetQueuedHandler);
+
         m_changedHandler = DocumentAdapter::ChangedEvent::Handler(
             [this](const Dom::Patch& patch)
             {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.h
@@ -42,6 +42,7 @@ namespace AZ::DocumentPropertyEditor
         Dom::Path GetRowPath(const Dom::Path& sourcePath) const;
 
         DocumentAdapter::ResetEvent::Handler m_resetHandler;
+        DocumentAdapter::ResetQueuedEvent::Handler m_resetQueuedHandler;
         ChangedEvent::Handler m_changedHandler;
         MessageEvent::Handler m_domMessageHandler;
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.cpp
@@ -126,6 +126,28 @@ namespace AzQtComponents
         StyleManager::styleSheetStyle(widget)->polish(widget);
     }
 
+    bool StyleManager::setObjectProperty(QWidget* widget, const char* propertyName, const QVariant& value)
+    {
+        if (!widget)
+        {
+            return false;
+        }
+
+        if (!propertyName)
+        {
+            return false;
+        }
+
+        if (widget->property(propertyName) == value)
+        {
+            return false;
+        }
+
+        widget->setProperty(propertyName, value);
+        return true;
+    }
+
+
     StyleManager::StyleManager(QObject* parent)
         : QObject(parent)
         , m_stylesheetPreprocessor(new StylesheetPreprocessor(this))

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StyleManager.h
@@ -12,7 +12,6 @@
 #include <AzCore/IO/Path/Path_fwd.h>
 
 #include <QObject>
-#include <QColor>
 #include <QHash>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'AzQtComponents::StyleManager::m_widgetToStyleSheetMap': class 'QHash<QWidget *,QString>' needs to have dll-interface to be used by clients of class 'AzQtComponents::StyleManager'
 #include <QPointer>
@@ -21,6 +20,7 @@ AZ_POP_DISABLE_WARNING
 class QApplication;
 class QStyle;
 class QWidget;
+class QColor;
 
 namespace AzQtComponents
 {
@@ -65,6 +65,9 @@ namespace AzQtComponents
         static QStyle* baseStyle(const QWidget* widget);
 
         static void repolishStyleSheet(QWidget* widget);
+
+        //! Utility - set an object property, and return true if it changed.
+        static bool setObjectProperty(QWidget* widget, const char* propertyName, const QVariant& value);
 
         explicit StyleManager(QObject* parent);
         ~StyleManager() override;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ComboBox.cpp
@@ -144,9 +144,16 @@ namespace AzQtComponents
 
                     case QEvent::DynamicPropertyChange:
                     {
-                        auto styleSheet = StyleManager::styleSheetStyle(cbWidget);
-                        styleSheet->unpolish(cbWidget);
-                        styleSheet->polish(cbWidget);
+                        // ignore properties coming from inside the style sheet system itself, which are all by convention
+                        // prefixed with _q_
+                        QDynamicPropertyChangeEvent* eventFull = static_cast<QDynamicPropertyChangeEvent*>(event);
+                        QString propertyName = QString::fromUtf8(eventFull->propertyName());
+                        if (!propertyName.startsWith(QStringLiteral("_q_")))
+                        {
+                            auto styleSheet = StyleManager::styleSheetStyle(cbWidget);
+                            styleSheet->unpolish(cbWidget);
+                            styleSheet->polish(cbWidget);
+                        }
                     }
                     break;
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/LineEdit.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/LineEdit.cpp
@@ -8,6 +8,7 @@
 
 #include <AzQtComponents/Components/Widgets/LineEdit.h>
 #include <AzQtComponents/Components/Style.h>
+#include <AzQtComponents/Components/StyleManager.h>
 #include <AzQtComponents/Components/ConfigHelpers.h>
 
 #include <QLineEdit>
@@ -499,16 +500,20 @@ namespace AzQtComponents
 
     void LineEdit::setExternalError(QLineEdit* lineEdit, bool hasExternalError)
     {
-        lineEdit->setProperty(HasExternalError, hasExternalError);
-        lineEdit->style()->unpolish(lineEdit);
-        lineEdit->style()->polish(lineEdit);
+        if (AzQtComponents::StyleManager::setObjectProperty(lineEdit, HasExternalError, hasExternalError))
+        {
+            lineEdit->style()->unpolish(lineEdit);
+            lineEdit->style()->polish(lineEdit);
+        }
     }
 
     void LineEdit::setErrorIconEnabled(QLineEdit* lineEdit, bool enabled)
     {
-        lineEdit->setProperty(ErrorIconEnabled, enabled);
-        lineEdit->style()->unpolish(lineEdit);
-        lineEdit->style()->polish(lineEdit);
+        if (AzQtComponents::StyleManager::setObjectProperty(lineEdit, ErrorIconEnabled, enabled))
+        {
+            lineEdit->style()->unpolish(lineEdit);
+            lineEdit->style()->polish(lineEdit);
+        }
     }
 
     bool LineEdit::errorIconEnabled(QLineEdit* lineEdit)

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ScrollBar.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ScrollBar.cpp
@@ -165,10 +165,17 @@ namespace AzQtComponents
                 {
                     case QEvent::DynamicPropertyChange:
                     {
-                        if (auto styleSheet = StyleManager::styleSheetStyle(cornerWidget))
+                        // ignore properties coming from inside the style sheet system itself, which are all by convention
+                        // prefixed with _q_
+                        QDynamicPropertyChangeEvent* eventFull = static_cast<QDynamicPropertyChangeEvent*>(event);
+                        QString propertyName = QString::fromUtf8(eventFull->propertyName());
+                        if (!propertyName.startsWith(QStringLiteral("_q_")))
                         {
-                            styleSheet->unpolish(cornerWidget);
-                            styleSheet->polish(cornerWidget);
+                            if (auto styleSheet = StyleManager::styleSheetStyle(cornerWidget))
+                            {
+                                styleSheet->unpolish(cornerWidget);
+                                styleSheet->polish(cornerWidget);
+                            }
                         }
                     }
                     break;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
@@ -526,9 +526,16 @@ bool SpinBoxWatcher::filterSpinBoxEvents(QAbstractSpinBox* spinBox, QEvent* even
 
         case QEvent::DynamicPropertyChange:
         {
-            auto styleSheet = StyleManager::styleSheetStyle(spinBox);
-            styleSheet->unpolish(spinBox);
-            styleSheet->polish(spinBox);
+            // ignore properties coming from inside the style sheet system itself, which are all by convention
+            // prefixed with _q_
+            QDynamicPropertyChangeEvent* eventFull = static_cast<QDynamicPropertyChangeEvent*>(event);
+            QString propertyName = QString::fromUtf8(eventFull->propertyName());
+            if (!propertyName.startsWith(QStringLiteral("_q_")))
+            {
+                auto styleSheet = StyleManager::styleSheetStyle(spinBox);
+                styleSheet->unpolish(spinBox);
+                styleSheet->polish(spinBox);
+            }
             break;
         }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TreeView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TreeView.cpp
@@ -40,14 +40,21 @@ namespace AzQtComponents
                 {
                     case QEvent::DynamicPropertyChange:
                     {
-                        auto widget = qobject_cast<QWidget*>(obj);
-                        auto styleSheet = StyleManager::styleSheetStyle(widget);
-                        if (styleSheet)
+                        // ignore properties coming from inside the style sheet system itself, which are all by convention
+                        // prefixed with _q_
+                        QDynamicPropertyChangeEvent* eventFull = static_cast<QDynamicPropertyChangeEvent*>(event);
+                        QString propertyName = QString::fromUtf8(eventFull->propertyName());
+                        if (!propertyName.startsWith(QStringLiteral("_q_")))
                         {
-                            styleSheet->unpolish(widget);
-                            styleSheet->polish(widget);
+                            auto widget = qobject_cast<QWidget*>(obj);
+                            auto styleSheet = StyleManager::styleSheetStyle(widget);
+                            if (styleSheet)
+                            {
+                                styleSheet->unpolish(widget);
+                                styleSheet->polish(widget);
+                            }
+                            widget->update();
                         }
-                        widget->update();
                         break;
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabOverrideLabelHandler.h>
+#include <AzQtComponents/Components/StyleManager.h>
 
 namespace AzToolsFramework::Prefab
 {
@@ -62,9 +63,10 @@ namespace AzToolsFramework::Prefab
         AZStd::string_view labelText = PrefabOverrideLabel::Value.ExtractFromDomNode(m_node).value_or("");
         m_textLabel->setText(QString::fromUtf8(labelText.data(), aznumeric_cast<int>(labelText.size())));
 
-        m_textLabel->setProperty(OverriddenPropertyName, QVariant(m_overridden));
-        m_textLabel->RefreshStyle();
-
+        if (AzQtComponents::StyleManager::setObjectProperty(m_textLabel, OverriddenPropertyName, m_overridden))
+        {
+            m_textLabel->RefreshStyle();
+        }
         // Set up icon
         m_iconButton->setIcon(m_overridden ? *m_overrideIcon : *m_emptyIcon);
         m_iconButton->setIconSize(kIconSize);
@@ -73,9 +75,9 @@ namespace AzToolsFramework::Prefab
 
     bool PrefabOverrideLabelHandler::ResetToDefaults()
     {
+        // avoid setting properties related to styling, we'll do that in refreshUI
         m_overridden = false;
-        m_textLabel->setText(QString());
-        m_textLabel->setProperty(OverriddenPropertyName, false);
+        m_textLabel->setText(QString()); 
         m_iconButton->setIcon(*m_emptyIcon);
         m_iconButton->setIconSize(kIconSize);
         m_node = AZ::Dom::Value();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -1347,6 +1347,13 @@ namespace AzToolsFramework
             });
         m_adapter->ConnectResetHandler(m_resetHandler);
 
+        m_resetQueuedHandler = AZ::DocumentPropertyEditor::DocumentAdapter::ResetQueuedEvent::Handler(
+            [this]()
+            {
+                this->RequestExecuteQueuedReset();
+            });
+        m_adapter->ConnectResetQueuedHandler(m_resetQueuedHandler);
+
         m_changedHandler = AZ::DocumentPropertyEditor::DocumentAdapter::ChangedEvent::Handler(
             [this](const AZ::Dom::Patch& patch)
             {
@@ -1551,15 +1558,6 @@ namespace AzToolsFramework
             applyFilterRecursively(m_rootNode, applyFilterRecursively);
             update(); // Need to redraw for the linting to be applied
         }
-    }
-
-    // this happens when something *outside* of the control of the DPE has changed the underlying data.
-    // for example, clicking a manipulator in the viewport and changing it.  Since the change
-    // does not originate anywhere in the DPE's domain, it cannot know that the value has changed and that the
-    // tree needs to be refreshed, except by listening for this event which is spontaneous.
-    void DocumentPropertyEditor::QueueInvalidation([[maybe_unused]] PropertyModificationRefreshLevel level)
-    {
-        RequestExecuteQueuedReset();
     }
 
     void DocumentPropertyEditor::SetSavedExpanderStateForRow(const AZ::Dom::Path& rowPath, bool isExpanded)
@@ -1901,18 +1899,11 @@ namespace AzToolsFramework
             }
         };
 
-        auto handlePropertyEditorChanged = [&](const AZ::Dom::Value&, AZ::DocumentPropertyEditor::Nodes::ValueChangeType)
-        {
-            RequestExecuteQueuedReset();
-        };
-
         message.Match(
             AZ::DocumentPropertyEditor::Nodes::Adapter::QueryKey,
             showKeyQueryDialog,
             AZ::DocumentPropertyEditor::Nodes::Adapter::QuerySubclass,
-            showQuerySubclassDialog,
-            AZ::DocumentPropertyEditor::Nodes::PropertyEditor::OnChanged,
-            handlePropertyEditorChanged);
+            showQuerySubclassDialog);
     }
 
     void DocumentPropertyEditor::RequestExecuteQueuedReset()
@@ -1923,15 +1914,15 @@ namespace AzToolsFramework
         }
 
         m_executeQueuedResetAlreadyQueued = true;
+
         // When a value changes, we'd like to queue the execution of any property editor tree updates.
-        QTimer::singleShot(
-            1,  // 1 to place it AFTER all other 0 timer or queued events.
-            this,
-            [this]()
-            {
-                m_executeQueuedResetAlreadyQueued = false;
-                m_adapter->ExecuteQueuedReset();
-            });
+        // It should happen *soon* but not immediately, so queue it on the invoke method queue to happen
+        // once the event pump resumes.
+        QMetaObject::invokeMethod(this, [this]() {
+            m_executeQueuedResetAlreadyQueued = false;
+            m_adapter->ExecuteQueuedReset();
+            },
+            Qt::QueuedConnection);
     }
 
     void DocumentPropertyEditor::RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -231,7 +231,6 @@ namespace AzToolsFramework
         void SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName = {}) override;
         void ClearInstances() override;
         void SetFilterString(AZStd::string str) override; // Only used for linting, filtering is handled by the DocumentAdapter
-        void QueueInvalidation(PropertyModificationRefreshLevel level) override;
         // ~IPropertyEditor overrides
 
         AZ::Dom::Value GetDomValueForRow(DPERowWidget* row) const;
@@ -303,6 +302,7 @@ namespace AzToolsFramework
 
         AZ::DocumentPropertyEditor::DocumentAdapterPtr m_adapter;
         AZ::DocumentPropertyEditor::DocumentAdapter::ResetEvent::Handler m_resetHandler;
+        AZ::DocumentPropertyEditor::DocumentAdapter::ResetQueuedEvent::Handler m_resetQueuedHandler;
         AZ::DocumentPropertyEditor::DocumentAdapter::ChangedEvent::Handler m_changedHandler;
         AZ::DocumentPropertyEditor::DocumentAdapter::MessageEvent::Handler m_domMessageHandler;
         AZ::DocumentPropertyEditor::DocumentAdapter::FilterEvent::Handler m_filterHandler;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h
@@ -208,24 +208,17 @@ namespace AzToolsFramework
 
         ~RpePropertyHandlerWrapper()
         {
+            IndividualPropertyHandlerEditNotifications::Bus::Handler::BusDisconnect();
+
             if (m_widget)
             {
-                // Detect whether this is being run in the Editor or during a Unit Test.
-                AZ::ApplicationTypeQuery appType;
-                AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
-                if (appType.IsValid() && !appType.IsEditor())
-                {
-                    // In Unit Tests, immediately delete the widget to prevent triggering the leak detection mechanism.
-                    delete m_widget;
-                    m_widget = nullptr;
-                }
-                else
-                {
-                    // In the Editor, use deleteLater as it is more stable.
-                    m_widget->deleteLater();
-                }
+                // Its tempting to call deleteLater here, but the case where a handler is destroyed is
+                // when the DPE is either itself being destroyed, or, the DPE is re-pooling all of its handlers
+                // and this is a handler that cannot be pooled.  In that case, we don't want any widgets
+                // sitting around as hidden children for any amount of time, as the style manager will iterate over them
+                // and try to apply styles to them, which is a super heavy slow down.
+                delete m_widget;
             }
-            IndividualPropertyHandlerEditNotifications::Bus::Handler::BusDisconnect();
         }
 
         QWidget* GetWidget() override

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -466,7 +466,7 @@ namespace AzToolsFramework
 
     void PropertyRowWidget::SetOverridden(bool overridden)
     {
-        if(AzQtComponents::StyleManager::setObjectProperty(this, "IsOverridden", overridden))
+        if (AzQtComponents::StyleManager::setObjectProperty(this, "IsOverridden", overridden))
         {
             RefreshStyle();
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyRowWidget.cpp
@@ -466,10 +466,8 @@ namespace AzToolsFramework
 
     void PropertyRowWidget::SetOverridden(bool overridden)
     {
-        bool currentOverrideValue = property("IsOverridden").toBool();
-        if (currentOverrideValue != overridden)
+        if(AzQtComponents::StyleManager::setObjectProperty(this, "IsOverridden", overridden))
         {
-            setProperty("IsOverridden", overridden);
             RefreshStyle();
         }
     }

--- a/Code/Tools/ProjectManager/Source/FormComboBoxWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/FormComboBoxWidget.cpp
@@ -8,6 +8,7 @@
 
 #include <AzQtComponents/Components/StyledLineEdit.h>
 #include <AzQtComponents/Components/Widgets/LineEdit.h>
+#include <AzQtComponents/Components/StyleManager.h>
 #include <FormComboBoxWidget.h>
 #include <QEvent>
 #include <QFrame>
@@ -92,20 +93,26 @@ namespace O3DE::ProjectManager
     void FormComboBoxWidget::setErrorLabelVisible(bool visible)
     {
         m_errorLabel->setVisible(visible);
-        m_frame->setProperty("Valid", !visible);
-        refreshStyle();
+        if (AzQtComponents::StyleManager::setObjectProperty(m_frame, "Valid", !visible))
+        {
+            refreshStyle();
+        }
     }
 
     void FormComboBoxWidget::onFocus()
     {
-        m_frame->setProperty("Focus", true);
-        refreshStyle();
+        if (AzQtComponents::StyleManager::setObjectProperty(m_frame, "Focus", true))
+        {
+            refreshStyle();
+        }
     }
 
     void FormComboBoxWidget::onFocusOut()
     {
-        m_frame->setProperty("Focus", false);
-        refreshStyle();
+        if (AzQtComponents::StyleManager::setObjectProperty(m_frame, "Focus", false))
+        {
+            refreshStyle();
+        }
     }
 
     void FormComboBoxWidget::refreshStyle()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapCaptureComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapCaptureComponent.cpp
@@ -109,9 +109,6 @@ namespace AZ
         {
             CubeMapCaptureComponentConfig& configuration = m_controller.m_configuration;
 
-            AzToolsFramework::ScopedUndoBatch undoBatch("CubeMap Render");
-            SetDirty();
-
             return RenderCubeMap(
                 [&](RenderCubeMapCallback callback, AZStd::string& relativePath) { m_controller.RenderCubeMap(callback, relativePath); },
                 "Capturing Cubemap...",

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapRenderer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapRenderer.cpp
@@ -25,7 +25,7 @@ namespace AZ
         AZ::u32 EditorCubeMapRenderer::RenderCubeMap(
             AZStd::function<void(RenderCubeMapCallback, AZStd::string&)> renderCubeMapFn,
             const AZStd::string dialogText,
-            const AZ::Entity* entity,
+            const AZ::Entity* entityRequestingRender,
             const AZStd::string& folderName,
             AZStd::string& relativePath,
             CubeMapCaptureType captureType,
@@ -35,12 +35,13 @@ namespace AZ
             {
                 return AZ::Edit::PropertyRefreshLevels::None;
             }
+            
+            AZ::EntityId entityId = entityRequestingRender->GetId();
 
             // retrieve entity visibility
             bool isHidden = false;
             AzToolsFramework::EditorEntityInfoRequestBus::EventResult(
-                isHidden,
-                entity->GetId(),
+                isHidden, entityId,
                 &AzToolsFramework::EditorEntityInfoRequestBus::Events::IsHidden);
 
             // the entity must be visible in order to capture
@@ -95,7 +96,7 @@ namespace AZ
                     fileSuffix = CubeMapDiffuseFileSuffix;
                 }
 
-                cubeMapRelativePath = folderName + "/" + entity->GetName() + "_" + uuidString + fileSuffix;
+                cubeMapRelativePath = folderName + "/" + entityRequestingRender->GetName() + "_" + uuidString + fileSuffix;
 
                 // replace any invalid filename characters
                 auto invalidCharacters = [](char letter)
@@ -139,6 +140,7 @@ namespace AZ
                 // write the cubemap data to the .dds file
                 WriteOutputFile(cubeMapFullPath.c_str(), cubeMapFaceTextureData, cubeMapTextureFormat);
                 m_renderInProgress = false;
+               
             };
 
             // initiate the cubemap bake, this will invoke the buildCubeMapCallback when the cubemap data is ready

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapRenderer.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CubeMapCapture/EditorCubeMapRenderer.h
@@ -59,7 +59,7 @@ namespace AZ
             AZ::u32 RenderCubeMap(
                 AZStd::function<void(RenderCubeMapCallback, AZStd::string&)> renderCubeMapFn,
                 const AZStd::string dialogText,
-                const AZ::Entity* entity,
+                const AZ::Entity* entityRequestingRender,
                 const AZStd::string& folderName,
                 AZStd::string& relativePath,
                 CubeMapCaptureType captureType,

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/EditorReflectionProbeComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/EditorReflectionProbeComponent.cpp
@@ -211,7 +211,8 @@ namespace AZ
                         m_controller.UpdateCubeMap();
 
                         // update the UI
-                        AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh, AzToolsFramework::PropertyModificationRefreshLevel::Refresh_AttributesAndValues);
+                        using NotifyBus = AzToolsFramework::ToolsApplicationNotificationBus;
+                        NotifyBus::Broadcast(&NotifyBus::Events::InvalidatePropertyDisplayForComponent, AZ::EntityComponentIdPair(GetEntityId(), GetId()), AzToolsFramework::Refresh_Values);
                     }
                     else if (notificationType == CubeMapAssetNotificationType::Error)
                     {
@@ -339,8 +340,6 @@ namespace AZ
                 configuration.m_bakedCubeMapRelativePath.clear();
             }
 
-            AzToolsFramework::ScopedUndoBatch undoBatch("ReflectionProbe Bake");
-
             AZ::u32 result = RenderCubeMap(
                 [&](RenderCubeMapCallback callback, AZStd::string& relativePath) { m_controller.BakeReflectionProbe(callback, relativePath); },
                 "Baking Reflection Probe...",
@@ -350,14 +349,13 @@ namespace AZ
                 CubeMapCaptureType::Specular,
                 m_bakedCubeMapQualityLevel);
 
+            AzToolsFramework::ScopedUndoBatch undoBatch("CubeMap Render");
+            undoBatch.MarkEntityDirty(GetEntityId());
             // update quality level
             m_controller.m_configuration.m_bakedCubeMapQualityLevel = m_bakedCubeMapQualityLevel;
 
             // update UI cubemap path display
             m_bakedCubeMapRelativePath = configuration.m_bakedCubeMapRelativePath;
-
-            SetDirty();
-
             return result;
         }
     } // namespace Render

--- a/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/EditorComponents/EditorDiffuseProbeGridComponent.cpp
@@ -605,12 +605,10 @@ namespace AZ
             CheckoutSourceTextureFile(probeDataTextureFullPath);
 
             // update the configuration
-            AzToolsFramework::ScopedUndoBatch undoBatch("DiffuseProbeGrid bake");
             configuration.m_bakedIrradianceTextureRelativePath = irradianceTextureRelativePath;
             configuration.m_bakedDistanceTextureRelativePath = distanceTextureRelativePath;
             configuration.m_bakedProbeDataTextureRelativePath = probeDataTextureRelativePath;
-            SetDirty();
-
+            
             // callback for the texture readback
             DiffuseProbeGridBakeTexturesCallback bakeTexturesCallback = [this, irradianceTextureFullPath, distanceTextureFullPath, probeDataTextureFullPath](
                 DiffuseProbeGridTexture irradianceTexture,
@@ -638,6 +636,9 @@ namespace AZ
                     AZ_Assert(outcome.IsSuccess(), "Failed to write ProbeData texture .dds file [%s]", probeDataTextureFullPath.c_str());
                 }
 
+                // Only create the batch when the callback completes, as this is when data is valid for saving.
+                AzToolsFramework::ScopedUndoBatch undoBatch("DiffuseProbeGrid bake");
+                SetDirty();
                 m_bakeInProgress = false;
             };
 


### PR DESCRIPTION
## What does this PR do?

### Technical Summary
#### Changes to the way model resets are queued.  

The DPE (the view) has an underlying adapter (the model).
  
In normal ModelView architecture, changes to the underlying data is supposed to go into the model, and then the model, after updating, is supposed to inform the view about the changes so that it can rebuild its widgets/repaint/etc.

The issue is that in the case of DPE, the model (the "Adapter") is not a Qt object, its just a plain AzFramework thing.  This is nice for various reasons (imgui renderer anyone?), but, one issue is that there's no way for the view itself to safely queue a function for later invocation in AzCore except on tickbus.   Unlike Qt, which can use QTimer singleshot, and even qmetaobject::Invoke method, and tickbus is way too late.   

We also don't want the view to actually reset, deleting objects, moving its data around *during* a commit operation like when the callstack contains widget interactions or data model operations already.  In most cases this means queuing a reset on the event queue, and then doing it when the callstack unwinds.  But there's no way to do that currently in AzFramework.

The previous code was basically just queuing a reset of the model (the adapter) and then waiting for the DPE (the view) to inform it that its time to reset (execute queued reset).   The DPE would do so by alternate external means, such as being told a property changed, or given an EBUS message about refreshing.  This is not really great, since there could be gaps.

This new code uses the Az Event system to issue an event from the view when it would like to be reset ASAP.  The view gets this reset event via normal Az events, and then issues the execute Queued Reset ASAP but not within the same callstack.  There is no gap that it can be missed in and no need for the DPE to be listening on all sorts of busses/events for the notification.

Note that the DPE (view) and Adapter (model) is like a Qt model and view architecture, specifically like the Abstract Tree or Item Views, in that you can have a sort/filter view proxy on top of a model.  In Qt, this proxy has an internal reference to the "real" underlying model, and the view points at the proxy model.  In DPE, this is known as a Meta Adapter, and the Meta Adapter has a pointer to the "real" underlying adapter.  As such, events from the "real" adapter have to be echoed up the chain by the Meta Adapter.

#### Changes to the setProperties stuff on objects
Qt Style Sheet objects do not listen for dynamic property change.  So if you have a style sheet that changes how a button looks based on a custom property like `isOverriddenPrefab` or something, then you have to nudge the style system in Qt by issuing a unpolish/polish call on the style for each possibly affected widget.  The problem is, qt also sets dynamic properties for various reasons that don't actually have to do with styling at all.  
This change improves performance by
* Making it so that we only repolish a widget when the dynamic property *actually* changes
* Places where we listen via event filter for **all** dynamic property change, we ignore all the internal non-style-related qt properties, which by convention, start with `_q_`.

#### removal of deleteLater in the rpePropertyWrapper
* style sheets are automatically re-evaluated by qt (expensive call) whenever a widget changes which style sheets affect it.  And if you reparent a widget, this changes which style sheets affect it - for example, changing a widget from its parent being some deep widget in the heirarchy, to nullptr, it no longer inherits any styles from those intervening widgets it was a child of, so it automatically gets repolished.  This includes widgets marked for `delete later` wasting enormous amounts of time.  Since the shuffling of widgets around and creating new widgets is no longer possible to happen DURING widget operations (due to the queuing) we can delete immediately, eliminating those widgets from any reparenting and styling.
 
#### Fix for undo in cube map gens
* A couple classes used a cube map generator and would open an undo batch when they *started* the baking operation instead of when they completed it and changed their properties, this is fixed.
   
### Standard Summary

It turns out a lot of the slow performance is entirely due to the Qt Style sheets.  (Turning them off entirely makes most inspector operations nearly instantaneous).

This change improves performance slightly by reducing the number of times the style sheet is needlessly evaluated.  The true fix will have to be a rework of the style sheets - we load too many, and we set them on too many levels.

Style Sheets are re-evaluated whenever a control is "unpolished" and then "repolished" and is automatically re-evaluated when the style itself changes.

Unfortunately, the style of a widget changes whenever it is affected by a different set of style sheets.  Since a widget is affected by its own style sheet (if any) plus any style sheets all the way up the hierarchy, it means that operations like "widget->setParent(nullptr)" and other hierarchy changes affect the style of the widget and its descendants, causing all of them to cascade a style sheet update.  This means that temporarily removing a widget into a pool for reuse by clearing its parent, then pulling it back out of the pool later to reuse, causes it to re-evaluate its sheet, something the DPE does for most widgets.

This also fixes some minor update issues when it comes to cube map and reflection probe updates after baking.  They were leaving an undo open, and were not actually visually updating their UI after the update.

Also, found a better way to handle when the DPE Widget (the view) needs to signal that its an appropriate time to refresh its adapter.  Instead of relying on outside events coming in to notify of this, the adapter (as in, the "model" in the view model architecture) now just signals that it has been told to reset, and the view the queues and handles the reset ASAP.  If the "model" itself had some sort of event queue system, the view would not have to be involved, but the model is actually pure AzFramework, no Qt involved, and thus has no way of queuing a function call to happen immediately after the current callstack (except relying on something like "tick"), wheras the view, being a qt object, can do so using the qt metaobject invoke.

## How was this PR tested?

Lots and lots of clicking around in entities, properties, containers, selections.

Transparent-box testing in the debugger mostly, triggering breakpoints on widget polish/unpolish, and ensuring that when the Property Inspector was refreshed, we only issue ONE unpolish/polish when the widget is pooled, and ONE polish/unpolish when the widget is pulled out from the pool to place into the gui.  (Note - one per widget and child widget).

Previously there would be significantly more, unnecessary widget style polish/unpolish.


