### PR TITLE
Resolve pip's PEP 660 editable installs in the embedded interpreter

### DIFF
--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -2091,12 +2091,16 @@ namespace O3DE::ProjectManager
         };
         AZ::StringFunc::TokenizeVisitor(Py_EncodeLocale(Py_GetPath(), nullptr), SplitPath, DELIM);
         bool appended{ false };
-        AZStd::string pathAppend{ "import sys\n" };
+        // site.addsitedir instead of sys.path.append: it also executes any
+        // .pth files in the added directory, which is how pip's PEP 660
+        // editable installs (__editable__.*.pth import hooks) become
+        // importable; a plain sys.path entry never runs them.
+        AZStd::string pathAppend{ "import sys\nimport site\n" };
         for (const auto& thisStr : extendPaths)
         {
             if (!oldPathSet.contains(thisStr.c_str()))
             {
-                pathAppend.append(AZStd::string::format("sys.path.append(r'%s')\n", thisStr.c_str()));
+                pathAppend.append(AZStd::string::format("site.addsitedir(r'%s')\n", thisStr.c_str()));
                 appended = true;
             }
         }

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -631,12 +631,16 @@ namespace EditorPythonBindings
         };
         AZ::StringFunc::TokenizeVisitor(Py_EncodeLocale(Py_GetPath(), nullptr), SplitPath, DELIM);
         bool appended{ false };
-        AZStd::string pathAppend{ "import sys\n" };
+        // site.addsitedir instead of sys.path.append: it also executes any
+        // .pth files in the added directory, which is how pip's PEP 660
+        // editable installs (__editable__.*.pth import hooks) become
+        // importable; a plain sys.path entry never runs them.
+        AZStd::string pathAppend{ "import sys\nimport site\n" };
         for (const auto& thisStr : extendPaths)
         {
             if (!oldPathSet.contains(thisStr))
             {
-                pathAppend.append(AZStd::string::format("sys.path.append(r'%s')\n", thisStr.c_str()));
+                pathAppend.append(AZStd::string::format("site.addsitedir(r'%s')\n", thisStr.c_str()));
                 appended = true;
             }
         }


### PR DESCRIPTION

The engine pip-installs several of its own packages into the venv in editable mode (scripts/o3de, Tools/LyTestTools, Tools/RemoteConsole, and on some paths the pyside packages). How pip records an editable install changed: older pip wrote .egg-link files, which the engine handles by parsing them directly in PythonLoader::ReadPythonEggLinkPaths, but current pip records PEP 660 editables as a pair of __editable__.<name>.pth plus an import-hook finder module in site-packages. A .pth file only executes when the directory is processed by the site module; the engine's ExtendSysPath added directories with a plain sys.path.append, which never runs them. The result is that with a current pip none of the engine's editable packages resolve: the Project Manager fails its o3de module imports at startup, and the python asset builders cannot import o3de either.

The fix is one line of intent: ExtendSysPath now adds directories with site.addsitedir instead of sys.path.append. addsitedir appends the directory (deduplicating against sys.path) and processes any .pth files in it, which is exactly the documented mechanism PEP 660 editables rely on. Directories without .pth files behave as before, and the existing .egg-link parsing is untouched, so older layouts keep working.

This is not only a concern for unusual interpreter setups. The bundled 3.10 package ships pip 23.0.1, and because the engine's packages are setup.py-only (no pyproject.toml), that pip still takes the legacy develop path and produces .egg-link files today; I verified this by running the bundled interpreter's pip against scripts/o3de, which yields o3de.egg-link. Both halves of that condition are living on borrowed time: pip 25 removed the legacy develop path entirely, and adding a pyproject.toml to any of these packages flips it to PEP 660 immediately. Either event, on the next bundled python package refresh or a routine packaging modernization, silently breaks every editable install and the Project Manager loses its python bindings. The engine's own issue history already has adjacent cases in this subsystem (#19909, #19915, #16398).

Testing done (Linux, Fedora 44, interpreter with pip 26 which produces only PEP 660 editables):

- Before the change: Project Manager startup asserts with ModuleNotFoundError, No module named o3de; the PythonAssetBuilder createJobs stage fails the same way.
- After the change: Project Manager starts and its o3de.* imports succeed; an Editor --runpython script confirms import o3de resolves through the pth hook to scripts/o3de; AssetProcessorBatch over AutomatedTesting completes with the python-driven assets processing.

