### PR TITLE
Upgrade GoogleTest to v1.18.0

### DIFF
--- a/Code/Editor/Lib/Tests/test_EditorPythonBindings.cpp
+++ b/Code/Editor/Lib/Tests/test_EditorPythonBindings.cpp
@@ -32,7 +32,6 @@ namespace EditorPythonBindingsUnitTests
 {
     using ::testing::NiceMock;
     using ::testing::Return;
-    using ::testing::Invoke;
     using ::testing::A;
     using ::testing::_;
 
@@ -48,7 +47,7 @@ namespace EditorPythonBindingsUnitTests
         {
             m_cvarType = cvarType;
             ON_CALL(m_cvarMock, GetType()).WillByDefault(Return(m_cvarType));
-            ON_CALL(m_cvarMock, Set(A<T>())).WillByDefault(Invoke(func));
+            ON_CALL(m_cvarMock, Set(A<T>())).WillByDefault(func);
             ON_CALL(m_console, GetCVar(_)).WillByDefault(Return(&m_cvarMock));
             ON_CALL(m_system, GetIConsole()).WillByDefault(Return(&m_console));
             ON_CALL(m_editorMock, GetSystem()).WillByDefault(Return(&m_system));
@@ -294,7 +293,7 @@ namespace EditorPythonBindingsUnitTests
             AZStd::string data;
             MockEditor mockEditor;
             mockEditor.PrepareGetIConsole();
-            ON_CALL(mockEditor.m_console, ExecuteString(_,_,_)).WillByDefault(Invoke([&data](const char* command, const bool, const bool) { data = command; }));
+            ON_CALL(mockEditor.m_console, ExecuteString(_,_,_)).WillByDefault([&data](const char* command, const bool, const bool) { data = command; });
 
             const char* testCvar = "enable_feature game.sim";
             AZStd::array<AZ::BehaviorArgument, 1> args;

--- a/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializationTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializationTests.cpp
@@ -522,7 +522,7 @@ namespace JsonSerializationTests
             reinterpret_cast<JsonSerializerMock*>(m_jsonRegistrationContext->GetSerializerForType(azrtti_typeid<SimpleInheritence>()));
         EXPECT_CALL(*mock, Store(_, _, _, _, _))
             .Times(Exactly(1))
-            .WillRepeatedly(Invoke([](rapidjson::Value& output, const void*, const void*, const AZ::Uuid&, AZ::JsonSerializerContext& context)
+            .WillRepeatedly([](rapidjson::Value& output, const void*, const void*, const AZ::Uuid&, AZ::JsonSerializerContext& context)
                 {
                     // Insert some values to allow verification later on.
                     output.SetObject();
@@ -530,7 +530,7 @@ namespace JsonSerializationTests
                     output.AddMember("var1", 88, context.GetJsonAllocator());
                     output.AddMember("var2", 42, context.GetJsonAllocator());
                     return context.Report(Tasks::WriteValue, Outcomes::Success, "");
-                }));
+                });
 
         AZStd::unique_ptr<BaseClass> instance{ aznew SimpleInheritence() };
         ResultCode result = AZ::JsonSerialization::Store(*m_jsonDocument, m_jsonDocument->GetAllocator(), instance, *m_serializationSettings);

--- a/Code/Framework/AzCore/Tests/Streamer/BlockCacheTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/BlockCacheTests.cpp
@@ -644,11 +644,11 @@ namespace AZ::IO
             .Times(count * 2) // Once for the file meta file retrieval and a second time for the read.
             .WillRepeatedly(Invoke(this, &BlockCacheTest::QueueReadRequest));
         EXPECT_CALL(*m_mock, UpdateStatus(_))
-            .WillRepeatedly(Invoke([](StreamStackEntry::Status& status)
+            .WillRepeatedly([](StreamStackEntry::Status& status)
             {
                 status.m_numAvailableSlots = 64;
                 status.m_isIdle = false;
-            }));
+            });
         EXPECT_CALL(*this, ReadFile(_, _, _, _)).Times(count);
 
         constexpr size_t scratchBufferSize = 128_kib;

--- a/Code/Framework/AzCore/Tests/Streamer/SchedulerTests.cpp
+++ b/Code/Framework/AzCore/Tests/Streamer/SchedulerTests.cpp
@@ -307,7 +307,6 @@ namespace AZ::IO
     {
         using ::testing::_;
         using ::testing::AtLeast;
-        using ::testing::Invoke;
         using ::testing::Return;
 
         EXPECT_CALL(*m_mock, UpdateStatus(_)).Times(AtLeast(1));
@@ -315,14 +314,14 @@ namespace AZ::IO
         EXPECT_CALL(*m_mock, PrepareRequest(_)).Times(AtLeast(1));
         EXPECT_CALL(*m_mock, ExecuteRequests()).Times(AtLeast(1));
         EXPECT_CALL(*m_mock, QueueRequest(_)).Times(1)
-            .WillOnce(Invoke([this](FileRequest* request)
+            .WillOnce([this](FileRequest* request)
             {
                 auto* read = request->GetCommandFromChain<Requests::ReadRequestData>();
                 ASSERT_NE(nullptr, read);
                 EXPECT_LT(read->m_deadline, FileRequest::s_noDeadlineTime);
                 EXPECT_EQ(read->m_priority, IStreamerTypes::s_priorityHighest);
                 m_mock->ForwardQueueRequest(request);
-            }));
+            });
 
         AZStd::atomic_int counter = 2;
         AZStd::binary_semaphore sync;
@@ -355,7 +354,6 @@ namespace AZ::IO
     {
         using::testing::_;
         using ::testing::AnyNumber;
-        using ::testing::Invoke;
 
         constexpr static size_t Iterations = 16;
 
@@ -367,7 +365,7 @@ namespace AZ::IO
         // Pretend to be busy [Iterations] times, then set the status to idle so the Scheduler thread can exit.
         EXPECT_CALL(*m_mock, ExecuteRequests())
             .Times(Iterations + 1)
-            .WillRepeatedly(Invoke([this, &counter]()
+            .WillRepeatedly([this, &counter]()
             {
                 if (counter++ >= Iterations)
                 {
@@ -379,7 +377,7 @@ namespace AZ::IO
                     AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1));
                     return true;
                 }
-            }));
+            });
 
         if (m_streamer)
         {

--- a/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Streamer/StreamStackEntryConformityTests.h
@@ -119,7 +119,6 @@ namespace AZ::IO
     TYPED_TEST_P(StreamStackEntryConformityTests, PrepareRequest_UnsupportedRequestIsForwarded_RequestIsForwarded)
     {
         using ::testing::_;
-        using ::testing::Invoke;
 
         auto mock = AZStd::make_shared<StreamStackEntryMock>();
         auto entry = this->m_description.CreateInstance();
@@ -128,7 +127,7 @@ namespace AZ::IO
         FileRequest* request = this->CreateUnknownRequest();
         EXPECT_CALL(*mock, PrepareRequest(_))
             .Times(1)
-            .WillOnce(Invoke([request](FileRequest* forwarded) { EXPECT_EQ(request, forwarded); }));
+            .WillOnce([request](FileRequest* forwarded) { EXPECT_EQ(request, forwarded); });
 
         entry.PrepareRequest(request);
 
@@ -138,7 +137,6 @@ namespace AZ::IO
     TYPED_TEST_P(StreamStackEntryConformityTests, QueueRequest_UnsupportedRequestIsForwarded_RequestIsForwarded)
     {
         using ::testing::_;
-        using ::testing::Invoke;
 
         auto mock = AZStd::make_shared<StreamStackEntryMock>();
         auto entry = this->m_description.CreateInstance();
@@ -147,7 +145,7 @@ namespace AZ::IO
         FileRequest* request = this->CreateUnknownRequest();
         EXPECT_CALL(*mock, QueueRequest(_))
             .Times(1)
-            .WillOnce(Invoke([request](FileRequest* forwarded) { EXPECT_EQ(request, forwarded); }));
+            .WillOnce([request](FileRequest* forwarded) { EXPECT_EQ(request, forwarded); });
 
         entry.QueueRequest(request);
 

--- a/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
@@ -6,142 +6,79 @@
 #
 #
 
-# GoogleTest and GoogleMock used to be two different repositories, but they are now combined into one repository.
-# This script fetches the combined repository and builds both libraries.
+# GoogleTest and GoogleMock come from one repository, so a single fetch builds both.
+# Installer/Findgoogletest.cmake replaces this file in pre-built installer mode.
 
-if (TARGET 3rdParty::googletest::GTest)
+if (TARGET 3rdParty::googletest::GTest OR TARGET 3rdParty::googletest::GMock)
     return()
 endif()
 
-if (TARGET 3rdParty::googletest::GMock)
-    return()
-endif()
-
-# You should not be generating dependencies on googletest (via AzTest)
-# if you are on a platform that cannot actually compile googletest (See cmake/Platform/platformname/PAL_platformname.cmake)
+# Do not depend on googletest (via AzTest) where it cannot compile.
+# See cmake/Platform/<platform>/PAL_<platform>.cmake
 if (NOT PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
     return()
 endif()
 
 block()
-
-
-    # there are optional flags you can pass FetchContent that make the project cleaner but require newer versions of cmake
-
     set(ADDITIONAL_FETCHCONTENT_FLAGS "")
-
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25")
-        list(APPEND ADDITIONAL_FETCHCONTENT_FLAGS "SYSTEM")  # treat it as a 3p library, that is, do not issue warnings using the same warning level
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
+        list(APPEND ADDITIONAL_FETCHCONTENT_FLAGS "SYSTEM") # do not apply our warning level to googletest headers
     endif()
 
-    set(CMAKE_POLICY_DEFAULT_CMP0148 OLD)
-    set(OLD_CMAKE_WARN_DEPRECATED ${CMAKE_WARN_DEPRECATED})
-    set(CMAKE_WARN_DEPRECATED FALSE CACHE BOOL "" FORCE)
     o3de_fetch_content(googletest
-        VERSION "v1.15.2"
+        VERSION "v1.18.0"
         LICENSE "BSD-3-Clause"
-        URL "https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz"
-        URL_HASH "7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926"
+        URL "https://github.com/google/googletest/archive/refs/tags/v1.18.0.tar.gz"
+        URL_HASH "6e3191c1455468b3fc35a417fb565c1c5071aee1b7e7f85e30cf48a98d37d8b5"
         GIT "https://github.com/google/googletest.git"
-        GIT_HASH "b514bdc898e2951020cbdca1304b75f5950d1f59"
+        GIT_HASH "063de7e9578f82b369302001269680b4b1553359"
         ${ADDITIONAL_FETCHCONTENT_FLAGS}
     )
 
-    # CMAKE_ARGS don't actually affect FetchContent (currently by design) https://gitlab.kitware.com/cmake/cmake/-/issues/20799
-    set(PYTHONINTERP_FOUND ON)
-    set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-    set(PYTHON_VERSION_STRING ${Python_VERSION})
-    set(gtest_force_shared_crt ON)
+    # FetchContent ignores CMAKE_ARGS by design (https://gitlab.kitware.com/cmake/cmake/-/issues/20799),
+    # so configure googletest through normal variables that its option() calls pick up via CMP0077.
     set(BUILD_GMOCK ON)
-    set(BUILD_GTEST ON)
-    set(INSTALL_GTEST OFF)
     set(BUILD_SHARED_LIBS OFF)
+    set(INSTALL_GTEST OFF) # AzTest installs what it needs below
     set(gmock_build_tests OFF)
-    set(gtest_build_tests OFF)
     set(gtest_build_samples OFF)
-    set(gtest_hide_internal_symbols OFF) # Required as AZtest modifies internal runtime flags such as FLAGS_gtest_catch_exceptions
+    set(gtest_build_tests OFF)
+    set(gtest_force_shared_crt ON)
+    set(gtest_hide_internal_symbols OFF) # AzTest modifies internal flags such as FLAGS_gtest_catch_exceptions
 
-    # Save values that apply globally that the 3rd party library may mess with
-    # Some of these are null, hence the set(xxx "quoted value") so that if it isn't set it becomes the empty string.
-
-    set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
-    set(OLD_CMAKE_CXX_VISIBILITY_PRESET "${CMAKE_CXX_VISIBILITY_PRESET}")
-    set(OLD_CMAKE_VISIBILITY_INLINES_HIDDEN "${CMAKE_VISIBILITY_INLINES_HIDDEN}")
-
-    set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL}) # save the old CMAKE_MESSAGE_LOG_LEVEL
+    set(OLD_LOG_LEVEL ${CMAKE_MESSAGE_LOG_LEVEL})
     set(CMAKE_MESSAGE_LOG_LEVEL ${O3DE_FETCHCONTENT_MESSAGE_LEVEL})
 
     FetchContent_MakeAvailable(googletest)
 
     set(CMAKE_MESSAGE_LOG_LEVEL ${OLD_LOG_LEVEL})
 
-    set(CMAKE_WARN_DEPRECATED ON CACHE BOOL "" FORCE)
-    if (NOT "${OLD_CMAKE_CXX_VISIBILITY_PRESET}" STREQUAL "")
-        set(CMAKE_CXX_VISIBILITY_PRESET "${OLD_CMAKE_CXX_VISIBILITY_PRESET}")
-    else()
-        unset(CMAKE_CXX_VISIBILITY_PRESET)
-    endif()
-    if (NOT "${OLD_CMAKE_VISIBILITY_INLINES_HIDDEN}" STREQUAL "")
-        set(CMAKE_VISIBILITY_INLINES_HIDDEN "${OLD_CMAKE_VISIBILITY_INLINES_HIDDEN}")
-    else()
-        unset(CMAKE_VISIBILITY_INLINES_HIDDEN)
-    endif()
-
-
     foreach(targetname gtest gmock gtest_main gmock_main)
         if (NOT TARGET ${targetname})
             continue()
         endif()
-        # Let's not clutter the root of any IDE folder structure with 3rd party dependencies
-        # Setting the FOLDER makes it show up there in the solution build in VS and similarly
-        # any other IDEs that organize in folders.
         set_target_properties(${targetname} PROPERTIES FOLDER "3rdParty Dependencies")
-        # fast math is incompatible with google test / google mock / etc.
+        # Fast math is incompatible with googletest.
         target_compile_options(${targetname} ${O3DE_TARGET_COMPILE_OPTION_DISABLE_FAST_MATH})
-
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21")
-            # Workaround for a googletest bug with char conversions recognized by Clang 21+
-            # See https://github.com/google/googletest/issues/4762
-            # TODO: remove when googletest is updated
-            target_compile_options(${targetname} PUBLIC -Wno-character-conversion)
-        endif()
     endforeach()
 
-    unset(CMAKE_POLICY_DEFAULT_CMP0148)
-    set(CMAKE_WARN_DEPRECATED ${OLD_CMAKE_WARN_DEPRECATED} CACHE BOOL "" FORCE)
+    # Not ly_create_alias: it also registers these for auto-generated imported targets in the installer,
+    # which would duplicate the find-file installed below.
+    add_library(3rdParty::googletest::GTest ALIAS gtest)
+    add_library(3rdParty::googletest::GMock ALIAS gmock)
 
-    FetchContent_GetProperties(
-        googletest
-        SOURCE_DIR googletest_source_dir)
-        
-    # GoogleTest and GoogleMock are considered public API - accessed by adding a dependency to AZ::AzTest.
-    # This means we DO need to ship the include folders, in the installer and we do need the static libs, in case you link to AzTest.
-    # By Default, no headers or includes are actually shipped, so we need to explicitly add them using ly_install.
-    # doing so also helps us split them up between debug and non-debug versions
+    # Both are public API for anything depending on AZ::AzTest, so the installer has to ship the headers and static libs, neither of which happens by default.
+    # Headers go under include/gmock_gtest/ so adding that as an include path keeps #include <gtest/gtest.h> working without exposing the rest of include/.
+    FetchContent_GetProperties(googletest SOURCE_DIR googletest_source_dir)
 
-    # install the headers
-    # note that source files include these headers using the name of the library, for example, they do
-    # #include <gtest/gtest.h> and #include <gmock/gmock.h>, not just <gmock.h> or <gtest.h>
-    # One option would be to just put these folders in (root)/include/gtest and (root)/include/gmock
-    # and then add (root)/include as the include path for targets using these libraries.
-    # However, that would cause any OTHER files in (root)/include to be visible to the compiler when all
-    # you asked for is gmock/gtest.  So to avoid this, we instead copy the include files into
-    # install/gmock_gtest/gmock 
-    # install/gmock_gtest/gtest
-    # and have install/gmock_gtest be the include path that is added to your compiler settings when you use these libraries, 
-    # so that #include <gtest/gtest> still works (since its relative to that path) BUT it adds no additional other
-    # files or libraries to your include path that would otherwise leak in.
     ly_install(DIRECTORY ${googletest_source_dir}/googletest/include/gtest DESTINATION include/gmock_gtest COMPONENT CORE)
     ly_install(DIRECTORY ${googletest_source_dir}/googlemock/include/gmock DESTINATION include/gmock_gtest COMPONENT CORE)
-    # include the license files just for good measure (Although using the library will disclose the
-    # source git repository and version anyway.
     ly_install(FILES ${googletest_source_dir}/LICENSE COMPONENT CORE DESTINATION include/gmock_gtest/gtest)
     ly_install(FILES ${googletest_source_dir}/LICENSE COMPONENT CORE DESTINATION include/gmock_gtest/gmock)
 
-    # Make the installer find-files be used when in an installer pre-built mode
+    # Installer mode resolves googletest through this find-file instead.
     ly_install(FILES ${CMAKE_CURRENT_LIST_DIR}/Installer/Findgoogletest.cmake DESTINATION cmake/3rdParty)
 
-    # install the libraries making sure to use different directories for debug/release/etc
     set(BASE_LIBRARY_FOLDER "lib/${PAL_PLATFORM_NAME}")
     foreach(conf IN LISTS CMAKE_CONFIGURATION_TYPES)
         string(TOUPPER ${conf} UCONF)
@@ -152,15 +89,6 @@ block()
                 CONFIGURATIONS ${conf}
         )
     endforeach()
-
-    # do not use ly_create_alias as that will autogenerate duplicate calls inside the installer.
-    # ly_create_alias would create "GTest", "GMock" and "GTest::GTest" and "GMock::GMock" aliases, as well
-    # as add them to an internal list of targets to autogenerate imported targets for.
-
-    # That's okay if you're going to let the installer do its own thing, but in our case, we're including 
-    # a FindXXXX in the installer, so create them directly, without calling the LY macro
-    add_library(3rdParty::googletest::GTest ALIAS gtest)
-    add_library(3rdParty::googletest::GMock ALIAS gmock)
 
 endblock()
 

--- a/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
@@ -9,19 +9,19 @@
 # GoogleTest and GoogleMock come from one repository, so a single fetch builds both.
 # Installer/Findgoogletest.cmake replaces this file in pre-built installer mode.
 
-if (TARGET 3rdParty::googletest::GTest OR TARGET 3rdParty::googletest::GMock)
+if(TARGET 3rdParty::googletest::GTest OR TARGET 3rdParty::googletest::GMock)
     return()
 endif()
 
 # Do not depend on googletest (via AzTest) where it cannot compile.
 # See cmake/Platform/<platform>/PAL_<platform>.cmake
-if (NOT PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
+if(NOT PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
     return()
 endif()
 
 block()
     set(ADDITIONAL_FETCHCONTENT_FLAGS "")
-    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
         list(APPEND ADDITIONAL_FETCHCONTENT_FLAGS "SYSTEM") # do not apply our warning level to googletest headers
     endif()
 
@@ -54,7 +54,7 @@ block()
     set(CMAKE_MESSAGE_LOG_LEVEL ${OLD_LOG_LEVEL})
 
     foreach(targetname gtest gmock gtest_main gmock_main)
-        if (NOT TARGET ${targetname})
+        if(NOT TARGET ${targetname})
             continue()
         endif()
         set_target_properties(${targetname} PROPERTIES FOLDER "3rdParty Dependencies")
@@ -89,7 +89,6 @@ block()
                 CONFIGURATIONS ${conf}
         )
     endforeach()
-
 endblock()
 
 set(googletest_FOUND TRUE)

--- a/Code/Framework/AzTest/3rdParty/Installer/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Installer/Findgoogletest.cmake
@@ -9,13 +9,13 @@
 # Installer-mode counterpart of Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
 # The libraries are already built here, so just import them.
 
-if (TARGET 3rdParty::googletest::GTest OR TARGET 3rdParty::googletest::GMock)
+if(TARGET 3rdParty::googletest::GTest OR TARGET 3rdParty::googletest::GMock)
     return()
 endif()
 
 # Do not depend on googletest (via AzTest) where it cannot compile.
 # See cmake/Platform/<platform>/PAL_<platform>.cmake
-if (NOT PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
+if(NOT PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
     return()
 endif()
 

--- a/Code/Framework/AzTest/3rdParty/Installer/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Installer/Findgoogletest.cmake
@@ -7,7 +7,7 @@
 #
 
 # Installer-mode counterpart of Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
-# The libraries are already built here, so just import them. Keep the version below in sync with that file.
+# The libraries are already built here, so just import them.
 
 if (TARGET 3rdParty::googletest::GTest OR TARGET 3rdParty::googletest::GMock)
     return()

--- a/Code/Framework/AzTest/3rdParty/Installer/Findgoogletest.cmake
+++ b/Code/Framework/AzTest/3rdParty/Installer/Findgoogletest.cmake
@@ -6,39 +6,31 @@
 #
 #
 
-if (TARGET 3rdParty::googletest::GTest)
+# Installer-mode counterpart of Code/Framework/AzTest/3rdParty/Findgoogletest.cmake
+# The libraries are already built here, so just import them. Keep the version below in sync with that file.
+
+if (TARGET 3rdParty::googletest::GTest OR TARGET 3rdParty::googletest::GMock)
     return()
 endif()
 
-if (TARGET 3rdParty::googletest::GMock)
-    return()
-endif()
-
-# You should not be generating dependencies on googletest (via AzTest)
-# if you are on a platform that cannot actually compile googletest (See cmake/Platform/platformname/PAL_platformname.cmake)
+# Do not depend on googletest (via AzTest) where it cannot compile.
+# See cmake/Platform/<platform>/PAL_<platform>.cmake
 if (NOT PAL_TRAIT_TEST_GOOGLE_TEST_SUPPORTED)
     return()
 endif()
 
-
-# This file is run when in pre-built installer mode, and thus GTest and GMock are pre-built static libraries
-# ALWAYS DISCLOSE THE USE OF 3rd Party Libraries.  Even if they are internally linked.
-message(STATUS "AzTest library uses googletest v1.15.2 (BSD-3-Clause) from https://github.com/google/googletest.git")
-
 set(BASE_LIBRARY_FOLDER "${LY_ROOT_FOLDER}/lib/${PAL_PLATFORM_NAME}")
 
-add_library(gtest STATIC IMPORTED GLOBAL)
-set_target_properties(gtest PROPERTIES 
-    IMPORTED_LOCATION       "${BASE_LIBRARY_FOLDER}/profile/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-    IMPORTED_LOCATION_DEBUG "${BASE_LIBRARY_FOLDER}/debug/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
-ly_target_include_system_directories(TARGET gtest INTERFACE "${LY_ROOT_FOLDER}/include/gmock_gtest")
+foreach(targetname gtest gmock)
+    add_library(${targetname} STATIC IMPORTED GLOBAL)
+    set_target_properties(${targetname} PROPERTIES
+        IMPORTED_LOCATION "${BASE_LIBRARY_FOLDER}/profile/${CMAKE_STATIC_LIBRARY_PREFIX}${targetname}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        IMPORTED_LOCATION_DEBUG "${BASE_LIBRARY_FOLDER}/debug/${CMAKE_STATIC_LIBRARY_PREFIX}${targetname}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+    )
+    # Both include their headers as <gtest/...> and <gmock/...>, relative to this one folder.
+    ly_target_include_system_directories(TARGET ${targetname} INTERFACE "${LY_ROOT_FOLDER}/include/gmock_gtest")
+endforeach()
 
-add_library(gmock STATIC IMPORTED GLOBAL)
-set_target_properties(gmock PROPERTIES 
-    IMPORTED_LOCATION       "${BASE_LIBRARY_FOLDER}/profile/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}"
-    IMPORTED_LOCATION_DEBUG "${BASE_LIBRARY_FOLDER}/debug/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}")
-ly_target_include_system_directories(TARGET gmock INTERFACE "${LY_ROOT_FOLDER}/include/gmock_gtest")
-    
 add_library(3rdParty::googletest::GTest ALIAS gtest)
 add_library(3rdParty::googletest::GMock ALIAS gmock)
 

--- a/Code/Framework/AzToolsFramework/Tests/AssetUtils.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/AssetUtils.cpp
@@ -157,8 +157,7 @@ namespace UnitTest
 
         void SetupMocks()
         {
-            ON_CALL(*this, Open(_, _, _)).WillByDefault(testing::Invoke(
-                [&](const char* filePath, AZ::IO::OpenMode mode, AZ::IO::HandleType& fileHandle)
+            ON_CALL(*this, Open(_, _, _)).WillByDefault([&](const char* filePath, AZ::IO::OpenMode mode, AZ::IO::HandleType& fileHandle)
                 {
                     auto found = m_fileHandleContentMap.find(AZ::Uuid::CreateName(filePath));
                     if (found == m_fileHandleContentMap.end())
@@ -168,11 +167,9 @@ namespace UnitTest
 
                     fileHandle = found->second.first;
                     return AZ::IO::Result(AZ::IO::ResultCode::Success);
-                }
-            ));
+                });
 
-            ON_CALL(*this, Read(_, _, _, _, _)).WillByDefault(testing::Invoke(
-                [&](AZ::IO::HandleType fileHandle, void* buffer, AZ::u64 size, bool failOnFewerThanSizeBytesRead, AZ::u64* bytesRead)
+            ON_CALL(*this, Read(_, _, _, _, _)).WillByDefault([&](AZ::IO::HandleType fileHandle, void* buffer, AZ::u64 size, bool failOnFewerThanSizeBytesRead, AZ::u64* bytesRead)
                 {
                     for (auto iter = m_fileHandleContentMap.begin(); iter != m_fileHandleContentMap.end(); iter++)
                     {
@@ -184,11 +181,9 @@ namespace UnitTest
                     }
 
                     return AZ::IO::Result(AZ::IO::ResultCode::Error);
-                }
-            ));
+                });
 
-            ON_CALL(*this, Size(testing::Matcher<AZ::IO::HandleType>(_), testing::Matcher<AZ::u64&>(_))).WillByDefault(testing::Invoke(
-                [&](AZ::IO::HandleType fileHandle, AZ::u64& size)
+            ON_CALL(*this, Size(testing::Matcher<AZ::IO::HandleType>(_), testing::Matcher<AZ::u64&>(_))).WillByDefault([&](AZ::IO::HandleType fileHandle, AZ::u64& size)
                 {
                     for (auto iter = m_fileHandleContentMap.begin(); iter != m_fileHandleContentMap.end(); iter++)
                     {
@@ -200,11 +195,9 @@ namespace UnitTest
                     }
 
                     return AZ::IO::Result(AZ::IO::ResultCode::Error);
-                }
-            ));
+                });
 
-            ON_CALL(*this, Exists(_)).WillByDefault(testing::Invoke(
-                [&](const char* filePath)
+            ON_CALL(*this, Exists(_)).WillByDefault([&](const char* filePath)
                 {
                     auto found = m_fileHandleContentMap.find(AZ::Uuid::CreateName(filePath));
                     if (found == m_fileHandleContentMap.end())
@@ -213,8 +206,7 @@ namespace UnitTest
                     }
 
                     return true;
-                }
-            ));
+                });
 
             ON_CALL(*this, Close(_))
                 .WillByDefault(

--- a/Code/Framework/AzToolsFramework/Tests/Metadata/MetadataManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Metadata/MetadataManagerTests.cpp
@@ -110,42 +110,37 @@ namespace UnitTest
             using namespace AZ;
 
             ON_CALL(*m_fileIOMock, Open(_, _, _))
-                .WillByDefault(Invoke(
-                    [](auto filePath, auto, IO::HandleType& handle)
+                .WillByDefault([](auto filePath, auto, IO::HandleType& handle)
                     {
                         handle = AZ::u32(AZStd::hash<AZStd::string>{}( filePath ));
                         return AZ::IO::Result(AZ::IO::ResultCode::Success);
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Size(An<AZ::IO::HandleType>(), _))
-                .WillByDefault(Invoke(
-                    [this](auto handle, AZ::u64& size)
+                .WillByDefault([this](auto handle, AZ::u64& size)
                     {
                         size = m_mockFiles[handle].size();
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Size(An<const char*>(), _))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath, AZ::u64& size)
+                .WillByDefault([this](const char* filePath, AZ::u64& size)
                     {
                         auto handle = AZ::u32(AZStd::hash<AZStd::string>{}(filePath));
                         size = m_mockFiles[handle].size();
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Exists(_))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath)
+                .WillByDefault([this](const char* filePath)
                     {
                         auto handle = AZ::u32(AZStd::hash<AZStd::string>{}(filePath));
                         auto itr = m_mockFiles.find(handle);
                         return itr != m_mockFiles.end() && itr->second.size() > 0;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Read(_, _, _, _, _))
-                .WillByDefault(Invoke(
-                    [this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
+                .WillByDefault([this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
                     {
                         auto itr = m_mockFiles.find(handle);
 
@@ -157,11 +152,10 @@ namespace UnitTest
                         memcpy(buffer, itr->second.c_str(), itr->second.size());
                         *bytesRead = itr->second.size();
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Write(_, _, _, _))
-                .WillByDefault(Invoke(
-                    [this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
+                .WillByDefault([this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
                     {
                         AZStd::string& file = m_mockFiles[fileHandle];
 
@@ -169,7 +163,7 @@ namespace UnitTest
                         memcpy((void*)file.c_str(), buffer, size);
                         *bytesWritten = size;
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             m_metadata = AZ::Interface<AzToolsFramework::IMetadataRequests>::Get();
 

--- a/Code/Framework/AzToolsFramework/Tests/Metadata/UuidUtilTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Metadata/UuidUtilTests.cpp
@@ -69,42 +69,37 @@ namespace UnitTest
             using namespace AZ;
 
             ON_CALL(*m_fileIOMock, Open(_, _, _))
-                .WillByDefault(Invoke(
-                    [](auto filePath, auto, IO::HandleType& handle)
+                .WillByDefault([](auto filePath, auto, IO::HandleType& handle)
                     {
                         handle = AZ::u32(AZStd::hash<AZStd::string>{}( filePath ));
                         return AZ::IO::Result(AZ::IO::ResultCode::Success);
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Size(An<AZ::IO::HandleType>(), _))
-                .WillByDefault(Invoke(
-                    [this](auto handle, AZ::u64& size)
+                .WillByDefault([this](auto handle, AZ::u64& size)
                     {
                         size = m_mockFiles[handle].size();
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Size(An<const char*>(), _))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath, AZ::u64& size)
+                .WillByDefault([this](const char* filePath, AZ::u64& size)
                     {
                         auto handle = AZ::u32(AZStd::hash<AZStd::string>{}(filePath));
                         size = m_mockFiles[handle].size();
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Exists(_))
-                .WillByDefault(Invoke(
-                    [this](const char* filePath)
+                .WillByDefault([this](const char* filePath)
                     {
                         auto handle = AZ::u32(AZStd::hash<AZStd::string>{}(filePath));
                         auto itr = m_mockFiles.find(handle);
                         return itr != m_mockFiles.end() && itr->second.size() > 0;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Read(_, _, _, _, _))
-                .WillByDefault(Invoke(
-                    [this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
+                .WillByDefault([this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
                     {
                         auto itr = m_mockFiles.find(handle);
 
@@ -116,11 +111,10 @@ namespace UnitTest
                         memcpy(buffer, itr->second.c_str(), itr->second.size());
                         *bytesRead = itr->second.size();
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             ON_CALL(*m_fileIOMock, Write(_, _, _, _))
-                .WillByDefault(Invoke(
-                    [this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
+                .WillByDefault([this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
                     {
                         AZStd::string& file = m_mockFiles[fileHandle];
 
@@ -128,7 +122,7 @@ namespace UnitTest
                         memcpy((void*)file.c_str(), buffer, size);
                         *bytesWritten = size;
                         return AZ::IO::ResultCode::Success;
-                    }));
+                    });
 
             m_utilInterface = AZ::Interface<AzToolsFramework::IUuidUtil>::Get();
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/MockPrefabFileIOActionValidator.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/MockPrefabFileIOActionValidator.cpp
@@ -79,13 +79,13 @@ namespace UnitTest
                     testing::Return(AZ::IO::Result(expectedSizeResultCode))));
 
         EXPECT_CALL(*m_fileIOMock.get(), Read(fileHandle, testing::_, prefabFileContent.size(), testing::_, testing::_))
-            .WillRepeatedly(testing::Invoke([prefabFileContent, expectedReadResultCode](AZ::IO::HandleType, void* buffer, AZ::u64, bool, AZ::u64* bytesRead)
+            .WillRepeatedly([prefabFileContent, expectedReadResultCode](AZ::IO::HandleType, void* buffer, AZ::u64, bool, AZ::u64* bytesRead)
                 {
                     memcpy(buffer, prefabFileContent.data(), prefabFileContent.size());
                     *bytesRead = prefabFileContent.size();
 
                     return AZ::IO::Result(expectedReadResultCode);
-                }));
+                });
 
         EXPECT_CALL(*m_fileIOMock.get(), Close(fileHandle))
             .WillRepeatedly(testing::Return(AZ::IO::Result(expectedCloseResultCode)));

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
@@ -326,8 +326,7 @@ namespace UnitTests
         using namespace AZ;
 
         ON_CALL(*m_fileIOMock, Open(_, _, _))
-            .WillByDefault(Invoke(
-                [this](auto filePath, IO::OpenMode mode, IO::HandleType& handle)
+            .WillByDefault([this](auto filePath, IO::OpenMode mode, IO::HandleType& handle)
                 {
                     AZStd::string normalizedPath(filePath);
                     AzFramework::StringFunc::Path::Normalize(normalizedPath);
@@ -342,30 +341,27 @@ namespace UnitTests
                     }
 
                     return AZ::IO::Result(AZ::IO::ResultCode::Success);
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Tell(_, _))
-            .WillByDefault(Invoke(
-                [](auto, auto& offset)
+            .WillByDefault([](auto, auto& offset)
                 {
                     offset = 0;
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Size(An<AZ::IO::HandleType>(), _))
-            .WillByDefault(Invoke(
-                [this](auto handle, AZ::u64& size)
+            .WillByDefault([this](auto handle, AZ::u64& size)
                 {
                     auto itr = m_mockFiles.find(handle);
 
                     size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
 
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Size(An<const char*>(), _))
-            .WillByDefault(Invoke(
-                [this](const char* filePath, AZ::u64& size)
+            .WillByDefault([this](const char* filePath, AZ::u64& size)
                 {
                     AZStd::string normalizedPath(filePath);
                     AzFramework::StringFunc::Path::Normalize(normalizedPath);
@@ -375,22 +371,20 @@ namespace UnitTests
                     size = itr != m_mockFiles.end() ? itr->second.second.size() : 0;
 
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Exists(_))
-            .WillByDefault(Invoke(
-                [this](const char* filePath)
+            .WillByDefault([this](const char* filePath)
                 {
                     AZStd::string normalizedPath(filePath);
                     AzFramework::StringFunc::Path::Normalize(normalizedPath);
                     auto handle = ComputeHandle(AZ::IO::PathView(normalizedPath));
                     auto itr = m_mockFiles.find(handle);
                     return itr != m_mockFiles.end();
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Rename(_, _))
-            .WillByDefault(Invoke(
-                [this](const char* originalPath, const char* newPath)
+            .WillByDefault([this](const char* originalPath, const char* newPath)
                 {
                     AZStd::string normalizedOriginalPath(originalPath);
                     AzFramework::StringFunc::Path::Normalize(normalizedOriginalPath);
@@ -417,11 +411,10 @@ namespace UnitTests
                     }
 
                     return AZ::IO::ResultCode::Error;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Remove(_))
-            .WillByDefault(Invoke(
-                [this](const char* filePath)
+            .WillByDefault([this](const char* filePath)
                 {
                     AZStd::string normalizedPath(filePath);
                     AzFramework::StringFunc::Path::Normalize(normalizedPath);
@@ -430,11 +423,10 @@ namespace UnitTests
                     m_mockFiles.erase(handle);
 
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Read(_, _, _, _, _))
-            .WillByDefault(Invoke(
-                [this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
+            .WillByDefault([this](auto handle, void* buffer, auto, auto, AZ::u64* bytesRead)
                 {
                     auto itr = m_mockFiles.find(handle);
 
@@ -446,11 +438,10 @@ namespace UnitTests
                     memcpy(buffer, itr->second.second.c_str(), itr->second.second.size());
                     *bytesRead = itr->second.second.size();
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, Write(_, _, _, _))
-            .WillByDefault(Invoke(
-                [this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
+            .WillByDefault([this](IO::HandleType fileHandle, const void* buffer, AZ::u64 size, AZ::u64* bytesWritten)
                 {
                     auto& pair = m_mockFiles[fileHandle];
 
@@ -463,11 +454,10 @@ namespace UnitTests
                     }
 
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, FindFiles(_, _, _))
-            .WillByDefault(Invoke(
-                [this](const char* filePath, const char* filter, auto callback)
+            .WillByDefault([this](const char* filePath, const char* filter, auto callback)
                 {
                     if ((!filePath)||(filePath[0] == 0))
                     {
@@ -531,11 +521,10 @@ namespace UnitTests
                         }
                     }
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         ON_CALL(*m_fileIOMock, IsDirectory(_))
-            .WillByDefault(Invoke(
-                [this](const char* filePath)
+            .WillByDefault([this](const char* filePath)
                 {
                     AZStd::string normalizedPath(filePath);
                     AzFramework::StringFunc::Path::Normalize(normalizedPath);
@@ -564,7 +553,7 @@ namespace UnitTests
                         }
                     }
                     return false;
-                }));
+                });
         }
 
         MockVirtualFileIO::~MockVirtualFileIO()

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
@@ -504,16 +504,16 @@ namespace AZ::SceneAPI::Containers
             m_componentApplication = AZStd::make_unique<::testing::NiceMock<MockSceneComponentApplication>>();
 
             ON_CALL(*m_componentApplication, GetBehaviorContext())
-                .WillByDefault(::testing::Invoke([this]()
+                .WillByDefault([this]()
                     {
                         return this->m_behaviorContext.get();
-                    }));
+                    });
 
             ON_CALL(*m_componentApplication, GetSerializeContext())
-                .WillByDefault(::testing::Invoke([this]()
+                .WillByDefault([this]()
                     {
                         return this->m_serializeContext.get();
-                    }));
+                    });
 
             m_editorPythonConsoleInterface = AZStd::make_unique<MockEditorPythonConsoleInterface>();
         }
@@ -522,7 +522,7 @@ namespace AZ::SceneAPI::Containers
         {
             EXPECT_CALL(*m_editorPythonConsoleInterface, FetchPythonTypeName(::testing::_))
                 .Times(6)
-                .WillRepeatedly(::testing::Invoke([](const AZ::BehaviorParameter&) {return "int"; }));
+                .WillRepeatedly([](const AZ::BehaviorParameter&) {return "int"; });
         }
 
         void TearDown() override
@@ -811,20 +811,20 @@ namespace AZ::SceneAPI::Containers
 
             m_componentApplication = AZStd::make_unique<::testing::NiceMock<MockSceneComponentApplication>>();
 
-            ON_CALL(*m_componentApplication, GetBehaviorContext()).WillByDefault(::testing::Invoke([this]()
+            ON_CALL(*m_componentApplication, GetBehaviorContext()).WillByDefault([this]()
                 {
                     return this->m_behaviorContext.get();
-                }));
+                });
 
-            ON_CALL(*m_componentApplication, GetSerializeContext()).WillByDefault(::testing::Invoke([this]()
+            ON_CALL(*m_componentApplication, GetSerializeContext()).WillByDefault([this]()
                 {
                     return this->m_serializeContext.get();
-                }));
+                });
 
-            ON_CALL(*m_componentApplication, GetJsonRegistrationContext()).WillByDefault(::testing::Invoke([this]()
+            ON_CALL(*m_componentApplication, GetJsonRegistrationContext()).WillByDefault([this]()
                 {
                     return this->m_jsonRegistrationContext.get();
-                }));
+                });
         }
 
         void TearDown() override

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/SceneGraphSelectorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Utilities/SceneGraphSelectorTests.cpp
@@ -24,7 +24,6 @@ namespace AZ
             using ::testing::Return;
             using ::testing::ReturnRef;
             using ::testing::Eq;
-            using ::testing::Invoke;
             using ::testing::_;
             using ::testing::Matcher;
 
@@ -74,7 +73,7 @@ namespace AZ
                         }
                     };
                     EXPECT_CALL(m_testNodeSelectionList, EnumerateSelectedNodes(_))
-                        .WillRepeatedly(Invoke(enumerateSelectedNodesInvoke));
+                        .WillRepeatedly(enumerateSelectedNodesInvoke);
 
                     auto enumerateUnselectedNodesInvoke =
                         [&unselectedNodes](const DataTypes::ISceneNodeSelectionList::EnumerateNodesCallback& callback)
@@ -88,41 +87,41 @@ namespace AZ
                         }
                     };
                     EXPECT_CALL(m_testNodeSelectionList, EnumerateUnselectedNodes(_))
-                        .WillRepeatedly(Invoke(enumerateUnselectedNodesInvoke));
+                        .WillRepeatedly(enumerateUnselectedNodesInvoke);
 
                     auto isSelectedNodeInvoke = [&selectedNodes](const AZStd::string& name)
                     {
                         return (AZStd::find(selectedNodes.begin(), selectedNodes.end(), name) != selectedNodes.end());
                     };
-                    EXPECT_CALL(m_testNodeSelectionList, IsSelectedNode(_)).WillRepeatedly(Invoke(isSelectedNodeInvoke));
+                    EXPECT_CALL(m_testNodeSelectionList, IsSelectedNode(_)).WillRepeatedly(isSelectedNodeInvoke);
 
                     auto selectedNodeInvoke = [&selectedNodes](const AZStd::string& name)
                         {
                             selectedNodes.push_back(name);
                         };
                     EXPECT_CALL(m_testNodeSelectionList, AddSelectedNode(_))
-                        .WillRepeatedly(Invoke(selectedNodeInvoke));
+                        .WillRepeatedly(selectedNodeInvoke);
 
                     auto removeNodeInvoke = [&unselectedNodes](const AZStd::string& name)
                         {
                             unselectedNodes.push_back(name);
                         };
                     EXPECT_CALL(m_testNodeSelectionList, RemoveSelectedNode(Matcher<const AZStd::string&>(_)))
-                        .WillRepeatedly(Invoke(removeNodeInvoke));
+                        .WillRepeatedly(removeNodeInvoke);
 
                     auto clearSelectedNodes = [&selectedNodes]()
                         {
                             selectedNodes.clear();
                         };
                     EXPECT_CALL(m_testNodeSelectionList, ClearSelectedNodes())
-                        .WillRepeatedly(Invoke(clearSelectedNodes));
+                        .WillRepeatedly(clearSelectedNodes);
 
                     auto clearUnselectedNodes = [&unselectedNodes]()
                         {
                             unselectedNodes.clear();
                         };
                     EXPECT_CALL(m_testNodeSelectionList, ClearUnselectedNodes())
-                        .WillRepeatedly(Invoke(clearUnselectedNodes));
+                        .WillRepeatedly(clearUnselectedNodes);
                 }
 
                 static bool IsValidTestNodeType([[maybe_unused]] const Containers::SceneGraph& graph, [[maybe_unused]] Containers::SceneGraph::NodeIndex& index)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MotionBlur.shadervariantlist
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MotionBlur.shadervariantlist
@@ -4,6 +4,6 @@
         {   "StableId": 1, "Options" : { "o_sampleQuality": 0 } },
         {   "StableId": 2, "Options" : { "o_sampleQuality": 1 } },
         {   "StableId": 3, "Options" : { "o_sampleQuality": 2 } },
-        {   "StableId": 4, "Options" : { "o_sampleQuality": 3 } },
-    ]    
+        {   "StableId": 4, "Options" : { "o_sampleQuality": 3 } }
+    ]
 }

--- a/Gems/AudioSystem/Code/Tests/AudioSystemTest.cpp
+++ b/Gems/AudioSystem/Code/Tests/AudioSystemTest.cpp
@@ -870,9 +870,8 @@ public:
     void TestSuccessfulPreloadParsing(const char* controlsFolder, int numExpectedPreloads, int numExpectedBanksPerPreload)
     {
         using ::testing::_;
-        using ::testing::InvokeWithoutArgs;
         ON_CALL(m_mockFileCacheManager, TryAddFileCacheEntry(_, eADS_GLOBAL, _))
-            .WillByDefault(InvokeWithoutArgs(GenerateNewId));
+            .WillByDefault(GenerateNewId);
 
         m_xmlProcessor.ParsePreloadsData(controlsFolder, eADS_GLOBAL);
 

--- a/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
@@ -156,12 +156,10 @@ namespace Multiplayer
             m_rigidBody = AZStd::make_unique<PhysX::RigidBody>();
             m_mockSceneInterface = AZStd::make_unique<testing::NiceMock<Multiplayer::MockSceneInterface>>();
             ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _))
-                .WillByDefault(Invoke(
-                    [this](AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle)
+                .WillByDefault([this](AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle)
                     {
                         return m_rigidBody.get();
-                    }
-            ));
+                    });
 
             m_mockDefaultWorld = AZStd::make_unique<Multiplayer::MockPhysicsDefaultWorldRequestsHandler>();
 

--- a/Gems/RecastNavigation/Code/Tests/EditorNavigationMeshTest.cpp
+++ b/Gems/RecastNavigation/Code/Tests/EditorNavigationMeshTest.cpp
@@ -31,7 +31,6 @@
 namespace RecastNavigation
 {
     using testing::_;
-    using testing::Invoke;
     using testing::NiceMock;
     using testing::Return;
     using AZStd::unique_ptr;
@@ -148,20 +147,20 @@ namespace RecastNavigation
             m_hit->m_shape = m_mockPhysicsShape.get();
 
             // Fake result when querying PhysX world.
-            ON_CALL(*m_mockSceneInterface, QueryScene(_, _)).WillByDefault(Invoke([this]
+            ON_CALL(*m_mockSceneInterface, QueryScene(_, _)).WillByDefault([this]
             (AzPhysics::SceneHandle, const AzPhysics::SceneQueryRequest* request)
                 {
                     const AzPhysics::OverlapRequest* overlapRequest = static_cast<const AzPhysics::OverlapRequest*>(request);
                     overlapRequest->m_unboundedOverlapHitCallback({ *m_hit });
                     return AzPhysics::SceneQueryHits();
-                }));
+                });
 
             // Fake a simulated body within query results.
-            ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _)).WillByDefault(Invoke([this]
+            ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _)).WillByDefault([this]
             (AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle)
                 {
                     return m_mockSimulatedBody.get();
-                }));
+                });
             // Provide a position and an orientation of a simulated body.
             ON_CALL(*m_mockSimulatedBody, GetOrientation()).WillByDefault(Return(AZ::Quaternion::CreateIdentity()));
             ON_CALL(*m_mockSimulatedBody, GetPosition()).WillByDefault(Return(AZ::Vector3::CreateZero()));
@@ -233,11 +232,11 @@ namespace RecastNavigation
 
         void AddTestGeometry(bool indexed)
         {
-            ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this, indexed]
+            ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this, indexed]
             (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
                 {
                     AddTestGeometry(vertices, indices, indexed);
-                }));
+                });
         }
     };
 

--- a/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
+++ b/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
@@ -28,7 +28,6 @@
 namespace RecastNavigationTests
 {
     using testing::_;
-    using testing::Invoke;
     using testing::NiceMock;
     using testing::Return;
     using AZStd::unique_ptr;
@@ -140,20 +139,20 @@ namespace RecastNavigationTests
             m_hit->m_shape = m_mockPhysicsShape.get();
 
             // Fake result when querying PhysX world.
-            ON_CALL(*m_mockSceneInterface, QueryScene(_, _)).WillByDefault(Invoke([this]
+            ON_CALL(*m_mockSceneInterface, QueryScene(_, _)).WillByDefault([this]
             (AzPhysics::SceneHandle, const AzPhysics::SceneQueryRequest* request)
                 {
                     const AzPhysics::OverlapRequest* overlapRequest = static_cast<const AzPhysics::OverlapRequest*>(request);
                     overlapRequest->m_unboundedOverlapHitCallback({ *m_hit });
                     return AzPhysics::SceneQueryHits();
-                }));
+                });
 
             // Fake a simulated body within query results.
-            ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _)).WillByDefault(Invoke([this]
+            ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _)).WillByDefault([this]
             (AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle)
                 {
                     return m_mockSimulatedBody.get();
-                }));
+                });
             // Provide a position and an orientation of a simulated body.
             ON_CALL(*m_mockSimulatedBody, GetOrientation()).WillByDefault(Return(AZ::Quaternion::CreateIdentity()));
             ON_CALL(*m_mockSimulatedBody, GetPosition()).WillByDefault(Return(AZ::Vector3::CreateZero()));
@@ -218,11 +217,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
@@ -246,19 +245,19 @@ namespace RecastNavigationTests
             m_hit->m_entityId = AZ::EntityId{ 1 };
             m_hit->m_shape = m_mockPhysicsShape.get();
 
-            ON_CALL(*m_mockSceneInterface, QueryScene(_, _)).WillByDefault(Invoke([this]
+            ON_CALL(*m_mockSceneInterface, QueryScene(_, _)).WillByDefault([this]
             (AzPhysics::SceneHandle, const AzPhysics::SceneQueryRequest* request)
                 {
                     const AzPhysics::OverlapRequest* overlapRequest = static_cast<const AzPhysics::OverlapRequest*>(request);
                     overlapRequest->m_unboundedOverlapHitCallback({ *m_hit });
                     return AzPhysics::SceneQueryHits();
-                }));
+                });
 
-            ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _)).WillByDefault(Invoke([]
+            ON_CALL(*m_mockSceneInterface, GetSimulatedBodyFromHandle(_, _)).WillByDefault([]
             (AzPhysics::SceneHandle, AzPhysics::SimulatedBodyHandle)
                 {
                     return nullptr; // empty physical body
-                }));
+                });
         }
 
         /*
@@ -282,11 +281,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
@@ -315,11 +314,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
     }
@@ -343,14 +342,14 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 /*
                  * Testing with non-indexed triangle data. No way to verify, though. This test must not crash, though.
                  */
                 AddTestGeometry(vertices, indices, false);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
     }
@@ -365,11 +364,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
@@ -399,11 +398,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, false);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 
@@ -420,11 +419,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 
@@ -490,11 +489,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 
@@ -516,11 +515,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 
@@ -542,11 +541,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 
@@ -568,11 +567,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         AZStd::vector<AZ::Vector3> waypoints;
         DetourNavigationRequestBus::EventResult(waypoints, AZ::EntityId(1), &DetourNavigationRequests::FindPathBetweenPositions,
@@ -592,11 +591,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         AZStd::vector<AZ::Vector3> waypoints;
         DetourNavigationRequestBus::EventResult(waypoints, AZ::EntityId(1), &DetourNavigationRequests::FindPathBetweenEntities,
@@ -618,11 +617,11 @@ namespace RecastNavigationTests
 
         MockTransforms mockTransforms({ AZ::EntityId(1), AZ::EntityId(2) });
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         AZStd::vector<AZ::Vector3> waypoints;
         DetourNavigationRequestBus::EventResult(waypoints, AZ::EntityId(1), &DetourNavigationRequests::FindPathBetweenEntities,
@@ -665,11 +664,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshAsync);
@@ -683,11 +682,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshAsync);
@@ -720,11 +719,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         for (int i = 1; i <= 2; ++i)
         {
@@ -741,11 +740,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshAsync);
@@ -762,11 +761,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshAsync);
@@ -787,11 +786,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshAsync);
@@ -810,11 +809,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         bool result = false;
@@ -834,11 +833,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         const Wait wait(AZ::EntityId(1));
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshAsync);
@@ -860,11 +859,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         AZStd::vector<AZStd::shared_ptr<RecastNavigation::TileGeometry>> tiles;
         RecastNavigation::RecastNavigationProviderRequestBus::EventResult(tiles, e.GetId(),
@@ -882,11 +881,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
 
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 
@@ -907,11 +906,11 @@ namespace RecastNavigationTests
         ActivateEntity(e);
         SetupNavigationMesh();
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([this]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([this]
         (AZStd::vector<AZ::Vector3>& vertices, AZStd::vector<AZ::u32>& indices, const AZ::Aabb*)
             {
                 AddTestGeometry(vertices, indices, true);
-            }));
+            });
         
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 
@@ -920,14 +919,14 @@ namespace RecastNavigationTests
             AZ::Vector3(0.f, 0.f, 0.f), AZ::Vector3(2.f, 2.f, 0.f));
         EXPECT_GT(waypoints.size(), 1);
 
-        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault(Invoke([]
+        ON_CALL(*m_mockPhysicsShape.get(), GetGeometry(_, _, _)).WillByDefault([]
         (
             [[maybe_unused]] AZStd::vector<AZ::Vector3>& vertices,
             [[maybe_unused]] AZStd::vector<AZ::u32>& indices,
             [[maybe_unused]] const AZ::Aabb*)
             {
                 // Act as if there colliders are gone.
-            }));
+            });
         
         RecastNavigationMeshRequestBus::Event(e.GetId(), &RecastNavigationMeshRequests::UpdateNavigationMeshBlockUntilCompleted);
 

--- a/Gems/SceneProcessing/Code/Tests/SceneBuilder/SceneBuilderTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/SceneBuilder/SceneBuilderTests.cpp
@@ -299,27 +299,25 @@ struct SourceDependencyMockedIOTests : UnitTest::LeakDetectionFixture
         using namespace ::testing;
 
         ON_CALL(m_ioMock, Open(_, _, _))
-            .WillByDefault(Invoke(
-                [](auto, auto, IO::HandleType& handle)
+            .WillByDefault([](auto, auto, IO::HandleType& handle)
                 {
                     handle = 1234;
                     return AZ::IO::Result(AZ::IO::ResultCode::Success);
-                }));
+                });
 
-        ON_CALL(m_ioMock, Size(An<AZ::IO::HandleType>(), _)).WillByDefault(Invoke([](auto, AZ::u64& size)
+        ON_CALL(m_ioMock, Size(An<AZ::IO::HandleType>(), _)).WillByDefault([](auto, AZ::u64& size)
         {
             size = strlen(SourceDependencyJson::TestJson);
             return AZ::IO::ResultCode::Success;
-        }));
+        });
 
         EXPECT_CALL(m_ioMock, Read(_, _, _, _, _))
-            .WillRepeatedly(Invoke(
-                [](auto, void* buffer, auto, auto, AZ::u64* bytesRead)
+            .WillRepeatedly([](auto, void* buffer, auto, auto, AZ::u64* bytesRead)
                 {
                     memcpy(buffer, SourceDependencyJson::TestJson, strlen(SourceDependencyJson::TestJson));
                     *bytesRead = strlen(SourceDependencyJson::TestJson);
                     return AZ::IO::ResultCode::Success;
-                }));
+                });
 
         EXPECT_CALL(m_ioMock, Close(_)).WillRepeatedly(Return(AZ::IO::ResultCode::Success));
     }

--- a/cmake/3rdPartyPackages.cmake
+++ b/cmake/3rdPartyPackages.cmake
@@ -799,8 +799,12 @@ function(o3de_fetch_content arg_NAME)
     # would insert a spurious empty argument into FetchContent_Declare.
     set(fc_args)
 
+    # Stamp extracted files with the extraction time, matching CMP0135 NEW (see cmake/Policy.cmake).
+    # Keeping the archive's own timestamps makes a newly extracted version look older than the
+    # object files built from the previous one, so a version bump silently links stale objects
+    # against the new headers instead of recompiling.
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
-        list(APPEND fc_args DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+        list(APPEND fc_args DOWNLOAD_EXTRACT_TIMESTAMP FALSE)
     endif()
 
     # Forward any extra arguments we don't explicitly handle


### PR DESCRIPTION
## What does this PR do?

Updates googletest from v1.15.2 to v1.18.0.

Most of the diff is fallout from that. 1.17 deprecated the single-argument `Invoke()`, `InvokeWithoutArgs()` and `DoAll()` wrappers, and we build tests with `-Werror`, so they had to go. All three are plain identity functions in gmock now, so dropping them is a no-op:

```cpp
.WillOnce(Invoke([]{ ... })) => .WillOnce([]{ ... })
```

The two-argument forms like `Invoke(this, &Foo::Bar)` aren't deprecated and are left alone.

I also cleaned up `Findgoogletest.cmake`. A good chunk of it was working around things 1.18 no longer does: the `CMP0148` / `PYTHONINTERP_*` shims (nothing references `FindPythonInterp` anymore), the `CMAKE_WARN_DEPRECATED` save/restore (which restored ON rather than the saved value), the visibility preset save/restore (dead while gtest_hide_internal_symbols is OFF), BUILD_GTEST (not actually an option), and the `-Wno-character-conversion` workaround for [google/googletest#4762](https://github.com/google/googletest/issues/4762), which 1.18 fixes.

Last thing, `o3de_fetch_content` now passes `DOWNLOAD_EXTRACT_TIMESTAMP FALSE`. We were passing TRUE, which is the CMP0135 OLD behavior and quietly overrode the `NEW` we set in `Policy.cmake`. Extracted files kept their archive timestamps, so bumping a 3p version made the new headers look older than the objects built against the old ones, and ninja would report "no work to do". I ran into this trying to A/B the two googletest versions.

## How was this PR tested?

- macOS (AppleClang 21, CMake 4.4). Clean configure, and all test targets built with no errors or new warnings.
- Ran `SUITE_main`. To confirm the failures there were pre-existing, I built `AzCore.Tests` against both 1.15.2 and 1.18.0 with everything else held constant.
- Windows and Linux are untested locally. The Invoke sweep was repo-wide, so platform-gated tests are covered in source, but AR is the first real check on those.
