### PR TITLE
Fix Vulkan device-lost hang when recreating a swapchain during resize

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -77,6 +77,17 @@ namespace AZ
         {
             if (m_pendingRecreation)
             {
+                // Drain all in-flight GPU work before recreating (see ResizeInternal for the
+                // rationale): rotating the frame context's binary semaphores while a frame is
+                // still in flight causes non-acquired-image / unsignalable-semaphore device-lost
+                // hangs.
+                auto& device = static_cast<Device&>(GetDevice());
+                if (m_presentationQueue)
+                {
+                    m_presentationQueue->FlushCommands();
+                }
+                device.GetCommandQueueContext().WaitForIdle();
+
                 VkSwapchainKHR oldSwapchain = m_nativeSwapChain;
                 ShutdownImages();
                 CreateSwapchain();
@@ -213,6 +224,18 @@ namespace AZ
             auto& presentationQueue = device.GetCommandQueueContext().GetOrCreatePresentationCommandQueue(*this);
             m_presentationQueue = &presentationQueue;
 
+            // Make sure no GPU work is still in flight referencing the binary semaphores and
+            // swapchain images we are about to rotate/destroy. A window resize (e.g. a drag)
+            // recreates the swapchain out of lockstep with an already-compiled frame; without
+            // fully draining first, submits end up waiting on a semaphore that can no longer be
+            // signaled (VUID-vkQueueSubmit-pWaitSemaphores-03238), rendering to a non-acquired
+            // swapchain image, or re-signaling a recycled semaphore (VUID-...-00067) -> the
+            // observed Vulkan device-lost hang. This is especially reproducible with a second
+            // window (e.g. the Animation Editor), which shares the per-device swapchain
+            // semaphore pool with the main viewport.
+            m_presentationQueue->FlushCommands();
+            device.GetCommandQueueContext().WaitForIdle();
+
             CreateSwapchain();
 
             if (nativeDimensions)
@@ -340,6 +363,20 @@ namespace AZ
             RHI::ResultCode result = AcquireNewImage(&acquiredImageIndex);
             if (result == RHI::ResultCode::Fail)
             {
+                // Acquire failed, so we skip queuing the present command below. This frame's
+                // submit already signaled m_presentableSemaphore, and it will never be waited
+                // (no present happens). Mark the current pair non-recyclable so the still-
+                // signaled binary semaphore is not handed back to the shared pool and signaled
+                // again (VUID-vkQueueSubmit-pSignalSemaphores-00067). The swapchain is recreated
+                // (and these semaphores deleted) via ProcessRecreation.
+                if (m_currentFrameContext.m_imageAvailableSemaphore)
+                {
+                    m_currentFrameContext.m_imageAvailableSemaphore->SetRecycleValue(false);
+                }
+                if (m_currentFrameContext.m_presentableSemaphore)
+                {
+                    m_currentFrameContext.m_presentableSemaphore->SetRecycleValue(false);
+                }
                 m_pendingRecreation = true;
                 return 0;
             }


### PR DESCRIPTION
### Problem

Opening a second Vulkan window — reproduced with the **EMotionFX Animation Editor** — and then dragging/resizing it reliably causes a `VK_ERROR_DEVICE_LOST` hang on Linux/NVIDIA. The editor freezes in `AZ::Vulkan::BinaryFence::WaitOnCpuInternal`.

### Root cause

The Vulkan swapchain rotates its binary semaphores (`m_imageAvailableSemaphore` / `m_presentableSemaphore`) inside `AcquireNewImage`, which runs at present time **and** during recreation. A resize recreates the swapchain immediately (`ResizeInternal` → `CreateSwapchain`) and out of lockstep with an already-compiled frame, whose `FrameGraphCompiler` already captured the previous semaphores. Because **all swapchains share a single per-device `SwapChainSemaphoreAllocator`**, a second window makes this race frequent. The result is one of:

- `VUID-vkQueueSubmit-pWaitSemaphores-03238` — waiting on a binary semaphore that can no longer be signaled,
- `UNASSIGNED-non-acquired-swapchain-image-used` — layout transition / render on an image not acquired since the last present,
- `VUID-vkQueueSubmit-pSignalSemaphores-00067` — re-signaling a recycled semaphore,

any of which can trip the driver into device-lost, after which the next CPU fence wait asserts.

### Fix

- `SwapChain::ResizeInternal` and `SwapChain::ProcessRecreation`: flush the presentation queue and wait for all command queues to be idle **before** recreating the native swapchain, so no in-flight frame references the semaphores/images being rotated.
- `SwapChain::PresentInternal`: on the acquire-failed path (which skips the present), mark the still-signaled binary semaphores non-recyclable so they are not returned to the shared pool and signaled again before being waited on.

### Testing

Linux, NVIDIA RTX 2060 (driver 580.x), Vulkan 1.4, EMotionFX Animation Editor.

- **Before:** device-lost hang within ~20–60s of opening the Animation Editor and dragging its window.
- **After:** aggressive drag / resize / maximize no longer produces a device-lost hang.

**Scope / honesty:** this is a robust mitigation, not a full elimination of the underlying design issue. Draining before recreation reliably prevents the swapchain/semaphore validation errors from escalating to `VK_ERROR_DEVICE_LOST`, but under heavy resizing the `pWaitSemaphores-03238` / `pSignalSemaphores-00067` / non-acquired-image validation-layer messages may still be reported transiently, because acquisition is still folded into present rather than performed at the start of the frame. A larger restructuring (acquire at frame start, per-swapchain semaphore sets, deferring resize to a frame boundary) would remove the race entirely and is left for a follow-up. Feedback welcome on whether to pursue that here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
