### PR TITLE
Fix build errors triggered in non-unity

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/Menu.h
@@ -12,6 +12,7 @@
 class QLineEdit;
 class QSettings;
 class QStyleOption;
+class QWidget;
 
 namespace AzQtComponents
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/PropertyHandlerWidget.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/std/string/string_view.h>
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
 class QWidget;
 class QString;

--- a/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/QuadShape.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Translation/TranslationDef.h>
 #include <LmbrCentral/Shape/QuadShapeComponentBus.h>
 #include <Shape/ShapeDisplay.h>
 

--- a/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsg.cpp
+++ b/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsg.cpp
@@ -18,6 +18,7 @@
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/hash.h>
+#include <AzCore/std/sort.h>
 #include <AzCore/std/utils.h>
 #include <WhiteBox/WhiteBoxToolApi.h>
 

--- a/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsgCore.cpp
+++ b/Gems/WhiteBox/Code/Source/Core/WhiteBoxCsgCore.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <map>
 #include <AzCore/std/containers/map.h>
 #include <tuple>
 

--- a/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxDrawShapeMode.cpp
+++ b/Gems/WhiteBox/Code/Source/Viewport/WhiteBoxDrawShapeMode.cpp
@@ -10,6 +10,7 @@
 
 #include "WhiteBoxShapeBuilders.h"
 
+#include "EditorWhiteBoxComponentModeBus.h"
 #include "EditorWhiteBoxComponentModeTypes.h"
 #include "Viewport/WhiteBoxManipulatorBounds.h"
 #include "Viewport/WhiteBoxViewportConstants.h"


### PR DESCRIPTION
## What does this PR do?

 Adds missing includes/forward-declarations exposed by building non-unity. The problems were caused by the changes in:  #19916 and #19848

Solves #19923

## How was this PR tested?

Completed the full build on Linux box, with non-unity option switched on.
