### PR TITLE
Fixes crashes and UI flicker related to prefab handling

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -115,13 +115,7 @@ namespace AZ::DocumentPropertyEditor
 
         // Upgrade the reset type to HardReset in case its already queued as a soft reset.
         m_queuedResetType = m_queuedResetType == DocumentResetType::HardReset ? DocumentResetType::HardReset : resetType;
-
-        // De-bounce the reset event.
-        if (!m_isResetQueued)
-        {
-            m_isResetQueued = true;
-            NotifyResetQueued();
-        }
+        NotifyResetQueued();
     }
 
     void DocumentAdapter::NotifyResetQueued()
@@ -131,25 +125,29 @@ namespace AZ::DocumentPropertyEditor
         // The filtered adapter may be a proxy on top of the "Real adapter".  There are two Adapters involved, the "underlying" real one
         // and a filter.  The GUI is watching the filtered one, the filtered one watching the underlying one.
         // This means that for the document to get these kind of events, the filtered adapter needs to pass any events relevant up the chain
+        m_isResetQueued = true;
         m_resetQueuedEvent.Signal();
     }
 
     void DocumentAdapter::ExecuteQueuedReset()
     {
-        // Called by the view when its a good time to execute the queued reset, like when the callstack is short and simple.
-        if (m_isResetQueued)
-        {
-            NotifyResetDocument(m_queuedResetType);
-        }
+        // This is invoked by the document (which is the GUI widget itself) when it knows that the callstack is no longer
+        // deep inside some event handling callstack such as undo or value change, and its safe to rebuild the document out from
+        // under it.
+        NotifyResetDocument(m_queuedResetType);
     }
 
     void DocumentAdapter::NotifyResetDocument(DocumentResetType resetType)
     {
         // this is the actual reset function, which overrides any queuing, so reset it.
+        if (!m_isResetQueued)
+        {
+            return;
+        }
         m_isResetQueued = false;
-
         if (resetType == DocumentResetType::HardReset || m_cachedContents.IsNull())
         {
+            m_queuedResetType = DocumentResetType::SoftReset;
             // If it's a hard reset, or we don't have any lazily cached contents, just send the reset signal.
             m_cachedContents.SetNull();
             m_resetEvent.Signal();

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/MetaAdapter.cpp
@@ -86,12 +86,13 @@ namespace AZ::DocumentPropertyEditor
 
     void MetaAdapter::ExecuteQueuedReset()
     {
-        DocumentAdapter::ExecuteQueuedReset();
         // if we're told to execute a queued reset, we need to forward that to our source.
         if (m_sourceAdapter)
         {
             m_sourceAdapter->ExecuteQueuedReset();
         }
+        // and then update ourselves since we're probably some sort of filtered map or view of the source we just reset.
+        DocumentAdapter::ExecuteQueuedReset();
     }
 
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -1312,6 +1312,11 @@ namespace AZ::DocumentPropertyEditor
         QueueResetDocument(DocumentResetType::HardReset);
     }
 
+    void ReflectionAdapter::ClearValue()
+    {
+        m_instance = nullptr;
+    }
+
     void ReflectionAdapter::InvokeChangeNotify(const AZ::Dom::Value& domNode)
     {
         using Nodes::PropertyEditor;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.cpp
@@ -163,7 +163,9 @@ namespace AZ::DocumentPropertyEditor
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
-                impl->m_adapter->NotifyResetDocument();
+                // the "this pointer" is actually deleted by notifyResetDocument, and we'd prefer if that did NOT happen
+                // within this same callstack which is likely responding to a button click, so we queue a reset instead.
+                impl->m_adapter->QueueResetDocument();
             }
 
             void StoreReservedInstance(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path)
@@ -176,9 +178,10 @@ namespace AZ::DocumentPropertyEditor
                 AZ::Dom::Value newValue = impl->GetContainerValue(m_containerInstance, containerNode);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
-                // rebuild the view based on the new contents, which could be many rows.
-                // This deletes the 'this' pointer!
-                impl->m_adapter->NotifyResetDocument(); 
+
+                // the "this pointer" is actually deleted by notifyResetDocument, and we'd prefer if that did NOT happen
+                // within this same callstack which is likely responding to a button click, so we queue a reset instead.
+                impl->m_adapter->QueueResetDocument();
             }
 
             void OnAddElement(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path)
@@ -475,7 +478,9 @@ namespace AZ::DocumentPropertyEditor
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
-                impl->m_adapter->NotifyResetDocument();
+                // the "this pointer" is actually deleted by notifyResetDocument, and we'd prefer if that did NOT happen
+                // within this same callstack which is likely responding to a button click, so we queue a reset instead.
+                impl->m_adapter->QueueResetDocument();
             }
 
             void OnMoveElement(ReflectionAdapterReflectionImpl* impl, const AZ::Dom::Path& path, bool moveForward)
@@ -488,7 +493,9 @@ namespace AZ::DocumentPropertyEditor
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::InProgressEdit);
                 Nodes::PropertyEditor::OnChanged.InvokeOnDomNode(containerNode, newValue, Nodes::ValueChangeType::FinishedEdit);
 
-                impl->m_adapter->NotifyResetDocument();
+                // the "this pointer" is actually deleted by notifyResetDocument, and we'd prefer if that did NOT happen
+                // within this same callstack which is likely responding to a button click, so we queue a reset instead.
+                impl->m_adapter->QueueResetDocument();
             }
 
             AZ::SerializeContext::IDataContainer* m_container = nullptr;
@@ -1302,7 +1309,7 @@ namespace AZ::DocumentPropertyEditor
         m_typeId = AZStd::move(typeId);
 
         // new top-value, do a full reset
-        NotifyResetDocument(DocumentResetType::HardReset);
+        QueueResetDocument(DocumentResetType::HardReset);
     }
 
     void ReflectionAdapter::InvokeChangeNotify(const AZ::Dom::Value& domNode)

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/ReflectionAdapter.h
@@ -51,6 +51,9 @@ namespace AZ::DocumentPropertyEditor
         //! this adapter will produce a property grid based on its contents.
         void SetValue(void* instance, AZ::TypeId typeId);
 
+        //! Clear the value, so no refreshes occur.  Can happen when the object behind the value is deleted.
+        void ClearValue();
+
         //! Invokes the ChangeNotify attribute for an Adapter, if present, and follows up
         //! with a tree refresh if needed.
         static void InvokeChangeNotify(const AZ::Dom::Value& domNode);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/SettingsRegistryAdapter.cpp
@@ -321,7 +321,7 @@ namespace AZ::DocumentPropertyEditor
         {
             // For now just trigger a soft reset.
             // This will still only send the view patches for what's actually changed.
-            NotifyResetDocument();
+            QueueResetDocument();
         };
 
         return message.Match(

--- a/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/ExampleAdapter.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/DPEDebugViewStandalone/ExampleAdapter.cpp
@@ -121,7 +121,7 @@ namespace AZ::DocumentPropertyEditor
                                 break;
                             }
                         }
-                        NotifyResetDocument();
+                        QueueResetDocument();
                     });
                 builder.EndPropertyEditor();
             }
@@ -136,7 +136,7 @@ namespace AZ::DocumentPropertyEditor
                     ColorTreeNode child;
                     child.m_parent = entry.m_node;
                     entry.m_node->m_children.push_back(child);
-                    NotifyResetDocument();
+                    QueueResetDocument();
                 });
             builder.EndPropertyEditor();
 
@@ -170,6 +170,6 @@ namespace AZ::DocumentPropertyEditor
         {
             m_matrix[i].resize(m_columnCount);
         }
-        NotifyResetDocument();
+        QueueResetDocument();
     }
 } // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -420,10 +420,10 @@ namespace AzToolsFramework
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
-        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnStartPlayInEditorBegin);
-
-        //cache the current selected entities.
+        // cache the current selected entities.
         ToolsApplicationRequests::Bus::BroadcastResult(m_selectedBeforeStartingGame, &ToolsApplicationRequests::GetSelectedEntities);
+
+        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnStartPlayInEditorBegin);
         //deselect entities if selected when entering game mode before deactivating the entities in StartPlayInEditor(...)
         if (!m_selectedBeforeStartingGame.empty())
         {
@@ -455,10 +455,10 @@ namespace AzToolsFramework
             "PrefabEditorEntityOwnershipInterface");
         service->StopPlayInEditor();
 
+        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnStopPlayInEditor);
+        
         ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, m_selectedBeforeStartingGame);
         m_selectedBeforeStartingGame.clear();
-
-        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnStopPlayInEditor);
     }
 
     //=========================================================================

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -494,6 +494,12 @@ namespace AzToolsFramework
 
     void PrefabEditorEntityOwnershipService::StartPlayInEditor()
     {
+        if (auto* instanceUpdateExecutor = AZ::Interface<AzToolsFramework::Prefab::InstanceUpdateExecutorInterface>::Get(); instanceUpdateExecutor)
+        {
+            // flush any remaining template instance updates in the queue, before we start play.
+            instanceUpdateExecutor->UpdateTemplateInstancesInQueue();
+            instanceUpdateExecutor->SetShouldPauseInstancePropagation(true);
+        }
         // This is a workaround until the replacement for GameEntityContext is done
         AzFramework::GameEntityContextEventBus::Broadcast(&AzFramework::GameEntityContextEventBus::Events::OnPreGameEntitiesStarted);
         m_gameModeEvent.Signal(GameModeState::Started);
@@ -611,6 +617,12 @@ namespace AzToolsFramework
         }
 
         m_playInEditorData.m_isEnabled = false;
+        
+        if (auto* instanceUpdateExecutor = AZ::Interface<AzToolsFramework::Prefab::InstanceUpdateExecutorInterface>::Get();
+            instanceUpdateExecutor)
+        {
+            instanceUpdateExecutor->SetShouldPauseInstancePropagation(false);
+        }
     }
 
     bool PrefabEditorEntityOwnershipService::IsValidRootAliasPath(Prefab::RootAliasPath rootAliasPath) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -41,6 +41,13 @@ namespace AzToolsFramework::Prefab
 
     void PrefabComponentAdapter::SetComponent(AZ::Component* componentInstance)
     {
+        if (!componentInstance)
+        {
+            // the component we were looking at is destroyed - stop performing logic, a refresh is coming soon.
+            m_entityAlias.clear();
+            m_componentAlias.clear();
+            return;
+        }
         auto owningInstance = AZ::Interface<InstanceEntityMapperInterface>::Get()->FindOwningInstance(
             componentInstance->GetEntityId());
         AZ_Assert(owningInstance.has_value(), "Entity owning the component doesn't have an owning prefab instance.");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/DocumentPropertyEditor/PrefabComponentAdapter.cpp
@@ -46,6 +46,7 @@ namespace AzToolsFramework::Prefab
             // the component we were looking at is destroyed - stop performing logic, a refresh is coming soon.
             m_entityAlias.clear();
             m_componentAlias.clear();
+            ClearValue();
             return;
         }
         auto owningInstance = AZ::Interface<InstanceEntityMapperInterface>::Get()->FindOwningInstance(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -352,6 +352,18 @@ namespace AzToolsFramework::Prefab
         {
             PrefabFocusNotificationBus::Broadcast(&PrefabFocusNotifications::OnPrefabFocusChanged,
                 previousFocusedInstanceContainerEntityId, currentFocusedInstanceContainerEntityId);
+
+            AZ::EntityId instanceToFocusOn = currentFocusedInstanceContainerEntityId.IsValid() ? currentFocusedInstanceContainerEntityId
+                                                                                               : previousFocusedInstanceContainerEntityId;
+            if (instanceToFocusOn.IsValid())
+            {
+                ScopedUndoBatch undoBatch("Select Prefab");
+                // For convenience, select the instance root you just opened.
+                const EntityIdList selectedEntities = EntityIdList{ instanceToFocusOn };
+                auto selectionUndo = aznew SelectionCommand(selectedEntities, "Select Open Prefab");
+                selectionUndo->SetParent(undoBatch.GetUndoBatch());
+                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, selectedEntities);
+            }
         }
 
         // Force propagation on both the previous and the new focused instances to ensure they are represented correctly.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -10,6 +10,7 @@
 
 #include <AzToolsFramework/Commands/SelectionCommand.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
@@ -120,25 +121,46 @@ namespace AzToolsFramework::Prefab
         }
     }
 
+    SelectionCommand* PrefabFocusHandler::CreateSelectionCommandForFocusedPrefab(AZ::EntityId referenceId)
+    {
+        using AzFramework::EntityContextId;
+        using AzFramework::EntityIdContextQueryBus;
+
+        // update selection - if there is a focused instance, select its container.  Default to the editor context.
+        EntityContextId contextId = AZ::Uuid::CreateNull();
+        EditorEntityContextRequestBus::BroadcastResult(contextId, &EditorEntityContextRequests::GetEditorEntityContextId);
+
+        if (referenceId.IsValid())
+        {
+            EntityIdContextQueryBus::EventResult(contextId, referenceId, &EntityIdContextQueryBus::Events::GetOwningContextId);
+        }
+
+        EntityIdList selectedEntities;
+        if (AZ::EntityId focusedId = GetFocusedPrefabContainerEntityId(contextId); focusedId.IsValid())
+        {
+            selectedEntities.push_back(focusedId);
+        }
+        return new SelectionCommand(selectedEntities, "Select entities");
+    }
+
     PrefabFocusOperationResult PrefabFocusHandler::FocusOnOwningPrefab(AZ::EntityId entityId)
     {
+        
         // Initialize Undo Batch object
-        ScopedUndoBatch undoBatch("Edit Prefab");
-
-        // Clear selection
-        {
-            const EntityIdList selectedEntities = EntityIdList{};
-            auto selectionUndo = aznew SelectionCommand(selectedEntities, "Clear Selection");
-            selectionUndo->SetParent(undoBatch.GetUndoBatch());
-            ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, selectedEntities);
-        }
+        ScopedUndoBatch undoBatch("Focus on Prefab");
 
         // Add undo element
         {
             auto editUndo = aznew PrefabFocusUndo("Focus Prefab");
             editUndo->Capture(entityId);
             editUndo->SetParent(undoBatch.GetUndoBatch());
-            FocusOnPrefabInstanceOwningEntityId(entityId);
+            editUndo->Redo();
+        }
+       
+        if (auto selectionUndo = CreateSelectionCommandForFocusedPrefab(entityId); selectionUndo)
+        {
+            selectionUndo->SetParent(undoBatch.GetUndoBatch());
+            selectionUndo->Redo();
         }
 
         return AZ::Success();
@@ -171,24 +193,21 @@ namespace AzToolsFramework::Prefab
         AZ::EntityId entityId = parentInstance->get().GetContainerEntityId();
 
         // Initialize Undo Batch object
-        ScopedUndoBatch undoBatch("Edit Prefab");
-
-        // Clear selection
-        {
-            const EntityIdList selectedEntities = EntityIdList{};
-            auto selectionUndo = aznew SelectionCommand(selectedEntities, "Clear Selection");
-            selectionUndo->SetParent(undoBatch.GetUndoBatch());
-            ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, selectedEntities);
-        }
+        ScopedUndoBatch undoBatch("Focus step up");
 
         // Add undo element
         {
             auto editUndo = aznew PrefabFocusUndo("Focus Prefab");
             editUndo->Capture(entityId);
             editUndo->SetParent(undoBatch.GetUndoBatch());
-            FocusOnPrefabInstanceOwningEntityId(entityId);
+            editUndo->Redo();
         }
 
+        if (auto selectionUndo = CreateSelectionCommandForFocusedPrefab(entityId); selectionUndo)
+        {
+            selectionUndo->SetParent(undoBatch.GetUndoBatch());
+            selectionUndo->Redo();
+        }
         return AZ::Success();
     }
 
@@ -352,18 +371,6 @@ namespace AzToolsFramework::Prefab
         {
             PrefabFocusNotificationBus::Broadcast(&PrefabFocusNotifications::OnPrefabFocusChanged,
                 previousFocusedInstanceContainerEntityId, currentFocusedInstanceContainerEntityId);
-
-            AZ::EntityId instanceToFocusOn = currentFocusedInstanceContainerEntityId.IsValid() ? currentFocusedInstanceContainerEntityId
-                                                                                               : previousFocusedInstanceContainerEntityId;
-            if (instanceToFocusOn.IsValid())
-            {
-                ScopedUndoBatch undoBatch("Select Prefab");
-                // For convenience, select the instance root you just opened.
-                const EntityIdList selectedEntities = EntityIdList{ instanceToFocusOn };
-                auto selectionUndo = aznew SelectionCommand(selectedEntities, "Select Open Prefab");
-                selectionUndo->SetParent(undoBatch.GetUndoBatch());
-                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, selectedEntities);
-            }
         }
 
         // Force propagation on both the previous and the new focused instances to ensure they are represented correctly.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
@@ -26,6 +26,7 @@ namespace AzToolsFramework
     class FocusModeInterface;
     class ReadOnlyEntityPublicInterface;
     class ReadOnlyEntityQueryInterface;
+    class SelectionCommand;
 }
 
 namespace AzToolsFramework::Prefab
@@ -88,6 +89,11 @@ namespace AzToolsFramework::Prefab
 
         PrefabFocusOperationResult FocusOnPrefabInstance(InstanceOptionalReference focusedInstance);
         void RefreshInstanceFocusPath();
+
+        // helper function.  Finds out which prefab instance is currently focused, and creates
+        // a selection command that will select the container entity.
+        // uses the reference entity Id to figure out which context should be queried.
+        SelectionCommand* CreateSelectionCommandForFocusedPrefab(AZ::EntityId referenceId);
 
         void SetInstanceContainersOpenState(const RootAliasPath& rootAliasPath, bool openState) const;
         void SetInstanceContainersOpenStateOfAllDescendantContainers(InstanceOptionalReference instance, bool openState) const;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -82,7 +82,7 @@ namespace AZ::DocumentPropertyEditor
     {
         if (!componentInstance) // This happens if the entity we're attached to is destroyed and becomes invalid.
         {
-            SetValue(nullptr, AZ::Uuid::CreateNull());
+            ClearValue();
             return;
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -80,9 +80,9 @@ namespace AZ::DocumentPropertyEditor
 
     void ComponentAdapter::SetComponent(AZ::Component* componentInstance)
     {
-        AZ_Assert(componentInstance, "ComponentAdapter::SetComponent - component is null.");
-        if (!componentInstance)
+        if (!componentInstance) // This happens if the entity we're attached to is destroyed and becomes invalid.
         {
+            SetValue(nullptr, AZ::Uuid::CreateNull());
             return;
         }
 
@@ -117,7 +117,7 @@ namespace AZ::DocumentPropertyEditor
         SetValue(componentInstance, instanceTypeId);
     }
 
-    bool ComponentAdapter::IsComponentValid() const
+    AZ::Component* ComponentAdapter::GetComponentInstanceFromId() const
     {
         if (m_entityId.IsValid())
         {
@@ -126,13 +126,22 @@ namespace AZ::DocumentPropertyEditor
             // Since DoRefresh() gets called on the next tick, the entity and its components could have been destroyed by then.
             if (entity == nullptr)
             {
-                return false;
+                return nullptr;
             }
 
-            bool isEntityActive = entity->GetState() == AZ::Entity::State::Active;
-            return isEntityActive && entity->FindComponent(m_componentId) != nullptr;
+            return entity->FindComponent(m_componentId);
         }
 
+        return nullptr;
+    }
+
+    bool ComponentAdapter::IsComponentValid() const
+    {
+        AZ::Component* component = GetComponentInstanceFromId();
+        if (component)
+        {
+            return component->GetEntity()->GetState() == AZ::Entity::State::Active;
+        }
         return false;
     }
 
@@ -205,7 +214,7 @@ namespace AZ::DocumentPropertyEditor
         ReflectionAdapter::CreateLabel(adapterBuilder, labelText, serializedPath);
     }
 
-    void ComponentAdapter::OnEntityDestruction(const AZ::EntityId& entityId)
+    void ComponentAdapter::OnEntityDeactivated(const AZ::EntityId& entityId)
     {
         if (entityId == m_entityId)
         {
@@ -214,10 +223,11 @@ namespace AZ::DocumentPropertyEditor
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusDisconnect();
             AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusDisconnect();
             AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusDisconnect(m_entityId);
+            SetComponent(nullptr);
         }
     }
 
-    void ComponentAdapter::OnEntityInitialized(const AZ::EntityId& entityId)
+    void ComponentAdapter::OnEntityActivated(const AZ::EntityId& entityId)
     {
         if (entityId == m_entityId)
         {
@@ -225,6 +235,7 @@ namespace AZ::DocumentPropertyEditor
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusConnect();
             AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusConnect();
             AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusConnect(m_entityId);
+            SetComponent(GetComponentInstanceFromId());
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.cpp
@@ -104,7 +104,15 @@ namespace AZ::DocumentPropertyEditor
         if (!AZ::EntitySystemBus::Handler::BusIsConnected())
         {
             AZ::EntitySystemBus::Handler::BusConnect(); // listens for "On Entity Destruction" / "On Entity Initialized".
+        }
+
+        if (!AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusIsConnected())
+        {
             AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusConnect();
+        }
+
+        if (!AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusIsConnected())
+        {
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusConnect();
         }
 
@@ -216,6 +224,8 @@ namespace AZ::DocumentPropertyEditor
 
     void ComponentAdapter::OnEntityDeactivated(const AZ::EntityId& entityId)
     {
+        // There is no "Component is destroyed" event, so we have to listen for the entity deactivation
+        // and make no assumptions from that point until we get our entity back.
         if (entityId == m_entityId)
         {
             // stop listening for all events except Entity Initialized, which will be reconnected when the entity is re-initialized
@@ -235,6 +245,9 @@ namespace AZ::DocumentPropertyEditor
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusConnect();
             AzToolsFramework::ToolsApplicationEvents::Bus::Handler::BusConnect();
             AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler::BusConnect(m_entityId);
+
+            // We can't assume that its the same component, even if the component id AND memory is the same.
+            // The component could have been destroyed and recreated, so we need to re-fetch the component instance from the entity.
             SetComponent(GetComponentInstanceFromId());
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -60,12 +60,13 @@ namespace AZ::DocumentPropertyEditor
         void CreateLabel(AdapterBuilder* adapterBuilder, AZStd::string_view labelText, AZStd::string_view serializedPath) override;
 
         //! Gets notification from the EntitySystemBus before destroying an entity.
-        void OnEntityDestruction(const AZ::EntityId&) override;
-        void OnEntityInitialized(const AZ::EntityId&) override;
+        void OnEntityDeactivated(const AZ::EntityId&) override;
+        void OnEntityActivated(const AZ::EntityId&) override;
 
     private:
         //! Checks if the component is still valid in the entity.
         bool IsComponentValid() const;
+        AZ::Component* GetComponentInstanceFromId() const;
         void DoRefresh();
 
     protected:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -470,7 +470,7 @@ namespace AzToolsFramework
                     GetDPE()->ClearDirtyHandler(handlerInfo.handlerInterface);
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
                 }
-                else if (auto rowWidget = qobject_cast<DPERowWidget*>(childWidget))
+                else if (auto* rowWidget = qobject_cast<DPERowWidget*>(childWidget); rowWidget)
                 {
                     if (DocumentPropertyEditor::ShouldUseWidgetPooling())
                     {
@@ -481,21 +481,25 @@ namespace AzToolsFramework
                         delete rowWidget;
                     }
                 }
-                else // if it's not a row or a PropertyHandler, it must be a label
+                else if (auto* label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget); label)
                 {
                     if (DocumentPropertyEditor::ShouldUseWidgetPooling())
                     {
-                        auto* label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget);
-                        AZ_Assert(label, "unknown widget in DPERowWidget!");
-                        if (label)
-                        {
-                            DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
-                        }
+                        DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
                     }
                     else
                     {
-                        delete rowWidget;
+                        delete label;
                     }
+                }
+                else
+                {
+                    // likely someone introduced a new type of widget but hasn't handled all the cases
+                    // for its housekeeping.
+                    AZ_Assert(false, "unknown widget type discovered in DPE row.");
+                    // we still have a valid childWidget pointer, though, so we can at least delete it
+                    // to avoid memory leak.
+                    delete childWidget;
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -34,7 +34,15 @@ AZ_CVAR(
     true,
     nullptr,
     AZ::ConsoleFunctorFlags::DontReplicate | AZ::ConsoleFunctorFlags::DontDuplicate,
-    "If set, enables experimental DPE-based CVar Editor");
+    "If set, enables DPE-based CVar Editor");
+
+AZ_CVAR(
+    bool,
+    ed_enableDPEWidgetPooling,
+    false,
+    nullptr,
+    AZ::ConsoleFunctorFlags::DontReplicate | AZ::ConsoleFunctorFlags::DontDuplicate,
+    "If set, DPE will use widget pooling to attempt to improve performance.");
 
 static constexpr const char* GetHandlerPropertyName()
 {
@@ -453,22 +461,40 @@ namespace AzToolsFramework
                 auto handlerInfo = DocumentPropertyEditor::GetInfoFromWidget(childWidget);
                 if (!handlerInfo.IsNull())
                 {
-                    childWidget->hide();
-                    m_columnLayout->removeWidget(childWidget);
+                    if (DocumentPropertyEditor::ShouldUseWidgetPooling())
+                    {
+                        // try to put the widget back in the pooling, which means removing it from the layout, and hiding it
+                        childWidget->hide();
+                        m_columnLayout->removeWidget(childWidget);
+                    }
                     GetDPE()->ClearDirtyHandler(handlerInfo.handlerInterface);
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
                 }
                 else if (auto rowWidget = qobject_cast<DPERowWidget*>(childWidget))
                 {
-                    DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowWidget);
+                    if (DocumentPropertyEditor::ShouldUseWidgetPooling())
+                    {
+                        DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowWidget);
+                    }
+                    else
+                    {
+                        delete rowWidget;
+                    }
                 }
                 else // if it's not a row or a PropertyHandler, it must be a label
                 {
-                    auto* label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget);
-                    AZ_Assert(label, "unknown widget in DPERowWidget!");
-                    if (label)
+                    if (DocumentPropertyEditor::ShouldUseWidgetPooling())
                     {
-                        DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
+                        auto* label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget);
+                        AZ_Assert(label, "unknown widget in DPERowWidget!");
+                        if (label)
+                        {
+                            DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
+                        }
+                    }
+                    else
+                    {
+                        delete rowWidget;
                     }
                 }
             }
@@ -607,27 +633,48 @@ namespace AzToolsFramework
                 }
                 if (!newOwner)
                 {
-                    DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowToRemove);
+                    if (DocumentPropertyEditor::ShouldUseWidgetPooling())
+                    {
+                        DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowToRemove);
+                    }
+                    else
+                    {
+                        delete rowToRemove;
+                    }
                 }
             }
             else if (auto handlerInfo = DocumentPropertyEditor::GetInfoFromWidget(childWidget); !handlerInfo.IsNull())
             {
-                childWidget->hide();
-                m_columnLayout->removeWidget(childWidget);
-                RemoveCachedAttributes(childIndex);
+                // if `newOwner` is not null we are moving the widget, not removing it, so don't release the handler
                 if (!newOwner)
                 {
+                    if (DocumentPropertyEditor::ShouldUseWidgetPooling())
+                    {
+                        // remove it from the layout and hide it so we can reuse it later.
+                        childWidget->hide();
+                        m_columnLayout->removeWidget(childWidget);
+                    }
+
                     GetDPE()->ClearDirtyHandler(handlerInfo.handlerInterface);
                     DocumentPropertyEditor::ReleaseHandler(handlerInfo);
                 }
+                
+                RemoveCachedAttributes(childIndex);
             }
             else // not a row, not a PropertyHandler, must be a label
             {
-                auto label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget);
-                AZ_Assert(label, "not a label, unknown widget discovered!");
-                if (label && !newOwner)
+                if (DocumentPropertyEditor::ShouldUseWidgetPooling())
                 {
-                    DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
+                    auto label = qobject_cast<AzQtComponents::ElidingLabel*>(childWidget);
+                    AZ_Assert(label, "not a label, unknown widget discovered!");
+                    if (label && !newOwner)
+                    {
+                        DocumentPropertyEditor::GetLabelPool()->RecycleInstance(label);
+                    }
+                }
+                else
+                {
+                    delete childWidget;
                 }
             }
         }
@@ -940,8 +987,13 @@ namespace AzToolsFramework
                         // check if this patch has morphed the PropertyHandler into a different type
                         if (handlerId != handlerInfo.handlerId)
                         {
-                            childWidget->hide();
-                            m_columnLayout->removeWidget(childWidget);
+                            if (DocumentPropertyEditor::ShouldUseWidgetPooling())
+                            {
+                                // remove the existing handler widget from the layout and hide it so we can reuse it later.
+                                childWidget->hide();
+                                m_columnLayout->removeWidget(childWidget);
+                            }
+
                             theDPE->ClearDirtyHandler(handlerInfo.handlerInterface);
                             DocumentPropertyEditor::ReleaseHandler(handlerInfo);
 
@@ -1226,7 +1278,14 @@ namespace AzToolsFramework
                 DPERowWidget* rowChild = qobject_cast<DPERowWidget*>(currentChild);
                 if (rowChild)
                 {
-                    DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowChild);
+                    if (DocumentPropertyEditor::ShouldUseWidgetPooling())
+                    {
+                        DocumentPropertyEditor::GetRowPool()->RecycleInstance(rowChild);
+                    }
+                    else
+                    {
+                        delete rowChild;
+                    }
                     currentChild = nullptr;
                 }
             }
@@ -1387,7 +1446,14 @@ namespace AzToolsFramework
     void DocumentPropertyEditor::Clear()
     {
         m_dirtyHandlers.clear();
-        m_rowPool->RecycleInstance(m_rootNode);
+        if (ShouldUseWidgetPooling())
+        {
+            m_rowPool->RecycleInstance(m_rootNode);
+        }
+        else
+        {
+            delete m_rootNode;
+        }
         m_rootNode = nullptr;
     }
 
@@ -1522,6 +1588,16 @@ namespace AzToolsFramework
         Clear();
     }
 
+    void DocumentPropertyEditor::InvalidateAll([[maybe_unused]] const char* filter)
+    {
+        // If the DPE is a standalone control, this is not going to be called by anyone.  However if its part of a larger
+        // control cluster (like an entity inspector that has multiple DPEs in it) then the parent control can *optionally*
+        // call this when it rebuilds itself to synchronize all the rebuilds all at once.  When that happens, it should be
+        // happening from a "short" call stack - ie, not from inside a deep call stack inside a value change operation.
+        m_executeQueuedResetAlreadyQueued = false;
+        m_adapter->ExecuteQueuedReset();
+    }
+
     void DocumentPropertyEditor::SetFilterString(AZStd::string str)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
@@ -1617,7 +1693,10 @@ namespace AzToolsFramework
             }
         };
 
-        applyExpansionRecursively(m_rootNode, AZ::Dom::Path(), this, applyExpansionRecursively);
+        if (m_rootNode)
+        {
+            applyExpansionRecursively(m_rootNode, AZ::Dom::Path(), this, applyExpansionRecursively);
+        }
     }
 
     void DocumentPropertyEditor::ExpandAll()
@@ -1668,6 +1747,16 @@ namespace AzToolsFramework
             console->GetCvarValue(GetEnableCVarEditorName(), dpeCVarEditorEnabled);
         }
         return dpeCVarEditorEnabled;
+    }
+
+    bool DocumentPropertyEditor::ShouldUseWidgetPooling()
+    {
+        bool dpeShouldUseWidgetPooling = false;
+        if (auto* console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
+        {
+            console->GetCvarValue("ed_enableDPEWidgetPooling", dpeShouldUseWidgetPooling);
+        }
+        return dpeShouldUseWidgetPooling;
     }
 
     QVBoxLayout* DocumentPropertyEditor::GetVerticalLayout()
@@ -1916,13 +2005,19 @@ namespace AzToolsFramework
         m_executeQueuedResetAlreadyQueued = true;
 
         // When a value changes, we'd like to queue the execution of any property editor tree updates.
-        // It should happen *soon* but not immediately, so queue it on the invoke method queue to happen
-        // once the event pump resumes.
-        QMetaObject::invokeMethod(this, [this]() {
+        // However, we want it to happen when we're not still inside the deep callstack of a property editor change
+        // callback.  So queue it to happen when we return to the message pump:
+        QMetaObject::invokeMethod(this, &DocumentPropertyEditor::ExecuteQueuedReset, Qt::QueuedConnection);
+    }
+
+    void DocumentPropertyEditor::ExecuteQueuedReset()
+    {
+        // debounce this, in case something else reset before we got here:
+        if (m_executeQueuedResetAlreadyQueued)
+        {
             m_executeQueuedResetAlreadyQueued = false;
             m_adapter->ExecuteQueuedReset();
-            },
-            Qt::QueuedConnection);
+        }
     }
 
     void DocumentPropertyEditor::RegisterHandlerPool(AZ::Name handlerName, AZStd::shared_ptr<AZ::InstancePoolBase> handlerPool)
@@ -2002,16 +2097,19 @@ namespace AzToolsFramework
 
     void DocumentPropertyEditor::ReleaseHandler(HandlerInfo& handler)
     {
-        if (handler.handlerInterface->ResetToDefaults())
+        if (ShouldUseWidgetPooling())
         {
-            auto poolManager = static_cast<AZ::InstancePoolManager*>(AZ::Interface<AZ::InstancePoolManagerInterface>::Get());
-            auto handlerName = GetNameForHandlerId(handler.handlerId);
-            auto handlerPool = poolManager->GetPool<PropertyHandlerWidgetInterface>(handlerName);
-
-            if (handlerPool)
+            if (handler.handlerInterface->ResetToDefaults())
             {
-                handlerPool->RecycleInstance(handler.handlerInterface);
-                return;
+                auto poolManager = static_cast<AZ::InstancePoolManager*>(AZ::Interface<AZ::InstancePoolManagerInterface>::Get());
+                auto handlerName = GetNameForHandlerId(handler.handlerId);
+                auto handlerPool = poolManager->GetPool<PropertyHandlerWidgetInterface>(handlerName);
+
+                if (handlerPool)
+                {
+                    handlerPool->RecycleInstance(handler.handlerInterface);
+                    return;
+                }
             }
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -231,6 +231,7 @@ namespace AzToolsFramework
         void SetSavedStateKey(AZ::u32 key, AZStd::string propertyEditorName = {}) override;
         void ClearInstances() override;
         void SetFilterString(AZStd::string str) override; // Only used for linting, filtering is handled by the DocumentAdapter
+        void InvalidateAll(const char* filter) override;
         // ~IPropertyEditor overrides
 
         AZ::Dom::Value GetDomValueForRow(DPERowWidget* row) const;
@@ -241,6 +242,7 @@ namespace AzToolsFramework
         void SetSpawnDebugView(bool shouldSpawn);
 
         static bool ShouldReplaceCVarEditor();
+        static bool ShouldUseWidgetPooling();
 
         static constexpr const char* GetEnableCVarEditorName()
         {
@@ -287,6 +289,7 @@ namespace AzToolsFramework
         //! set the DOM adapter for this DPE to inspect
         void SetAdapter(AZ::DocumentPropertyEditor::DocumentAdapterPtr theAdapter);
         void Clear();
+        void ExecuteQueuedReset();
 
     protected:
         QVBoxLayout* GetVerticalLayout();
@@ -298,6 +301,7 @@ namespace AzToolsFramework
         void HandleDomMessage(const AZ::DocumentPropertyEditor::AdapterMessage& message, AZ::Dom::Value& value);
         void RequestExecuteQueuedReset();
         void UpdateDirtyHandlers();
+
         bool m_executeQueuedResetAlreadyQueued = false;
 
         AZ::DocumentPropertyEditor::DocumentAdapterPtr m_adapter;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -1807,6 +1807,10 @@ namespace AzToolsFramework
     {
         // Ensure all descendants of the current focus root are expanded, so it is visible.
         ExpandAncestors(newFocusEntityId);
+
+        // Queue the new focus entity to be expanded, since you just chose to double click it, or clicked "edit"
+        // the user intends to edit the contents of this container entity.
+        QueueEntityToExpand(newFocusEntityId, true);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -1138,10 +1138,12 @@ namespace AzToolsFramework
 
     void EntityOutlinerWidget::OnPrefabInstancePropagationEnd()
     {
-        QTimer::singleShot(1, this, [this]() {
-            m_gui->m_objectTree->setUpdatesEnabled(true);
+        // Prevent GUI flicker - allow repaint immediately
+        m_gui->m_objectTree->setUpdatesEnabled(true);
+        QTimer::singleShot(1, this, [this]()
+            {
             m_gui->m_objectTree->expand(m_proxyModel->index(0,0));
-        });
+            });
     }
 
     void EntityOutlinerWidget::OnPrefabTemplateDirtyFlagUpdated(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -1116,8 +1116,10 @@ namespace AzToolsFramework
 
         void PrefabIntegrationManager::OnStartPlayInEditorBegin()
         {
-            // Focus on the root prefab (AZ::EntityId() will default to it)
-            s_prefabFocusPublicInterface->FocusOnOwningPrefab(AZ::EntityId());
+            // Focus on the root prefab (AZ::EntityId() will default to it).
+            // We use the private interface, so that it does not try to create an undo batch for the focus change.
+            // Since play in editor is not an edit operation
+            s_prefabFocusInterface->FocusOnPrefabInstanceOwningEntityId(AZ::EntityId());
         }
 
         void PrefabIntegrationManager::OnStopPlayInEditor()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -5336,6 +5336,11 @@ namespace AzToolsFramework
         }
     }
 
+    void EntityPropertyEditor::OnContextReset()
+    {
+        ClearInstances(true);
+    }
+
     void EntityPropertyEditor::CloseInspectorWindow()
     {
         for (auto& entityId : m_overrideSelectedEntityIds)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -218,6 +218,7 @@ namespace AzToolsFramework
         void OnStartPlayInEditor() override;
         void OnStopPlayInEditor() override;
         void OnPrepareForContextReset() override;
+        void OnContextReset() override;
         //////////////////////////////////////////////////////////////////////////
 
         // PropertyEditorEntityChangeNotificationBus overrides ...

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -2166,29 +2166,31 @@ namespace AzToolsFramework
 
             ReflectedPropertyEditor* promptEditor = new ReflectedPropertyEditor(&dialog);
 
+            // Do not allow the following elements to leave scope until the prompt is closed.
+            AZ::Edit::ElementData syntheticData;
+            bool hasProvidedFirstDynamicEditData = false;
+            auto dynamicEditDataProvider = [&](const void* objectPtr, const AZ::SerializeContext::ClassData* classData) -> const AZ::Edit::ElementData*
+            {
+                Q_UNUSED(classData)
+
+                // Ensure we only override the first instance of dynamic element data
+                // This prevents overriding the name field for compound editors like AZ::EntityId where the address
+                // of the first field may be equivalent to the object address
+                if (objectPtr == value && !hasProvidedFirstDynamicEditData)
+                {
+                    hasProvidedFirstDynamicEditData = true;
+                    return &syntheticData;
+                }
+                return nullptr;
+            };
+
             if (message)
             {
                 // Set the edit data for the key prompt
-                AZ::Edit::ElementData syntheticData;
                 syntheticData.m_elementId = AZ::Crc32();
                 syntheticData.m_name = message;
                 syntheticData.m_description = "";
-
-                bool hasProvidedFirstDynamicEditData = false;
-                promptEditor->SetDynamicEditDataProvider([&](const void* objectPtr, const AZ::SerializeContext::ClassData* classData) -> const AZ::Edit::ElementData*
-                    {
-                        Q_UNUSED(classData)
-
-                        // Ensure we only override the first instance of dynamic element data
-                        // This prevents overriding the name field for compound editors like AZ::EntityId where the address
-                        // of the first field may be equivalent to the object address
-                        if (objectPtr == value && !hasProvidedFirstDynamicEditData)
-                        {
-                            hasProvidedFirstDynamicEditData = true;
-                            return &syntheticData;
-                        }
-                        return nullptr;
-                    });
+                promptEditor->SetDynamicEditDataProvider(dynamicEditDataProvider);
             }
 
             // Prompt using a new ReflectedPropertyEditor to query the value


### PR DESCRIPTION
## What does this PR do?

I was working through how the outliner and the DPE handle focus and unfocus on prefabs (as in, double click the prefab in the outliner) in response to a crash report by @yaakuro.

I found the cause of the crash, as well as related flickering/inconsistent outliner issues, all related to focus handling.

### Crash fix: Entering focus mode 
This crash was caused by the DPE's component adapter keeping a pointer to the component itself, but not correctly dropping that pointer when the entity owning the component is refreshed.

Note that the entity is destroyed, then recreated, with the same ID when prefab propogation occurs.  The component DPE didn't realize that just because the entity id is the same, the underlying pointer may point at fresh memory.

### UI Flicker Fix
The outliner would flicker constantly during prefab propagation, which happens when entities are added, modified, removed, or prefabs are opened or closed.

This is because the outliner set itself as updates disabled and then only enabled updates after a timer timeout.  The problem with doing that is that if updates are disabled for a control, its parent is still allowed to paint itself, but the paint process doesn't repaint the child, only the parent.  This means that widgets that have children (like frames, with contents), will have the frame paint, but not the contents paint.  Thus causing a blank widget to display for one frame.

## How was this PR tested?
Tons of transparent-box testing, with the debugger, as well as a bunch of opaque-box testing (clicking about in debug and profile mode). 
* Undo redo
* Prefab creation, focus
* Nested prefab entering and leaving

I was running with ADDRESS SANITIZER enabled the entire time.
