### PR TITLE
fix(maestro): Fix operator precedence in CCompoundSplineTrack::RemoveKey

### DIFF
--- a/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/CompoundSplineTrack.cpp
@@ -633,7 +633,8 @@ namespace Maestro
                 continue;
             }
             
-            if (const int subKeyIdx = m_subTracks[i]->FindKey(time) >= 0)
+            const int subKeyIdx = m_subTracks[i]->FindKey(time);
+            if (subKeyIdx >= 0)
             {
                 m_subTracks[i]->RemoveKey(subKeyIdx);
             }


### PR DESCRIPTION
## What does this PR do?
Fixes an operator precedence error in `CCompoundSplineTrack::RemoveKey` where `const int subKeyIdx = m_subTracks[i]->FindKey(time) >= 0` evaluated `>=` before `=`, assigning boolean `0`/`1` to `subKeyIdx` instead of the key index return value.

Separates the key lookup from the conditional check to ensure keyframes at index 0 are removed properly instead of incorrectly deleting keyframe 1.

Fixes #19519

## How was this PR tested?
- Verified operator precedence fix in `CompoundSplineTrack.cpp`.