### PR TITLE
Eliminates a hack that was causing infinite repaint

### DIFF
--- a/Code/Editor/MainStatusBar.cpp
+++ b/Code/Editor/MainStatusBar.cpp
@@ -61,6 +61,14 @@ void StatusBarItem::SetText(const QString& text)
 
 void StatusBarItem::SetIcon(const QPixmap& icon)
 {
+    qint64 iconCacheKey = icon.cacheKey();
+    if (iconCacheKey == m_iconCacheKey)
+    {
+        return;
+    }
+
+    m_iconCacheKey = iconCacheKey;
+
     QIcon origIcon = m_icon;
 
     if (icon.isNull())
@@ -86,16 +94,20 @@ void StatusBarItem::SetIcon(const QPixmap& icon)
     }
 
     // don't generate paintevents unless we absolutely have changed!
-    if (origIcon.cacheKey() != m_icon.cacheKey())
-    {
-        update();
-    }
+    update();
 }
 
 void StatusBarItem::SetIcon(const QIcon& icon)
 {
     QIcon origIcon = m_icon;
 
+    qint64 iconCacheKey = icon.cacheKey();
+    if (iconCacheKey == m_iconCacheKey)
+    {
+        return;
+    }
+
+    m_iconCacheKey = iconCacheKey;
     m_icon = icon;
 
     if (icon.isNull() ^ origIcon.isNull())
@@ -103,11 +115,7 @@ void StatusBarItem::SetIcon(const QIcon& icon)
         updateGeometry();
     }
 
-    // don't generate paintevents unless we absolutely have changed!
-    if (origIcon.cacheKey() != m_icon.cacheKey())
-    {
-        update();
-    }
+    update();
 }
 
 void StatusBarItem::SetToolTip(const QString& tip)

--- a/Code/Editor/MainStatusBar.h
+++ b/Code/Editor/MainStatusBar.h
@@ -56,9 +56,10 @@ protected:
 
 private:
     QIcon m_icon;
+    qint64 m_iconCacheKey = 0;
     QString m_text;
-    bool m_isClickable;
-    bool m_hasLeadingSpacer;
+    bool m_isClickable = false;
+    bool m_hasLeadingSpacer = false;
 };
 
 class MainStatusBar

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
@@ -1738,69 +1738,9 @@ namespace internal
         QLineEdit::keyPressEvent(ev);
     }
 
-    static void setLineEditTextFormat(QLineEdit* lineEdit, const QList<QTextLayout::FormatRange>& formats)
-    {
-        if (!lineEdit)
-            return;
-
-        QList<QInputMethodEvent::Attribute> attributes;
-        for (const QTextLayout::FormatRange& fr : formats)
-        {
-            QInputMethodEvent::AttributeType type = QInputMethodEvent::TextFormat;
-            int start = fr.start;
-            int length = fr.length;
-            QVariant value = fr.format;
-            attributes.append(QInputMethodEvent::Attribute(type, start, length, value));
-        }
-        QInputMethodEvent event(QString(), attributes);
-        QCoreApplication::sendEvent(lineEdit, &event);
-    }
-
-    static void clearLineEditTextFormat(QLineEdit* lineEdit)
-    {
-        setLineEditTextFormat(lineEdit, QList<QTextLayout::FormatRange>());
-    }
-
     void SpinBoxLineEdit::paintEvent(QPaintEvent* event)
     {
-        QAbstractSpinBox* abstractSpinBox = qobject_cast<QAbstractSpinBox*>(parent());
-        QSpinBox* spinBox = reinterpret_cast<QSpinBox*>(abstractSpinBox);
-        bool fixLeftAlignment = !spinBox->property(g_hoveredPropertyName).toBool() && !hasFocus();
-        int suffixSize = static_cast<int>(spinBox->suffix().size());
-        QString beforeText;
-        int cursorPos = 0;
-        if (fixLeftAlignment)
-        {
-            // Reset the cursorposition to ensure left-aligned values
-            cursorPos = cursorPosition();
-            setCursorPosition(0);
-        }
-        if (suffixSize)
-        {
-            QList<QTextLayout::FormatRange> formats;
-            int size = static_cast<int>(text().size());
-
-            QTextCharFormat f;
-            f.setForeground(QColor(0x888888));
-
-            QTextLayout::FormatRange fr_task;
-            fr_task.start = size - suffixSize;
-            fr_task.length = suffixSize;
-            fr_task.format = f;
-
-            formats.append(fr_task);
-
-            setLineEditTextFormat(this, formats);
-        }
         QLineEdit::paintEvent(event);
-        if (suffixSize)
-        {
-            clearLineEditTextFormat(this);
-        }
-        if (fixLeftAlignment)
-        {
-            setCursorPosition(cursorPos);
-        }
     }
 } // namespace internal
 


### PR DESCRIPTION
## What does this PR do?

The QSpinBox component tries to render its suffix (if it has one) in a lighter text color than the rest of the text.

This suffix is only shown in this color if the text is not currently being edited, and is not hovered over.

While this is a nice visual, the problem is how it was implemented.

The implementation of it is modifying the IME (Input method Editor) state of the control **during its painting**, which is going to negatively affect actual IME input (so chinese/japanese/etc inputs), as well as cause the control to invalidate itself during repaint.

This means that any time we have a QSpinBox on screen, painting it causes it to invalidate itself and trigger a new repaint, immediately, which causes it to repaint, immediately, which causes it to place itself back onto the paint queue, and so on, forever.  This means that the CPU spins processing spin box paint events endlessly when one is on screen.

I talked to SIG-UI/UX in discord about this, and the members there were okay with the removal of this text styling for now, considering the performance implications and the fact that its essentially using a hack (abusing IME), as we find a way to implement it in a way that does not interfere with IME input or cause infinite repaints (eating up all CPU.)

I also solved a similar problem in the status bar.  The status bar was repainting itself every 500ms becuase it was setting the Asset Processor status icon every 500ms.  There was code there to check if the same icon was being set and not to issue a repaint, but it was using the wrong comparison method, comparing the icon cache key when a new icon is being created each time (pointing at the same shared pixmap data).  So the icon's cache key was always different, but the pixmap data was the same.  (Qt refcounts the pixmap data).

With just these 2 changes, the main editor, script canvas, etc, do not issue any Qt repaint operations at all unless I move the cursor over them and cause controls to need redrawing.

## How was this PR tested?

Transparent-box testing - checking the code, putting breakpoints at QWidget::update, etc.

Manual testing in the editor and qt control gallery.

Note that the old spinboxes had text colors like this:

<img width="712" height="74" alt="Screenshot 2026-07-21 095238" src="https://github.com/user-attachments/assets/dd22bcd9-fec5-4d15-8203-3f2b848a826c" />

And text colors like this when hovered over:

<img width="238" height="42" alt="Screenshot 2026-07-21 095332" src="https://github.com/user-attachments/assets/95c3c207-db3e-4ac2-9ceb-70ab1173f57d" />

Now they use the same uniform text color, with the `m` (suffix) being the same color as the text.

Note also that the suffix disappears when you actually focus the field and edit it, and always has done that, so it only shows up when you have NOT clicked on the field.