### PR TITLE
Reflect SmoothCriticallyDamped function for scripting and add SmoothStep

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -275,6 +275,8 @@ namespace AZ
                 { { { "From", "" }, { "Rate", "" }, { "DeltaTime", "" }, { "Target", "" }, { "SmoothTime", "" } } })
             ->Attribute(
                 AZ::Script::Attributes::ToolTip, "Returns a smoothed value towards a target using a critically damped spring system")
+            ->Method<float(const float&, const float&, float)>("SmoothStep", &AZ::SmoothStep, { { { "a", "" },{ "b", "" },{ "t", "" } } })
+                ->Attribute(AZ::Script::Attributes::ToolTip, "Returns a smooth S-curve interpolation between two values 'a' and 'b'")
             ->Method("Clamp", &GetClamp<float>)
             ->Method("IsEven", &IsEven<int>)
             ->Method<bool(int)>("IsOdd", &IsOdd<int>, {{{"Value",""}}})

--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -269,6 +269,12 @@ namespace AZ
                 ->Attribute(AZ::Script::Attributes::ToolTip, "Returns a linear interpolation between two values 'a' and 'b'")
             ->Method<float(float, float, float)>("LerpInverse", &AZ::LerpInverse, { { { "a", "" },{ "b", "" },{ "value", "" } } })
                 ->Attribute(AZ::Script::Attributes::ToolTip, "Returns a value t where Lerp(a,b,t)==value (or 0 if a==b)")
+            ->Method<AZStd::tuple<float, float>(float&, float&, float, const float&, float)>(
+                "SmoothCriticallyDamped",
+                &AZ::SmoothCriticallyDamped,
+                { { { "From", "" }, { "Rate", "" }, { "DeltaTime", "" }, { "Target", "" }, { "SmoothTime", "" } } })
+            ->Attribute(
+                AZ::Script::Attributes::ToolTip, "Returns a smoothed value towards a target using a critically damped spring system")
             ->Method("Clamp", &GetClamp<float>)
             ->Method("IsEven", &IsEven<int>)
             ->Method<bool(int)>("IsOdd", &IsOdd<int>, {{{"Value",""}}})

--- a/Code/Framework/AzCore/AzCore/Math/MathUtils.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathUtils.h
@@ -452,6 +452,13 @@ namespace AZ
         }
     }
 
+    //! Returns the successive critically dampted value and updated rate..
+    AZ_MATH_INLINE AZStd::tuple<float, float> SmoothCriticallyDamped(float& value, float& valueRate, float timeDelta, const float& target, float smoothTime)
+    {
+        SmoothCriticallyDamped<float>(value, valueRate, timeDelta, target, smoothTime);
+        return AZStd::make_tuple(value, valueRate);
+    }
+
     //! Returns true if the number provided is even.
     template<typename T>
     constexpr AZStd::enable_if_t<AZStd::is_integral<T>::value, bool> IsEven(T a)

--- a/Code/Framework/AzCore/AzCore/Math/MathUtils.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathUtils.h
@@ -459,6 +459,15 @@ namespace AZ
         return AZStd::make_tuple(value, valueRate);
     }
 
+    //! Returns a smooth S-curve interpolation between 2 values.
+    template<typename T>
+    AZ_MATH_INLINE T SmoothStep(const T& a, const T& b, float t)
+    {
+        t = GetClamp(t, 0.f, 1.f);
+        float smoothT = t * t * (3.f - 2.f * t);
+        return a + (b - a) * smoothT;
+    }
+
     //! Returns true if the number provided is even.
     template<typename T>
     constexpr AZStd::enable_if_t<AZStd::is_integral<T>::value, bool> IsEven(T a)

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -228,6 +228,7 @@ namespace AZ
                 Method("Lerp", &Quaternion::Lerp)->
                 Method("Slerp", &Quaternion::Slerp)->
                 Method("Squad", &Quaternion::Squad)->
+                Method("SmoothCriticallyDamped", &Quaternion::SmoothCriticallyDamped)->
                 Method("GetConjugate", &Quaternion::GetConjugate)->
                 Method("GetInverseFast", &Quaternion::GetInverseFast)->
                     Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)->

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -229,6 +229,7 @@ namespace AZ
                 Method("Slerp", &Quaternion::Slerp)->
                 Method("Squad", &Quaternion::Squad)->
                 Method("SmoothCriticallyDamped", &Quaternion::SmoothCriticallyDamped)->
+                Method("SmoothStep", &Quaternion::SmoothStep)->
                 Method("GetConjugate", &Quaternion::GetConjugate)->
                 Method("GetInverseFast", &Quaternion::GetInverseFast)->
                     Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)->

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -207,6 +207,11 @@ namespace AZ
         //! Squad(p,a,b,q,t) = Slerp(Slerp(p,q,t), Slerp(a,b,t); 2(1-t)t).
         Quaternion Squad(const Quaternion& dest, const Quaternion& in, const Quaternion& out, float t) const;
 
+        //! Smooths a value towards a target using a critically damped spring system.
+        //! This function adjusts `value` towards `target` while maintaining continuity of `value` and its rate of change (`valueRate`).
+        //! The smoothing is controlled by `smoothTime`, with `timeDelta` representing the time since the last update.
+        Quaternion SmoothCriticallyDamped(Quaternion& valueRate, float timeDelta, const Quaternion& target, float smoothTime) const;
+
         //! Checks if the quaternion is close to another quaternion with a given floating point tolerance.
         bool IsClose(const Quaternion& q, float tolerance = Constants::Tolerance) const;
 

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -212,6 +212,9 @@ namespace AZ
         //! The smoothing is controlled by `smoothTime`, with `timeDelta` representing the time since the last update.
         Quaternion SmoothCriticallyDamped(Quaternion& valueRate, float timeDelta, const Quaternion& target, float smoothTime) const;
 
+        //! Performs a smooth S-curve interpolation between this quaternion and a desination.
+        Quaternion SmoothStep(const Quaternion& dest, float t) const;
+
         //! Checks if the quaternion is close to another quaternion with a given floating point tolerance.
         bool IsClose(const Quaternion& q, float tolerance = Constants::Tolerance) const;
 

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -405,6 +405,14 @@ namespace AZ
     }
 
 
+    AZ_MATH_INLINE Quaternion Quaternion::SmoothCriticallyDamped(Quaternion& valueRate, float timeDelta, const Quaternion& target, float smoothTime) const
+    {
+        Quaternion result = *this;
+        AZ::SmoothCriticallyDamped(result, valueRate, timeDelta, target, smoothTime);
+        return result;
+    }
+
+
     AZ_MATH_INLINE bool Quaternion::IsClose(const Quaternion& q, float tolerance) const
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -413,6 +413,12 @@ namespace AZ
     }
 
 
+    AZ_MATH_INLINE Quaternion Quaternion::SmoothStep(const Quaternion& dest, float t) const
+    {
+        return AZ::SmoothStep(*this, dest, t);
+    }
+
+
     AZ_MATH_INLINE bool Quaternion::IsClose(const Quaternion& q, float tolerance) const
     {
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
@@ -250,6 +250,7 @@ namespace AZ
                 Method("AngleSafeDeg", &Vector2::AngleSafeDeg)->
                 Method("Lerp", &Vector2::Lerp)->
                 Method("Slerp", &Vector2::Slerp)->
+                Method("SmoothCriticallyDamped", &Vector2::SmoothCriticallyDamped)->
                 Method("Dot", &Vector2::Dot)->
                 Method("GetPerpendicular", &Vector2::GetPerpendicular)->
                 Method("IsClose", &Vector2::IsClose, behaviorContext->MakeDefaultValues(Constants::Tolerance))->

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
@@ -251,6 +251,7 @@ namespace AZ
                 Method("Lerp", &Vector2::Lerp)->
                 Method("Slerp", &Vector2::Slerp)->
                 Method("SmoothCriticallyDamped", &Vector2::SmoothCriticallyDamped)->
+                Method("SmoothStep", &Vector2::SmoothStep)->
                 Method("Dot", &Vector2::Dot)->
                 Method("GetPerpendicular", &Vector2::GetPerpendicular)->
                 Method("IsClose", &Vector2::IsClose, behaviorContext->MakeDefaultValues(Constants::Tolerance))->

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.h
@@ -159,6 +159,11 @@ namespace AZ
         //! Linearly interpolates between the two vectors and normalizes the result.
         Vector2 Nlerp(const Vector2& dest, float t) const;
 
+        //! Smooths a value towards a target using a critically damped spring system.
+        //! This function adjusts `value` towards `target` while maintaining continuity of `value` and its rate of change (`valueRate`).
+        //! The smoothing is controlled by `smoothTime`, with `timeDelta` representing the time since the last update.
+        Vector2 SmoothCriticallyDamped(Vector2& valueRate, float timeDelta, const Vector2& target, float smoothTime) const;
+
         //! Gets perpendicular vector, i.e. rotates through 90 degrees.
         //! The positive rotation direction is defined such that the x-axis is rotated into the y-axis.
         Vector2 GetPerpendicular() const;

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.h
@@ -164,6 +164,9 @@ namespace AZ
         //! The smoothing is controlled by `smoothTime`, with `timeDelta` representing the time since the last update.
         Vector2 SmoothCriticallyDamped(Vector2& valueRate, float timeDelta, const Vector2& target, float smoothTime) const;
 
+        //! Performs a smooth S-curve interpolation between this vector and a desination.
+        Vector2 SmoothStep(const Vector2& dest, float t) const;
+
         //! Gets perpendicular vector, i.e. rotates through 90 degrees.
         //! The positive rotation direction is defined such that the x-axis is rotated into the y-axis.
         Vector2 GetPerpendicular() const;

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.inl
@@ -310,6 +310,11 @@ namespace AZ
         return result;
     }
 
+    AZ_MATH_INLINE Vector2 Vector2::SmoothStep(const Vector2& dest, float t) const
+    {
+        return AZ::SmoothStep(*this, dest, t);
+    }
+
     AZ_MATH_INLINE Vector2 Vector2::GetPerpendicular() const
     {
         return Vector2(-m_y, m_x);

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.inl
@@ -303,6 +303,13 @@ namespace AZ
         return Lerp(dest, t).GetNormalizedSafe(Constants::Tolerance);
     }
 
+    AZ_MATH_INLINE Vector2 Vector2::SmoothCriticallyDamped(Vector2& valueRate, float timeDelta, const Vector2& target, float smoothTime) const
+    {
+        Vector2 result = *this;
+        AZ::SmoothCriticallyDamped(result, valueRate, timeDelta, target, smoothTime);
+        return result;
+    }
+
     AZ_MATH_INLINE Vector2 Vector2::GetPerpendicular() const
     {
         return Vector2(-m_y, m_x);

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
@@ -270,6 +270,7 @@ namespace AZ
                 Method("Lerp", &Vector3::Lerp)->
                 Method("Slerp", &Vector3::Slerp)->
                 Method("SmoothCriticallyDamped", &Vector3::SmoothCriticallyDamped)->
+                Method("SmoothStep", &Vector3::SmoothStep)->
                 Method("Dot", &Vector3::Dot)->
                 Method("Cross", &Vector3::Cross)->
                 Method("CrossXAxis", &Vector3::CrossXAxis)->

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
@@ -269,6 +269,7 @@ namespace AZ
                 Method("AngleSafeDeg", &Vector3::AngleSafeDeg)->
                 Method("Lerp", &Vector3::Lerp)->
                 Method("Slerp", &Vector3::Slerp)->
+                Method("SmoothCriticallyDamped", &Vector3::SmoothCriticallyDamped)->
                 Method("Dot", &Vector3::Dot)->
                 Method("Cross", &Vector3::Cross)->
                 Method("CrossXAxis", &Vector3::CrossXAxis)->

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.h
@@ -188,6 +188,9 @@ namespace AZ
         //! The smoothing is controlled by `smoothTime`, with `timeDelta` representing the time since the last update.
         Vector3 SmoothCriticallyDamped(Vector3& valueRate, float timeDelta, const Vector3& target, float smoothTime) const;
 
+        //! Performs a smooth S-curve interpolation between this vector and a desination.
+        Vector3 SmoothStep(const Vector3& dest, float t) const;
+
         //! Dot product of two vectors.
         float Dot(const Vector3& rhs) const;
 

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.h
@@ -183,6 +183,11 @@ namespace AZ
         //! Linearly interpolates between the two vectors and normalizes the result.
         Vector3 Nlerp(const Vector3& dest, float t) const;
 
+        //! Smooths a value towards a target using a critically damped spring system.
+        //! This function adjusts `value` towards `target` while maintaining continuity of `value` and its rate of change (`valueRate`).
+        //! The smoothing is controlled by `smoothTime`, with `timeDelta` representing the time since the last update.
+        Vector3 SmoothCriticallyDamped(Vector3& valueRate, float timeDelta, const Vector3& target, float smoothTime) const;
+
         //! Dot product of two vectors.
         float Dot(const Vector3& rhs) const;
 

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.inl
@@ -332,6 +332,13 @@ namespace AZ
         return Vector3(Simd::Vec3::Madd(GetSimdValue(), Simd::Vec3::SplatIndex1(sinCos), relVecSinTheta));
     }
 
+    AZ_MATH_INLINE Vector3 Vector3::SmoothCriticallyDamped(Vector3& valueRate, float timeDelta, const Vector3& target, float smoothTime) const
+    {
+        Vector3 result = *this;
+        AZ::SmoothCriticallyDamped(result, valueRate, timeDelta, target, smoothTime);
+        return result;
+    }
+
     AZ_MATH_INLINE Vector3 Vector3::Nlerp(const Vector3& dest, float t) const
     {
         return Lerp(dest, t).GetNormalizedSafe(Constants::Tolerance);

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.inl
@@ -339,6 +339,11 @@ namespace AZ
         return result;
     }
 
+    AZ_MATH_INLINE Vector3 Vector3::SmoothStep(const Vector3& dest, float t) const
+    {
+        return AZ::SmoothStep(*this, dest, t);
+    }
+
     AZ_MATH_INLINE Vector3 Vector3::Nlerp(const Vector3& dest, float t) const
     {
         return Lerp(dest, t).GetNormalizedSafe(Constants::Tolerance);

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math.names
@@ -10,6 +10,66 @@
             },
             "methods": [
                 {
+                    "base": "SmoothCriticallyDamped",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Smooth Critically Damped"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Smooth Critically Damped is invoked"
+                    },
+                    "details": {
+                        "name": "Smooth Critically Damped"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "From"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Rate"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Delta Time"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Target"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Smooth Time"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Smoothed Result"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Updated Rate"
+                            }
+                        }
+                    ]
+                },
+                {
                     "base": "DivideByNumber",
                     "entry": {
                         "name": "In",

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/Math.names
@@ -891,6 +891,48 @@
                     ]
                 },
                 {
+                    "base": "SmoothStep",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will invoke Smooth Step"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after Smooth Step is invoked"
+                    },
+                    "details": {
+                        "name": "Smooth Step"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "A"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "B"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Time"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Result"
+                            }
+                        }
+                    ]
+                },
+                {
                     "base": "GetSinCos",
                     "entry": {
                         "name": "In",

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_QuaternionFunctions_SmoothCriticallyDamped.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_QuaternionFunctions_SmoothCriticallyDamped.names
@@ -1,0 +1,68 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_QuaternionFunctions_SmoothCriticallyDamped",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Smooth Critically Damped",
+                "category": "Math/Quaternion"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_QuaternionFunctions_SmoothCriticallyDamped",
+                    "details": {
+                        "name": "Smooth Critically Damped",
+                        "tooltip": "Returns a smoothed value towards a target using a critically damped spring system."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "From"
+                            }
+                        },
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "Rate"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Delta Time"
+                            }
+                        },
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "Target"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Smooth Time"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "Smoothed Result"
+                            }
+                        },
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "Updated Rate"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_QuaternionFunctions_SmoothStep.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_QuaternionFunctions_SmoothStep.names
@@ -1,0 +1,50 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_QuaternionFunctions_SmoothStep",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Smooth Step",
+                "category": "Math/Quaternion"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_QuaternionFunctions_SmoothStep",
+                    "details": {
+                        "name": "Smooth Step",
+                        "tooltip": "Returns a smooth S-curve interpolation between 2 values."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "From"
+                            }
+                        },
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "To"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "T"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{73103120-3DD3-4873-BAB3-9713FA2804FB}",
+                            "details": {
+                                "name": "Quaternion"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector2Functions_SmoothCriticallyDamped.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector2Functions_SmoothCriticallyDamped.names
@@ -1,0 +1,68 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_Vector2Functions_SmoothCriticallyDamped",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Smooth Critically Damped",
+                "category": "Math/Vector2"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_Vector2Functions_SmoothCriticallyDamped",
+                    "details": {
+                        "name": "Smooth Critically Damped",
+                        "tooltip": "Returns a smoothed value towards a target using a critically damped spring system."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "From"
+                            }
+                        },
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "Rate"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Delta Time"
+                            }
+                        },
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "Target"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Smooth Time"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "Smoothed Result"
+                            }
+                        },
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "Updated Rate"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector2Functions_SmoothStep.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector2Functions_SmoothStep.names
@@ -1,0 +1,50 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_Vector2Functions_SmoothStep",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Smooth Step",
+                "category": "Math/Vector2"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_Vector2Functions_SmoothStep",
+                    "details": {
+                        "name": "Smooth Step",
+                        "tooltip": "Returns a smooth S-curve interpolation between 2 values."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "From"
+                            }
+                        },
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "To"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "T"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3D80F623-C85C-4741-90D0-E4E66164E6BF}",
+                            "details": {
+                                "name": "Vector 2"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector3Functions_SmoothCriticallyDamped.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector3Functions_SmoothCriticallyDamped.names
@@ -1,0 +1,68 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_Vector3Functions_SmoothCriticallyDamped",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Smooth Critically Damped",
+                "category": "Math/Vector3"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_Vector3Functions_SmoothCriticallyDamped",
+                    "details": {
+                        "name": "Smooth Critically Damped",
+                        "tooltip": "Returns a smoothed value towards a target using a critically damped spring system."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "From"
+                            }
+                        },
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Rate"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Delta Time"
+                            }
+                        },
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Target"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "Smooth Time"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Smoothed Result"
+                            }
+                        },
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Updated Rate"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector3Functions_SmoothStep.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/GlobalMethods/ScriptCanvas_Vector3Functions_SmoothStep.names
@@ -1,0 +1,50 @@
+{
+    "entries": [
+        {
+            "base": "ScriptCanvas_Vector3Functions_SmoothStep",
+            "context": "BehaviorMethod",
+            "variant": "",
+            "details": {
+                "name": "Smooth Step",
+                "category": "Math/Vector3"
+            },
+            "methods": [
+                {
+                    "base": "ScriptCanvas_Vector3Functions_SmoothStep",
+                    "details": {
+                        "name": "Smooth Step",
+                        "tooltip": "Returns a smooth S-curve interpolation between 2 values."
+                    },
+                    "params": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "From"
+                            }
+                        },
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "To"
+                            }
+                        },
+                        {
+                            "typeid": "{110C4B14-11A8-4E9D-8638-5051013A56AC}",
+                            "details": {
+                                "name": "T"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{8379EB7D-01FA-4538-B64B-A6543B4BE73D}",
+                            "details": {
+                                "name": "Vector 3"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.ScriptCanvasFunction.xml
@@ -125,6 +125,12 @@
             <Parameter Name="SmoothTime"/>
         </Function>
         
+        <Function Name="SmoothStep">
+            <Parameter Name="From"/>
+            <Parameter Name="To"/>
+            <Parameter Name="T"/>
+        </Function>
+        
         <Function Name="ToAngleDegrees">
             <Parameter Name="Source"/>
         </Function>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.ScriptCanvasFunction.xml
@@ -117,6 +117,14 @@
             <Parameter Name="T"/>
         </Function>
         
+        <Function Name="SmoothCriticallyDamped">
+            <Parameter Name="From"/>
+            <Parameter Name="Rate"/>
+            <Parameter Name="DeltaTime"/>
+            <Parameter Name="Target"/>
+            <Parameter Name="SmoothTime"/>
+        </Function>
+        
         <Function Name="ToAngleDegrees">
             <Parameter Name="Source"/>
         </Function>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
@@ -136,6 +136,13 @@ namespace ScriptCanvas
             return from.Squad(to, in, out, aznumeric_cast<float>(t));
         }
 
+        AZStd::tuple<QuaternionType, QuaternionType> SmoothCriticallyDamped(
+            QuaternionType from, QuaternionType rate, const NumberType deltaTime, const QuaternionType target, const NumberType smoothTime)
+        {
+            QuaternionType smoothedResult = from.SmoothCriticallyDamped(rate, aznumeric_cast<float>(deltaTime), target, aznumeric_cast<float>(smoothTime));
+            return AZStd::make_tuple(smoothedResult, rate);
+        }
+
         NumberType ToAngleDegrees(QuaternionType source)
         {
             return aznumeric_caster(AZ::RadToDeg(source.GetAngle()));

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
@@ -143,6 +143,11 @@ namespace ScriptCanvas
             return AZStd::make_tuple(smoothedResult, rate);
         }
 
+        QuaternionType SmoothStep(QuaternionType a, QuaternionType b, NumberType t)
+        {
+            return a.SmoothStep(b, aznumeric_cast<float>(t));
+        }
+
         NumberType ToAngleDegrees(QuaternionType source)
         {
             return aznumeric_caster(AZ::RadToDeg(source.GetAngle()));

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
@@ -64,6 +64,9 @@ namespace ScriptCanvas
 
         QuaternionType Squad(QuaternionType from, QuaternionType to, QuaternionType in, QuaternionType out, NumberType t);
 
+        AZStd::tuple<QuaternionType, QuaternionType> SmoothCriticallyDamped(
+            QuaternionType from, QuaternionType rate, const NumberType deltaTime, const QuaternionType target, const NumberType smoothTime);
+
         NumberType ToAngleDegrees(QuaternionType source);
 
         QuaternionType CreateFromEulerAngles(NumberType pitch, NumberType roll, NumberType yaw);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
@@ -67,6 +67,8 @@ namespace ScriptCanvas
         AZStd::tuple<QuaternionType, QuaternionType> SmoothCriticallyDamped(
             QuaternionType from, QuaternionType rate, const NumberType deltaTime, const QuaternionType target, const NumberType smoothTime);
 
+        QuaternionType SmoothStep(QuaternionType a, QuaternionType b, NumberType t);
+
         NumberType ToAngleDegrees(QuaternionType source);
 
         QuaternionType CreateFromEulerAngles(NumberType pitch, NumberType roll, NumberType yaw);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.ScriptCanvasFunction.xml
@@ -130,6 +130,12 @@
             <Parameter Name="SmoothTime"/>
         </Function>
         
+        <Function Name="SmoothStep">
+            <Parameter Name="From"/>
+            <Parameter Name="To"/>
+            <Parameter Name="T"/>
+        </Function>
+        
         <Function Name="ToPerpendicular">
             <Parameter Name="Source"/>
         </Function>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.ScriptCanvasFunction.xml
@@ -122,6 +122,14 @@
             <Parameter Name="T"/>
         </Function>
         
+        <Function Name="SmoothCriticallyDamped">
+            <Parameter Name="From"/>
+            <Parameter Name="Rate"/>
+            <Parameter Name="DeltaTime"/>
+            <Parameter Name="Target"/>
+            <Parameter Name="SmoothTime"/>
+        </Function>
+        
         <Function Name="ToPerpendicular">
             <Parameter Name="Source"/>
         </Function>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
@@ -138,6 +138,13 @@ namespace ScriptCanvas
             return from.Slerp(to, aznumeric_cast<float>(t));
         }
 
+        AZStd::tuple<Vector2Type, Vector2Type> SmoothCriticallyDamped(
+            Vector2Type from, Vector2Type rate, const NumberType deltaTime, const Vector2Type target, const NumberType smoothTime)
+        {
+            Vector2Type smoothedResult = from.SmoothCriticallyDamped(rate, aznumeric_cast<float>(deltaTime), target, aznumeric_cast<float>(smoothTime));
+            return AZStd::make_tuple(smoothedResult, rate);
+        }
+
         Vector2Type ToPerpendicular(const Vector2Type source)
         {
             return source.GetPerpendicular();

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
@@ -145,6 +145,11 @@ namespace ScriptCanvas
             return AZStd::make_tuple(smoothedResult, rate);
         }
 
+        Vector2Type SmoothStep(const Vector2Type& from, const Vector2Type& to, NumberType t)
+        {
+            return from.SmoothStep(to, aznumeric_cast<float>(t));
+        }
+
         Vector2Type ToPerpendicular(const Vector2Type source)
         {
             return source.GetPerpendicular();

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
@@ -66,6 +66,9 @@ namespace ScriptCanvas
 
         Vector2Type Slerp(const Vector2Type from, const Vector2Type to, const NumberType t);
 
+        AZStd::tuple<Vector2Type, Vector2Type> SmoothCriticallyDamped(
+            Vector2Type from, Vector2Type rate, const NumberType deltaTime, const Vector2Type target, const NumberType smoothTime);
+
         Vector2Type ToPerpendicular(const Vector2Type source);
 
         AZStd::tuple<Vector2Type, NumberType> DirectionTo(const Vector2Type from, const Vector2Type to, NumberType optionalScale = 1.f);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
@@ -69,6 +69,8 @@ namespace ScriptCanvas
         AZStd::tuple<Vector2Type, Vector2Type> SmoothCriticallyDamped(
             Vector2Type from, Vector2Type rate, const NumberType deltaTime, const Vector2Type target, const NumberType smoothTime);
 
+        Vector2Type SmoothStep(const Vector2Type& from, const Vector2Type& to, NumberType t);
+
         Vector2Type ToPerpendicular(const Vector2Type source);
 
         AZStd::tuple<Vector2Type, NumberType> DirectionTo(const Vector2Type from, const Vector2Type to, NumberType optionalScale = 1.f);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.ScriptCanvasFunction.xml
@@ -155,6 +155,12 @@
             <Parameter Name="SmoothTime"/>
         </Function>
         
+        <Function Name="SmoothStep">
+            <Parameter Name="From"/>
+            <Parameter Name="To"/>
+            <Parameter Name="T"/>
+        </Function>
+        
         <Function Name="DirectionTo">
             <Parameter Name="From" DefaultValue="Data::Vector3Type()"/>
             <Parameter Name="To" DefaultValue="Data::Vector3Type()"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.ScriptCanvasFunction.xml
@@ -147,6 +147,14 @@
             <Parameter Name="T"/>
         </Function>
         
+        <Function Name="SmoothCriticallyDamped">
+            <Parameter Name="From"/>
+            <Parameter Name="Rate"/>
+            <Parameter Name="DeltaTime"/>
+            <Parameter Name="Target"/>
+            <Parameter Name="SmoothTime"/>
+        </Function>
+        
         <Function Name="DirectionTo">
             <Parameter Name="From" DefaultValue="Data::Vector3Type()"/>
             <Parameter Name="To" DefaultValue="Data::Vector3Type()"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
@@ -167,6 +167,13 @@ namespace ScriptCanvas
             return from.Slerp(to, aznumeric_cast<float>(t));
         }
 
+        AZStd::tuple<Vector3Type, Vector3Type> SmoothCriticallyDamped(
+            Vector3Type from, Vector3Type rate, const NumberType deltaTime, const Vector3Type target, const NumberType smoothTime)
+        {
+            Vector3Type smoothedResult = from.SmoothCriticallyDamped(rate, aznumeric_cast<float>(deltaTime), target, aznumeric_cast<float>(smoothTime));
+            return AZStd::make_tuple(smoothedResult, rate);
+        }
+
         AZStd::tuple<Vector3Type, NumberType> DirectionTo(const Vector3Type from, const Vector3Type to, NumberType optionalScale)
         {
             Vector3Type r = to - from;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
@@ -174,6 +174,11 @@ namespace ScriptCanvas
             return AZStd::make_tuple(smoothedResult, rate);
         }
 
+        Vector3Type SmoothStep(const Vector3Type& from, const Vector3Type& to, NumberType t)
+        {
+            return from.SmoothStep(to, aznumeric_cast<float>(t));
+        }
+
         AZStd::tuple<Vector3Type, NumberType> DirectionTo(const Vector3Type from, const Vector3Type to, NumberType optionalScale)
         {
             Vector3Type r = to - from;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
@@ -78,6 +78,8 @@ namespace ScriptCanvas
         AZStd::tuple<Vector3Type, Vector3Type> SmoothCriticallyDamped(
             Vector3Type from, Vector3Type rate, const NumberType deltaTime, const Vector3Type target, const NumberType smoothTime);
 
+        Vector3Type SmoothStep(const Vector3Type& from, const Vector3Type& to, NumberType t);
+
         AZStd::tuple<Vector3Type, NumberType> DirectionTo(const Vector3Type from, const Vector3Type to, NumberType optionalScale = 1.f);
     } // namespace Vector3Functions
 } // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
@@ -75,6 +75,9 @@ namespace ScriptCanvas
 
         Vector3Type Slerp(const Vector3Type from, const Vector3Type to, const NumberType t);
 
+        AZStd::tuple<Vector3Type, Vector3Type> SmoothCriticallyDamped(
+            Vector3Type from, Vector3Type rate, const NumberType deltaTime, const Vector3Type target, const NumberType smoothTime);
+
         AZStd::tuple<Vector3Type, NumberType> DirectionTo(const Vector3Type from, const Vector3Type to, NumberType optionalScale = 1.f);
     } // namespace Vector3Functions
 } // namespace ScriptCanvas


### PR DESCRIPTION
## What does this PR do?

### SmoothCriticallyDamped
Makes `SmoothCriticallyDamped(...)` available to use in Lua and Script Canvas. Specifically, reflect methods for floats/numbers, Vector2, Vector3, and Quaternion.

### SmoothStep
Adds `SmoothStep(...)` and reflects it for for use in Lua and Script Canvas. Specifically, reflect methods for floats/numbers, Vector2, Vector3, and Quaternion.


**SmoothCriticallyDamped** in Script Canvas and Lua:
<img width="1329" height="635" alt="Screenshot From 2026-07-19 12-08-23" src="https://github.com/user-attachments/assets/5c76dc9f-a960-45ac-9e4a-9abb8d1159a3" />

<img width="613" height="490" alt="Screenshot From 2026-07-19 14-25-26" src="https://github.com/user-attachments/assets/6c725d8a-ba14-45e0-90db-ff84e856d1ac" />

**SmoothStep** in Script Canvas and Lua:
<img width="1483" height="492" alt="Screenshot From 2026-07-20 12-24-10" src="https://github.com/user-attachments/assets/6e35b626-e213-4bfb-9060-955304e45364" />

<img width="411" height="600" alt="Screenshot From 2026-07-20 12-26-37" src="https://github.com/user-attachments/assets/cf836c7d-7f02-4c0d-b9b7-a007518cc555" />

Related:
https://github.com/o3de/o3de/pull/18801
Closes https://github.com/o3de/o3de/issues/14490

## How was this PR tested?

### SmoothCriticallyDamped
This video shows the result of using the two **SmoothCriticallyDamped** Script Canvas scripts screenshotted below (specifically, this was tested on top of 0296e6d4b89b327d91d4fe2a76dc9646ae8418be):
<video src="https://github.com/user-attachments/assets/603cd49a-14d8-4b9b-86ef-1f2e18987e5d" controls width="100%"></video>

**SmoothCriticallyDamped** script used to test it with float, Vector3, and Quaternion (used on the cube):
<img width="5380" height="1860" alt="image" src="https://github.com/user-attachments/assets/4c030761-1be1-4d82-a852-06e1dfb6b140" />

**SmoothCriticallyDamped** script used to test it with Vector2 (used on the sphere):
<img width="4800" height="660" alt="image" src="https://github.com/user-attachments/assets/85aa2c82-12ea-469a-b5c6-e10328a2554a" />

### SmoothStep
This video shows the result of using the two **SmoothStep** Script Canvas scripts screenshotted below (specifically, this was tested on top of 0296e6d4b89b327d91d4fe2a76dc9646ae8418be):
<video src="https://github.com/user-attachments/assets/0e77fff5-d224-4282-ab63-6a3222bb0cc5" controls width="100%"></video>

**SmoothStep** script used to test it with float, Vector3, and Quaternion (used on the cube):
<img width="4620" height="1380" alt="image" src="https://github.com/user-attachments/assets/582cc279-9046-4f76-acad-fdc52ed5b35a" />

**SmoothStep** script used to test it with Vector2 (used on the sphere):
<img width="4340" height="500" alt="image" src="https://github.com/user-attachments/assets/46397869-bc52-4847-9bce-e36bc5a60660" />