### PR TITLE
Added material overrides and copy/paste for the emitters

### DIFF
--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleAssetData.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleAssetData.cpp
@@ -59,6 +59,7 @@ namespace OpenParticle
             newEmitter->m_config = emitter->m_config;
             newEmitter->m_renderConfig = emitter->m_renderConfig;
             newEmitter->m_material = emitter->m_material;
+            newEmitter->m_materialOverrides = emitter->m_materialOverrides;
             newEmitter->m_model = emitter->m_model;
             newEmitter->m_skeletonModel = emitter->m_skeletonModel;
             newEmitter->m_meshSampleType = emitter->m_meshSampleType;
@@ -99,6 +100,7 @@ namespace OpenParticle
             newEmitter->m_config = emitter->m_config;
             newEmitter->m_renderConfig = emitter->m_renderConfig;
             newEmitter->m_material = emitter->m_material;
+            newEmitter->m_materialOverrides = emitter->m_materialOverrides;
             newEmitter->m_model = emitter->m_model;
             newEmitter->m_skeletonModel = emitter->m_skeletonModel;
             newEmitter->m_meshSampleType = emitter->m_meshSampleType;
@@ -282,6 +284,7 @@ namespace OpenParticle
             fn(emitter->m_updateModules);
             fn(emitter->m_eventModules);
             archive.Material(materialAsset);
+            archive.MaterialOverrides(emitter->m_materialOverrides);
             if (emitter->m_renderConfig.is<SimuCore::ParticleCore::MeshConfig>())
             {
                 archive.Model(modelAsset);

--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSourceData.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSourceData.cpp
@@ -87,6 +87,7 @@ namespace OpenParticle
             newEmitter->m_config = emitter->m_config;
             newEmitter->m_renderConfig = emitter->m_renderConfig;
             newEmitter->m_material = emitter->m_material;
+            newEmitter->m_materialOverrides = emitter->m_materialOverrides;
             newEmitter->m_model = emitter->m_model;
             newEmitter->m_skeletonModel = emitter->m_skeletonModel;
             newEmitter->m_emitModules.assign(emitter->m_emitModules.begin(), emitter->m_emitModules.end());
@@ -122,6 +123,7 @@ namespace OpenParticle
             newEmitter->m_config = emitter->m_config;
             newEmitter->m_renderConfig = emitter->m_renderConfig;
             newEmitter->m_material = emitter->m_material;
+            newEmitter->m_materialOverrides = emitter->m_materialOverrides;
             newEmitter->m_model = emitter->m_model;
             newEmitter->m_skeletonModel = emitter->m_skeletonModel;
             newEmitter->m_emitModules.assign(emitter->m_emitModules.begin(), emitter->m_emitModules.end());
@@ -290,6 +292,7 @@ namespace OpenParticle
             auto emitter = aznew ParticleAssetData::EmitterInfo();
             emitter->m_name = editEmitter->m_name;
             emitter->m_material = editEmitter->m_material;
+            emitter->m_materialOverrides = editEmitter->m_materialOverrides;
             emitter->m_model = editEmitter->m_model;
             emitter->m_skeletonModel = editEmitter->m_skeletonModel;
             emitter->m_config = DataConvertor::ToRuntime(editEmitter->m_config);
@@ -588,6 +591,7 @@ namespace OpenParticle
 
         detailInfo->m_name = emitterInfo->m_name;
         detailInfo->m_material = emitterInfo->m_material;
+        detailInfo->m_materialOverrides = emitterInfo->m_materialOverrides;
         detailInfo->m_model =  emitterInfo->m_model;
         detailInfo->m_skeletonModel = emitterInfo->m_skeletonModel;
         detailInfo->m_isUse = true;
@@ -639,7 +643,7 @@ namespace OpenParticle
         auto emitter = AddEmitter(str);
         m_details.emplace_back(aznew ParticleSourceData::DetailInfo());
         EmitterInfoToDetailInfo(m_details.back(), emitter);
-        SetDefaultModules(m_details.back());
+        SetDefaultModules(m_details.back(), emitter);
         return m_details.back();
     }
 
@@ -670,6 +674,8 @@ namespace OpenParticle
         detailInfo->m_name = emitterInfo->m_name;
         emitterInfo->m_material = detailInfo->m_material;
         detailInfo->m_material = emitterInfo->m_material;
+        emitterInfo->m_materialOverrides = detailInfo->m_materialOverrides;
+        detailInfo->m_materialOverrides = emitterInfo->m_materialOverrides;
         emitterInfo->m_model = detailInfo->m_model;
         detailInfo->m_model = emitterInfo->m_model;
         emitterInfo->m_skeletonModel = detailInfo->m_skeletonModel;
@@ -696,8 +702,21 @@ namespace OpenParticle
         switch (index)
         {
             case DetailConstant::ASSET_MATERIAL:
+            {
+                // emitter->m_material still holds the previous asset at this point, so this tells us whether
+                // the user actually swapped materials or just re-picked the same one.
+                const bool materialChanged = emitter->m_material.GetId() != detailInfo->m_material.GetId();
                 emitter->m_material = detailInfo->m_material;
+                if (materialChanged)
+                {
+                    // A different material can mean a different property layout. Drop overrides that no
+                    // longer resolve but keep the ones that do, which is what you want when swapping
+                    // between two materials built from the same material type.
+                    PruneMaterialPropertyOverrides(emitter->m_material, detailInfo->m_materialOverrides);
+                }
+                emitter->m_materialOverrides = detailInfo->m_materialOverrides;
                 break;
+            }
             case DetailConstant::ASSET_MODEL:
                 emitter->m_model = detailInfo->m_model;
                 break;
@@ -1208,7 +1227,7 @@ namespace OpenParticle
         return used;
     }
 
-    void ParticleSourceData::SetDefaultModules(DetailInfo* detailInfo)
+    void ParticleSourceData::SetDefaultModules(DetailInfo* detailInfo, EmitterInfo* emitterInfo)
     {
         SelectModule(detailInfo, "Emitter", "Emitter");
         SelectModule(detailInfo, "Spawn", "Spawn Rate");
@@ -1224,8 +1243,22 @@ namespace OpenParticle
 
         if (defaultSpriteEmitMaterialId.IsValid())
         {
+            // PreLoad to match ConvertSourceFileNameToAsset, which is what the load path uses. When these two
+            // disagree the builder records the product dependency with one behaviour while the runtime asset
+            // carries the other, which is what produces "expected to load, but the Asset Catalog has no
+            // dependency recorded" warnings.
             detailInfo->m_material =
-                AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::MaterialAsset>(defaultSpriteEmitMaterialId, AZ::Data::AssetLoadBehaviorNamespace::NoLoad);
+                AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::MaterialAsset>(defaultSpriteEmitMaterialId, AZ::Data::AssetLoadBehavior::PreLoad);
+
+            // The emitter needs it too. Only the detail used to be assigned here, so a freshly added emitter
+            // carried an invalid material until the user happened to touch the material picker, and
+            // CreateParticleAsset would fail with "no material assigned to render in emitter <name>".
+            // The save path hid this by substituting the default material on write, so the file on disk
+            // looked correct while the in memory emitter did not.
+            if (emitterInfo != nullptr)
+            {
+                emitterInfo->m_material = detailInfo->m_material;
+            }
         }
     }
 
@@ -1643,6 +1676,7 @@ namespace OpenParticle
         destEmitter->m_config = sourceEmitter->m_config;
         destEmitter->m_renderConfig = sourceEmitter->m_renderConfig;
         destEmitter->m_material = sourceEmitter->m_material;
+        destEmitter->m_materialOverrides = sourceEmitter->m_materialOverrides;
         destEmitter->m_model = sourceEmitter->m_model;
         destEmitter->m_skeletonModel = sourceEmitter->m_skeletonModel;
         destEmitter->m_emitModules.assign(sourceEmitter->m_emitModules.begin(), sourceEmitter->m_emitModules.end());
@@ -1676,6 +1710,7 @@ namespace OpenParticle
     void ParticleSourceData::CopyDetailFromDetail(DetailInfo* sourceDetail, EmitterInfo* destEmitter, DetailInfo* destDetail)
     {
         destEmitter->m_material = sourceDetail->m_material;
+        destEmitter->m_materialOverrides = sourceDetail->m_materialOverrides;
         destEmitter->m_model = sourceDetail->m_model;
         destEmitter->m_skeletonModel = sourceDetail->m_skeletonModel;
         // copy modules

--- a/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp
@@ -593,6 +593,19 @@ namespace OpenParticle
 
         AZ::Data::AssetLoadBehavior loadBehavior = AZ::Data::AssetLoadBehavior::PreLoad;
         resultCode.Combine(ConvertSourceFileNameToAsset(emitInfo->m_material, inputValue, "material", loadBehavior, context));
+
+        // Optional. Particle files authored before per-emitter material overrides existed simply have no
+        // "materialOverrides" member and load with an empty map.
+        if (inputValue.IsObject() && inputValue.HasMember("materialOverrides"))
+        {
+            resultCode.Combine(ContinueLoadingFromJsonObjectField(
+                &emitInfo->m_materialOverrides,
+                azrtti_typeid<MaterialPropertyOverrideMap>(),
+                inputValue,
+                "materialOverrides",
+                context));
+        }
+
         resultCode.Combine(ConvertSourceFileNameToAsset(emitInfo->m_model, inputValue, "model", loadBehavior, context));
         resultCode.Combine(ConvertSourceFileNameToAsset(emitInfo->m_skeletonModel, inputValue, "skeleton model", loadBehavior, context));
 
@@ -702,13 +715,28 @@ namespace OpenParticle
             {
                 // we don't actually have to load the asset, just want to place it into a struct for serialize.
                 mat = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::MaterialAsset>(
-                    defaultSpriteEmitMaterialId, AZ::Data::AssetLoadBehaviorNamespace::NoLoad);
+                    // PreLoad to match the load path, so the behaviour written to the file agrees with the
+                    // behaviour the asset is given when it is read back.
+                    defaultSpriteEmitMaterialId, AZ::Data::AssetLoadBehavior::PreLoad);
             }
         }
 
         auto materialAssetType = azrtti_typeid<AZ::Data::Asset<AZ::RPI::MaterialAsset>>();
         auto modelAssetType = azrtti_typeid<AZ::Data::Asset<AZ::RPI::ModelAsset>>();
         resultCode.Combine(ContinueStoringToJsonObjectField(outputValue, "material", &mat, nullptr, materialAssetType, context));
+
+        // Only written when the emitter actually overrides something, so untouched particle files stay byte
+        // identical to what they were before this feature existed.
+        if (!info->m_materialOverrides.empty())
+        {
+            resultCode.Combine(ContinueStoringToJsonObjectField(
+                outputValue,
+                "materialOverrides",
+                &info->m_materialOverrides,
+                nullptr,
+                azrtti_typeid<MaterialPropertyOverrideMap>(),
+                context));
+        }
 
         if (info->m_model.GetId().IsValid())
         {

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/Asset/ParticleArchive.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/Asset/ParticleArchive.cpp
@@ -42,13 +42,18 @@ namespace OpenParticle
 
     void ParticleArchive::EmitterInfo::Reflect(AZ::ReflectContext* context)
     {
+        ReflectMaterialPropertyOverrides(context);
+
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<ParticleArchive::EmitterInfo>()
-                ->Version(0)
+                // Version 1 added per-emitter material property overrides. Older assets simply deserialize
+                // with an empty override map, which is exactly the previous behaviour.
+                ->Version(1)
                 ->Field("config", &ParticleArchive::EmitterInfo::m_config)
                 ->Field("render", &ParticleArchive::EmitterInfo::m_render)
                 ->Field("material", &ParticleArchive::EmitterInfo::m_material)
+                ->Field("materialOverrides", &ParticleArchive::EmitterInfo::m_materialOverrides)
                 ->Field("model", &ParticleArchive::EmitterInfo::m_model)
                 ->Field("skeleton model", &ParticleArchive::EmitterInfo::m_skeletonModel)
                 ->Field("effectors", &ParticleArchive::EmitterInfo::m_effectors)
@@ -315,6 +320,13 @@ namespace OpenParticle
     {
         auto& emitter = m_emitterInfos.back();
         emitter.m_material = asset;
+        return *this;
+    }
+
+    ParticleArchive& ParticleArchive::MaterialOverrides(const MaterialPropertyOverrideMap& overrides)
+    {
+        auto& emitter = m_emitterInfos.back();
+        emitter.m_materialOverrides = overrides;
         return *this;
     }
 

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/Asset/ParticleArchive.h
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/Asset/ParticleArchive.h
@@ -22,6 +22,8 @@
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <Atom/RPI.Public/Model/Model.h>
 
+#include <OpenParticleSystem/MaterialPropertyOverride.h>
+
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/RTTI/TypeInfo.h>
 
@@ -57,6 +59,9 @@ namespace OpenParticle
             AZ::u32 m_config = 0;
             AZStd::pair<AZ::Uuid, AZ::u32> m_render;
             AZ::Data::Asset<AZ::RPI::MaterialAsset> m_material;
+            //! Property values that differ from m_material for this emitter only. Applied to the emitter's
+            //! own material instance at load, so two emitters can share a material asset and still look different.
+            MaterialPropertyOverrideMap m_materialOverrides;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_model;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_skeletonModel;
             AZStd::vector<AZStd::tuple<AZ::Uuid, AZ::u32>> m_effectors;
@@ -78,6 +83,8 @@ namespace OpenParticle
         ParticleArchive& RenderConfig(const AZStd::any& val);
 
         ParticleArchive& Material(const AZ::Data::Asset<AZ::RPI::MaterialAsset>& asset);
+
+        ParticleArchive& MaterialOverrides(const MaterialPropertyOverrideMap& overrides);
 
         ParticleArchive& Model(const AZ::Data::Asset<AZ::RPI::ModelAsset>& asset);
 

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/MaterialPropertyOverride.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/MaterialPropertyOverride.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <OpenParticleSystem/MaterialPropertyOverride.h>
+
+#include <Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h>
+#include <Atom/RPI.Reflect/Material/MaterialTypeAsset.h>
+
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace OpenParticle
+{
+    namespace
+    {
+        //! Coerces whatever numeric type happens to be sitting in the any into the type the property wants.
+        //! The editor stores doubles for float properties, and script can hand back int for uint, so a plain
+        //! any_cast is not enough.
+        template<typename TargetType>
+        AZ::RPI::MaterialPropertyValue ConvertNumericType(const AZStd::any& value)
+        {
+            if (value.is<bool>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<bool>(value));
+            }
+            if (value.is<int8_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<int8_t>(value));
+            }
+            if (value.is<int16_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<int16_t>(value));
+            }
+            if (value.is<int32_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<int32_t>(value));
+            }
+            if (value.is<int64_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<int64_t>(value));
+            }
+            if (value.is<uint8_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<uint8_t>(value));
+            }
+            if (value.is<uint16_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<uint16_t>(value));
+            }
+            if (value.is<uint32_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<uint32_t>(value));
+            }
+            if (value.is<uint64_t>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<uint64_t>(value));
+            }
+            if (value.is<float>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<float>(value));
+            }
+            if (value.is<double>())
+            {
+                return aznumeric_cast<TargetType>(AZStd::any_cast<double>(value));
+            }
+
+            return AZ::RPI::MaterialPropertyValue::FromAny(value);
+        }
+    } // namespace
+
+    void ReflectMaterialPropertyOverrides(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->RegisterGenericType<MaterialPropertyOverrideMap>();
+        }
+    }
+
+    AZ::RPI::MaterialPropertyValue ConvertMaterialPropertyValue(
+        const AZ::RPI::MaterialPropertyDescriptor* propertyDescriptor, const AZStd::any& value)
+    {
+        if (propertyDescriptor == nullptr)
+        {
+            return AZ::RPI::MaterialPropertyValue::FromAny(value);
+        }
+
+        switch (propertyDescriptor->GetDataType())
+        {
+        case AZ::RPI::MaterialPropertyDataType::Enum:
+            // Enums round trip through the editor as either the symbolic name or the raw index.
+            if (value.is<AZ::Name>())
+            {
+                return propertyDescriptor->GetEnumValue(AZStd::any_cast<AZ::Name>(value));
+            }
+            if (value.is<AZStd::string>())
+            {
+                return propertyDescriptor->GetEnumValue(AZ::Name(AZStd::any_cast<AZStd::string>(value)));
+            }
+            return ConvertNumericType<uint32_t>(value);
+        case AZ::RPI::MaterialPropertyDataType::Int:
+            return ConvertNumericType<int32_t>(value);
+        case AZ::RPI::MaterialPropertyDataType::UInt:
+            return ConvertNumericType<uint32_t>(value);
+        case AZ::RPI::MaterialPropertyDataType::Float:
+            return ConvertNumericType<float>(value);
+        case AZ::RPI::MaterialPropertyDataType::Bool:
+            return ConvertNumericType<bool>(value);
+        default:
+            break;
+        }
+
+        // Vector/Color/Image/SamplerState are all handled by FromAny, including resolving an asset id or an
+        // image asset reference into something Material::SetPropertyValue can consume.
+        return AZ::RPI::MaterialPropertyValue::FromAny(value);
+    }
+
+    bool ApplyMaterialPropertyOverrides(
+        const AZ::Data::Instance<AZ::RPI::Material>& material, const MaterialPropertyOverrideMap& overrides)
+    {
+        if (!material || overrides.empty())
+        {
+            return true;
+        }
+
+        for (const auto& [propertyId, propertyValue] : overrides)
+        {
+            if (propertyValue.empty())
+            {
+                continue;
+            }
+
+            bool wasRenamed = false;
+            AZ::Name newName;
+            AZ::RPI::MaterialPropertyIndex propertyIndex = material->FindPropertyIndex(propertyId, &wasRenamed, &newName);
+
+            // If the material type renamed this property and we also carry an override under the new name,
+            // the new name wins and the stale entry is ignored rather than silently clobbering it.
+            if (wasRenamed && overrides.find(newName) != overrides.end())
+            {
+                AZ_Warning(
+                    "OpenParticle", false,
+                    "Emitter material property '%s' was renamed to '%s' and an override exists for both. "
+                    "The override using the old name will be ignored.",
+                    propertyId.GetCStr(), newName.GetCStr());
+                continue;
+            }
+
+            if (propertyIndex.IsNull())
+            {
+                AZ_Warning(
+                    "OpenParticle", false,
+                    "Emitter material property override '%s' does not exist on material '%s' and will be ignored.",
+                    propertyId.GetCStr(), material->GetAsset().GetHint().c_str());
+                continue;
+            }
+
+            const auto* propertyDescriptor = material->GetMaterialPropertiesLayout()->GetPropertyDescriptor(propertyIndex);
+            material->SetPropertyValue(propertyIndex, ConvertMaterialPropertyValue(propertyDescriptor, propertyValue));
+        }
+
+        // Compile can fail when the SRG is still queued for this frame. Reporting that lets the caller retry.
+        return !material->NeedsCompile() || material->Compile();
+    }
+
+    void PruneMaterialPropertyOverrides(
+        const AZ::Data::Asset<AZ::RPI::MaterialAsset>& materialAsset, MaterialPropertyOverrideMap& overrides)
+    {
+        if (overrides.empty())
+        {
+            return;
+        }
+
+        // Without a loaded asset there is no layout to validate against, so leave the overrides alone rather
+        // than throwing away values that are probably still valid.
+        if (!materialAsset.IsReady() || materialAsset->GetMaterialPropertiesLayout() == nullptr)
+        {
+            return;
+        }
+
+        const auto* layout = materialAsset->GetMaterialPropertiesLayout();
+        for (auto it = overrides.begin(); it != overrides.end();)
+        {
+            AZ::Name propertyId = it->first;
+            if (materialAsset->GetMaterialTypeAsset())
+            {
+                materialAsset->GetMaterialTypeAsset()->ApplyPropertyRenames(propertyId);
+            }
+
+            if (layout->FindPropertyIndex(propertyId).IsNull())
+            {
+                it = overrides.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+} // namespace OpenParticle

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/MaterialPropertyOverride.h
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/MaterialPropertyOverride.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Public/Material/Material.h>
+#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
+#include <Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h>
+#include <Atom/RPI.Reflect/Material/MaterialPropertyValue.h>
+
+#include <AzCore/Name/Name.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/any.h>
+#include <AzCore/std/containers/unordered_map.h>
+
+namespace OpenParticle
+{
+    //! Per-emitter material property overrides.
+    //!
+    //! Every emitter owns its own AZ::RPI::Material instance (see EmitterInstance::Setup), which means two
+    //! emitters can reference the same .material asset and still hold different property values. This map
+    //! stores the values that differ from the assigned material asset, keyed by the full material property
+    //! id (for example "baseColor.color" or "baseColor.textureMap").
+    //!
+    //! This mirrors AZ::Render::MaterialAssignment::m_propertyOverrides used by the mesh material component,
+    //! but is redeclared here so the runtime gem does not have to depend on AtomLyIntegration_CommonFeatures.
+    using MaterialPropertyOverrideMap = AZStd::unordered_map<AZ::Name, AZStd::any>;
+
+    //! Registers the generic types needed to serialize a MaterialPropertyOverrideMap.
+    //! Safe to call more than once; SerializeContext ignores duplicate generic type registrations.
+    void ReflectMaterialPropertyOverrides(AZ::ReflectContext* context);
+
+    //! Converts a stored AZStd::any into a MaterialPropertyValue of the type the property actually expects.
+    //! Numeric and enum properties need coercing because the editor and script layers are loose about which
+    //! concrete numeric type they hand back. Everything else falls through to MaterialPropertyValue::FromAny,
+    //! which already knows how to turn asset ids and image assets into image property values.
+    AZ::RPI::MaterialPropertyValue ConvertMaterialPropertyValue(
+        const AZ::RPI::MaterialPropertyDescriptor* propertyDescriptor, const AZStd::any& value);
+
+    //! Applies every override in the map to the given material instance and compiles it.
+    //! Returns true if the instance is up to date afterwards (nothing to compile, or the compile succeeded).
+    //! A false return generally means the material SRG was still in use this frame and the caller should
+    //! try again next tick.
+    bool ApplyMaterialPropertyOverrides(
+        const AZ::Data::Instance<AZ::RPI::Material>& material, const MaterialPropertyOverrideMap& overrides);
+
+    //! Drops overrides whose property id does not exist in the given material asset.
+    //! Used when an emitter is pointed at a different material so stale ids do not linger in the source data.
+    void PruneMaterialPropertyOverrides(
+        const AZ::Data::Asset<AZ::RPI::MaterialAsset>& materialAsset, MaterialPropertyOverrideMap& overrides);
+} // namespace OpenParticle

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticlePipelineState.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticlePipelineState.cpp
@@ -16,9 +16,10 @@
 
 namespace OpenParticle
 {
-    void EmitterInstance::Setup(AZ::Data::Asset<AZ::RPI::MaterialAsset>& mat)
+    void EmitterInstance::Setup(AZ::Data::Asset<AZ::RPI::MaterialAsset>& mat, const MaterialPropertyOverrideMap& overrides)
     {
         m_materialAsset = mat;
+        m_materialOverrides = overrides;
         // Preload the material asset so it's ready when Create() needs it.
         // Without this, material sub-assets from the particle archive may not be
         // loaded when the particle system activates on level load.
@@ -34,8 +35,13 @@ namespace OpenParticle
                 "EmitterInstance::Setup - Material::Create() returned null. "
                 "The MaterialAsset or MaterialTypeAsset may not be fully loaded.");
             m_needsPipelineRebuild = true;
+            m_needsMaterialOverrideApply = !m_materialOverrides.empty();
             return;
         }
+
+        // Overrides have to land before the pipeline is built: a property can drive a shader option or
+        // enable/disable a shader item, which changes which draw items ReBuildPipeline produces.
+        m_needsMaterialOverrideApply = !ApplyMaterialOverrides();
 
         ReBuildPipeline();
 
@@ -49,6 +55,24 @@ namespace OpenParticle
         }
     }
 
+    bool EmitterInstance::ApplyMaterialOverrides()
+    {
+        if (!m_material)
+        {
+            return m_materialOverrides.empty();
+        }
+
+        if (!ApplyMaterialPropertyOverrides(m_material, m_materialOverrides))
+        {
+            return false;
+        }
+
+        // Keep the recorded change id in step so TryRebuildPipeline does not mistake our own property
+        // writes for an external material reload and rebuild the pipeline every frame.
+        m_materialChangeId = m_material->GetCurrentChangeId();
+        return true;
+    }
+
     void EmitterInstance::Reset()
     {
         m_perDrawSrgs.clear();
@@ -58,7 +82,7 @@ namespace OpenParticle
 
     bool EmitterInstance::TryRebuildPipeline()
     {
-        if (!m_needsPipelineRebuild)
+        if (!m_needsPipelineRebuild && !m_needsMaterialOverrideApply)
         {
             return false;
         }
@@ -79,6 +103,23 @@ namespace OpenParticle
             else
             {
                 return false;
+            }
+        }
+
+        // Retry any overrides that could not be compiled earlier. This must happen before the change id
+        // check below, since applying them is what moves the change id forward.
+        if (m_needsMaterialOverrideApply)
+        {
+            if (!ApplyMaterialOverrides())
+            {
+                return false;
+            }
+            m_needsMaterialOverrideApply = false;
+
+            // Overrides landed but the pipeline was already valid, so there is nothing left to rebuild.
+            if (!m_needsPipelineRebuild && !m_shaders.empty())
+            {
+                return true;
             }
         }
 

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticlePipelineState.h
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticlePipelineState.h
@@ -19,6 +19,7 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <AtomCore/Instance/InstanceData.h>
+#include <OpenParticleSystem/MaterialPropertyOverride.h>
 #include <OpenParticleSystem/ParticleModel.h>
 
 #include <OpenParticleSystem/Asset/ParticleAsset.h>
@@ -86,12 +87,18 @@ namespace OpenParticle
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_objSrg;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_matSrg;
         AZ::Data::Asset<AZ::RPI::MaterialAsset> m_materialAsset;
+        //! Values this emitter overrides on its private copy of the material.
+        MaterialPropertyOverrideMap m_materialOverrides;
         ParticleModel m_model;
         AZ::RPI::Material::ChangeId m_materialChangeId = AZ::RPI::Material::DEFAULT_CHANGE_ID;
         AZ::RPI::Scene* m_scene = nullptr;
         AZ::u32 m_sortId = 0;
         bool m_needsPipelineRebuild = false;
-        void Setup(AZ::Data::Asset<AZ::RPI::MaterialAsset>& mat);
+        //! Set when ApplyMaterialOverrides could not compile the material this frame, so it is retried.
+        bool m_needsMaterialOverrideApply = false;
+        void Setup(AZ::Data::Asset<AZ::RPI::MaterialAsset>& mat, const MaterialPropertyOverrideMap& overrides);
+        //! Pushes m_materialOverrides onto m_material and compiles. Returns false if the compile has to be retried.
+        bool ApplyMaterialOverrides();
         void ReBuildPipeline();
         bool TryRebuildPipeline();
         void Reset();

--- a/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleSystem.cpp
+++ b/Gems/OpenParticleSystem/Code/Source/Runtime/OpenParticleSystem/ParticleSystem.cpp
@@ -494,7 +494,7 @@ namespace OpenParticle
                 if (it != m_emitterInstances.end())
                 {
                     AZ::Data::Asset<AZ::RPI::MaterialAsset> typedAsset(asset);
-                    it->second.Setup(typedAsset);
+                    it->second.Setup(typedAsset, archive.m_emitterInfos[emitter.first].m_materialOverrides);
 
                     AZ::RHI::ShaderInputNameIndex objectIdIndex = "m_objectId";
                     if (it->second.m_objSrg != nullptr)
@@ -1045,12 +1045,15 @@ namespace OpenParticle
 
             HandleSkeletonModel(*emitter.second);
             auto& materialAsset = archive.m_emitterInfos[emitter.first].m_material;
+            const auto& materialOverrides = archive.m_emitterInfos[emitter.first].m_materialOverrides;
             if (materialAsset && materialAsset->IsReady())
             {
-                efd.Setup(materialAsset);
+                efd.Setup(materialAsset, materialOverrides);
             }
             else if (materialAsset)
             {
+                // Remember the overrides now so they are applied as soon as OnAssetReady runs Setup.
+                efd.m_materialOverrides = materialOverrides;
                 AZ::Data::AssetBus::MultiHandler::BusConnect(materialAsset.GetId());
             }
 

--- a/Gems/OpenParticleSystem/Code/Source/Serializer/ParticleAssetData.h
+++ b/Gems/OpenParticleSystem/Code/Source/Serializer/ParticleAssetData.h
@@ -18,6 +18,7 @@
 #include <Serializer/DataConvertor.h>
 
 #include <OpenParticleSystem/Asset/ParticleAsset.h>
+#include <OpenParticleSystem/MaterialPropertyOverride.h>
 
 namespace OpenParticle
 {
@@ -42,6 +43,8 @@ namespace OpenParticle
             AZStd::any m_config;
             AZStd::any m_renderConfig;
             AZ::Data::Asset<AZ::RPI::MaterialAsset> m_material;
+            //! Per-emitter material property overrides, copied verbatim into the built ParticleArchive.
+            MaterialPropertyOverrideMap m_materialOverrides;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_model;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_skeletonModel;
             AZStd::list<AZStd::any> m_emitModules;

--- a/Gems/OpenParticleSystem/Code/Source/Serializer/ParticleSourceData.h
+++ b/Gems/OpenParticleSystem/Code/Source/Serializer/ParticleSourceData.h
@@ -60,6 +60,9 @@ namespace OpenParticle
             AZStd::any m_config;
             AZStd::any m_renderConfig;
             AZ::Data::Asset<AZ::RPI::MaterialAsset> m_material;
+            //! Material property values authored for this emitter alone. Empty means "use the material as-is",
+            //! which lets two emitters share one .material asset and still render differently.
+            MaterialPropertyOverrideMap m_materialOverrides;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_model;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_skeletonModel;
             AZStd::list<AZStd::any> m_emitModules;
@@ -229,6 +232,9 @@ namespace OpenParticle
             bool m_solo = false;
             AZStd::string m_name;
             AZ::Data::Asset<AZ::RPI::MaterialAsset> m_material;
+            //! Editor-side mirror of EmitterInfo::m_materialOverrides. The inspector edits this copy and
+            //! UpdateEmitterAsset(ASSET_MATERIAL) syncs it back onto the emitter.
+            MaterialPropertyOverrideMap m_materialOverrides;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_model;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_skeletonModel;
             AZStd::unordered_map<AZStd::string, ModuleType> m_modules;
@@ -383,7 +389,10 @@ namespace OpenParticle
         void RemovedModulesModuleSort(DetailInfo* detailInfo, EmitterInfo* emitterInfo) const;
         const TypeId::value_type& GetTypeIdItem(const AZStd::string& className, const AZStd::string& moduleName) const;
         void RemoveUnusedModule(DetailInfo* detailInfo, AZStd::any& any) const;
-        void SetDefaultModules(DetailInfo* detailInfo);
+        //! Applies the default module set and default material to a newly created emitter.
+        //! The material has to be written to both the detail and the emitter: the detail feeds the editor
+        //! UI, but it is the emitter that gets baked into the particle asset.
+        void SetDefaultModules(DetailInfo* detailInfo, EmitterInfo* emitterInfo);
 
         void StashDistribution(AZStd::any& any, const void* detailInfo, const AZStd::string& className, const AZStd::string& moduleName);
         bool PopDistribution(AZStd::any& any, const void* detailInfo, const AZStd::string& className, const AZStd::string& moduleName, bool stash = false);

--- a/Gems/OpenParticleSystem/Code/openparticlesystem_files.cmake
+++ b/Gems/OpenParticleSystem/Code/openparticlesystem_files.cmake
@@ -35,6 +35,8 @@ set(FILES
         Source/Runtime/OpenParticleSystem/ParticleSystem.cpp
         Source/Runtime/OpenParticleSystem/ParticlePipelineState.h
         Source/Runtime/OpenParticleSystem/ParticlePipelineState.cpp
+        Source/Runtime/OpenParticleSystem/MaterialPropertyOverride.h
+        Source/Runtime/OpenParticleSystem/MaterialPropertyOverride.cpp
         Source/Runtime/OpenParticleSystem/ParticleModel.h
         Source/Runtime/OpenParticleSystem/ParticleModel.cpp
         Source/Runtime/OpenParticleSystem/Asset/ParticleAssetHandler.h

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.cpp
@@ -14,6 +14,8 @@
 #include <Window/EffectorInspector.h>
 #include <Document/ParticleDocumentBus.h>
 #include <OpenParticleSystemEditor/Window/AssetWidget.h>
+#include <Window/MaterialPropertyDialog.h>
+#include <QMessageBox>
 
 namespace OpenParticleSystemEditor
 {
@@ -55,7 +57,17 @@ namespace OpenParticleSystemEditor
 
         InitComboBox();
 
+        m_detail = detail;
+
         m_materialAssetWidget = new AssetWidget(MATERIAL_DESCRIPTION.toUtf8().data(), azrtti_typeid<AZ::RPI::MaterialAsset>(), this);
+        m_materialPropertiesButton = new QPushButton(tr("Edit Material Properties..."), this);
+        m_materialPropertiesButton->setToolTip(
+            tr("Override material property values for this emitter only. Other emitters using the same "
+               "material are unaffected."));
+        connect(m_materialPropertiesButton, &QPushButton::clicked, this, &ComboBoxWidget::OpenMaterialPropertyDialog);
+        m_clearOverridesButton = new QPushButton(tr("Clear Overrides"), this);
+        m_clearOverridesButton->setToolTip(tr("Clear all material property overrides for this emitter."));
+        connect(m_clearOverridesButton, &QPushButton::clicked, this, &ComboBoxWidget::ClearMaterialOverrides);
         m_modelAssetWidget = new AssetWidget(MESH_DESCRIPTION.toUtf8().data(), azrtti_typeid<AZ::RPI::ModelAsset>(), this);
         m_skeletonModelAssetWidget = new AssetWidget(MESH_DESCRIPTION.toUtf8().data(), azrtti_typeid<AZ::RPI::ModelAsset>(), this);
         
@@ -108,6 +120,10 @@ namespace OpenParticleSystemEditor
         m_layout->addLayout(hLayout);
         m_layout->addWidget(m_propertyEditor);
         m_layout->addWidget(m_materialAssetWidget);
+        QHBoxLayout* materialButtonLayout = new QHBoxLayout();
+        materialButtonLayout->addWidget(m_materialPropertiesButton, 1);
+        materialButtonLayout->addWidget(m_clearOverridesButton);
+        m_layout->addLayout(materialButtonLayout);
         m_layout->addWidget(m_modelAssetWidget);
         m_layout->addWidget(m_skeletonModelAssetWidget);
 
@@ -144,6 +160,8 @@ namespace OpenParticleSystemEditor
         m_layout->removeWidget(m_nameLabel);
         m_layout->removeWidget(m_comboBox);
         m_layout->removeWidget(m_materialAssetWidget);
+        // The two material buttons live in the nested materialButtonLayout, not in m_layout, so there is
+        // nothing to remove here - deleting them below detaches them from their own layout.
         m_layout->removeWidget(m_modelAssetWidget);
         m_layout->removeWidget(m_skeletonModelAssetWidget);
         m_propertyEditor->deleteLater();
@@ -160,6 +178,22 @@ namespace OpenParticleSystemEditor
 
         delete m_materialAssetWidget;
         m_materialAssetWidget = nullptr;
+
+        delete m_materialPropertiesButton;
+        m_materialPropertiesButton = nullptr;
+
+        delete m_clearOverridesButton;
+        m_clearOverridesButton = nullptr;
+
+        // The dialog holds a DetailInfo* owned by the source data, so it must not outlive this widget.
+        if (m_materialPropertyDialog != nullptr)
+        {
+            m_materialPropertyDialog->close();
+            delete m_materialPropertyDialog;
+            m_materialPropertyDialog = nullptr;
+        }
+
+        m_detail = nullptr;
 
         delete m_modelAssetWidget;
         m_modelAssetWidget = nullptr;
@@ -204,7 +238,10 @@ namespace OpenParticleSystemEditor
             [this, busWidgetName, materialAsset](AZ::Data::AssetId newId)
             {
                 *materialAsset = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::MaterialAsset>(newId, AZ::Data::AssetLoadBehavior::PreLoad);
+                // OnMaterialChanged syncs the detail onto the emitter and prunes overrides that the new
+                // material does not have, so the panel is rebuilt after that rather than before.
                 Q_EMIT(OnMaterialChanged());
+                RefreshMaterialProperties();
                 EBUS_EVENT_ID(busWidgetName, OpenParticleSystemEditor::ParticleDocumentRequestBus, NotifyParticleSourceDataModified);
             });
 
@@ -227,6 +264,103 @@ namespace OpenParticleSystemEditor
             });
     }
 
+    void ComboBoxWidget::RefreshMaterialProperties()
+    {
+        // Guard every pointer this touches, not just one of them: Clear() tears the widgets down one at a
+        // time, so checking a single member would leave a window where it is still set and the others are not.
+        if (m_materialPropertiesButton == nullptr || m_clearOverridesButton == nullptr || m_materialAssetWidget == nullptr)
+        {
+            return;
+        }
+
+        // Only offer property overrides where a material actually applies. isHidden rather than isVisible:
+        // this runs during construction, before the widget has a parent layout, and isVisible would report
+        // false for everything at that point.
+        const bool hasMaterial =
+            m_detail != nullptr && !m_materialAssetWidget->isHidden() && m_detail->m_material.GetId().IsValid();
+
+        m_materialPropertiesButton->setVisible(hasMaterial);
+
+        m_clearOverridesButton->setVisible(hasMaterial);
+        UpdateClearOverridesButtonState();
+
+        // Only touch the dialog if one is already open; this must not pop a window on its own.
+        if (m_materialPropertyDialog != nullptr)
+        {
+            m_materialPropertyDialog->SetDetail(hasMaterial ? m_detail : nullptr);
+        }
+    }
+
+    void ComboBoxWidget::OpenMaterialPropertyDialog()
+    {
+        if (m_detail == nullptr || !m_detail->m_material.GetId().IsValid())
+        {
+            return;
+        }
+
+        if (m_materialPropertyDialog == nullptr)
+        {
+            m_materialPropertyDialog = new MaterialPropertyDialog(this);
+            connect(
+                m_materialPropertyDialog, &MaterialPropertyDialog::OnMaterialPropertyChanged, this,
+                [this](bool editingFinished)
+                {
+                    UpdateClearOverridesButtonState();
+                    Q_EMIT OnMaterialPropertiesChanged(editingFinished);
+                });
+        }
+
+        m_materialPropertyDialog->SetDetail(m_detail);
+        m_materialPropertyDialog->show();
+        m_materialPropertyDialog->raise();
+        m_materialPropertyDialog->activateWindow();
+    }
+
+    void ComboBoxWidget::UpdateClearOverridesButtonState()
+    {
+        if (m_clearOverridesButton != nullptr)
+        {
+            m_clearOverridesButton->setEnabled(m_detail != nullptr && !m_detail->m_materialOverrides.empty());
+        }
+    }
+
+    void ComboBoxWidget::ClearMaterialOverrides()
+    {
+        if (m_detail == nullptr || m_detail->m_materialOverrides.empty())
+        {
+            return;
+        }
+
+        const int count = static_cast<int>(m_detail->m_materialOverrides.size());
+        if (QMessageBox::question(
+                this, tr("Clear Overrides"),
+                tr("Remove all %1 material property override(s) from this emitter?").arg(count),
+                QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
+        {
+            return;
+        }
+
+        // QMessageBox spins a nested event loop, so the emitter panel could have been torn down while it was
+        // up. Re-check rather than trusting the pointer we validated before the prompt.
+        if (m_detail == nullptr)
+        {
+            return;
+        }
+
+        m_detail->m_materialOverrides.clear();
+
+        // Refresh the open inspector before notifying: the notification rebuilds the particle asset, and the
+        // dialog holds a DetailInfo* we want re-read while we still know it is valid.
+        if (m_materialPropertyDialog != nullptr)
+        {
+            m_materialPropertyDialog->SetDetail(m_detail);
+        }
+        UpdateClearOverridesButtonState();
+
+        // Same path a property edit takes: syncs the (now empty) map onto the emitter and marks the doc modified.
+        Q_EMIT OnMaterialPropertiesChanged(true);
+    }
+
     void ComboBoxWidget::SetAssetWidgetVisible()
     {
         m_materialAssetWidget->setVisible(false);
@@ -246,6 +380,8 @@ namespace OpenParticleSystemEditor
             m_materialAssetWidget->setVisible(true);
             m_modelAssetWidget->setVisible(true);
         }
+
+        RefreshMaterialProperties();
     }
 
     bool ComboBoxWidget::IsMeshRenderer() const

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.h
@@ -13,6 +13,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
 #include <QComboBox>
+#include <QPushButton>
 #include <Serializer/ParticleSourceData.h>
 #include <ParticleCommonData.h>
 #include <QVBoxLayout>
@@ -29,6 +30,7 @@ namespace OpenParticleSystemEditor
     const QString RENDERER_LABEL = QCoreApplication::translate("ComboBoxWidget", "Renderer");
 
     class AssetWidget;
+    class MaterialPropertyDialog;
 
     using AssetChangeCB = AZStd::function<void(AZ::Data::AssetId)>;
     //! ComboBoxWidget represents a widget that has a drop down combo at the top which lets you select a class of objects
@@ -76,9 +78,21 @@ namespace OpenParticleSystemEditor
         void OnMaterialChanged();
         void OnModelChanged();
         void OnSkeletonModelChanged();
+        // signal that a per-emitter material property override was edited.
+        // editingFinished is false for the intermediate values produced while dragging a control.
+        void OnMaterialPropertiesChanged(bool editingFinished);
 
     private:
         void SetAssetWidgetVisible();
+        // Shows or hides the "Edit Material Properties" button and keeps an open dialog pointed at the
+        // current emitter and material.
+        void RefreshMaterialProperties();
+        // Opens the per-emitter material property dialog, creating it on first use.
+        void OpenMaterialPropertyDialog();
+        // Drops every per-emitter override so the emitter renders with the material asset's own values.
+        void ClearMaterialOverrides();
+        // Cheap enable/disable only - must not touch the dialog, which would rebuild it mid-drag.
+        void UpdateClearOverridesButtonState();
         void InitComboBox();
         void SetUI();
 
@@ -91,8 +105,13 @@ namespace OpenParticleSystemEditor
         QVBoxLayout* m_layout;
         QWidget* m_parent;
         AssetWidget* m_materialAssetWidget = nullptr;
+        QPushButton* m_materialPropertiesButton = nullptr;
+        QPushButton* m_clearOverridesButton = nullptr;
+        MaterialPropertyDialog* m_materialPropertyDialog = nullptr;
         AssetWidget* m_modelAssetWidget = nullptr;
         AssetWidget* m_skeletonModelAssetWidget = nullptr;
+        // Kept so the material property panel can be pointed at the emitter being edited.
+        OpenParticle::ParticleSourceData::DetailInfo* m_detail = nullptr;
         AZStd::vector<AZStd::pair<AZStd::string, QString>> m_locationClasses;
         AZStd::vector<AZStd::pair<AZStd::string, QString>> m_rendererClasses;
     };

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.cpp
@@ -202,6 +202,9 @@ namespace OpenParticleSystemEditor
                 m_comboBoxWidget = new ComboBoxWidget(className, m_detail, m_serializeContext, this, this);
                 m_ui->verticalLayout->addWidget(m_comboBoxWidget);
                 QObject::connect(m_comboBoxWidget, &ComboBoxWidget::OnMaterialChanged, this, &EffectorInspector::OnComboBoxMaterialChanged);
+                QObject::connect(
+                    m_comboBoxWidget, &ComboBoxWidget::OnMaterialPropertiesChanged, this,
+                    &EffectorInspector::OnComboBoxMaterialPropertiesChanged);
                 QObject::connect(m_comboBoxWidget, &ComboBoxWidget::OnModelChanged, this, &EffectorInspector::OnComboBoxModelChanged);
                 QObject::connect(m_comboBoxWidget, &ComboBoxWidget::OnSkeletonModelChanged, this, &EffectorInspector::OnComboBoxSkeletonModelChanged);
                 break;
@@ -657,6 +660,23 @@ namespace OpenParticleSystemEditor
         AZStd::string modifiedEffect = m_ui->particleName->text().toUtf8().constData();
         // This will have modified the assets listed in the "Detail" object, but not the actual emitter, so sync them.
         m_sourceData->UpdateEmitterAsset(modifiedEffect, OpenParticle::ParticleSourceData::DetailConstant::ASSET_MATERIAL);
+    }
+
+    void EffectorInspector::OnComboBoxMaterialPropertiesChanged(bool editingFinished)
+    {
+        AZStd::string modifiedEffect = m_ui->particleName->text().toUtf8().constData();
+        // The property widget edited the "Detail" copy of the override map, so push it onto the emitter.
+        // ASSET_MATERIAL covers both the asset and its overrides.
+        m_sourceData->UpdateEmitterAsset(modifiedEffect, OpenParticle::ParticleSourceData::DetailConstant::ASSET_MATERIAL);
+
+        // Intermediate values from a slider or colour-picker drag are recorded in the source data but do not
+        // trigger a document update. NotifyParticleSourceDataModified rebuilds the whole particle asset and
+        // respawns the preview system, which is far too heavy to run on every mouse move, so the viewport
+        // catches up when the user releases.
+        if (editingFinished)
+        {
+            EBUS_EVENT_ID(m_widgetName, OpenParticleSystemEditor::ParticleDocumentRequestBus, NotifyParticleSourceDataModified);
+        }
     }
 
     void EffectorInspector::OnComboBoxModelChanged()

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/EffectorInspector.h
@@ -104,6 +104,7 @@ namespace OpenParticleSystemEditor
 
     private Q_SLOTS:
         void OnComboBoxMaterialChanged();
+        void OnComboBoxMaterialPropertiesChanged(bool editingFinished);
         void OnComboBoxModelChanged();
         void OnComboBoxSkeletonModelChanged();
     };

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyDialog.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyDialog.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Window/MaterialPropertyDialog.h>
+#include <Window/MaterialPropertyWidget.h>
+
+#include <AzCore/Asset/AssetManagerBus.h>
+#include <AzCore/std/string/string.h>
+
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
+#include <QLabel>
+#include <QVBoxLayout>
+AZ_POP_DISABLE_WARNING
+
+namespace OpenParticleSystemEditor
+{
+    MaterialPropertyDialog::MaterialPropertyDialog(QWidget* parent)
+        : QDialog(parent)
+    {
+        setWindowTitle(tr("Emitter Material Properties"));
+
+        // Modeless with the standard min/max buttons so it can be resized and left open next to the viewport
+        // while iterating. Qt::Window rather than the default dialog flags is what gives it the maximise box.
+        setWindowFlags(Qt::Window);
+        setModal(false);
+        setSizeGripEnabled(true);
+        resize(380, 560);
+
+        m_heading = new QLabel(this);
+        m_heading->setWordWrap(true);
+        m_heading->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+        m_propertyWidget = new MaterialPropertyWidget(this);
+
+        auto* layout = new QVBoxLayout(this);
+        layout->addWidget(m_heading);
+        layout->addWidget(m_propertyWidget, 1);
+        setLayout(layout);
+
+        connect(
+            m_propertyWidget, &MaterialPropertyWidget::OnMaterialPropertyChanged, this,
+            [this](bool editingFinished)
+            {
+                Q_EMIT OnMaterialPropertyChanged(editingFinished);
+            });
+    }
+
+    void MaterialPropertyDialog::SetDetail(OpenParticle::ParticleSourceData::DetailInfo* detail)
+    {
+        if (detail == nullptr || !detail->m_material.GetId().IsValid())
+        {
+            m_propertyWidget->SetDetail(nullptr);
+            close();
+            return;
+        }
+
+        m_propertyWidget->SetDetail(detail);
+        UpdateHeading(detail);
+    }
+
+    void MaterialPropertyDialog::UpdateHeading(OpenParticle::ParticleSourceData::DetailInfo* detail)
+    {
+        AZStd::string materialPath;
+        AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+            materialPath, &AZ::Data::AssetCatalogRequests::GetAssetPathById, detail->m_material.GetId());
+
+        if (materialPath.empty())
+        {
+            materialPath = detail->m_material.GetHint();
+        }
+
+        setWindowTitle(tr("Material Properties - %1").arg(QString::fromUtf8(detail->m_name.c_str())));
+
+        // Spelling out that edits are scoped to this emitter is worth the line: the same .material can be
+        // assigned to several emitters, and nothing else on screen says the values are not shared.
+        m_heading->setText(
+            tr("<b>%1</b><br/>%2<br/><i>Overrides apply to this emitter only. Other emitters using the same "
+               "material are unaffected.</i>")
+                .arg(QString::fromUtf8(detail->m_name.c_str()))
+                .arg(QString::fromUtf8(materialPath.c_str())));
+    }
+} // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyDialog.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyDialog.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include <Serializer/ParticleSourceData.h>
+
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
+#include <QDialog>
+AZ_POP_DISABLE_WARNING
+
+class QLabel;
+
+namespace OpenParticleSystemEditor
+{
+    class MaterialPropertyWidget;
+
+    //! Floating window that hosts the per-emitter material property inspector.
+    //!
+    //! The emitter panel this is launched from is only ~249px wide and already lives inside a scroll area,
+    //! which is far too cramped for a full material property layout. The mesh Material Component solves the
+    //! same problem the same way, by opening a separate resizable inspector instead of inlining one.
+    //!
+    //! Modeless, so the viewport stays interactive while properties are tweaked. Parented to the widget that
+    //! owns the emitter's DetailInfo so it is torn down automatically when that emitter goes away.
+    class MaterialPropertyDialog : public QDialog
+    {
+        Q_OBJECT
+
+    public:
+        AZ_CLASS_ALLOCATOR(MaterialPropertyDialog, AZ::SystemAllocator, 0);
+
+        explicit MaterialPropertyDialog(QWidget* parent = nullptr);
+        ~MaterialPropertyDialog() override = default;
+
+        //! Points the dialog at an emitter and updates the title. Passing nullptr closes it, which is what
+        //! happens when the emitter loses its material or switches to a renderer that has none.
+        void SetDetail(OpenParticle::ParticleSourceData::DetailInfo* detail);
+
+    Q_SIGNALS:
+        //! Forwarded from the inspector. editingFinished is false for the intermediate values produced
+        //! while a control is still being dragged.
+        void OnMaterialPropertyChanged(bool editingFinished);
+
+    private:
+        void UpdateHeading(OpenParticle::ParticleSourceData::DetailInfo* detail);
+
+        MaterialPropertyWidget* m_propertyWidget = nullptr;
+        QLabel* m_heading = nullptr;
+    };
+} // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyWidget.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyWidget.cpp
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Window/MaterialPropertyWidget.h>
+
+#include <Atom/RPI.Edit/Common/AssetUtils.h>
+#include <Atom/RPI.Edit/Material/MaterialUtils.h>
+#include <Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h>
+
+#include <AtomToolsFramework/Inspector/InspectorPropertyGroupWidget.h>
+#include <AtomToolsFramework/Util/MaterialPropertyUtil.h>
+#include <AtomToolsFramework/Util/Util.h>
+
+#include <AzFramework/StringFunc/StringFunc.h>
+
+namespace OpenParticleSystemEditor
+{
+    AZStd::unordered_set<AZ::u32> MaterialPropertyWidget::s_expandedGroups;
+
+    MaterialPropertyWidget::MaterialPropertyWidget(QWidget* parent)
+        : AtomToolsFramework::InspectorWidget(parent)
+    {
+        SetGroupSettingsPrefix("/O3DE/OpenParticleSystem/MaterialPropertyWidget");
+    }
+
+    MaterialPropertyWidget::~MaterialPropertyWidget()
+    {
+        UnloadMaterial();
+    }
+
+    bool MaterialPropertyWidget::IsLoaded() const
+    {
+        return m_materialAsset.IsReady() && m_materialTypeAsset.IsReady();
+    }
+
+    void MaterialPropertyWidget::Reset()
+    {
+        m_groups.clear();
+        AtomToolsFramework::InspectorWidget::Reset();
+    }
+
+    bool MaterialPropertyWidget::ShouldGroupAutoExpanded(const AZStd::string& groupName) const
+    {
+        // Inverted from the base class: collapsed unless the user opened this group earlier in the session.
+        return s_expandedGroups.find(AZ::Crc32(groupName)) != s_expandedGroups.end();
+    }
+
+    void MaterialPropertyWidget::OnGroupExpanded(const AZStd::string& groupName)
+    {
+        s_expandedGroups.insert(AZ::Crc32(groupName));
+        AtomToolsFramework::InspectorWidget::OnGroupExpanded(groupName);
+    }
+
+    void MaterialPropertyWidget::OnGroupCollapsed(const AZStd::string& groupName)
+    {
+        s_expandedGroups.erase(AZ::Crc32(groupName));
+        AtomToolsFramework::InspectorWidget::OnGroupCollapsed(groupName);
+    }
+
+    void MaterialPropertyWidget::SetDetail(OpenParticle::ParticleSourceData::DetailInfo* detail)
+    {
+        const AZ::Data::AssetId newAssetId = detail ? detail->m_material.GetId() : AZ::Data::AssetId();
+
+        // Same emitter and same material - the layout is still valid, so only refresh the values.
+        // This keeps group expansion state and avoids rebuilding the whole property editor on every click.
+        if (m_detail == detail && m_materialAssetId == newAssetId && IsLoaded())
+        {
+            RefreshValues();
+            return;
+        }
+
+        m_detail = detail;
+
+        UnloadMaterial();
+
+        if (m_detail == nullptr || !newAssetId.IsValid())
+        {
+            setVisible(false);
+            return;
+        }
+
+        if (!LoadMaterial())
+        {
+            setVisible(false);
+            return;
+        }
+
+        setVisible(true);
+        Populate();
+        LoadOverridesFromDetail();
+    }
+
+    void MaterialPropertyWidget::RefreshValues()
+    {
+        if (!IsLoaded())
+        {
+            return;
+        }
+
+        LoadOverridesFromDetail();
+    }
+
+    bool MaterialPropertyWidget::LoadMaterial()
+    {
+        m_materialAssetId = m_detail->m_material.GetId();
+
+        auto materialAssetOutcome = AZ::RPI::AssetUtils::LoadAsset<AZ::RPI::MaterialAsset>(m_materialAssetId);
+        if (!materialAssetOutcome)
+        {
+            AZ_Warning("MaterialPropertyWidget", false, "Failed to load the material assigned to this emitter.");
+            UnloadMaterial();
+            return false;
+        }
+
+        m_materialAsset = materialAssetOutcome.GetValue();
+        m_materialTypeAsset = m_materialAsset->GetMaterialTypeAsset();
+
+        // The property layout that ships in the material type product asset only carries ids and raw types.
+        // Display names, descriptions, groups, ranges and enum labels all live in the .materialtype source
+        // file, so that is what we load to build a UI that matches the mesh material inspector.
+        const AZStd::string materialTypeSourcePath = AZ::RPI::AssetUtils::GetSourcePathByAssetId(m_materialTypeAsset.GetId());
+        if (materialTypeSourcePath.empty())
+        {
+            AZ_Warning("MaterialPropertyWidget", false, "Could not locate the source material type for this emitter's material.");
+            UnloadMaterial();
+            return false;
+        }
+
+        auto materialTypeOutcome = AZ::RPI::MaterialUtils::LoadMaterialTypeSourceData(materialTypeSourcePath);
+        if (!materialTypeOutcome.IsSuccess())
+        {
+            AZ_Warning("MaterialPropertyWidget", false, "Failed to load material type source data: %s", materialTypeSourcePath.c_str());
+            UnloadMaterial();
+            return false;
+        }
+
+        m_materialTypeSourceData = materialTypeOutcome.TakeValue();
+        return true;
+    }
+
+    void MaterialPropertyWidget::UnloadMaterial()
+    {
+        Reset();
+        m_materialAssetId = {};
+        m_materialAsset = {};
+        m_materialTypeAsset = {};
+        m_materialTypeSourceData = {};
+    }
+
+    void MaterialPropertyWidget::Populate()
+    {
+        AddGroupsBegin();
+
+        m_materialTypeSourceData.EnumeratePropertyGroups(
+            [this](const AZ::RPI::MaterialTypeSourceData::PropertyGroupStack& propertyGroupStack)
+            {
+                using namespace AZ::RPI;
+
+                const MaterialTypeSourceData::PropertyGroup* propertyGroupDefinition = propertyGroupStack.back();
+                MaterialNameContext groupNameContext = MaterialTypeSourceData::MakeMaterialNameContext(propertyGroupStack);
+
+                AZStd::vector<AZStd::string> groupNameVector;
+                AZStd::vector<AZStd::string> groupDisplayNameVector;
+                groupNameVector.reserve(propertyGroupStack.size());
+                groupDisplayNameVector.reserve(propertyGroupStack.size());
+
+                for (const auto& nextGroup : propertyGroupStack)
+                {
+                    groupNameVector.push_back(nextGroup->GetName());
+                    groupDisplayNameVector.push_back(
+                        !nextGroup->GetDisplayName().empty() ? nextGroup->GetDisplayName() : nextGroup->GetName());
+                }
+
+                AZStd::string groupId;
+                AzFramework::StringFunc::Join(groupId, groupNameVector.begin(), groupNameVector.end(), ".");
+
+                auto& group = m_groups[groupId];
+                group.m_name = groupId;
+                AzFramework::StringFunc::Join(
+                    group.m_displayName, groupDisplayNameVector.begin(), groupDisplayNameVector.end(), " | ");
+                group.m_description = !propertyGroupDefinition->GetDescription().empty()
+                    ? propertyGroupDefinition->GetDescription()
+                    : group.m_displayName;
+
+                group.m_properties.reserve(propertyGroupDefinition->GetProperties().size());
+                for (const auto& propertyDefinition : propertyGroupDefinition->GetProperties())
+                {
+                    AtomToolsFramework::DynamicPropertyConfig propertyConfig;
+
+                    // The id has to be assigned before conversion because it is folded into the description.
+                    propertyConfig.m_id = propertyDefinition->GetName();
+                    groupNameContext.ContextualizeProperty(propertyConfig.m_id);
+
+                    AtomToolsFramework::ConvertToPropertyConfig(propertyConfig, *propertyDefinition);
+
+                    const auto& propertyIndex = m_materialAsset->GetMaterialPropertiesLayout()->FindPropertyIndex(propertyConfig.m_id);
+                    if (propertyIndex.IsNull())
+                    {
+                        // Declared in the source data but absent from the built layout; nothing to override.
+                        continue;
+                    }
+
+                    propertyConfig.m_groupName = group.m_name;
+                    propertyConfig.m_groupDisplayName = group.m_displayName;
+                    propertyConfig.m_showThumbnail = true;
+
+                    // There is no parent material in this workflow. The emitter's overrides sit directly on top
+                    // of the assigned material asset, so the asset's values act as both the reset target and the
+                    // baseline the "modified" indicator compares against.
+                    const auto& assetValue = m_materialAsset->GetPropertyValues()[propertyIndex.GetIndex()];
+                    propertyConfig.m_defaultValue = AtomToolsFramework::ConvertToEditableType(assetValue);
+                    propertyConfig.m_parentValue = propertyConfig.m_defaultValue;
+                    propertyConfig.m_originalValue = propertyConfig.m_defaultValue;
+
+                    group.m_properties.emplace_back(propertyConfig);
+                }
+
+                // A group whose properties were all filtered out would render as an empty header.
+                if (group.m_properties.empty())
+                {
+                    m_groups.erase(groupId);
+                    return true;
+                }
+
+                // Passing the same group as both instance and comparison instance enables the custom value
+                // comparison that drives the "this value is overridden" indicator icon.
+                auto propertyGroupWidget = new AtomToolsFramework::InspectorPropertyGroupWidget(
+                    &group, &group, group.TYPEINFO_Uuid(), this, this, GetGroupSaveStateKey(group.m_name), {},
+                    [this](const auto node)
+                    {
+                        return GetInstanceNodePropertyIndicator(node);
+                    },
+                    0);
+
+                AddGroup(group.m_name, group.m_displayName, group.m_description, propertyGroupWidget);
+                return true;
+            });
+
+        AddGroupsEnd();
+    }
+
+    void MaterialPropertyWidget::LoadOverridesFromDetail()
+    {
+        if (m_detail == nullptr || !IsLoaded())
+        {
+            return;
+        }
+
+        m_updatingUi = true;
+
+        // Material types can rename properties between versions. Migrate the stored ids first so the values
+        // land on the right controls instead of silently disappearing.
+        if (m_materialTypeAsset)
+        {
+            AZStd::vector<AZStd::pair<AZ::Name, AZ::Name>> renamedProperties;
+            for (const auto& overridePair : m_detail->m_materialOverrides)
+            {
+                AZ::Name newName = overridePair.first;
+                if (m_materialTypeAsset->ApplyPropertyRenames(newName))
+                {
+                    renamedProperties.emplace_back(overridePair.first, newName);
+                }
+            }
+            for (const auto& [oldName, newName] : renamedProperties)
+            {
+                m_detail->m_materialOverrides[newName] = m_detail->m_materialOverrides[oldName];
+                m_detail->m_materialOverrides.erase(oldName);
+            }
+        }
+
+        for (auto& groupPair : m_groups)
+        {
+            auto& group = groupPair.second;
+            for (auto& property : group.m_properties)
+            {
+                const auto& propertyConfig = property.GetConfig();
+                const auto overrideItr = m_detail->m_materialOverrides.find(propertyConfig.m_id);
+
+                // No override means show the value the material asset itself carries.
+                const auto& editValue = overrideItr != m_detail->m_materialOverrides.end()
+                    ? overrideItr->second
+                    : propertyConfig.m_originalValue;
+
+                // Round trip through the runtime type so values that arrived as an asset id or a loosely
+                // typed number end up in the exact shape the control expects.
+                const auto runtimeValue = AtomToolsFramework::ConvertToRuntimeType(editValue);
+                property.SetValue(
+                    runtimeValue.IsValid() ? AtomToolsFramework::ConvertToEditableType(runtimeValue) : editValue);
+            }
+        }
+
+        m_updatingUi = false;
+
+        RebuildAll();
+    }
+
+    void MaterialPropertyWidget::SaveOverrideToDetail(const AtomToolsFramework::DynamicProperty& property)
+    {
+        if (m_detail == nullptr)
+        {
+            return;
+        }
+
+        // Only store genuine differences. Dragging a slider back to the material's own value removes the
+        // entry entirely, which keeps the .particle file clean and lets the emitter fall back to sharing
+        // the material's value if the material is later edited.
+        if (AtomToolsFramework::ArePropertyValuesEqual(property.GetValue(), property.GetConfig().m_originalValue))
+        {
+            m_detail->m_materialOverrides.erase(property.GetId());
+        }
+        else
+        {
+            m_detail->m_materialOverrides[property.GetId()] = property.GetValue();
+        }
+    }
+
+    AZ::Crc32 MaterialPropertyWidget::GetGroupSaveStateKey(const AZStd::string& groupName) const
+    {
+        return AZ::Crc32(AZStd::string::format(
+            "MaterialPropertyWidget::PropertyGroup::%s::%s", m_materialAssetId.ToString<AZStd::string>().c_str(), groupName.c_str()));
+    }
+
+    bool MaterialPropertyWidget::IsInstanceNodePropertyModified(const AzToolsFramework::InstanceDataNode* node) const
+    {
+        const auto property = AtomToolsFramework::FindAncestorInstanceDataNodeByType<AtomToolsFramework::DynamicProperty>(node);
+        return property && !AtomToolsFramework::ArePropertyValuesEqual(property->GetValue(), property->GetConfig().m_originalValue);
+    }
+
+    const char* MaterialPropertyWidget::GetInstanceNodePropertyIndicator(const AzToolsFramework::InstanceDataNode* node) const
+    {
+        if (IsInstanceNodePropertyModified(node))
+        {
+            return ":/Icons/changed_property.svg";
+        }
+        return ":/Icons/blank.png";
+    }
+
+    void MaterialPropertyWidget::BeforePropertyModified([[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+    }
+
+    void MaterialPropertyWidget::AfterPropertyModified(AzToolsFramework::InstanceDataNode* node)
+    {
+        if (m_updatingUi)
+        {
+            return;
+        }
+
+        const auto property = AtomToolsFramework::FindAncestorInstanceDataNodeByType<AtomToolsFramework::DynamicProperty>(node);
+        if (property)
+        {
+            SaveOverrideToDetail(*property);
+
+            // Fired continuously while dragging so the viewport tracks the edit live.
+            Q_EMIT OnMaterialPropertyChanged(false);
+        }
+    }
+
+    void MaterialPropertyWidget::SetPropertyEditingActive([[maybe_unused]] AzToolsFramework::InstanceDataNode* node)
+    {
+    }
+
+    void MaterialPropertyWidget::SetPropertyEditingComplete(AzToolsFramework::InstanceDataNode* node)
+    {
+        if (m_updatingUi)
+        {
+            return;
+        }
+
+        const auto property = AtomToolsFramework::FindAncestorInstanceDataNodeByType<AtomToolsFramework::DynamicProperty>(node);
+        if (property)
+        {
+            SaveOverrideToDetail(*property);
+
+            // The edit has settled, so listeners can now do the expensive work such as marking the
+            // document modified.
+            Q_EMIT OnMaterialPropertyChanged(true);
+        }
+    }
+
+    void MaterialPropertyWidget::SealUndoStack()
+    {
+    }
+} // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyWidget.h
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/MaterialPropertyWidget.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Edit/Material/MaterialTypeSourceData.h>
+#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
+#include <Atom/RPI.Reflect/Material/MaterialTypeAsset.h>
+
+#include <AtomToolsFramework/DynamicProperty/DynamicPropertyGroup.h>
+#include <AtomToolsFramework/Inspector/InspectorWidget.h>
+
+#include <AzCore/std/containers/map.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/string/string.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI_Internals.h>
+
+#include <Serializer/ParticleSourceData.h>
+
+namespace OpenParticleSystemEditor
+{
+    //! Shows the full property layout of the material assigned to one emitter and lets the user override
+    //! individual values for that emitter only.
+    //!
+    //! This is the particle editor equivalent of the mesh Material Component's property inspector. Because
+    //! every emitter builds its own AZ::RPI::Material instance at runtime, two emitters can point at the same
+    //! .material asset and still carry different values; this widget is what authors those differences.
+    //!
+    //! Edited values are written into DetailInfo::m_materialOverrides. The owning inspector is responsible
+    //! for syncing that map back onto the emitter and notifying the document so the viewport updates.
+    class MaterialPropertyWidget
+        : public AtomToolsFramework::InspectorWidget
+        , public AzToolsFramework::IPropertyEditorNotify
+    {
+        Q_OBJECT
+
+    public:
+        AZ_CLASS_ALLOCATOR(MaterialPropertyWidget, AZ::SystemAllocator, 0);
+
+        explicit MaterialPropertyWidget(QWidget* parent = nullptr);
+        ~MaterialPropertyWidget() override;
+
+        //! Points the widget at an emitter. Pass nullptr to clear it.
+        //! Rebuilds the whole property layout if the assigned material asset changed since the last call.
+        void SetDetail(OpenParticle::ParticleSourceData::DetailInfo* detail);
+
+        // AtomToolsFramework::InspectorRequestBus::Handler overrides...
+        void Reset() override;
+
+    protected:
+        // AtomToolsFramework::InspectorWidget overrides...
+        //! Every group starts collapsed. A full material layout has more groups than fit on screen, and the
+        //! base class default of "expanded unless previously collapsed" means opening this on a PBR material
+        //! dumps hundreds of rows at once.
+        bool ShouldGroupAutoExpanded(const AZStd::string& groupName) const override;
+        void OnGroupExpanded(const AZStd::string& groupName) override;
+        void OnGroupCollapsed(const AZStd::string& groupName) override;
+
+    Q_SIGNALS:
+        //! Raised whenever an override value changes. `editingFinished` is false while a slider or colour
+        //! picker is still being dragged, so listeners can throttle expensive work such as saving.
+        void OnMaterialPropertyChanged(bool editingFinished);
+
+    private:
+        //! Re-reads values out of the detail's override map without rebuilding the layout.
+        void RefreshValues();
+
+        //! True once a material and its material type source data have been loaded successfully.
+        bool IsLoaded() const;
+
+        // AzToolsFramework::IPropertyEditorNotify overrides...
+        void BeforePropertyModified(AzToolsFramework::InstanceDataNode* node) override;
+        void AfterPropertyModified(AzToolsFramework::InstanceDataNode* node) override;
+        void SetPropertyEditingActive(AzToolsFramework::InstanceDataNode* node) override;
+        void SetPropertyEditingComplete(AzToolsFramework::InstanceDataNode* node) override;
+        void SealUndoStack() override;
+
+        //! Loads the material asset and the material type source data that describes its property layout.
+        //! The source data is what carries display names, groups, ranges and enum labels; the runtime
+        //! layout alone would only give us ids and raw types.
+        bool LoadMaterial();
+        void UnloadMaterial();
+
+        //! Builds one DynamicPropertyGroup per material property group and adds it to the inspector.
+        void Populate();
+
+        //! Copies the current override map (falling back to the material asset's own values) into the
+        //! dynamic properties so the UI reflects what will actually render.
+        void LoadOverridesFromDetail();
+
+        //! Writes one edited property back into DetailInfo::m_materialOverrides. Values that match the
+        //! assigned material are removed rather than stored, so the map only ever holds real differences.
+        void SaveOverrideToDetail(const AtomToolsFramework::DynamicProperty& property);
+
+        AZ::Crc32 GetGroupSaveStateKey(const AZStd::string& groupName) const;
+        bool IsInstanceNodePropertyModified(const AzToolsFramework::InstanceDataNode* node) const;
+        const char* GetInstanceNodePropertyIndicator(const AzToolsFramework::InstanceDataNode* node) const;
+
+        OpenParticle::ParticleSourceData::DetailInfo* m_detail = nullptr;
+
+        AZ::Data::AssetId m_materialAssetId;
+        AZ::Data::Asset<AZ::RPI::MaterialAsset> m_materialAsset;
+        AZ::Data::Asset<AZ::RPI::MaterialTypeAsset> m_materialTypeAsset;
+        AZ::RPI::MaterialTypeSourceData m_materialTypeSourceData;
+
+        //! Ordered so the groups always appear in the same sequence between rebuilds.
+        AZStd::map<AZStd::string, AtomToolsFramework::DynamicPropertyGroup> m_groups;
+
+        //! Guards against re-entrancy while LoadOverridesFromDetail is pushing values into the editors.
+        bool m_updatingUi = false;
+
+        //! Groups the user has opened, so expansion survives switching emitters or reopening the dialog.
+        //! Deliberately per session rather than persisted: which groups matter changes with the material.
+        static AZStd::unordered_set<AZ::u32> s_expandedGroups;
+    };
+} // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleGraphicsView.cpp
+++ b/Gems/OpenParticleSystem/Tools/OpenParticleSystemEditor/Window/ParticleGraphicsView.cpp
@@ -457,7 +457,17 @@ namespace OpenParticleSystemEditor
         }
 
         QGraphicsProxyWidget* itemProxyWidget = dynamic_cast<QGraphicsProxyWidget*>(graphicsItem);
+        if (itemProxyWidget == nullptr)
+        {
+            return;
+        }
+
         ParticleItemWidget* itemWidget = dynamic_cast<ParticleItemWidget*>(itemProxyWidget->widget());
+        if (itemWidget == nullptr || itemWidget->m_detail == nullptr)
+        {
+            return;
+        }
+
         AZStd::string emitterName = itemWidget->m_detail->m_name;
         OpenParticle::ParticleSourceData::DetailInfo* detail = nullptr;
         EBUS_EVENT_ID_RESULT(detail, m_busID, ParticleDocumentRequestBus, CopyDetail, emitterName);
@@ -479,8 +489,24 @@ namespace OpenParticleSystemEditor
 
         EBUS_EVENT_ID_RESULT(sourceDetail, widgetName, ParticleDocumentRequestBus, GetDetail);
         EBUS_EVENT_ID_RESULT(sourceEmitter, widgetName, ParticleDocumentRequestBus, GetEmitter);
+
+        // The buffer belongs to the source document. If that particle has since been closed there is no
+        // handler on its bus id, so both pointers come back null and there is nothing to paste.
+        if (sourceDetail == nullptr || sourceEmitter == nullptr)
+        {
+            AZ_Warning(
+                "Emitter", false,
+                "Nothing to paste. The emitter was copied from '%s', which is no longer open.", widgetName.c_str());
+            return;
+        }
+
         OpenParticle::ParticleSourceData::DetailInfo* destDetail = nullptr;
         EBUS_EVENT_ID_RESULT(destDetail, m_busID, ParticleDocumentRequestBus, SetEmitterAndDetail, sourceEmitter, sourceDetail);
+        if (destDetail == nullptr)
+        {
+            AZ_Warning("Emitter", false, "Failed to paste the copied emitter into this particle.");
+            return;
+        }
 
         NewItem(destDetail, false, destDetail->m_name);
         
@@ -861,29 +887,35 @@ namespace OpenParticleSystemEditor
     void ParticleGraphicsView::ShowMenu(const QPoint& pos)
     {
         QMenu* menu = new QMenu(this);
+        // The menu is shown rather than exec'd, so hand it over to Qt to clean up once it closes.
+        menu->setAttribute(Qt::WA_DeleteOnClose);
+
+        const bool onItem = PointOnItem(pos);
+
+        // The copy buffer lives on whichever document was copied from. CopyItem broadcasts that document's
+        // id to every open particle, so a non empty name here means there is something to paste, whether it
+        // was copied from this particle or from another one that is currently open.
+        AZStd::string copyWidgetName;
+        EBUS_EVENT_RESULT(copyWidgetName, ParticleDocumentRequestBus, GetCopyWidgetName);
+
         // in order "Add,Copy,Paste,Delete"
         menu->addAction(m_pActAddItem);
-        if (PointOnItem(pos))
+        m_pActAddItem->setEnabled(true);
+
+        // Copy acts on the emitter under the cursor, so it only means anything over an item.
+        menu->addAction(m_pActCopyItem);
+        m_pActCopyItem->setEnabled(onItem);
+
+        menu->addAction(m_pActPasteItem);
+        m_pActPasteItem->setEnabled(!copyWidgetName.empty());
+
+        if (onItem)
         {
             menu->addAction(m_pActDelItem);
+            m_pActDelItem->setEnabled(true);
         }
 
         menu->move(cursor().pos());
-        if (this->scene()->selectedItems().isEmpty())
-        {
-            this->m_pActDelItem->setEnabled(true);
-            this->m_pActCopyItem->setEnabled(true);
-            AZStd::string widgetName = "";
-            EBUS_EVENT_RESULT(widgetName, ParticleDocumentRequestBus, GetCopyWidgetName);
-            if (!widgetName.empty())
-            {
-                this->m_pActPasteItem->setEnabled(true);
-            }
-        }
-        else
-        {
-            this->m_pActAddItem->setEnabled(true);
-        }
         menu->show();
     }
 } // namespace OpenParticleSystemEditor

--- a/Gems/OpenParticleSystem/Tools/openparticlesystemeditor_files.cmake
+++ b/Gems/OpenParticleSystem/Tools/openparticlesystemeditor_files.cmake
@@ -39,6 +39,10 @@ set(FILES
     OpenParticleSystemEditor/Window/LightingPresetMenu.cpp
     OpenParticleSystemEditor/Window/ComboBoxWidget.h
     OpenParticleSystemEditor/Window/ComboBoxWidget.cpp
+    OpenParticleSystemEditor/Window/MaterialPropertyWidget.h
+    OpenParticleSystemEditor/Window/MaterialPropertyWidget.cpp
+    OpenParticleSystemEditor/Window/MaterialPropertyDialog.h
+    OpenParticleSystemEditor/Window/MaterialPropertyDialog.cpp
     OpenParticleSystemEditor/Window/PropertyEditorWidget.h
     OpenParticleSystemEditor/Window/PropertyEditorWidget.cpp
     OpenParticleSystemEditor/Window/EventHandlerWidget.h


### PR DESCRIPTION
# Per-emitter material property overrides, Clear Overrides, and emitter copy/paste fixes

## Summary

Every particle emitter already builds its own `AZ::RPI::Material` instance at runtime (`EmitterInstance::Setup`), but there was no way to author values on it. Two emitters pointing at the same `.material` asset were locked to identical values, and the only way to vary them was to duplicate the material file.

This PR adds per-emitter material property overrides — the particle-editor equivalent of the mesh Material Component's property inspector — plus a way to clear them, and fixes the emitter copy/paste context menu so it carries those overrides and stops crashing on edge cases.

---

## 1. Per-emitter material property overrides

A new **Edit Material Properties…** button appears on the emitter panel whenever a renderer with a material is selected (Sprite, Ribbon, Mesh). It opens a resizable, modeless inspector showing the material's full property layout.

**Editor**

- The layout is built from the `.materialtype` **source** data, not just the built runtime layout, so it carries display names, descriptions, groups, value ranges, and enum labels — the same presentation as the mesh Material Component inspector.
- Only genuine differences are stored. Dragging a value back to the material's own value removes the entry rather than storing a duplicate, so `.particle` files stay clean and the emitter falls back to sharing the material's value if the material is later edited.
- Modified properties show the standard changed-value indicator icon.
- Property groups start collapsed — a full PBR layout is several hundred rows — and expansion state persists across emitter switches within a session.
- The dialog is modeless so the viewport stays interactive while tweaking. The viewport updates when a control is released; intermediate values from a slider or colour-picker drag are recorded but do not trigger the full particle-asset rebuild.
- Reassigning the emitter's material prunes overrides whose property ids no longer resolve and keeps the ones that do, which is the useful behaviour when swapping between two materials built from the same material type.
- Stored property ids are migrated through `MaterialTypeAsset::ApplyPropertyRenames`, so a material type that renames a property between versions does not silently drop the value.

**Runtime**

- `MaterialPropertyOverrideMap` (`AZStd::unordered_map<AZ::Name, AZStd::any>`) mirrors `AZ::Render::MaterialAssignment::m_propertyOverrides`, redeclared locally so the runtime gem does not need to depend on `AtomLyIntegration_CommonFeatures`.
- Overrides are applied and compiled **before** the pipeline is built, because a property can drive a shader option or enable/disable a shader item, which changes which draw items `ReBuildPipeline` produces.
- If the material SRG is still in use for the frame, the compile is deferred and retried on a later tick rather than dropped.
- Numeric and enum values are coerced to the type the property descriptor actually expects; vectors, colours, images and sampler states fall through to `MaterialPropertyValue::FromAny`.

**File compatibility — both directions are backward compatible, no asset re-export required**

- `.particle` (JSON): new **optional** `materialOverrides` member. Files authored before this feature have no such member and load with an empty map. The member is only written when the emitter actually overrides something, so untouched particle files stay byte-identical.
- Runtime archive: `ParticleArchive::EmitterInfo` bumped `Version(0)` → `Version(1)` with a new `materialOverrides` field. Older serialized assets deserialize with an empty map, which is exactly the previous behaviour.

## 2. Clear Overrides

A **Clear Overrides** button sits next to Edit Material Properties, enabled only when the emitter actually has overrides.

- Prompts for confirmation, showing how many overrides will be removed.
- Clears the map, refreshes an open property inspector so every control snaps back to the material's own value and the modified indicators clear, syncs the emptied map onto the emitter, and marks the document modified.
- Because `EmitterInstance::Setup` creates a fresh material instance via `Material::Create`, clearing genuinely reverts the emitter to the material asset's values rather than leaving stale compiled values behind.

## 3. Emitter copy/paste

The copy/paste context-menu actions existed but were unreliable. This PR makes them work and carries material overrides through them.

- **Overrides travel with the emitter.** `m_materialOverrides` is now copied in every copy path: `CopyEmitter`, `CopyDetail`, `CopyEmitterFromEmitter`, and `CopyDetailFromDetail`.
- **`CopyItem` no longer crashes on a non-emitter target.** The `dynamic_cast` results and the detail pointer were used unguarded, so right-clicking anything that was not an emitter item dereferenced null.
- **`PasteItem` handles a closed source document.** The copy buffer lives on whichever document was copied from; if that particle has since been closed there is no handler on its bus id and both pointers come back null. That case now warns and returns instead of crashing. A failed paste is likewise reported rather than dereferenced.
- **Context-menu enable logic was inverted.** It was keyed on `scene()->selectedItems().isEmpty()`, so Copy/Paste/Delete were only enabled when *nothing* was selected, and Copy and Delete were offered regardless of whether the cursor was over an emitter. Copy and Delete are now gated on the cursor being over an item, and Paste on the copy buffer being non-empty — including when the emitter was copied from a different particle that is still open.
- **The menu leaked on every right-click.** It was created with `new QMenu(this)` and `show()`n rather than `exec()`d, so it was never destroyed; it now carries `Qt::WA_DeleteOnClose`.

## Incidental fixes found along the way

- **Newly added emitters had no material on the emitter itself.** `SetDefaultModules` assigned the default sprite material to the `DetailInfo` but not the `EmitterInfo`, so a freshly added emitter carried an invalid material until the user happened to touch the material picker, and `CreateParticleAsset` failed with *"no material assigned to render in emitter &lt;name&gt;"*. The save path masked this by substituting the default material on write, so the file on disk looked correct while the in-memory emitter did not.
- **Asset load behaviour mismatch.** The default sprite material was stored with `NoLoad` but read back with `PreLoad`. Both sides now use `PreLoad` so the behaviour written to the file agrees with the behaviour the asset is given when it is read back.
- **Material sub-assets could be unloaded on level load.** `EmitterInstance::Setup` now queues a load when the material asset is not ready, and retries material creation and pipeline build on a later tick instead of leaving the emitter unrendered.

---

## How this was tested

- Assigned one `.material` to two emitters, overrode base colour on one, confirmed the other was unaffected in the viewport and after save/reload.
- Verified an override set back to the material's own value is dropped from the saved `.particle` file.
- Cleared overrides on an emitter and confirmed the viewport and the inspector both revert to the material's values.
- Swapped an emitter's material to another material of the same material type (overrides preserved) and to an unrelated one (non-resolving overrides pruned).
- Loaded a `.particle` authored before this change and confirmed it opens with no overrides and re-saves byte-identical.
- Copied an emitter with overrides and pasted it into the same particle and into a second open particle.
- Right-clicked empty graph space, and pasted after closing the document the emitter was copied from.
- Added a new emitter and saved without touching the material picker.

## Files changed

**New**

- `Code/Source/Runtime/OpenParticleSystem/MaterialPropertyOverride.{h,cpp}` — override map type, value coercion, apply, prune
- `Tools/OpenParticleSystemEditor/Window/MaterialPropertyWidget.{h,cpp}` — the property inspector
- `Tools/OpenParticleSystemEditor/Window/MaterialPropertyDialog.{h,cpp}` — modeless host window

**Modified**

- `Code/Source/Runtime/OpenParticleSystem/ParticlePipelineState.{h,cpp}` — apply overrides on the emitter's material instance, deferred retry
- `Code/Source/Runtime/OpenParticleSystem/Asset/ParticleArchive.{h,cpp}` — `EmitterInfo` version 1 + `materialOverrides` field
- `Code/Source/Runtime/OpenParticleSystem/ParticleSystem.cpp` — pass overrides into `EmitterInstance::Setup`
- `Code/Source/Editor/Serializer/ParticleSystemSerializer.cpp` — optional `materialOverrides` JSON member
- `Code/Source/Editor/Serializer/ParticleSourceData.cpp`, `Code/Source/Serializer/ParticleSourceData.h` — override plumbing, copy paths, prune on material swap, new-emitter material fix
- `Code/Source/Editor/Serializer/ParticleAssetData.cpp`, `Code/Source/Serializer/ParticleAssetData.h` — `EmitterInfo::m_materialOverrides`
- `Tools/OpenParticleSystemEditor/Window/ComboBoxWidget.{h,cpp}` — the two buttons and the dialog lifetime
- `Tools/OpenParticleSystemEditor/Window/EffectorInspector.{h,cpp}` — sync overrides onto the emitter and notify the document
- `Tools/OpenParticleSystemEditor/Window/ParticleGraphicsView.cpp` — copy/paste guards and context-menu logic
- `Code/openparticlesystem_files.cmake`, `Tools/openparticlesystemeditor_files.cmake` — new sources
