### PR TITLE
Fix 13757 asset browser context menu groups

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -670,13 +670,6 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                     newAssetBrowser->SelectAsset(fullFilePath.c_str());
                 });
 
-            AZStd::vector<const ProductAssetBrowserEntry*> products;
-            entry->GetChildrenRecursively<ProductAssetBrowserEntry>(products);
-
-            if (!products.empty() || (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source))
-            {
-                CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
-            }
             if (calledFromAssetBrowser && selectionIsSource)
             {
                 // Add Rename option
@@ -758,6 +751,9 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
             action->setShortcut(QKeySequence("Ctrl+D"));
             action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 
+            menu->addSeparator();
+            CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
+
             // Add Move to option
             menu->addAction(
                 QObject::tr("Move to"),
@@ -781,13 +777,20 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                     }
                 });
         }
+        if (!calledFromAssetBrowser || !selectionIsSource)
+        {
+            CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
+        }
     }
     break;
     case AssetBrowserEntry::AssetEntryType::Folder:
     {
         fullFilePath = entry->GetFullPath();
 
-        CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
+        if (!calledFromAssetBrowser || numOfEntries != 1)
+        {
+            CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
+        }
 
         if (calledFromAssetBrowser)
         {
@@ -842,6 +845,9 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
                     });
                 action->setShortcut(QKeySequence::Delete);
                 action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+
+                menu->addSeparator();
+                CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
 
                 // Add Move to option
                 menu->addAction(


### PR DESCRIPTION
What does this PR do?

Fixes #13757 

The Asset Browser context menu previously mixed primary asset actions with secondary file utility actions without a divider.

This change groups Rename, Delete, and Duplicate as primary actions. It then inserts a separator before secondary actions, including Show in Explorer, clipboard actions, and Move to. Folder context menus now follow the same grouping.

How was this PR tested?

* Verified the branch is one commit ahead of "development" and modifies only "Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp".
* Verified that both source-asset and folder context-menu paths insert the separator before file utility actions.
* The full O3DE Editor build and manual UI validation were not run because this environment does not provide the required Editor runtime.
