### PR TITLE
Fix maximize button on frameless floating windows (Linux/X11)

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Titlebar.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Titlebar.cpp
@@ -26,6 +26,7 @@
 #include <QStackedLayout>
 #include <QVector>
 #include <QWindow>
+#include <QScreen>
 
 namespace AzQtComponents
 {
@@ -199,10 +200,34 @@ namespace AzQtComponents
     void TitleBar::handleMaximize()
     {
         QWidget* w = window();
+        if (!w)
+        {
+            return;
+        }
+
+#if defined(Q_OS_LINUX)
+        // On X11, AzQtComponents' custom-decorated floating windows do not honor
+        // setWindowState(Qt::WindowMaximized): the window manager silently ignores it for a
+        // frameless/customized top-level, so the maximize button appears to do nothing (e.g.
+        // the floating EMotion FX Animation Editor). Emulate maximize/restore by resizing to
+        // the available screen geometry and restoring the previous geometry instead.
+        if (m_emulatedMaximized)
+        {
+            w->setGeometry(m_normalGeometryBeforeMaximize);
+            m_emulatedMaximized = false;
+        }
+        else if (QScreen* screen = w->screen())
+        {
+            m_normalGeometryBeforeMaximize = w->geometry();
+            w->setGeometry(screen->availableGeometry());
+            m_emulatedMaximized = true;
+        }
+#else
         if (w->windowState() & Qt::WindowMaximized)
             w->setWindowState(Qt::WindowNoState);
         else
             w->setWindowState(Qt::WindowMaximized);
+#endif
     }
 
     void TitleBar::handleMinimize()
@@ -1100,6 +1125,14 @@ namespace AzQtComponents
 
     bool TitleBar::isMaximized() const
     {
+#if defined(Q_OS_LINUX)
+        // On Linux the maximize button is emulated (see handleMaximize), so reflect that state
+        // here too. This also lets dragWindow() restore an emulated-maximized window on drag.
+        if (m_emulatedMaximized)
+        {
+            return true;
+        }
+#endif
         return window() && window()->isMaximized();
     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Titlebar.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Titlebar.h
@@ -247,6 +247,8 @@ namespace AzQtComponents
         bool m_resizingTop = false;
         bool m_resizingRight = false;
         bool m_resizingLeft = false;
+        bool m_emulatedMaximized = false; // Linux: maximize is emulated via geometry (see handleMaximize)
+        QRect m_normalGeometryBeforeMaximize;
         qreal m_relativeDragPos = 0.0;
         qreal m_lastLocalPosX = 0.0;
         QMenu* m_tabsContextMenu = nullptr;


### PR DESCRIPTION
### Problem

On Linux/X11, the **maximize** button on AzQtComponents custom-decorated floating windows does nothing. Reproduced with the **EMotion FX Animation Editor**: clicking maximize on its floating window has no effect.

### Root cause

`AzQtComponents::TitleBar::handleMaximize()` calls `setWindowState(Qt::WindowMaximized)`. For a frameless / customized floating top-level window, the X11 window manager silently ignores this request, so the button appears dead.

(On Windows, `WindowDecorationWrapper::specialFlagsForOS` injects `Qt::WindowMaximizeButtonHint`; on macOS native decoration handles it. Linux has no equivalent path.)

### Fix

Scoped to Linux with `#if defined(Q_OS_LINUX)`; other platforms keep the native `setWindowState` path unchanged.

- `TitleBar::handleMaximize()` — emulate maximize/restore by resizing the window to `QScreen::availableGeometry()` and restoring a saved geometry (`m_normalGeometryBeforeMaximize` / `m_emulatedMaximized`).
- `TitleBar::isMaximized()` — reflect the emulated state, so the title-bar context menu (Maximize/Restore) stays consistent and `dragWindow()` restores a maximized window when it is dragged.

### Testing

Linux/X11 (NVIDIA), EMotion FX Animation Editor floating window:

- Maximize now fills the available screen area (below panels/taskbar).
- Clicking maximize again restores the previous size and position.
- Dragging a maximized window restores it and follows the cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
