### PR TITLE
Fix Metal color clears for render scopes without draw work

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -185,7 +185,7 @@ namespace AZ
                 needsEncoder |= NeedsEncoder(m_renderPassContext.m_renderPassDescriptor.depthAttachment);
                 needsEncoder |= NeedsEncoder(m_renderPassContext.m_renderPassDescriptor.stencilAttachment);
 
-                for(uint32_t i = 0; i < RHI::Limits::Pipeline::AttachmentColorCountMax && needsEncoder; ++i)
+                for(uint32_t i = 0; i < RHI::Limits::Pipeline::AttachmentColorCountMax && !needsEncoder; ++i)
                 {
                     MTLRenderPassColorAttachmentDescriptor* colorDescriptor = [m_renderPassContext.m_renderPassDescriptor.colorAttachments objectAtIndexedSubscript:i];
                     needsEncoder |= NeedsEncoder(colorDescriptor);


### PR DESCRIPTION
## What does this PR do?

Fixes Metal rendering corruption when a render scope has no draw items but still needs to clear or resolve a color attachment. ([See the issue on the Discord thread here](https://discord.com/channels/805939474655346758/1349060320383074434/1534723008969838795))

`Metal::Scope::Begin()` decides whether an otherwise empty scope needs a render command encoder. This regression was introduced by [(#18311)](https://github.com/o3de/o3de/pull/18311), specifically commit [`a947f75f`](https://github.com/o3de/o3de/commit/a947f75f816a4f207184a35b184a6d223b60e5be). That refactor replaced the previous explicit clear/resolve flags with inspection of the native Metal attachment descriptors, but the color-attachment loop was guarded by `needsEncoder` instead of `!needsEncoder`.

Because `needsEncoder` starts false, the loop skipped every color attachment unless depth or stencil had already established that an encoder was needed. In the repro, Forward had no draw items, and only its color attachment required a clear. Metal therefore created no Forward render encoder, so the `Forward.DiffuseImage` clear was never encoded. The next pass legally loaded the uncleared transient heap texture and exposed stale heap contents as deterministic triangles, bands, black gaps, and green dots. Post-processing and presentation only propagated those pixels, which is also why Metal API validation did not report an invalid command.

The fix changes the loop guard to `!needsEncoder`, inspect color attachments until one requires a clear or resolve encoder, then stop. This restores the intended pre-#18311 behavior without creating encoders for scopes that truly have no work, and matches DX12 and Vulkan behavior where attachment clears do not depend on draw count.

### Before

<img width="1129" height="581" alt="metal_before" src="https://github.com/user-attachments/assets/88f89aca-5696-4046-b9f4-847a59734b8b" />

### After

<img width="1129" height="581" alt="metal_after" src="https://github.com/user-attachments/assets/2ac250e1-f51c-4bc9-ad33-0ed83fc3938d" />

## How was this PR tested?

- Tested from `upstream/development` on macOS 27.0, Xcode 27.0, and an Apple M4 10-core GPU.
- The bad trace has no `Root.MainPipeline_0.OpaquePass.Forward` render encoder. The first consumer, `DiffuseGlobalIlluminationPass.DiffuseCompositePass`, loads an already-corrupt `Forward.DiffuseImage`.
- Captured fresh before/after Metal traces. After the fix, the zero-draw Forward encoder exists with `loadAction = Clear`, `Forward.DiffuseImage` is valid at the first consumer, and the image remains valid through ACES and `CopyToSwapChain`.
- Metal API and load-action validation reported no new errors, GPU timeout, readback stall, or ignored submission.
