### PR TITLE
Fixes a debug assert that occurs in LyShine when picking assets

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -141,7 +141,8 @@ namespace AzToolsFramework
         m_completer->setCaseSensitivity(Qt::CaseInsensitive);
         m_completer->setFilterMode(Qt::MatchContains);
 
-        connect(m_completer->completionModel(), &QAbstractItemModel::modelReset, this, &PropertyAssetCtrl::OnCompletionModelReset);
+        m_completerResetConnection = connect(
+            m_completer->completionModel(), &QAbstractItemModel::modelReset, this, &PropertyAssetCtrl::OnCompletionModelReset);
         connect(m_completer, static_cast<void (QCompleter::*)(const QModelIndex& index)>(&QCompleter::activated), this, &PropertyAssetCtrl::OnAutocomplete);
 
         m_view = new AssetCompleterListView(this);
@@ -774,6 +775,10 @@ namespace AzToolsFramework
         AssetEditor::AssetEditorNotificationsBus::Handler::BusDisconnect();
         AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
         AssetSystemBus::Handler::BusDisconnect();
+        if (m_completerResetConnection)
+        {
+            QObject::disconnect(m_completerResetConnection);
+        }
     }
 
     void PropertyAssetCtrl::OnEditButtonClicked()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -107,6 +107,7 @@ namespace AzToolsFramework
         QCompleter* m_completer = nullptr;
         AssetCompleterModel* m_model = nullptr;
         AssetCompleterListView* m_view = nullptr;
+        QMetaObject::Connection m_completerResetConnection;
 
         AZ::Data::AssetId m_defaultAssetID;
 


### PR DESCRIPTION
## What does this PR do?

Fixes a popup debug runtime assert that the debug Qt catches, when you actually use a property
asset control (like the "which font to use?" control in a text element)

When an asset picker populates, it uses a autocompleter.

However, the autocompleter emits a modelReset signal when it is destroyed.  The PropertyAssetCtrl was not disconnecting from this signal on destruction,
which causes the signal to emit later when the child object is destroyed, at which time the PropertyAssetCtrl is already mostly destroyed.

## How was this PR tested?

Its a 100% repro if you create a text element in lyshine, and click on its "font" asset, modifying that in any way causes it to spawn an autocompleter.  Once you refresh the property view by picking any other lyshine entity in the scene, it crashes.

(Only in Qt debug mode)

after this fix, no more crash.

