### PR TITLE
Added an indicator for when the snapping is active

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -156,6 +156,7 @@ void EditorActionsHandler::Initialize(MainWindow* mainWindow)
     AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
     AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
     AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler::BusConnect(DefaultViewportId);
+    AzToolsFramework::ViewportSnapping::ViewportSnappingNotificationBus::Handler::BusConnect();
     AzToolsFramework::EditorPickModeNotificationBus::Handler::BusConnect(editorEntityContextId);
     AzToolsFramework::ContainerEntityNotificationBus::Handler::BusConnect(editorEntityContextId);
 
@@ -171,6 +172,7 @@ EditorActionsHandler::~EditorActionsHandler()
         AzToolsFramework::ContainerEntityNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorPickModeNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler::BusDisconnect();
+        AzToolsFramework::ViewportSnapping::ViewportSnappingNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEventsBus::Handler::BusDisconnect();
@@ -233,6 +235,7 @@ void EditorActionsHandler::OnActionUpdaterRegistrationHook()
     m_actionManagerInterface->RegisterActionUpdater(EditorIdentifiers::EntitySelectionChangedUpdaterIdentifier);
     m_actionManagerInterface->RegisterActionUpdater(EditorIdentifiers::GameModeStateChangedUpdaterIdentifier);
     m_actionManagerInterface->RegisterActionUpdater(EditorIdentifiers::GridSnappingStateChangedUpdaterIdentifier);
+    m_actionManagerInterface->RegisterActionUpdater(EditorIdentifiers::GeometrySnappingStateChangedUpdaterIdentifier);
     m_actionManagerInterface->RegisterActionUpdater(EditorIdentifiers::IconsStateChangedUpdaterIdentifier);
     m_actionManagerInterface->RegisterActionUpdater(EditorIdentifiers::RecentFilesChangedUpdaterIdentifier);
     m_actionManagerInterface->RegisterActionUpdater(EditorIdentifiers::UndoRedoUpdaterIdentifier);
@@ -830,7 +833,70 @@ void EditorActionsHandler::OnActionRegistrationHook()
             // snapping and bind most of the keyboard for it.
             m_actionManagerInterface->AssignModeToAction(
                 AzToolsFramework::DefaultActionContextModeIdentifier, snapModeAction.m_identifier);
+
+            m_actionManagerInterface->AddActionToUpdater(
+                EditorIdentifiers::GeometrySnappingStateChangedUpdaterIdentifier, snapModeAction.m_identifier);
         }
+
+        {
+            constexpr AZStd::string_view actionIdentifier = "o3de.action.edit.snap.snapToNone";
+            AzToolsFramework::ActionProperties actionProperties;
+            actionProperties.m_name = "None";
+            actionProperties.m_description = "Disable geometry snapping.";
+            actionProperties.m_category = "Edit";
+            actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
+
+            m_actionManagerInterface->RegisterCheckableAction(
+                EditorIdentifiers::MainWindowActionContextIdentifier,
+                actionIdentifier,
+                actionProperties,
+                []
+                {
+                    if (auto* snapping = AzToolsFramework::ViewportSnapping::ViewportSnappingRequests::Get())
+                    {
+                        snapping->SetSnapMode(SnapMode::Off);
+                    }
+                },
+                []() -> bool
+                {
+                    return AzToolsFramework::ViewportSnapping::GetSnapMode() == SnapMode::Off;
+                });
+
+            m_actionManagerInterface->AddActionToUpdater(
+                EditorIdentifiers::GeometrySnappingStateChangedUpdaterIdentifier, actionIdentifier);
+        }
+
+        constexpr AZStd::string_view actionIdentifier = "o3de.action.edit.snap.geometrySnapping";
+        AzToolsFramework::ActionProperties actionProperties;
+        actionProperties.m_name = "Geometry Snapping";
+        actionProperties.m_description = "Toggle geometry snapping.";
+        actionProperties.m_category = "Edit";
+        actionProperties.m_iconPath = ":/stylesheet/img/UI20/toolbar/Vertex_snapping.svg";
+        actionProperties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
+        actionProperties.m_toolBarVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
+
+        m_actionManagerInterface->RegisterCheckableAction(
+            EditorIdentifiers::MainWindowActionContextIdentifier,
+            actionIdentifier,
+            actionProperties,
+            []
+            {
+                if (auto* snapping = AzToolsFramework::ViewportSnapping::ViewportSnappingRequests::Get())
+                {
+                    using AzToolsFramework::ViewportSnapping::SnapMode;
+                    snapping->SetSnapMode(
+                        snapping->IsSnappingEnabled() ? SnapMode::Off : SnapMode::Face);
+                }
+            },
+            []() -> bool
+            {
+                return AzToolsFramework::ViewportSnapping::IsSnappingEnabled();
+            });
+
+        m_actionManagerInterface->AddActionToUpdater(
+            EditorIdentifiers::GeometrySnappingStateChangedUpdaterIdentifier, actionIdentifier);
+
+        UpdateGeometrySnappingAction();
 
         // Ctrl+Shift+V for vertex, the mode this is most often wanted in. Single letters are
         // claimed by component modes, so a plain "V" is not available.
@@ -1988,6 +2054,8 @@ void EditorActionsHandler::OnMenuBindingHook()
                         EditorIdentifiers::EditModifySnapToMenuIdentifier, "o3de.action.edit.snap.snapToFace", 400);
                     m_menuManagerInterface->AddActionToMenu(
                         EditorIdentifiers::EditModifySnapToMenuIdentifier, "o3de.action.edit.snap.snapToFaceCenter", 500);
+                    m_menuManagerInterface->AddActionToMenu(
+                        EditorIdentifiers::EditModifySnapToMenuIdentifier, "o3de.action.edit.snap.snapToNone", 600);
                 }
             }
             m_menuManagerInterface->AddSubMenuToMenu(EditorIdentifiers::EditModifyMenuIdentifier, EditorIdentifiers::EditModifyModesMenuIdentifier, 200);
@@ -2344,6 +2412,43 @@ void EditorActionsHandler::OnGridSnappingChanged([[maybe_unused]] bool enabled)
 void EditorActionsHandler::OnIconsVisibilityChanged([[maybe_unused]] bool enabled)
 {
     m_actionManagerInterface->TriggerActionUpdater(EditorIdentifiers::IconsStateChangedUpdaterIdentifier);
+}
+
+void EditorActionsHandler::OnSnapModeChanged([[maybe_unused]] AzToolsFramework::ViewportSnapping::SnapMode mode)
+{
+    UpdateGeometrySnappingAction();
+    m_actionManagerInterface->TriggerActionUpdater(EditorIdentifiers::GeometrySnappingStateChangedUpdaterIdentifier);
+}
+
+void EditorActionsHandler::UpdateGeometrySnappingAction()
+{
+    constexpr AZStd::string_view actionIdentifier = "o3de.action.edit.snap.geometrySnapping";
+    const AzToolsFramework::ViewportSnapping::SnapMode mode = AzToolsFramework::ViewportSnapping::GetSnapMode();
+
+    const char* modeName = nullptr;
+    switch (mode)
+    {
+    case AzToolsFramework::ViewportSnapping::SnapMode::Vertex:
+        modeName = "Vertex";
+        break;
+    case AzToolsFramework::ViewportSnapping::SnapMode::Edge:
+        modeName = "Edge";
+        break;
+    case AzToolsFramework::ViewportSnapping::SnapMode::EdgeMidpoint:
+        modeName = "Edge Midpoint";
+        break;
+    case AzToolsFramework::ViewportSnapping::SnapMode::Face:
+        modeName = "Face";
+        break;
+    case AzToolsFramework::ViewportSnapping::SnapMode::FaceCenter:
+        modeName = "Face Center";
+        break;
+    case AzToolsFramework::ViewportSnapping::SnapMode::Off:
+        break;
+    }
+
+    m_actionManagerInterface->SetActionName(
+        actionIdentifier, modeName ? AZStd::string::format("Geometry Snapping: %s", modeName) : "Geometry Snapping");
 }
 
 void EditorActionsHandler::OnEntityPickModeStarted()

--- a/Code/Editor/Core/EditorActionsHandler.h
+++ b/Code/Editor/Core/EditorActionsHandler.h
@@ -15,6 +15,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityNotificationBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzToolsFramework/ViewportSnapping/ViewportSnapping.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 class CCryEditApp;
@@ -41,6 +42,7 @@ class EditorActionsHandler
     , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
     , private AzToolsFramework::ToolsApplicationNotificationBus::Handler
     , private AzToolsFramework::ViewportInteraction::ViewportSettingsNotificationBus::Handler
+    , private AzToolsFramework::ViewportSnapping::ViewportSnappingNotificationBus::Handler
     , private AzToolsFramework::EditorPickModeNotificationBus::Handler
     , private AzToolsFramework::ContainerEntityNotificationBus::Handler
 {
@@ -87,6 +89,9 @@ private:
     void OnGridSnappingChanged(bool enabled) override;
     void OnIconsVisibilityChanged(bool enabled) override;
 
+    // ViewportSnappingNotificationBus overrides ...
+    void OnSnapModeChanged(AzToolsFramework::ViewportSnapping::SnapMode mode) override;
+
     // EditorPickModeNotificationBus overrides ...
     void OnEntityPickModeStarted() override;
     void OnEntityPickModeStopped() override;
@@ -114,6 +119,8 @@ private:
     // View Bookmarks
     int m_defaultBookmarkCount = 12;
     void InitializeViewBookmarkActions();
+
+    void UpdateGeometrySnappingAction();
 
     bool m_initialized = false;
 

--- a/Code/Editor/ViewPane.cpp
+++ b/Code/Editor/ViewPane.cpp
@@ -513,8 +513,8 @@ void CLayoutViewPane::OnMenuBindingHook()
         // first because the entries above quantise a value, while this snaps to what is in the
         // level - related enough to share the menu, different enough not to read as one group.
         m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::ViewportOptionsMenuIdentifier, 850);
-        m_menuManagerInterface->AddSubMenuToMenu(
-            EditorIdentifiers::ViewportOptionsMenuIdentifier, EditorIdentifiers::EditModifySnapToMenuIdentifier, 900);
+        m_menuManagerInterface->AddActionToMenu(
+            EditorIdentifiers::ViewportOptionsMenuIdentifier, "o3de.action.edit.snap.geometrySnapping", 875);
     }
 }
 
@@ -531,6 +531,11 @@ void CLayoutViewPane::OnToolBarBindingHook()
         EditorIdentifiers::ViewportTopToolBarIdentifier, "o3de.action.view.showHelpers", EditorIdentifiers::ViewportHelpersMenuIdentifier, 700);
     m_toolBarManagerInterface->AddActionWithSubMenuToToolBar(
         EditorIdentifiers::ViewportTopToolBarIdentifier, "o3de.action.viewport.resizeIcon", EditorIdentifiers::ViewportSizeMenuIdentifier, 800);
+    m_toolBarManagerInterface->AddActionWithSubMenuToToolBar(
+        EditorIdentifiers::ViewportTopToolBarIdentifier,
+        "o3de.action.edit.snap.geometrySnapping",
+        EditorIdentifiers::EditModifySnapToMenuIdentifier,
+        850);
     m_toolBarManagerInterface->AddActionWithSubMenuToToolBar(
         EditorIdentifiers::ViewportTopToolBarIdentifier, "o3de.action.viewport.menuIcon", EditorIdentifiers::ViewportOptionsMenuIdentifier, 900);
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Editor/ActionManagerIdentifiers/EditorActionUpdaterIdentifiers.h
@@ -22,6 +22,7 @@ namespace EditorIdentifiers
     inline constexpr AZStd::string_view GameModeStateChangedUpdaterIdentifier = "o3de.updater.onGameModeStateChanged";
     inline constexpr AZStd::string_view GridShowingChangedUpdaterIdentifier = "o3de.updater.onGridShowingChanged";
     inline constexpr AZStd::string_view GridSnappingStateChangedUpdaterIdentifier = "o3de.updater.onGridSnappingStateChanged";
+    inline constexpr AZStd::string_view GeometrySnappingStateChangedUpdaterIdentifier = "o3de.updater.onGeometrySnappingStateChanged";
     inline constexpr AZStd::string_view IconsStateChangedUpdaterIdentifier = "o3de.updater.onViewportIconsStateChanged";
     inline constexpr AZStd::string_view LevelLoadedUpdaterIdentifier = "o3de.updater.onLevelLoaded";
     inline constexpr AZStd::string_view RecentFilesChangedUpdaterIdentifier = "o3de.updater.onRecentFilesChanged";

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSnapping/ViewportSnapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSnapping/ViewportSnapper.cpp
@@ -158,6 +158,11 @@ namespace AzToolsFramework
 
         void ViewportSnapper::SetSnapMode(const SnapMode mode)
         {
+            if (m_mode == mode)
+            {
+                return;
+            }
+
             m_mode = mode;
 
             if (m_mode == SnapMode::Off)
@@ -165,6 +170,8 @@ namespace AzToolsFramework
                 // Do not hold mesh caches while the feature is off.
                 m_visibleGeometrySource.Clear();
             }
+
+            ViewportSnappingNotificationBus::Broadcast(&ViewportSnappingNotifications::OnSnapModeChanged, m_mode);
         }
 
         bool ViewportSnapper::IsSnappingEnabled() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSnapping/ViewportSnapping.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSnapping/ViewportSnapping.h
@@ -11,6 +11,7 @@
 #include <AzToolsFramework/ViewportSnapping/ViewportSnapSourceBus.h>
 
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/RTTI.h>
@@ -93,6 +94,19 @@ namespace AzToolsFramework
             Face,
             FaceCenter
         };
+
+        class ViewportSnappingNotifications : public AZ::EBusTraits
+        {
+        public:
+            virtual void OnSnapModeChanged([[maybe_unused]] SnapMode mode)
+            {
+            }
+
+        protected:
+            ~ViewportSnappingNotifications() = default;
+        };
+
+        using ViewportSnappingNotificationBus = AZ::EBus<ViewportSnappingNotifications>;
 
         //! Editor-wide geometry snapping service.
         //!


### PR DESCRIPTION
Added an indicator for when the snapping is active.

Now there is an icon that goes blue when the snapping is active. next to the icon there is a dropdown where you can pick the snap mode
<img width="469" height="177" alt="Screenshot 2026-08-28 215723" src="https://github.com/user-attachments/assets/4fdaf08b-e054-4a8f-88fd-122b6e7b8822" />
<img width="439" height="191" alt="Screenshot 2026-08-28 215656" src="https://github.com/user-attachments/assets/4026a0a9-c47f-44de-867c-957649d3b40c" />

the default mode is vertex snap. 

tested on windows