### PR TITLE
Fix two GIL handling bugs in the embedded python integration

### DIFF
--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -8,6 +8,8 @@
 
 #include <PythonBindings.h>
 
+#include <AzCore/std/optional.h>
+
 #include <ProjectManagerDefs.h>
 #include <osdefs.h> // for DELIM
 
@@ -331,6 +333,7 @@ namespace O3DE::ProjectManager
                 ExtendSysPath(extendedPaths);
             }
 
+            {
             // Acquire GIL before calling Python code
             AZStd::lock_guard<decltype(m_lock)> lock(m_lock);
             pybind11::gil_scoped_acquire acquire;
@@ -357,6 +360,17 @@ namespace O3DE::ProjectManager
             m_pathlib = pybind11::module::import("pathlib");
 
             m_pythonStarted = !PyErr_Occurred();
+            }
+
+            if (m_pythonStarted)
+            {
+                // Release the GIL from the initializing thread. The
+                // interpreter keeps the GIL held after initialization;
+                // leaving it held would block any other thread that enters
+                // python through gil_scoped_acquire. StopPython restores
+                // this thread state before finalizing the interpreter.
+                m_initialThreadState = PyEval_SaveThread();
+            }
             return m_pythonStarted;
         }
         catch ([[maybe_unused]] const std::exception& e)
@@ -370,6 +384,13 @@ namespace O3DE::ProjectManager
     {
         if (Py_IsInitialized())
         {
+            if (m_initialThreadState)
+            {
+                // Re-adopt the thread state that StartPython released;
+                // finalize must run with the GIL held.
+                PyEval_RestoreThread(static_cast<PyThreadState*>(m_initialThreadState));
+                m_initialThreadState = nullptr;
+            }
             RedirectOutput::Shutdown();
             pybind11::finalize_interpreter();
         }
@@ -385,7 +406,15 @@ namespace O3DE::ProjectManager
         }
 
         AZStd::lock_guard<decltype(m_lock)> lock(m_lock);
-        pybind11::gil_scoped_release release;
+        // gil_scoped_release requires the calling thread to hold the GIL
+        // (it calls PyEval_SaveThread, which needs a current thread state).
+        // A thread that has never entered python yet has no thread state,
+        // so it must skip straight to the acquire, which creates one.
+        AZStd::optional<pybind11::gil_scoped_release> release;
+        if (PyGILState_Check())
+        {
+            release.emplace();
+        }
         pybind11::gil_scoped_acquire acquire;
 
         m_pythonErrorStrings.clear();

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -124,6 +124,10 @@ namespace O3DE::ProjectManager
 
         AZ::IO::FixedMaxPath m_enginePath;
         mutable AZStd::recursive_mutex m_lock;
+        // PyThreadState of the thread that initialized the interpreter,
+        // released after startup so other threads can acquire the GIL
+        // (see StartPython / StopPython)
+        void* m_initialThreadState = nullptr;
 
         pybind11::handle m_gemProperties;
         pybind11::handle m_engineTemplate;

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -314,7 +314,14 @@ namespace EditorPythonBindings
         // to be locked) and therefore it's already got the GIL acquired.
         if (m_lockRecursiveCounter == 1)
         {
-            m_releaseGIL = AZStd::make_unique<pybind11::gil_scoped_release>();
+            // gil_scoped_release requires the calling thread to hold the GIL
+            // (it calls PyEval_SaveThread, which needs a current thread state).
+            // A thread that has never entered python yet has no thread state,
+            // so it must skip straight to the acquire, which creates one.
+            if (PyGILState_Check())
+            {
+                m_releaseGIL = AZStd::make_unique<pybind11::gil_scoped_release>();
+            }
             m_acquireGIL = AZStd::make_unique<pybind11::gil_scoped_acquire>();
         }
     }
@@ -602,18 +609,31 @@ namespace EditorPythonBindings
             }
             RedirectOutput::Intialize(PyImport_ImportModule("azlmbr_redirect"));
 
-            // Acquire GIL before calling Python code
-            PythonGILScopedLock lock(m_lock, m_lockRecursiveCounter);
-
-            if (EditorPythonBindings::PythonSymbolEventBus::GetTotalNumOfEventHandlers() == 0)
+            bool startResult = false;
             {
-                m_symbolLogHelper = AZStd::make_shared<PythonSystemComponent::SymbolLogHelper>();
+                // Acquire GIL before calling Python code
+                PythonGILScopedLock lock(m_lock, m_lockRecursiveCounter);
+
+                if (EditorPythonBindings::PythonSymbolEventBus::GetTotalNumOfEventHandlers() == 0)
+                {
+                    m_symbolLogHelper = AZStd::make_shared<PythonSystemComponent::SymbolLogHelper>();
+                }
+
+                // print Python version using AZ logging
+                const int verRet = PyRun_SimpleStringFlags("import sys \nprint (sys.version) \n", nullptr);
+                AZ_Error("python", verRet == 0, "Error trying to fetch the version number in Python!");
+                startResult = verRet == 0 && !PyErr_Occurred();
             }
 
-            // print Python version using AZ logging
-            const int verRet = PyRun_SimpleStringFlags("import sys \nprint (sys.version) \n", nullptr);
-            AZ_Error("python", verRet == 0, "Error trying to fetch the version number in Python!");
-            return verRet == 0 && !PyErr_Occurred();
+            // Release the GIL from the initializing thread. The interpreter
+            // keeps the GIL held after initialization; leaving it held would
+            // block any other thread (for example an asset builder job
+            // thread) that enters python through gil_scoped_acquire.
+            // StopPythonInterpreter restores this thread state before
+            // finalizing the interpreter.
+            m_initialThreadState = PyEval_SaveThread();
+
+            return startResult;
         }
         catch ([[maybe_unused]] const std::exception& e)
         {
@@ -652,6 +672,13 @@ namespace EditorPythonBindings
     {
         if (Py_IsInitialized())
         {
+            if (m_initialThreadState)
+            {
+                // Re-adopt the thread state that StartPythonInterpreter
+                // released; finalize must run with the GIL held.
+                PyEval_RestoreThread(static_cast<PyThreadState*>(m_initialThreadState));
+                m_initialThreadState = nullptr;
+            }
             RedirectOutput::Shutdown();
             pybind11::finalize_interpreter();
         }

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.h
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.h
@@ -71,6 +71,10 @@ namespace EditorPythonBindings
         AZStd::semaphore m_initalizeWaiter;
         AZStd::recursive_mutex m_lock;
         int m_lockRecursiveCounter = 0;
+        // PyThreadState of the thread that initialized the interpreter,
+        // released after startup so other threads can acquire the GIL
+        // (see StartPythonInterpreter / StopPythonInterpreter)
+        void* m_initialThreadState = nullptr;
         AZStd::shared_ptr<SymbolLogHelper> m_symbolLogHelper;
         PythonActionManagerHandler m_pythonActionManagerHandler;
         AzToolsFramework::EmbeddedPython::PythonLoader m_pythonLoader;


### PR DESCRIPTION

Running the python asset builders on an AssetBuilder job thread surfaced two related bugs in how the embedded python integration handles the GIL (python's global interpreter lock, which a thread must hold while it executes python code; the interpreter also gives each participating thread a small per-thread state object, and a thread that has never entered python has none). pybind11 documents the precondition directly in gil.h: the GIL must be held when gil_scoped_release is constructed (the guarding assert compiles out in release builds), and PythonGILScopedLock::Lock plus the Project Manager's ExecuteWithLockErrorHandling construct it unconditionally, including on threads that have never entered python. With pybind11 3.x and Python 3.14 that is a deterministic segfault on the AssetBuilder job thread, and after guarding it the same path deadlocks against the GIL that initialization leaves parked on the starting thread. The current bundled combination (pybind11 2.10, Python 3.10) tolerates the same sequence today: we verified that by cold-processing AutomatedTesting on an unmodified development tree, where the python-built assets (the PythonAssetBuilder mock asset and the SceneAPI script-processed fbx files) process successfully, and by cold-processing again with these fixes applied, where the same assets again process successfully through the python builders. So this is not a live crash for default builds; it is a documented-precondition violation that becomes fatal on current python/pybind11 stacks, and the fix is required before the engine can run them.

Bug 1: gil_scoped_release constructed without holding the GIL. pybind11 documents the precondition on gil_scoped_release directly in gil.h: The GIL must be held when this constructor is called (its constructor calls PyEval_SaveThread, which requires a current thread state; the assert guarding it compiles out in release builds). PythonSystemComponent::PythonGILScopedLock::Lock and the Project Manager's ExecuteWithLockErrorHandling constructed gil_scoped_release unconditionally. On a thread that has never entered python there is no thread state, and PyEval_SaveThread crashes. Observed as a segfault with this stack on an AssetBuilder job thread (abbreviated):

```
#0 PyEval_SaveThread ()
#1 pybind11::gil_scoped_release::gil_scoped_release (pybind11 gil.h)
#3 EditorPythonBindings::PythonSystemComponent::PythonGILScopedLock::Lock
#6 PythonAssetBuilder::PythonBuilderNotificationHandler::OnCreateJobsRequest
#20 AssetBuilderComponent::JobThread
```

The fix constructs the release only when PyGILState_Check reports the GIL held; the subsequent gil_scoped_acquire creates a thread state for fresh threads, which is what it is designed to do.

Bug 2: the GIL stays held on the initializing thread forever. Py_Initialize leaves the calling thread holding the GIL. StartPythonInterpreter returned with the GIL still held, so after fixing bug 1 the same job-thread path stopped crashing and instead blocked inside gil_scoped_acquire until the Asset Processor's 120 second builder timeout killed the worker. The fix is the standard embedding pattern: after startup completes, the initializing thread releases its thread state with PyEval_SaveThread and stores it; StopPythonInterpreter restores it with PyEval_RestoreThread before finalize_interpreter, which must run with the GIL held. With the GIL released at rest, any thread (including the main thread on its next call) enters python through the existing lock plus gil_scoped_acquire machinery.

Both fixes together take the python asset builders on Linux from crash (bug 1), to hang (bug 2 exposed), to working: an AssetProcessorBatch pass over AutomatedTesting processes all python-driven assets (the PythonAssetBuilder mock builder and the SceneAPI script processor assets) with zero failures, zero hangs and zero builder crashes. The Editor and Project Manager paths, which run python from their initializing thread, behave as before.

This may also explain long-standing intermittent reports of python-related crashes that produce no stacktrace, such as #12539: the crash in bug 1 happens inside the signal-unsafe window of a builder worker and the crash handler does not always produce a report there. That is a plausible connection rather than a verified one.

Testing done (Linux, Fedora 44): profile builds of Editor, AssetProcessor, AssetBuilder, AssetProcessorBatch, ProjectManager; AssetProcessorBatch full pass over AutomatedTesting before and after each fix showing the crash-to-hang-to-working progression; Editor --runpython verification; Project Manager startup with working python bindings.

