### PR TITLE
Add null checks for ConsoleViewPane to prevent wild pointer access

### DIFF
--- a/Code/Editor/QtViewPaneManager.cpp
+++ b/Code/Editor/QtViewPaneManager.cpp
@@ -1121,8 +1121,11 @@ void QtViewPaneManager::RestoreDefaultLayout(bool resetSettings)
         int screenHeight = QApplication::primaryScreen()->size().height();
 
         // Add the console view pane first
-        m_mainWindow->addDockWidget(Qt::BottomDockWidgetArea, consoleViewPane->m_dockWidget);
-        consoleViewPane->m_dockWidget->setFloating(false);
+        if (consoleViewPane)
+        {
+            m_mainWindow->addDockWidget(Qt::BottomDockWidgetArea, consoleViewPane->m_dockWidget);
+            consoleViewPane->m_dockWidget->setFloating(false);
+        }
 
         if (assetBrowserViewPane)
         {
@@ -1131,18 +1134,20 @@ void QtViewPaneManager::RestoreDefaultLayout(bool resetSettings)
 
             static const float bottomTabWidgetPercentage = 0.25f;
             int newHeight = static_cast<int>((float)screenHeight * bottomTabWidgetPercentage);
-
-            AzQtComponents::DockTabWidget* bottomTabWidget = m_advancedDockManager->tabifyDockWidget(assetBrowserViewPane->m_dockWidget, consoleViewPane->m_dockWidget, m_mainWindow);
-            if (bottomTabWidget)
+            if(consoleViewPane)
             {
-                bottomTabWidget->setCurrentWidget(assetBrowserViewPane->m_dockWidget);
+                AzQtComponents::DockTabWidget* bottomTabWidget = m_advancedDockManager->tabifyDockWidget(assetBrowserViewPane->m_dockWidget, consoleViewPane->m_dockWidget, m_mainWindow);
+                if (bottomTabWidget)
+                {
+                    bottomTabWidget->setCurrentWidget(assetBrowserViewPane->m_dockWidget);
 
-                QDockWidget* bottomTabWidgetParent = qobject_cast<QDockWidget*>(bottomTabWidget->parentWidget());
-                m_mainWindow->resizeDocks({ bottomTabWidgetParent }, { newHeight }, Qt::Vertical);
-            }
-            else
-            {
-                m_mainWindow->resizeDocks({ assetBrowserViewPane->m_dockWidget }, { newHeight }, Qt::Vertical);
+                    QDockWidget* bottomTabWidgetParent = qobject_cast<QDockWidget*>(bottomTabWidget->parentWidget());
+                    m_mainWindow->resizeDocks({ bottomTabWidgetParent }, { newHeight }, Qt::Vertical);
+                }
+                else
+                {
+                    m_mainWindow->resizeDocks({ assetBrowserViewPane->m_dockWidget }, { newHeight }, Qt::Vertical);
+                }
             }
         }
 


### PR DESCRIPTION
bugfix : Bug Report-Crash in RestoreDefaultLayout when Console View Pane is unavailable
 #20014

## What does this PR do?

Adds null checking for ConsoleViewPane in QtViewPaneManager to avoid accidental access to wild pointers when no ConsoleView instance has been created.

**Old behavior:** When no ConsoleView instance existed, accessing ConsoleViewPane could result in wild pointer dereference.

**New behavior:** Null checks are performed before accessing ConsoleViewPane, preventing potential crashes from invalid pointer access.