### PR TITLE
Fix non-unity build

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.h
@@ -9,9 +9,10 @@
 
 #include <AzQtComponents/AzQtComponentsAPI.h>
 
-class QLineEdit;
-class QSettings;
+class QWidget;
 class QStyleOption;
+class QSettings;
+class QLineEdit;
 
 namespace AzQtComponents
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include <AzCore/std/string/string_view.h>
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
+
 class QWidget;
 class QString;
 

--- a/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <LmbrCentral/Shape/QuadShapeComponentBus.h>
 #include <Shape/ShapeDisplay.h>
 

--- a/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsg.cpp
+++ b/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsg.cpp
@@ -18,6 +18,7 @@
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/hash.h>
+#include <AzCore/std/sort.h>
 #include <AzCore/std/utils.h>
 #include <WhiteBox/WhiteBoxToolApi.h>
 

--- a/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsgCore.cpp
+++ b/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsgCore.cpp
@@ -9,11 +9,11 @@
 #include "WhiteBoxCsgCore.h"
 
 #include <algorithm>
-#include <cmath>
-#include <AzCore/std/containers/map.h>
-#include <tuple>
-
 #include <AzCore/Debug/Trace.h>
+#include <AzCore/std/containers/map.h>
+#include <cmath>
+#include <map>
+#include <tuple>
 
 // manifold (Apache-2.0) - see 3rdParty/FindManifold.cmake
 #include <manifold/manifold.h>

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxDrawShapeMode.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxDrawShapeMode.cpp
@@ -8,42 +8,40 @@
 
 #include "WhiteBoxDrawShapeMode.h"
 
-#include "WhiteBoxShapeBuilders.h"
-
+#include "EditorWhiteBoxComponent.h"
+#include "EditorWhiteBoxComponentModeBus.h"
 #include "EditorWhiteBoxComponentModeTypes.h"
+#include "Util/WhiteBoxMathUtil.h"
 #include "Viewport/WhiteBoxManipulatorBounds.h"
 #include "Viewport/WhiteBoxViewportConstants.h"
-#include "Util/WhiteBoxMathUtil.h"
+#include "WhiteBoxShapeBuilders.h"
 
-#include <AzCore/Math/IntersectSegment.h>
-#include <AzCore/Math/Plane.h>
-#include <AzCore/Math/MathStringConversions.h>
-#include <AzFramework/Entity/EntityDebugDisplayBus.h>
-#include <AzToolsFramework/Maths/TransformUtils.h>
-#include <AzToolsFramework/Undo/UndoSystem.h>
-#include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
-#include <WhiteBox/EditorWhiteBoxComponentBus.h>
-#include <WhiteBox/WhiteBoxToolApi.h>
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
-#include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
-
-#include <AzFramework/Render/GeometryIntersectionStructures.h>
-#include <AzFramework/Visibility/EntityVisibilityBoundsUnionSystem.h>
 #include <Atom/RPI.Public/ViewportContext.h>
-#include <AzFramework/Render/Intersector.h>           // IntersectorBus / IntersectorInterface
-#include <AzFramework/Render/GeometryIntersectionStructures.h>  // RayRequest / RayResult
-#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
-#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
-#include <AzToolsFramework/API/ComponentModeCollectionInterface.h>
-#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
-#include <AzToolsFramework/ViewportUi/ViewportUiRequestBus.h>
-#include <AzCore/Math/MathUtils.h>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Math/IntersectSegment.h>
+#include <AzCore/Math/MathStringConversions.h>
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/Math/Plane.h>
 #include <AzCore/std/containers/array.h>
-#include "EditorWhiteBoxComponent.h"
+#include <AzFramework/Entity/EntityDebugDisplayBus.h>
+#include <AzFramework/Render/GeometryIntersectionStructures.h>
+#include <AzFramework/Render/Intersector.h>
+#include <AzFramework/Visibility/EntityVisibilityBoundsUnionSystem.h>
+#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
+#include <AzToolsFramework/ActionManager/HotKey/HotKeyManagerInterface.h>
+#include <AzToolsFramework/API/ComponentModeCollectionInterface.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
+#include <AzToolsFramework/Maths/TransformUtils.h>
+#include <AzToolsFramework/Undo/UndoSystem.h>
+#include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
+#include <AzToolsFramework/ViewportUi/ViewportUiRequestBus.h>
 #include <cmath>
+#include <WhiteBox/EditorWhiteBoxComponentBus.h>
+#include <WhiteBox/WhiteBoxToolApi.h>
 
 
 namespace WhiteBox


### PR DESCRIPTION
## What does this PR do?

Fix missing includes or forward declarations so that when unity build is disabled o3de can still compile

## How was this PR tested?
 
Local windows build
