### PR TITLE
Expose input vibration requests to scripting

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
@@ -9,6 +9,7 @@
 #include <AzFramework/Input/System/InputSystemComponent.h>
 
 #include <AzFramework/Input/Buses/Notifications/InputSystemNotificationBus.h>
+#include <AzFramework/Input/Buses/Requests/InputHapticFeedbackRequestBus.h>
 
 #include <AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
@@ -134,6 +135,11 @@ namespace AzFramework
             behaviorContext->EBus<InputSystemRequestBus>("InputSystemRequestBus")
                 ->Attribute(AZ::Script::Attributes::Category, "Input")
                 ->Event("RecreateEnabledInputDevices", &InputSystemRequestBus::Events::RecreateEnabledInputDevices)
+                ;
+
+            behaviorContext->EBus<InputHapticFeedbackRequestBus>("InputHapticFeedbackRequestBus")
+                ->Attribute(AZ::Script::Attributes::Category, "Input")
+                ->Event("SetVibration", &InputHapticFeedbackRequestBus::Events::SetVibration)
                 ;
         }
 


### PR DESCRIPTION
## What does this PR do?

O3DE already provides `InputHapticFeedbackRequestBus` for controlling gamepad vibration in C++, but the bus was not reflected to the `BehaviorContext`. As a result, `SetVibration` could not be called from Lua or Script Canvas.

This PR exposes `InputHapticFeedbackRequestBus` and its `SetVibration` event to scripting.

Requests can be sent in two ways:

- `Event` addresses a specific device using its `InputDeviceId`.
- `Broadcast` sends the request to all connected gamepads by default.

```lua
local gamepad0 = InputDeviceId("gamepad", 0)
local gamepad1 = InputDeviceId("gamepad", 1)

-- Event sends vibration only to the specified gamepad.
InputHapticFeedbackRequestBus.Event.SetVibration(gamepad0, 1.0, 1.0)

-- Broadcast sends vibration to all connected gamepads by default.
InputHapticFeedbackRequestBus.Broadcast.SetVibration(1.0, 1.0)
```

Constructing an `InputDeviceId` from Lua was enabled by the prerequisite PR: [Fix InputDeviceId construction in Lua (#20027)](https://github.com/o3de/o3de/pull/20027).

## How was this PR tested?

- Successfully built the Editor target in the `profile` configuration on Windows.
- Verified through Lua `ScriptContext` with two separately addressed gamepad handlers that `Event.SetVibration` reaches only the requested gamepad and preserves both motor-speed values.
- Verified that a two-gamepad Lua test script is successfully processed by the Asset Processor.
