### PR TITLE
fix(maestro): Fix operator precedence in CCompoundSplineTrack::RemoveKey

### DIFF
--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
@@ -633,7 +633,8 @@ namespace Maestro
                 continue;
             }
             
-            if (const int subKeyIdx = m_subTracks[i]->FindKey(time) >= 0)
+            const int subKeyIdx = m_subTracks[i]->FindKey(time);
+            if (subKeyIdx >= 0)
             {
                 m_subTracks[i]->RemoveKey(subKeyIdx);
             }


### PR DESCRIPTION
## What does this PR do?
Separates `FindKey` result assignment from the comparison check in `CCompoundSplineTrack::RemoveKey`. 

Previously, `if (const int subKeyIdx = m_subTracks[i]->FindKey(time) >= 0)` evaluated `>=` before `=`, causing `subKeyIdx` to be assigned a boolean `1` or `0` instead of the actual key index returned by `FindKey(time)`. This resulted in keyframe #1 being deleted by mistake whenever keyframe #0 was selected.

Fixes #19519

## How was this PR tested?
- Verified operator precedence fix in `Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp`.