### PR TITLE
Fix zero-item FrameGraph command list count

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -152,7 +152,7 @@ namespace AZ
                     {
                         // And then create a new group for the current scope with dedicated [1, N] command lists.
                         const uint32_t commandListCount =
-                            AZStd::clamp(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u, estimatedItemCount);
+                            AZStd::max(AZStd::min(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), estimatedItemCount), 1u);
 
                         FrameGraphExecuteGroup* scopeContextGroup = AddGroup<FrameGraphExecuteGroup>();
                         scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -174,7 +174,7 @@ namespace AZ
                     {
                         // And then create a new group for the current scope with dedicated [1, N] command lists.
                         const AZ::u32 commandListCount =
-                            AZStd::clamp(RHI::DivideByMultiple(totalScopeCost, CommandListCostThreshold), 1u, estimatedItemCount);
+                            AZStd::max(AZStd::min(RHI::DivideByMultiple(totalScopeCost, CommandListCostThreshold), estimatedItemCount), 1u);
 
                         FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
                         scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -179,7 +179,7 @@ namespace AZ
                     {
                         // And then create a new group for the current scope with dedicated [1, N] secondary command lists
                         const uint32_t commandListCount =
-                            AZStd::clamp(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), 1u, estimatedItemCount);
+                            AZStd::max(AZStd::min(AZ::DivideAndRoundUp(totalScopeCost, CommandListCostThreshold), estimatedItemCount), 1u);
                         FrameGraphExecuteGroupSecondary* scopeContextGroup = AddGroup<FrameGraphExecuteGroupSecondary>();
                         scopeContextGroup->Init(static_cast<Device&>(scope.GetDevice()), scope, commandListCount, GetJobPolicy());
                     }


### PR DESCRIPTION
## What does this PR do?

Corrects zero-item FrameGraph command-list creation in DX12, Vulkan, and Metal. This supersedes #20011.

`GetEstimatedItemCount()` describes the expected draw, dispatch, or copy submissions for a scope, so zero is valid when a pass has nothing to submit. The previous clamp used a range of `[1, estimatedItemCount]`; when the estimate was zero, it produced zero command lists and violated the execution group's requirement to have at least one.

This change applies the item-count limit before enforcing the command-list minimum. The scope keeps its zero item and submit counts, while its dedicated execute group receives one command list for scope work such as clears, barriers, and render-pass transitions. Nonzero scopes keep the same partitioning behavior.

## How was this PR tested?

- Built the Editor and `Atom_RHI.Tests` on Windows.
- Passed `FrameGraphTests.TestSingleEmptyScope` and `FrameSchedulerTests.Test`.
- Exercised 200-frame DX12 and Vulkan Editor smoke runs without the zero-command-list assertion or crash.

The matching Metal change was not built or runtime-tested on Windows.
