### PR TITLE
Atom Upscaler Changes

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
@@ -7,16 +7,43 @@
  */
 #pragma once
 
+// This header declares ID3D12*/IDXGI* pointers, so it must pull in the D3D12 and DXGI headers
+// itself. Without these it only compiles when the including translation unit happens to have
+// included them first, which is why including it from a gem (e.g. FSR3) failed with
+// "missing ';' before '*'".
+//
+// PlatformIncl.h MUST come first. <d3d12.h> includes <windows.h>, and a bare <windows.h> pulls in
+// the legacy <winsock.h>. Any translation unit that later reaches <WinSock2.h> then fails with a
+// wall of C2011/C2375 redefinitions (sockaddr, fd_set, timeval, accept, bind, ...), because the
+// two socket headers declare the same symbols with different linkage. PlatformIncl.h defines
+// WIN32_LEAN_AND_MEAN (and NOMINMAX) before <windows.h>, which suppresses the legacy header and
+// leaves WinSock2.h free to define those symbols once.
+#include <AzCore/PlatformIncl.h>
+
+#include <d3d12.h>
+#include <dxgi1_6.h>
+
+#include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/DeviceBuffer.h>
 #include <Atom/RHI/DeviceFence.h>
 #include <Atom/RHI/DeviceImage.h>
 #include <Atom/RHI/PhysicalDevice.h>
 
-#include <AzCore/PlatformIncl.h>
-#include <d3d12.h>
-#include <dxgi.h>
-#include <dxgi1_4.h>
+// Base_Platform.h, NOT <d3d12.h> + <dxgi*.h> directly.
+//
+// The desktop headers are wrong on platforms whose D3D12 comes from a different SDK. Including
+// <d3d12.h> alongside a console's own d3d12 header trips that header's own guard --
+//     error C1189: D3D12_X cannot be mixed with stock DXGICommon
+// followed by a cascade of errors inside dxgi.h. Base_Platform.h resolves through o3de_pal_dir to
+// whichever D3D12 header the platform actually uses, which is the same indirection the rest of
+// this gem already relies on.
+//
+// The DXGI includes are dropped rather than replaced: the only DXGI name used here is
+// IDXGIAdapter3 in GetPhysicalDeviceNativeHandle below, and a forward declaration is sufficient for
+// a returned pointer. Platforms with real DXGI get it transitively; platforms without one
+// forward-declare it in their own Base header.
+#include <Atom/RHI.Reflect/DX12/Base_Platform.h>
 
 namespace AZ
 {
@@ -50,5 +77,13 @@ namespace AZ
         size_t GetImageMemoryViewSize(RHI::DeviceImage& image);
         size_t GetImageAllocationOffset(RHI::DeviceImage& image);
         size_t GetImageHeapOffset(RHI::DeviceImage& image);
+
+        //! Provide access to the native command list for recording into via external libraries
+        ID3D12GraphicsCommandList* GetCommandListNativeHandle(RHI::CommandList& commandList);
+
+        //! Provide access to the native graphics queue, which is also the queue the RHI presents on.
+        //! Needed by external presentation libraries (frame-generation proxy swapchains) that must
+        //! serialize their own submissions against the queue the application presents from.
+        ID3D12CommandQueue* GetPresentCommandQueueNativeHandle(RHI::Device& device);
     } // namespace DX12
 } // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/SwapChainProxy.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Interface/DX12/SwapChainProxy.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+// Windows only. The proxy traffics in IDXGISwapChain4, which does not exist on D3D12 platforms
+// that have no DXGI (consoles present through their own path and never create a DXGI swapchain).
+#if defined(AZ_PLATFORM_WINDOWS)
+
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/RTTI/RTTI.h>
+
+// PlatformIncl.h MUST come first; see the comment in RHIDX12Interface.h for why a bare
+// <windows.h> (pulled in by <d3d12.h>) breaks any translation unit that later reaches WinSock2.
+#include <AzCore/PlatformIncl.h>
+
+#include <d3d12.h>
+#include <dxgi1_6.h>
+
+namespace AZ::DX12
+{
+    //! Lets a gem substitute its own IDXGISwapChain4 implementation for the one Atom creates.
+    //!
+    //! WHY THIS EXISTS: frame-generation upscalers (AMD FSR3, NVIDIA DLSS-G) do not present the
+    //! frames the application renders. They wrap the real swapchain in a proxy that owns the
+    //! present timeline, injects interpolated frames between the application's frames and paces
+    //! them. That wrapping can only happen where the swapchain is created -- an already-created
+    //! swapchain has back buffers the RHI has handed out as RHI::Image resources, so it cannot be
+    //! swapped underneath them. Hence a hook here rather than an accessor a gem calls later.
+    //!
+    //! Register an implementation with AZ::Interface<ISwapChainProxy> BEFORE the render window is
+    //! created -- a system component's Init() is early enough, Activate() is not guaranteed to be.
+    //! At most one proxy may be registered; a second registration is a programming error.
+    //!
+    //! Reference counting: ReplaceSwapChain is handed ONE reference, which it owns. If it returns
+    //! true it must release (or transfer ownership of) the incoming swapchain and write back a
+    //! replacement it also holds one reference to. If it returns false it must leave the incoming
+    //! pointer and its reference untouched.
+    class ISwapChainProxy
+    {
+    public:
+        AZ_RTTI(ISwapChainProxy, "{3E1D5B24-9A07-4C6F-8B31-6D2F0A7C4E58}");
+
+        virtual ~ISwapChainProxy() = default;
+
+        //! @param presentQueue the ID3D12CommandQueue the RHI presents on.
+        //! @param inOutSwapChain in: the swapchain Atom just created; out: the replacement.
+        //! @return true if inOutSwapChain was replaced. False leaves Atom using the original.
+        virtual bool ReplaceSwapChain(ID3D12CommandQueue* presentQueue, IDXGISwapChain4*& inOutSwapChain) = 0;
+
+        //! Called just before the RHI releases its reference, so the proxy can flush any
+        //! outstanding presents and drop cached handles to it.
+        virtual void OnSwapChainDestroyed(IDXGISwapChain4* swapChain) = 0;
+    };
+
+    using SwapChainProxyInterface = AZ::Interface<ISwapChainProxy>;
+} // namespace AZ::DX12
+
+#endif // AZ_PLATFORM_WINDOWS

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.cpp
@@ -8,6 +8,7 @@
 
 #include <RHI/SwapChain_Windows.h>
 
+#include <Atom/RHI.Interface/DX12/SwapChainProxy.h>
 #include <RHI/Device.h>
 #include <RHI/Conversions.h>
 #include <RHI/Image.h>
@@ -63,6 +64,8 @@ namespace AZ
             RHI::ResultCode result = device.CreateSwapChain(reinterpret_cast<IUnknown*>(descriptor.m_window.GetIndex()), swapChainDesc, m_swapChain);
             if (result == RHI::ResultCode::Success)
             {
+                TryReplaceWithProxy(device);
+
                 ConfigureDisplayMode(*nativeDimensions);
 
                 // According to various docs (and the D3D12Fulscreen sample), when tearing is supported
@@ -93,24 +96,96 @@ namespace AZ
 
         void SwapChain::ShutdownInternal()
         {
+            // Let a registered proxy (frame-generation swapchain) flush outstanding presents and
+            // drop its handle before we release ours -- it may still own GPU work on this chain.
+            if (m_replacedByProxy)
+            {
+                if (auto* proxy = SwapChainProxyInterface::Get())
+                {
+                    proxy->OnSwapChainDestroyed(m_swapChain.get());
+                }
+                m_replacedByProxy = false;
+            }
+
             // We must exit exclusive full screen mode before shutting down.
             // Safe to call even if not in the exclusive full screen state.
             m_swapChain->SetFullscreenState(0, nullptr);
             m_swapChain = nullptr;
         }
 
+        void SwapChain::TryReplaceWithProxy(Device& device)
+        {
+            auto* proxy = SwapChainProxyInterface::Get();
+            if (!proxy || !m_swapChain)
+            {
+                return;
+            }
+
+            ID3D12CommandQueue* presentQueue =
+                device.GetCommandQueueContext().GetCommandQueue(RHI::HardwareQueueClass::Graphics).GetPlatformQueue();
+            if (!presentQueue)
+            {
+                return;
+            }
+
+            // Hand the proxy exactly one reference, per the ISwapChainProxy contract, and take one
+            // back. The local raw pointer holds that transferred reference across the call so the
+            // chain cannot be destroyed underneath us while m_swapChain is momentarily empty.
+            IDXGISwapChainX* transferred = m_swapChain.get();
+            transferred->AddRef();
+            m_swapChain = nullptr;
+
+            IDXGISwapChain4* replacement = transferred;
+            const bool replaced = proxy->ReplaceSwapChain(presentQueue, replacement);
+            if (!replaced || !replacement)
+            {
+                // Contract says a declining proxy leaves the pointer and its reference untouched.
+                replacement = transferred;
+            }
+
+            m_swapChain = replacement;  // intrusive_ptr adds its own reference...
+            replacement->Release();     // ...so give up the transferred one.
+
+            m_replacedByProxy = replaced && (replacement != transferred);
+            AZ_TracePrintf(
+                "DX12",
+                "SwapChain: proxy %s the DXGI swapchain.",
+                m_replacedByProxy ? "replaced" : "declined to replace");
+        }
+
         uint32_t SwapChain::PresentInternal()
         {
             if (m_swapChain)
             {
-                // It is recommended to always pass the DXGI_PRESENT_ALLOW_TEARING flag when it is supported, even when presenting in windowed mode.
-                // But it cannot be used in an application that is currently in full screen exclusive mode, set by calling SetFullscreenState(TRUE).
-                // To use this flag in full screen Win32 apps the application should present to a fullscreen borderless window and disable automatic
-                // ALT+ENTER fullscreen switching using IDXGIFactory::MakeWindowAssociation (please see implementation of SwapChain::InitInternal).
-                // UINT presentFlags = (m_isTearingSupported && !m_isInFullScreenExclusiveState) ? DXGI_PRESENT_ALLOW_TEARING : 0;
-                HRESULT hresult = m_swapChain->Present(GetDescriptor().m_verticalSyncInterval, 0);
+                // This is a flip model swapchain (DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL). Present(0, 0) on a
+                // flip model chain does NOT run unlocked - DXGI still waits to flip at vblank, it just
+                // discards the frames queued in between. The frame rate stays pinned to the display's
+                // refresh rate no matter what the vsync interval is set to. Passing
+                // DXGI_PRESENT_ALLOW_TEARING is the only way to actually present unlocked, and the
+                // swapchain is already created with DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING to permit it
+                // (see InitInternal).
+                //
+                // The flag is only legal with a sync interval of 0 - passing it alongside a non-zero
+                // interval fails the Present with DXGI_ERROR_INVALID_CALL. It also cannot be used while
+                // in full screen exclusive mode, entered via SetFullscreenState(TRUE); full screen Win32
+                // apps wanting tearing should use a borderless window with automatic ALT+ENTER switching
+                // disabled through IDXGIFactory::MakeWindowAssociation (see InitInternal).
+                const uint32_t verticalSyncInterval = GetDescriptor().m_verticalSyncInterval;
+                const UINT presentFlags =
+                    (verticalSyncInterval == 0 && m_isTearingSupported && !m_isInFullScreenExclusiveState)
+                    ? DXGI_PRESENT_ALLOW_TEARING
+                    : 0;
 
-                GetDevice().AssertSuccess(hresult);
+                HRESULT hresult = m_swapChain->Present(verticalSyncInterval, presentFlags);
+
+                if (!GetDevice().AssertSuccess(hresult))
+                {
+                    // A failed Present (e.g. DXGI_ERROR_DEVICE_REMOVED) may have already run
+                    // Device::OnDeviceRemoved()'s cleanup by this point, which can invalidate swapchain
+                    // image state. Don't touch GetImageCount()/advance the index on top of that -- matches
+                    // ResizeInternal()'s handling of the same AssertSuccess() failure case below.
+                    return GetCurrentImageIndex();
+                }
 
                 return (GetCurrentImageIndex() + 1) % GetImageCount();
             }

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/SwapChain_Windows.h
@@ -44,6 +44,10 @@ namespace AZ
             bool SetExclusiveFullScreenState(bool fullScreenState) override;
             //////////////////////////////////////////////////////////////////////////
 
+            //! Offers the freshly created DXGI swapchain to a registered AZ::DX12::ISwapChainProxy
+            //! (frame-generation proxy swapchain) and adopts the replacement if it takes it.
+            void TryReplaceWithProxy(Device& device);
+
             void ConfigureDisplayMode(const RHI::SwapChainDimensions& dimensions);
             void EnsureColorSpace(const DXGI_COLOR_SPACE_TYPE& colorSpace);
             void DisableHdr();
@@ -55,6 +59,7 @@ namespace AZ
             RHI::Ptr<IDXGISwapChainX> m_swapChain;
             bool m_isInFullScreenExclusiveState = false; //!< Was SetFullscreenState used to enter full screen exclusive state?
             bool m_isTearingSupported = false; //!< Is tearing support available for full screen borderless windowed mode?
+            bool m_replacedByProxy = false; //!< Is m_swapChain a proxy handed to us by an ISwapChainProxy?
         };
     }
 }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI.Reflect/RHIDX12Interface.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI.Reflect/RHIDX12Interface.cpp
@@ -10,6 +10,7 @@
 #include <RHI/DX12.h>
 
 #include <RHI/Buffer.h>
+#include <RHI/CommandList.h>
 #include <RHI/Device.h>
 #include <RHI/Fence.h>
 #include <RHI/Image.h>
@@ -28,7 +29,17 @@ namespace AZ
         IDXGIAdapter3* GetPhysicalDeviceNativeHandle(const RHI::PhysicalDevice& device)
         {
             AZ_Assert(azrtti_cast<const PhysicalDevice*>(&device), "%s can only be called with a DX12 RHI object", __FUNCTION__);
-            return static_cast<const PhysicalDevice*>(&device)->GetAdapter();
+
+            // reinterpret_cast because GetAdapter() returns IDXGIAdapterX, whose definition is
+            // per-platform. Where DXGI is real (Windows) IDXGIAdapterX IS IDXGIAdapter3, so this
+            // is a no-op cast between identical types. Where there is no DXGI at all, the alias is
+            // IUnknown and the pointer is ALWAYS null -- such platforms enumerate no adapters, so
+            // PhysicalDevice::GetAdapter has nothing to return. Casting a null pointer is
+            // well-defined and nothing can dereference the result.
+            //
+            // A static_cast cannot express this: the two types are unrelated on a platform without
+            // DXGI, so it fails to compile there while being redundant everywhere else.
+            return reinterpret_cast<IDXGIAdapter3*>(static_cast<const PhysicalDevice*>(&device)->GetAdapter());
         }
 
         ID3D12Fence* GetFenceNativeHandle(RHI::DeviceFence& fence)
@@ -111,6 +122,24 @@ namespace AZ
             AZ_Assert(azrtti_cast<Image*>(&image), "%s can only be called with a DX12 RHI object", __FUNCTION__);
             auto& dx12Image = static_cast<Image&>(image);
             return dx12Image.GetMemoryView().GetHeapOffset();
+        }
+
+        ID3D12GraphicsCommandList* GetCommandListNativeHandle(RHI::CommandList& commandList)
+        {
+            // No azrtti_cast assert here: AZ::DX12::CommandList does not declare AZ_TYPE_INFO/AZ_RTTI,
+            // so azrtti_cast<CommandList*> would fail the HasAzTypeInfo_v static-assert. Other helpers
+            // in this file can use the assert because their target types (Device, Buffer, Image,
+            // PhysicalDevice, FenceImpl) all have AZ_RTTI.
+            return static_cast<CommandList&>(commandList).GetCommandList();
+        }
+
+        ID3D12CommandQueue* GetPresentCommandQueueNativeHandle(RHI::Device& device)
+        {
+            AZ_Assert(azrtti_cast<Device*>(&device), "%s can only be called with a DX12 RHI object", __FUNCTION__);
+            return static_cast<Device&>(device)
+                .GetCommandQueueContext()
+                .GetCommandQueue(RHI::HardwareQueueClass::Graphics)
+                .GetPlatformQueue();
         }
     } // namespace DX12
 } // namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/atom_rhi_dx12_interface_common_files.cmake
+++ b/Gems/Atom/RHI/DX12/Code/atom_rhi_dx12_interface_common_files.cmake
@@ -8,5 +8,6 @@
 
 set(FILES
     Include/Atom/RHI.Interface/DX12/RHIDX12Interface.h
+    Include/Atom/RHI.Interface/DX12/SwapChainProxy.h
     Source/RHI.Reflect/RHIDX12Interface.cpp
 )


### PR DESCRIPTION
## What does this PR do?

Adds Support for Upscalars in Atom that may need native RHI resources (device, swapchain, etc)

## How was this PR tested?

Tested on Windows & Ubuntu 26.05
