### PR TITLE
Add PhysX test for same collision group and layer

### DIFF
--- a/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
@@ -138,6 +138,23 @@ namespace PhysX
         EXPECT_TRUE(collisionEvents.m_beginCollisions.empty());
     }
 
+    TEST_F(PhysXCollisionFilteringTest, SameCollisionGroupSameLayerCollide)
+    {
+        auto stationaryBox = TestUtils::CreateStaticBoxEntity(m_testSceneHandle, AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.5f));
+        auto fallingBox = TestUtils::CreateBoxEntity(m_testSceneHandle, AZ::Vector3(0.0f, 0.0f, 1.0f), AZ::Vector3(1.0f, 1.0f, 1.0f));
+
+        TestUtils::SetCollisionLayer(stationaryBox, LayerA);
+        TestUtils::SetCollisionLayer(fallingBox, LayerA);
+        TestUtils::SetCollisionGroup(stationaryBox, GroupA);
+        TestUtils::SetCollisionGroup(fallingBox, GroupA);
+
+        CollisionCallbacksListener collisionEvents(fallingBox->GetId());
+
+        TestUtils::UpdateScene(m_defaultScene, AzPhysics::SystemConfiguration::DefaultFixedTimestep, FramesToUpdate);
+
+        EXPECT_FALSE(collisionEvents.m_beginCollisions.empty());
+    }
+
     TEST_F(PhysXCollisionFilteringTest, TestSetCollidesWithGroupOnDynamicObject)
     {
         auto ground = TestUtils::CreateStaticBoxEntity(m_testSceneHandle, AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.5f));


### PR DESCRIPTION
## What does this PR do?

Adds a GTest to `PhysX.Tests.PhysXCollisionFilteringTest` for the `SameCollisionGroupSameLayerCollide` scenario.

The test creates a stationary collider and a falling dynamic collider, assigns both the same collision layer (`LayerA`) and collision group (`GroupA`), advances the PhysX scene, and verifies that a collision-begin event is generated.

This replaces the core collision behavior previously covered by the deprecated Python test with a focused PhysX GTest.

Related issue: o3de/o3de#15279

## How was this PR tested?

The test uses the existing `PhysXDefaultWorldTest` fixture, collision filtering helpers, `CollisionCallbacksListener`, and fixed-step scene update utilities already used by neighboring tests in `PhysXCollisionFilteringTest.cpp`.

The change is limited to one test file and adds a single collision-filtering test case. Full CI validation is pending.

