### PR TITLE
Port embedded python initialization to the PyConfig API

### DIFF
--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -9,7 +9,6 @@
 #include <PythonBindings.h>
 
 #include <ProjectManagerDefs.h>
-#include <osdefs.h> // for DELIM
 
 // Qt defines slots, which interferes with the use here.
 #pragma push_macro("slots")
@@ -293,25 +292,37 @@ namespace O3DE::ProjectManager
 
         AZStd::wstring pyHomePath;
         AZStd::to_wstring(pyHomePath, pyBasePath);
-        Py_SetPythonHome(pyHomePath.c_str());
 
         PyImport_AppendInittab("azlmbr_redirect", RedirectOutput::PyInit_RedirectOutput);
 
         try
         {
-            // ignore system location for sites site-packages
-            Py_IsolatedFlag = 1; // -I - Also sets Py_NoUserSiteDirectory.  If removed PyNoUserSiteDirectory should be set.
-            Py_IgnoreEnvironmentFlag = 1; // -E
-            Py_DontWriteBytecodeFlag = 1; // Do not generate precompiled bytecode
-
-            const bool initializeSignalHandlers = true;
-            pybind11::initialize_interpreter(initializeSignalHandlers);
+            // Configure and start the interpreter through the PyConfig API
+            // (Py_SetPythonHome and the pre-init configuration globals are
+            // deprecated). The isolated configuration ignores the environment
+            // and the user site directory, matching the intent of the previous
+            // Py_IsolatedFlag / Py_IgnoreEnvironmentFlag setup.
+            PyConfig config;
+            PyConfig_InitIsolatedConfig(&config);
+            config.install_signal_handlers = 1;
+            config.write_bytecode = 0; // Do not generate precompiled bytecode
+            PyStatus pyStatus = PyConfig_SetString(&config, &config.home, pyHomePath.c_str());
+            if (!PyStatus_Exception(pyStatus))
+            {
+                pyStatus = Py_InitializeFromConfig(&config);
+            }
+            PyConfig_Clear(&config);
+            if (PyStatus_Exception(pyStatus))
+            {
+                AZ_Error("python", false, "Python initialization failed with %s!", pyStatus.err_msg ? pyStatus.err_msg : "an unknown error");
+                return false;
+            }
 
             // display basic Python information
             AZ_Trace("python", "Py_GetVersion=%s \n", Py_GetVersion());
-            AZ_Trace("python", "Py_GetPath=%ls \n", Py_GetPath());
-            AZ_Trace("python", "Py_GetExecPrefix=%ls \n", Py_GetExecPrefix());
-            AZ_Trace("python", "Py_GetProgramFullPath=%ls \n", Py_GetProgramFullPath());
+            AZ_Trace("python", "sys.executable=%s \n", pybind11::module_::import("sys").attr("executable").cast<std::string>().c_str());
+            AZ_Trace("python", "sys.exec_prefix=%s \n", pybind11::module_::import("sys").attr("exec_prefix").cast<std::string>().c_str());
+            AZ_Trace("python", "sys.path=%s \n", pybind11::str(pybind11::module_::import("sys").attr("path")).cast<std::string>().c_str());
 
             RedirectOutput::Intialize(PyImport_ImportModule("azlmbr_redirect"), &PythonBindings::OnStdOut, &PythonBindings::OnStdError);
 
@@ -433,7 +444,7 @@ namespace O3DE::ProjectManager
                 engineInfo.m_path = Py_To_String(enginePath);
 
                 auto thisEnginePath = m_manifest.attr("get_this_engine_path")();
-                if (pybind11::isinstance(thisEnginePath, m_pathlib.attr("Path")().get_type()) &&
+                if (pybind11::isinstance(thisEnginePath, pybind11::type::of(m_pathlib.attr("Path")())) &&
                     thisEnginePath.attr("samefile")(enginePath).cast<bool>())
                 {
                     engineInfo.m_thisEngine = true;
@@ -2084,12 +2095,12 @@ namespace O3DE::ProjectManager
 
     bool PythonBindings::ExtendSysPath(const AZStd::vector<AZ::IO::Path>& extendPaths)
     {
+        // Collect the interpreter's current sys.path entries (Py_GetPath is deprecated)
         AZStd::unordered_set<AZ::IO::Path> oldPathSet;
-        auto SplitPath = [&oldPathSet](AZStd::string_view pathPart)
+        for (pybind11::handle pathEntry : pybind11::module_::import("sys").attr("path"))
         {
-            oldPathSet.emplace(AZ::IO::FixedMaxPath(pathPart));
-        };
-        AZ::StringFunc::TokenizeVisitor(Py_EncodeLocale(Py_GetPath(), nullptr), SplitPath, DELIM);
+            oldPathSet.emplace(AZ::IO::FixedMaxPath(pathEntry.cast<std::string>().c_str()));
+        }
         bool appended{ false };
         AZStd::string pathAppend{ "import sys\n" };
         for (const auto& thisStr : extendPaths)

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -11,7 +11,6 @@
 
 #include <EditorPythonBindings/PythonCommon.h>
 #include <Source/PythonSymbolsBus.h>
-#include <osdefs.h> // for DELIM
 #include <pybind11/embed.h>
 #include <pybind11/eval.h>
 #include <pybind11/pybind11.h>
@@ -574,25 +573,37 @@ namespace EditorPythonBindings
         }
         AZStd::wstring pyHomePath;
         AZStd::to_wstring(pyHomePath, pyBasePath);
-        Py_SetPythonHome(pyHomePath.c_str());
 
         PyImport_AppendInittab("azlmbr_redirect", RedirectOutput::PyInit_RedirectOutput);
         try
         {
-            // ignore system location for sites site-packages
-            Py_IsolatedFlag = 1; // -I - Also sets Py_NoUserSiteDirectory.  If removed PyNoUserSiteDirectory should be set.
-            Py_IgnoreEnvironmentFlag = 1; // -E
-            Py_InspectFlag = 1; // unhandled SystemExit will terminate the process unless Py_InspectFlag is set
-            Py_DontWriteBytecodeFlag = 1; // Do not generate precompiled bytecode
-
-            const bool initializeSignalHandlers = true;
-            pybind11::initialize_interpreter(initializeSignalHandlers);
+            // Configure and start the interpreter through the PyConfig API
+            // (Py_SetPythonHome and the pre-init configuration globals are
+            // deprecated). The isolated configuration ignores the environment
+            // and the user site directory, matching the intent of the previous
+            // Py_IsolatedFlag / Py_IgnoreEnvironmentFlag setup.
+            PyConfig config;
+            PyConfig_InitIsolatedConfig(&config);
+            config.install_signal_handlers = 1;
+            config.inspect = 1; // unhandled SystemExit will terminate the process unless inspect is set
+            config.write_bytecode = 0; // Do not generate precompiled bytecode
+            PyStatus pyStatus = PyConfig_SetString(&config, &config.home, pyHomePath.c_str());
+            if (!PyStatus_Exception(pyStatus))
+            {
+                pyStatus = Py_InitializeFromConfig(&config);
+            }
+            PyConfig_Clear(&config);
+            if (PyStatus_Exception(pyStatus))
+            {
+                AZ_Warning("python", false, "Python initialization failed with %s!", pyStatus.err_msg ? pyStatus.err_msg : "an unknown error");
+                return false;
+            }
 
             // display basic Python information
             AZ_Trace("python", "Py_GetVersion=%s \n", Py_GetVersion());
-            AZ_Trace("python", "Py_GetPath=%ls \n", Py_GetPath());
-            AZ_Trace("python", "Py_GetExecPrefix=%ls \n", Py_GetExecPrefix());
-            AZ_Trace("python", "Py_GetProgramFullPath=%ls \n", Py_GetProgramFullPath());
+            AZ_Trace("python", "sys.executable=%s \n", pybind11::module_::import("sys").attr("executable").cast<std::string>().c_str());
+            AZ_Trace("python", "sys.exec_prefix=%s \n", pybind11::module_::import("sys").attr("exec_prefix").cast<std::string>().c_str());
+            AZ_Trace("python", "sys.path=%s \n", pybind11::str(pybind11::module_::import("sys").attr("path")).cast<std::string>().c_str());
 
             // Add custom site packages after initializing the interpreter above.  Calling Py_SetPath before initialization
             // alters the behavior of the initializer to not compute default search paths. See https://docs.python.org/3/c-api/init.html#c.Py_SetPath
@@ -624,12 +635,12 @@ namespace EditorPythonBindings
 
     bool PythonSystemComponent::ExtendSysPath(const AZStd::unordered_set<AZStd::string>& extendPaths)
     {
+        // Collect the interpreter's current sys.path entries (Py_GetPath is deprecated)
         AZStd::unordered_set<AZStd::string> oldPathSet;
-        auto SplitPath = [&oldPathSet](AZStd::string_view pathPart)
+        for (pybind11::handle pathEntry : pybind11::module_::import("sys").attr("path"))
         {
-            oldPathSet.emplace(pathPart);
-        };
-        AZ::StringFunc::TokenizeVisitor(Py_EncodeLocale(Py_GetPath(), nullptr), SplitPath, DELIM);
+            oldPathSet.emplace(pathEntry.cast<std::string>().c_str());
+        }
         bool appended{ false };
         AZStd::string pathAppend{ "import sys\n" };
         for (const auto& thisStr : extendPaths)
@@ -799,29 +810,24 @@ namespace EditorPythonBindings
             // Acquire GIL before calling Python code
             PythonGILScopedLock lock(m_lock, m_lockRecursiveCounter);
 
-            // Create standard "argc" / "argv" command-line parameters to pass in to the Python script via sys.argv.
-            // argc = number of parameters.  This will always be at least 1, since the first parameter is the script name.
-            // argv = the list of parameters, in wchar format.
-            // Our expectation is that the args passed into this function does *not* already contain the script name.
-            int argc = aznumeric_cast<int>(args.size()) + 1;
-
-            // Note:  This allocates from PyMem to ensure that Python has access to the memory.
-            wchar_t** argv = static_cast<wchar_t**>(PyMem_Malloc(argc * sizeof(wchar_t*)));
-
-            // Python 3.x is expecting wchar* strings for the command-line args.
-            argv[0] = Py_DecodeLocale(theFilename.c_str(), nullptr);
-
-            for (int arg = 0; arg < args.size(); arg++)
+            // Pass the standard command-line parameters to the Python script via sys.argv.
+            // The first entry is always the script name; our expectation is that the args
+            // passed into this function does *not* already contain the script name.
+            // (PySys_SetArgvEx is deprecated.) Mirroring its updatePath behavior, the
+            // script's folder is prepended to sys.path for "import" commands.
+            pybind11::list pythonArgs;
+            pythonArgs.append(theFilename.c_str());
+            for (const AZStd::string_view& arg : args)
             {
-                AZStd::string argString(args[arg]);
-                argv[arg + 1] = Py_DecodeLocale(argString.c_str(), nullptr);
+                pythonArgs.append(AZStd::string(arg).c_str());
             }
-            // Tell Python the command-line args.
-            // Note that this has a side effect of adding the script's path to the set of directories checked for "import" commands.
-            const int updatePath = 1;
-            PySys_SetArgvEx(argc, argv, updatePath);
+            auto pySys = pybind11::module_::import("sys");
+            pySys.attr("argv") = pythonArgs;
 
-            Py_DontWriteBytecodeFlag = 1;
+            AZStd::string scriptFolder;
+            AzFramework::StringFunc::Path::GetFullPath(theFilename.c_str(), scriptFolder);
+            pySys.attr("path").attr("insert")(0, scriptFolder.c_str());
+
             PyCompilerFlags flags;
             flags.cf_flags = 0;
             const int bAutoCloseFile = true;
@@ -834,13 +840,6 @@ namespace EditorPythonBindings
                 EditorPythonConsoleNotificationBus::Broadcast(&EditorPythonConsoleNotificationBus::Events::OnExceptionMessage, message.c_str());
                 pythonScriptResult = Result::Error_PythonException;
             }
-
-            // Free any memory allocated for the command-line args.
-            for (int arg = 0; arg < argc; arg++)
-            {
-                PyMem_RawFree(argv[arg]);
-            }
-            PyMem_Free(argv);
         }
         catch ([[maybe_unused]] const std::exception& e)
         {

--- a/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
@@ -583,7 +583,7 @@ namespace EditorPythonBindings
             {
                 return pybind11::cast<PythonProxyObject*>(pyObj)->GetWrappedTypeName();
             }
-            return pybind11::cast<AZStd::string>(pybind11::str(pyObj.get_type()));
+            return pybind11::cast<AZStd::string>(pybind11::str(pybind11::type::of(pyObj)));
         }
     }
 


### PR DESCRIPTION

The embedded interpreter setup in EditorPythonBindings and in the Project Manager still uses the legacy pre-init API: Py_SetPythonHome, the Py_IsolatedFlag/Py_IgnoreEnvironmentFlag/Py_InspectFlag/Py_DontWriteBytecodeFlag globals, the Py_GetPath/Py_GetExecPrefix/Py_GetProgramFullPath queries, and PySys_SetArgvEx. All of these are deprecated as of Python 3.11 through 3.13, and because the Linux build compiles with -Werror they fail the build outright against Python 3.13 or newer headers. This blocks any future python package upgrade past 3.12 without touching this code.

This change replaces the legacy setup with PyConfig_InitIsolatedConfig plus Py_InitializeFromConfig, which preserves the isolated, no-environment, no-bytecode intent of the old flags and has been available since Python 3.8, so behavior on the current bundled 3.10 package is unchanged. It is also the same mechanism pybind11's own embed.h uses when running on Python 3.11 or newer.

Details:

- Py_SetPythonHome plus the four pre-init globals become one PyConfig block (isolated config, install_signal_handlers, inspect where it was set before, write_bytecode disabled, config.home from the existing PythonLoader home path).
- The startup traces that used Py_GetPath/Py_GetExecPrefix/Py_GetProgramFullPath now read sys.path, sys.exec_prefix and sys.executable from the live interpreter.
- ExecuteByFilenameWithArgs passed script arguments through PySys_SetArgvEx with a manual wide-string conversion; it now assigns sys.argv directly and prepends the script folder to sys.path, mirroring the previous updatePath behavior. This also removes a small leak: the old code passed the result of Py_EncodeLocale into a tokenizer without ever freeing it.
- Two uses of pybind11's deprecated handle::get_type() become pybind11::type::of(), available since pybind11 2.6, so the bundled pybind11 2.10 is unaffected.

One deliberate behavior change to call out: the previous initialization path ended up prepending an empty entry (the current working directory) to sys.path as a side effect of PySys_SetArgvEx with an empty argv. The isolated PyConfig does not do that. Scripts that relied on cwd-relative imports would see a difference; paths that the engine adds explicitly (gem script folders, project paths, the venv site-packages) are unaffected. Having the working directory on sys.path implicitly is generally considered an import hijack risk, which is why the isolated configuration omits it.

Testing done (Linux, Fedora 44, in a prototype configuration that builds against system Python 3.14.7):

- Full profile build of Editor, AssetProcessor, AssetBuilder, AssetProcessorBatch and ProjectManager with -Werror against the Python 3.14.7 headers; the tree does not compile against those headers without this change.
- With this change the interpreter initializes, runs scripts and passes arguments identically to before: Editor launched with AutomatedTesting and a --runpython script verifying the interpreter version, azlmbr bus calls and sys.argv contents; Project Manager starts with working python bindings; AssetProcessorBatch processes AutomatedTesting.
- The default bundled configuration was not rebuilt for this PR; the PyConfig API used is identical on the bundled 3.10 (available since 3.8), and I am happy to run any bundled-configuration validation reviewers want.

