### PR TITLE
Fix gamepad hot-plug detection in Editor

### DIFF
--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
@@ -22,6 +22,7 @@
 // AzFramework
 #include <AzFramework/Input/Buses/Notifications/RawInputNotificationBus_Platform.h>
 #include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
+#include <AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 
 #include <dbt.h>
@@ -44,6 +45,17 @@ namespace Editor
         else if (msg->message == WM_EXITSIZEMOVE)
         {
             m_isMovingOrResizing = false;
+        }
+
+        // Notify the input system about device changes even when the Editor
+        // is not currently in game mode.
+        if (msg->message == WM_DEVICECHANGE)
+        {
+            if (msg->wParam == DBT_DEVNODES_CHANGED)
+            {
+                AzFramework::RawInputNotificationBusWindows::Broadcast(
+                    &AzFramework::RawInputNotificationsWindows::OnRawInputDeviceChangeEvent);
+            }
         }
 
         // Prevent the user from being able to move the window in game mode.
@@ -110,11 +122,6 @@ namespace Editor
             }
             else if (msg->message == WM_DEVICECHANGE)
             {
-                if (msg->wParam == DBT_DEVNODES_CHANGED) // DBT_DEVNODES_CHANGED
-                {
-                    AzFramework::RawInputNotificationBusWindows::Broadcast(
-                        &AzFramework::RawInputNotificationsWindows::OnRawInputDeviceChangeEvent);
-                }
                 return true;
             }
             else if (msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_CHAR)
@@ -127,6 +134,30 @@ namespace Editor
         }
 
         return false;
+    }
+
+    void EditorQtApplicationWindows::OnInputDeviceConnectedEvent(const AzFramework::InputDevice& inputDevice)
+    {
+        const auto& inputDeviceId = inputDevice.GetInputDeviceId();
+
+        if (!AzFramework::InputDeviceGamepad::IsGamepadDevice(inputDeviceId))
+        {
+            return;
+        }
+
+        AZ_Printf("Input", "Gamepad connected (index %u)\n", inputDeviceId.GetIndex());
+    }
+
+    void EditorQtApplicationWindows::OnInputDeviceDisconnectedEvent(const AzFramework::InputDevice& inputDevice)
+    {
+        const auto& inputDeviceId = inputDevice.GetInputDeviceId();
+
+        if (!AzFramework::InputDeviceGamepad::IsGamepadDevice(inputDeviceId))
+        {
+            return;
+        }
+
+        AZ_Printf("Input", "Gamepad disconnected (index %u)\n", inputDeviceId.GetIndex());
     }
 
     bool EditorQtApplicationWindows::eventFilter(QObject* object, QEvent* event)

--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
@@ -15,6 +15,9 @@
 #include <QLoggingCategory>
 #include <QTimer>
 
+// AzCore
+#include <AzCore/Console/ILogger.h>
+
 // AzQtComponents
 #include <AzQtComponents/Components/Titlebar.h>
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
@@ -145,7 +148,7 @@ namespace Editor
             return;
         }
 
-        AZ_Printf("Input", "Gamepad connected (index %u)\n", inputDeviceId.GetIndex());
+        AZLOG(InputDevices, "Gamepad connected (index %u)", inputDeviceId.GetIndex());
     }
 
     void EditorQtApplicationWindows::OnInputDeviceDisconnectedEvent(const AzFramework::InputDevice& inputDevice)
@@ -157,7 +160,7 @@ namespace Editor
             return;
         }
 
-        AZ_Printf("Input", "Gamepad disconnected (index %u)\n", inputDeviceId.GetIndex());
+        AZLOG(InputDevices, "Gamepad disconnected (index %u)", inputDeviceId.GetIndex());
     }
 
     bool EditorQtApplicationWindows::eventFilter(QObject* object, QEvent* event)

--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.h
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.h
@@ -8,21 +8,35 @@
 
 #pragma once
 
+#include <AzFramework/Input/Buses/Notifications/InputDeviceNotificationBus.h>
+
 #include <Editor/Core/QtEditorApplication.h>
 
 namespace Editor
 {
-    class EditorQtApplicationWindows : public EditorQtApplication
+    class EditorQtApplicationWindows
+    : public EditorQtApplication
+    , private AzFramework::InputDeviceNotificationBus::Handler
     {
     public:
         EditorQtApplicationWindows(int& argc, char** argv)
             : EditorQtApplication(argc, argv)
         {
+            AzFramework::InputDeviceNotificationBus::Handler::BusConnect();
+        }
+
+        ~EditorQtApplicationWindows() override
+        {
+            AzFramework::InputDeviceNotificationBus::Handler::BusDisconnect();
         }
 
         // QAbstractNativeEventFilter:
         bool nativeEventFilter(const QByteArray& eventType, void* message, qintptr* result) override;
 
         bool eventFilter(QObject* object, QEvent* event) override;
+
+    private:
+        void OnInputDeviceConnectedEvent(const AzFramework::InputDevice& inputDevice) override;
+        void OnInputDeviceDisconnectedEvent(const AzFramework::InputDevice& inputDevice) override;
     };
 } // namespace Editor


### PR DESCRIPTION
## What does this PR do?

Fixes gamepad hot-plug detection in the Windows Editor while outside Game Mode.

The Windows gamepad implementation performs an initial XInput connection
check and then relies on WM_DEVICECHANGE notifications to retry disconnected
gamepads.

Previously, the Editor only forwarded WM_DEVICECHANGE notifications to the
AzFramework input system while already in Game Mode. As a result, connecting
a gamepad while working in Edit Mode did not cause the input system to detect
the newly connected device.

This PR forwards device change notifications regardless of Game Mode, allowing
the input system to detect gamepads immediately when they are connected in the
Editor.

The existing Game Mode event filtering behavior is preserved.

<img width="556" height="142" alt="image" src="https://github.com/user-attachments/assets/2d3c9cf9-4b34-42bd-a4fb-00d041aff22a" />


## How was this PR tested?

Tested on Windows with an XInput gamepad.

- Started the Editor with the gamepad disconnected.
- Connected the gamepad while still in Edit Mode.
- Verified that disconnecting and reconnecting the gamepad works without restarting the Editor.
- Verified that connection and disconnection events appear in the Editor console.
