### PR TITLE
Fix Script Canvas Ctrl+S prompting Save As instead of overwriting

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1737,36 +1737,41 @@ namespace ScriptCanvasEditor
             selectedFile = suggestedFilename.c_str();
         }
 
-        QString filter = suggestedFileFilter.c_str();
-
-        AzFramework::StringFunc::Path::Normalize(suggestedDirectoryPath);
-
-        QDir dir(suggestedDirectoryPath.c_str());
-        if (!dir.exists())
+        // Only prompt for a destination (Save As) when we do not already have a valid target. For an
+        // in-place save the Save::InPlace branch above fills selectedFile from the existing absolute
+        // path and sets isValidFileName, so skip the dialog and overwrite the existing file. Prior to
+        // #19850 the surrounding while(!isValidFileName) loop provided this guard; removing that loop
+        // (to fix the Save As cancel infinite loop) also made the dialog fire for in-place saves.
+        if (!isValidFileName)
         {
-            auto result = AZ::IO::SystemFile::CreateDir(suggestedDirectoryPath.c_str());
-            if (!result)
+            AzFramework::StringFunc::Path::Normalize(suggestedDirectoryPath);
+
+            QDir dir(suggestedDirectoryPath.c_str());
+            if (!dir.exists())
             {
-                AZ_Error("Script Canvas", false, "Failed to make new folder: %s", suggestedDirectoryPath.c_str());
-                return false;
+                auto result = AZ::IO::SystemFile::CreateDir(suggestedDirectoryPath.c_str());
+                if (!result)
+                {
+                    AZ_Error("Script Canvas", false, "Failed to make new folder: %s", suggestedDirectoryPath.c_str());
+                    return false;
+                }
             }
-        }
 
-        AZ::IO::FixedMaxPath fullPath = suggestedDirectoryPath.c_str();
-        AZStd::string suggestedFileName = sourceHandle.GetSuggestedFileName() + SourceDescription::GetFileExtension();
-        fullPath /= suggestedFileName;
+            AZ::IO::FixedMaxPath fullPath = suggestedDirectoryPath.c_str();
+            AZStd::string suggestedFileName = sourceHandle.GetSuggestedFileName() + SourceDescription::GetFileExtension();
+            fullPath /= suggestedFileName;
 
-        QString localSelectedFilter;
-        QFileDialog::Options options;
-        QString filePath = AzQtComponents::FileDialog::GetSaveFileName(this, QObject::tr("Save As..."), fullPath.c_str(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"), &localSelectedFilter, options);
+            QString localSelectedFilter;
+            QFileDialog::Options options;
+            QString filePath = AzQtComponents::FileDialog::GetSaveFileName(this, QObject::tr("Save As..."), fullPath.c_str(), QObject::tr("All ScriptCanvas Files (*.scriptcanvas)"), &localSelectedFilter, options);
 
-        selectedFile = filePath.toUtf8().toStdString().c_str();
+            selectedFile = filePath.toUtf8().toStdString().c_str();
 
-        // If the selected file is empty that means we just cancelled.
-        // So we want to break out.
-        if (!selectedFile.isEmpty())
-        {
-            isValidFileName = true;
+            // If the selected file is empty that means we just cancelled.
+            if (!selectedFile.isEmpty())
+            {
+                isValidFileName = true;
+            }
         }
 
         if (isValidFileName)


### PR DESCRIPTION
## What does this PR do?

Fixes Script Canvas in-place save (Ctrl+S, or File > Save) opening the Save As dialog instead of overwriting the file.

Old behavior: after saving a graph once, any subsequent Ctrl+S or File > Save re-opened the Save As dialog every time, so the user could not overwrite in place and could end up saving a second copy under a different name.

New behavior: an in-place save writes back to the existing file silently. The Save As dialog only appears for a new/unsaved graph (or an explicit Save As).

Root cause: `MainWindow::SaveAssetImpl` always ran the `GetSaveFileName` dialog block. For a `Save::InPlace` request the code just above it already fills `selectedFile` from the existing absolute path and sets `isValidFileName`, so the dialog should be skipped. This is a regression from #19850 ("Fix an infinite loop if Save As cancelled"), which removed the surrounding `while (!isValidFileName)` loop that had implicitly guarded the dialog: for an in-place save `isValidFileName` was already true, so the loop body never ran. With the loop gone the dialog began firing unconditionally, including for in-place saves.

Fix: guard the dialog block with `if (!isValidFileName)` so it only runs when there is no valid target yet. Because the guard runs the dialog at most once, a cancelled Save As still returns without looping, preserving the #19850 fix. Also drops a dead `QString filter` local that was never read.

The diff looks large but is almost entirely re-indentation from the new `if` scope; view with whitespace ignored (append `?w=1` to the Files-changed URL) for the one-branch logical change.

Addresses #19972.

## How was this PR tested?

Built a profile Editor from this branch (Fedora 44 Linux, clang, Qt 6.10) and ran the exact repro from #19972:

1. Create a new Script Canvas graph, Ctrl+S, save under a name. The Save As dialog appears, as expected for a new graph.
2. Modify the graph, Ctrl+S again. The file is overwritten silently, with no dialog and no second copy created (confirmed on disk: only the original file exists).

Also confirmed the #19850 case still holds: invoking Save As and cancelling the dialog does not loop and does not save.
