### PR TITLE
Fix build: fetch content misses extension

### DIFF
--- a/cmake/3rdPartyPackages.cmake
+++ b/cmake/3rdPartyPackages.cmake
@@ -818,10 +818,11 @@ function(o3de_fetch_content arg_NAME)
     set(url_download_succeeded FALSE)
     if(arg_URL AND NOT O3DE_FETCHCONTENT_FORCE_GIT)
         foreach(current_url IN LISTS arg_URL)
+            get_filename_component(url_filename "${current_url}" NAME)
             if(download_cache_dir)
-                set(target_file "${download_cache_dir}/${arg_URL_HASH}")
+                set(target_file "${download_cache_dir}/${arg_URL_HASH}-${url_filename}")
             else()
-                set(target_file "${CMAKE_BINARY_DIR}/downloads/${arg_NAME}/${arg_URL_HASH}")
+                set(target_file "${CMAKE_BINARY_DIR}/downloads/${arg_NAME}/${arg_URL_HASH}-${url_filename}")
             endif()
 
             # Check if we already have the file with the correct hash


### PR DESCRIPTION
## What does this PR do?

Changes in #19622 introduced the mechanism to cache the downloaded data with SHA256 filename, without any extension. CMake's `ExternalProject.cmake` determines how to extract an archive from the filename's suffix. A hash with no extension makes it fail. This change creates the name of the cached file as a combination of the hash and the filename.

## How was this PR tested?

The `development` branch builds correctly with this fix, fails without it with the following error:
```
CMake Error at /usr/share/cmake-3.28/Modules/FetchContent.cmake:1667 (message):
  CMake step for googletest failed: 1
Call Stack (most recent call first):
  /usr/share/cmake-3.28/Modules/FetchContent.cmake:1819:EVAL:2 (__FetchContent_directPopulate)
  /usr/share/cmake-3.28/Modules/FetchContent.cmake:1819 (cmake_language)
  /usr/share/cmake-3.28/Modules/FetchContent.cmake:2033 (FetchContent_Populate)
  /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake:74 (FetchContent_MakeAvailable)
  /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de/cmake/LYWrappers.cmake:608 (find_package)
  /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de/cmake/LYWrappers.cmake:266 (ly_parse_third_party_dependencies)
  /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de/Code/Framework/AzTest/CMakeLists.txt:20 (ly_add_target)`
```