### PR TITLE
Remove nightly schedule from AR Canary workflow

### DIFF
--- a/.github/workflows/ar-canary.yml
+++ b/.github/workflows/ar-canary.yml
@@ -11,8 +11,6 @@ name: AR Canary
 run-name: ${{ format('AR Canary - {0}', github.ref_name) }}
 
 on:
-  schedule:
-    - cron: '0 4 * * *'   # Nightly at 04:00 UTC
   workflow_dispatch:
     inputs:
       android_build:


### PR DESCRIPTION
## What does this PR do?

Removes the scheduled cron job for nightly runs, which prevent it from running in forks. We will be executing the scheduled nightly runs through a separate process not tied this workflow.

## How was this PR tested?

Tested in my fork
