### PR TITLE
Add Lua construction and generic asset picker support for AssetId

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
@@ -10,11 +10,56 @@
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/string/conversions.h>
 
 AZ_INSTANTIATE_EBUS_MULTI_ADDRESS(AZCORE_API, AZ::Data::AssetEvents);
+
+namespace
+{
+    void AssetIdScriptConstructor(AZ::Data::AssetId* thisPtr, AZ::ScriptDataContext& scriptDataContext)
+    {
+        new (thisPtr) AZ::Data::AssetId();
+
+        const int argumentCount = scriptDataContext.GetNumArguments();
+        if (argumentCount == 0)
+        {
+            return;
+        }
+
+        if ((argumentCount == 1 || argumentCount == 2)
+            && (scriptDataContext.IsString(0) || scriptDataContext.IsClass<AZ::Uuid>(0))
+            && (argumentCount == 1 || scriptDataContext.IsNumber(1)))
+        {
+            AZ::u32 subId = 0;
+            if (argumentCount == 2)
+            {
+                scriptDataContext.ReadArg(1, subId);
+            }
+
+            if (scriptDataContext.IsString(0))
+            {
+                const char* guidString = nullptr;
+                scriptDataContext.ReadArg(0, guidString);
+                *thisPtr = AZ::Data::AssetId(guidString, subId);
+            }
+            else
+            {
+                AZ::Uuid guid;
+                scriptDataContext.ReadArg(0, guid);
+                *thisPtr = AZ::Data::AssetId(guid, subId);
+            }
+            return;
+        }
+
+        scriptDataContext.GetScriptContext()->Error(
+            AZ::ScriptContext::ErrorType::Error,
+            true,
+            "AssetId expects zero arguments, or a UUID or UUID string and an optional numeric sub ID");
+    }
+} // namespace
 
 namespace AZ::Data
 {
@@ -73,6 +118,7 @@ namespace AZ::Data
                 ->Constructor()
                 ->Constructor<const Uuid&, u32>()
                 ->Constructor<AZStd::string_view, u32>()
+                ->Attribute(AZ::Script::Attributes::ConstructorOverride, &AssetIdScriptConstructor)
                 ->Method("CreateString", &Data::AssetId::CreateString)
                 ->Method("IsValid", &Data::AssetId::IsValid)
                     ->Attribute(AZ::Script::Attributes::Alias, "is_valid")

--- a/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
@@ -8,11 +8,19 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetInternal/WeakAsset.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 
 namespace UnitTest
 {
     using namespace AZ;
     using namespace AZ::Data;
+
+    namespace
+    {
+        bool g_constructorResultMatches = false;
+    }
 
     using AssetIdTest = LeakDetectionFixture;
 
@@ -95,6 +103,68 @@ namespace UnitTest
         AZStd::string asString = assetId.ToString<AZStd::string>(AZ::Data::AssetId::SubIdDisplayType::Decimal);
         auto subId = asString.substr(asString.find_first_of(':') + 1);
         EXPECT_STRCASEEQ(subId.c_str(), "4294967295");
+    }
+
+    class AssetIdScriptConstructorTest
+        : public LeakDetectionFixture
+    {
+    protected:
+        void SetUp() override
+        {
+            LeakDetectionFixture::SetUp();
+
+            g_constructorResultMatches = false;
+            m_behaviorContext = AZStd::make_unique<BehaviorContext>();
+            AssetId::Reflect(m_behaviorContext.get());
+            m_behaviorContext->Property(
+                "constructorResultMatches", BehaviorValueProperty(&g_constructorResultMatches));
+
+            m_scriptContext = AZStd::make_unique<ScriptContext>();
+            m_scriptContext->BindTo(m_behaviorContext.get());
+        }
+
+        void TearDown() override
+        {
+            m_scriptContext.reset();
+            m_behaviorContext.reset();
+
+            LeakDetectionFixture::TearDown();
+        }
+
+        AZStd::unique_ptr<BehaviorContext> m_behaviorContext;
+        AZStd::unique_ptr<ScriptContext> m_scriptContext;
+    };
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithNoArguments_CreatesInvalidAssetIdInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local assetId = AssetId()\n"
+            "constructorResultMatches = not assetId:IsValid()\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
+    }
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithGuid_UsesDefaultSubIdInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local assetId = AssetId('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}')\n"
+            "local expected = AssetId.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}:0')\n"
+            "constructorResultMatches = assetId == expected\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
+    }
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithGuidAndSubId_PreservesBothArgumentsInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local assetId = AssetId('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}', 42)\n"
+            "local expected = AssetId.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}:2a')\n"
+            "constructorResultMatches = assetId == expected\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
     }
 
     using AssetTest = LeakDetectionFixture;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/EBus/Results.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Asset/AssetTypeInfoBus.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzFramework/StringFunc/StringFunc.h>
@@ -21,6 +22,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/Undo/UndoSystem.h>
+#include <AzCore/std/containers/array.h>
 #include <AzCore/std/sort.h>
 #include <AzCore/Script/ScriptContextDebug.h>
 
@@ -81,6 +83,57 @@ namespace AzToolsFramework
         const char* UiFieldName = "ui";
         const char* UiOrderValue = "order";
         const char* DescriptionFieldName = "description";
+        const char* AssetTypeFieldName = "assetType";
+        constexpr size_t MaxAssetTypeCount = 8;
+
+        namespace
+        {
+            constexpr AZ::Crc32 SupportedAssetTypesAttribute = AZ_CRC_CE("SupportedAssetTypes");
+
+            bool ResolveAssetType(const char* displayName, AZ::Data::AssetType& assetType)
+            {
+                size_t matchCount = 0;
+                AZ::AssetTypeInfoBus::EnumerateHandlers(
+                    [displayName, &assetType, &matchCount](AZ::AssetTypeInfo* assetTypeInfo)
+                    {
+                        const char* registeredDisplayName = assetTypeInfo->GetAssetTypeDisplayName();
+                        if (registeredDisplayName && strcmp(displayName, registeredDisplayName) == 0)
+                        {
+                            assetType = assetTypeInfo->GetAssetType();
+                            ++matchCount;
+                        }
+                        return true;
+                    });
+
+                AZ_Warning(
+                    "Script",
+                    matchCount == 1,
+                    "Lua property asset type '%s' must match exactly one registered asset type; found %zu matches",
+                    displayName,
+                    matchCount);
+                return matchCount == 1;
+            }
+
+            void ReplaceAssetTypeFilter(AZ::Edit::ElementData& editData, AZStd::vector<AZ::Data::AssetType> assetTypes)
+            {
+                for (auto attribute = editData.m_attributes.begin(); attribute != editData.m_attributes.end();)
+                {
+                    if (attribute->first == SupportedAssetTypesAttribute)
+                    {
+                        delete attribute->second;
+                        attribute = editData.m_attributes.erase(attribute);
+                    }
+                    else
+                    {
+                        ++attribute;
+                    }
+                }
+
+                auto* supportedAssetTypes =
+                    aznew AZ::Edit::AttributeData<AZStd::vector<AZ::Data::AssetType>>(AZStd::move(assetTypes));
+                editData.m_attributes.emplace_back(SupportedAssetTypesAttribute, supportedAssetTypes);
+            }
+        } // namespace
 
         bool ScriptEditorComponent::DoComponentsMatch(const ScriptEditorComponent* thisComponent, const ScriptEditorComponent* otherComponent)
         {
@@ -259,6 +312,11 @@ namespace AzToolsFramework
         {
             LSV_BEGIN(sdc.GetNativeContext(), 0);
 
+            if (azstricmp(name, AssetTypeFieldName) == 0)
+            {
+                return LoadAssetTypeAttribute(sdc, valueIndex, name, ed, prop);
+            }
+
             /////////////////////////////////////////////////////////////////////////////////
             // This is an example that you can do you the custom OnUnhandledAttribute message 
             // check for data element properties, not real attributes.
@@ -321,6 +379,110 @@ namespace AzToolsFramework
             }
 
             return true;
+        }
+
+        //=========================================================================
+        // LoadAssetTypeAttribute
+        //=========================================================================
+        bool ScriptEditorComponent::LoadAssetTypeAttribute(
+            AZ::ScriptDataContext& sdc,
+            int valueIndex,
+            const char* name,
+            AZ::Edit::ElementData& editData,
+            AZ::ScriptProperty* property)
+        {
+            LSV_BEGIN(sdc.GetNativeContext(), 0);
+
+            if (!property || property->GetDataTypeUuid() != azrtti_typeid<AZ::Data::AssetId>())
+            {
+                AZ_Warning("Script", false, "Attribute '%s' can only be used with an AssetId property", name);
+                return false;
+            }
+
+            AZStd::vector<AZStd::string> displayNames;
+            bool isValid = true;
+            if (sdc.IsString(valueIndex))
+            {
+                const char* displayName = nullptr;
+                isValid = sdc.ReadValue(valueIndex, displayName) && displayName && displayName[0] != '\0';
+                if (isValid)
+                {
+                    displayNames.emplace_back(displayName);
+                }
+            }
+            else if (sdc.IsTable(valueIndex))
+            {
+                AZ::ScriptDataContext assetTypesTable;
+                isValid = sdc.InspectTable(valueIndex, assetTypesTable);
+                if (isValid)
+                {
+                    AZStd::array<AZStd::string, MaxAssetTypeCount> indexedDisplayNames;
+                    AZStd::array<bool, MaxAssetTypeCount> populatedIndices{};
+                    size_t entryCount = 0;
+                    const char* fieldName = nullptr;
+                    int fieldIndex = 0;
+                    int elementIndex = 0;
+                    while (assetTypesTable.InspectNextElement(elementIndex, fieldName, fieldIndex))
+                    {
+                        const char* displayName = nullptr;
+                        const bool isValidEntry = fieldName == nullptr && fieldIndex >= 1
+                            && fieldIndex <= aznumeric_cast<int>(MaxAssetTypeCount) && !populatedIndices[fieldIndex - 1]
+                            && assetTypesTable.IsString(elementIndex) && assetTypesTable.ReadValue(elementIndex, displayName)
+                            && displayName && displayName[0] != '\0';
+                        if (!isValidEntry)
+                        {
+                            isValid = false;
+                            break;
+                        }
+
+                        populatedIndices[fieldIndex - 1] = true;
+                        indexedDisplayNames[fieldIndex - 1] = displayName;
+                        ++entryCount;
+                    }
+
+                    isValid = isValid && entryCount >= 1 && entryCount <= MaxAssetTypeCount;
+                    for (size_t index = 0; isValid && index < entryCount; ++index)
+                    {
+                        isValid = populatedIndices[index];
+                        if (isValid)
+                        {
+                            displayNames.push_back(AZStd::move(indexedDisplayNames[index]));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                isValid = false;
+            }
+
+            AZ_Warning(
+                "Script",
+                isValid,
+                "Attribute '%s' must be a non-empty asset type display name or a contiguous Lua array containing between 1 and %zu names",
+                AssetTypeFieldName,
+                MaxAssetTypeCount);
+
+            AZStd::vector<AZ::Data::AssetType> assetTypes;
+            for (const AZStd::string& displayName : displayNames)
+            {
+                AZ::Data::AssetType assetType;
+                if (!ResolveAssetType(displayName.c_str(), assetType)
+                    || AZStd::find(assetTypes.begin(), assetTypes.end(), assetType) != assetTypes.end())
+                {
+                    AZ_Warning("Script", false, "Lua property asset types must resolve to distinct registered types");
+                    isValid = false;
+                    break;
+                }
+                assetTypes.push_back(assetType);
+            }
+
+            if (!isValid)
+            {
+                assetTypes = { AZ::Data::s_invalidAssetType };
+            }
+            ReplaceAssetTypeFilter(editData, AZStd::move(assetTypes));
+            return isValid;
         }
 
         //=========================================================================

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/ScriptEditorComponent.h
@@ -85,6 +85,12 @@ namespace AzToolsFramework
             void SortProperties(AzFramework::ScriptPropertyGroup& group);
 
             bool LoadAttribute(AZ::ScriptDataContext& sdc, int valueIndex, const char* name, AZ::Edit::ElementData& ed, AZ::ScriptProperty* prop);
+            bool LoadAssetTypeAttribute(
+                AZ::ScriptDataContext& sdc,
+                int valueIndex,
+                const char* name,
+                AZ::Edit::ElementData& editData,
+                AZ::ScriptProperty* property);
             bool LoadDefaultAsset(AZ::ScriptDataContext& sdc, int valueIndex, const char* name, AzFramework::ScriptPropertyGroup& group, ElementInfo& elementInfo);
             bool LoadDefaultEntityRef(AZ::ScriptDataContext& sdc, int valueIndex, const char* name, AzFramework::ScriptPropertyGroup& group, ElementInfo& elementInfo);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -349,8 +349,9 @@ namespace AzToolsFramework
     bool PropertyAssetCtrl::CanAcceptAsset(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType) const
     {
         const auto selectableAssetTypes = GetSelectableAssetTypes();
-        const auto isSelectableAssetType =
-            AZStd::find(selectableAssetTypes.begin(), selectableAssetTypes.end(), assetType) != selectableAssetTypes.end();
+        // An empty list means no type filter is configured, matching the asset browser display filter behavior.
+        const auto isSelectableAssetType = selectableAssetTypes.empty()
+            || AZStd::find(selectableAssetTypes.begin(), selectableAssetTypes.end(), assetType) != selectableAssetTypes.end();
         return (assetId.IsValid() && !assetType.IsNull() && isSelectableAssetType);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -42,6 +42,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzFramework/Asset/SimpleAsset.h>
 #include <AzFramework/Asset/AssetCatalogBus.h>
 #include <AzFramework/API/ApplicationAPI.h>
+#include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
 #include <AzQtComponents/Components/StyleManager.h>
 #include <AzToolsFramework/ToolsComponents/EditorAssetMimeDataContainer.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
@@ -67,6 +68,12 @@ AZ_POP_DISABLE_WARNING
 
 namespace AzToolsFramework
 {
+    namespace
+    {
+        static constexpr auto SupportedAssetTypesDpeAttribute =
+            AZ::DocumentPropertyEditor::AttributeDefinition<AZStd::vector<AZ::Data::AssetType>>("SupportedAssetTypes");
+    }
+
     /* ----- PropertyAssetCtrl ----- */
 
     PropertyAssetCtrl::PropertyAssetCtrl(QWidget* pParent, QString optionalValidDragDropExtensions)
@@ -1739,6 +1746,12 @@ namespace AzToolsFramework
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });
         return newCtrl;
+    }
+
+    void AssetIdPropertyHandlerDefault::RegisterWithPropertySystem(
+        AZ::DocumentPropertyEditor::PropertyEditorSystemInterface* system)
+    {
+        system->RegisterNodeAttribute<AZ::DocumentPropertyEditor::Nodes::PropertyEditor>(SupportedAssetTypesDpeAttribute);
     }
 
     void AssetIdPropertyHandlerDefault::ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -327,6 +327,7 @@ namespace AzToolsFramework
         virtual void UpdateWidgetInternalTabbing(PropertyAssetCtrl* widget) override { widget->UpdateTabOrder(); }
 
         virtual QWidget* CreateGUI(QWidget* pParent) override;
+        void RegisterWithPropertySystem(AZ::DocumentPropertyEditor::PropertyEditorSystemInterface* system) override;
         virtual void ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         virtual void WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
         virtual bool ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;

--- a/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Script/ScriptComponentTests.cpp
@@ -7,13 +7,17 @@
  */
 
 #include <AzCore/Asset/AssetManagerComponent.h>
+#include <AzCore/Asset/AssetTypeInfoBus.h>
+#include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Script/ScriptAsset.h>
 #include <AzCore/Script/ScriptSystemComponent.h>
 #include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Task/TaskGraphSystemComponent.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzFramework/DocumentPropertyEditor/PropertyEditorSystem.h>
 #include <AzToolsFramework/ToolsComponents/ScriptEditorComponent.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx>
 
 #include "EntityTestbed.h"
 
@@ -30,6 +34,91 @@ namespace UnitTest
     // Global Properties used for Testing
     int mySubValue = 0;
     int myReloadValue = 0;
+
+    namespace
+    {
+        constexpr AZ::Crc32 SupportedAssetTypesAttribute = AZ_CRC_CE("SupportedAssetTypes");
+
+        class TestAssetTypeInfo
+            : public AZ::AssetTypeInfoBus::Handler
+        {
+        public:
+            TestAssetTypeInfo(AZ::Data::AssetType assetType, const char* displayName)
+                : m_assetType(assetType)
+                , m_displayName(displayName)
+            {
+                BusConnect(m_assetType);
+            }
+
+            ~TestAssetTypeInfo() override
+            {
+                BusDisconnect();
+            }
+
+            AZ::Data::AssetType GetAssetType() const override
+            {
+                return m_assetType;
+            }
+
+            const char* GetAssetTypeDisplayName() const override
+            {
+                return m_displayName;
+            }
+
+        private:
+            AZ::Data::AssetType m_assetType;
+            const char* m_displayName;
+        };
+
+        class AssetIdScriptPropertyStub
+            : public AZ::ScriptProperty
+        {
+        public:
+            const void* GetDataAddress() const override
+            {
+                return nullptr;
+            }
+
+            AZ::TypeId GetDataTypeUuid() const override
+            {
+                return azrtti_typeid<AZ::Data::AssetId>();
+            }
+
+            AZ::ScriptProperty* Clone([[maybe_unused]] const char* name = nullptr) const override
+            {
+                return nullptr;
+            }
+
+            bool Write([[maybe_unused]] AZ::ScriptContext& context) override
+            {
+                return false;
+            }
+
+        protected:
+            void CloneDataFrom([[maybe_unused]] const AZ::ScriptProperty* scriptProperty) override
+            {
+            }
+        };
+
+        class TestScriptEditorComponent
+            : public AzToolsFramework::Components::ScriptEditorComponent
+        {
+        public:
+            using ScriptEditorComponent::LoadAttribute;
+        };
+
+        AZStd::vector<AZ::Data::AssetType> ReadSupportedAssetTypes(const AZ::Edit::ElementData& editData)
+        {
+            AZStd::vector<AZ::Data::AssetType> assetTypes;
+            AZ::Attribute* attribute = editData.FindAttribute(SupportedAssetTypesAttribute);
+            if (attribute)
+            {
+                AZ::AttributeReader reader(nullptr, attribute);
+                reader.Read<AZStd::vector<AZ::Data::AssetType>>(assetTypes);
+            }
+            return assetTypes;
+        }
+    } // namespace
 
     class ScriptComponentTest
         : public UnitTest::LeakDetectionFixture
@@ -110,6 +199,33 @@ namespace UnitTest
 
             auto* scriptComponent = gameEntity.FindComponent<ScriptComponent>();
             return scriptComponent;
+        }
+
+        bool LoadAssetTypeAttributes(const AZStd::string& attributes, AZ::Edit::ElementData& editData)
+        {
+            const AZStd::string script = AZStd::string::format("AssetTypeAttributeTest = %s", attributes.c_str());
+            if (!m_scriptContext->Execute(script.c_str(), "AssetTypeAttributeTest"))
+            {
+                return false;
+            }
+
+            AZ::ScriptDataContext attributeTable;
+            if (!m_scriptContext->InspectTable("AssetTypeAttributeTest", attributeTable))
+            {
+                return false;
+            }
+
+            TestScriptEditorComponent component;
+            AssetIdScriptPropertyStub property;
+            bool result = true;
+            const char* attributeName = nullptr;
+            int attributeFieldIndex = 0;
+            int attributeIndex = 0;
+            while (attributeTable.InspectNextElement(attributeIndex, attributeName, attributeFieldIndex))
+            {
+                result = component.LoadAttribute(attributeTable, attributeIndex, attributeName, editData, &property) && result;
+            }
+            return result;
         }
 
         ComponentApplication m_app;
@@ -241,5 +357,127 @@ namespace UnitTest
         Entity editorEntity, gameEntity;
         auto* scriptComponent = BuildGameEntity(scriptAsset, gameEntity);
         EXPECT_NE(scriptComponent->GetScriptProperty("myNum"), nullptr);
+    }
+
+    TEST_F(ScriptComponentTest, LuaAssetIdPropertyAcceptsOneAssetTypeDisplayName)
+    {
+        const AZ::Data::AssetType modelAssetType{ "{8F38B502-014C-4E46-A867-20CB7BC24954}" };
+        TestAssetTypeInfo modelAssetTypeInfo(modelAssetType, "ModelAsset");
+        AZ::Edit::ElementData editData;
+
+        EXPECT_TRUE(LoadAssetTypeAttributes("{ assetType = 'ModelAsset' }", editData));
+        EXPECT_THAT(ReadSupportedAssetTypes(editData), ::testing::ElementsAre(modelAssetType));
+        ASSERT_NE(editData.FindAttribute(SupportedAssetTypesAttribute), nullptr);
+        EXPECT_FALSE(editData.FindAttribute(SupportedAssetTypesAttribute)->m_describesChildren);
+
+        editData.ClearAttributes();
+    }
+
+    TEST_F(ScriptComponentTest, LuaAssetIdPropertyAcceptsBetweenOneAndEightAssetTypes)
+    {
+        const AZStd::array<AZ::Data::AssetType, 8> assetTypes = {
+            AZ::Data::AssetType{ "{5091E379-381F-4603-8941-9AC13550D6FB}" },
+            AZ::Data::AssetType{ "{A6DF59CF-6D35-4FB3-AE0C-631144C88A07}" },
+            AZ::Data::AssetType{ "{A0B281BB-2835-46AD-A3AE-5E1D07468320}" },
+            AZ::Data::AssetType{ "{C5AC91D0-D70F-4305-93F7-3CC00FA243F7}" },
+            AZ::Data::AssetType{ "{C9E956F0-AD2B-4C14-9493-F9E89538A60F}" },
+            AZ::Data::AssetType{ "{52CC79AD-1D7C-4B83-A59B-7089ABBD9E82}" },
+            AZ::Data::AssetType{ "{E1D10AD6-4CF5-418D-9A16-82FE01A6A609}" },
+            AZ::Data::AssetType{ "{4437603D-FBD6-4B59-BA2B-11554A4C3425}" }
+        };
+        TestAssetTypeInfo firstTypeInfo(assetTypes[0], "TestAsset1");
+        TestAssetTypeInfo secondTypeInfo(assetTypes[1], "TestAsset2");
+        TestAssetTypeInfo thirdTypeInfo(assetTypes[2], "TestAsset3");
+        TestAssetTypeInfo fourthTypeInfo(assetTypes[3], "TestAsset4");
+        TestAssetTypeInfo fifthTypeInfo(assetTypes[4], "TestAsset5");
+        TestAssetTypeInfo sixthTypeInfo(assetTypes[5], "TestAsset6");
+        TestAssetTypeInfo seventhTypeInfo(assetTypes[6], "TestAsset7");
+        TestAssetTypeInfo eighthTypeInfo(assetTypes[7], "TestAsset8");
+
+        for (size_t typeCount = 1; typeCount <= assetTypes.size(); ++typeCount)
+        {
+            SCOPED_TRACE(typeCount);
+            AZStd::string attribute = "{ assetType = {";
+            for (size_t index = 0; index < typeCount; ++index)
+            {
+                attribute += AZStd::string::format("'TestAsset%zu',", index + 1);
+            }
+            attribute += "} }";
+
+            AZ::Edit::ElementData editData;
+            EXPECT_TRUE(LoadAssetTypeAttributes(attribute, editData));
+            const AZStd::vector<AZ::Data::AssetType> actualAssetTypes = ReadSupportedAssetTypes(editData);
+            ASSERT_EQ(actualAssetTypes.size(), typeCount);
+            EXPECT_TRUE(AZStd::equal(actualAssetTypes.begin(), actualAssetTypes.end(), assetTypes.begin()));
+            editData.ClearAttributes();
+        }
+    }
+
+    TEST_F(ScriptComponentTest, LuaAssetIdPropertyRejectsInvalidAssetTypeFilters)
+    {
+        const AZ::Data::AssetType firstAssetType{ "{72C86438-A410-41D5-A927-854799F62DC0}" };
+        const AZ::Data::AssetType secondAssetType{ "{48415517-F909-4F5F-B9AA-57073A6B3090}" };
+        TestAssetTypeInfo firstTypeInfo(firstAssetType, "TestAsset1");
+        TestAssetTypeInfo secondTypeInfo(secondAssetType, "TestAsset2");
+        TestAssetTypeInfo ambiguousTypeInfo(secondAssetType, "TestAsset1");
+
+        const AZStd::array<const char*, 6> invalidAttributes = {
+            "{ assetType = 'MissingAsset' }",
+            "{ assetType = 'TestAsset1' }",
+            "{ assetType = {} }",
+            "{ assetType = {'TestAsset2', 'TestAsset2'} }",
+            "{ assetType = {'TestAsset1', 'TestAsset2', 'TestAsset3', 'TestAsset4', 'TestAsset5', 'TestAsset6', 'TestAsset7', 'TestAsset8', 'TestAsset9'} }",
+            "{ assetType = 42 }"
+        };
+
+        for (const char* attribute : invalidAttributes)
+        {
+            SCOPED_TRACE(attribute);
+            AZ::Edit::ElementData editData;
+            EXPECT_FALSE(LoadAssetTypeAttributes(attribute, editData));
+            EXPECT_THAT(ReadSupportedAssetTypes(editData), ::testing::ElementsAre(AZ::Data::s_invalidAssetType));
+            editData.ClearAttributes();
+        }
+    }
+
+    TEST_F(ScriptComponentTest, AssetIdSupportedAssetTypesRoundTripsThroughDpe)
+    {
+        AZ::DocumentPropertyEditor::PropertyEditorSystem propertyEditorSystem;
+        AzToolsFramework::AssetIdPropertyHandlerDefault assetIdPropertyHandler;
+        assetIdPropertyHandler.RegisterWithPropertySystem(&propertyEditorSystem);
+
+        const AZ::Name attributeName = propertyEditorSystem.LookupNameFromId(SupportedAssetTypesAttribute);
+        EXPECT_EQ(attributeName, AZ::Name("SupportedAssetTypes"));
+
+        const AZ::DocumentPropertyEditor::AttributeDefinitionInterface* supportedAssetTypesDefinition = nullptr;
+        propertyEditorSystem.EnumerateRegisteredAttributes(
+            attributeName,
+            [&supportedAssetTypesDefinition](const AZ::DocumentPropertyEditor::AttributeDefinitionInterface& definition)
+            {
+                if (definition.GetTypeId() == azrtti_typeid<AZStd::vector<AZ::Data::AssetType>>())
+                {
+                    supportedAssetTypesDefinition = &definition;
+                }
+            });
+        ASSERT_NE(supportedAssetTypesDefinition, nullptr);
+
+        const AZStd::vector<AZ::Data::AssetType> expectedAssetTypes = {
+            AZ::Data::AssetType{ "{18F441A4-DB79-42F1-A2D7-70E450A05D64}" },
+            AZ::Data::AssetType{ "{70984272-AB02-4A86-B55D-8AE3A16F6744}" }
+        };
+        AZ::AttributeData<AZStd::vector<AZ::Data::AssetType>> legacyAttribute(expectedAssetTypes);
+
+        const AZ::Dom::Value domValue = supportedAssetTypesDefinition->LegacyAttributeToDomValue(
+            AZ::PointerObject{ nullptr, AZ::TypeId::CreateNull() }, &legacyAttribute);
+        ASSERT_FALSE(domValue.IsNull());
+
+        AZStd::shared_ptr<AZ::Attribute> restoredAttribute =
+            supportedAssetTypesDefinition->DomValueToLegacyAttribute(domValue, true);
+        ASSERT_NE(restoredAttribute, nullptr);
+
+        AZStd::vector<AZ::Data::AssetType> actualAssetTypes;
+        AZ::AttributeReader restoredAttributeReader(nullptr, restoredAttribute.get());
+        ASSERT_TRUE(restoredAttributeReader.Read<AZStd::vector<AZ::Data::AssetType>>(actualAssetTypes));
+        EXPECT_EQ(actualAssetTypes, expectedAssetTypes);
     }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/UI/PropertyAssetCtrlTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/UI/PropertyAssetCtrlTests.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
+
+namespace UnitTest
+{
+    class TestPropertyAssetCtrl : public AzToolsFramework::PropertyAssetCtrl
+    {
+    public:
+        bool CanAccept(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType) const
+        {
+            return CanAcceptAsset(assetId, assetType);
+        }
+    };
+
+    class PropertyAssetCtrlTest : public ToolsApplicationFixture<>
+    {
+    };
+
+    TEST_F(PropertyAssetCtrlTest, CanAcceptAsset_EmptySelectableTypes_AcceptsAnyValidAssetType)
+    {
+        TestPropertyAssetCtrl propertyAssetCtrl;
+        const AZ::Data::AssetId assetId(AZ::Uuid::CreateRandom(), 1);
+        const AZ::Data::AssetType assetType = AZ::Uuid::CreateRandom();
+
+        EXPECT_TRUE(propertyAssetCtrl.CanAccept(assetId, assetType));
+    }
+
+    TEST_F(PropertyAssetCtrlTest, CanAcceptAsset_EmptySelectableTypes_RejectsInvalidAssetData)
+    {
+        TestPropertyAssetCtrl propertyAssetCtrl;
+        const AZ::Data::AssetId assetId(AZ::Uuid::CreateRandom(), 1);
+        const AZ::Data::AssetType assetType = AZ::Uuid::CreateRandom();
+
+        EXPECT_FALSE(propertyAssetCtrl.CanAccept(AZ::Data::AssetId(), assetType));
+        EXPECT_FALSE(propertyAssetCtrl.CanAccept(assetId, AZ::Data::AssetType::CreateNull()));
+    }
+
+    TEST_F(PropertyAssetCtrlTest, CanAcceptAsset_NonEmptySelectableTypes_OnlyAcceptsListedTypes)
+    {
+        TestPropertyAssetCtrl propertyAssetCtrl;
+        const AZ::Data::AssetId assetId(AZ::Uuid::CreateRandom(), 1);
+        const AZ::Data::AssetType supportedAssetType = AZ::Uuid::CreateRandom();
+        const AZ::Data::AssetType unsupportedAssetType = AZ::Uuid::CreateRandom();
+        propertyAssetCtrl.SetSupportedAssetTypes({ supportedAssetType });
+
+        EXPECT_TRUE(propertyAssetCtrl.CanAccept(assetId, supportedAssetType));
+        EXPECT_FALSE(propertyAssetCtrl.CanAccept(assetId, unsupportedAssetType));
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -186,6 +186,7 @@ set(FILES
     UI/EntityIdQLineEditTests.cpp
     UI/EntityOutlinerTests.cpp
     UI/EntityPropertyEditorTests.cpp
+    UI/PropertyAssetCtrlTests.cpp
     UI/AssetBrowserTests.cpp
     UndoStack.cpp
     Viewport/ClusterTests.cpp


### PR DESCRIPTION
## Summary

This PR partially addresses #19202 by adding Lua-side construction support for `AZ::Data::AssetId` and allowing generic `AssetId` properties to use the existing asset picker when no explicit asset type filter is configured.

The current implementation supports:

```lua
AssetId()
AssetId("{GUID}")
AssetId("{GUID}", subId)
```

It also updates `PropertyAssetCtrl` so that an empty list of selectable asset types is treated as no filter, allowing any valid registered asset type instead of rejecting all assets.

## Motivation

The original issue pointed out that Lua currently cannot directly create an `AssetId`, which makes generic asset references awkward and often requires per-asset-type wrappers such as `SpawnableScriptAssetRef`.

The goal of this change is to reuse the existing `AssetId` reflection and property editor infrastructure rather than introduce another wrapper type.

## Asset type filtering

It is not currently clear what the best script-facing representation for asset types should be, or how that metadata should be exposed without introducing an API that is too specific or difficult to extend.

Since the original discussion also suggested finding a more generic solution that can work with registered asset types, I would prefer to get design feedback before establishing that part of the Lua API.

For now, an `AssetId` property without a type filter can select any valid asset type.

## Testing

Added coverage for:

* Constructing an empty `AssetId` from Lua.
* Constructing an `AssetId` from a GUID.
* Constructing an `AssetId` from a GUID and sub ID.
* Accepting any valid asset type when no picker filter is configured.
* Preserving existing filtering behavior when supported asset types are explicitly specified.