### PR TITLE
Fixes an assert crash that happened each frame

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -88,7 +88,10 @@ namespace AZ
                         mergedHardwareQueueClass = scope.GetHardwareQueueClass();
                     }
 
-                    const uint32_t estimatedItemCount = scope.GetEstimatedItemCount();
+                    // estimate at least 1 item, to avoid any future division by zero or zero-size-list creation
+                    const uint32_t scopeEstimatedItemCount = scope.GetEstimatedItemCount();
+                    AZ_WarningOnce("FrameGraphExecuter", scopeEstimatedItemCount > 0, "Scope %s has an estimated item count of 0.", scope.GetName().GetCStr());
+                    const uint32_t estimatedItemCount = AZStd::max(scopeEstimatedItemCount, 1u);
 
                     const uint32_t CommandListCostThreshold =
                         AZStd::max(

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -109,7 +109,10 @@ namespace AZ
                         mergedHardwareQueueClass = scope.GetHardwareQueueClass();
                     }
 
-                    const AZ::u32 estimatedItemCount = scope.GetEstimatedItemCount();
+                    // estimate at least 1 item, to avoid any future division by zero or zero-size-list creation
+                    const uint32_t scopeEstimatedItemCount = scope.GetEstimatedItemCount();
+                    AZ_WarningOnce("FrameGraphExecuter", scopeEstimatedItemCount > 0, "Scope %s has an estimated item count of 0", scope.GetName().GetCStr());
+                    const uint32_t estimatedItemCount = AZStd::max(scopeEstimatedItemCount, 1u);
 
                     const uint32_t CommandListCostThreshold =
                         AZStd::max(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -112,7 +112,10 @@ namespace AZ
                         mergedHardwareQueueClass = scope.GetHardwareQueueClass();
                     }
 
-                    const uint32_t estimatedItemCount = scope.GetEstimatedItemCount();
+                    // estimate at least 1 item, to avoid any future division by zero or zero-size-list creation
+                    const uint32_t scopeEstimatedItemCount = scope.GetEstimatedItemCount();
+                    AZ_WarningOnce("FrameGraphExecuter", scopeEstimatedItemCount > 0, "Scope %s has an estimated item count of 0", scope.GetName().GetCStr());
+                    const uint32_t estimatedItemCount = AZStd::max(scopeEstimatedItemCount, 1u);
 
                     const uint32_t CommandListCostThreshold =
                         AZStd::max(


### PR DESCRIPTION
## What does this PR do?

In the editor, if you ever used the vulkan pipeline, then you would get an assert every frame as well as further issues down the road.

Credit to @Styx-Hc finding a fix to this.

This change ensures that the estimated item count is at least 1, to avoid division by zero issues, or zero size list creation.

Note that it still emits a warning, but this warning indicates it is related to the **preview renderer** in the editor, which only exists in the editor, not on mobile target platforms, and is only used when certain UIs like the asset picker appear.

We can dig further into the warning in the future, but for now, this at least prevents downstream crashing from 0 size lists.

## How was this PR tested?

Testing on PC with the vulkan + mobile pipeline enabled, which would previously crash and cause memory access problems without this fix.

Note that after this warning message was added, we were able to discover the culprit:
```
 [Warning] (FrameGraphExecuter) - Scope Root.PreviewRendererSystemComponent Preview Pipeline.Pipeline.DepthPrePass.DepthPass has an estimated item count of 0
```


