### PR TITLE
fix(atom): move group barrier before early exit in SSS shader to prevent GPU deadlock

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.azsl
@@ -202,6 +202,8 @@ void MainCS(
         );
     }
 
+    GroupMemoryBarrierWithGroupSync();
+
     // If current thread don't need further convolution then terminate and return
     // Case 1: factor < EPSILON, factor is zero so further computation is not necessary
     // Case 2: factor is nonzero but subsurface scattering is disabled at this pixel
@@ -210,8 +212,6 @@ void MainCS(
         PassSrg::m_outputTexture[dispatchID.xy] = float4(colorX.rgb, 0.0f);
         return;
     }
-
-    GroupMemoryBarrierWithGroupSync();
 
     //+--------------------------------------+
     //|  subsurface scattering preprocessing |


### PR DESCRIPTION
**_Summery:_** Relocates `GroupMemoryBarrierWithGroupSync()` in **`ScreenSpaceSubsurfaceScatteringCS.azsl`** so it executes before thread termination checks.

**_Old behavior:_**
- Non-SSS threads exited early before reaching `GroupMemoryBarrierWithGroupSync()`.
- On hardware such as Intel Iris Xe integrated GPUs, this barrier imbalance causes an immediate thread deadlock and TDR GPU crash when enabling SSS in EnhancedPBR.
- Note: Certain discrete GPU drivers silently tolerate this spec violation, which is likely why the crash was not observed on higher-end hardware

**_New behavior:_**
- `GroupMemoryBarrierWithGroupSync()` executes before any early exit condition checks.
- All threads in the group safely synchronize shared memory before any thread terminates, adhering strictly to Vulkan and DirectX 12 barrier specifications.
- SSS renders correctly without hanging the GPU driver or crashing on Intel Iris Xe.

**_Issue:_** Fixes #19838 

## How was this PR tested?

**_Testing Environment:_**
- **GPU:** Intel Iris Xe (iGPU)
- Material/Asset: EnhancedPBR material on a 3D mesh.

**_Testing Steps & Results:_**
- Assigned an `EnhancedPBR` material with Subsurface Scattering (SSS) enabled to a mesh in the editor.
- Verified that the viewport and Atom renderer no longer lock up, crash, or trigger a GPU driver TDR upon enabling SSS.
- Confirmed SSS passes execute properly and render the expected scatter effect without graphical artifacts.