### PR TITLE
UiCanvasComponent: Do not block certain input events when `m_isConsumingAllInputEvents` is false while hoving over interactables

### DIFF
--- a/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
@@ -2785,7 +2785,7 @@ bool UiCanvasComponent::HandleKeyInputEvent(const AzFramework::InputChannel::Sna
                 // If there is any active or hover interactable then we consider this event handled.
                 // Otherwise we can end up sending events to underlying canvases even though there
                 // is an interactable in this canvas that should block the events
-                if (m_activeInteractable.IsValid() || m_hoverInteractable.IsValid())
+                if ((m_activeInteractable.IsValid() || m_hoverInteractable.IsValid()) && m_isConsumingAllInputEvents)
                 {
                     result = true;
                 }


### PR DESCRIPTION
## What does this PR do?

Only block input events that are defined in `UiNavigationHelper::Command(...)` on active or hovered interactables when `m_isConsumingAllInputEvents` is true.

This fixes #19930.

## How was this PR tested?

The same test was performed that's found in #19930, pressing escape is no longer blocked when the mouse pointer is hovering over an interactable.