### PR TITLE
QtGallery exporter of pages.

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.cpp
@@ -42,14 +42,21 @@
 #include "TreeViewPage.h"
 #include "TypographyPage.h"
 
+#include <AzQtComponents/Components/Widgets/Card.h>
+
 #include <QAction>
+#include <QComboBox>
 #include <QCoreApplication>
 #include <QDir>
+#include <QDockWidget>
 #include <QMap>
 #include <QMenu>
 #include <QMenuBar>
 #include <QPixmap>
+#include <QPushButton>
 #include <QSettings>
+#include <QTimer>
+#include <QTreeView>
 
 #include <cctype>
 
@@ -180,6 +187,143 @@ void ComponentDemoWidget::captureAllPages(const QString& outputDirPath)
                           .arg(outputDirPath)
                           .arg(pageIndex, 2, 10, QLatin1Char('0'))
                           .arg(pageName));
+
+        capturePageInteractions(outputDirPath, pageIndex, pageName);
+    }
+}
+
+void ComponentDemoWidget::selectPage(const QString& pageNameOrIndex)
+{
+    bool isNumber = false;
+    const int numericIndex = pageNameOrIndex.toInt(&isNumber);
+    if (isNumber && numericIndex >= 0 && numericIndex < ui->demoSelector->count())
+    {
+        ui->demoSelector->setCurrentIndex(numericIndex);
+        return;
+    }
+
+    for (int pageIndex = 0; pageIndex < ui->demoSelector->count(); ++pageIndex)
+    {
+        if (ui->demoSelector->itemText(pageIndex).contains(pageNameOrIndex, Qt::CaseInsensitive))
+        {
+            ui->demoSelector->setCurrentIndex(pageIndex);
+            return;
+        }
+    }
+}
+
+void ComponentDemoWidget::capturePageInteractions(const QString& outputDirPath, int pageIndex, const QString& pageName)
+{
+    QWidget* page = ui->demoWidgetStack->currentWidget();
+    if (!page)
+    {
+        return;
+    }
+
+    const auto settle = []()
+    {
+        QCoreApplication::processEvents();
+        QCoreApplication::processEvents();
+    };
+    const auto capturePath = [outputDirPath, pageIndex, pageName](const QString& suffix)
+    {
+        return QStringLiteral("%1/%2_%3__%4.png")
+            .arg(outputDirPath)
+            .arg(pageIndex, 2, 10, QLatin1Char('0'))
+            .arg(pageName)
+            .arg(suffix);
+    };
+
+    // Expanded state: open every tree and card so collapsed-only content is captured
+    bool expandedAnything = false;
+    for (QTreeView* treeView : page->findChildren<QTreeView*>())
+    {
+        treeView->expandAll();
+        expandedAnything = true;
+    }
+    for (AzQtComponents::Card* card : page->findChildren<AzQtComponents::Card*>())
+    {
+        card->setExpanded(true);
+        expandedAnything = true;
+    }
+    if (expandedAnything)
+    {
+        settle();
+        window()->grab().save(capturePath(QStringLiteral("expanded")));
+    }
+
+    // Combo popups: open each visible combo on the page and grab the popup window
+    int comboIndex = 0;
+    for (QComboBox* combo : page->findChildren<QComboBox*>())
+    {
+        if (!combo->isVisible() || combo->count() == 0)
+        {
+            continue;
+        }
+        combo->showPopup();
+        settle();
+        if (QWidget* popup = QApplication::activePopupWidget())
+        {
+            popup->grab().save(capturePath(QStringLiteral("combo%1-popup").arg(comboIndex)));
+        }
+        combo->hidePopup();
+        settle();
+        if (++comboIndex >= 3)
+        {
+            break;
+        }
+    }
+
+    // Modal dialog launchers (color picker etc.): a watchdog grabs and closes the
+    // dialog while the button's exec() blocks
+    int dialogIndex = 0;
+    for (QPushButton* button : page->findChildren<QPushButton*>())
+    {
+        const QString buttonText = button->text().toLower();
+        const bool opensDialog = buttonText.contains(QStringLiteral("picker"))
+            || buttonText.contains(QStringLiteral("dialog"))
+            || buttonText.contains(QStringLiteral("rgb"))
+            || buttonText.contains(QStringLiteral("hsl"))
+            || buttonText.contains(QStringLiteral("hsv"));
+        if (!button->isVisible() || !opensDialog)
+        {
+            continue;
+        }
+
+        const QString dialogCapturePath = capturePath(QStringLiteral("dialog%1").arg(dialogIndex));
+        QTimer::singleShot(900, this, [dialogCapturePath]()
+        {
+            if (QWidget* modal = QApplication::activeModalWidget())
+            {
+                modal->grab().save(dialogCapturePath);
+                modal->close();
+            }
+        });
+        button->click();
+        settle();
+        if (++dialogIndex >= 3)
+        {
+            break;
+        }
+    }
+
+    // Dock widgets: float each one and grab its window, then re-dock
+    int dockIndex = 0;
+    for (QDockWidget* dockWidget : page->findChildren<QDockWidget*>())
+    {
+        if (!dockWidget->isVisible())
+        {
+            continue;
+        }
+        dockWidget->setFloating(true);
+        settle();
+        dockWidget->window()->grab().save(capturePath(QStringLiteral("dock%1-floating").arg(dockIndex)));
+        dockWidget->setFloating(false);
+        settle();
+        if (++dockIndex >= 3)
+        {
+            break;
+        }
     }
 }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.cpp
@@ -43,9 +43,12 @@
 #include "TypographyPage.h"
 
 #include <QAction>
+#include <QCoreApplication>
+#include <QDir>
 #include <QMap>
 #include <QMenu>
 #include <QMenuBar>
+#include <QPixmap>
 #include <QSettings>
 
 #include <cctype>
@@ -149,6 +152,35 @@ void ComponentDemoWidget::addPage(QWidget* widget, const QString& title)
 {
     ui->demoSelector->addItem(title);
     ui->demoWidgetStack->addWidget(widget);
+}
+
+void ComponentDemoWidget::captureAllPages(const QString& outputDirPath)
+{
+    QDir().mkpath(outputDirPath);
+
+    for (int pageIndex = 0; pageIndex < ui->demoSelector->count(); ++pageIndex)
+    {
+        ui->demoSelector->setCurrentIndex(pageIndex);
+
+        // let polish, layout and paint settle before grabbing
+        QCoreApplication::processEvents();
+        QCoreApplication::processEvents();
+
+        QString pageName = ui->demoSelector->itemText(pageIndex).toLower();
+        for (int charIndex = 0; charIndex < pageName.size(); ++charIndex)
+        {
+            if (!pageName.at(charIndex).isLetterOrNumber())
+            {
+                pageName[charIndex] = QLatin1Char('-');
+            }
+        }
+
+        const QPixmap pageGrab = window()->grab();
+        pageGrab.save(QStringLiteral("%1/%2_%3.png")
+                          .arg(outputDirPath)
+                          .arg(pageIndex, 2, 10, QLatin1Char('0'))
+                          .arg(pageName));
+    }
 }
 
 void ComponentDemoWidget::setupMenuBar()

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.h
@@ -24,6 +24,11 @@ public:
     explicit ComponentDemoWidget(QWidget* parent = nullptr);
     ~ComponentDemoWidget() override;
 
+    //! Rasterizes every gallery page into outputDirPath as numbered PNGs
+    //! (whole window, including the custom title bar chrome). Used by the
+    //! --screenshot-dir command line mode for style parity evaluation.
+    void captureAllPages(const QString& outputDirPath);
+
 Q_SIGNALS:
     void styleChanged(bool enableLegacyUI);
     void refreshStyle();

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/ComponentDemoWidget.h
@@ -25,9 +25,20 @@ public:
     ~ComponentDemoWidget() override;
 
     //! Rasterizes every gallery page into outputDirPath as numbered PNGs
-    //! (whole window, including the custom title bar chrome). Used by the
-    //! --screenshot-dir command line mode for style parity evaluation.
+    //! (whole window, including the custom title bar chrome), plus secondary
+    //! interaction states per page: expanded trees/cards, open combo popups,
+    //! modal dialogs (grabbed and closed via watchdog), floated dock widgets.
+    //! Used by the --screenshot-dir command line mode for parity evaluation.
     void captureAllPages(const QString& outputDirPath);
+
+    //! Selects a page by (case-insensitive, partial) title match or numeric
+    //! index. Used by the --page command line option.
+    void selectPage(const QString& pageNameOrIndex);
+
+private:
+    void capturePageInteractions(const QString& outputDirPath, int pageIndex, const QString& pageName);
+
+public:
 
 Q_SIGNALS:
     void styleChanged(bool enableLegacyUI);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/main.cpp
@@ -163,6 +163,14 @@ int main(int argc, char **argv)
     // Pairs with --disable-stylesheets to produce flattened vs qss-mode sets
     // for side-by-side parity evaluation.
     const QStringList arguments = QApplication::arguments();
+
+    // --page <name-or-index>: start on a specific gallery page
+    const int pageArgIndex = arguments.indexOf(QStringLiteral("--page"));
+    if (pageArgIndex >= 0 && pageArgIndex + 1 < arguments.size())
+    {
+        widget->selectPage(arguments.at(pageArgIndex + 1));
+    }
+
     const int screenshotArgIndex = arguments.indexOf(QStringLiteral("--screenshot-dir"));
     if (screenshotArgIndex >= 0 && screenshotArgIndex + 1 < arguments.size())
     {

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/main.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/main.cpp
@@ -33,6 +33,7 @@
 #include <QApplication>
 #include <QMainWindow>
 #include <QSettings>
+#include <QTimer>
 
 #include <iostream>
 
@@ -157,6 +158,20 @@ int main(int argc, char **argv)
     });
 
     app.setQuitOnLastWindowClosed(true);
+
+    // --screenshot-dir <path>: rasterize every gallery page to PNG and exit.
+    // Pairs with --disable-stylesheets to produce flattened vs qss-mode sets
+    // for side-by-side parity evaluation.
+    const QStringList arguments = QApplication::arguments();
+    const int screenshotArgIndex = arguments.indexOf(QStringLiteral("--screenshot-dir"));
+    if (screenshotArgIndex >= 0 && screenshotArgIndex + 1 < arguments.size())
+    {
+        const QString screenshotDir = arguments.at(screenshotArgIndex + 1);
+        QTimer::singleShot(800, widget, [widget, screenshotDir]() {
+            widget->captureAllPages(screenshotDir);
+            QApplication::quit();
+        });
+    }
 
     app.exec();
 }


### PR DESCRIPTION
## What does this PR do?
Run the control gallery with command: `--screenshot-dir <export directory>`

It runs through each of the pages, exports as png, and then closes.

## How was this PR tested?

I used it to export pages.

This is to rapidly evaluate QtGallery styling outcomes from, arguably vanilla, to altered results and see how they turned out.