### PR TITLE
Fix 15280 ball joint breakable test

### DIFF
--- a/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
@@ -138,23 +138,6 @@ namespace PhysX
         EXPECT_TRUE(collisionEvents.m_beginCollisions.empty());
     }
 
-    TEST_F(PhysXCollisionFilteringTest, SameCollisionGroupSameLayerCollide)
-    {
-        auto stationaryBox = TestUtils::CreateStaticBoxEntity(m_testSceneHandle, AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.5f));
-        auto fallingBox = TestUtils::CreateBoxEntity(m_testSceneHandle, AZ::Vector3(0.0f, 0.0f, 1.0f), AZ::Vector3(1.0f, 1.0f, 1.0f));
-
-        TestUtils::SetCollisionLayer(stationaryBox, LayerA);
-        TestUtils::SetCollisionLayer(fallingBox, LayerA);
-        TestUtils::SetCollisionGroup(stationaryBox, GroupA);
-        TestUtils::SetCollisionGroup(fallingBox, GroupA);
-
-        CollisionCallbacksListener collisionEvents(fallingBox->GetId());
-
-        TestUtils::UpdateScene(m_defaultScene, AzPhysics::SystemConfiguration::DefaultFixedTimestep, FramesToUpdate);
-
-        EXPECT_FALSE(collisionEvents.m_beginCollisions.empty());
-    }
-
     TEST_F(PhysXCollisionFilteringTest, TestSetCollidesWithGroupOnDynamicObject)
     {
         auto ground = TestUtils::CreateStaticBoxEntity(m_testSceneHandle, AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.5f));

--- a/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXCollisionFilteringTest.cpp
@@ -138,6 +138,23 @@ namespace PhysX
         EXPECT_TRUE(collisionEvents.m_beginCollisions.empty());
     }
 
+    TEST_F(PhysXCollisionFilteringTest, SameCollisionGroupSameLayerCollide)
+    {
+        auto stationaryBox = TestUtils::CreateStaticBoxEntity(m_testSceneHandle, AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.5f));
+        auto fallingBox = TestUtils::CreateBoxEntity(m_testSceneHandle, AZ::Vector3(0.0f, 0.0f, 1.0f), AZ::Vector3(1.0f, 1.0f, 1.0f));
+
+        TestUtils::SetCollisionLayer(stationaryBox, LayerA);
+        TestUtils::SetCollisionLayer(fallingBox, LayerA);
+        TestUtils::SetCollisionGroup(stationaryBox, GroupA);
+        TestUtils::SetCollisionGroup(fallingBox, GroupA);
+
+        CollisionCallbacksListener collisionEvents(fallingBox->GetId());
+
+        TestUtils::UpdateScene(m_defaultScene, AzPhysics::SystemConfiguration::DefaultFixedTimestep, FramesToUpdate);
+
+        EXPECT_FALSE(collisionEvents.m_beginCollisions.empty());
+    }
+
     TEST_F(PhysXCollisionFilteringTest, TestSetCollidesWithGroupOnDynamicObject)
     {
         auto ground = TestUtils::CreateStaticBoxEntity(m_testSceneHandle, AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.5f));

--- a/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
@@ -209,6 +209,53 @@ namespace PhysX
         EXPECT_GT(followerEndPosition.GetZ(), followerPosition.GetZ());
     }
 
+    TEST_F(PhysXJointsTest, Joint_BallJoint_BreaksUnderForce)
+    {
+        // Place a follower below a heavy lead body, configure a breakable ball joint,
+        // and give the follower an initial lateral velocity. The joint should break.
+        const AZ::Vector3 followerPosition(0.0f, 0.0f, -1.0f);
+        const AZ::Vector3 followerInitialLinearVelocity(5.0f, 2.0f, 0.0f);
+
+        const AZ::Vector3 leadPosition(0.0f, 0.0f, 1.0f);
+        const AZ::Vector3 leadInitialLinearVelocity(0.0f, 0.0f, 0.0f);
+
+        const AZ::Vector3 jointLocalPosition(0.0f, 0.0f, 2.0f);
+        const AZ::Quaternion jointLocalRotation = AZ::Quaternion::CreateRotationY(90.0f);
+        const AZ::Transform jointLocalTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
+            jointLocalRotation,
+            jointLocalPosition);
+
+        // Templated joint component type is irrelevant since joint component is not created for this invocation.
+        auto leadEntity = AddBodyColliderEntity<JointComponent>(
+            m_testSceneHandle, leadPosition, leadInitialLinearVelocity);
+
+        auto jointConfig = AZStd::make_shared<JointComponentConfiguration>();
+        jointConfig->m_leadEntity = leadEntity->GetId();
+        jointConfig->m_localTransformFromFollower = jointLocalTransform;
+
+        auto jointGenericProperties = AZStd::make_shared<JointGenericProperties>(
+            JointGenericProperties::GenericJointFlag::Breakable, 1.0f, 1.0f);
+
+        auto followerEntity = AddBodyColliderEntity<BallJointComponent>(
+            m_testSceneHandle,
+            followerPosition,
+            followerInitialLinearVelocity,
+            jointConfig,
+            jointGenericProperties);
+
+        const AZ::Vector3 followerEndPosition = RunJointTest(m_defaultScene, followerEntity->GetId());
+
+        AZ::Vector3 leadEndPosition;
+        AZ::TransformBus::EventResult(
+            leadEndPosition, leadEntity->GetId(), &AZ::TransformBus::Events::GetWorldTranslation);
+
+        EXPECT_NEAR(leadEndPosition.GetX(), leadPosition.GetX(), 0.2f);
+        EXPECT_NEAR(leadEndPosition.GetY(), leadPosition.GetY(), 0.2f);
+        EXPECT_NEAR(leadEndPosition.GetZ(), leadPosition.GetZ(), 0.2f);
+        EXPECT_GT(followerEndPosition.GetX() - followerPosition.GetX(), 0.2f);
+        EXPECT_NEAR(followerEndPosition.GetZ(), followerPosition.GetZ(), 0.2f);
+    }
+
     TEST_F(PhysXJointsTest, Joint_BallJoint_GlobalConstraint)
     {
         // Place an entity in the world with a rigid body, physx collider, and a ball joint components.

--- a/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
@@ -167,6 +167,7 @@ namespace PhysX
         EXPECT_GT(followerEndPosition.GetX(), followerPosition.GetX());
         EXPECT_GT(abs(followerEndPosition.GetZ()), FLT_EPSILON);
     }
+
     TEST_F(PhysXJointsTest, Joint_BallJoint_FollowerSwingsUpAboutLead)
     {
         // Place lead on top of follower, tie them together with ball joint and send the follower moving sideways in the X and Y directions.

--- a/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
@@ -62,6 +62,7 @@ namespace PhysX
 
         if (jointConfig)
         {
+            rigitBodyConfig.m_computeMass = false;
             jointConfig->m_followerEntity = entity->GetId();
 
             JointGenericProperties defaultJointGenericProperties;

--- a/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
@@ -167,7 +167,6 @@ namespace PhysX
         EXPECT_GT(followerEndPosition.GetX(), followerPosition.GetX());
         EXPECT_GT(abs(followerEndPosition.GetZ()), FLT_EPSILON);
     }
-
     TEST_F(PhysXJointsTest, Joint_BallJoint_FollowerSwingsUpAboutLead)
     {
         // Place lead on top of follower, tie them together with ball joint and send the follower moving sideways in the X and Y directions.
@@ -220,7 +219,7 @@ namespace PhysX
         const AZ::Vector3 leadInitialLinearVelocity(0.0f, 0.0f, 0.0f);
 
         const AZ::Vector3 jointLocalPosition(0.0f, 0.0f, 2.0f);
-        const AZ::Quaternion jointLocalRotation = AZ::Quaternion::CreateRotationY(90.0f);
+        const AZ::Quaternion jointLocalRotation = AZ::Quaternion::CreateRotationY(AZ::DegToRad(90.0f));
         const AZ::Transform jointLocalTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
             jointLocalRotation,
             jointLocalPosition);
@@ -236,12 +235,16 @@ namespace PhysX
         auto jointGenericProperties = AZStd::make_shared<JointGenericProperties>(
             JointGenericProperties::GenericJointFlag::Breakable, 1.0f, 1.0f);
 
+        auto jointLimits = AZStd::make_shared<JointLimitProperties>();
+        jointLimits->m_isLimited = false;
+
         auto followerEntity = AddBodyColliderEntity<BallJointComponent>(
             m_testSceneHandle,
             followerPosition,
             followerInitialLinearVelocity,
             jointConfig,
-            jointGenericProperties);
+            jointGenericProperties,
+            jointLimits);
 
         const AZ::Vector3 followerEndPosition = RunJointTest(m_defaultScene, followerEntity->GetId());
 

--- a/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
@@ -56,14 +56,13 @@ namespace PhysX
         // Make lead body very heavy
         if (!jointConfig)
         {
+            rigidBodyConfig.m_computeMass = false;
             rigidBodyConfig.m_mass = 9999.0f;
         }
         entity->CreateComponent<PhysX::RigidBodyComponent>(rigidBodyConfig, sceneHandle);
 
         if (jointConfig)
         {
-            rigitBodyConfig.m_computeMass = false;
-            rigitBodyConfig.m_mass = 9900.0f;
             jointConfig->m_followerEntity = entity->GetId();
 
             JointGenericProperties defaultJointGenericProperties;

--- a/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
+++ b/Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp
@@ -63,6 +63,7 @@ namespace PhysX
         if (jointConfig)
         {
             rigitBodyConfig.m_computeMass = false;
+            rigitBodyConfig.m_mass = 9900.0f;
             jointConfig->m_followerEntity = entity->GetId();
 
             JointGenericProperties defaultJointGenericProperties;


### PR DESCRIPTION
## What does this PR do?

Adds `Joint_BallJoint_BreaksUnderForce` to `PhysX.Tests.PhysXJointsTest`.

Previously, the breakable ball-joint scenario was covered only by the deprecated `Joints_BallBreakable` pytest. This GTest recreates that scenario with a heavy stationary lead body and a follower given initial velocity `(5, 2, 0)`. It verifies that the lead remains near its initial position and that the follower moves in the positive X direction without significant Z displacement after the ball joint breaks.

Fixes #15280 

## How was this PR tested?

* Compared the GTest setup and assertions with the removed `Joints_BallBreakable` pytest and its prefab configuration.
* Verified that the branch is one commit ahead of `development` and changes only `Gems/PhysX/Core/Code/Tests/PhysXJointsTest.cpp`.
* The full O3DE build and test suite were not run in this environment.

