### PR TITLE
Fix hard edges at terrain detail layer boundaries with no macro material

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Conversions.cpp
@@ -175,11 +175,19 @@ namespace AZ
             const uint32_t elementOffsetBase = static_cast<uint32_t>(buffer.GetMemoryView().GetOffset()) / bufferViewDescriptor.m_elementSize;
             const uint32_t elementOffset = elementOffsetBase + bufferViewDescriptor.m_elementOffset;
 
-            if (elementOffsetBase * bufferViewDescriptor.m_elementSize != buffer.GetMemoryView().GetOffset())
-            {
-                AZ_Error("RHI DX12", false, "ConvertBufferView - SRV: buffer wasn't aligned with element size; buffer should be created"
-                    " with proper alignment");
-            }
+            // elementOffsetBase is computed via truncating integer division. If the buffer's pool
+            // sub-allocation offset isn't a whole multiple of the element size (e.g. a generic pool
+            // allocator that doesn't align sub-allocations per-element-size), the lost remainder silently
+            // shifts FirstElement to the wrong element -- the view then reads from the wrong location in
+            // the underlying pool buffer with no further signal that anything is wrong. AZ_Error only logs
+            // and lets that corrupted FirstElement through; escalate to AZ_Assert (matching the equivalent
+            // Vulkan check in Gems/Atom/RHI/Vulkan/Code/Source/RHI/BufferView.cpp) so validation/profile
+            // builds catch this at creation time instead of silently misreading buffer contents at runtime.
+#if defined(AZ_RHI_ENABLE_VALIDATION)
+            AZ_Assert(elementOffsetBase * bufferViewDescriptor.m_elementSize == buffer.GetMemoryView().GetOffset(),
+                "ConvertBufferView - SRV: buffer wasn't aligned with element size; buffer should be created"
+                " with proper alignment");
+#endif
 
             shaderResourceView = {};
             shaderResourceView.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
@@ -223,11 +231,13 @@ namespace AZ
             const uint32_t elementOffsetBase = static_cast<uint32_t>(buffer.GetMemoryView().GetOffset()) / bufferViewDescriptor.m_elementSize;
             const uint32_t elementOffset = elementOffsetBase + bufferViewDescriptor.m_elementOffset;
 
-            if (elementOffsetBase * bufferViewDescriptor.m_elementSize != buffer.GetMemoryView().GetOffset())
-            {
-                AZ_Error("RHI DX12", false, "ConvertBufferView - UAV: buffer wasn't aligned with element size; buffer should be created"
-                    " with proper alignment");
-            }
+            // See the matching comment in the SRV overload above: an unaligned pool sub-allocation offset
+            // must not be allowed to silently produce a wrong FirstElement via truncating division.
+#if defined(AZ_RHI_ENABLE_VALIDATION)
+            AZ_Assert(elementOffsetBase * bufferViewDescriptor.m_elementSize == buffer.GetMemoryView().GetOffset(),
+                "ConvertBufferView - UAV: buffer wasn't aligned with element size; buffer should be created"
+                " with proper alignment");
+#endif
             unorderedAccessView = {};
             unorderedAccessView.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
             unorderedAccessView.Format = ConvertFormat(bufferViewDescriptor.m_elementFormat);

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainDetailMaterialManager.cpp
@@ -915,6 +915,17 @@ namespace Terrain
                     aznumeric_cast<uint8_t>(m_detailMaterials.GetData(region->m_defaultDetailMaterialId).m_detailMaterialBufferIndex);
                 pixel.m_material1 = defaultMaterial;
             }
+            else if (foundMaterials == 1 && firstWeight < 1.0f)
+            {
+                // Only one material matched and it doesn't fully cover this position (e.g. a gradient
+                // falling off toward the edge of its area) -- blend the remaining weight against the
+                // region's default material instead of leaving material2/blend unset, which rendered
+                // the one matched material at full opacity right up to the point its weight hit zero,
+                // producing a hard edge instead of a smooth transition.
+                pixel.m_material2 = region->m_defaultDetailMaterialId == InvalidDetailMaterialId ? m_passthroughMaterialId :
+                    aznumeric_cast<uint8_t>(m_detailMaterials.GetData(region->m_defaultDetailMaterialId).m_detailMaterialBufferIndex);
+                pixel.m_blend = aznumeric_cast<uint8_t>((1.0f - firstWeight) * 255.0f + 0.5f);
+            }
             else if (foundMaterials == 2)
             {
                 float totalWeight = firstWeight + secondWeight;


### PR DESCRIPTION
TerrainDetailMaterialManager::UpdateDetailTexture() only handled two cases when authoring a position's detail-material pixel: zero matched surface tags (use the region's default material) and two (blend between them by weight). A very common third case -- exactly one matched tag whose weight is less than 1.0, e.g. at the falloff edge of a single gradient-driven layer -- fell through both branches. The tag's own material rendered at full opacity for any weight above zero, and the position instantly switched to the fully-opaque default material the moment weight hit zero: a hard, unblended edge exactly on that contour instead of a smooth transition.

This is normally masked by a Macro Material's spatially-varying base-color multiply/crossfade, which is why the artifact only shows up when texturing terrain directly with per-layer materials and no Macro Material, per the official tutorial's alternate workflow.

Fixes #19887

## What does this PR do?

Fixes #19887. see https://ptb.discord.com/channels/805939474655346758/1542426353427681350 for more info in the discord.

## How was this PR tested?

Tested Locally on Windows and Ubuntu (O3DE 26.05)

_This is @JailbreakPapa's work account. please ping that github account for questions/concerns regarding this PR._