### PR TITLE
Fix LyShine editor crash from zero-size viewport window

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -31,6 +31,8 @@ namespace AtomToolsFramework
         : QWidget(parent)
         , AzFramework::InputChannelEventListener(AzFramework::InputChannelEventListener::GetPriorityDefault())
     {
+        setMinimumSize(1, 1);
+
         if (shouldInitializeViewportContext)
         {
             InitializeViewportContext();


### PR DESCRIPTION
## What does this PR do?

Fixes the issue that RenderViewportWidget ever can get 0x0 which prevents a crash.

Qt layout can create 0x0 windows during editor startup, causing Vulkan swapchain creation to fail and the whole editor to crash. Added minimum size constraints. Not sure if this is only a , Wayland, XWayland, KDE Plasma issue but it happens on my system. 

## How was this PR tested?

On my local computer having Kubuntu 26.04 LTS

