### PR TITLE
Adds more ENV Var space for mac, to avoid AR failure.

### DIFF
--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Process/ProcessWatcher_Mac.cpp
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Process/ProcessWatcher_Mac.cpp
@@ -286,7 +286,7 @@ namespace AzFramework
         }
         commandAndArgs[commandTokens.size()] = nullptr;
         
-        constexpr int MaxEnvVariables = 128;
+        constexpr int MaxEnvVariables = 256;
         using EnvironmentVariableContainer = AZStd::fixed_vector<char*, MaxEnvVariables>;
         EnvironmentVariableContainer environmentVariables;
         for (char **env = ::environ; *env; env++)


### PR DESCRIPTION
## What does this PR do?

IOS / Mac AR set too many enviroment variables, and died with this message
```
System: Trace::Assert
 /Users/runner/work/o3de/o3de/Code/Framework/AzCore/AzCore/std/containers/fixed_vector.h(199): (6122074112) 'reference AZStd::Internal::fixed_trivial_storage<char *, 128>::emplace_back(Args &&...) [T = char *, Capacity = 128, Args = <char *const &>]'
System: emplace_back cannot be invoked on full storage
```

I suspect this is caused by this code

```cpp
  constexpr int MaxEnvVariables = 128;
        using EnvironmentVariableContainer = AZStd::fixed_vector<char*, MaxEnvVariables>;
        for (char **env = ::environ; *env; env++)
        {
            environmentVariables.push_back(*env);
        }
```

This PR doubles the amount of ENV Vars mac can handle for subprocess, a the cost about 1k additional stack space in this function.

## How was this PR tested?

I have no mac, so its going to have to be an AR test.