### PR TITLE
Ignore python's dist/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .vscode/
 .gradle/
 __pycache__
+dist/
 /[Bb]uild
 [Oo]ut/**
 CMakeUserPresets.json


### PR DESCRIPTION
## What does this PR do?

This PR adds the dist/ directory to .gitignore.

The project contains some python code, and some have a setup.py file and it can be build using command _python -m build_. When doing that, a dist/ folder is generated in the project. This folder contains distribution artifacts such as wheels and source tarballs (e.g., .whl, .tar.gz). These files are build outputs and should not be tracked in version control.

## How was this PR tested?

After adding the dist/ directory to .gitignore, git will ignore it.
