### PR TITLE
Fix Preview Action Log background

### DIFF
--- a/Gems/LyShine/Code/Editor/Widgets/PreviewActionWidget/PreviewActionLog.cpp
+++ b/Gems/LyShine/Code/Editor/Widgets/PreviewActionWidget/PreviewActionLog.cpp
@@ -24,6 +24,8 @@ PreviewActionLog::PreviewActionLog([[maybe_unused]] EditorWindow* editorWindow)
     // turn off line wrap, this allows the user to dock on the left and make narrow and just see the
     // start of the message (the action name)
     setLineWrapMode(QTextEdit::NoWrap);
+
+    setStyleSheet("background-color: #222222;");
 }
 
 PreviewActionLog::~PreviewActionLog()


### PR DESCRIPTION
## What does this PR do?

Fixes the Preview Action Log readability in LyShine.

<img width="784" height="197" alt="image" src="https://github.com/user-attachments/assets/1fd7bcd8-0b23-4a68-b9f1-c7e078d90af8" />


Previously, the Preview Action Log could use a light background, which made some log text difficult to read depending on the current UI styling.

This PR gives the Preview Action Log a dark background so the text remains clearly visible and consistent with the rest of the editor UI.

<img width="851" height="145" alt="image" src="https://github.com/user-attachments/assets/3bbe1e36-a52e-4b2f-a041-f74dedd205f4" />


## How was this PR tested?

Tested in the O3DE Editor with the LyShine Preview Action Log open.

Verified that:
- The log uses the new dark background.
- Existing log messages remain readable.
- The widget continues to behave normally when docked and resized.