### PR TITLE
Fix ScriptCanvas activation test synchronization

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/scripting/ScriptCanvasComponent_OnEntityActivatedDeactivated_PrintMessage.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/ScriptCanvasComponent_OnEntityActivatedDeactivated_PrintMessage.py
@@ -82,8 +82,8 @@ def ScriptCanvasComponent_OnEntityActivatedDeactivated_PrintMessage():
      2) Create all the entities we need for the test
      3) Start the Tracer
      4) Enter Game Mode
-     5) Wait one second for graph timers then exit game mode
-     6) Validate Print message
+     5) Wait for graph timers and expected print messages
+     6) Exit Game Mode
 
     Note:
      - Any passed and failed tests are written to the Editor.log file.
@@ -94,7 +94,7 @@ def ScriptCanvasComponent_OnEntityActivatedDeactivated_PrintMessage():
     from editor_python_test_tools.utils import TestHelper
     from editor_python_test_tools.utils import Report, Tracer
     import azlmbr.legacy.general as general
-    from scripting_utils.scripting_constants import (WAIT_TIME_3, WAIT_TIME_1)
+    from scripting_utils.scripting_constants import WAIT_TIME_3
 
     test_entities = [
         testEntity("ActivationTest", "inactive", "activator.scriptcanvas"),
@@ -118,13 +118,14 @@ def ScriptCanvasComponent_OnEntityActivatedDeactivated_PrintMessage():
         # 4) Enter Game Mode
         TestHelper.enter_game_mode(Tests.game_mode_entered)
 
-        # 5) Wait one second for graph timers then exit game mode
-        general.idle_wait(WAIT_TIME_1)
-        TestHelper.exit_game_mode(Tests.game_mode_exited)
+        # 5) Wait until both activation callbacks have been reported.  The callbacks are
+        # scheduled by the graph timer, so a fixed wait can inspect the tracer too early.
+        found_expected_lines = TestHelper.wait_for_condition(
+            lambda: scripting_tools.located_expected_tracer_lines(section_tracer, EXPECTED_LINES), WAIT_TIME_3
+        )
 
-        # 6) Validate Print message
-        found_expected_lines = scripting_tools.located_expected_tracer_lines(section_tracer, EXPECTED_LINES)
-        TestHelper.wait_for_condition(lambda: found_expected_lines is not None, WAIT_TIME_3)
+        # 6) Exit Game Mode after the messages have been observed.
+        TestHelper.exit_game_mode(Tests.game_mode_exited)
 
     Report.result(Tests.lines_found, found_expected_lines)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #8853.

The test previously checked tracer output once after a fixed one-second delay. It then waited only for the already-evaluated boolean to be non-null, so it did not actually wait for the ScriptCanvas activation and deactivation messages. This could cause the test to fail when the graph timer completed later.

The test now waits in game mode until both expected tracer messages are observed, then exits game mode.

## How was this PR tested?

* `python3 -m py_compile AutomatedTesting/Gem/PythonTests/scripting/ScriptCanvasComponent_OnEntityActivatedDeactivated_PrintMessage.py`
* `git diff --check`

The full periodic Editor test was not run locally because it requires the O3DE Windows Editor, GPU, and AutomatedTesting project runtime.

