### PR TITLE
AudioSystem Gem Editor and Engine fixes: FileCacheManager dangling pointer and invisible Connection Properties.

### DIFF
--- a/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.cpp
@@ -128,6 +128,7 @@ namespace AudioControls
             m_connectionPropertiesWidget = nullptr;
         }
 
+        bool hideConnectionProperties = true;
         if (connection && connection->HasProperties())
         {
             if (IAudioSystemEditor* audioSystemImpl = CAudioControlsEditorPlugin::GetAudioSystemEditorImpl())
@@ -148,9 +149,12 @@ namespace AudioControls
                     {
                         connect(m_connectionPropertiesWidget, SIGNAL(PropertiesChanged()), this, SLOT(CurrentConnectionModified()));
                     }
+                    hideConnectionProperties = false;
                 }
             }
         }
+
+        m_connectionPropertiesFrame->setHidden(hideConnectionProperties);
     }
 
     //-------------------------------------------------------------------------------------------//

--- a/Gems/AudioSystem/Code/Source/Engine/FileCacheManager.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/FileCacheManager.cpp
@@ -730,11 +730,12 @@ namespace Audio
             audioFileEntry->m_fileSize,
             audioFileEntry->m_memoryBlockAlignment
         );
+
+        audioFileEntry->m_memoryBlock = nullptr; // <- DeAllocate doesn't set the pointer back to nullptr, thus leaving an dangling pointer instead, this is why fails when you change the g_languageAudio cvar.
         audioFileEntry->m_flags.ClearFlags(eAFF_CACHED | eAFF_REMOVABLE);
         m_currentByteTotal -= audioFileEntry->m_fileSize;
         AZ_Warning("FileCacheManager", audioFileEntry->m_useCount == 0, "Use-count of file '%s' is non-zero while uncaching it! Use Count: %d", audioFileEntry->m_filePath.c_str(), audioFileEntry->m_useCount);
         audioFileEntry->m_useCount = 0;
-
     #if !defined(AUDIO_RELEASE)
         audioFileEntry->m_timeCached = AZStd::chrono::steady_clock::time_point();
     #endif // !AUDIO_RELEASE


### PR DESCRIPTION
## What does this PR do?

* Fixes a dangling pointer when AudioSystem's FileCacheManager.cpp uncaches a file without removing the audioFileEntry, this happens when change the language cvar `g_languageAudio` and should change the sound banks/files with the new language, the dangling pointer of the old buffer is still there causing the load to fail when tries to allocate new data due a null pointer check.
* Fix Audio Control Editor Inspector not showing custom connnection properties widgets if available from IAudioSystemEditor implementations.

## How was this PR tested?

* Tested with my AudioEngineFMOD gem, that tries to unload/load localized sound banks by changing `g_languageAudio` Cvar in the Editor's console.
* Creating a example ATL Trigger, and drag and drop an FMOD Event from the "Middleware Controls" panel should show an QWidget showing FMOD Event-specific widgets to manipulate behavior and properties and `AudioControls::IAudioSystemEditor::CreateConnectionPropertiesWidget()` should be implemented accordingly