### PR TITLE
fix(build): Preserve argument quoting and tilde expansion in o3de.sh

### DIFF
--- a/scripts/o3de.sh
+++ b/scripts/o3de.sh
@@ -37,5 +37,5 @@ if [ ! -f "$PYTHON_EXECUTABLE" ]; then
 fi
 
 #run the o3de.py pass along the command
-$PYTHON_EXECUTABLE "$SCRIPT_DIR/o3de.py" $*
+$PYTHON_EXECUTABLE "$SCRIPT_DIR/o3de.py" "$@"
 exit $?


### PR DESCRIPTION
## What does this PR do?
Replaces unquoted `$*` with `"$@"` when forwarding command-line arguments to `o3de.py` in `scripts/o3de.sh`.

Previously, using unquoted `$*` caused Bash to strip argument quoting and word-split path arguments containing tildes (`~`) or spaces when calling `o3de.sh` (e.g. `o3de.sh register --all-gems-path ~/devroot/...`). Using `"$@"` preserves parameter quoting and allows tilde and path expansion to work correctly.

Fixes #19679

## How was this PR tested?
- Verified argument forwarding in `scripts/o3de.sh`.