### PR TITLE
Support automatic inertia calculation in ArticulationLink

### DIFF
--- a/Gems/PhysX/Core/Code/Source/Articulation.cpp
+++ b/Gems/PhysX/Core/Code/Source/Articulation.cpp
@@ -15,6 +15,7 @@
 #include <PhysX/MathConversion.h>
 #include <PhysX/NativeTypeIdentifiers.h>
 #include <PhysX/PhysXLocks.h>
+#include <extensions/PxRigidBodyExt.h>
 
 namespace PhysX
 {
@@ -58,6 +59,25 @@ namespace PhysX
         m_pxLink->setActorFlag(physx::PxActorFlag::eDISABLE_GRAVITY, configuration.m_gravityEnabled == false);
 
         AddCollisionShape(thisLinkData);
+
+        // Compute or set inertia tensor from attached shapes.
+        // Note: setMass() alone does NOT update the inertia tensor (PxShape.h:193),
+        // so we must explicitly compute it after shapes are attached.
+        // No scene lock needed: SetupFromLinkData runs during construction (before scene).
+        if (configuration.m_computeInertiaTensor)
+        {
+            if (!m_physicsShapes.empty())
+            {
+                physx::PxVec3 pxCenterOfMass = PxMathConvert(configuration.m_centerOfMassOffset);
+                physx::PxRigidBodyExt::setMassAndUpdateInertia(
+                    *m_pxLink, configuration.m_mass, &pxCenterOfMass, false);
+            }
+        }
+        else
+        {
+            m_pxLink->setMassSpaceInertiaTensor(
+                PxMathConvert(configuration.m_inertiaTensor.RetrieveScale()));
+        }
     }
 
     void ArticulationLink::AddCollisionShape(const ArticulationLinkData& thisLinkData)

--- a/Gems/PhysX/Core/Code/Source/Articulation.cpp
+++ b/Gems/PhysX/Core/Code/Source/Articulation.cpp
@@ -64,9 +64,16 @@ namespace PhysX
         // Note: setMass() alone does NOT update the inertia tensor (PxShape.h:193),
         // so we must explicitly compute it after shapes are attached.
         // No scene lock needed: SetupFromLinkData runs during construction (before scene).
-        if (configuration.m_computeInertiaTensor && !AZ::IsClose(configuration.m_mass, 0.0f))
+        if (configuration.m_computeInertiaTensor)
         {
-            if (!m_physicsShapes.empty())
+            if(configuration.m_mass <= 0.0f)
+            {   
+                // Inertia Use the default value, do not set it.
+                AZ_Warning("ArticulationLink::SetupFromLinkData",
+                           false, 
+                           "When calculating inertia, MASS=%f must be Greater Than zero.", configuration.m_mass);
+            }
+            else if (!m_physicsShapes.empty())
             {
                 physx::PxVec3 pxCenterOfMass = PxMathConvert(configuration.m_centerOfMassOffset);
                 physx::PxRigidBodyExt::setMassAndUpdateInertia(

--- a/Gems/PhysX/Core/Code/Source/Articulation.cpp
+++ b/Gems/PhysX/Core/Code/Source/Articulation.cpp
@@ -64,7 +64,7 @@ namespace PhysX
         // Note: setMass() alone does NOT update the inertia tensor (PxShape.h:193),
         // so we must explicitly compute it after shapes are attached.
         // No scene lock needed: SetupFromLinkData runs during construction (before scene).
-        if (configuration.m_computeInertiaTensor)
+        if (configuration.m_computeInertiaTensor && !AZ::IsClose(configuration.m_mass, 0.0f))
         {
             if (!m_physicsShapes.empty())
             {

--- a/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
+++ b/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
@@ -106,6 +106,8 @@ namespace PhysX
                 ->Field("Sleep threshold", &ArticulationLinkConfiguration::m_sleepMinEnergy)
                 ->Field("Start Asleep", &ArticulationLinkConfiguration::m_startAsleep)
                 ->Field("Centre of mass offset", &ArticulationLinkConfiguration::m_centerOfMassOffset)
+                ->Field("Compute inertia", &ArticulationLinkConfiguration::m_computeInertiaTensor)
+                ->Field("Inertia tensor", &ArticulationLinkConfiguration::m_inertiaTensor)
                 ->Field("Maximum Angular Velocity", &ArticulationLinkConfiguration::m_maxAngularVelocity)
                 ->Field("SolverPositionIterations", &ArticulationLinkConfiguration::m_solverPositionIterations)
                 ->Field("SolverVelocityIterations", &ArticulationLinkConfiguration::m_solverVelocityIterations)
@@ -148,5 +150,10 @@ namespace PhysX
     bool ArticulationLinkConfiguration::IsSingleDofJointType() const
     {
         return HingePropertiesVisible() || PrismaticPropertiesVisible();
+    }
+
+    AZ::Crc32 ArticulationLinkConfiguration::GetInertiaVisibility() const
+    {
+        return !m_computeInertiaTensor ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
     }
 } // namespace PhysX

--- a/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.h
+++ b/Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.h
@@ -89,6 +89,18 @@ namespace PhysX
         bool m_startAsleep = false;
         bool m_gravityEnabled = true;
 
+        // Inertia tensor compute flag.
+        // Default: false to preserve existing project behavior (PhysX native default inertia (1,1,1)).
+        // Set to true to auto-compute inertia from collider shapes via setMassAndUpdateInertia.
+        bool m_computeInertiaTensor = false;      //!< If true, inertia is auto-computed from collider shapes.
+
+        //! Inertia tensor used when m_computeInertiaTensor is false.
+        //! Defaults to identity matrix matching PhysX PxRigidBody default.
+        AZ::Matrix3x3 m_inertiaTensor = AZ::Matrix3x3::CreateIdentity();
+
+        // Edit context visibility helper.
+        AZ::Crc32 GetInertiaVisibility() const;
+
         // PhysX specific Rigid Body configuration
 
         AZ::u8 m_solverPositionIterations = 4; //!< Higher values can improve stability at the cost of performance.

--- a/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
@@ -17,6 +17,7 @@
 #include <Source/ArticulationLinkComponent.h>
 #include <Source/EditorArticulationLinkComponent.h>
 #include <Source/EditorColliderComponent.h>
+#include <Editor/InertiaPropertyHandler.h>
 
 namespace PhysX
 {
@@ -77,6 +78,19 @@ namespace PhysX
                         QT_TRANSLATE_NOOP("PhysX", "COM offset"),
                         QT_TRANSLATE_NOOP("PhysX", "Local space offset for the center of mass (COM)."))
                     ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetLengthUnit())
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ArticulationLinkConfiguration::m_computeInertiaTensor,
+                        QT_TRANSLATE_NOOP("PhysX", "Compute inertia"),
+                        QT_TRANSLATE_NOOP("PhysX", "When active, inertia is computed based on the mass and shape of the articulation link."))
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
+                        Editor::InertiaHandler,
+                        &ArticulationLinkConfiguration::m_inertiaTensor,
+                        QT_TRANSLATE_NOOP("PhysX", "Inertia diagonal"),
+                        QT_TRANSLATE_NOOP("PhysX", "Inertia diagonal elements that specify an inertia tensor; determines the "
+                        "torque required to rotate the articulation link on each axis."))
+                    ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetInertiaUnit())
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ArticulationLinkConfiguration::m_linearDamping,
@@ -206,6 +220,7 @@ namespace PhysX
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDofJointType)
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, QT_TRANSLATE_NOOP("PhysX", "Sensors"))
+
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(nullptr, &ArticulationLinkConfiguration::m_sensorConfigs, "Sensor Configurations", "Sensor configurations")
                     ->EndGroup()

--- a/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp
@@ -90,6 +90,7 @@ namespace PhysX
                         QT_TRANSLATE_NOOP("PhysX", "Inertia diagonal"),
                         QT_TRANSLATE_NOOP("PhysX", "Inertia diagonal elements that specify an inertia tensor; determines the "
                         "torque required to rotate the articulation link on each axis."))
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::GetInertiaVisibility)
                     ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetInertiaUnit())
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,


### PR DESCRIPTION
bugfix : Bug Report-ArticulationLink lacks Inertia Tensor configuration and auto-compute, causing PhysX simulation mismatch with Isaac Sim
 #20016

ArticulationLink supports automatic inertia calculation

What does this PR do?

Adds automatic inertia tensor computation for ArticulationLink components, resolving the significant simulation discrepancies in joint chains between O3DE and Isaac Sim.

Previously, setMass() alone does not update the inertia tensor in PhysX (see PxShape.h:193), so articulation links used a default identity inertia (1,1,1) unless manually specified. This caused joint chain behavior in O3DE to diverge noticeably from Isaac Sim, where inertia is auto-computed from collider shapes.

This PR adds:

- A new Compute inertia boolean property (m_computeInertiaTensor) on ArticulationLinkConfiguration. When enabled, PxRigidBodyExt::setMassAndUpdateInertia is called after shapes are attached to compute the inertia tensor from the attached collider geometry and mass.
- A new Inertia tensor property (m_inertiaTensor) on ArticulationLinkConfiguration, exposed when auto-compute is disabled, allowing users to manually specify the inertia diagonal.
- Editor UI integration for both properties in EditorArticulationLinkComponent, including a custom InertiaHandler for the inertia tensor field and a PropertyRefreshLevels::EntireTree refresh on toggle to show/hide the manual inertia field.
- Serialization support via Reflect for both new fields.

Default is false to preserve existing project behavior (PhysX native default inertia).

Files changed:
- Gems/PhysX/Core/Code/Source/Articulation.cpp — inertia computation logic
- Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.cpp — serialization & visibility helper
- Gems/PhysX/Core/Code/Source/Articulation/ArticulationLinkConfiguration.h — new fields & method declaration
- Gems/PhysX/Core/Code/Source/EditorArticulationLinkComponent.cpp — editor UI integration

How was this PR tested?

Verified that enabling Compute inertia on an ArticulationLink with attached colliders produces an inertia tensor consistent with the collider geometry and mass, and that the resulting joint chain simulation behavior matches Isaac Sim output. Verified that disabling the flag preserves the previous default (1,1,1) inertia behavior.