### PR TITLE
Fix Qt6 NodePalette crashes and out-of-bounds reads (Script Canvas add-node)

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -132,6 +132,13 @@ namespace GraphCanvas
 
         NodePaletteTreeItem* currentItem = static_cast<GraphCanvas::NodePaletteTreeItem*>(index.internalPointer());
 
+        if (!currentItem)
+        {
+            // index() can return an invalid index (hasIndex fails, or FindChildByRow misses),
+            // which leaves a null internalPointer(). Guard the dereferences below.
+            return false;
+        }
+
         if (m_hasSourceSlotFilter && m_sourceSlotFilter.count(currentItem) == 0)
         {
             return false;
@@ -337,26 +344,40 @@ namespace GraphCanvas
 
     void NodePaletteSortFilterProxyModel::SetFilter(const QString& filter)
     {
+        beginFilterChange();
         // Remove whitespace and escape() so every regexp special character is escaped with a backslash
         // Then ignore all whitespace by adding \s* (regex optional whitespace match) in between every other character.
         // We use \s* instead of simply removing all whitespace from the filter and node-names in order to preserve the node-name and accurately highlight the matching portion.
         // Example: "OnGraphStart" or "On Graph Start"
         m_filter = filter.simplified().replace(" ", "");
-        
-        QString regExIgnoreWhitespace = QRegularExpression::escape(QString(m_filter[0]));
-        for (int i = 1; i < m_filter.size(); ++i)
+
+        // Guard the empty case: clearing the search box routes empty text here (OnFilterTextChanged
+        // -> UpdateFilter -> SetFilter("")), and m_filter[0] on an empty string is an out-of-bounds
+        // read. An empty regex matches everything, which is the intended "no filter" behavior.
+        QString regExIgnoreWhitespace;
+        if (!m_filter.isEmpty())
         {
-            regExIgnoreWhitespace.append("\\s*");
-            regExIgnoreWhitespace.append(QRegularExpression::escape(QString(m_filter[i])));
+            regExIgnoreWhitespace = QRegularExpression::escape(QString(m_filter[0]));
+            for (int i = 1; i < m_filter.size(); ++i)
+            {
+                regExIgnoreWhitespace.append("\\s*");
+                regExIgnoreWhitespace.append(QRegularExpression::escape(QString(m_filter[i])));
+            }
         }
-        
+
         m_filterRegex = QRegularExpression(regExIgnoreWhitespace, QRegularExpression::PatternOption::CaseInsensitiveOption);
+        endFilterChange();
     }
 
     void NodePaletteSortFilterProxyModel::ClearFilter()
     {
+        // Qt6: bracket the filter change with begin/endFilterChange rather than relying on a
+        // caller-side invalidate(). A raw invalidate() rebuilds all mappings and crashes in
+        // QSortFilterProxyModelPrivate::create_mapping_recursive while remapping persistent indexes.
+        beginFilterChange();
         m_filter.clear();
         m_filterRegex = QRegularExpression(m_filter, QRegularExpression::PatternOption::CaseInsensitiveOption);
+        endFilterChange();
     }
 
     QCompleter* NodePaletteSortFilterProxyModel::GetCompleter()

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteWidget.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/NodePaletteWidget.cpp
@@ -232,7 +232,6 @@ namespace GraphCanvas
             m_ui->searchFilter->clear();
 
             m_model->ClearFilter();
-            m_model->invalidate();
         }
 
         {
@@ -659,7 +658,6 @@ namespace GraphCanvas
         QString text = m_ui->searchFilter->userInputText();
 
         m_model->SetFilter(text);
-        m_model->invalidate();
 
         if (!m_model->HasFilter())
         {


### PR DESCRIPTION
## What does this PR do?

Fixes three related Qt6 bugs in the GraphCanvas node palette (used by Script Canvas, Material Canvas, and any node editor), documented in #19966:

1. **Crash opening the add-node palette.** `NodePaletteWidget::ResetDisplay` and `UpdateFilter` called a raw `QSortFilterProxyModel::invalidate()` on the node-palette filter model. Under Qt6 the full `invalidate()` rebuilds all mappings and crashes in `QSortFilterProxyModelPrivate::create_mapping_recursive` while remapping persistent indexes. This change brackets `NodePaletteSortFilterProxyModel::SetFilter()`/`ClearFilter()` in `beginFilterChange()`/`endFilterChange()` (the Qt6-safe pattern already used elsewhere in the gem) and removes the redundant external `invalidate()` calls.

2. **Null dereference in `filterAcceptsRow`.** `sourceModel()->index()` can return an invalid index (null `internalPointer()`), and the subsequent `currentItem->ClearHighlight()` dereferenced it. Guarded.

3. **Out-of-bounds read in `SetFilter`.** `m_filter[0]` on an empty string (clearing the search box routes empty text here) read past the end and built a garbage regex. Guarded the empty case.

Note on approach for (1): #19966 suggested clearing the view's selection / current index / expanded state before `invalidate()`. This PR instead uses the `beginFilterChange()`/`endFilterChange()` bracket that the gem already applies to its other filter proxies (`ResetSourceSlotFilter`/`FilterForSourceSlot`, `GraphCanvasComboBox`, `BookmarkTableModel`, `GraphOutlinerTableModel`), which resolves the same root cause. Happy to switch approaches if reviewers prefer.

Addresses #19966
Addresses #19977

## How was this PR tested?

Built the editor from `development` (Fedora 44 Linux, Qt 6.10.2, clang 22.1.8, profile config) and ran Script Canvas under gdb. Before: opening the add-node palette a second time crashed (SIGSEGV in the linked issues). After: opening and adding nodes, filtering via the palette search box, clearing the search box (the `SetFilter("")` path), and delete/connect/drag all run without a crash. #19966 also reports these on Windows 11, so they are not Linux-specific.
