### PR TITLE
Delete project remove shortcut

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -253,5 +253,10 @@ namespace O3DE::ProjectManager
         {
             return AZ::Failure(QObject::tr("Creating desktop shortcuts functionality not implemented for this platform yet."));
         }
+
+        bool DeleteDesktopShortcut(const QString& filename)
+        {
+            return false;
+        }
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -212,5 +212,10 @@ namespace O3DE::ProjectManager
         {
             return AZ::Failure(QObject::tr("Creating desktop shortcuts functionality not implemented for this platform yet."));
         }
+
+        bool DeleteDesktopShortcut(const QString& filename)
+        {
+            return false;
+        }
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -366,5 +366,13 @@ namespace O3DE::ProjectManager
 
             return AZ::Success(QObject::tr("A desktop shortcut has been successfully created.<br>You can view the file <a href=\"%1\">here</a>.").arg(desktopPath));
         }
+
+        bool DeleteDesktopShortcut(const QString& filename)
+        {
+            const QString desktopPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+            const QString shortcutPath = QString("%1/%2.lnk").arg(desktopPath).arg(filename);
+
+            return QFile::remove(shortcutPath);
+        }
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -382,7 +382,7 @@ namespace O3DE::ProjectManager
         {
             AZ::IO::FixedMaxPath editorExecutablePath = ProjectUtils::GetEditorExecutablePath(m_projectInfo.m_path.toUtf8().constData());
 
-            const QString shortcutName = QString("%1 Editor").arg(m_projectInfo.m_displayName); 
+            const QString shortcutName = QString(ProjectUtils::EditorShortcutFilenameFormat.data()).arg(m_projectInfo.m_displayName); 
             const QString arg = QString("--regset=\"/Amazon/AzCore/Bootstrap/project_path=%1\"").arg(m_projectInfo.m_path);
 
             auto result = ProjectUtils::CreateDesktopShortcut(shortcutName, editorExecutablePath.c_str(), { arg });

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -27,6 +27,10 @@ namespace O3DE::ProjectManager
         static constexpr AZStd::string_view EngineJsonFilename = "engine.json";
         static constexpr AZStd::string_view ProjectJsonFilename = "project.json";
 
+        // Without the file extension to be cross platform.
+        // %1 to be replaced with project name.
+        static constexpr AZStd::string_view EditorShortcutFilenameFormat = "%1 Editor";
+
         bool RegisterProject(const QString& path, QWidget* parent = nullptr);
         bool UnregisterProject(const QString& path, QWidget* parent = nullptr);
         bool CopyProjectDialog(const QString& origPath, ProjectInfo& newProjectInfo, QWidget* parent = nullptr);

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -113,6 +113,11 @@ namespace O3DE::ProjectManager
          */
         AZ::Outcome<QString, QString> CreateDesktopShortcut(const QString& filename, const QString& targetPath, const QStringList& arguments);
 
+        /*
+        * Delete a desktop shortcut previously created.
+        * @param filename the name of the desktop fortcut file
+        * @return bool true if deleted false otherwise
+        */
         bool DeleteDesktopShortcut(const QString& filename);
 
         /**

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -109,6 +109,8 @@ namespace O3DE::ProjectManager
          */
         AZ::Outcome<QString, QString> CreateDesktopShortcut(const QString& filename, const QString& targetPath, const QStringList& arguments);
 
+        bool DeleteDesktopShortcut(const QString& filename);
+
         /**
          * Lookup the location of an Editor executable executable that can be used with the
          * supplied project path

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -659,6 +659,9 @@ namespace O3DE::ProjectManager
                 ProjectUtils::DeleteProjectFiles(projectPath);
                 QGuiApplication::restoreOverrideCursor();
 
+                const QString shortcutName = QString("%1 Editor").arg(projectName);
+                ProjectUtils::DeleteDesktopShortcut(shortcutName);
+
                 emit NotifyProjectRemoved(projectPath);
             }
         }

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -659,7 +659,7 @@ namespace O3DE::ProjectManager
                 ProjectUtils::DeleteProjectFiles(projectPath);
                 QGuiApplication::restoreOverrideCursor();
 
-                const QString shortcutName = QString("%1 Editor").arg(projectName);
+                const QString shortcutName = QString(ProjectUtils::EditorShortcutFilenameFormat.data()).arg(projectName);
                 ProjectUtils::DeleteDesktopShortcut(shortcutName);
 
                 emit NotifyProjectRemoved(projectPath);


### PR DESCRIPTION
## What does this PR do?

Fixes #18940 

Old behavior: after deleting project in project manager shortcut on the Desktop was left.

New behavior: after deleting project files, the Desktop shortcut is also deleted if found.

I've used the same filename formatting as in shortcut creation function and made it into a constant.

Changing shortcut's name after it's creation is not detectable(I think). So if shortcut's name was changed it won't be deleted.

For the MacOS and Linux the shortcut creation functions haven't been implemented yet. So I also left deletion functions empty.

## How was this PR tested?

Tested only on Windows 11 machine with debug build.

I didn't find Unit tests for shortcut creation, so I decided not to implement them for deletion functionality. If they are needed, guidance on how to add them would be appreciated.
