### PR TITLE
Wire the Linux python preload library names from the build

### DIFF
--- a/Gems/EditorPythonBindings/Code/CMakeLists.txt
+++ b/Gems/EditorPythonBindings/Code/CMakeLists.txt
@@ -61,6 +61,19 @@ ly_add_source_properties(
             O3DE_GEM_NAME=${gem_name}
             O3DE_GEM_VERSION=${gem_version})
 
+if (PAL_PLATFORM_NAME STREQUAL "Linux")
+    # The Linux module preloads the python shared library by name (see
+    # Source/Platform/Linux/InitializePython.h); wire the name from the build's
+    # single source of truth so it always matches the configured python.
+    ly_add_source_properties(
+        SOURCES
+            Source/EditorPythonBindingsModule.cpp
+        PROPERTY COMPILE_DEFINITIONS
+        VALUES
+            O3DE_PYTHON_SHARED_LIBRARY_NAME="${LY_PYTHON_SHARED_LIB}"
+    )
+endif()
+
 # builders and tools use EditorPythonBindings.Editor
 ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS ${gem_name}.Editor)
 ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS ${gem_name}.Editor)

--- a/Gems/EditorPythonBindings/Code/Source/Platform/Linux/InitializePython.h
+++ b/Gems/EditorPythonBindings/Code/Source/Platform/Linux/InitializePython.h
@@ -12,9 +12,14 @@
 
 namespace EditorPythonBindings
 {
-    // s_libPythonLibraryFile must match the library name listed in (O3DE Engine Root)/python/runtime/.../python-config.cmake
-    // in the set(${MY}_LIBRARY_xxxx sections.
-    const char* s_libPythonLibraryFile = "libpython3.10.so.1.0"; 
+    // The python shared library to preload so that python extension modules
+    // resolve the interpreter's symbols. The name is provided by the build
+    // from the LY_PYTHON_SHARED_LIB cmake variable, so it always matches the
+    // python the engine is configured against.
+#if !defined(O3DE_PYTHON_SHARED_LIBRARY_NAME)
+    #error O3DE_PYTHON_SHARED_LIBRARY_NAME must be defined; it is wired from LY_PYTHON_SHARED_LIB in the gem CMakeLists.txt
+#endif
+    const char* s_libPythonLibraryFile = O3DE_PYTHON_SHARED_LIBRARY_NAME;
 
     class InitializePython
     {

--- a/Gems/QtForPython/Code/CMakeLists.txt
+++ b/Gems/QtForPython/Code/CMakeLists.txt
@@ -66,6 +66,19 @@ ly_add_source_properties(
             O3DE_GEM_NAME=${gem_name}
             O3DE_GEM_VERSION=${gem_version})
 
+if (PAL_PLATFORM_NAME STREQUAL "Linux")
+    # The Linux module preloads the python shared library by name (see
+    # Source/Platform/Linux/InitializeEmbeddedPyside.h); wire the name from the build's
+    # single source of truth so it always matches the configured python.
+    ly_add_source_properties(
+        SOURCES
+            Source/QtForPythonModule.cpp
+        PROPERTY COMPILE_DEFINITIONS
+        VALUES
+            O3DE_PYTHON_SHARED_LIBRARY_NAME="${LY_PYTHON_SHARED_LIB}"
+    )
+endif()
+
 # the above target is used in both builders like AssetProcessor and Tools like the Editor
 # but is not used in clients or servers
 ly_create_alias(NAME ${gem_name}.Tools     NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)

--- a/Gems/QtForPython/Code/Source/Platform/Linux/InitializeEmbeddedPyside.h
+++ b/Gems/QtForPython/Code/Source/Platform/Linux/InitializeEmbeddedPyside.h
@@ -12,12 +12,26 @@
 
 namespace QtForPython
 {
-    // #QT6_TODO lib names might need adjustments
-    // s_libPythonLibraryFile must match the library name listed in (O3DE Engine Root)/python/runtime/.../python-config.cmake
-    // in the set(${MY}_LIBRARY_xxxx sections.
-    const char* s_libPythonLibraryFile = "libpython3.10.so.1.0"; 
+    // The python shared library name is provided by the build from the
+    // LY_PYTHON_SHARED_LIB cmake variable (see the gem CMakeLists.txt), so it
+    // always matches the python the engine is configured against. The
+    // pyside6/shiboken6 names default to the 3rdParty package layout and can
+    // be overridden by builds that provide those libraries differently; there
+    // is no in-repo source of truth for the packaged names to wire them from.
+#if !defined(O3DE_PYTHON_SHARED_LIBRARY_NAME)
+    #error O3DE_PYTHON_SHARED_LIBRARY_NAME must be defined; it is wired from LY_PYTHON_SHARED_LIB in the gem CMakeLists.txt
+#endif
+    const char* s_libPythonLibraryFile = O3DE_PYTHON_SHARED_LIBRARY_NAME;
+#if defined(O3DE_PYSIDE6_SHARED_LIBRARY_NAME)
+    const char* s_libPysideLibraryFile = O3DE_PYSIDE6_SHARED_LIBRARY_NAME;
+#else
     const char* s_libPysideLibraryFile = "libpyside6.abi3.so.6.10";
+#endif
+#if defined(O3DE_SHIBOKEN6_SHARED_LIBRARY_NAME)
+    const char* s_libShibokenLibraryFile = O3DE_SHIBOKEN6_SHARED_LIBRARY_NAME;
+#else
     const char* s_libShibokenLibraryFile = "libshiboken6.abi3.so.6.10";
+#endif
     const char* s_libQtTestLibraryFile = "libQt6Test.so.6";
 
     class InitializeEmbeddedPyside


### PR DESCRIPTION

The Linux platform headers that preload the python stack into the process dlopen their libraries by hardcoded file name: EditorPythonBindings' InitializePython.h loads libpython3.10.so.1.0, and QtForPython's InitializeEmbeddedPyside.h loads libpython3.10.so.1.0, libpyside6.abi3.so.6.10 and libshiboken6.abi3.so.6.10. Both headers carry comments acknowledging the fragility (the names "must match the library name listed in ... python-config.cmake", and InitializeEmbeddedPyside.h has a QT6_TODO that "lib names might need adjustments"). The engine already knows the python name authoritatively in cmake as LY_PYTHON_SHARED_LIB, so the header literal is a second copy of a fact with a single source of truth, and any python package rev that changes the name desyncs it silently: the dlopen failure only surfaces as an easy-to-miss error in builder logs, and python extension modules that rely on the preloaded symbols being in the global namespace fail much later and far from the cause.

This change makes the python name always come from the build: the two module sources receive O3DE_PYTHON_SHARED_LIBRARY_NAME as a compile definition wired from LY_PYTHON_SHARED_LIB (Linux only, via ly_add_source_properties, following the existing O3DE_GEM_NAME pattern in the same files), and the headers reject compilation with a clear #error if the definition is missing. The stale-literal failure mode is gone rather than patched: a future python package bump changes LY_PYTHON_SHARED_LIB and the preload follows automatically. The pyside6 and shiboken6 names become define-with-fallback (O3DE_PYSIDE6_SHARED_LIBRARY_NAME, O3DE_SHIBOKEN6_SHARED_LIBRARY_NAME): builds that provide those libraries differently can override them, and the default literals are unchanged because there is no in-repo source of truth for the packaged names to wire from. Overriding values should be SONAME-level file names rather than development symlink paths: the libX.so symlink only exists where a development package is installed, while the SONAME name resolves through the loader on any machine and stays valid across patch releases. Default builds compile to byte-identical preload names; the only change is where the python name comes from.

Related history: #17699 fixed a load failure in this same shared-library-resolution area for the ShaderManagementConsole, and the Linux InitializeEmbeddedPyside.h was introduced in March 2026 already carrying a QT6_TODO that the lib names might need adjustments. Deriving the names from the build closes that TODO and removes the future sync point that every python or pyside package rev otherwise creates.

Testing done (Linux, Fedora 44), on the default bundled configuration and on a system-python prototype configuration:

- Default configuration: build compiles clean; the compile command for the module sources carries O3DE_PYTHON_SHARED_LIBRARY_NAME="libpython3.10.so.1.0" derived from LY_PYTHON_SHARED_LIB; strings on the built modules show exactly the same preload names as before this change (python wired, pyside/shiboken/QtTest via the unchanged fallbacks); an AssetProcessorBatch run over AutomatedTesting launches builders with zero preload failures in the job logs.
- System-python configuration: the same wiring yields O3DE_PYTHON_SHARED_LIBRARY_NAME="libpython3.14.so.1.0" with no configuration-specific code, the built module bakes that name, and builder runs show zero preload failures with the python builders functioning end to end.
- The bundled pyside package was checked to confirm its shipped file names match the current fallback literals, so default-build preload behavior is unchanged.

