### PR TITLE
Fixes several issues with the install verison of O3DE-SDK

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/3rdParty/Findassimp.cmake
+++ b/Code/Tools/SceneAPI/SDKWrapper/3rdParty/Findassimp.cmake
@@ -54,6 +54,7 @@ block()
     set(ASSIMP_INSTALL OFF)  # Disable since we're using Assimp as a sub module
     set(ASSIMP_WARNINGS_AS_ERRORS OFF)  # Not sure why this doesn't work. Warnings are still treated as error; needed to add warning disabled commandline parameters to PAL_assimp_<compiler>.cmake
     set(TINYUSDZ_USE_CCACHE OFF)
+    set(BUILD_SHARED_LIBS OFF)
 
     # Assimp requires ZLIB
     find_package(ZLIB REQUIRED)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MotionBlur.shadervariantlist
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MotionBlur.shadervariantlist
@@ -4,6 +4,6 @@
         {   "StableId": 1, "Options" : { "o_sampleQuality": 0 } },
         {   "StableId": 2, "Options" : { "o_sampleQuality": 1 } },
         {   "StableId": 3, "Options" : { "o_sampleQuality": 2 } },
-        {   "StableId": 4, "Options" : { "o_sampleQuality": 3 } },
+        {   "StableId": 4, "Options" : { "o_sampleQuality": 3 } }
     ]    
 }

--- a/scripts/o3de/CMakeLists.txt
+++ b/scripts/o3de/CMakeLists.txt
@@ -22,12 +22,6 @@ ly_install_files(FILES README.txt
     DESTINATION scripts/o3de
 )
 
-ly_install_directory(
-    DIRECTORIES
-        o3de.egg-info
-    VERBATIM
-)
-
 ly_install_directory(DIRECTORIES .
     EXCLUDE_PATTERNS
         tests


### PR DESCRIPTION
## What does this PR do?

1.  No longer attempts to copy an non-existent egg-link file
2.  Links assimp statically.  Its not acutally used or exposed outside of the scene API dll, which is always a dll, so its not necessary to ship it.
3.  Fixes the motion blur asset, which was missing integration into stabilization

## How was this PR tested?

Testing on linux, making an installer locally, then using that installer to make a project.  No issues running the project.
