### PR TITLE
Project Manager: add bottom padding to engine settings

### DIFF
--- a/Code/Tools/ProjectManager/Source/EngineSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/EngineSettingsScreen.cpp
@@ -93,6 +93,7 @@ namespace O3DE::ProjectManager
         m_defaultProjectTemplates->setErrorLabelText(tr("Please provide a valid path to a folder that exists"));
         connect(m_defaultProjectTemplates->lineEdit(), &QLineEdit::textChanged, this, &EngineSettingsScreen::OnTextChanged);
         layout->addWidget(m_defaultProjectTemplates);
+        layout->addSpacing(24);
 
         QVBoxLayout* mainLayout = new QVBoxLayout();
         mainLayout->setAlignment(Qt::AlignTop);


### PR DESCRIPTION
## What does this PR do?

This PR fixes the inconsistent bottom spacing on the Project Manager Engine Settings screen.

Previously, when scrolling to the bottom of the Engine Settings list, the final `Default Project Templates Folder` field had little to no spacing beneath it, making the bottom of the page visually inconsistent with the spacing above the `O3DE Settings` title.

This change adds 24 px of spacing after the final settings field, matching the existing 24 px top margin used by the `O3DE Settings` title and providing consistent vertical spacing across the page.

Related issue: #7791 

## How was this PR tested?

This is a layout-only change using `QVBoxLayout::addSpacing(24)` and does not modify Engine Settings behavior or data handling.

The change was reviewed against the existing `#formTitleLabel` styling in `ProjectManager.qss`, which uses a 24 px top margin. No local runtime or automated tests were performed.