### PR TITLE
Atom: Improve foliage/alpha-cutout rendering with alpha-weighted mips and A2C

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/AlbedoWithGenericAlpha.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/AlbedoWithGenericAlpha.preset
@@ -9,7 +9,7 @@
             "RGB_Weight": "CIEXYZ",
             "PixelFormat": "BC3",
             "MipMapSetting": {
-                "MipGenType": "Box"
+                "MipGenType": "AlphaWeighted"
             }
         },
         "PlatformsPresets": {
@@ -20,7 +20,7 @@
                 "PixelFormat": "ASTC_4x4",
                 "MaxTextureSize": 2048,
                 "MipMapSetting": {
-                    "MipGenType": "Box"
+                    "MipGenType": "AlphaWeighted"
                 }
             },
             "ios": {
@@ -30,7 +30,7 @@
                 "PixelFormat": "ASTC_6x6",
                 "MaxTextureSize": 2048,
                 "MipMapSetting": {
-                    "MipGenType": "Box"
+                    "MipGenType": "AlphaWeighted"
                 }
             },
             "mac": {
@@ -39,7 +39,7 @@
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "BC3",
                 "MipMapSetting": {
-                    "MipGenType": "Box"
+                    "MipGenType": "AlphaWeighted"
                 }
             },
             "provo": {
@@ -48,7 +48,7 @@
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "BC3",
                 "MipMapSetting": {
-                    "MipGenType": "Box"
+                    "MipGenType": "AlphaWeighted"
                 }
             }
         }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingDefines.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingDefines.h
@@ -86,7 +86,8 @@ namespace ImageProcessingAtom
         quadratic,      //Also called bilinear or Welch window
         gaussian,       //It remove high frequency noise in a highly controllable way.
         blackmanHarris,
-        kaiserSinc      //Good for foliage and tree assets exported from Speedtree.
+        kaiserSinc,     //Good for foliage and tree assets exported from Speedtree.
+        alphaWeighted   //Box filter that weights RGB by alpha, preventing dark fringes in cutout mipmaps.
     };
 
     enum class MipGenEvalType : AZ::u32

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -685,6 +685,15 @@ namespace ImageProcessingAtom
                 outPreset = m_defaultPresetAlpha;
             }
         }
+        else if (outPreset == m_defaultPreset)
+        {
+            auto image = IImageObjectPtr(LoadImageFromFile(imageFilePath));
+            if (image && image->GetAlphaContent() != EAlphaContent::eAlphaContent_Absent &&
+                image->GetAlphaContent() != EAlphaContent::eAlphaContent_OnlyWhite)
+            {
+                outPreset = m_defaultPresetAlpha;
+            }
+        }
 
         return outPreset;
     }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/MipmapSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/MipmapSettings.cpp
@@ -44,6 +44,7 @@ namespace ImageProcessingAtom
                     ->EnumAttribute(MipGenType::gaussian, QT_TRANSLATE_NOOP("Atom::Asset", "Gaussian"))
                     ->EnumAttribute(MipGenType::blackmanHarris, QT_TRANSLATE_NOOP("Atom::Asset", "BlackmanHarris"))
                     ->EnumAttribute(MipGenType::kaiserSinc, QT_TRANSLATE_NOOP("Atom::Asset", "KaiserSinc"))
+                    ->EnumAttribute(MipGenType::alphaWeighted, QT_TRANSLATE_NOOP("Atom::Asset", "AlphaWeighted"))
                     ->Attribute(AZ::Edit::Attributes::Min, 0)
                 ;
             }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
@@ -83,6 +83,7 @@ namespace ImageProcessingAtom
                 ->Value("Gaussian", MipGenType::gaussian)
                 ->Value("BlackmanHarris", MipGenType::blackmanHarris)
                 ->Value("KaiserSinc", MipGenType::kaiserSinc)
+                ->Value("AlphaWeighted", MipGenType::alphaWeighted)
                 ;
 
             serialize->Enum<EPixelFormat>()

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
@@ -84,6 +84,7 @@ namespace ImageProcessingAtom
                         ->EnumAttribute(MipGenType::gaussian, QT_TRANSLATE_NOOP("Atom::Asset", "Gaussian"))
                         ->EnumAttribute(MipGenType::blackmanHarris, QT_TRANSLATE_NOOP("Atom::Asset", "BlackmanHarris"))
                         ->EnumAttribute(MipGenType::kaiserSinc, QT_TRANSLATE_NOOP("Atom::Asset", "KaiserSinc"))
+                        ->EnumAttribute(MipGenType::alphaWeighted, QT_TRANSLATE_NOOP("Atom::Asset", "AlphaWeighted"))
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &TextureSettings::m_mipGenEval, QT_TRANSLATE_NOOP("Atom::Asset", "Pixel Sampler"), QT_TRANSLATE_NOOP("Atom::Asset", "The Pixel Sampler specifies how the final pixel value is calculated when mipmaps are generated."))
                         ->EnumAttribute(MipGenEvalType::max, QT_TRANSLATE_NOOP("Atom::Asset", "Max"))
                         ->EnumAttribute(MipGenEvalType::min, QT_TRANSLATE_NOOP("Atom::Asset", "Min"))

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/FIR-Filter.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/FIR-Filter.cpp
@@ -1268,6 +1268,8 @@ namespace ImageProcessingAtom
             return eWindowFunction_BlackmanHarris;
         case MipGenType::kaiserSinc:
             return eWindowFunction_KaiserSinc;
+        case MipGenType::alphaWeighted:
+            return eWindowFunction_Box;
         default:
             AZ_Assert(false, "unable find filter type for mipmap gen type %d", filterType);
             return eWindowFunction_BlackmanHarris;
@@ -1276,9 +1278,127 @@ namespace ImageProcessingAtom
 
     /* #################################################################################################################### \
     */
+    void FilterImageAlphaWeighted(
+        const IImageObjectPtr srcImg, int srcMip, IImageObjectPtr dstImg, int dstMip, QRect* srcRect, QRect* dstRect)
+    {
+        if (srcImg->GetPixelFormat() != ePixelFormat_R32G32B32A32F || dstImg->GetPixelFormat() != ePixelFormat_R32G32B32A32F)
+        {
+            AZ_Assert(false, "FilterImageAlphaWeighted only supports R32G32B32A32F format");
+            return;
+        }
+
+        uint32 srcWidth, srcHeight;
+        uint8* pSrcMem;
+        uint32 dwSrcPitch;
+        srcImg->GetImagePointer(srcMip, pSrcMem, dwSrcPitch);
+        srcWidth = srcImg->GetWidth(srcMip);
+        srcHeight = srcImg->GetHeight(srcMip);
+
+        uint32 dstWidth, dstHeight;
+        uint8* pDstMem;
+        uint32 dwDstPitch;
+        dstImg->GetImagePointer(dstMip, pDstMem, dwDstPitch);
+        dstWidth = dstImg->GetWidth(dstMip);
+        dstHeight = dstImg->GetHeight(dstMip);
+
+        uint32 srcLeft = 0, srcTop = 0, srcRight = srcWidth, srcBottom = srcHeight;
+        uint32 dstLeft = 0, dstTop = 0;
+        if (srcRect)
+        {
+            srcLeft = srcRect->left();
+            srcTop = srcRect->top();
+            srcRight = srcRect->right();
+            srcBottom = srcRect->bottom();
+        }
+        if (dstRect)
+        {
+            dstLeft = dstRect->left();
+            dstTop = dstRect->top();
+        }
+
+        uint32 srcRegionWidth = srcRight - srcLeft;
+        uint32 srcRegionHeight = srcBottom - srcTop;
+
+        for (uint32 dy = 0; dy < dstHeight; dy++)
+        {
+            for (uint32 dx = 0; dx < dstWidth; dx++)
+            {
+                uint32 sx0 = srcLeft + (dx * srcRegionWidth) / dstWidth;
+                uint32 sx1 = srcLeft + ((dx + 1) * srcRegionWidth) / dstWidth;
+                uint32 sy0 = srcTop + (dy * srcRegionHeight) / dstHeight;
+                uint32 sy1 = srcTop + ((dy + 1) * srcRegionHeight) / dstHeight;
+
+                if (sx1 <= sx0)
+                {
+                    sx1 = sx0 + 1;
+                }
+                if (sy1 <= sy0)
+                {
+                    sy1 = sy0 + 1;
+                }
+                if (sx1 > srcRight)
+                {
+                    sx1 = srcRight;
+                }
+                if (sy1 > srcBottom)
+                {
+                    sy1 = srcBottom;
+                }
+
+                float rSum = 0.0f, gSum = 0.0f, bSum = 0.0f, aSum = 0.0f;
+                float weightSum = 0.0f;
+                uint32 count = 0;
+
+                for (uint32 sy = sy0; sy < sy1; sy++)
+                {
+                    for (uint32 sx = sx0; sx < sx1; sx++)
+                    {
+                        const float* pSrc = reinterpret_cast<const float*>(pSrcMem + sy * dwSrcPitch) + sx * 4;
+                        float a = pSrc[3];
+                        float weight = (a > 0.0f) ? a : 0.0001f;
+                        rSum += pSrc[0] * weight;
+                        gSum += pSrc[1] * weight;
+                        bSum += pSrc[2] * weight;
+                        aSum += a;
+                        weightSum += weight;
+                        count++;
+                    }
+                }
+
+                if (count == 0)
+                {
+                    continue;
+                }
+
+                float* pDst = reinterpret_cast<float*>(pDstMem + (dy + dstTop) * dwDstPitch) + (dx + dstLeft) * 4;
+                if (weightSum > 0.0f)
+                {
+                    pDst[0] = rSum / weightSum;
+                    pDst[1] = gSum / weightSum;
+                    pDst[2] = bSum / weightSum;
+                }
+                else
+                {
+                    pDst[0] = rSum / count;
+                    pDst[1] = gSum / count;
+                    pDst[2] = bSum / count;
+                }
+                pDst[3] = aSum / count;
+            }
+        }
+    }
+
+    /* #################################################################################################################### \
+    */
     void FilterImage(MipGenType filterType, MipGenEvalType evalType, float blurH, float blurV, const IImageObjectPtr srcImg, int srcMip,
         IImageObjectPtr dstImg, int dstMip, QRect* srcRect, QRect* dstRect)
     {
+        if (filterType == MipGenType::alphaWeighted)
+        {
+            FilterImageAlphaWeighted(srcImg, srcMip, dstImg, dstMip, srcRect, dstRect);
+            return;
+        }
+
         int filterIndex = MipGenTypeToFilterIndex(filterType);
         int filterOp = static_cast<int>(evalType);
         FilterImage(filterIndex, filterOp, blurH, blurV, srcImg, srcMip, dstImg, dstMip, srcRect, dstRect);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/PresetInfoPopup.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/PresetInfoPopup.cpp
@@ -32,8 +32,8 @@ namespace ImageProcessingAtomEditor
 
     static const char* MipGenTypeToString(MipGenType mipGenType)
     {
-        static const char* mipGenTypeNames[] = { "Point", "Box", "Triangle", "Quadratic", "Gaussian", "BlackmanHarris", "KaiserSinc" };
-        AZ_Assert(mipGenType <= MipGenType::kaiserSinc, "Invalid MipGenType!");
+        static const char* mipGenTypeNames[] = { "Point", "Box", "Triangle", "Quadratic", "Gaussian", "BlackmanHarris", "KaiserSinc", "AlphaWeighted" };
+        AZ_Assert(mipGenType <= MipGenType::alphaWeighted, "Invalid MipGenType!");
         return mipGenTypeNames[(int)mipGenType];
     }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Tests/ImageProcessing_Test.cpp
@@ -939,7 +939,8 @@ namespace UnitTest
                 { MipGenType::triangle, "triangle" },
                 { MipGenType::quadratic, "Quadratic" },
                 { MipGenType::blackmanHarris, "blackmanHarris" },
-                { MipGenType::kaiserSinc, "kaiserSinc" }
+                { MipGenType::kaiserSinc, "kaiserSinc" },
+                { MipGenType::alphaWeighted, "alphaWeighted" }
             }
         };
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/AlphaToCoverage.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/AlphaToCoverage.lua
@@ -1,0 +1,32 @@
+--------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+
+function GetMaterialPropertyDependencies()
+    return {"useAlphaToCoverage"}
+end
+
+function Process(context)
+    local useA2C = false
+    if context:HasMaterialProperty("useAlphaToCoverage") then
+        useA2C = context:GetMaterialPropertyValue_bool("useAlphaToCoverage")
+    end
+
+    local lastShader = context:GetShaderCount() - 1
+    if useA2C then
+        for i = 0, lastShader do
+            context:GetShader(i):GetRenderStatesOverride():SetAlphaToCoverageEnabled(true)
+        end
+    else
+        for i = 0, lastShader do
+            context:GetShader(i):GetRenderStatesOverride():ClearAlphaToCoverageEnabled()
+        end
+    end
+end

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
@@ -72,7 +72,7 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
     float fresnelAlpha = FresnelSchlickWithRoughness(lightingData.GetSpecularNdotV(), surface.alpha, surface.roughnessLinear).x;
     float alpha = lerp(fresnelAlpha, surface.alpha, surface.opacityAffectsSpecularFactor);
 
-    if (o_opacity_mode == OpacityMode::Blended)
+    if (o_opacity_mode == OpacityMode::Blended || o_opacity_mode == OpacityMode::Cutout)
     {
         OUT.m_color1.a = alpha;
     }

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPassVertexAndPixel.azsli
@@ -67,7 +67,19 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
     // --- Diffuse Lighting ---
 
     OUT.m_diffuseColor.rgb = lightingData.diffuseLighting;
-    OUT.m_diffuseColor.a = -1;  // Disable Subsurface Scattering
+
+#if defined(MATERIAL_HAS_ALPHA_TO_COVERAGE) && defined(MATERIAL_HAS_SURFACE_ALPHA)
+    if (o_alphaToCoverage && o_opacity_mode == OpacityMode::Cutout)
+    {
+        OUT.m_diffuseColor.a = surface.alpha;
+    }
+    else
+    {
+        OUT.m_diffuseColor.a = -1;
+    }
+#else
+    OUT.m_diffuseColor.a = -1;
+#endif
 
     // --- Specular Lighting ---
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/MainPipeline.materialpipeline
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/MainPipeline.materialpipeline
@@ -132,6 +132,11 @@
                 "name": "hasPerPixelClip",
                 "type": "Bool",
                 "defaultValue": false
+            },
+            {
+                "name": "useAlphaToCoverage",
+                "type": "Bool",
+                "defaultValue": false
             }
         ],
         "functors": 
@@ -148,6 +153,12 @@
                 "args": {
                     //TODO(MaterialPipeline): Make the builder touch up this path so it can be relative to the .materialpipeline file
                     "file": "Materials/Pipelines/Common/DoubleSided.lua"
+                }
+            },
+            {
+                "type": "Lua",
+                "args": {
+                    "file": "Materials/Pipelines/Common/AlphaToCoverage.lua"
                 }
             }
         ]

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR.azsli
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#define MATERIAL_HAS_OPACITY_EDGE_SOFTNESS 1
+
 #include <Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_MaterialInputs.azsli>
 
 #if MATERIALPIPELINE_SHADER_HAS_PIXEL_STAGE

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/OpacityPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/OpacityPropertyGroup.json
@@ -74,6 +74,30 @@
                 "type": "ShaderInput",
                 "name": "m_opacityAffectsSpecularFactor"
             }
+        },
+        {
+            "name": "edgeSoftness",
+            "displayName": "Edge Softness",
+            "description": "Softens the cutout edge for Cutout opacity mode. 0.0 = hard cutout, >0.0 = smooth anti-aliased edge.",
+            "type": "Float",
+            "min": 0.0,
+            "max": 0.5,
+            "defaultValue": 0.0,
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_opacityEdgeSoftness"
+            }
+        },
+        {
+            "name": "alphaToCoverage",
+            "displayName": "Alpha to Coverage",
+            "description": "Enables Alpha-to-Coverage (A2C) for anti-aliased cutout edges using MSAA. Only applies to Cutout opacity mode.",
+            "type": "Bool",
+            "defaultValue": false,
+            "connection": {
+                "type": "ShaderOption",
+                "name": "o_alphaToCoverage"
+            }
         }
     ],
     "functors": [

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.azsli
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#define MATERIAL_HAS_OPACITY_EDGE_SOFTNESS 1
+
 #include <Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_MaterialInputs.azsli>
 
 #if MATERIALPIPELINE_SHADER_HAS_PIXEL_STAGE

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
@@ -10,7 +10,7 @@
 ----------------------------------------------------------------------------------------------------
 
 function GetMaterialPropertyDependencies()
-    return {"mode", "alphaSource", "textureMap"}
+    return {"mode", "alphaSource", "textureMap", "edgeSoftness", "alphaToCoverage"}
 end
  
 OpacityMode_Opaque = 0
@@ -28,10 +28,29 @@ function Process(context)
     if context:HasMaterialProperty("mode") then
         opacityMode = context:GetMaterialPropertyValue_enum("mode")
     end
-    
-    context:SetInternalMaterialPropertyValue_bool("hasPerPixelClip", opacityMode == OpacityMode_Cutout)
-    context:SetInternalMaterialPropertyValue_bool("isTransparent", opacityMode == OpacityMode_Blended)
+
+    local edgeSoftness = 0.0
+    if context:HasMaterialProperty("edgeSoftness") then
+        edgeSoftness = context:GetMaterialPropertyValue_float("edgeSoftness")
+    end
+
+    local alphaToCoverage = false
+    if context:HasMaterialProperty("alphaToCoverage") then
+        alphaToCoverage = context:GetMaterialPropertyValue_bool("alphaToCoverage")
+    end
+
+    -- When edgeSoftness > 0 and mode is Cutout, switch to the transparent (blended) pipeline
+    -- so the smoothed alpha can blend with the background for anti-aliased cutout edges.
+    -- hasPerPixelClip is false in this case because clipping is handled by the shader's
+    -- smoothstep + clip logic, not the per-pixel clip flag that switches to customZ shaders.
+    local useSoftEdge = (opacityMode == OpacityMode_Cutout and edgeSoftness > 0.0)
+
+    local useA2C = (opacityMode == OpacityMode_Cutout and alphaToCoverage and not useSoftEdge)
+
+    context:SetInternalMaterialPropertyValue_bool("hasPerPixelClip", opacityMode == OpacityMode_Cutout and not useSoftEdge)
+    context:SetInternalMaterialPropertyValue_bool("isTransparent", opacityMode == OpacityMode_Blended or useSoftEdge)
     context:SetInternalMaterialPropertyValue_bool("isTintedTransparent", opacityMode == OpacityMode_TintedTransparent)
+    context:SetInternalMaterialPropertyValue_bool("useAlphaToCoverage", useA2C)
 end
 
 function ProcessEditor(context)
@@ -48,6 +67,14 @@ function ProcessEditor(context)
     context:SetMaterialPropertyVisibility("textureMap", mainVisibility)
     context:SetMaterialPropertyVisibility("textureMapUv", mainVisibility)
     context:SetMaterialPropertyVisibility("factor", mainVisibility)
+
+    if(opacityMode == OpacityMode_Cutout) then
+        context:SetMaterialPropertyVisibility("edgeSoftness", MaterialPropertyVisibility_Enabled)
+        context:SetMaterialPropertyVisibility("alphaToCoverage", MaterialPropertyVisibility_Enabled)
+    else
+        context:SetMaterialPropertyVisibility("edgeSoftness", MaterialPropertyVisibility_Hidden)
+        context:SetMaterialPropertyVisibility("alphaToCoverage", MaterialPropertyVisibility_Hidden)
+    end
 
     if(opacityMode == OpacityMode_Blended or opacityMode == OpacityMode_TintedTransparent) then
         context:SetMaterialPropertyVisibility("alphaAffectsSpecular", MaterialPropertyVisibility_Enabled)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/AlphaUtils.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/AlphaUtils.azsli
@@ -8,7 +8,10 @@
 
 #pragma once
 
+#define MATERIAL_HAS_ALPHA_TO_COVERAGE 1
+
 option enum class OpacityMode {Opaque, Cutout, Blended, TintedTransparent} o_opacity_mode;
+option bool o_alphaToCoverage;
 
 void CheckClipping(real alpha, real opacityFactor)
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialFunctions/StandardGetAlphaAndClip.azsli
@@ -16,6 +16,32 @@ real GetAlphaAndClip(const MaterialParameters params, float2 uvs[UvSetCount], fl
     float2 baseColorUV = uvs[params.m_baseColorMapUvIndex];
     float2 opacityUV = uvs[params.m_opacityMapUvIndex];
     real alpha = SampleAlpha(GetMaterialTexture(params.m_baseColorMap), GetMaterialTexture(params.m_opacityMap), baseColorUV, opacityUV, GetMaterialTextureSampler(), o_opacity_source, uvDxDy, customDerivatives);
-    CheckClipping(alpha, real(params.m_opacityFactor));
-    return real(params.m_opacityFactor) * alpha;
+
+    real opacityFactor = real(params.m_opacityFactor);
+
+#ifdef MATERIAL_HAS_OPACITY_EDGE_SOFTNESS
+    real edgeSoftness = real(params.m_opacityEdgeSoftness);
+
+    if (o_opacity_mode == OpacityMode::Cutout && edgeSoftness > 0.0)
+    {
+        real threshold = 1.0 - opacityFactor;
+        real smoothedAlpha = smoothstep(threshold - edgeSoftness, threshold + edgeSoftness, alpha);
+        clip(smoothedAlpha - 0.001);
+        return smoothedAlpha;
+    }
+#endif
+
+#ifdef MATERIALPIPELINE_SHADER_HAS_PIXEL_STAGE
+    if (o_alphaToCoverage && o_opacity_mode == OpacityMode::Cutout)
+    {
+        real threshold = 1.0 - opacityFactor;
+        clip(alpha - threshold + 0.001);
+        real centered = alpha - threshold + 0.5;
+        real sharpness = 6.0;
+        return saturate((centered - 0.5) * sharpness + 0.5);
+    }
+#endif
+
+    CheckClipping(alpha, opacityFactor);
+    return opacityFactor * alpha;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/StandardPBR/StandardPBR_SurfaceData.azsli
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#define MATERIAL_HAS_SURFACE_ALPHA 1
+
 // This #define magic lets you use the Surface class in this file without making it the final Surface
 // used in your shader. Simply #define Surface to your custom definition before including this file
 //

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -6,6 +6,7 @@
 # 
 
 set(FILES
+    Materials/Pipelines/Common/AlphaToCoverage.lua
     Materials/Pipelines/Common/DepthPass.azsli
     Materials/Pipelines/Common/DepthPass_CustomZ.azsli
     Materials/Pipelines/Common/DoubleSided.lua


### PR DESCRIPTION
## What does this PR do?
 
This PR improves foliage and alpha-cutout rendering in Atom by addressing three common artifacts:
 
1. **Gray/dark fringes at distance** — Transparent (black) pixels in cutout textures bleed into opaque edges during mip generation, producing gray halos when viewed at a distance (lower mip levels). A new `MipGenType::alphaWeighted` filter weights each source pixel's RGB by its alpha during downsampling so transparent pixels don't dilute opaque colors. Applied to the `AlbedoWithGenericAlpha` preset by default.
 
2. **Jagged cutout edges** — Hard `clip()` produces aliased cutout edges. Two new material properties provide anti-aliasing:
   - `alphaToCoverage` — Converts cutout alpha to MSAA coverage samples (A2C) for hardware anti-aliased edges. Includes a sharpened alpha mapping to avoid blurry edges, with a `clip()` fallback for correct cutout on non-MSAA deferred targets.
   - `edgeSoftness` — Smoothstep-based soft cutout edges via the transparent (blended) pipeline, as an alternative to A2C.
 
3. **Silent alpha stripping** — `GetSuggestedPreset` now checks the source image's alpha content and uses the alpha-preserving preset when a meaningful alpha channel is present, even if the file mask matched the default alpha-stripping preset. Backwards compatible: images with no alpha or all-white alpha still get the alpha-stripping preset.
 
**Old behavior:** Cutout foliage textures appeared gray at distance due to mip bleeding. Cutout edges were hard-aliased. Textures with meaningful alpha could silently lose their alpha channel based on filename patterns.
 
**New behavior:** Foliage stays green at all distances with alpha-weighted mips. Cutout edges can be anti-aliased via A2C (MSAA) or edgeSoftness (blended). Alpha is preserved when the source image has one.
 
## How was this PR tested?
 
- Built and verified the changes in the O3DE Editor using a test project with foliage assets
- Confirmed existing image processing unit tests still pass