### PR TITLE
Fixes crash when detaching prefab, and imgui crash

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -186,10 +186,12 @@ namespace AzToolsFramework
     {
         ToolsApplicationRequests::Bus::Handler::BusConnect();
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusConnect();
+        AZ::EntitySystemBus::Handler::BusConnect();
     }
 
     ToolsApplication::~ToolsApplication()
     {
+        AZ::EntitySystemBus::Handler::BusDisconnect();
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusDisconnect();
         ToolsApplicationRequests::Bus::Handler::BusDisconnect();
         Stop();
@@ -681,14 +683,20 @@ namespace AzToolsFramework
         // * Filter any duplicates.
 
         // Filter out any invalid or non-selectable entities
-        EntityIdList selectedEntitiesFiltered;
-        selectedEntitiesFiltered.reserve(selectedEntities.size());
-
         // if the new viewport interaction model is enabled we do not want to
         // filter out locked entities as this breaks with the logic of being
         // able to select locked entities in the entity outliner
-        selectedEntitiesFiltered.insert(
-            selectedEntitiesFiltered.begin(), selectedEntities.begin(), selectedEntities.end());
+        EntityIdList selectedEntitiesFiltered;
+        selectedEntitiesFiltered.reserve(selectedEntities.size());
+
+        std::copy_if(
+            selectedEntities.begin(),
+            selectedEntities.end(),
+            std::back_inserter(selectedEntitiesFiltered),
+            [this](const AZ::EntityId& entityId)
+            {
+                return EntityExists(entityId);
+            });
 
         EntityIdList newlySelectedIds;
         EntityIdList newlyDeselectedIds;
@@ -1395,6 +1403,19 @@ namespace AzToolsFramework
     void ToolsApplication::OnPrefabInstancePropagationEnd()
     {
         m_freezeSelectionUpdates = false;
+    }
+
+    void ToolsApplication::OnEntityDeactivated(const AZ::EntityId& entityId)
+    {
+        // If the entity in question is in the selection list, then remove it from the selection list and issue a selection updated.
+        EntityIdList::iterator foundIter = AZStd::find(m_selectedEntities.begin(), m_selectedEntities.end(), entityId);
+        if (foundIter != m_selectedEntities.end())
+        {
+            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::BeforeEntitySelectionChanged);
+            m_selectedEntities.erase(foundIter);
+            EntitySelectionEvents::Bus::Event(entityId, &EntitySelectionEvents::OnDeselected);
+            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::AfterEntitySelectionChanged, EntityIdList(), EntityIdList{ entityId } );
+        }
     }
 
     void ToolsApplication::CreateUndosForDirtyEntities()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -186,12 +186,10 @@ namespace AzToolsFramework
     {
         ToolsApplicationRequests::Bus::Handler::BusConnect();
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusConnect();
-        AZ::EntitySystemBus::Handler::BusConnect();
     }
 
     ToolsApplication::~ToolsApplication()
     {
-        AZ::EntitySystemBus::Handler::BusDisconnect();
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusDisconnect();
         ToolsApplicationRequests::Bus::Handler::BusDisconnect();
         Stop();
@@ -695,7 +693,14 @@ namespace AzToolsFramework
             std::back_inserter(selectedEntitiesFiltered),
             [this](const AZ::EntityId& entityId)
             {
-                return EntityExists(entityId);
+                if (AZ::Entity* resultEntity = FindEntity(entityId);resultEntity)
+                {
+                    if (resultEntity->GetState() == AZ::Entity::State::Active)
+                    {
+                        return true;
+                    }
+                }
+                return false;
             });
 
         EntityIdList newlySelectedIds;
@@ -1403,19 +1408,6 @@ namespace AzToolsFramework
     void ToolsApplication::OnPrefabInstancePropagationEnd()
     {
         m_freezeSelectionUpdates = false;
-    }
-
-    void ToolsApplication::OnEntityDeactivated(const AZ::EntityId& entityId)
-    {
-        // If the entity in question is in the selection list, then remove it from the selection list and issue a selection updated.
-        EntityIdList::iterator foundIter = AZStd::find(m_selectedEntities.begin(), m_selectedEntities.end(), entityId);
-        if (foundIter != m_selectedEntities.end())
-        {
-            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::BeforeEntitySelectionChanged);
-            m_selectedEntities.erase(foundIter);
-            EntitySelectionEvents::Bus::Event(entityId, &EntitySelectionEvents::OnDeselected);
-            ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::AfterEntitySelectionChanged, EntityIdList(), EntityIdList{ entityId } );
-        }
     }
 
     void ToolsApplication::CreateUndosForDirtyEntities()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -679,13 +679,13 @@ namespace AzToolsFramework
         // * Filter out any unselectable entities
         // * Calculate selection/deselection delta so we can notify specific entities only on change.
         // * Filter any duplicates.
+        EntityIdList selectedEntitiesFiltered;
+        selectedEntitiesFiltered.reserve(selectedEntities.size());
 
         // Filter out any invalid or non-selectable entities
         // if the new viewport interaction model is enabled we do not want to
         // filter out locked entities as this breaks with the logic of being
         // able to select locked entities in the entity outliner
-        EntityIdList selectedEntitiesFiltered;
-        selectedEntitiesFiltered.reserve(selectedEntities.size());
 
         std::copy_if(
             selectedEntities.begin(),

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
@@ -10,7 +10,6 @@
 
 
 #include <AzCore/base.h>
-#include <AzCore/Component/EntityBus.h>
 #include <AzFramework/Application/Application.h>
 #include <AzFramework/Asset/SimpleAsset.h>
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
@@ -162,9 +161,13 @@ namespace AzToolsFramework
         };
         //////////////////////////////////////////////////////////////////////////
 
+        //////////////////////////////////////////////////////////////////////////
         // PrefabPublicNotificationBus::Handler
+
         void OnPrefabInstancePropagationBegin() override;
         void OnPrefabInstancePropagationEnd() override;
+
+        //////////////////////////////////////////////////////////////////////////
 
         void CreateUndosForDirtyEntities();
         void ConsistencyCheckUndoCache();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
@@ -30,7 +30,6 @@ namespace AzToolsFramework
         : public AzFramework::Application
         , private ToolsApplicationRequests::Bus::Handler
         , public AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
-        , private AZ::EntitySystemBus::Handler
     {
     public:
         AZ_RTTI(ToolsApplication, "{2895561E-BE90-4CC3-8370-DD46FCF74C01}", AzFramework::Application);
@@ -166,9 +165,6 @@ namespace AzToolsFramework
         // PrefabPublicNotificationBus::Handler
         void OnPrefabInstancePropagationBegin() override;
         void OnPrefabInstancePropagationEnd() override;
-
-        // EntitySystemBus::MultiHandler
-        void OnEntityDeactivated(const AZ::EntityId&) override;
 
         void CreateUndosForDirtyEntities();
         void ConsistencyCheckUndoCache();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
@@ -10,6 +10,7 @@
 
 
 #include <AzCore/base.h>
+#include <AzCore/Component/EntityBus.h>
 #include <AzFramework/Application/Application.h>
 #include <AzFramework/Asset/SimpleAsset.h>
 #include <AzToolsFramework/AzToolsFrameworkAPI.h>
@@ -29,6 +30,7 @@ namespace AzToolsFramework
         : public AzFramework::Application
         , private ToolsApplicationRequests::Bus::Handler
         , public AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
+        , private AZ::EntitySystemBus::Handler
     {
     public:
         AZ_RTTI(ToolsApplication, "{2895561E-BE90-4CC3-8370-DD46FCF74C01}", AzFramework::Application);
@@ -161,13 +163,12 @@ namespace AzToolsFramework
         };
         //////////////////////////////////////////////////////////////////////////
 
-        //////////////////////////////////////////////////////////////////////////
         // PrefabPublicNotificationBus::Handler
-
         void OnPrefabInstancePropagationBegin() override;
         void OnPrefabInstancePropagationEnd() override;
 
-        //////////////////////////////////////////////////////////////////////////
+        // EntitySystemBus::MultiHandler
+        void OnEntityDeactivated(const AZ::EntityId&) override;
 
         void CreateUndosForDirtyEntities();
         void ConsistencyCheckUndoCache();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
@@ -47,7 +47,7 @@ namespace AzToolsFramework
         }
     }
 
-    void SelectionCommand::FlushExecutorIfNecessary(const AzToolsFramework::EntityIdList& checkList)
+    void SelectionCommand::FlushExecutorIfNecessary()
     {
         // we only need to flush the executor if we are actually during an undo/redo op.
 
@@ -59,34 +59,25 @@ namespace AzToolsFramework
         {
             return;
         }
-
-        auto entityCannotBeFound = [](const AZ::EntityId& entityId) -> bool
+        
+        // flush the executor
+        if (auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
+            instanceUpdateExecutorInterface)
         {
-            return GetEntityById(entityId) == nullptr;
-        };
-
-        // check if any of the entityIds cannot be found and are null:
-        if (std::any_of(checkList.begin(), checkList.end(), entityCannotBeFound)) 
-        {
-            // flush the executor
-            if (auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
-                instanceUpdateExecutorInterface)
-            {
-                instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue(/*flush=*/true);
-            }
+            instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue(/*flush=*/true);
         }
     }
 
     void SelectionCommand::Undo()
     {
-        FlushExecutorIfNecessary(m_previousSelectionList);
+        FlushExecutorIfNecessary();
         AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
             &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, m_previousSelectionList);
     }
 
     void SelectionCommand::Redo()
     {
-        FlushExecutorIfNecessary(m_proposedSelectionList);
+        FlushExecutorIfNecessary();
         AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
             &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, m_proposedSelectionList);
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.cpp
@@ -8,6 +8,8 @@
 
 #include "SelectionCommand.h"
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h>
 
 namespace AzToolsFramework
 {
@@ -45,14 +47,46 @@ namespace AzToolsFramework
         }
     }
 
+    void SelectionCommand::FlushExecutorIfNecessary(const AzToolsFramework::EntityIdList& checkList)
+    {
+        // we only need to flush the executor if we are actually during an undo/redo op.
+
+        bool isDuringUndo = false;
+        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+            isDuringUndo, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::IsDuringUndoRedo);
+
+        if (!isDuringUndo)
+        {
+            return;
+        }
+
+        auto entityCannotBeFound = [](const AZ::EntityId& entityId) -> bool
+        {
+            return GetEntityById(entityId) == nullptr;
+        };
+
+        // check if any of the entityIds cannot be found and are null:
+        if (std::any_of(checkList.begin(), checkList.end(), entityCannotBeFound)) 
+        {
+            // flush the executor
+            if (auto instanceUpdateExecutorInterface = AZ::Interface<Prefab::InstanceUpdateExecutorInterface>::Get();
+                instanceUpdateExecutorInterface)
+            {
+                instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue(/*flush=*/true);
+            }
+        }
+    }
+
     void SelectionCommand::Undo()
     {
+        FlushExecutorIfNecessary(m_previousSelectionList);
         AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
             &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, m_previousSelectionList);
     }
 
     void SelectionCommand::Redo()
     {
+        FlushExecutorIfNecessary(m_proposedSelectionList);
         AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
             &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, m_proposedSelectionList);
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.h
@@ -45,7 +45,7 @@ namespace AzToolsFramework
         EntityIdList m_previousSelectionList;
         EntityIdList m_proposedSelectionList;
 
-        void FlushExecutorIfNecessary(const AzToolsFramework::EntityIdList& checkList);
+        void FlushExecutorIfNecessary();
     };
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Commands/SelectionCommand.h
@@ -44,6 +44,8 @@ namespace AzToolsFramework
     protected:
         EntityIdList m_previousSelectionList;
         EntityIdList m_proposedSelectionList;
+
+        void FlushExecutorIfNecessary(const AzToolsFramework::EntityIdList& checkList);
     };
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -497,7 +497,8 @@ namespace AzToolsFramework
         if (auto* instanceUpdateExecutor = AZ::Interface<AzToolsFramework::Prefab::InstanceUpdateExecutorInterface>::Get(); instanceUpdateExecutor)
         {
             // flush any remaining template instance updates in the queue, before we start play.
-            instanceUpdateExecutor->UpdateTemplateInstancesInQueue();
+            const bool flush = true;
+            instanceUpdateExecutor->UpdateTemplateInstancesInQueue(flush);
             instanceUpdateExecutor->SetShouldPauseInstancePropagation(true);
         }
         // This is a workaround until the replacement for GameEntityContext is done

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityBus.h
@@ -13,6 +13,8 @@
 
 #include <AzFramework/Entity/EntityContext.h>
 
+#include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
+
 namespace AzToolsFramework
 {
     //! Used to notify changes of state for read-only entities.
@@ -47,6 +49,38 @@ namespace AzToolsFramework
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         using BusIdType = AzFramework::EntityContextId;
+
+        // When a new handler connects or disconnects, make sure to invalidate the existing state.
+        template <class Bus>
+        struct ReadOnlyConnectionPolicy
+            : public AZ::EBusConnectionPolicy<Bus>
+        {
+            static void Connect(typename Bus::BusPtr& busPtr,
+                typename Bus::Context& context,
+                typename Bus::HandlerNode& handler,
+                typename Bus::Context::ConnectLockGuard& connectLock,
+                const typename Bus::BusIdType& id = 0)
+            {
+                AZ::EBusConnectionPolicy<Bus>::Connect(busPtr, context, handler, connectLock, id);
+                if (auto readOnlyEntityQueryInterface = AZ::Interface<ReadOnlyEntityQueryInterface>::Get())
+                {
+                    readOnlyEntityQueryInterface->RefreshReadOnlyStateForAllEntities();
+                }
+            }
+            static void Disconnect(typename Bus::Context& context,
+                typename Bus::HandlerNode& handler,
+                typename Bus::BusPtr& ptr)
+            {
+                AZ::EBusConnectionPolicy<Bus>::Disconnect(context, handler, ptr);
+                if (auto readOnlyEntityQueryInterface = AZ::Interface<ReadOnlyEntityQueryInterface>::Get())
+                {
+                    readOnlyEntityQueryInterface->RefreshReadOnlyStateForAllEntities();
+                }
+            }
+        };
+        template<typename Bus>
+        using ConnectionPolicy = ReadOnlyConnectionPolicy<Bus>;
+
         //////////////////////////////////////////////////////////////////////////
         
         //! Triggered when an entity's read-only status is queried.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp
@@ -72,18 +72,7 @@ namespace AzToolsFramework
 
     void ReadOnlyEntitySystemComponent::RefreshReadOnlyStateForAllEntities()
     {
-        for (auto& elem : m_readOnlystates)
-        {
-            AZ::EntityId entityId = elem.first;
-            bool wasReadOnly = elem.second;
-            QueryReadOnlyStateForEntity(entityId);
-
-            if (bool isReadOnly = m_readOnlystates[entityId]; wasReadOnly != isReadOnly)
-            {
-                ReadOnlyEntityPublicNotificationBus::Broadcast(
-                    &ReadOnlyEntityPublicNotificationBus::Events::OnReadOnlyEntityStatusChanged, entityId, isReadOnly);
-            }
-        }
+        m_readOnlystates.clear(); // just clear the cache, since it will be lazily refreshed on request
     }
 
     void ReadOnlyEntitySystemComponent::OnPrepareForContextReset()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -18,6 +18,7 @@
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h>
 #include <AzToolsFramework/Prefab/Instance/TemplateInstanceMapperInterface.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
@@ -60,6 +61,14 @@ namespace AzToolsFramework
                 "Prefab - InstanceUpdateExecutor::RegisterInstanceUpdateExecutorInterface - "
                 "Instance Dom Generator Interface could not be found. "
                 "Check that it is being correctly initialized.");
+
+            m_instanceEntityMapperInterface = AZ::Interface<InstanceEntityMapperInterface>::Get();
+            AZ_Assert(
+                m_instanceEntityMapperInterface != nullptr,
+                "Prefab - InstanceUpdateExecutor::RegisterInstanceUpdateExecutorInterface - "
+                "Instance Entity Mapper Interface could not be found. "
+                "Check that it is being correctly initialized.");
+
         }
 
         void InstanceUpdateExecutor::UnregisterInstanceUpdateExecutorInterface()
@@ -69,6 +78,7 @@ namespace AzToolsFramework
             m_instanceDomGeneratorInterface = nullptr;
             m_templateInstanceMapperInterface = nullptr;
             m_prefabSystemComponentInterface = nullptr;
+            m_instanceEntityMapperInterface = nullptr;
 
             AZ::Interface<InstanceUpdateExecutorInterface>::Unregister(this);
         }
@@ -179,6 +189,28 @@ namespace AzToolsFramework
                     // if an entity selected was deleted and stayed deleted, the framework takes care of that.
                     bool shouldAttemptToUpdateSelection = false;
 
+                    // Turn the list of EntityIDs into actual entity alias paths so that we can check if any of the
+                    // selected entities were replaced (their EntityId would change but their alias would remain the same)
+
+                     // map of "alias" -> "old entity id" for all selected entities
+                    AZStd::unordered_map<AliasPath, AZ::EntityId> selectedEntityAliasPaths; 
+
+                    selectedEntityAliasPaths.reserve(selectedEntityIds.size());
+                    for (const auto& selectedEntityId : selectedEntityIds)
+                    {
+                        auto owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(selectedEntityId);
+                        if (owningInstance.has_value())
+                        {
+                            auto entityAlias = owningInstance->get().GetEntityAlias(selectedEntityId);
+                            if (entityAlias.has_value())
+                            {
+                                AliasPath absoluteEntityPath = owningInstance->get().GetAbsoluteInstanceAliasPath();
+                                absoluteEntityPath.Append(entityAlias.value());
+                                selectedEntityAliasPaths[absoluteEntityPath] = selectedEntityId;
+                            }
+                        }
+                    }
+
                     // Process all instances in the queue, capped to the batch size.
                     // Even though we potentially initialized the batch size to the queue, it's possible for the queue size to shrink
                     // during instance processing if the instance gets deleted and it was queued multiple times.  To handle this, we
@@ -272,15 +304,27 @@ namespace AzToolsFramework
                                 &AzToolsFramework::EditorEntityContextRequests::HandleEntitiesAdded, newEntities);
 
                             // was anything in the instance that updated selected?
-                            instanceToUpdate->GetAllEntitiesInHierarchyConst(
+                            AliasPath instancePath = instanceToUpdate->GetAbsoluteInstanceAliasPath();
+
+                            instanceToUpdate->GetConstEntities(
                                 [&](const AZ::Entity& entity)
                                 {
-                                    if (AZStd::find(selectedEntityIds.begin(), selectedEntityIds.end(), entity.GetId()) != selectedEntityIds.end())
+                                    AliasPath entityPath = instancePath;
+                                    auto alias = instanceToUpdate->GetEntityAlias(entity.GetId());
+                                    if (alias.has_value())
                                     {
-                                        shouldAttemptToUpdateSelection = true;
-                                        return false;
+                                        // The alias always has a value, because we just created one:
+                                        entityPath.Append(alias.value());
+
+                                        if (auto found = selectedEntityAliasPaths.find(entityPath); found != selectedEntityAliasPaths.end())
+                                        {
+                                            const AZ::EntityId& oldEntityId = found->second;
+                                            shouldAttemptToUpdateSelection = true;
+                                            AZStd::replace(selectedEntityIds.begin(), selectedEntityIds.end(), oldEntityId, entity.GetId());
+                                            found->second = entity.GetId();
+                                        }
                                     }
-                                    return true; // keep iterating.
+                                    return true; // returning true means keep iterating.
                                 });
 
                             if (!m_isRootPrefabInstanceLoaded &&

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -175,6 +175,10 @@ namespace AzToolsFramework
                     EntityIdList selectedEntityIds;
                     ToolsApplicationRequestBus::BroadcastResult(selectedEntityIds, &ToolsApplicationRequests::GetSelectedEntities);
 
+                    // we only need to update the selection if a selected entity got replaced.
+                    // if an entity selected was deleted and stayed deleted, the framework takes care of that.
+                    bool shouldAttemptToUpdateSelection = false;
+
                     // Process all instances in the queue, capped to the batch size.
                     // Even though we potentially initialized the batch size to the queue, it's possible for the queue size to shrink
                     // during instance processing if the instance gets deleted and it was queued multiple times.  To handle this, we
@@ -267,6 +271,18 @@ namespace AzToolsFramework
                             AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
                                 &AzToolsFramework::EditorEntityContextRequests::HandleEntitiesAdded, newEntities);
 
+                            // was anything in the instance that updated selected?
+                            instanceToUpdate->GetAllEntitiesInHierarchyConst(
+                                [&](const AZ::Entity& entity)
+                                {
+                                    if (AZStd::find(selectedEntityIds.begin(), selectedEntityIds.end(), entity.GetId()) != selectedEntityIds.end())
+                                    {
+                                        shouldAttemptToUpdateSelection = true;
+                                        return false;
+                                    }
+                                    return true; // keep iterating.
+                                });
+
                             if (!m_isRootPrefabInstanceLoaded &&
                                 instanceToUpdate->GetTemplateSourcePath() == m_rootPrefabInstanceSourcePath)
                             {
@@ -275,20 +291,14 @@ namespace AzToolsFramework
                             }
                         }
                     }
-                    for (auto entityIdIterator = selectedEntityIds.begin(); entityIdIterator != selectedEntityIds.end(); entityIdIterator++)
-                    {
-                        // Since entities get recreated during propagation, we need to check whether the entities
-                        // corresponding to the list of selected entity ids are present or not.
-                        AZ::Entity* entity = GetEntityById(*entityIdIterator);
-                        if (entity == nullptr)
-                        {
-                            selectedEntityIds.erase(entityIdIterator--);
-                        }
-                    }
 
                     // Notify Propagation has ended, then update selection (which is frozen during propagation, so this order matters)
                     PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnPrefabInstancePropagationEnd);
-                    ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
+
+                    if (shouldAttemptToUpdateSelection)
+                    {
+                        ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
+                    }
                 }
 
                 m_updatingTemplateInstancesInQueue = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -160,7 +160,7 @@ namespace AzToolsFramework
             }
         }
 
-        bool InstanceUpdateExecutor::UpdateTemplateInstancesInQueue()
+        bool InstanceUpdateExecutor::UpdateTemplateInstancesInQueue(bool flush)
         {
             AZ_PROFILE_FUNCTION(AzToolsFramework);
 
@@ -172,8 +172,12 @@ namespace AzToolsFramework
             {
                 m_updatingTemplateInstancesInQueue = true;
 
-                const int instanceCountToUpdateInBatch =
-                    m_instanceCountToUpdateInBatch == 0 ? static_cast<int>(m_instancesUpdateQueue.size()) : m_instanceCountToUpdateInBatch;
+                const bool shouldLimitQueueSize = !flush && m_instanceCountToUpdateInBatch > 0;
+
+                const int instanceCountToUpdateInBatch = shouldLimitQueueSize ?
+                     AZStd::min(aznumeric_cast<int>(m_instancesUpdateQueue.size()), m_instanceCountToUpdateInBatch)
+                    : aznumeric_cast<int>(m_instancesUpdateQueue.size());
+
                 TemplateId currentTemplateId = InvalidTemplateId;
                 TemplateReference currentTemplateReference = AZStd::nullopt;
 
@@ -185,14 +189,10 @@ namespace AzToolsFramework
                     EntityIdList selectedEntityIds;
                     ToolsApplicationRequestBus::BroadcastResult(selectedEntityIds, &ToolsApplicationRequests::GetSelectedEntities);
 
-                    // we only need to update the selection if a selected entity got replaced.
-                    // if an entity selected was deleted and stayed deleted, the framework takes care of that.
-                    bool shouldAttemptToUpdateSelection = false;
-
                     // Turn the list of EntityIDs into actual entity alias paths so that we can check if any of the
                     // selected entities were replaced (their EntityId would change but their alias would remain the same)
 
-                     // map of "alias" -> "old entity id" for all selected entities
+                    // map of "alias" -> "old entity id" for all selected entities
                     AZStd::unordered_map<AliasPath, AZ::EntityId> selectedEntityAliasPaths; 
 
                     selectedEntityAliasPaths.reserve(selectedEntityIds.size());
@@ -303,11 +303,15 @@ namespace AzToolsFramework
                             AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
                                 &AzToolsFramework::EditorEntityContextRequests::HandleEntitiesAdded, newEntities);
 
-                            // was anything in the instance that updated selected?
-                            AliasPath instancePath = instanceToUpdate->GetAbsoluteInstanceAliasPath();
+                            if (!selectedEntityAliasPaths.empty())
+                            {
+                                // was anything in the instance that updated selected?
+                                AliasPath instancePath = instanceToUpdate->GetAbsoluteInstanceAliasPath();
 
-                            instanceToUpdate->GetConstEntities(
-                                [&](const AZ::Entity& entity)
+                                // Loop over all new entities and check if their alias path matches
+                                // any of the selected entity alias paths.  If it does, update the entityId
+                                // in the seelcted entity list to the new entityId:
+                                auto updateSelectionCallback = [&](const AZ::Entity& entity)
                                 {
                                     AliasPath entityPath = instancePath;
                                     auto alias = instanceToUpdate->GetEntityAlias(entity.GetId());
@@ -319,13 +323,15 @@ namespace AzToolsFramework
                                         if (auto found = selectedEntityAliasPaths.find(entityPath); found != selectedEntityAliasPaths.end())
                                         {
                                             const AZ::EntityId& oldEntityId = found->second;
-                                            shouldAttemptToUpdateSelection = true;
                                             AZStd::replace(selectedEntityIds.begin(), selectedEntityIds.end(), oldEntityId, entity.GetId());
                                             found->second = entity.GetId();
                                         }
                                     }
-                                    return true; // returning true means keep iterating.
-                                });
+                                    return true; // returning true in this callback means keep iterating.
+                                };
+
+                                instanceToUpdate->GetConstEntities(updateSelectionCallback);
+                            }
 
                             if (!m_isRootPrefabInstanceLoaded &&
                                 instanceToUpdate->GetTemplateSourcePath() == m_rootPrefabInstanceSourcePath)
@@ -339,10 +345,9 @@ namespace AzToolsFramework
                     // Notify Propagation has ended, then update selection (which is frozen during propagation, so this order matters)
                     PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnPrefabInstancePropagationEnd);
 
-                    if (shouldAttemptToUpdateSelection)
-                    {
-                        ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
-                    }
+                    // eliminate any dead entity Ids and then reselect the entities that were replaced during propagation.
+                    AZStd::erase_if(selectedEntityIds, [](const AZ::EntityId& entityId) { return !GetEntityById(entityId); });
+                    ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
                 }
 
                 m_updatingTemplateInstancesInQueue = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -43,6 +43,7 @@ namespace AzToolsFramework
         void InstanceUpdateExecutor::RegisterInstanceUpdateExecutorInterface()
         {
             AZ::Interface<InstanceUpdateExecutorInterface>::Register(this);
+            ToolsApplicationNotificationBus::Handler::BusConnect();
 
             m_prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
             AZ_Assert(m_prefabSystemComponentInterface != nullptr,
@@ -73,6 +74,8 @@ namespace AzToolsFramework
 
         void InstanceUpdateExecutor::UnregisterInstanceUpdateExecutorInterface()
         {
+            ToolsApplicationNotificationBus::Handler::BusDisconnect();
+
             m_GameModeEventHandler.Disconnect();
 
             m_instanceDomGeneratorInterface = nullptr;
@@ -382,6 +385,19 @@ namespace AzToolsFramework
         void InstanceUpdateExecutor::SetShouldPauseInstancePropagation(bool shouldPausePropagation)
         {
             m_shouldPausePropagation = shouldPausePropagation;
+        }
+
+        void InstanceUpdateExecutor::AfterUndoRedo()
+        {
+            // After undo/redo, the instance update queue may have been populated.  Make sure that the queue is processed,
+            // so that deletions/creations are complete before control returns to the application.
+            // Note that this signal only comes from when a user actually initiates an undo or redo (or a test script does
+            // on behalf of simulating a user), and not from when undo or redo operations are being performed as part of
+            // building the undo stack during an op.  If this ever causes a perf issue, we can relax this requirement.
+            if (!m_shouldPausePropagation)
+            {
+                UpdateTemplateInstancesInQueue(true);
+            }
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -12,11 +12,12 @@
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/std/containers/deque.h>
 #include <AzFramework/Entity/EntityContext.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/AzToolsFrameworkAPI.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomTypes.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
-#include <AzToolsFramework/AzToolsFrameworkAPI.h>
 
 namespace AzToolsFramework
 {
@@ -30,6 +31,7 @@ namespace AzToolsFramework
 
         class AZTF_API InstanceUpdateExecutor
             : public InstanceUpdateExecutorInterface
+            , private AzToolsFramework::ToolsApplicationNotificationBus::Handler
         {
         public:
             AZ_RTTI(InstanceUpdateExecutor, "{E21DB0D4-0478-4DA9-9011-31BC96F55837}", InstanceUpdateExecutorInterface);
@@ -59,6 +61,9 @@ namespace AzToolsFramework
             void LazyConnectGameModeEventHandler();
 
             void AddInstanceToQueue(Instance* instance);
+
+            // ToolsApplicationNotificationBus overrides ...
+            void AfterUndoRedo() override;
 
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -41,7 +41,7 @@ namespace AzToolsFramework
             void AddTemplateInstancesToQueue(TemplateId instanceTemplateId, InstanceOptionalConstReference instanceToExclude = AZStd::nullopt) override;
 
             // Note, this function destroys and re-creates Entity* and Component*, do not assume your pointers are still good after this.
-            bool UpdateTemplateInstancesInQueue() override;
+            bool UpdateTemplateInstancesInQueue(bool flush) override;
             bool IsUpdatingTemplateInstancesInQueue() const override;
 
             void RemoveTemplateInstanceFromQueue(Instance* instance) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -26,6 +26,7 @@ namespace AzToolsFramework
         class PrefabSystemComponentInterface;
         class TemplateInstanceMapperInterface;
         class InstanceDomGeneratorInterface;
+        class InstanceEntityMapperInterface;
 
         class AZTF_API InstanceUpdateExecutor
             : public InstanceUpdateExecutorInterface
@@ -62,6 +63,7 @@ namespace AzToolsFramework
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;
             InstanceDomGeneratorInterface* m_instanceDomGeneratorInterface = nullptr;
+            InstanceEntityMapperInterface* m_instanceEntityMapperInterface = nullptr;
             AZ::IO::Path m_rootPrefabInstanceSourcePath;
             AZStd::deque<Instance*> m_instancesUpdateQueue;
             AZStd::unordered_set<Instance*> m_uniqueInstancesForPropagation;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -34,7 +34,10 @@ namespace AzToolsFramework
 
             //! Updates instances in the waiting queue.
             //! @return bool on whether the operation succeeds.
-            virtual bool UpdateTemplateInstancesInQueue() = 0;
+            //! @param flush (default true) - if set to true, all instances in the queue will be updated in one go.
+            //!     Otherwise, the update executor can update a limited number per call and will continue to do so each time
+            //!     this function is called until the queue is empty.
+            virtual bool UpdateTemplateInstancesInQueue(bool flush = true) = 0;
 
             //! @return bool on whether instances are currently updated in the waiting queue.
             virtual bool IsUpdatingTemplateInstancesInQueue() const = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -6,12 +6,14 @@
  *
  */
 
+#include <AzToolsFramework/Prefab/PrefabPublicHandler.h>
+
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/JSON/stringbuffer.h>
 #include <AzCore/JSON/writer.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
-#include <AzCore/Utils/TypeHash.h>
 #include <AzCore/std/sort.h>
+#include <AzCore/Utils/TypeHash.h>
 
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
@@ -23,19 +25,19 @@
 #include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/EditorPrefabComponent.h>
 #include <AzToolsFramework/Prefab/Instance/Instance.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityIdMapper.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
-#include <AzToolsFramework/Prefab/Instance/InstanceDomGeneratorInterface.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <AzToolsFramework/Prefab/PrefabEditorPreferences.h>
 #include <AzToolsFramework/Prefab/PrefabInstanceUtils.h>
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
-#include <AzToolsFramework/Prefab/PrefabPublicHandler.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
+#include <AzToolsFramework/Prefab/PrefabUndoHelpers.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndo.h>
 #include <AzToolsFramework/Prefab/Undo/PrefabUndoUpdateLink.h>
-#include <AzToolsFramework/Prefab/PrefabUndoHelpers.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h>
 
@@ -1488,13 +1490,12 @@ namespace AzToolsFramework
             // destroyed.
             EntityIdList selectedEntities;
             ToolsApplicationRequestBus::BroadcastResult(selectedEntities, &ToolsApplicationRequests::GetSelectedEntities);
-            auto sizeOfList = entitiesThatWillBeRemoved.size();
-            AZStd::erase_if(selectedEntities, [&entitiesThatWillBeRemoved](const AZ::EntityId& entityId)
+            auto erased_count = AZStd::erase_if(selectedEntities, [&entitiesThatWillBeRemoved](const AZ::EntityId& entityId)
             {
                 return entitiesThatWillBeRemoved.contains(entityId);
             });
 
-            if (selectedEntities.size() != sizeOfList)
+            if (erased_count > 0)
             {
                 // If the selected entities include any of the entities being destroyed, we need to deselect all of them.
                 SelectionCommand* newSelection = aznew SelectionCommand(selectedEntities, "Deselect Deleted Entities");
@@ -1631,6 +1632,9 @@ namespace AzToolsFramework
             // 6.  Reorder entities to maintain the proper order
             // 7.  (If not keeping the container) destroy the container entity.
 
+            // If we keep container, we will need its final new alias path later to restore selection during redo
+            AliasPath containerEntityNewAliasPath;
+
             // Restore selection if possible, after this operation.
             AzToolsFramework::EntityIdList selectedEntities;
             AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
@@ -1722,6 +1726,14 @@ namespace AzToolsFramework
                             [[maybe_unused]] const bool containerEntityAdded = parentInstance.AddEntity(AZStd::move(containerEntity));
                             AZ_Assert(containerEntityAdded, "Add target Instance's container entity to its parent Instance failed.");
                             containerEntityRawPtr->Activate();
+
+                            containerEntityNewAliasPath = parentInstance.GetAbsoluteInstanceAliasPath();
+
+                            auto containerEntityAlias = parentInstance.GetEntityAlias(containerEntityRawPtr->GetId());
+                            AZ_Assert(
+                                containerEntityAlias.has_value(),
+                                "Can't get the alias of the container entity in its new parent instance.");
+                            containerEntityNewAliasPath.Append(containerEntityAlias.value());
                         }
                     }
 
@@ -1869,12 +1881,21 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    // if the container entity was previously selected, make sure it reselects it.
                     if (AZStd::find(selectedEntities.begin(), selectedEntities.end(), containerEntityId) != selectedEntities.end())
                     {
+                        // restore the selection here.  This list will have the "old" container entity id, which hasn't yet
+                        // been updated and will only update when the executor flushes, so its a valid entityId right now until next tick.
+                        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::SetSelectedEntities, selectedEntities);
+
+                        // For undo, redo, figure out what the new container entity id will be, and store the new id in the undo so that
+                        // it functions later, once the executor has updated them.
+                        AZ::EntityId newContainerEntityId = InstanceEntityIdMapper::GenerateEntityIdForAliasPath(containerEntityNewAliasPath);
+                        AZStd::replace(selectedEntities.begin(), selectedEntities.end(), containerEntityId, newContainerEntityId);
+
+                        // Note that we don't actually run the redo here, the above "setSelectedEntities" took care of that.
                         auto selectionUndo = aznew SelectionCommand(selectedEntities, "Select Prefab Container Entity");
                         selectionUndo->SetParent(outerUndoBatch.GetUndoBatch());
-                        selectionUndo->Redo();
                     }
                 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1627,6 +1627,10 @@ namespace AzToolsFramework
             // 6.  Reorder entities to maintain the proper order
             // 7.  (If not keeping the container) destroy the container entity.
 
+            // Restore selection if possible, after this operation.
+            AzToolsFramework::EntityIdList selectedEntities;
+            AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+
             AZ_PROFILE_FUNCTION(AzToolsFramework);
             {
                 ScopedUndoBatch outerUndoBatch("Detach Prefab");  // outer undo is for the entire thing - detach AND (optional) delete
@@ -1670,22 +1674,39 @@ namespace AzToolsFramework
 
                     RemoveLink(detachedInstance, parentTemplateId, undoBatch.GetUndoBatch());
 
+                    AZStd::vector<const AZ::Entity*> detachedEntitiesToUpdate;
+
                     // Detach container entity from the detached instance
                     AZStd::unique_ptr<AZ::Entity> containerEntity = detachedInstance->DetachContainerEntity();
-                    EditorPrefabComponent* editorPrefabComponent = containerEntity->FindComponent<EditorPrefabComponent>();
-                    containerEntity->Deactivate();
-                    [[maybe_unused]] const bool editorPrefabComponentRemoved = containerEntity->RemoveComponent(editorPrefabComponent);
-                    AZ_Assert(editorPrefabComponentRemoved, "Remove EditorPrefabComponent failed.");
-                    delete editorPrefabComponent;
-                    containerEntity->Activate();
+                    AZ_Assert(containerEntity, "Can't detach container entity from the detached Instance.");
 
-                    AZStd::vector<const AZ::Entity*> detachedEntitiesToUpdate;
+                    // Scope to prevent any escape of raw ptr beyond this point.
+                    if (AZ::Entity* containerEntityRawPtr = containerEntity.get(); containerEntityRawPtr)
+                    {
+                        detachedEntitiesToUpdate.push_back(containerEntityRawPtr);
+                        EditorPrefabComponent* editorPrefabComponent = containerEntityRawPtr->FindComponent<EditorPrefabComponent>();
+                        AZ_Assert(editorPrefabComponent, "Can't find EditorPrefabComponent on the container entity of the detached Instance.");
+                       
+                        if (editorPrefabComponent)
+                        {
+                            containerEntity->Deactivate();
+                            [[maybe_unused]] const bool editorPrefabComponentRemoved =
+                                containerEntityRawPtr->RemoveComponent(editorPrefabComponent);
+                            AZ_Assert(editorPrefabComponentRemoved, "Remove EditorPrefabComponent failed.");
+                            delete editorPrefabComponent;
+                            // Reattach to the parent so that ownership remains intact when it reactivates
+                            // We reassign ownership to the parentInstance here, which invalidates our unique_ptr
+                            // but retains the actual object (no deletion), so the raw ptr stays valid to reactivate afterwards.
+                            [[maybe_unused]] const bool containerEntityAdded = parentInstance.AddEntity(AZStd::move(containerEntity));
+                            AZ_Assert(containerEntityAdded, "Add target Instance's container entity to its parent Instance failed.");
+                            containerEntityRawPtr->Activate();
+                        }
+                    }
+
                     AZStd::vector<AZ::EntityId> entitiesToReorder; // entities that need to be moved in the parent order.
                     // Add the container entity to parent instance and add it to list so that we can update it in template as well.
                     // it will be deleted later.
-                    detachedEntitiesToUpdate.push_back(containerEntity.get());
-                    [[maybe_unused]] const bool containerEntityAdded = parentInstance.AddEntity(AZStd::move(containerEntity));
-                    AZ_Assert(containerEntityAdded, "Add target Instance's container entity to its parent Instance failed.");
+                    
 
                     // Detach entities and add them to the parent instance.
                     detachedInstance->DetachEntities(
@@ -1826,7 +1847,15 @@ namespace AzToolsFramework
                 // note that this is still within the scope of the "outer" undo batch, so it still counts as one operation.
                 if (!keepContainerEntity)
                 {
+                    // the only entity which actually could get deleted in this operation is the container entity.
                     DeleteFromInstance({containerEntityId});
+                }
+                else
+                {
+                    if (AZStd::find(selectedEntities.begin(), selectedEntities.end(), containerEntityId) != selectedEntities.end())
+                    {
+                        ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, selectedEntities);
+                    }
                 }
 
                 // before the current undo batch expires, clear any dirty entities.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1469,21 +1469,6 @@ namespace AzToolsFramework
                 return retrieveEntitiesAndInstancesOutcome;
             }
 
-            // Gets selected entities.
-            EntityIdList selectedEntities;
-            ToolsApplicationRequestBus::BroadcastResult(selectedEntities, &ToolsApplicationRequests::GetSelectedEntities);
-            SelectionCommand* selCommand = aznew SelectionCommand(selectedEntities, "Delete Entities");
-            selCommand->SetParent(undoBatch.GetUndoBatch());
-            AZ_PROFILE_SCOPE(AzToolsFramework, "Internal::DeleteEntities:RunRedo");
-            selCommand->RunRedo();
-
-            // We insert a "deselect all" command before we delete the entities. This ensures the delete operations aren't changing
-            // selection state, which triggers expensive UI updates. By deselecting up front, we are able to do those expensive
-            // UI updates once at the start instead of once for each entity.
-            EntityIdList deselection;
-            SelectionCommand* deselectAllCommand = aznew SelectionCommand(deselection, "Deselect Entities");
-            deselectAllCommand->SetParent(undoBatch.GetUndoBatch());
-
             // Removing instances and entities for one owning instance...
             // - Detach instance objects and entity objects.
             // - Update focused template DOM accordingly with undo/redo support.
@@ -1498,6 +1483,25 @@ namespace AzToolsFramework
                         entitiesThatWillBeRemoved.insert(entity->GetId());
                     }
                 });
+
+            // Gets selected entities.  We only need to do selection-related operations if the selected entities include the entities being
+            // destroyed.
+            EntityIdList selectedEntities;
+            ToolsApplicationRequestBus::BroadcastResult(selectedEntities, &ToolsApplicationRequests::GetSelectedEntities);
+            auto sizeOfList = entitiesThatWillBeRemoved.size();
+            AZStd::erase_if(selectedEntities, [&entitiesThatWillBeRemoved](const AZ::EntityId& entityId)
+            {
+                return entitiesThatWillBeRemoved.contains(entityId);
+            });
+
+            if (selectedEntities.size() != sizeOfList)
+            {
+                // If the selected entities include any of the entities being destroyed, we need to deselect all of them.
+                SelectionCommand* newSelection = aznew SelectionCommand(selectedEntities, "Deselect Deleted Entities");
+                newSelection->SetParent(undoBatch.GetUndoBatch());
+                newSelection->Redo();
+            }
+
 
             // Set of parent entities that need to be updated. It should not include entities that will be removed.
             AZStd::unordered_set<const AZ::Entity*> parentEntitiesToUpdate;
@@ -1634,7 +1638,6 @@ namespace AzToolsFramework
             AZ_PROFILE_FUNCTION(AzToolsFramework);
             {
                 ScopedUndoBatch outerUndoBatch("Detach Prefab");  // outer undo is for the entire thing - detach AND (optional) delete
-
                 {
                     ScopedUndoBatch undoBatch("Detach Prefab - Actual Detach"); // inner undo is just for the detach part.
                     AZ_PROFILE_SCOPE(AzToolsFramework, "Internal::DetachPrefab::UndoCapture");
@@ -1659,6 +1662,25 @@ namespace AzToolsFramework
                     parentEntity = GetEntityById(containerParentId);
                     AZ_Assert(parentEntity, "Can't get the parent entity of the detached prefab instance.");
 
+                    // if we are going to delete the container entity, we need to deselect it first, so that
+                    // the undo of this operation (which happens in reverse order) reselects it last, after it exists again!
+                    if (AZStd::find(selectedEntities.begin(), selectedEntities.end(), containerEntityId) != selectedEntities.end())
+                    {
+                        AzToolsFramework::EntityIdList withoutContainer;
+
+                        std::copy_if(
+                            selectedEntities.begin(),
+                            selectedEntities.end(),
+                            std::back_inserter(withoutContainer),
+                            [containerEntityId](const AZ::EntityId& entityId)
+                            {
+                                return entityId != containerEntityId;
+                            });
+                        auto selectionUndo = aznew SelectionCommand(withoutContainer, "Deselect Prefab Container Entity");
+                        selectionUndo->SetParent(undoBatch.GetUndoBatch());
+                        selectionUndo->Redo();
+                    }
+
                     // Capture the order that entities were in the container before we do any moving around
                     AZStd::vector<AZ::EntityId> priorOrder = AzToolsFramework::GetEntityChildOrder(containerEntityId);
 
@@ -1680,15 +1702,15 @@ namespace AzToolsFramework
                     AZStd::unique_ptr<AZ::Entity> containerEntity = detachedInstance->DetachContainerEntity();
                     AZ_Assert(containerEntity, "Can't detach container entity from the detached Instance.");
 
-                    // Scope to prevent any escape of raw ptr beyond this point.
+                    // Scope to prevent escape of containerEntityRawPtr
                     if (AZ::Entity* containerEntityRawPtr = containerEntity.get(); containerEntityRawPtr)
                     {
-                        detachedEntitiesToUpdate.push_back(containerEntityRawPtr);
                         EditorPrefabComponent* editorPrefabComponent = containerEntityRawPtr->FindComponent<EditorPrefabComponent>();
                         AZ_Assert(editorPrefabComponent, "Can't find EditorPrefabComponent on the container entity of the detached Instance.");
                        
                         if (editorPrefabComponent)
                         {
+                            detachedEntitiesToUpdate.push_back(containerEntityRawPtr);
                             containerEntity->Deactivate();
                             [[maybe_unused]] const bool editorPrefabComponentRemoved =
                                 containerEntityRawPtr->RemoveComponent(editorPrefabComponent);
@@ -1702,11 +1724,6 @@ namespace AzToolsFramework
                             containerEntityRawPtr->Activate();
                         }
                     }
-
-                    AZStd::vector<AZ::EntityId> entitiesToReorder; // entities that need to be moved in the parent order.
-                    // Add the container entity to parent instance and add it to list so that we can update it in template as well.
-                    // it will be deleted later.
-                    
 
                     // Detach entities and add them to the parent instance.
                     detachedInstance->DetachEntities(
@@ -1852,9 +1869,12 @@ namespace AzToolsFramework
                 }
                 else
                 {
+                    // if the container entity was previously selected, make sure it reselects it.
                     if (AZStd::find(selectedEntities.begin(), selectedEntities.end(), containerEntityId) != selectedEntities.end())
                     {
-                        ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, selectedEntities);
+                        auto selectionUndo = aznew SelectionCommand(selectedEntities, "Select Prefab Container Entity");
+                        selectionUndo->SetParent(outerUndoBatch.GetUndoBatch());
+                        selectionUndo->Redo();
                     }
                 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -135,7 +135,7 @@ namespace AzToolsFramework
 
         void PrefabSystemComponent::OnSystemTick()
         {
-            m_instanceUpdateExecutor.UpdateTemplateInstancesInQueue();
+            m_instanceUpdateExecutor.UpdateTemplateInstancesInQueue(/*flush=*/false);
             GarbageCollectTemplates(false);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -1085,7 +1085,19 @@ namespace AzToolsFramework
 
         bool TransformComponent::IsAddNonUniformScaleButtonReadOnly()
         {
-            return FindPresentOrPendingComponent(EditorNonUniformScaleComponent::TYPEINFO_Uuid()) != nullptr;
+            if (FindPresentOrPendingComponent(EditorNonUniformScaleComponent::TYPEINFO_Uuid()) != nullptr)
+            {
+                return true; // its read only becuase you cannot add a second one and one already exists on it.
+            }
+
+            // You also cannot add any other kind of component to a container entity.
+            if (auto* containerEntityInterface = AZ::Interface<AzToolsFramework::ContainerEntityInterface>::Get(); containerEntityInterface)
+            {
+                // if we are a container entity, the button should be read only.
+                return (containerEntityInterface->IsContainer(GetEntityId()));
+            }
+
+            return false; // nothing is preventing you from adding a non uniform scale component
         }
 
         bool TransformComponent::AddNonUniformScaleComponent(const AZ::Vector3& nonUniformScale)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/Procedural/ProceduralPrefabReadOnlyHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/Procedural/ProceduralPrefabReadOnlyHandler.cpp
@@ -31,13 +31,6 @@ namespace AzToolsFramework
 
             EditorEntityContextRequestBus::BroadcastResult(m_editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
             ReadOnlyEntityQueryRequestBus::Handler::BusConnect(m_editorEntityContextId);
-
-             // Refresh the whole read-only cache
-            if (auto readOnlyEntityQueryInterface = AZ::Interface<ReadOnlyEntityQueryInterface>::Get())
-            {
-                readOnlyEntityQueryInterface->RefreshReadOnlyStateForAllEntities();
-            }
-
             PrefabFocusNotificationBus::Handler::BusConnect(m_editorEntityContextId);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -2133,10 +2133,6 @@ namespace AzToolsFramework
             // tick can happen first.
             QTimer::singleShot(0, this, &EntityPropertyEditor::UpdateContents);
 
-            //saving state any time refresh gets queued because requires valid components
-            //attempting to call directly anywhere state needed to be preserved always occurred with QueuePropertyRefresh
-            SaveComponentEditorState();
-
             QScrollBar* verticalScroll = m_gui->m_componentList->verticalScrollBar();
             QScrollBar* horizontalScroll = m_gui->m_componentList->horizontalScrollBar();
             m_savedVerticalScroll = verticalScroll->value();
@@ -3663,7 +3659,6 @@ namespace AzToolsFramework
         {
             componentEditor->SetSelected(false);
         }
-        SaveComponentEditorState();
         UpdateInternalState();
     }
 
@@ -3704,15 +3699,21 @@ namespace AzToolsFramework
             // only want to allow selection when component editor is enabled
             if (componentEditor->isEnabled())
             {
-                componentEditor->SetSelected(true);
-                m_componentEditorLastSelectedIndex = GetComponentEditorIndex(componentEditor);
-                selectedChanged = true;
+                if (!componentEditor->isSelected())
+                {
+                    componentEditor->SetSelected(true);
+                    m_componentEditorLastSelectedIndex = GetComponentEditorIndex(componentEditor);
+                    selectedChanged = true;
+                }
             }
         }
-        SaveComponentEditorState();
-        UpdateInternalState();
-        NotifySelectionChanges();
 
+        if (selectedChanged)
+        {
+            SaveComponentEditorState();
+            UpdateInternalState();
+            NotifySelectionChanges();
+        }
         return selectedChanged;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -282,7 +282,6 @@ namespace AzToolsFramework
         });
         connect(newCtrl, &PropertyColorCtrl::editingFinished, this, [newCtrl]()
         {
-            // editing finished implies color changed.
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
         });
@@ -416,8 +415,8 @@ namespace AzToolsFramework
             });
         connect(newCtrl, &PropertyColorCtrl::editingFinished, this, [newCtrl]()
             {
-                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-                    &PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
+                PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
+                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
             });
         // note: Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -282,8 +282,9 @@ namespace AzToolsFramework
         });
         connect(newCtrl, &PropertyColorCtrl::editingFinished, this, [newCtrl]()
         {
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(
-                &PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
+            // editing finished implies color changed.
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
         });
         return newCtrl;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
@@ -13,8 +13,10 @@
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Entity/EntityContext.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorLockComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorVisibilityComponent.h>
@@ -525,46 +527,109 @@ namespace UnitTest
         ASSERT_TRUE(m_connected);
     }
 
-    AZ::EntityId CreateDefaultEditorEntity(const char* name, AZ::Entity** outEntity /*= nullptr*/)
+    AZ::EntityId CreateDefaultEditorEntity(const char* name, AZ::Entity** outEntity /*= nullptr*/, AZ::EntityId parentId /*= AZ::EntityId()*/)
     {
         AZ::EntityId entityId;
-        AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
-            entityId, &AzToolsFramework::EditorEntityContextRequestBus::Events::CreateNewEditorEntity, name);
+        AZ::Entity* entity = nullptr;
 
-        if (!entityId.IsValid())
+        using AzToolsFramework::EditorEntityContextRequestBus;
+        using AzToolsFramework::Prefab::PrefabPublicInterface;
+        using AzToolsFramework::PrefabEditorEntityOwnershipInterface;
+        using AzToolsFramework::ToolsApplicationRequestBus;
+
+        // If the prefab system is active and running, use it to make the entity, otherwise make a simple one
+
+        auto* prefabPublicHandler = AZ::Interface<PrefabPublicInterface>::Get();
+        auto* prefabEditorEntityOwnershipInterface = AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get();
+        if ((prefabPublicHandler) &&
+            (prefabEditorEntityOwnershipInterface) &&
+            (prefabEditorEntityOwnershipInterface->IsRootPrefabAssigned()))
         {
-            AZ_Error("CreateDefaultEditorEntity", false, "Failed to create editor entity '%s'", name);
-            return AZ::EntityId();
+            if (!parentId.IsValid())
+            {
+                parentId = GetRootInstanceEntityId();
+            }
+
+            auto createResult = prefabPublicHandler->CreateEntity(parentId, AZ::Vector3::CreateZero());
+            EXPECT_NO_FATAL_FAILURE(createResult.IsSuccess()) << "Failed to create editor entity " << name;
+            if (createResult.IsSuccess())
+            {
+                entityId = createResult.GetValue();
+            }
+            else
+            {
+                return AZ::EntityId();
+            }
+
+            entity = GetEntityById(entityId);
+            EXPECT_NO_FATAL_FAILURE(entity) << "Failed to create entity for test" << name;
+            if (entity)
+            {
+                entity->Deactivate();
+                entity->SetName(name);
+                EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequestBus::Events::AddRequiredComponents, *entity);
+                entity->Activate();
+
+                AzToolsFramework::ScopedUndoBatch undoBatch("Create and configure entity");
+                prefabPublicHandler->GenerateUndoNodesForEntityChangeAndUpdateCache(entityId, undoBatch.GetUndoBatch());
+            }
+
+            // Don't keep the entities selected (which is the default for "create new entity" in editor.
+            ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, AzToolsFramework::EntityIdList{});
         }
-
-        AZ::Entity* entity = GetEntityById(entityId);
-
-        if (!entity)
+        else
         {
-            AZ_Error("CreateDefaultEditorEntity", false, "Invalid entity obtained from Id %s", entityId.ToString().c_str());
-            return AZ::EntityId();
+            // we are in a simple, basic test, which does not have the prefab system enabled, make basic entity
+            AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+                entityId, &AzToolsFramework::EditorEntityContextRequestBus::Events::CreateNewEditorEntity, name);
+
+            if (!entityId.IsValid())
+            {
+                AZ_Error("CreateDefaultEditorEntity", false, "Failed to create editor entity '%s'", name);
+                return AZ::EntityId();
+            }
+            entity = GetEntityById(entityId);
+
+            if (!entity)
+            {
+                AZ_Error("CreateDefaultEditorEntity", false, "Invalid entity obtained from Id %s", entityId.ToString().c_str());
+                return AZ::EntityId();
+            }
+
+            entity->Deactivate();
+
+            // Add required components for the Editor entity if they are not added.
+            CreateComponentIfMissing<Components::TransformComponent>(entity);
+            CreateComponentIfMissing<Components::EditorLockComponent>(entity);
+            CreateComponentIfMissing<Components::EditorVisibilityComponent>(entity);
+
+            // This is necessary to prevent a warning in the undo system.
+            AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
+                &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity, entity->GetId());
+
+            entity->Activate();
         }
-
-        entity->Deactivate();
-
-        // Add required components for the Editor entity if they are not added.
-        CreateComponentIfMissing<Components::TransformComponent>(entity);
-        CreateComponentIfMissing<Components::EditorLockComponent>(entity);
-        CreateComponentIfMissing<Components::EditorVisibilityComponent>(entity);
-
-        // This is necessary to prevent a warning in the undo system.
-        AzToolsFramework::ToolsApplicationRequests::Bus::Broadcast(
-            &AzToolsFramework::ToolsApplicationRequests::Bus::Events::AddDirtyEntity,
-            entity->GetId());
-
-        entity->Activate();
-
+        
         if (outEntity)
         {
             *outEntity = entity;
         }
 
-        return entity->GetId();
+        AZ_Assert(GetEntityById(entityId) != nullptr, "Failed to create entity '%s'", name);
+
+        return entityId;
+    }
+
+    AZ::EntityId GetRootInstanceEntityId()
+    {
+        if (auto* ownership = AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get(); ownership)
+        {
+            if (auto instanceRef = ownership->GetRootPrefabInstance(); instanceRef.has_value())
+            {
+                return instanceRef->get().GetContainerEntityId();
+            }
+        }
+        return AZ::EntityId();
     }
 
     AZ::Data::AssetId SaveAsSlice(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
@@ -551,7 +551,7 @@ namespace UnitTest
             }
 
             auto createResult = prefabPublicHandler->CreateEntity(parentId, AZ::Vector3::CreateZero());
-            EXPECT_NO_FATAL_FAILURE(createResult.IsSuccess()) << "Failed to create editor entity " << name;
+            AZ_Error("CreateDefaultEditorEntity", entity, "Failed to create entity for test %s - CreateEntity failed", name)
             if (createResult.IsSuccess())
             {
                 entityId = createResult.GetValue();
@@ -562,17 +562,19 @@ namespace UnitTest
             }
 
             entity = GetEntityById(entityId);
-            EXPECT_NO_FATAL_FAILURE(entity) << "Failed to create entity for test" << name;
-            if (entity)
+            AZ_Error("CreateDefaultEditorEntity", entity, "Failed to create entity for test %s - Could not GetEntityById", name);
+            if (!entity)
             {
-                entity->Deactivate();
-                entity->SetName(name);
-                EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequestBus::Events::AddRequiredComponents, *entity);
-                entity->Activate();
-
-                AzToolsFramework::ScopedUndoBatch undoBatch("Create and configure entity");
-                prefabPublicHandler->GenerateUndoNodesForEntityChangeAndUpdateCache(entityId, undoBatch.GetUndoBatch());
+                return AZ::EntityId();
             }
+
+            entity->Deactivate();
+            entity->SetName(name);
+            EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequestBus::Events::AddRequiredComponents, *entity);
+            entity->Activate();
+
+            AzToolsFramework::ScopedUndoBatch undoBatch("Create and configure entity");
+            prefabPublicHandler->GenerateUndoNodesForEntityChangeAndUpdateCache(entityId, undoBatch.GetUndoBatch());
 
             // Don't keep the entities selected (which is the default for "create new entity" in editor.
             ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, AzToolsFramework::EntityIdList{});

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
@@ -551,20 +551,20 @@ namespace UnitTest
             }
 
             auto createResult = prefabPublicHandler->CreateEntity(parentId, AZ::Vector3::CreateZero());
-            AZ_Error("CreateDefaultEditorEntity", entity, "Failed to create entity for test %s - CreateEntity failed", name)
             if (createResult.IsSuccess())
             {
                 entityId = createResult.GetValue();
             }
             else
             {
+                AZ_Error("CreateDefaultEditorEntity", false, "Failed to create entity %s for test - Prefab CreateEntity failed", name)
                 return AZ::EntityId();
             }
 
             entity = GetEntityById(entityId);
-            AZ_Error("CreateDefaultEditorEntity", entity, "Failed to create entity for test %s - Could not GetEntityById", name);
             if (!entity)
             {
+                AZ_Error("CreateDefaultEditorEntity", false, "Failed to create entity %s for test - Could not GetEntityById", name);
                 return AZ::EntityId();
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
@@ -345,7 +345,11 @@ namespace UnitTest
 
             if (auto* ownershipInterface = AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get(); ownershipInterface)
             {
-                ownershipInterface->CreateNewLevelPrefab("UnitTestRoot.prefab", "");
+                // you can create an application manually that already has all of this stuff initialized.
+                if (!ownershipInterface->IsRootPrefabAssigned())
+                {
+                    ownershipInterface->CreateNewLevelPrefab("UnitTestRoot.prefab", "");
+                }
 
                 InstanceOptionalReference rootInstance = ownershipInterface->GetRootPrefabInstance();
                 ASSERT_TRUE(rootInstance.has_value());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
@@ -38,6 +38,8 @@
 #include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
 #include <AzToolsFramework/Editor/ActionManagerUtils.h>
 #include <AzToolsFramework/Entity/EditorEntityTransformBus.h>
+#include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
+#include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <AzToolsFramework/Viewport/ActionBus.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
@@ -327,7 +329,35 @@ namespace UnitTest
 
             AzToolsFramework::ActionManagerSystemComponent::TriggerRegistrationNotifications();
 
+            InitializeRootPrefab();
+
             SetUpEditorFixtureImpl();
+        }
+
+        virtual void InitializeRootPrefab()
+        {
+            using AzToolsFramework::Prefab::InstanceOptionalReference;
+            using AzToolsFramework::Prefab::EntityOptionalReference;
+            using AzToolsFramework::PrefabEditorEntityOwnershipInterface;
+            using AzToolsFramework::Prefab::PrefabFocusPublicInterface;
+            using AzToolsFramework::Prefab::PrefabFocusOperationResult;
+            using AzToolsFramework::ToolsApplicationRequestBus;
+
+            if (auto* ownershipInterface = AZ::Interface<PrefabEditorEntityOwnershipInterface>::Get(); ownershipInterface)
+            {
+                ownershipInterface->CreateNewLevelPrefab("UnitTestRoot.prefab", "");
+
+                InstanceOptionalReference rootInstance = ownershipInterface->GetRootPrefabInstance();
+                ASSERT_TRUE(rootInstance.has_value());
+
+                // Focus on root prefab instance.
+                auto* prefabFocusPublicInterface = AZ::Interface<PrefabFocusPublicInterface>::Get();
+                EXPECT_TRUE(prefabFocusPublicInterface != nullptr);
+                PrefabFocusOperationResult focusResult =prefabFocusPublicInterface->FocusOnOwningPrefab(rootInstance->get().GetContainerEntityId());
+                EXPECT_TRUE(focusResult.IsSuccess());
+            }
+
+            ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, AzToolsFramework::EntityIdList{});
         }
 
         void TearDown() override final
@@ -507,11 +537,15 @@ namespace UnitTest
 
     /// Create an Entity as it would appear in the Editor.
     /// Optional second parameter of Entity pointer if required.
-    AZ::EntityId CreateDefaultEditorEntity(const char* name, AZ::Entity** outEntity = nullptr);
+    AZ::EntityId CreateDefaultEditorEntity(const char* name, AZ::Entity** outEntity = nullptr, AZ::EntityId parentId = AZ::EntityId());
 
     /// Create a Layer Entity as it would appear in the Editor.
     /// Optional second parameter of Entity pointer if required.
     AZ::EntityId CreateEditorLayerEntity(const char* name, AZ::Entity** outEntity = nullptr);
+
+    /// Get the EntityId of the root prefab instance in the editor (the "level" entity, also known as
+    /// the root instance's container entity)
+    AZ::EntityId GetRootInstanceEntityId();
 
     /// Create a component for a given entity if the component is missing.
     template<class ComponentType>

--- a/Code/Framework/AzToolsFramework/Tests/ComponentModeSwitcherTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ComponentModeSwitcherTests.cpp
@@ -402,7 +402,9 @@ namespace UnitTest
         AZ::EntityId entityId = CreateDefaultEditorEntity("ComponentModeEntity", &entity);
 
         entity->Deactivate();
-        AZStd::unique_ptr<AZ::Component> placeholder1{entity->CreateComponent<PlaceholderEditorComponent>()};
+
+        // In this case, the CreateComponent function also retains ownership of the created component (in the entity).
+        AZ::Component* placeholder1 = entity->CreateComponent<PlaceholderEditorComponent>();
         entity->CreateComponent<AnotherPlaceholderEditorComponent>();
         entity->Activate();
 
@@ -413,10 +415,10 @@ namespace UnitTest
         EXPECT_EQ(2, componentModeSwitcher->GetComponentCount());
 
         // Then if one component is disabled, there should only be one component on the switcher
-        // Disabling the component removes it from the entity, which is why its ownership is maintained here in a
-        // unique_ptr
+        // Disabling the component removes it from the entity, but then adds it straight back to the "pending components" list on the same entity
+        // which maintains ownership of the component, and will still cause it to be erased.  (So don't keep it in a smart pointer).
         AzToolsFramework::EntityCompositionRequestBus::Broadcast(
-            &AzToolsFramework::EntityCompositionRequests::DisableComponents, AZStd::vector<AZ::Component*>{ placeholder1.get() });
+            &AzToolsFramework::EntityCompositionRequests::DisableComponents, AZStd::vector<AZ::Component*>{ placeholder1 });
 
         EXPECT_EQ(1, componentModeSwitcher->GetComponentCount());
 

--- a/Code/Framework/AzToolsFramework/Tests/ComponentModeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ComponentModeTests.cpp
@@ -485,6 +485,8 @@ namespace UnitTest
     {
         using PlaceHolderComponent = TestComponentModeComponent<PlaceHolderComponentMode>;
 
+        GetApplication()->RegisterComponentDescriptor(PlaceHolderComponent::CreateDescriptor());
+
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
         AZ::Entity* entity = nullptr;
@@ -494,10 +496,7 @@ namespace UnitTest
 
         // Add placeholder component which implements component mode.
         entity->CreateComponent<PlaceHolderComponent>();
-
-        AZ_TEST_START_TRACE_SUPPRESSION;
         entity->Activate();
-        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -367,14 +367,15 @@ namespace UnitTest
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
-        // note: entity1 is created in the fixture setup
-        AzToolsFramework::SelectEntity(m_entityId1);
-
+        // Note that creating entities currently selects them for convenience.  We may have to change that.
         AZ::EntityId entity2 = CreateDefaultEditorEntity("Entity2");
         AZ::EntityId entity3 = CreateDefaultEditorEntity("Entity3");
         AZ::EntityId entity4 = CreateDefaultEditorEntity("Entity4");
         AZ::EntityId entity5 = CreateDefaultEditorEntity("Entity5");
         AZ::EntityId entity6 = CreateDefaultEditorEntity("Entity6");
+
+        // note: entity1 is created in the fixture setup
+        AzToolsFramework::SelectEntity(m_entityId1);
 
         AzToolsFramework::SetEntityVisibility(entity2, false);
         AzToolsFramework::SetEntityLockState(entity3, true);
@@ -389,7 +390,7 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
         const AzToolsFramework::EntityIdList selectedEntities = SelectedEntities();
-        const AzToolsFramework::EntityIdList expectedSelectedEntities = { entity4, entity5, entity6 };
+        const AzToolsFramework::EntityIdList expectedSelectedEntities = { GetRootInstanceEntityId(), entity4, entity5, entity6 };
         EXPECT_THAT(selectedEntities, UnorderedElementsAreArray(expectedSelectedEntities));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     }
@@ -419,7 +420,7 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
         const AzToolsFramework::EntityIdList selectedEntities = SelectedEntities();
-        const AzToolsFramework::EntityIdList expectedSelectedEntities = { m_entityId1, entity2, entity3, entity4 };
+        const AzToolsFramework::EntityIdList expectedSelectedEntities = { GetRootInstanceEntityId(), m_entityId1, entity2, entity3, entity4 };
         EXPECT_THAT(selectedEntities, UnorderedElementsAreArray(expectedSelectedEntities));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     }

--- a/Code/Framework/AzToolsFramework/Tests/Entity/ReadOnly/ReadOnlyEntityFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Entity/ReadOnly/ReadOnlyEntityFixture.cpp
@@ -66,11 +66,6 @@ namespace AzToolsFramework
     ReadOnlyHandlerAlwaysTrue::~ReadOnlyHandlerAlwaysTrue()
     {
         ReadOnlyEntityQueryRequestBus::Handler::BusDisconnect();
-
-        if (auto readOnlyEntityQueryInterface = AZ::Interface<ReadOnlyEntityQueryInterface>::Get())
-        {
-            readOnlyEntityQueryInterface->RefreshReadOnlyStateForAllEntities();
-        }
     }
 
     void ReadOnlyHandlerAlwaysTrue::IsReadOnly([[maybe_unused]] const AZ::EntityId& entityId, bool& isReadOnly)
@@ -89,11 +84,6 @@ namespace AzToolsFramework
     ReadOnlyHandlerAlwaysFalse::~ReadOnlyHandlerAlwaysFalse()
     {
         ReadOnlyEntityQueryRequestBus::Handler::BusDisconnect();
-
-        if (auto readOnlyEntityQueryInterface = AZ::Interface<ReadOnlyEntityQueryInterface>::Get())
-        {
-            readOnlyEntityQueryInterface->RefreshReadOnlyStateForAllEntities();
-        }
     }
 
     ReadOnlyHandlerEntityId::ReadOnlyHandlerEntityId(AZ::EntityId entityId)
@@ -108,11 +98,6 @@ namespace AzToolsFramework
     ReadOnlyHandlerEntityId::~ReadOnlyHandlerEntityId()
     {
         ReadOnlyEntityQueryRequestBus::Handler::BusDisconnect();
-
-        if (auto readOnlyEntityQueryInterface = AZ::Interface<ReadOnlyEntityQueryInterface>::Get())
-        {
-            readOnlyEntityQueryInterface->RefreshReadOnlyStateForAllEntities();
-        }
     }
 
     void ReadOnlyHandlerEntityId::IsReadOnly(const AZ::EntityId& entityId, bool& isReadOnly)

--- a/Code/Framework/AzToolsFramework/Tests/FocusMode/EditorFocusModeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/FocusMode/EditorFocusModeTests.cpp
@@ -33,6 +33,10 @@ namespace UnitTest
 
     TEST_F(EditorFocusModeFixture, GetFocusedEntitiesRoot)
     {
+        m_focusModeInterface->SetFocusRoot(m_entityMap[CityEntityName]);
+        // if we focus on the city, itself, as well as all its children, should return.
+        // if we clear the focus, the world will be included in this list (the root)
+
         AzToolsFramework::EntityIdList entities = m_focusModeInterface->GetFocusedEntities(m_editorEntityContextId);
         
         using ::testing::UnorderedElementsAre;
@@ -54,13 +58,16 @@ namespace UnitTest
     {
         m_focusModeInterface->ClearFocusRoot(m_editorEntityContextId);
 
+        // if we clear the focus root, we are actually setting it to the root (the world).
+        // the list of entities should be the same as if we set the focus root to the world, which should return
+        // all entities in the world, including one for the world itself.
         AzToolsFramework::EntityIdList entities = m_focusModeInterface->GetFocusedEntities(m_editorEntityContextId);
-
         using ::testing::UnorderedElementsAre;
-        EXPECT_EQ(entities.size(), 6);
+        EXPECT_EQ(entities.size(), 7);
         EXPECT_THAT(
             entities,
             UnorderedElementsAre(
+                GetRootInstanceEntityId(),
                 m_entityMap[CityEntityName], m_entityMap[StreetEntityName], m_entityMap[CarEntityName], m_entityMap[Passenger1EntityName],
                 m_entityMap[SportsCarEntityName], m_entityMap[Passenger2EntityName]));
     }

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDeleteTests.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <Prefab/PrefabTestFixture.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <Prefab/PrefabTestFixture.h>
 
 namespace UnitTest
 {
@@ -108,5 +108,81 @@ namespace UnitTest
 
         ValidateEntityNotUnderInstance(GetRootContainerEntityId(), parentEntityAlias);
         ValidateNestedInstanceNotUnderInstance(GetRootContainerEntityId(), childPrefabName);
+    }
+
+    TEST_F(PrefabDeleteTests, DeleteSelectedEntity_UndoRedoRestoresSelectionBeforeNextTick)
+    {
+        const AZ::EntityId entityId = CreateEditorEntityUnderRoot("SelectedEntity");
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::SetSelectedEntities, AzToolsFramework::EntityIdList{ entityId });
+
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ entityId });
+        ASSERT_TRUE(result.IsSuccess());
+        ProcessDeferredUpdates();
+
+        EXPECT_EQ(AzToolsFramework::GetEntityById(entityId), nullptr);
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::UndoPressed);
+
+        EXPECT_NE(AzToolsFramework::GetEntityById(entityId), nullptr);
+        AzToolsFramework::EntityIdList selectedEntities;
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        EXPECT_EQ(selectedEntities.front(), entityId);
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::RedoPressed);
+
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        EXPECT_TRUE(selectedEntities.empty());
+
+        ProcessDeferredUpdates();
+        EXPECT_EQ(AzToolsFramework::GetEntityById(entityId), nullptr);
+    }
+
+    TEST_F(PrefabDeleteTests, DeleteOneOfTwoSelectedEntities_UndoRedoRestoresTheCompleteSelection)
+    {
+        const AZ::EntityId entityToDeleteId = CreateEditorEntityUnderRoot("EntityToDelete");
+        const AZ::EntityId entityToKeepId = CreateEditorEntityUnderRoot("EntityToKeep");
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::SetSelectedEntities,
+            AzToolsFramework::EntityIdList{ entityToDeleteId, entityToKeepId });
+
+        PrefabOperationResult result = m_prefabPublicInterface->DeleteEntitiesAndAllDescendantsInInstance({ entityToDeleteId });
+        ASSERT_TRUE(result.IsSuccess());
+        ProcessDeferredUpdates();
+
+        AzToolsFramework::EntityIdList selectedEntities;
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        EXPECT_EQ(selectedEntities.front(), entityToKeepId);
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::UndoPressed);
+        ProcessDeferredUpdates();
+
+        EXPECT_NE(AzToolsFramework::GetEntityById(entityToDeleteId), nullptr);
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 2);
+        EXPECT_NE(AZStd::find(selectedEntities.begin(), selectedEntities.end(), entityToDeleteId), selectedEntities.end());
+        EXPECT_NE(AZStd::find(selectedEntities.begin(), selectedEntities.end(), entityToKeepId), selectedEntities.end());
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::RedoPressed);
+
+        EXPECT_EQ(AzToolsFramework::GetEntityById(entityToDeleteId), nullptr);
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        EXPECT_EQ(selectedEntities.front(), entityToKeepId);
+
+        ProcessDeferredUpdates();
+        EXPECT_EQ(AzToolsFramework::GetEntityById(entityToDeleteId), nullptr);
     }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDetachPrefabAndRemoveContainerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDetachPrefabAndRemoveContainerTests.cpp
@@ -573,4 +573,47 @@ namespace UnitTest
             childEntityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArrayAfterDetach[2]);
         EXPECT_EQ(childEntityName, blackWheelEntityName);
     }
+
+    TEST_F(PrefabDetachPrefabTests, DetachSelectedPrefabAndRemoveContainer_UndoRedoRestoresExpectedSelection)
+    {
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        const AZ::IO::Path prefabFilepath = engineRootPath / "SelectedPrefab";
+
+        const AZ::EntityId childEntityId = CreateEditorEntityUnderRoot("ChildEntity");
+        const AZ::EntityId containerEntityId = CreateEditorPrefab(prefabFilepath, { childEntityId });
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::SetSelectedEntities, AzToolsFramework::EntityIdList{ containerEntityId });
+
+        PrefabOperationResult result = m_prefabPublicInterface->DetachPrefabAndRemoveContainerEntity(containerEntityId);
+        ASSERT_TRUE(result.IsSuccess());
+        ProcessDeferredUpdates();
+
+        EXPECT_EQ(AzToolsFramework::GetEntityById(containerEntityId), nullptr);
+        AzToolsFramework::EntityIdList selectedEntities;
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        EXPECT_TRUE(selectedEntities.empty());
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::UndoPressed);
+
+        EXPECT_NE(AzToolsFramework::GetEntityById(containerEntityId), nullptr);
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        EXPECT_EQ(selectedEntities.front(), containerEntityId);
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::RedoPressed);
+
+        EXPECT_EQ(AzToolsFramework::GetEntityById(containerEntityId), nullptr);
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        EXPECT_TRUE(selectedEntities.empty());
+
+        ProcessDeferredUpdates();
+        EXPECT_EQ(AzToolsFramework::GetEntityById(containerEntityId), nullptr);
+    }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDetachPrefabTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabDetachPrefabTests.cpp
@@ -528,4 +528,56 @@ namespace UnitTest
             childEntityName, &AZ::ComponentApplicationRequests::GetEntityName, entityOrderArrayAfterDetach[2]);
         EXPECT_EQ(childEntityName, blackWheelEntityName);
     }
+
+    TEST_F(PrefabDetachPrefabTests, DetachSelectedPrefab_UndoRedoSelectsTheLiveContainerEntity)
+    {
+        AZ::IO::Path engineRootPath;
+        m_settingsRegistryInterface->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+        const AZ::IO::Path prefabFilepath = engineRootPath / "SelectedPrefab";
+
+        const AZ::EntityId childEntityId = CreateEditorEntityUnderRoot("ChildEntity");
+        const AZ::EntityId originalContainerEntityId = CreateEditorPrefab(prefabFilepath, { childEntityId });
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(
+            &AzToolsFramework::ToolsApplicationRequests::SetSelectedEntities, AzToolsFramework::EntityIdList{ originalContainerEntityId });
+
+        PrefabOperationResult result = m_prefabPublicInterface->DetachPrefab(originalContainerEntityId);
+        ASSERT_TRUE(result.IsSuccess());
+        ProcessDeferredUpdates();
+
+        AzToolsFramework::EntityIdList selectedEntities;
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        const AZ::EntityId detachedContainerEntityId = selectedEntities.front();
+        EXPECT_NE(detachedContainerEntityId, originalContainerEntityId);
+        EXPECT_NE(AzToolsFramework::GetEntityById(detachedContainerEntityId), nullptr);
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::UndoPressed);
+
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        EXPECT_EQ(selectedEntities.front(), originalContainerEntityId);
+        EXPECT_NE(AzToolsFramework::GetEntityById(selectedEntities.front()), nullptr);
+
+        AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::RedoPressed);
+
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        EXPECT_EQ(selectedEntities.front(), detachedContainerEntityId);
+        EXPECT_NE(AzToolsFramework::GetEntityById(selectedEntities.front()), nullptr);
+
+        ProcessDeferredUpdates();
+
+        selectedEntities.clear();
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        ASSERT_EQ(selectedEntities.size(), 1);
+        EXPECT_EQ(selectedEntities.front(), detachedContainerEntityId);
+        EXPECT_NE(AzToolsFramework::GetEntityById(selectedEntities.front()), nullptr);
+    }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.cpp
@@ -69,10 +69,6 @@ namespace UnitTest
         AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
             m_undoStack, &AzToolsFramework::ToolsApplicationRequestBus::Events::GetUndoStack);
         AZ_Assert(m_undoStack, "Failed to look up undo stack from tools application");
-
-        // This ensures that the flag (if root prefab is assigned) in prefab editor entity ownership service is set to true.
-        // Public prefab operations like "create prefab" will fail if the flag is off.
-        CreateRootPrefab();
     }
 
     void PrefabTestFixture::TearDownEditorFixtureImpl()
@@ -85,28 +81,6 @@ namespace UnitTest
     AZStd::unique_ptr<ToolsTestApplication> PrefabTestFixture::CreateTestApplication()
     {
         return AZStd::make_unique<PrefabTestToolsApplication>("PrefabTestApplication");
-    }
-
-    void PrefabTestFixture::CreateRootPrefab()
-    {
-        m_prefabEditorEntityOwnershipInterface->CreateNewLevelPrefab("UnitTestRoot.prefab", "");
-
-        InstanceOptionalReference rootInstance = m_prefabEditorEntityOwnershipInterface->GetRootPrefabInstance();
-        ASSERT_TRUE(rootInstance.has_value());
-        
-        EntityOptionalReference rootContainerEntity = rootInstance->get().GetContainerEntity();
-        ASSERT_TRUE(rootContainerEntity.has_value());
-        if (rootContainerEntity->get().GetState() == AZ::Entity::State::Constructed)
-        {
-            rootContainerEntity->get().Init();
-        }
-
-        // Focus on root prefab instance.
-        auto* prefabFocusPublicInterface = AZ::Interface<PrefabFocusPublicInterface>::Get();
-        EXPECT_TRUE(prefabFocusPublicInterface != nullptr);
-        PrefabFocusOperationResult focusResult = prefabFocusPublicInterface->FocusOnOwningPrefab(
-            rootContainerEntity->get().GetId());
-        EXPECT_TRUE(focusResult.IsSuccess());
     }
 
     void PrefabTestFixture::PropagateAllTemplateChanges()

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestFixture.h
@@ -57,9 +57,6 @@ namespace UnitTest
 
         AZStd::unique_ptr<ToolsTestApplication> CreateTestApplication() override;
 
-        //! Creates root prefab and focus on the root prefab instance as level.
-        void CreateRootPrefab();
-
         //! Functions that internally call prefab public interface APIs to create editor entities and prefab instances.
         //! Entities and instances are updated correctly, and template DOM representations are also updated accordingly.
         //! Note:

--- a/Code/Framework/AzToolsFramework/Tests/ToolsComponents/EditorTransformComponentTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ToolsComponents/EditorTransformComponentTests.cpp
@@ -81,14 +81,8 @@ namespace AzToolsFramework
         EntityIdList descendants;
         AZ::TransformBus::EventResult(descendants, hierarchy.m_parentId, &AZ::TransformBus::Events::GetAllDescendants);
 
-        // Order of descendants here and in other test cases depends on TransformHierarchyInformationBus
-        // Sorting it to get predictable order and be able to verify by index
-        std::sort(descendants.begin(), descendants.end());
-
-        EXPECT_EQ(descendants.size(), 3);
-        EXPECT_EQ(descendants[0], hierarchy.m_childId);
-        EXPECT_EQ(descendants[1], hierarchy.m_grandchild1Id);
-        EXPECT_EQ(descendants[2], hierarchy.m_grandchild2Id);
+        using ::testing::UnorderedElementsAre;
+        EXPECT_THAT(descendants, UnorderedElementsAre(hierarchy.m_childId, hierarchy.m_grandchild1Id, hierarchy.m_grandchild2Id));
     }
 
     TEST_F(EditorTransformComponentTest, TransformTests_GetEntityAndAllDescendants_AllDescendantsMatchHierarchyAndResultIncludesParentEntity)
@@ -100,10 +94,8 @@ namespace AzToolsFramework
 
         std::sort(entityAndDescendants.begin(), entityAndDescendants.end());
 
-        EXPECT_EQ(entityAndDescendants.size(), 4);
-        EXPECT_EQ(entityAndDescendants[0], hierarchy.m_parentId);
-        EXPECT_EQ(entityAndDescendants[1], hierarchy.m_childId);
-        EXPECT_EQ(entityAndDescendants[2], hierarchy.m_grandchild1Id);
-        EXPECT_EQ(entityAndDescendants[3], hierarchy.m_grandchild2Id);
+        // entity1 is selected after undo
+        using ::testing::UnorderedElementsAre;
+        EXPECT_THAT(entityAndDescendants, UnorderedElementsAre(hierarchy.m_parentId, hierarchy.m_childId, hierarchy.m_grandchild1Id, hierarchy.m_grandchild2Id));
     }
 } // namespace AzToolsFramework

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYEntityOutliner.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYEntityOutliner.cpp
@@ -188,7 +188,7 @@ namespace ImGui
         ImGui::Columns(1);
 
         // The 3rd parameter of this Combo box HAS to match the order of ImGuiLYEntityOutliner::HierarchyUpdateType
-        ImGui::Combo("Hierarchy Update Type", reinterpret_cast<int*>(&m_hierarchyUpdateType), "Constant\0Update Tick");
+        ImGui::Combo("Hierarchy Update Type", reinterpret_cast<int*>(&m_hierarchyUpdateType), "Constant\0Update Tick\0");
 
         // Refresh the hierarchy / display further options, based on update type
         switch (m_hierarchyUpdateType)

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxComponentTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxComponentTest.cpp
@@ -729,6 +729,11 @@ namespace UnitTest
         systemEntity->Deactivate();
         systemEntity->AddComponent(m_editorWhiteBoxSystemComponentDescriptor->CreateComponent());
         systemEntity->Activate();
+
+        // Destroying the system entity actually deletes absolutely everything, nearly equivalent to
+        // restarting the application.  We have to re-initialize things destroyed by this, most notably
+        // the things related to startup in the fixture that it does after starting the app.
+        InitializeRootPrefab();
     }
 
     void EditorWhiteBoxAssetFixture::TearDownEditorFixtureImpl()


### PR DESCRIPTION
## What does this PR do?

### Fix for detaching prefabs causing a crash
Fixes https://github.com/o3de/o3de/issues/19988

This is caused by the Detach function allowing the container entity to activate while not completely
ready to do so.

Basically, all entities need to be owned by some instance (For example, owned by the level instance, or owned by a prefab instance that the level has instantiated).

When detaching a prefab, the container entity is removed from the prefab instance, then deactivated, its "I am a prefab container" component is removed, then it is reactivated before it is added to the level instance.

This means that its active while not owned by anyone, causing asserts and crashes.

The code change in question makes it so that it is added to the level instance before it is reactivated.

It also makes the detached container reselect, if it still exists, for a smoother user experience.

### Fixes cases where a deleted entity or component could be selected still after deletion

This change also revealed cases where the instance update executor was deleting an entity or replacing one that was currently selected.  For example, 
* a component is destroyed and reserialized from json due to undo/redo/detach/instance override.
* After the update executor despawns and respawns the entity, it tries to restore selection, by calling SetSelectedEntities.
* SetSelectedEntities calls "Before Entity Selected" which causes the entity property editor and outliner to try to save the state of their GUIs (including current component expansion state) before the new selection comes in.  But its too late.  Those components are already dead.

I fixed this in 2 ways
* I no longer attempt to save state when a Clear() /  BeforeSelectionChange occurs.  There is no need.  The state saves whenever the state is changed.  The only thing the component state contains is whether or not it was selected or not.  This is automatically saved whenever selection changes already.
* I make it so that the update executor saves the alias paths (which is a stable reference to an entity, without its id, and without its pointer, a reference that is a path like `LevelRoot/Prefab10/entity5` rather than a memory address, and looks it up as it changes.  It updates the selection if any of the entities previously selected have a new Id.

### ImGUI simple crash
This also fixes a crash in ImGui.  When specifying a combo box in ImGUI, you specify a null-seperated list of items, and the last item must have two nulls after it.  The code was not adding any nulls, causing ImGUI to read beyond the end of the buffer.

## How was this PR tested?
A lot of basic testing (detaching prefabs, undoing and redoing detach, editing entity properties, etc).

Note that additional tests were added, supplied by @EnterTheArcane.
