### PR TITLE
Fixes an assert and UB in AudioControlsWriter

### DIFF
--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsWriter.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsWriter.cpp
@@ -78,18 +78,26 @@ namespace AudioControls
                 index = index.sibling(++i, 0);
             }
 
+            
             auto fileIO = AZ::IO::FileIOBase::GetInstance();
+
+            FilepathSet normalizedFilePaths; // Temp output variable
+
             AZStd::for_each(
-                m_foundLibraryPaths.begin(), m_foundLibraryPaths.end(),
-                [fileIO](AZStd::string& libraryPath) -> void
+                m_foundLibraryPaths.begin(),
+                m_foundLibraryPaths.end(),
+                [fileIO, &normalizedFilePaths](const AZStd::string& libraryPath) -> void
                 {
-                    if (auto newPathOpt = fileIO->ConvertToAlias(AZ::IO::PathView{ libraryPath });
-                        newPathOpt.has_value())
+                    AZStd::string newPath = libraryPath;
+                    if (auto newPathOpt = fileIO->ConvertToAlias(AZ::IO::PathView{ newPath }); newPathOpt.has_value())
                     {
-                        libraryPath = newPathOpt.value().Native();
+                        newPath = newPathOpt.value().Native();
                     }
-                    AZStd::to_lower(libraryPath.begin(), libraryPath.end());
+                    AZStd::to_lower(newPath.begin(), newPath.end());
+                    normalizedFilePaths.insert(newPath);
                 });
+
+            m_foundLibraryPaths.swap(normalizedFilePaths);
 
             // Delete libraries that don't exist anymore from disk
             FilepathSet librariesToDelete;


### PR DESCRIPTION
## What does this PR do?

The AudioControlsWriter class was creating an AZStd::set of file names, and then modifying the members of it in place, in memory, rather than creating a new set or reinserting.  This means that the elements may initially be in order when first inserted, but will be out of order by the time it uses a stl algorithm like set_difference.

MSVC debug actually triggers an assert in debug since it checks to see if the elements are out of order in a set (this should never be the case, as it sorts/rebalances on insertion and deletion).  The rest of the libraries (clang, etc) do not check, and just emit UB.

## How was this PR tested?

Tested in a pseudo test case I set up.  Also, verified by Discord user "system_v" who encountered this assert directly and used the patched code to check.