### PR TITLE
Free up extra disk space on macOS runners

### DIFF
--- a/.github/scripts/free-macos-disk-space.sh
+++ b/.github/scripts/free-macos-disk-space.sh
@@ -43,5 +43,51 @@ for xcode in /Applications/Xcode*.app; do
     sudo rm -rf "${xcode}"
 done
 
+ios_simulator_sdk_version=""
+if ! ios_simulator_sdk_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"; then
+    echo "Unable to determine the selected Xcode's iOS Simulator SDK version"
+fi
+
+if simulator_runtimes="$(xcrun simctl runtime list -j)"; then
+    keep_runtime_identifier="$(
+        jq -r --arg version "${ios_simulator_sdk_version}" '
+            [.[] | select(
+                .platformIdentifier == "com.apple.platform.iphonesimulator"
+                and .version == $version
+                and .state == "Ready"
+            )]
+            | first
+            | .identifier // empty
+        ' <<< "${simulator_runtimes}"
+    )"
+
+    if [[ -n "${keep_runtime_identifier}" ]]; then
+        echo "Keeping iOS ${ios_simulator_sdk_version} simulator runtime"
+    else
+        echo "No simulator runtime matches the selected Xcode. Removing all simulator runtimes"
+    fi
+
+    while IFS=$'\t' read -r runtime_identifier runtime_platform runtime_version; do
+        [[ -n "${runtime_identifier}" ]] || continue
+        echo "Removing simulator runtime: ${runtime_platform} ${runtime_version}"
+        if ! xcrun simctl runtime delete "${runtime_identifier}"; then
+            echo "Unable to remove simulator runtime: ${runtime_identifier}"
+        fi
+    done < <(
+        jq -r --arg keep "${keep_runtime_identifier}" '
+            .[]
+            | select(.deletable == true)
+            | select((.platformIdentifier // "") | endswith("simulator"))
+            | select(.identifier != $keep)
+            | [.identifier, .platformIdentifier, .version]
+            | @tsv
+        ' <<< "${simulator_runtimes}"
+    )
+
+    xcrun simctl delete unavailable || true
+else
+    echo "Unable to list simulator runtimes. Skipping simulator cleanup"
+fi
+
 echo "Disk space after cleanup:"
 df -h /

--- a/.github/scripts/free-macos-disk-space.sh
+++ b/.github/scripts/free-macos-disk-space.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+set -euo pipefail
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" || "${RUNNER_ENVIRONMENT:-}" != "github-hosted" ]]; then
+    echo "Skipping disk cleanup outside a GitHub-hosted runner"
+    exit 0
+fi
+
+if [[ "${RUNNER_OS:-}" != "macOS" ]]; then
+    echo "Skipping disk cleanup on ${RUNNER_OS}"
+    exit 0
+fi
+
+echo "Disk space before cleanup:"
+df -h /
+
+selected_xcode="$(xcode-select -p)"
+selected_xcode="${selected_xcode%/Contents/Developer}"
+selected_xcode="$(realpath "${selected_xcode}")"
+echo "Keeping selected Xcode installation: ${selected_xcode}"
+
+for xcode in /Applications/Xcode*.app; do
+    [[ -e "${xcode}" ]] || continue
+
+    resolved_xcode="$(realpath "${xcode}")"
+    if [[ "${resolved_xcode}" == "${selected_xcode}" ]]; then
+        continue
+    fi
+
+    if [[ "${resolved_xcode}" != /Applications/Xcode*.app ]]; then
+        echo "Skipping unexpected Xcode path: ${xcode} -> ${resolved_xcode}"
+        continue
+    fi
+
+    echo "Removing unused Xcode installation: ${xcode}"
+    sudo rm -rf "${xcode}"
+done
+
+echo "Disk space after cleanup:"
+df -h /

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           show-progress: false
 
+      - name: Free disk space
+        run: .github/scripts/free-macos-disk-space.sh
+
       - name: Git LFS pull
         run: |
           git lfs install
@@ -65,7 +68,7 @@ jobs:
           ccache_options: |
             cache_dir=${{ github.workspace }}/.ccache
             hash_dir=false
-            max_size=10G
+            max_size=5G
 
       - name: Check for rerun
         id: check-rerun
@@ -120,9 +123,11 @@ jobs:
         continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         run: |
-          if [ -f ${{ github.workspace }}/cache.tar ]; then
-            gtar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
-            rm ${{ github.workspace }}/cache.tar
+          if [ -f "${{ github.workspace }}/cache.tar" ]; then
+            trap 'rm -f "${{ github.workspace }}/cache.tar"' EXIT
+            gtar -xpf "${{ github.workspace }}/cache.tar" --ignore-failed-read
+            rm -f "${{ github.workspace }}/cache.tar"
+            trap - EXIT
             ccache --zero-stats --cleanup
           fi
 
@@ -161,7 +166,8 @@ jobs:
         if: ${{ (steps.extract-artifact.outcome == 'success' || steps.extract-artifact.outcome == 'skipped') && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         run: |
-          gtar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+          ccache --cleanup
+          gtar --format=posix -cpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
             .ccache \
             .o3de/python/downloaded_packages \
             3rdParty/downloaded_packages \

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           show-progress: false
 
+      - name: Free disk space
+        run: .github/scripts/free-macos-disk-space.sh
+
       - name: Git LFS pull
         # Minimal pull for profile builds, otherwise pull all
         run: |
@@ -66,7 +69,7 @@ jobs:
           ccache_options: |
             cache_dir=${{ github.workspace }}/.ccache
             hash_dir=false
-            max_size=10G
+            max_size=5G
 
       - name: Check for rerun
         id: check-rerun
@@ -121,9 +124,11 @@ jobs:
         continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         run: |
-          if [ -f ${{ github.workspace }}/cache.tar ]; then
-            gtar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
-            rm ${{ github.workspace }}/cache.tar
+          if [ -f "${{ github.workspace }}/cache.tar" ]; then
+            trap 'rm -f "${{ github.workspace }}/cache.tar"' EXIT
+            gtar -xpf "${{ github.workspace }}/cache.tar" --ignore-failed-read
+            rm -f "${{ github.workspace }}/cache.tar"
+            trap - EXIT
             ccache --zero-stats --cleanup
           fi
 
@@ -162,7 +167,8 @@ jobs:
         if: ${{ (steps.extract-artifact.outcome == 'success' || steps.extract-artifact.outcome == 'skipped') && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         run: |
-          gtar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+          ccache --cleanup
+          gtar --format=posix -cpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
             .ccache \
             .o3de/python/downloaded_packages \
             3rdParty/downloaded_packages \


### PR DESCRIPTION
## What does this PR do?

Mac and iOS builds could run out of disk space while restoring and creating build caches. This now frees space by removing unused Xcode installations from GitHub-hosted runners, reduces the compiler cache size, and ensures temporary cache archives are cleaned up after extraction.
