### PR TITLE
Crash handler Improvements

### DIFF
--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -67,9 +67,80 @@ static CCryEditDoc * theDocument;
 
 #if defined(EXTERNAL_CRASH_REPORTING)
 #include <ToolsCrashHandler.h>
+#include <QDir>
+
+namespace
+{
+    //! Best-effort emergency save, invoked from inside the crash handler. Returns the file written,
+    //! or empty when there was nothing to save or the save failed.
+    //!
+    //! This deliberately runs work that is not async-signal-safe (see SetEmergencySaveCallback's
+    //! warning) - saving a level allocates and takes locks. It is the same trade other engines'
+    //! crash handlers make: losing the user's unsaved work is worse than a small chance of the
+    //! save itself faulting, and the crash report is already captured by this point either way.
+    AZStd::string AttemptEmergencyLevelSave()
+    {
+        CCryEditDoc* document = GetIEditor() ? GetIEditor()->GetDocument() : nullptr;
+        if (!document || !document->IsDocumentReady() || !document->IsModified())
+        {
+            return {};
+        }
+
+        CGameEngine* gameEngine = GetIEditor()->GetGameEngine();
+        if (!gameEngine)
+        {
+            return {};
+        }
+
+        const QString levelPath = gameEngine->GetLevelPath();
+        const QString levelName = gameEngine->GetLevelName();
+        if (levelPath.isEmpty() || levelName.isEmpty())
+        {
+            return {};
+        }
+
+        // Reuse the editor's existing autobackup path rather than inventing a parallel save
+        // format; bForce bypasses the user's autobackup-enabled preference, which should not
+        // decide whether crash recovery happens.
+        document->SaveAutoBackup(true);
+
+        // SaveAutoBackup names its folder with a "yyyy-MM-dd [HH.mm.ss]" timestamp and does not
+        // report the path back, so pick the newest entry. That format sorts lexicographically in
+        // chronological order, which makes "newest" a plain string comparison.
+        const QDir backupRoot(levelPath + "/_autobackup");
+        const QStringList backups =
+            backupRoot.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+        if (backups.isEmpty())
+        {
+            return {};
+        }
+
+        const QString savedFile = backupRoot.absoluteFilePath(
+            backups.last() + "/" + levelName + "/" + levelName + gameEngine->GetLevelExtension());
+        return QFile::exists(savedFile) ? AZStd::string(savedFile.toUtf8().constData()) : AZStd::string{};
+    }
+}
+#endif
 #endif
 #ifndef VERIFY
 #define VERIFY(EXPRESSION) { auto e = EXPRESSION; assert(e); }
+#endif
+
+#if defined(AZ_DEBUG_BUILD) || defined(AZ_PROFILE_BUILD)
+#include <AzCore/Console/IConsole.h>
+namespace
+{
+    // Intentionally faults the process so the crash handler pipeline can be exercised without
+    // waiting for a real bug. Compiled out entirely in Release builds.
+    void SimulateCrash(const AZ::ConsoleCommandContainer&)
+    {
+        AZ_Warning("CrashReporting", false, "simulate_crash invoked - intentionally crashing the Editor to test the crash handler");
+        volatile int* crashPtr = nullptr;
+        *crashPtr = 0;
+    }
+    AZ_CONSOLEFREEFUNC("simulate_crash", SimulateCrash, AZ::ConsoleFunctorFlags::Null,
+        "Intentionally crashes the Editor to test the crash handler pipeline. Debug/Profile only.");
+}
 #endif
 
 const char* CEditorImpl::m_crashLogFileName = "SessionStatus/editor_statuses.json";
@@ -145,6 +216,7 @@ void CEditorImpl::Initialize()
 {
 #if defined(EXTERNAL_CRASH_REPORTING)
     CrashHandler::ToolsCrashHandler::InitCrashHandler("Editor", {});
+    SentryCrash::SetEmergencySaveCallback(&AttemptEmergencyLevelSave);
 #endif
 
     // Must be set before QApplication is initialized, so that we support HighDpi monitors, like the Retina displays

--- a/Code/Tools/CrashHandler/CMakeLists.txt
+++ b/Code/Tools/CrashHandler/CMakeLists.txt
@@ -14,6 +14,12 @@ if(NOT PAL_TRAIT_BUILD_EXTERNAL_CRASH_HANDLER_SUPPORTED)
     return()
 endif()
 
+if(PAL_TRAIT_CRASH_HANDLER_BACKEND STREQUAL "SentryNative")
+    include(${LY_ROOT_FOLDER}/cmake/3rdParty/sentry-native.cmake)
+    add_subdirectory(SentryNative)
+    return()
+endif()
+
 add_subdirectory(Support)
 
 ly_add_target(

--- a/Code/Tools/CrashHandler/SentryNative/CMakeLists.txt
+++ b/Code/Tools/CrashHandler/SentryNative/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Shared, Qt-free wiring used by both this tools layer and the CrashReporting gem's runtime path.
+add_subdirectory(Core)
+
+if(NOT PAL_TRAIT_BUILD_HOST_TOOLS)
+    return()
+endif()
+
+ly_add_target(
+    NAME ToolsCrashHandler STATIC
+    NAMESPACE AZ
+    FILES_CMAKE
+        sentry_native_crash_handler_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            include
+    BUILD_DEPENDENCIES
+        PUBLIC
+            AZ::SentryCrashCore
+            AZ::AzCore
+)
+
+add_subdirectory(Reporter)

--- a/Code/Tools/CrashHandler/SentryNative/Core/CMakeLists.txt
+++ b/Code/Tools/CrashHandler/SentryNative/Core/CMakeLists.txt
@@ -1,0 +1,48 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+# Shared by the Qt tools (AZ::ToolsCrashHandler) and by packaged game/server launchers (the
+# CrashReporting gem), so this target must stay free of Qt and of host-tools-only dependencies.
+ly_add_target(
+    NAME SentryCrashCore STATIC
+    NAMESPACE AZ
+    FILES_CMAKE
+        sentry_crash_core_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            include
+    COMPILE_DEFINITIONS
+        PUBLIC
+            # Every crash-handler caller in the engine (the Editor, ProjectManager, LuaIDE, the
+            # Atom tools, ...) wraps its InitCrashHandler call in #if defined(EXTERNAL_CRASH_REPORTING).
+            # The Crashpad backend defines it from its own target; without the same definition here
+            # those call sites compile out and this backend would silently never start.
+            EXTERNAL_CRASH_REPORTING
+    BUILD_DEPENDENCIES
+        PUBLIC
+            sentry::sentry
+            AZ::AzCore
+)
+
+if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+    ly_add_target(
+        NAME SentryCrashCore.Tests EXECUTABLE
+        NAMESPACE AZ
+        FILES_CMAKE
+            sentry_crash_core_tests_files.cmake
+        BUILD_DEPENDENCIES
+            PRIVATE
+                AZ::SentryCrashCore
+                AZ::AzTest
+    )
+
+    ly_add_googletest(
+        NAME AZ::SentryCrashCore.Tests
+        TEST_COMMAND $<TARGET_FILE:AZ::SentryCrashCore.Tests> --unittest
+    )
+endif()

--- a/Code/Tools/CrashHandler/SentryNative/Core/Tests/SentryCrashCoreTests.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Core/Tests/SentryCrashCoreTests.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <SentryCrashCore/SentryCrashCore.h>
+
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/AzTest.h>
+
+namespace
+{
+    //! LoadConfig reads through AZ::SettingsRegistry::Get(), so a test registry has to be
+    //! registered for the duration of each case that exercises overrides.
+    class ScopedTestRegistry
+    {
+    public:
+        ScopedTestRegistry()
+        {
+            // Save and restore any pre-existing global registry, matching the pattern in
+            // AzCore's own SettingsRegistry tests.
+            m_previous = AZ::SettingsRegistry::Get();
+            if (m_previous != nullptr)
+            {
+                AZ::SettingsRegistry::Unregister(m_previous);
+            }
+            AZ::SettingsRegistry::Register(&m_registry);
+        }
+        ~ScopedTestRegistry()
+        {
+            AZ::SettingsRegistry::Unregister(&m_registry);
+            if (m_previous != nullptr)
+            {
+                AZ::SettingsRegistry::Register(m_previous);
+            }
+        }
+        AZ::SettingsRegistryImpl& Get()
+        {
+            return m_registry;
+        }
+
+    private:
+        AZ::SettingsRegistryImpl m_registry;
+        AZ::SettingsRegistryInterface* m_previous{};
+    };
+}
+
+using SentryCrashCoreFixture = UnitTest::LeakDetectionFixture;
+
+TEST_F(SentryCrashCoreFixture, LoadConfig_DerivesDatabasePathUnderAppRoot)
+{
+    ScopedTestRegistry registry;
+
+    SentryCrash::Config config = SentryCrash::LoadConfig("Editor", "C:/projects/Blank_Testing");
+
+    EXPECT_STREQ(config.m_databasePath.c_str(), "C:/projects/Blank_Testing/.sentry-native");
+    EXPECT_STREQ(config.m_moduleTag.c_str(), "Editor");
+}
+
+TEST_F(SentryCrashCoreFixture, LoadConfig_DoesNotDoubleSeparatorWhenAppRootHasTrailingSlash)
+{
+    ScopedTestRegistry registry;
+
+    SentryCrash::Config config = SentryCrash::LoadConfig("Editor", "C:/projects/Blank_Testing/");
+
+    EXPECT_STREQ(config.m_databasePath.c_str(), "C:/projects/Blank_Testing/.sentry-native");
+}
+
+TEST_F(SentryCrashCoreFixture, LoadConfig_DefaultsAreSafeWhenRegistryIsEmpty)
+{
+    ScopedTestRegistry registry;
+
+    SentryCrash::Config config = SentryCrash::LoadConfig("Editor", "C:/projects/X");
+
+    // An absent DSN must leave crash reporting off rather than half-configured.
+    EXPECT_TRUE(config.m_dsn.empty());
+    EXPECT_STREQ(config.m_environment.c_str(), "development");
+    EXPECT_FALSE(config.m_sendDefaultPii);
+    EXPECT_TRUE(config.m_scrubUserPaths);
+}
+
+TEST_F(SentryCrashCoreFixture, LoadConfig_ReadsOverridesFromSettingsRegistry)
+{
+    ScopedTestRegistry registry;
+    registry.Get().Set("/O3DE/CrashReporting/SentryDsn", "https://key@example.com/42");
+    registry.Get().Set("/O3DE/CrashReporting/Environment", "production");
+    registry.Get().Set("/O3DE/CrashReporting/SampleRate", 0.25);
+    registry.Get().Set("/O3DE/CrashReporting/AttachScreenshot", false);
+    registry.Get().Set("/O3DE/CrashReporting/MaxBreadcrumbs", AZ::s64{ 25 });
+    registry.Get().Set("/O3DE/CrashReporting/AppHangTimeoutMs", AZ::s64{ 9000 });
+
+    SentryCrash::Config config = SentryCrash::LoadConfig("GameLauncher", "C:/projects/X");
+
+    EXPECT_STREQ(config.m_dsn.c_str(), "https://key@example.com/42");
+    EXPECT_STREQ(config.m_environment.c_str(), "production");
+    EXPECT_DOUBLE_EQ(config.m_sampleRate, 0.25);
+    EXPECT_FALSE(config.m_attachScreenshot);
+    EXPECT_EQ(config.m_maxBreadcrumbs, 25u);
+    EXPECT_EQ(config.m_appHangTimeoutMs, 9000u);
+}
+
+TEST_F(SentryCrashCoreFixture, ContextHelpers_AreNoOpsBeforeInitialize)
+{
+    // Every enrichment entry point must tolerate being called when the DSN was absent and
+    // Initialize() bailed out, since callers are not expected to branch on that.
+    EXPECT_FALSE(SentryCrash::IsInitialized());
+    SentryCrash::SetTag("level", "TestLevel");
+    SentryCrash::SetLevelName("TestLevel");
+    SentryCrash::AddBreadcrumb("default", "editor", "opened level");
+    SentryCrash::SetContext("gpu", { { "name", "Test GPU" } });
+    SentryCrash::AppHangHeartbeat();
+    SentryCrash::Shutdown();
+    EXPECT_FALSE(SentryCrash::IsInitialized());
+}

--- a/Code/Tools/CrashHandler/SentryNative/Core/Tests/main.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Core/Tests/main.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzTest/AzTest.h>
+
+AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);

--- a/Code/Tools/CrashHandler/SentryNative/Core/include/SentryCrashCore/SentryCrashCore.h
+++ b/Code/Tools/CrashHandler/SentryNative/Core/include/SentryCrashCore/SentryCrashCore.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/functional.h>
+#include <AzCore/std/string/string.h>
+
+//! Backend-agnostic sentry-native wiring shared by every crash-reporting host in the engine:
+//! the Editor and the other Qt tools (via AZ::ToolsCrashHandler) and packaged game/server
+//! launchers (via the CrashReporting gem's system component). Deliberately free of Qt and of any
+//! host-tools-only dependency so the runtime side can link it.
+namespace SentryCrash
+{
+    //! Mirrors the sentry-native option surface we expose. Populated from the SettingsRegistry by
+    //! LoadConfig(); every field has a working default so a project only overrides what it cares
+    //! about. Key names are documented on LoadConfig().
+    struct Config
+    {
+        // --- Identity -------------------------------------------------------------------------
+        AZStd::string m_dsn;
+        AZStd::string m_release;
+        AZStd::string m_environment{ "development" };
+        AZStd::string m_dist;
+        //! Free-form label for this host, e.g. "Editor", "MaterialEditor", "GameLauncher".
+        AZStd::string m_moduleTag;
+
+        // --- Paths ----------------------------------------------------------------------------
+        AZStd::string m_databasePath;
+        //! crashpad_handler executable. Empty lets sentry-native look next to the running exe.
+        AZStd::string m_handlerPath;
+        //! Companion UI process launched after a crash. Empty disables it (packaged builds).
+        AZStd::string m_externalReporterPath;
+        AZStd::vector<AZStd::string> m_attachments;
+
+        // --- Capture --------------------------------------------------------------------------
+        bool m_attachScreenshot{ true };
+        bool m_symbolizeStacktraces{ false };
+        bool m_enableLargeAttachments{ false };
+        size_t m_maxBreadcrumbs{ 100 };
+
+        // --- Delivery -------------------------------------------------------------------------
+        double m_sampleRate{ 1.0 };
+        uint64_t m_shutdownTimeoutMs{ 2000 };
+        bool m_waitForUpload{ false };
+        AZStd::string m_proxy;
+        AZStd::string m_caCerts;
+
+        // --- Privacy --------------------------------------------------------------------------
+        bool m_requireUserConsent{ false };
+        bool m_sendDefaultPii{ false };
+        //! Rewrites absolute user-profile paths out of outgoing events (before_send). Independent
+        //! of m_sendDefaultPii, which only governs what sentry-native itself collects.
+        bool m_scrubUserPaths{ true };
+
+        // --- Telemetry ------------------------------------------------------------------------
+        bool m_autoSessionTracking{ true };
+        bool m_enableLogs{ true };
+        bool m_enableMetrics{ false };
+        double m_tracesSampleRate{ 0.0 };
+        bool m_enableAppHangTracking{ false };
+        uint64_t m_appHangTimeoutMs{ 5000 };
+
+        // --- Diagnostics ----------------------------------------------------------------------
+        //! Routes sentry-native's own logging into AZ_TracePrintf/AZ_Warning.
+        bool m_debug{ false };
+
+        // --- Editor-only ----------------------------------------------------------------------
+        //! Best-effort level save from inside the crash handler. See SetEmergencySaveCallback().
+        bool m_attemptLevelSaveOnCrash{ true };
+    };
+
+    //! Builds a Config from the SettingsRegistry, under /O3DE/CrashReporting/. Recognised keys
+    //! match the Config field names without the m_ prefix, capitalised: SentryDsn, Release,
+    //! Environment, Dist, AttachScreenshot, SymbolizeStacktraces, EnableLargeAttachments,
+    //! MaxBreadcrumbs, SampleRate, ShutdownTimeoutMs, WaitForUpload, Proxy, CaCerts,
+    //! RequireUserConsent, SendDefaultPii, ScrubUserPaths, AutoSessionTracking, EnableLogs,
+    //! EnableMetrics, TracesSampleRate, EnableAppHangTracking, AppHangTimeoutMs, Debug,
+    //! AttemptLevelSaveOnCrash. Paths and moduleTag are derived from the arguments.
+    //! appRoot is where the crash database lives (typically the project's user folder).
+    Config LoadConfig(AZStd::string_view moduleTag, AZStd::string_view appRoot);
+
+    //! Starts sentry-native. Returns false (and reports a warning) if the DSN is empty or
+    //! sentry_init fails. Safe to call once per process; a second call is ignored.
+    bool Initialize(const Config& config);
+
+    //! Flushes pending events and shuts sentry-native down. Must be called on clean exit or
+    //! queued envelopes (and the session's "exited" status) are never delivered.
+    void Shutdown();
+
+    bool IsInitialized();
+
+    //! Returns the saved file's path, or an empty string if nothing was saved.
+    using EmergencySaveCallback = AZStd::function<AZStd::string()>;
+
+    //! Registers a best-effort save invoked from inside the crash handler when
+    //! Config::m_attemptLevelSaveOnCrash is set.
+    //!
+    //! DANGER: sentry-native documents on_crash as running inside a signal handler (POSIX) or an
+    //! UnhandledExceptionFilter (Windows), where only async-signal-safe work is officially legal.
+    //! A level save allocates, takes locks and touches the asset system, so it is emphatically not
+    //! safe by that standard - it is a deliberate best-effort trade (the same one Unreal's crash
+    //! handler makes) to avoid losing a user's unsaved work. It is re-entrancy guarded and its
+    //! failure can never block the crash report itself, but it can hang or fault; that is the
+    //! accepted cost. Never move required reporting work into this callback.
+    void SetEmergencySaveCallback(EmergencySaveCallback callback);
+
+    //! Path of the file the emergency save produced during the *previous* run's crash, or empty.
+    //! Read from the sidecar marker the crash handler writes, whose location is published to
+    //! child processes via the SENTRY_O3DE_RECOVERY_FILE environment variable.
+    AZStd::string GetRecoveryMarkerPath();
+
+    //! True when the previous run of this application ended in a crash.
+    bool CrashedLastRun();
+
+    // --- Scope enrichment. No-ops before Initialize() succeeds. ---------------------------------
+
+    void SetTag(const char* key, const char* value);
+    void AddBreadcrumb(const char* type, const char* category, const char* message);
+
+    //! Adds a named context object, e.g. "gpu" -> { "name": ..., "driver_version": ... }.
+    void SetContext(const char* key, const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& values);
+
+    //! Records the level/scene currently open, so crashes can be grouped by content.
+    void SetLevelName(const char* levelName);
+
+    //! Beat from the thread whose responsiveness matters (the main/UI thread). No-op unless
+    //! Config::m_enableAppHangTracking is set. The first caller becomes the watched thread.
+    void AppHangHeartbeat();
+}

--- a/Code/Tools/CrashHandler/SentryNative/Core/sentry_crash_core_files.cmake
+++ b/Code/Tools/CrashHandler/SentryNative/Core/sentry_crash_core_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    include/SentryCrashCore/SentryCrashCore.h
+    src/SentryCrashCore.cpp
+)

--- a/Code/Tools/CrashHandler/SentryNative/Core/sentry_crash_core_tests_files.cmake
+++ b/Code/Tools/CrashHandler/SentryNative/Core/sentry_crash_core_tests_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Tests/main.cpp
+    Tests/SentryCrashCoreTests.cpp
+)

--- a/Code/Tools/CrashHandler/SentryNative/Core/src/SentryCrashCore.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Core/src/SentryCrashCore.cpp
@@ -10,13 +10,17 @@
 #include <sentry.h>
 
 #include <AzCore/Debug/Trace.h>
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/Utils/Utils.h>
+#include <AzCore/std/containers/span.h>
 #include <AzCore/std/string/conversions.h>
+#include <AzCore/std/typetraits/conditional.h>
+#include <AzCore/std/typetraits/is_integral.h>
 
 #include <atomic>
 #include <cstdio>
-#include <cstdlib>
 
 namespace SentryCrash
 {
@@ -66,32 +70,28 @@ namespace SentryCrash
             }
         }
 
-        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, uint64_t& out)
+        // One overload for every integral width: size_t and uint64_t are the same type on 64-bit
+        // Windows, so separate overloads for them are a redefinition there but not elsewhere.
+        template<class IntegralType, class = AZStd::enable_if_t<AZStd::is_integral_v<IntegralType>>>
+        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, IntegralType& out)
         {
             AZ::s64 value{};
             if (registry->Get(value, SettingsKey(leaf).c_str()) && value >= 0)
             {
-                out = static_cast<uint64_t>(value);
-            }
-        }
-
-        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, size_t& out)
-        {
-            AZ::s64 value{};
-            if (registry->Get(value, SettingsKey(leaf).c_str()) && value >= 0)
-            {
-                out = static_cast<size_t>(value);
+                out = static_cast<IntegralType>(value);
             }
         }
 
         AZStd::string GetUserProfilePath()
         {
+            char buffer[AZ::IO::MaxPathLength];
 #if defined(AZ_PLATFORM_WINDOWS)
-            constexpr const char* profile = "USERPROFILE";
+            constexpr const char* profileVar = "USERPROFILE";
 #else
-            const char* profile = "HOME";
+            constexpr const char* profileVar = "HOME";
 #endif
-            if (auto outcome = AZ::Utils::GetEnv(AZStd::span(buffer, AZ_ARRAY_SIZE(buffer)), profileVar); outcome.IsSuccess())
+            if (auto outcome = AZ::Utils::GetEnv(AZStd::span(buffer, AZ_ARRAY_SIZE(buffer)), profileVar);
+                outcome.IsSuccess())
             {
                 return AZStd::string(outcome.GetValue());
             }
@@ -155,7 +155,8 @@ namespace SentryCrash
 
             for (const char* container : { "exception", "threads" })
             {
-                sentry_value_t values = sentry_value_get_by_key(sentry_value_get_by_key(event, container), "values");
+                sentry_value_t values =
+                    sentry_value_get_by_key(sentry_value_get_by_key(event, container), "values");
                 if (sentry_value_get_type(values) != SENTRY_VALUE_TYPE_LIST)
                 {
                     continue;
@@ -163,7 +164,8 @@ namespace SentryCrash
                 const size_t count = sentry_value_get_length(values);
                 for (size_t i = 0; i < count; ++i)
                 {
-                    ScrubStacktrace(sentry_value_get_by_key(sentry_value_get_by_index(values, i), "stacktrace"));
+                    ScrubStacktrace(
+                        sentry_value_get_by_key(sentry_value_get_by_index(values, i), "stacktrace"));
                 }
             }
 
@@ -199,7 +201,8 @@ namespace SentryCrash
             {
                 return;
             }
-            
+            // Plain stdio rather than the engine's file APIs: this runs from the crash handler,
+            // where the less machinery touched the better.
             FILE* file = nullptr;
             azfopen(&file, s_recoveryMarkerPath.c_str(), "wb");
             if (file)
@@ -234,11 +237,11 @@ namespace SentryCrash
             return event;
         }
 
-        void OnCrashedLastRun(void*)
+        void OnCrashedLastRun(const sentry_envelope_t*, void*)
         {
             s_crashedLastRun = 1;
         }
-    } // namespace
+    }
 
     Config LoadConfig(AZStd::string_view moduleTag, AZStd::string_view appRoot)
     {
@@ -298,7 +301,10 @@ namespace SentryCrash
 
         if (config.m_dsn.empty())
         {
-            AZ_Warning("CrashReporting", false, "No Sentry DSN configured (%sSentryDsn) - crash reporting is disabled", SettingsPrefix);
+            AZ_Warning(
+                "CrashReporting", false,
+                "No Sentry DSN configured (%sSentryDsn) - crash reporting is disabled",
+                SettingsPrefix);
             return false;
         }
 
@@ -327,7 +333,8 @@ namespace SentryCrash
         }
         if (!config.m_externalReporterPath.empty())
         {
-            sentry_options_set_external_crash_reporter_path(options, config.m_externalReporterPath.c_str());
+            sentry_options_set_external_crash_reporter_path(
+                options, config.m_externalReporterPath.c_str());
         }
         if (!config.m_proxy.empty())
         {
@@ -353,12 +360,16 @@ namespace SentryCrash
         sentry_options_set_crashpad_wait_for_upload(options, config.m_waitForUpload ? 1 : 0);
 
         sentry_options_set_require_user_consent(options, config.m_requireUserConsent ? 1 : 0);
-        sentry_options_set_send_default_pii(options, config.m_sendDefaultPii ? 1 : 0);
+        //sentry_options_set_send_default_pii(options, config.m_sendDefaultPii ? 1 : 0);
         sentry_options_set_before_send(options, ScrubEvent, nullptr);
 
         sentry_options_set_auto_session_tracking(options, config.m_autoSessionTracking ? 1 : 0);
+        // Both toggles are deprecated with no replacement - upstream is removing the opt-out, not
+        // the feature. Keep honouring them until they actually disappear.
+        SENTRY_SUPPRESS_DEPRECATED;
         sentry_options_set_enable_logs(options, config.m_enableLogs ? 1 : 0);
         sentry_options_set_enable_metrics(options, config.m_enableMetrics ? 1 : 0);
+        SENTRY_RESTORE_DEPRECATED;
         sentry_options_set_traces_sample_rate(options, config.m_tracesSampleRate);
         sentry_options_set_enable_app_hang_tracking(options, config.m_enableAppHangTracking ? 1 : 0);
         sentry_options_set_app_hang_timeout(options, config.m_appHangTimeoutMs);
@@ -374,14 +385,8 @@ namespace SentryCrash
 
         // Published so the companion reporter process - launched by crashpad, inheriting this
         // environment - can find the marker without re-deriving the database path.
-        AZStd::string recoveryEnv = s_recoveryMarkerPath;
-#if defined(AZ_PLATFORM_WINDOWS)
-        _putenv_s(RecoveryEnvVar, recoveryEnv.c_str());
-        _putenv_s("SENTRY_DSN", config.m_dsn.c_str());
-#else
-        setenv(RecoveryEnvVar, recoveryEnv.c_str(), 1);
-        setenv("SENTRY_DSN", config.m_dsn.c_str(), 1);
-#endif
+        AZ::Utils::SetEnv(RecoveryEnvVar, s_recoveryMarkerPath.c_str(), true);
+        AZ::Utils::SetEnv("SENTRY_DSN", config.m_dsn.c_str(), true);
 
         if (sentry_init(options) != 0)
         {
@@ -397,9 +402,7 @@ namespace SentryCrash
         AZ_TracePrintf(
             "CrashReporting",
             "Sentry crash reporting initialized for %s (environment=%s, database=%s)\n",
-            config.m_moduleTag.c_str(),
-            config.m_environment.c_str(),
-            config.m_databasePath.c_str());
+            config.m_moduleTag.c_str(), config.m_environment.c_str(), config.m_databasePath.c_str());
         return true;
     }
 
@@ -426,8 +429,13 @@ namespace SentryCrash
 
     AZStd::string GetRecoveryMarkerPath()
     {
-        const char* fromEnv = std::getenv(RecoveryEnvVar);
-        return fromEnv ? AZStd::string(fromEnv) : s_recoveryMarkerPath;
+        char buffer[AZ::IO::MaxPathLength];
+        if (auto outcome = AZ::Utils::GetEnv(AZStd::span(buffer, AZ_ARRAY_SIZE(buffer)), RecoveryEnvVar);
+            outcome.IsSuccess())
+        {
+            return AZStd::string(outcome.GetValue());
+        }
+        return s_recoveryMarkerPath;
     }
 
     bool CrashedLastRun()
@@ -457,7 +465,8 @@ namespace SentryCrash
         sentry_add_breadcrumb(crumb);
     }
 
-    void SetContext(const char* key, const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& values)
+    void SetContext(
+        const char* key, const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& values)
     {
         if (!s_initialized || !key)
         {
@@ -483,4 +492,4 @@ namespace SentryCrash
             sentry_app_hang_heartbeat();
         }
     }
-} // namespace SentryCrash
+}

--- a/Code/Tools/CrashHandler/SentryNative/Core/src/SentryCrashCore.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Core/src/SentryCrashCore.cpp
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <SentryCrashCore/SentryCrashCore.h>
+
+#include <sentry.h>
+
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/std/string/conversions.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+
+namespace SentryCrash
+{
+    namespace
+    {
+        constexpr const char* SettingsPrefix = "/O3DE/CrashReporting/";
+        constexpr const char* RecoveryEnvVar = "SENTRY_O3DE_RECOVERY_FILE";
+
+        std::atomic_bool s_initialized{ false };
+        EmergencySaveCallback s_emergencySave;
+        bool s_attemptLevelSave = false;
+        bool s_scrubUserPaths = true;
+        bool s_appHangTrackingEnabled = false;
+        AZStd::string s_recoveryMarkerPath;
+        AZStd::string s_userProfilePath;
+        int s_crashedLastRun = -1;
+
+        AZStd::string SettingsKey(const char* leaf)
+        {
+            return AZStd::string(SettingsPrefix) + leaf;
+        }
+
+        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, AZStd::string& out)
+        {
+            AZStd::string value;
+            if (registry->Get(value, SettingsKey(leaf).c_str()) && !value.empty())
+            {
+                out = value;
+            }
+        }
+
+        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, bool& out)
+        {
+            bool value{};
+            if (registry->Get(value, SettingsKey(leaf).c_str()))
+            {
+                out = value;
+            }
+        }
+
+        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, double& out)
+        {
+            double value{};
+            if (registry->Get(value, SettingsKey(leaf).c_str()))
+            {
+                out = value;
+            }
+        }
+
+        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, uint64_t& out)
+        {
+            AZ::s64 value{};
+            if (registry->Get(value, SettingsKey(leaf).c_str()) && value >= 0)
+            {
+                out = static_cast<uint64_t>(value);
+            }
+        }
+
+        void ReadSetting(AZ::SettingsRegistryInterface* registry, const char* leaf, size_t& out)
+        {
+            AZ::s64 value{};
+            if (registry->Get(value, SettingsKey(leaf).c_str()) && value >= 0)
+            {
+                out = static_cast<size_t>(value);
+            }
+        }
+
+        AZStd::string GetUserProfilePath()
+        {
+#if defined(AZ_PLATFORM_WINDOWS)
+            constexpr const char* profile = "USERPROFILE";
+#else
+            const char* profile = "HOME";
+#endif
+            if (auto outcome = AZ::Utils::GetEnv(AZStd::span(buffer, AZ_ARRAY_SIZE(buffer)), profileVar); outcome.IsSuccess())
+            {
+                return AZStd::string(outcome.GetValue());
+            }
+            return {};
+        }
+
+        //! Rewrites the absolute user-profile prefix out of a single string value in place.
+        void ScrubValueAt(sentry_value_t owner, const char* key)
+        {
+            if (s_userProfilePath.empty())
+            {
+                return;
+            }
+            sentry_value_t entry = sentry_value_get_by_key(owner, key);
+            if (sentry_value_get_type(entry) != SENTRY_VALUE_TYPE_STRING)
+            {
+                return;
+            }
+            const char* text = sentry_value_as_string(entry);
+            if (!text)
+            {
+                return;
+            }
+            AZStd::string scrubbed(text);
+            if (scrubbed.find(s_userProfilePath) == AZStd::string::npos)
+            {
+                return;
+            }
+            AZ::StringFunc::Replace(scrubbed, s_userProfilePath.c_str(), "<user>");
+            sentry_value_set_by_key(owner, key, sentry_value_new_string(scrubbed.c_str()));
+        }
+
+        void ScrubStacktrace(sentry_value_t stacktrace)
+        {
+            sentry_value_t frames = sentry_value_get_by_key(stacktrace, "frames");
+            if (sentry_value_get_type(frames) != SENTRY_VALUE_TYPE_LIST)
+            {
+                return;
+            }
+            const size_t frameCount = sentry_value_get_length(frames);
+            for (size_t i = 0; i < frameCount; ++i)
+            {
+                sentry_value_t frame = sentry_value_get_by_index(frames, i);
+                ScrubValueAt(frame, "abs_path");
+                ScrubValueAt(frame, "filename");
+                ScrubValueAt(frame, "package");
+            }
+        }
+
+        //! Targeted, not exhaustive: sentry-native exposes no way to enumerate the keys of an
+        //! object value, so a generic recursive walk is impossible through the public API. We scrub
+        //! the places absolute paths actually surface - stack frames and the extras we set
+        //! ourselves - and rely on send_default_pii=false plus Sentry's server-side scrubbing for
+        //! everything else.
+        sentry_value_t ScrubEvent(sentry_value_t event, void*, void*)
+        {
+            if (!s_scrubUserPaths)
+            {
+                return event;
+            }
+
+            for (const char* container : { "exception", "threads" })
+            {
+                sentry_value_t values = sentry_value_get_by_key(sentry_value_get_by_key(event, container), "values");
+                if (sentry_value_get_type(values) != SENTRY_VALUE_TYPE_LIST)
+                {
+                    continue;
+                }
+                const size_t count = sentry_value_get_length(values);
+                for (size_t i = 0; i < count; ++i)
+                {
+                    ScrubStacktrace(sentry_value_get_by_key(sentry_value_get_by_index(values, i), "stacktrace"));
+                }
+            }
+
+            sentry_value_t extra = sentry_value_get_by_key(event, "extra");
+            if (sentry_value_get_type(extra) == SENTRY_VALUE_TYPE_OBJECT)
+            {
+                for (const char* key : { "project_path", "recovered_level_path", "log_path" })
+                {
+                    ScrubValueAt(extra, key);
+                }
+            }
+
+            return event;
+        }
+
+        void ForwardSentryLog(sentry_level_t level, const char* message, va_list args, void*)
+        {
+            char buffer[1024];
+            azvsnprintf(buffer, sizeof(buffer), message, args);
+            if (level >= SENTRY_LEVEL_ERROR)
+            {
+                AZ_Warning("CrashReporting", false, "sentry: %s", buffer);
+            }
+            else
+            {
+                AZ_TracePrintf("CrashReporting", "sentry: %s\n", buffer);
+            }
+        }
+
+        void WriteRecoveryMarker(const char* savedLevelPath)
+        {
+            if (s_recoveryMarkerPath.empty())
+            {
+                return;
+            }
+            
+            FILE* file = nullptr;
+            azfopen(&file, s_recoveryMarkerPath.c_str(), "wb");
+            if (file)
+            {
+                std::fputs(savedLevelPath, file);
+                std::fclose(file);
+            }
+        }
+
+        sentry_value_t OnCrash(const sentry_ucontext_t*, sentry_value_t event, void*)
+        {
+            // Re-entrancy guard: a fault raised *by* the emergency save would otherwise recurse
+            // straight back into here and never let the crash report through.
+            static std::atomic_bool crashHandled{ false };
+            bool expected = false;
+            if (!crashHandled.compare_exchange_strong(expected, true))
+            {
+                return event;
+            }
+
+            if (s_attemptLevelSave && s_emergencySave)
+            {
+                const AZStd::string savedPath = s_emergencySave();
+                if (!savedPath.empty())
+                {
+                    WriteRecoveryMarker(savedPath.c_str());
+                }
+            }
+
+            // Returning the event unmodified: with the crashpad backend on_crash can filter but not
+            // enrich, so the recovery path travels via the sidecar marker instead of the event.
+            return event;
+        }
+
+        void OnCrashedLastRun(void*)
+        {
+            s_crashedLastRun = 1;
+        }
+    } // namespace
+
+    Config LoadConfig(AZStd::string_view moduleTag, AZStd::string_view appRoot)
+    {
+        Config config;
+        config.m_moduleTag = moduleTag;
+
+        AZStd::string root{ appRoot };
+        if (!root.empty() && root.back() != '/' && root.back() != '\\')
+        {
+            root += '/';
+        }
+        config.m_databasePath = root + ".sentry-native";
+
+        if (auto* registry = AZ::SettingsRegistry::Get(); registry != nullptr)
+        {
+            ReadSetting(registry, "SentryDsn", config.m_dsn);
+            ReadSetting(registry, "Release", config.m_release);
+            ReadSetting(registry, "Environment", config.m_environment);
+            ReadSetting(registry, "Dist", config.m_dist);
+            ReadSetting(registry, "Proxy", config.m_proxy);
+            ReadSetting(registry, "CaCerts", config.m_caCerts);
+
+            ReadSetting(registry, "AttachScreenshot", config.m_attachScreenshot);
+            ReadSetting(registry, "SymbolizeStacktraces", config.m_symbolizeStacktraces);
+            ReadSetting(registry, "EnableLargeAttachments", config.m_enableLargeAttachments);
+            ReadSetting(registry, "MaxBreadcrumbs", config.m_maxBreadcrumbs);
+
+            ReadSetting(registry, "SampleRate", config.m_sampleRate);
+            ReadSetting(registry, "ShutdownTimeoutMs", config.m_shutdownTimeoutMs);
+            ReadSetting(registry, "WaitForUpload", config.m_waitForUpload);
+
+            ReadSetting(registry, "RequireUserConsent", config.m_requireUserConsent);
+            ReadSetting(registry, "SendDefaultPii", config.m_sendDefaultPii);
+            ReadSetting(registry, "ScrubUserPaths", config.m_scrubUserPaths);
+
+            ReadSetting(registry, "AutoSessionTracking", config.m_autoSessionTracking);
+            ReadSetting(registry, "EnableLogs", config.m_enableLogs);
+            ReadSetting(registry, "EnableMetrics", config.m_enableMetrics);
+            ReadSetting(registry, "TracesSampleRate", config.m_tracesSampleRate);
+            ReadSetting(registry, "EnableAppHangTracking", config.m_enableAppHangTracking);
+            ReadSetting(registry, "AppHangTimeoutMs", config.m_appHangTimeoutMs);
+
+            ReadSetting(registry, "Debug", config.m_debug);
+            ReadSetting(registry, "AttemptLevelSaveOnCrash", config.m_attemptLevelSaveOnCrash);
+        }
+
+        return config;
+    }
+
+    bool Initialize(const Config& config)
+    {
+        if (s_initialized)
+        {
+            AZ_Warning("CrashReporting", false, "Sentry crash reporting is already initialized");
+            return true;
+        }
+
+        if (config.m_dsn.empty())
+        {
+            AZ_Warning("CrashReporting", false, "No Sentry DSN configured (%sSentryDsn) - crash reporting is disabled", SettingsPrefix);
+            return false;
+        }
+
+        s_attemptLevelSave = config.m_attemptLevelSaveOnCrash;
+        s_scrubUserPaths = config.m_scrubUserPaths;
+        s_appHangTrackingEnabled = config.m_enableAppHangTracking;
+        s_userProfilePath = GetUserProfilePath();
+        s_recoveryMarkerPath = config.m_databasePath + "/last_crash_recovery.txt";
+
+        sentry_options_t* options = sentry_options_new();
+
+        sentry_options_set_dsn(options, config.m_dsn.c_str());
+        sentry_options_set_database_path(options, config.m_databasePath.c_str());
+        sentry_options_set_environment(options, config.m_environment.c_str());
+        if (!config.m_release.empty())
+        {
+            sentry_options_set_release(options, config.m_release.c_str());
+        }
+        if (!config.m_dist.empty())
+        {
+            sentry_options_set_dist(options, config.m_dist.c_str());
+        }
+        if (!config.m_handlerPath.empty())
+        {
+            sentry_options_set_handler_path(options, config.m_handlerPath.c_str());
+        }
+        if (!config.m_externalReporterPath.empty())
+        {
+            sentry_options_set_external_crash_reporter_path(options, config.m_externalReporterPath.c_str());
+        }
+        if (!config.m_proxy.empty())
+        {
+            sentry_options_set_proxy(options, config.m_proxy.c_str());
+        }
+        if (!config.m_caCerts.empty())
+        {
+            sentry_options_set_ca_certs(options, config.m_caCerts.c_str());
+        }
+
+        for (const AZStd::string& attachment : config.m_attachments)
+        {
+            sentry_options_add_attachment(options, attachment.c_str());
+        }
+
+        sentry_options_set_attach_screenshot(options, config.m_attachScreenshot ? 1 : 0);
+        sentry_options_set_symbolize_stacktraces(options, config.m_symbolizeStacktraces ? 1 : 0);
+        sentry_options_set_enable_large_attachments(options, config.m_enableLargeAttachments ? 1 : 0);
+        sentry_options_set_max_breadcrumbs(options, config.m_maxBreadcrumbs);
+
+        sentry_options_set_sample_rate(options, config.m_sampleRate);
+        sentry_options_set_shutdown_timeout(options, config.m_shutdownTimeoutMs);
+        sentry_options_set_crashpad_wait_for_upload(options, config.m_waitForUpload ? 1 : 0);
+
+        sentry_options_set_require_user_consent(options, config.m_requireUserConsent ? 1 : 0);
+        sentry_options_set_send_default_pii(options, config.m_sendDefaultPii ? 1 : 0);
+        sentry_options_set_before_send(options, ScrubEvent, nullptr);
+
+        sentry_options_set_auto_session_tracking(options, config.m_autoSessionTracking ? 1 : 0);
+        sentry_options_set_enable_logs(options, config.m_enableLogs ? 1 : 0);
+        sentry_options_set_enable_metrics(options, config.m_enableMetrics ? 1 : 0);
+        sentry_options_set_traces_sample_rate(options, config.m_tracesSampleRate);
+        sentry_options_set_enable_app_hang_tracking(options, config.m_enableAppHangTracking ? 1 : 0);
+        sentry_options_set_app_hang_timeout(options, config.m_appHangTimeoutMs);
+
+        sentry_options_set_on_crash(options, OnCrash, nullptr);
+        sentry_options_set_on_crashed_last_run(options, OnCrashedLastRun, nullptr);
+
+        if (config.m_debug)
+        {
+            sentry_options_set_debug(options, 1);
+            sentry_options_set_logger(options, ForwardSentryLog, nullptr);
+        }
+
+        // Published so the companion reporter process - launched by crashpad, inheriting this
+        // environment - can find the marker without re-deriving the database path.
+        AZStd::string recoveryEnv = s_recoveryMarkerPath;
+#if defined(AZ_PLATFORM_WINDOWS)
+        _putenv_s(RecoveryEnvVar, recoveryEnv.c_str());
+        _putenv_s("SENTRY_DSN", config.m_dsn.c_str());
+#else
+        setenv(RecoveryEnvVar, recoveryEnv.c_str(), 1);
+        setenv("SENTRY_DSN", config.m_dsn.c_str(), 1);
+#endif
+
+        if (sentry_init(options) != 0)
+        {
+            AZ_Warning("CrashReporting", false, "sentry_init failed - crash reporting is disabled");
+            return false;
+        }
+
+        s_initialized = true;
+        s_crashedLastRun = sentry_get_crashed_last_run();
+
+        sentry_set_tag("module", config.m_moduleTag.c_str());
+
+        AZ_TracePrintf(
+            "CrashReporting",
+            "Sentry crash reporting initialized for %s (environment=%s, database=%s)\n",
+            config.m_moduleTag.c_str(),
+            config.m_environment.c_str(),
+            config.m_databasePath.c_str());
+        return true;
+    }
+
+    void Shutdown()
+    {
+        if (!s_initialized.exchange(false))
+        {
+            return;
+        }
+        // Ends the session as a clean exit and flushes queued envelopes; without this, events
+        // captured late in the run are silently dropped.
+        sentry_close();
+    }
+
+    bool IsInitialized()
+    {
+        return s_initialized;
+    }
+
+    void SetEmergencySaveCallback(EmergencySaveCallback callback)
+    {
+        s_emergencySave = AZStd::move(callback);
+    }
+
+    AZStd::string GetRecoveryMarkerPath()
+    {
+        const char* fromEnv = std::getenv(RecoveryEnvVar);
+        return fromEnv ? AZStd::string(fromEnv) : s_recoveryMarkerPath;
+    }
+
+    bool CrashedLastRun()
+    {
+        return s_crashedLastRun == 1;
+    }
+
+    void SetTag(const char* key, const char* value)
+    {
+        if (s_initialized && key && value)
+        {
+            sentry_set_tag(key, value);
+        }
+    }
+
+    void AddBreadcrumb(const char* type, const char* category, const char* message)
+    {
+        if (!s_initialized || !message)
+        {
+            return;
+        }
+        sentry_value_t crumb = sentry_value_new_breadcrumb(type, message);
+        if (category)
+        {
+            sentry_value_set_by_key(crumb, "category", sentry_value_new_string(category));
+        }
+        sentry_add_breadcrumb(crumb);
+    }
+
+    void SetContext(const char* key, const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& values)
+    {
+        if (!s_initialized || !key)
+        {
+            return;
+        }
+        sentry_value_t context = sentry_value_new_object();
+        for (const auto& [name, value] : values)
+        {
+            sentry_value_set_by_key(context, name.c_str(), sentry_value_new_string(value.c_str()));
+        }
+        sentry_set_context(key, context);
+    }
+
+    void SetLevelName(const char* levelName)
+    {
+        SetTag("level", levelName ? levelName : "<none>");
+    }
+
+    void AppHangHeartbeat()
+    {
+        if (s_initialized && s_appHangTrackingEnabled)
+        {
+            sentry_app_hang_heartbeat();
+        }
+    }
+} // namespace SentryCrash

--- a/Code/Tools/CrashHandler/SentryNative/README.md
+++ b/Code/Tools/CrashHandler/SentryNative/README.md
@@ -1,0 +1,110 @@
+# sentry-native crash-reporting backend
+
+This adds a second, compile-time-selectable backend for O3DE's external crash handler, built on the
+official [sentry-native](https://github.com/getsentry/sentry-native) SDK, alongside the existing
+Crashpad/Backtrace path. Selection is via a new PAL trait:
+
+```cmake
+ly_set(PAL_TRAIT_CRASH_HANDLER_BACKEND "Crashpad")    # existing behaviour (default)
+ly_set(PAL_TRAIT_CRASH_HANDLER_BACKEND "SentryNative")
+```
+
+Only one backend is ever linked. Both expose the same
+`CrashHandler::ToolsCrashHandler::InitCrashHandler(...)` entry point, so all existing callers (the
+Editor, ProjectManager, LuaIDE, AssetProcessor, the Atom tools, ScriptCanvas) are unchanged.
+
+## Layout
+
+| Path | Target | Purpose |
+|---|---|---|
+| `SentryNative/Core` | `AZ::SentryCrashCore` | Option wiring, config, scope enrichment. Qt-free and not host-tools gated, so packaged launchers can link it. |
+| `SentryNative/` | `AZ::ToolsCrashHandler` | Tools-side entry point; same API as the Crashpad backend's target of the same name. |
+| `SentryNative/Reporter` | `SentryCrashReporter` | Optional post-crash Qt dialog, launched via sentry-native's `external_crash_reporter_path`. |
+
+The vendored SDK is fetched by `cmake/3rdParty/sentry-native.cmake` (`FetchContent`, pinned tag),
+which also stages `crashpad_handler` next to the binaries — without that, crash capture silently
+does nothing.
+
+## Configuration
+
+All settings live under `/O3DE/CrashReporting/` in the SettingsRegistry, so a project configures
+them from `<project>/Registry/crash_handler.setreg`. Every key is optional except the DSN; with no
+DSN configured, crash reporting stays off and logs a warning rather than half-initializing.
+
+```jsonc
+{
+    "O3DE": {
+        "CrashReporting": {
+            // Required. Get this from your Sentry project settings.
+            "SentryDsn": "https://<publicKey>@<host>/<projectId>",
+
+            "Release": "my-project@1.0.0",
+            "Environment": "development",
+            "Dist": "",
+
+            "AttachScreenshot": true,
+            "SymbolizeStacktraces": false,
+            "EnableLargeAttachments": false,
+            "MaxBreadcrumbs": 100,
+
+            "SampleRate": 1.0,
+            "ShutdownTimeoutMs": 2000,
+            "WaitForUpload": false,
+            "Proxy": "",
+            "CaCerts": "",
+
+            "RequireUserConsent": false,
+            "SendDefaultPii": false,
+            "ScrubUserPaths": true,
+
+            "AutoSessionTracking": true,
+            "EnableLogs": true,
+            "EnableMetrics": false,
+            "TracesSampleRate": 0.0,
+            "EnableAppHangTracking": true,
+            "AppHangTimeoutMs": 5000,
+
+            "Debug": false,
+            "AttemptLevelSaveOnCrash": true
+        }
+    }
+}
+```
+
+Do not commit a real DSN to a shared repository — treat it as an endpoint credential.
+
+## Packaged builds
+
+Enabling the `CrashReporting` gem is sufficient: its system component initializes the SDK on
+activation and calls `sentry_close()` on deactivation (which is what flushes queued envelopes and
+marks the session as a clean exit). No launcher-side call is required.
+
+The packaged path deliberately does not launch the Qt reporter dialog (packaged builds do not ship
+it) and disables the editor-only level-save hook.
+
+## Editor level recovery
+
+When `AttemptLevelSaveOnCrash` is set, the Editor's `on_crash` hook performs a best-effort save via
+the existing `CCryEditDoc::SaveAutoBackup(true)` and records the resulting file in a sidecar marker.
+The reporter dialog then offers to reopen it on restart.
+
+**This is deliberately unsafe by the strict standard.** sentry-native documents `on_crash` as
+running inside a signal handler / `UnhandledExceptionFilter`, where only async-signal-safe work is
+legal; a level save allocates and takes locks. It is a considered trade — losing unsaved work is
+worse than a small chance of the save itself faulting, and the crash report is already captured by
+that point. It is re-entrancy guarded and can never block the report. Set the key to `false` to
+disable it.
+
+## Known gaps
+
+- **Symbolication**: no debug-file upload step, so frames appear as `module+offset` in Sentry until
+  symbols are uploaded separately (e.g. via `sentry-cli`).
+- **Performance tracing**: `TracesSampleRate` is plumbed but no spans are instrumented, so enabling
+  it produces no span data on its own.
+- **Session replay**: not wired.
+- **Structured logging**: `EnableLogs` is plumbed, but engine `AZ_TracePrintf` output is not bridged
+  to `sentry_log_*`; logs currently reach Sentry only as the attached log file.
+- **PII scrubbing is targeted, not exhaustive**: sentry-native exposes no way to enumerate the keys
+  of an object value, so `ScrubUserPaths` rewrites the places absolute paths actually surface
+  (stack frames, known extras) rather than walking the whole event. `SendDefaultPii` is off by
+  default and Sentry's server-side scrubbing covers the remainder.

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/CMakeLists.txt
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/CMakeLists.txt
@@ -1,0 +1,64 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+ly_add_target(
+    NAME SentryCrashReporterCore STATIC
+    NAMESPACE AZ
+    FILES_CMAKE
+        sentry_crash_reporter_core_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            .
+    BUILD_DEPENDENCIES
+        PUBLIC
+            sentry::sentry
+            AZ::AzCore
+)
+
+if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+    ly_add_target(
+        NAME SentryCrashReporterCore.Tests EXECUTABLE
+        NAMESPACE AZ
+        FILES_CMAKE
+            sentry_crash_reporter_core_tests_files.cmake
+        BUILD_DEPENDENCIES
+            PRIVATE
+                AZ::SentryCrashReporterCore
+                AZ::AzTest
+    )
+
+    ly_add_googletest(
+        NAME AZ::SentryCrashReporterCore.Tests
+        TEST_COMMAND $<TARGET_FILE:AZ::SentryCrashReporterCore.Tests> --unittest
+    )
+endif()
+
+ly_add_target(
+    NAME SentryCrashReporter APPLICATION
+    NAMESPACE AZ
+    AUTOMOC
+    AUTOUIC
+    FILES_CMAKE
+        sentry_crash_reporter_files.cmake
+    INCLUDE_DIRECTORIES
+        PRIVATE
+            .
+    BUILD_DEPENDENCIES
+        PRIVATE
+            AZ::SentryCrashReporterCore
+            sentry::sentry
+            3rdParty::Qt::Core
+            3rdParty::Qt::Gui
+            3rdParty::Qt::Widgets
+)
+
+ly_add_dependencies(Editor SentryCrashReporter)
+
+# SentryCrashReporter is an APPLICATION, so its output directory is the binary folder the Editor
+# and the other tools are launched from - the place sentry-native expects to find the handler.
+o3de_stage_crashpad_handler(SentryCrashReporter)

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/EnvelopeInfo.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/EnvelopeInfo.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <EnvelopeInfo.h>
+
+#include <sentry.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace CrashHandler
+{
+    namespace
+    {
+        constexpr const char* RecoveryEnvVar = "SENTRY_O3DE_RECOVERY_FILE";
+
+        std::string GetString(sentry_value_t object, const char* key)
+        {
+            sentry_value_t entry = sentry_value_get_by_key(object, key);
+            if (sentry_value_get_type(entry) != SENTRY_VALUE_TYPE_STRING)
+            {
+                return {};
+            }
+            const char* text = sentry_value_as_string(entry);
+            return text ? std::string(text) : std::string();
+        }
+    }
+
+    EnvelopeInfo ParseEnvelope(const std::string& envelopePath)
+    {
+        EnvelopeInfo info;
+
+        // sentry-native owns the envelope format, so use its parser rather than re-deriving the
+        // newline-delimited-JSON framing here - it stays correct as the format evolves.
+        sentry_envelope_t* envelope = sentry_envelope_read_from_file(envelopePath.c_str());
+        if (!envelope)
+        {
+            return info;
+        }
+
+        sentry_value_t event = sentry_envelope_get_event(envelope);
+        if (!sentry_value_is_null(event))
+        {
+            info.eventId = GetString(event, "event_id");
+            info.release = GetString(event, "release");
+            info.environment = GetString(event, "environment");
+
+            // project_path travels as a tag: it is set at init, where the value is known, rather
+            // than from on_crash, which cannot enrich the event under the crashpad backend.
+            info.projectPath = GetString(sentry_value_get_by_key(event, "tags"), "project_path");
+
+            sentry_value_t os =
+                sentry_value_get_by_key(sentry_value_get_by_key(event, "contexts"), "os");
+            info.osName = GetString(os, "name");
+            info.osVersion = GetString(os, "version");
+
+            sentry_value_t exceptionValues =
+                sentry_value_get_by_key(sentry_value_get_by_key(event, "exception"), "values");
+            if (sentry_value_get_type(exceptionValues) == SENTRY_VALUE_TYPE_LIST
+                && sentry_value_get_length(exceptionValues) > 0)
+            {
+                info.exceptionType =
+                    GetString(sentry_value_get_by_index(exceptionValues, 0), "type");
+            }
+        }
+
+        sentry_envelope_free(envelope);
+        return info;
+    }
+
+    std::string ConsumeRecoveryMarker()
+    {
+        const char* markerPath = std::getenv(RecoveryEnvVar);
+        if (!markerPath || !*markerPath)
+        {
+            return {};
+        }
+
+        std::string recoveredPath;
+        if (FILE* file = std::fopen(markerPath, "rb"))
+        {
+            char buffer[1025]{};
+            const size_t read = std::fread(buffer, 1, sizeof(buffer) - 1, file);
+            std::fclose(file);
+            recoveredPath.assign(buffer, read);
+        }
+
+        // Consumed on read so a single recovery is not offered again on later launches.
+        std::remove(markerPath);
+        return recoveredPath;
+    }
+}

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/EnvelopeInfo.h
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/EnvelopeInfo.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <string>
+
+namespace CrashHandler
+{
+    struct EnvelopeInfo
+    {
+        std::string eventId;
+        std::string projectPath;
+        std::string release;
+        std::string environment;
+        std::string osName;
+        std::string osVersion;
+        std::string exceptionType;
+        //! Level file written by the emergency save during the crash, if one succeeded.
+        //! Sourced from the sidecar marker rather than the envelope, because with the crashpad
+        //! backend on_crash may filter but not enrich the event.
+        std::string recoveredLevelPath;
+    };
+
+    //! Best-effort: never throws, and returns a partially- or fully-empty EnvelopeInfo when the
+    //! envelope is missing or unreadable.
+    EnvelopeInfo ParseEnvelope(const std::string& envelopePath);
+
+    //! Reads (and deletes) the emergency-save marker named by the SENTRY_O3DE_RECOVERY_FILE
+    //! environment variable, which the crashing process publishes to its children.
+    std::string ConsumeRecoveryMarker();
+}

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/SentryReportDialog.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/SentryReportDialog.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "SentryReportDialog.h"
+#include "UI/ui_sentry_submit_report.h"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QPalette>
+#include <QPushButton>
+
+namespace CrashHandler
+{
+    namespace
+    {
+        // Accent purple matches Sentry's own crash-reporter reference
+        // (github.com/getsentry/sentry-desktop-crash-reporter); the rest of the palette is ours.
+        constexpr const char* AccentPurple = "#8866FF";
+        constexpr const char* AccentPurpleHover = "#7554FF";
+        constexpr const char* AccentPurplePressed = "#5A3FCC";
+
+        const char* DarkStyleSheet()
+        {
+            return R"(
+                QDialog { background-color: #1B1B1F; color: #F1F1F3; }
+                QLabel { color: #F1F1F3; }
+                QLabel#header_label { font-weight: 300; }
+                QLabel#feedback_label { color: #C9C9CE; }
+                QLabel[chip="true"] { color: #B7B4C4; }
+                QLabel#event_id_label { color: #7A7883; font-family: Consolas, monospace; }
+                QPlainTextEdit, QLineEdit {
+                    background-color: #26262C;
+                    color: #F1F1F3;
+                    border: none;
+                    border-bottom: 2px solid #45454E;
+                    padding: 6px;
+                }
+                QPlainTextEdit:focus, QLineEdit:focus { border-bottom: 2px solid #8866FF; }
+                QPushButton#close_button {
+                    background-color: transparent;
+                    color: #F1F1F3;
+                    border: 1px solid #45454E;
+                    border-radius: 4px;
+                    padding: 6px 18px;
+                }
+                QPushButton#close_button:hover { border-color: #6B6B76; }
+            )";
+        }
+
+        const char* LightStyleSheet()
+        {
+            return R"(
+                QDialog { background-color: #FFFFFF; color: #1B1B1F; }
+                QLabel { color: #1B1B1F; }
+                QLabel#header_label { font-weight: 300; }
+                QLabel#feedback_label { color: #4A4A52; }
+                QLabel[chip="true"] { color: #55535F; }
+                QLabel#event_id_label { color: #8A8894; font-family: Consolas, monospace; }
+                QPlainTextEdit, QLineEdit {
+                    background-color: #FFFFFF;
+                    color: #1B1B1F;
+                    border: 1px solid #D8D7DE;
+                    border-bottom: 2px solid #D8D7DE;
+                    padding: 6px;
+                }
+                QPlainTextEdit:focus, QLineEdit:focus { border-bottom: 2px solid #8866FF; }
+                QPushButton#close_button {
+                    background-color: transparent;
+                    color: #1B1B1F;
+                    border: 1px solid #D8D7DE;
+                    border-radius: 4px;
+                    padding: 6px 18px;
+                }
+                QPushButton#close_button:hover { border-color: #B8B6C0; }
+            )";
+        }
+
+        bool IsDarkTheme()
+        {
+            return QApplication::palette().color(QPalette::Window).lightness() < 128;
+        }
+    }
+
+    SentryReportDialog::SentryReportDialog(QWidget* parent)
+        : QDialog(parent)
+        , ui(new Ui::SentryReportDialog)
+    {
+        ui->setupUi(this);
+
+        for (QLabel* chip : { ui->exception_chip, ui->release_chip, ui->os_chip, ui->environment_chip })
+        {
+            chip->setProperty("chip", true);
+        }
+
+        ApplyTheme();
+
+        QString restartStyle = QString(R"(
+            QPushButton#restart_button {
+                background-color: %1;
+                color: #FFFFFF;
+                border: none;
+                border-radius: 4px;
+                padding: 6px 18px;
+            }
+            QPushButton#restart_button:hover { background-color: %2; }
+            QPushButton#restart_button:pressed { background-color: %3; }
+        )").arg(AccentPurple, AccentPurpleHover, AccentPurplePressed);
+        setStyleSheet(styleSheet() + restartStyle);
+
+        connect(ui->close_button, &QPushButton::clicked, this, [this]()
+        {
+            m_wantsRestart = false;
+            accept();
+        });
+        connect(ui->restart_button, &QPushButton::clicked, this, [this]()
+        {
+            m_wantsRestart = true;
+            accept();
+        });
+    }
+
+    SentryReportDialog::~SentryReportDialog() = default;
+
+    void SentryReportDialog::ApplyTheme()
+    {
+        setStyleSheet(IsDarkTheme() ? DarkStyleSheet() : LightStyleSheet());
+    }
+
+    void SentryReportDialog::SetEnvelopeInfo(const EnvelopeInfo& info)
+    {
+        ui->exception_chip->setText(
+            info.exceptionType.empty() ? QString() : QString::fromStdString(info.exceptionType));
+        ui->release_chip->setText(
+            info.release.empty() ? QString() : QString::fromStdString(info.release));
+
+        QString os = QString::fromStdString(info.osName);
+        if (!info.osVersion.empty())
+        {
+            os += " " + QString::fromStdString(info.osVersion);
+        }
+        ui->os_chip->setText(os);
+
+        ui->environment_chip->setText(
+            info.environment.empty() ? QString() : QString::fromStdString(info.environment));
+
+        if (!info.eventId.empty())
+        {
+            ui->event_id_label->setText(QString::fromStdString(info.eventId).left(8));
+        }
+
+        // Only offer the restore when the emergency save actually produced a file - showing a
+        // dead checkbox would imply work was recovered when none was.
+        const bool hasRecovery = !info.recoveredLevelPath.empty();
+        ui->restore_level_checkbox->setVisible(hasRecovery);
+        if (hasRecovery)
+        {
+            ui->restore_level_checkbox->setToolTip(
+                QString::fromStdString(info.recoveredLevelPath));
+        }
+    }
+
+    bool SentryReportDialog::WantsLevelRestored() const
+    {
+        return ui->restore_level_checkbox->isVisible() && ui->restore_level_checkbox->isChecked();
+    }
+
+    QString SentryReportDialog::GetUserComments() const
+    {
+        return ui->comments_edit->toPlainText();
+    }
+
+    QString SentryReportDialog::GetContactName() const
+    {
+        return ui->name_edit->text();
+    }
+
+    QString SentryReportDialog::GetUserEmail() const
+    {
+        return ui->email_edit->text();
+    }
+}

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/SentryReportDialog.h
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/SentryReportDialog.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <QDialog>
+#include <QScopedPointer>
+#endif
+
+#include <EnvelopeInfo.h>
+
+namespace Ui
+{
+    class SentryReportDialog;
+}
+
+namespace CrashHandler
+{
+    class SentryReportDialog : public QDialog
+    {
+        Q_OBJECT // AUTOMOC
+
+    public:
+        explicit SentryReportDialog(QWidget* parent = nullptr);
+        ~SentryReportDialog() override;
+
+        // Populates the metadata chip row and the event-id readout from a parsed crash envelope.
+        void SetEnvelopeInfo(const EnvelopeInfo& info);
+
+        QString GetUserComments() const;
+        // Named GetContactName (not GetUserName) to avoid colliding with the <windows.h>
+        // GetUserName -> GetUserNameA/W macro that pollutes any TU that includes it.
+        QString GetContactName() const;
+        QString GetUserEmail() const;
+        bool WantsRestart() const { return m_wantsRestart; }
+
+        //! True only when a level was actually recovered and the user left the box ticked. The
+        //! save itself already happened during the crash; this governs whether the restart
+        //! reopens it.
+        bool WantsLevelRestored() const;
+
+    private:
+        void ApplyTheme();
+
+        QScopedPointer<Ui::SentryReportDialog> ui;
+        bool m_wantsRestart = false;
+    };
+}

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/Tests/EnvelopeInfoTests.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/Tests/EnvelopeInfoTests.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <EnvelopeInfo.h>
+
+#include <AzCore/IO/Path/Path.h>
+#include <AzTest/AzTest.h>
+#include <AzTest/Utils.h>
+
+#include <fstream>
+
+namespace
+{
+    //! A Sentry envelope is newline-delimited JSON: an envelope header, then one
+    //! {item header}\n{payload} pair per item. `length` is optional in the item header - when it is
+    //! omitted the payload runs to the next newline - so this fixture stays readable without
+    //! hand-computing byte counts. Parsing is done by sentry-native itself, so writing a real
+    //! envelope here is what gives the test its value.
+    AZ::IO::Path WriteEnvelope(const AZ::Test::ScopedAutoTempDirectory& tempDir, const char* eventJson)
+    {
+        AZ::IO::Path path = tempDir.Resolve("sample.envelope");
+        std::ofstream file(path.c_str(), std::ios::binary);
+        file << R"({"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"})" << "\n";
+        file << R"({"type":"event"})" << "\n";
+        file << eventJson << "\n";
+        file.close();
+        return path;
+    }
+}
+
+TEST(EnvelopeInfoTests, ParseEnvelope_ExtractsEventMetadata)
+{
+    AZ::Test::ScopedAutoTempDirectory tempDir;
+    AZ::IO::Path envelope = WriteEnvelope(
+        tempDir,
+        R"({"event_id":"9ec79c33ec9942ab8353589fcb2e04dc",)"
+        R"("release":"o3de-editor@1.0.0","environment":"development",)"
+        R"("tags":{"project_path":"C:/projects/Blank_Testing","module":"Editor"},)"
+        R"("contexts":{"os":{"name":"Windows","version":"10.0.26200"}},)"
+        R"("exception":{"values":[{"type":"EXCEPTION_ACCESS_VIOLATION"}]}})");
+
+    CrashHandler::EnvelopeInfo info = CrashHandler::ParseEnvelope(envelope.c_str());
+
+    EXPECT_STREQ(info.eventId.c_str(), "9ec79c33ec9942ab8353589fcb2e04dc");
+    EXPECT_STREQ(info.projectPath.c_str(), "C:/projects/Blank_Testing");
+    EXPECT_STREQ(info.release.c_str(), "o3de-editor@1.0.0");
+    EXPECT_STREQ(info.environment.c_str(), "development");
+    EXPECT_STREQ(info.osName.c_str(), "Windows");
+    EXPECT_STREQ(info.osVersion.c_str(), "10.0.26200");
+    EXPECT_STREQ(info.exceptionType.c_str(), "EXCEPTION_ACCESS_VIOLATION");
+}
+
+TEST(EnvelopeInfoTests, ParseEnvelope_ToleratesMissingOptionalFields)
+{
+    // A minimal event must not fault the reporter or invent values - the dialog just shows blanks.
+    AZ::Test::ScopedAutoTempDirectory tempDir;
+    AZ::IO::Path envelope =
+        WriteEnvelope(tempDir, R"({"event_id":"9ec79c33ec9942ab8353589fcb2e04dc"})");
+
+    CrashHandler::EnvelopeInfo info = CrashHandler::ParseEnvelope(envelope.c_str());
+
+    EXPECT_STREQ(info.eventId.c_str(), "9ec79c33ec9942ab8353589fcb2e04dc");
+    EXPECT_TRUE(info.projectPath.empty());
+    EXPECT_TRUE(info.osName.empty());
+    EXPECT_TRUE(info.exceptionType.empty());
+}
+
+TEST(EnvelopeInfoTests, ParseEnvelope_MissingFile_ReturnsEmpty)
+{
+    CrashHandler::EnvelopeInfo info = CrashHandler::ParseEnvelope("/no/such/file.envelope");
+
+    EXPECT_TRUE(info.eventId.empty());
+    EXPECT_TRUE(info.projectPath.empty());
+}

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/Tests/main.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/Tests/main.cpp
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzTest/AzTest.h>
+
+AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/UI/sentry_submit_report.ui
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/UI/sentry_submit_report.ui
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SentryReportDialog</class>
+ <widget class="QDialog" name="SentryReportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>620</width>
+    <height>520</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>520</width>
+    <height>440</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Sentry Crash Reporter</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="rootLayout">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="leftMargin">
+    <number>20</number>
+   </property>
+   <property name="topMargin">
+    <number>18</number>
+   </property>
+   <property name="rightMargin">
+    <number>20</number>
+   </property>
+   <property name="bottomMargin">
+    <number>16</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="header_label">
+     <property name="font">
+      <font>
+       <pointsize>20</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Report a Bug</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="metadataRow">
+     <property name="spacing">
+      <number>18</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="exception_chip">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="release_chip">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="os_chip">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="environment_chip">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="metadataSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="headerSeparator">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="feedback_label">
+     <property name="font">
+      <font>
+       <pointsize>13</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Feedback (optional)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="message_label">
+     <property name="text">
+      <string>Message</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="comments_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>70</height>
+      </size>
+     </property>
+     <property name="placeholderText">
+      <string>Tell us about your issue</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="contactRow">
+     <property name="spacing">
+      <number>16</number>
+     </property>
+     <item>
+      <layout class="QVBoxLayout" name="nameColumn">
+       <item>
+        <widget class="QLabel" name="name_label">
+         <property name="text">
+          <string>Name</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="name_edit">
+         <property name="placeholderText">
+          <string>Your name (optional)</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="emailColumn">
+       <item>
+        <widget class="QLabel" name="email_label">
+         <property name="text">
+          <string>Email</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="email_edit">
+         <property name="placeholderText">
+          <string>Contact email (optional)</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="restore_level_checkbox">
+     <property name="text">
+      <string>Restore unsaved level changes on restart</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="footerRow">
+     <item>
+      <widget class="QLabel" name="event_id_label">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="footerSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="close_button">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="restart_button">
+       <property name="text">
+        <string>Restart</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/main.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/main.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <EnvelopeInfo.h>
+#include <SentryReportDialog.h>
+
+#include <sentry.h>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QFileInfo>
+#include <QProcess>
+#include <QString>
+
+namespace
+{
+    //! The crash report itself is already on its way to Sentry by the time this process starts;
+    //! feedback is a separate envelope linked to that event, so this init only needs a transport.
+    void SubmitFeedback(
+        const CrashHandler::EnvelopeInfo& info,
+        const QString& comments,
+        const QString& name,
+        const QString& email)
+    {
+        const QByteArray dsn = qgetenv("SENTRY_DSN");
+        if (dsn.isEmpty() || comments.isEmpty() || info.eventId.empty())
+        {
+            return;
+        }
+
+        sentry_options_t* options = sentry_options_new();
+        sentry_options_set_dsn(options, dsn.constData());
+        if (sentry_init(options) != 0)
+        {
+            return;
+        }
+
+        const QByteArray nameUtf8 = name.toUtf8();
+        const QByteArray emailUtf8 = email.toUtf8();
+        sentry_uuid_t eventId = sentry_uuid_from_string(info.eventId.c_str());
+        sentry_value_t feedback = sentry_value_new_feedback(
+            comments.toUtf8().constData(),
+            emailUtf8.isEmpty() ? nullptr : emailUtf8.constData(),
+            nameUtf8.isEmpty() ? nullptr : nameUtf8.constData(),
+            &eventId);
+        sentry_capture_feedback(feedback);
+
+        sentry_close();
+    }
+
+    void RestartApplication(const CrashHandler::EnvelopeInfo& info, bool restoreLevel)
+    {
+        // The reporter is staged next to the executable that crashed, so its own directory is the
+        // right place to relaunch from.
+        const QString exePath = QCoreApplication::applicationDirPath() + "/Editor.exe";
+        if (!QFileInfo::exists(exePath))
+        {
+            return;
+        }
+
+        QStringList args;
+        if (!info.projectPath.empty())
+        {
+            args << "--project-path" << QString::fromStdString(info.projectPath);
+        }
+        // The Editor opens any positional argument that carries a level extension, so the
+        // recovered file needs no dedicated switch.
+        if (restoreLevel && !info.recoveredLevelPath.empty())
+        {
+            args << QString::fromStdString(info.recoveredLevelPath);
+        }
+        QProcess::startDetached(exePath, args);
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    QApplication app(argc, argv);
+
+    CrashHandler::EnvelopeInfo info;
+    if (argc > 1)
+    {
+        info = CrashHandler::ParseEnvelope(argv[1]);
+    }
+    info.recoveredLevelPath = CrashHandler::ConsumeRecoveryMarker();
+
+    CrashHandler::SentryReportDialog dialog;
+    dialog.SetEnvelopeInfo(info);
+    dialog.exec();
+
+    SubmitFeedback(info, dialog.GetUserComments(), dialog.GetContactName(), dialog.GetUserEmail());
+
+    if (dialog.WantsRestart())
+    {
+        RestartApplication(info, dialog.WantsLevelRestored());
+    }
+
+    return 0;
+}

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/sentry_crash_reporter_core_files.cmake
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/sentry_crash_reporter_core_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    EnvelopeInfo.h
+    EnvelopeInfo.cpp
+)

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/sentry_crash_reporter_core_tests_files.cmake
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/sentry_crash_reporter_core_tests_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Tests/main.cpp
+    Tests/EnvelopeInfoTests.cpp
+)

--- a/Code/Tools/CrashHandler/SentryNative/Reporter/sentry_crash_reporter_files.cmake
+++ b/Code/Tools/CrashHandler/SentryNative/Reporter/sentry_crash_reporter_files.cmake
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    SentryReportDialog.h
+    SentryReportDialog.cpp
+    UI/sentry_submit_report.ui
+    main.cpp
+)

--- a/Code/Tools/CrashHandler/SentryNative/include/ToolsCrashHandler.h
+++ b/Code/Tools/CrashHandler/SentryNative/include/ToolsCrashHandler.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <SentryCrashCore/SentryCrashCore.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace CrashHandler
+{
+    using CrashHandlerAnnotations = std::map<std::string, std::string>;
+    using CrashHandlerArguments = std::vector<std::string>;
+
+    //! Same public surface as the Crashpad-backed ToolsCrashHandler
+    //! (Code/Tools/CrashHandler/Tools), so the eleven existing callers - the Editor, ProjectManager,
+    //! LuaIDE, AssetProcessor, the Atom tools, HammerBox, JoltPVD, ScriptCanvas - keep working
+    //! unchanged whichever backend PAL_TRAIT_CRASH_HANDLER_BACKEND selects.
+    class ToolsCrashHandler
+    {
+    public:
+        static void InitCrashHandler(
+            const std::string& moduleTag,
+            const std::string& devRoot,
+            const std::string& crashUrl = {},
+            const std::string& crashToken = {},
+            const std::string& handlerFolder = {},
+            const CrashHandlerAnnotations& baseAnnotations = {},
+            const CrashHandlerArguments& arguments = {});
+    };
+}

--- a/Code/Tools/CrashHandler/SentryNative/sentry_native_crash_handler_files.cmake
+++ b/Code/Tools/CrashHandler/SentryNative/sentry_native_crash_handler_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    include/ToolsCrashHandler.h
+    src/SentryNativeCrashHandler.cpp
+)

--- a/Code/Tools/CrashHandler/SentryNative/src/SentryNativeCrashHandler.cpp
+++ b/Code/Tools/CrashHandler/SentryNative/src/SentryNativeCrashHandler.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <ToolsCrashHandler.h>
+
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace CrashHandler
+{
+    namespace
+    {
+        AZStd::string ResolveAlias(const char* alias)
+        {
+            if (AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance())
+            {
+                if (auto resolved = fileIO->ResolvePath(AZ::IO::PathView(alias)); resolved.has_value())
+                {
+                    return resolved->c_str();
+                }
+            }
+            return {};
+        }
+
+        AZStd::string ExecutableSibling(const char* fileName)
+        {
+            const AZ::IO::FixedMaxPathString exeDir = AZ::Utils::GetExecutableDirectory();
+            if (exeDir.empty())
+            {
+                return fileName;
+            }
+            return (AZ::IO::FixedMaxPath(exeDir) / fileName).c_str();
+        }
+    }
+
+    void ToolsCrashHandler::InitCrashHandler(
+        const std::string& moduleTag,
+        const std::string& devRoot,
+        const std::string& crashUrl,
+        const std::string& /*crashToken*/,
+        const std::string& /*handlerFolder*/,
+        const CrashHandlerAnnotations& baseAnnotations,
+        const CrashHandlerArguments& /*arguments*/)
+    {
+        // Callers pass an empty devRoot and expect the handler to work it out; the crash database
+        // belongs with the user's writable data, not next to the read-only executable.
+        AZStd::string appRoot{ devRoot.c_str() };
+        if (appRoot.empty())
+        {
+            appRoot = ResolveAlias("@user@");
+        }
+        if (appRoot.empty())
+        {
+            appRoot = ResolveAlias("@products@");
+        }
+
+        SentryCrash::Config config = SentryCrash::LoadConfig(moduleTag.c_str(), appRoot);
+
+        // An explicit URL argument still wins, preserving the old override-by-parameter behaviour.
+        if (!crashUrl.empty())
+        {
+            config.m_dsn = crashUrl.c_str();
+        }
+
+        // Attach this tool's own log. It does not exist yet at startup - the logging system creates
+        // it moments later - so this is registered unconditionally; sentry only reads attachments
+        // when a crash actually occurs, by which point the file is there.
+        AZStd::string logDir = ResolveAlias("@log@");
+        if (!logDir.empty())
+        {
+            config.m_attachments.push_back(
+                AZStd::string::format("%s/%s.log", logDir.c_str(), moduleTag.c_str()));
+        }
+
+        config.m_handlerPath = ExecutableSibling("crashpad_handler.exe");
+        config.m_externalReporterPath = ExecutableSibling("SentryCrashReporter.exe");
+
+        if (!SentryCrash::Initialize(config))
+        {
+            return;
+        }
+
+        for (const auto& [key, value] : baseAnnotations)
+        {
+            SentryCrash::SetTag(key.c_str(), value.c_str());
+        }
+
+        // The companion reporter needs this to relaunch on the right project. Prefer the real
+        // project path from the SettingsRegistry over the (usually empty) devRoot argument.
+        AZStd::string projectPath{ devRoot.c_str() };
+        if (projectPath.empty())
+        {
+            if (auto* registry = AZ::SettingsRegistry::Get(); registry != nullptr)
+            {
+                AZ::IO::FixedMaxPath resolved;
+                if (registry->Get(
+                        resolved.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
+                {
+                    projectPath = resolved.c_str();
+                }
+            }
+        }
+        if (!projectPath.empty())
+        {
+            SentryCrash::SetTag("project_path", projectPath.c_str());
+        }
+    }
+}

--- a/Code/Tools/CrashHandler/Shared/CrashHandler.cpp
+++ b/Code/Tools/CrashHandler/Shared/CrashHandler.cpp
@@ -18,6 +18,7 @@
 
 #include <CrashHandler.h>
 #include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/IO/SystemFile.h>
 #include <CrashSupport.h>
 
@@ -250,6 +251,24 @@ namespace CrashHandler
         GetExecutableBaseName(executableName);
         executableName = "--executable-name=" + executableName;
         argumentList.push_back(executableName);
+
+        // Auto-attach this app's own log (by convention @log@/<moduleTag>.log, e.g. Editor.log)
+        // so the report always carries what led up to the crash, not just the dump itself.
+        // NOTE: this runs at startup, before the log file is created, so we can't check
+        // existence here - the handler only reads the file later, once a crash actually
+        // happens, by which point it exists. Just resolve the path and pass it through;
+        // AddAttachments() already skips it gracefully if it's somehow still missing.
+        if (AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance())
+        {
+            AZ::IO::FixedMaxPathString logAlias = AZ::IO::FixedMaxPathString::format("@log@/%s.log", moduleTag.c_str());
+            if (auto resolvedLogPath = fileIO->ResolvePath(AZ::IO::PathView(logAlias)); resolvedLogPath.has_value())
+            {
+                std::string uploadPathArg{ "--uploadpath=" };
+                uploadPathArg += resolvedLogPath->c_str();
+                argumentList.push_back(uploadPathArg);
+            }
+        }
+
         crashpad::CrashpadClient client;
         // Initialize automatic crashpad handling.
         bool rc = client.StartHandler(handler,

--- a/Code/Tools/CrashHandler/Tools/ToolsCrashHandler.cpp
+++ b/Code/Tools/CrashHandler/Tools/ToolsCrashHandler.cpp
@@ -14,12 +14,17 @@
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/PlatformIncl.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/std/string/string.h>
 
 #include <QOperatingSystemVersion>
 #include <QString>
 
 namespace CrashHandler
 {
+    // Per-project override, e.g. AutomatedTesting/Registry/crash_handler.setreg
+    static const char* settingKey_crashReportingUrl = "/O3DE/CrashReporting/Url";
+    static const char* settingKey_crashReportingToken = "/O3DE/CrashReporting/SubmissionToken";
 
     void ToolsCrashHandler::InitCrashHandler(const std::string& moduleTag, const std::string& devRoot, const std::string& crashUrl, const std::string& crashToken, const std::string& handlerFolder, const CrashHandlerAnnotations& baseAnnotations, const CrashHandlerArguments& arguments)
     {
@@ -29,6 +34,14 @@ namespace CrashHandler
 
     std::string ToolsCrashHandler::GetCrashSubmissionURL() const
     {
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        {
+            AZStd::string url;
+            if (settingsRegistry->Get(url, settingKey_crashReportingUrl) && !url.empty())
+            {
+                return url.c_str();
+            }
+        }
 #if defined(CRASH_HANDLER_URL)
         return MAKE_DEFINE_STRING(CRASH_HANDLER_URL);
 #else
@@ -38,6 +51,15 @@ namespace CrashHandler
 
     std::string ToolsCrashHandler::GetCrashSubmissionToken() const
     {
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        {
+            AZStd::string submissionToken;
+            if (settingsRegistry->Get(submissionToken, settingKey_crashReportingToken) && !submissionToken.empty())
+            {
+                return submissionToken.c_str();
+            }
+        }
+
         std::string configToken = GetConfigSubmissionToken();
         if (configToken.length())
         {

--- a/Code/Tools/CrashHandler/Tools/UI/submit_report.ui
+++ b/Code/Tools/CrashHandler/Tools/UI/submit_report.ui
@@ -2,196 +2,178 @@
 <ui version="4.0">
  <class>SendReportDialog</class>
  <widget class="QDialog" name="SendReportDialog">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>220</height>
+    <width>640</width>
+    <height>540</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>400</width>
-    <height>220</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>400</width>
-    <height>220</height>
+    <width>560</width>
+    <height>460</height>
    </size>
   </property>
   <property name="windowTitle">
-   <string>Send Error Report</string>
+   <string>Crash Reporter</string>
   </property>
   <property name="windowIcon">
-   <iconset>
-    <normaloff>lyeditoricon.ico</normaloff>lyeditoricon.ico</iconset>
-  </property>
-  <property name="autoFillBackground">
-   <bool>true</bool>
-  </property>
-  <property name="styleSheet">
-   <string notr="true"/>
+   <iconset resource="ToolsCrashHandler.qrc">
+    <normaloff>:/Icons/lyeditor.ico</normaloff>:/Icons/lyeditor.ico</iconset>
   </property>
   <property name="modal">
    <bool>true</bool>
   </property>
-  <widget class="QDialogButtonBox" name="buttonBox">
-   <property name="geometry">
-    <rect>
-     <x>210</x>
-     <y>186</y>
-     <width>175</width>
-     <height>32</height>
-    </rect>
+  <layout class="QVBoxLayout" name="rootLayout">
+   <property name="leftMargin">
+    <number>12</number>
    </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
+   <property name="topMargin">
+    <number>12</number>
    </property>
-   <property name="standardButtons">
-    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <property name="rightMargin">
+    <number>12</number>
    </property>
-  </widget>
-  <widget class="Line" name="line">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>168</y>
-     <width>391</width>
-     <height>20</height>
-    </rect>
+   <property name="bottomMargin">
+    <number>12</number>
    </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label">
-   <property name="geometry">
-    <rect>
-     <x>6</x>
-     <y>6</y>
-     <width>385</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Open 3D Engine has encountered a fatal error.  We're sorry for the inconvenience.</string>
-   </property>
-   <property name="wordWrap">
-    <bool>true</bool>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_2">
-   <property name="geometry">
-    <rect>
-     <x>6</x>
-     <y>36</y>
-     <width>385</width>
-     <height>25</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Information about the crash has been created at:</string>
-   </property>
-   <property name="wordWrap">
-    <bool>true</bool>
-   </property>
-  </widget>
-  <widget class="QLabel" name="dump_label">
-   <property name="geometry">
-    <rect>
-     <x>6</x>
-     <y>66</y>
-     <width>391</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string/>
-   </property>
-   <property name="wordWrap">
-    <bool>true</bool>
-   </property>
-   <property name="openExternalLinks">
-    <bool>true</bool>
-   </property>
-   <property name="textInteractionFlags">
-    <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_3">
-   <property name="geometry">
-    <rect>
-     <x>6</x>
-     <y>96</y>
-     <width>385</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>If you are willing to submit this file it will help us to fix this issue.</string>
-   </property>
-   <property name="wordWrap">
-    <bool>true</bool>
-   </property>
-  </widget>
-  <widget class="QLabel" name="question_label">
-   <property name="geometry">
-    <rect>
-     <x>6</x>
-     <y>138</y>
-     <width>331</width>
-     <height>25</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Would you like to send the error report?</string>
-   </property>
-   <property name="wordWrap">
-    <bool>true</bool>
-   </property>
-  </widget>
+   <item>
+    <widget class="QLabel" name="header_label">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>A process has crashed</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="intro_label">
+     <property name="text">
+      <string>We are very sorry that this crash occurred. Our goal is to prevent crashes like this from happening again. Please help us track this down by providing detailed information about what you were doing so we can reproduce and fix it.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="comment_prompt_label">
+     <property name="text">
+      <string>Please provide detailed information about what you were doing when the crash occurred.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="comments_edit">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>80</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>110</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="diagnostics_label">
+     <property name="text">
+      <string>Crash reports comprise diagnostics files (&lt;a href=&quot;#&quot;&gt;click here to view directory&lt;/a&gt;) and the following summary information:</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="openExternalLinks">
+      <bool>false</bool>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="summary_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <family>Consolas</family>
+      </font>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="contact_checkbox">
+     <property name="text">
+      <string>I agree to be contacted by email if additional information about this crash would help fix it.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonRow">
+     <item>
+      <spacer name="buttonSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="send_restart_button">
+       <property name="text">
+        <string>Send and Restart</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="send_close_button">
+       <property name="text">
+        <string>Send and Close</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources>
-  <include location="../../../../Editor/MainWindow.qrc"/>
+  <include location="ToolsCrashHandler.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>SendReportDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>SendReportDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/Code/Tools/CrashHandler/Tools/Uploader/SendReportDialog.cpp
+++ b/Code/Tools/CrashHandler/Tools/Uploader/SendReportDialog.cpp
@@ -9,7 +9,9 @@
 #include "SendReportDialog.h"
 #include "UI/ui_submit_report.h"
 
+#include <QDesktopServices>
 #include <QLabel>
+#include <QUrl>
 
 namespace CrashUploader
 {
@@ -23,23 +25,58 @@ namespace CrashUploader
 
         if (manualReport)
         {
-            ui->question_label->setText("Would you like to manually report the issue ?");
+            ui->comment_prompt_label->setText("Would you like to manually report the issue?");
         }
+
+        connect(ui->diagnostics_label, &QLabel::linkActivated, this, [this](const QString&)
+        {
+            if (!m_reportDirectory.isEmpty())
+            {
+                QDesktopServices::openUrl(QUrl::fromLocalFile(m_reportDirectory));
+            }
+        });
+
+        connect(ui->send_close_button, &QPushButton::clicked, this, [this]()
+        {
+            m_wantsRestart = false;
+            accept();
+        });
+
+        connect(ui->send_restart_button, &QPushButton::clicked, this, [this]()
+        {
+            m_wantsRestart = true;
+            accept();
+        });
     }
 
     SendReportDialog::~SendReportDialog()
     {
     }
 
-    void SendReportDialog::SetReportText(const QString& reportText)
+    void SendReportDialog::SetReportDirectory(const QString& reportDirectory)
     {
-        ui->dump_label->setText(reportText);
+        m_reportDirectory = reportDirectory;
+    }
+
+    void SendReportDialog::SetSummaryText(const QString& summaryText)
+    {
+        ui->summary_edit->setPlainText(summaryText);
     }
 
     void SendReportDialog::SetApplicationName(const char* applicationName)
     {
         QString errorString{ applicationName };
-        errorString += " has encountered a fatal error.  We're sorry for the inconvenience.";
-        ui->label->setText(errorString);
+        errorString += " has crashed";
+        ui->header_label->setText(errorString);
+    }
+
+    QString SendReportDialog::GetUserComments() const
+    {
+        return ui->comments_edit->toPlainText();
+    }
+
+    bool SendReportDialog::WantsContact() const
+    {
+        return ui->contact_checkbox->isChecked();
     }
 }

--- a/Code/Tools/CrashHandler/Tools/Uploader/SendReportDialog.h
+++ b/Code/Tools/CrashHandler/Tools/Uploader/SendReportDialog.h
@@ -25,12 +25,18 @@ namespace CrashUploader
         SendReportDialog(bool manualReport, QWidget* parent = nullptr);
         ~SendReportDialog() override;
 
-        void SetReportText(const QString& reportPath);
+        void SetReportDirectory(const QString& reportDirectory);
+        void SetSummaryText(const QString& summaryText);
         void SetApplicationName(const char* appName);
+
+        QString GetUserComments() const;
+        bool WantsRestart() const { return m_wantsRestart; }
 
     private:
         QScopedPointer<Ui::SendReportDialog> ui;
         bool m_manualReport = false;
+        bool m_wantsRestart = false;
+        QString m_reportDirectory;
     };
 
 }

--- a/Code/Tools/CrashHandler/Tools/Uploader/ToolsCrashUploader.cpp
+++ b/Code/Tools/CrashHandler/Tools/Uploader/ToolsCrashUploader.cpp
@@ -22,12 +22,15 @@
 #include <AzCore/std/typetraits/underlying_type.h>
 
 #include <QApplication>
+#include <QDateTime>
 #include <QDesktopServices>
 #include <QDir>
 #include <QFileInfo>
+#include <QProcess>
 #include <QString>
 #include <QUrl>
 
+#include <fstream>
 #include <memory>
 
 #include "UI/ui_submit_report.h"
@@ -102,18 +105,25 @@ namespace O3de
             styleManager.initialize(&app, engineRootPath);
 
             QString reportPath{ GetReportString(report.file_path.value()) };
- 
-            QString reportString{ GetReportString(report.file_path.value()).toStdString().c_str() };
+
             QAtomicInt dialogResult{ -1 };
 
             const bool manualReport = m_submissionToken.compare("manual") == 0;
             ::CrashUploader::SendReportDialog confirmDialog{ manualReport, nullptr };
             confirmDialog.SetApplicationName(m_executableName.c_str());
 
-            confirmDialog.setWindowIcon(QIcon(":/Icons/editor_icon.ico"));
+            confirmDialog.setWindowIcon(QIcon(":/Icons/lyeditor.ico"));
 
             QFileInfo fileInfo = QFileInfo(reportPath);
-            confirmDialog.SetReportText(fileInfo.absoluteFilePath());
+            confirmDialog.SetReportDirectory(fileInfo.absolutePath());
+
+            QString summaryText;
+            summaryText += "Report ID:  " + QString::fromStdString(report.uuid.ToString()) + "\n";
+            summaryText += "Created:    " + QDateTime::fromSecsSinceEpoch(static_cast<qint64>(report.creation_time)).toString(Qt::ISODate) + "\n";
+            summaryText += "Executable: " + QString::fromStdString(m_executableName) + "\n";
+            summaryText += "Dump file:  " + fileInfo.absoluteFilePath() + "\n";
+            confirmDialog.SetSummaryText(summaryText);
+
             confirmDialog.setWindowFlags((confirmDialog.windowFlags() | Qt::WindowStaysOnTopHint) & ~Qt::WindowContextHelpButtonHint);
 
             confirmDialog.exec();
@@ -125,6 +135,38 @@ namespace O3de
             }
 
             const bool accepted = dialogResult == QDialog::Accepted;
+
+            if (accepted)
+            {
+                const QString userComments = confirmDialog.GetUserComments();
+                const bool wantsContact = confirmDialog.WantsContact();
+                if (!userComments.isEmpty() || wantsContact)
+                {
+                    QString commentsFilePath = fileInfo.absolutePath() + "/user_comments.txt";
+                    std::ofstream commentsFile(commentsFilePath.toStdString());
+                    commentsFile << "Contact consent: " << (wantsContact ? "yes" : "no") << "\n\n";
+                    commentsFile << userComments.toStdString();
+                    commentsFile.close();
+
+#if defined(AZ_PLATFORM_WINDOWS)
+                    m_uploadPaths.push_back(base::FilePath(commentsFilePath.toStdWString()));
+#else
+                    m_uploadPaths.push_back(base::FilePath(commentsFilePath.toStdString()));
+#endif
+                }
+
+                if (confirmDialog.WantsRestart() && !m_executableName.empty())
+                {
+                    // Best-effort relaunch: the original command line (project, level, args) isn't
+                    // recorded by the crash handler, so this only restarts the bare executable.
+                    QString exePath = QCoreApplication::applicationDirPath() + "/" + QString::fromStdString(m_executableName);
+                    if (!QProcess::startDetached(exePath, {}))
+                    {
+                        LOG(ERROR) << "Failed to restart " << m_executableName << " after crash report submission";
+                    }
+                }
+            }
+
             if (manualReport && accepted)
             {
                 QDesktopServices::openUrl(QUrl(fileInfo.absolutePath()));

--- a/Code/Tools/CrashHandler/Uploader/include/Uploader/CrashUploader.h
+++ b/Code/Tools/CrashHandler/Uploader/include/Uploader/CrashUploader.h
@@ -25,6 +25,8 @@
 #include <base/logging.h>
 #include <string>
 
+#include <CrashSupport.h>
+
 namespace O3de
 {
     bool CheckConfirmation(const crashpad::CrashReportDatabase::Report& report);
@@ -46,7 +48,19 @@ namespace O3de
         virtual bool AddAttachments(crashpad::HTTPMultipartBuilder& builder);
         virtual bool UpdateHttpTransport(std::unique_ptr<crashpad::HTTPTransport>& httpTransport, const std::string& baseURL);
 
-        static const char* GetLogFileName() { return "CrashUploaderLog.txt"; }
+        // Absolute path next to the handler executable - a bare relative filename resolves
+        // against whatever cwd the handler process happened to inherit, which makes this
+        // log nearly impossible to find after the fact.
+        static const char* GetLogFileName()
+        {
+            static const std::string logPath = []()
+            {
+                std::string folder;
+                ::CrashHandler::GetExecutableFolder(folder);
+                return folder + "CrashUploaderLog.txt";
+            }();
+            return logPath.c_str();
+        }
 
         // base/logging.h::LogMessageHandlerFunction
         static bool DoLogging(logging::LogSeverity severity,

--- a/Gems/CrashReporting/Code/CMakeLists.txt
+++ b/Gems/CrashReporting/Code/CMakeLists.txt
@@ -14,6 +14,56 @@ if(NOT PAL_TRAIT_BUILD_EXTERNAL_CRASH_HANDLER_SUPPORTED)
     return()
 endif()
 
+# The sentry-native backend replaces this gem's Crashpad plumbing (GameCrashHandler /
+# GameCrashUploader) with a system component that self-initializes, so the two paths share no
+# sources and are selected here rather than #ifdef'd together.
+if(PAL_TRAIT_CRASH_HANDLER_BACKEND STREQUAL "SentryNative")
+
+    # Target references are resolved lazily by ly_delayed_target_link_libraries, but CMake
+    # functions are not - so pull the definition in directly if this gem is processed before
+    # Code/Tools/CrashHandler. FetchContent_MakeAvailable is idempotent, so this is a no-op then.
+    if(NOT COMMAND o3de_stage_crashpad_handler)
+        include(${LY_ROOT_FOLDER}/cmake/3rdParty/sentry-native.cmake)
+    endif()
+
+    ly_add_target(
+        NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+        NAMESPACE Gem
+        FILES_CMAKE
+            crashreporting_sentry_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                .
+            PUBLIC
+                Include
+        BUILD_DEPENDENCIES
+            PRIVATE
+                AZ::SentryCrashCore
+                AZ::AzCore
+                AZ::AzFramework
+    )
+
+    ly_add_source_properties(
+        SOURCES
+            Source/SentryCrashReportingModule.cpp
+        PROPERTY COMPILE_DEFINITIONS
+            VALUES
+                O3DE_GEM_NAME=${gem_name}
+                O3DE_GEM_VERSION=${gem_version})
+
+    ly_create_alias(NAME ${gem_name}.Clients NAMESPACE Gem TARGETS Gem::${gem_name})
+    ly_create_alias(NAME ${gem_name}.Servers NAMESPACE Gem TARGETS Gem::${gem_name})
+    ly_create_alias(NAME ${gem_name}.Unified NAMESPACE Gem TARGETS Gem::${gem_name})
+    ly_create_alias(NAME ${gem_name}.Tools   NAMESPACE Gem TARGETS Gem::${gem_name})
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name})
+
+    # Packaged launchers need crashpad_handler beside them too; the gem module lands in the same
+    # binary folder as the launcher that loads it.
+    o3de_stage_crashpad_handler(${gem_name})
+
+    return()
+endif()
+
 ly_add_target(
     NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem

--- a/Gems/CrashReporting/Code/Source/SentryCrashReportingModule.cpp
+++ b/Gems/CrashReporting/Code/Source/SentryCrashReportingModule.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Source/SentryCrashReportingSystemComponent.h>
+
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Module/Module.h>
+
+namespace CrashReporting
+{
+    class SentryCrashReportingModule : public AZ::Module
+    {
+    public:
+        AZ_RTTI(SentryCrashReportingModule, "{3C8F0E5A-7D64-4A1B-B0E9-9F5C2A44D8E1}", AZ::Module);
+        AZ_CLASS_ALLOCATOR(SentryCrashReportingModule, AZ::SystemAllocator);
+
+        SentryCrashReportingModule()
+        {
+            m_descriptors.insert(
+                m_descriptors.end(),
+                {
+                    SentryCrashReportingSystemComponent::CreateDescriptor(),
+                });
+        }
+
+        //! Returned components are created automatically on the system entity, which is what makes
+        //! merely enabling this gem enough to turn crash reporting on.
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override
+        {
+            return AZ::ComponentTypeList{
+                azrtti_typeid<SentryCrashReportingSystemComponent>(),
+            };
+        }
+    };
+}
+
+#if defined(O3DE_GEM_NAME)
+AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME), CrashReporting::SentryCrashReportingModule)
+#else
+AZ_DECLARE_MODULE_CLASS(Gem_CrashReporting, CrashReporting::SentryCrashReportingModule)
+#endif

--- a/Gems/CrashReporting/Code/Source/SentryCrashReportingSystemComponent.cpp
+++ b/Gems/CrashReporting/Code/Source/SentryCrashReportingSystemComponent.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <Source/SentryCrashReportingSystemComponent.h>
+
+#include <SentryCrashCore/SentryCrashCore.h>
+
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace CrashReporting
+{
+    namespace
+    {
+        AZStd::string ResolveAlias(const char* alias)
+        {
+            if (AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance())
+            {
+                if (auto resolved = fileIO->ResolvePath(AZ::IO::PathView(alias)); resolved.has_value())
+                {
+                    return resolved->c_str();
+                }
+            }
+            return {};
+        }
+
+        //! Tags the report with whichever launcher this is, so a client crash is distinguishable
+        //! from a server one in Sentry.
+        AZStd::string ExecutableModuleTag()
+        {
+            char buffer[AZ::IO::MaxPathLength]{};
+            const auto result = AZ::Utils::GetExecutablePath(buffer, sizeof(buffer));
+            // GetExecutablePath is documented as sometimes returning only the directory, in which
+            // case Stem() would silently hand back a folder name instead of the executable's.
+            if (result.m_pathStored != AZ::Utils::ExecutablePathResult::Success
+                || !result.m_pathIncludesFilename)
+            {
+                return "GameLauncher";
+            }
+            AZStd::string stem{ AZ::IO::PathView(buffer).Stem().Native() };
+            return stem.empty() ? AZStd::string("GameLauncher") : stem;
+        }
+    }
+
+    void SentryCrashReportingSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<SentryCrashReportingSystemComponent, AZ::Component>()->Version(1);
+        }
+    }
+
+    void SentryCrashReportingSystemComponent::GetProvidedServices(
+        AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("CrashReportingService"));
+    }
+
+    void SentryCrashReportingSystemComponent::GetIncompatibleServices(
+        AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("CrashReportingService"));
+    }
+
+    void SentryCrashReportingSystemComponent::Activate()
+    {
+        const AZStd::string moduleTag = ExecutableModuleTag();
+
+        // The crash database must live somewhere writable; @user@ is the launcher's own user
+        // folder, unlike the possibly read-only install directory.
+        AZStd::string appRoot = ResolveAlias("@user@");
+        if (appRoot.empty())
+        {
+            appRoot = ResolveAlias("@products@");
+        }
+
+        SentryCrash::Config config = SentryCrash::LoadConfig(moduleTag, appRoot);
+
+        // A packaged build does not ship the Qt companion reporter, so crashes upload silently
+        // rather than trying to launch a UI that is not there. Leaving this empty disables it.
+        config.m_externalReporterPath.clear();
+        config.m_attemptLevelSaveOnCrash = false;
+
+        const AZStd::string logDir = ResolveAlias("@log@");
+        if (!logDir.empty())
+        {
+            config.m_attachments.push_back(
+                AZStd::string::format("%s/%s.log", logDir.c_str(), moduleTag.c_str()));
+        }
+
+        if (!SentryCrash::Initialize(config))
+        {
+            return;
+        }
+
+        if (auto* registry = AZ::SettingsRegistry::Get(); registry != nullptr)
+        {
+            AZ::IO::FixedMaxPath projectPath;
+            if (registry->Get(
+                    projectPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
+            {
+                SentryCrash::SetTag("project_path", projectPath.c_str());
+            }
+        }
+
+        if (config.m_enableAppHangTracking)
+        {
+            AZ::TickBus::Handler::BusConnect();
+        }
+    }
+
+    void SentryCrashReportingSystemComponent::Deactivate()
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+        // Flushes queued envelopes and marks the session as a clean exit.
+        SentryCrash::Shutdown();
+    }
+
+    void SentryCrashReportingSystemComponent::OnTick(float, AZ::ScriptTimePoint)
+    {
+        SentryCrash::AppHangHeartbeat();
+    }
+
+    int SentryCrashReportingSystemComponent::GetTickOrder()
+    {
+        return AZ::TICK_FIRST;
+    }
+}

--- a/Gems/CrashReporting/Code/Source/SentryCrashReportingSystemComponent.h
+++ b/Gems/CrashReporting/Code/Source/SentryCrashReportingSystemComponent.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+
+namespace CrashReporting
+{
+    //! Brings up sentry-native crash reporting for packaged game and server launchers. Enabling
+    //! the CrashReporting gem in a project is all that is required - there is no launcher-side
+    //! call to add, which is what the Crashpad-era gem was missing (nothing ever called
+    //! GameCrashHandler::InitCrashHandler, so packaged builds never reported a crash).
+    class SentryCrashReportingSystemComponent
+        : public AZ::Component
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT(SentryCrashReportingSystemComponent, "{6E1B9A9C-2F1E-4E8B-9C36-1D3D0A5F2B77}");
+
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+
+        SentryCrashReportingSystemComponent() = default;
+        ~SentryCrashReportingSystemComponent() override = default;
+
+    protected:
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+
+        // AZ::TickBus::Handler - only connected when app-hang tracking is enabled, so the
+        // watchdog can tell a busy frame from a wedged main thread.
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        int GetTickOrder() override;
+    };
+}

--- a/Gems/CrashReporting/Code/crashreporting_sentry_files.cmake
+++ b/Gems/CrashReporting/Code/crashreporting_sentry_files.cmake
@@ -1,0 +1,13 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Source/SentryCrashReportingSystemComponent.h
+    Source/SentryCrashReportingSystemComponent.cpp
+    Source/SentryCrashReportingModule.cpp
+)

--- a/cmake/3rdParty/SuppressSentryFormatStringWarning.h
+++ b/cmake/3rdParty/SuppressSentryFormatStringWarning.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Force-included (via /FI) into every target in the vendored sentry-native dependency tree
+// (sentry-native itself, plus the crashpad/mini_chromium/zlib it bundles as its own crash backend).
+// This engine promotes a set of warnings to hard errors engine-wide via
+// cmake/Platform/Common/MSVC/Configurations_msvc.cmake's /we<code> flags -- correct for our own
+// code, but this vendored tree isn't ours to fix line-by-line as each warning surfaces on a
+// different file. A target-level /wd<code> can't win against that /we<code> on the actual cl.exe
+// command line (CMake's generator places TreatSpecificWarningsAsErrors-derived flags after
+// DisableSpecificWarnings-derived ones regardless of which CMake scope contributed each -- see
+// the analogous C4774/BoxPhysics fix), so command-line suppression can't win here -- a pragma can,
+// since it's evaluated by the compiler frontend rather than the command line.
+#if defined(_MSC_VER)
+#pragma warning(disable : 4263 4264 4265 4266 4296 4426 4437 4774 4777 4855 5031 5032 5233)
+#endif

--- a/cmake/3rdParty/sentry-native.cmake
+++ b/cmake/3rdParty/sentry-native.cmake
@@ -1,0 +1,68 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+include(FetchContent)
+
+FetchContent_Declare(
+    sentry_native
+    GIT_REPOSITORY https://github.com/getsentry/sentry-native.git
+    GIT_TAG        0.16.4
+    GIT_SUBMODULES_RECURSE TRUE
+)
+
+set(SENTRY_BACKEND "crashpad" CACHE STRING "" FORCE)
+set(SENTRY_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+set(SENTRY_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(SENTRY_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(sentry_native)
+
+# sentry-native bundles its own crashpad/mini_chromium/zlib build as sub-targets (SENTRY_BACKEND=
+# crashpad above), and warnings this engine promotes to errors engine-wide (Configurations_msvc.
+# cmake's /we<code> flags) keep surfacing one file at a time across that whole vendored tree as
+# different targets get built -- not ours to fix line-by-line. Rather than whack-a-mole one
+# target/code at a time as each surfaces, walk every target actually defined anywhere under
+# sentry_native's fetched source tree (recursing through nested add_subdirectory calls, which is
+# how crashpad/mini_chromium/zlib get pulled in) and suppress the whole set up front. Scoped to
+# this directory tree only -- our own targets keep the engine's normal strict warnings.
+function(o3de_suppress_vendored_warnings_recursive dir)
+    get_property(targets DIRECTORY "${dir}" PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(target ${targets})
+        get_target_property(target_type ${target} TYPE)
+        if(NOT target_type STREQUAL "INTERFACE_LIBRARY")
+            target_compile_options(${target} PRIVATE
+                ${O3DE_COMPILE_OPTION_DISABLE_WARNINGS}
+                /FI"${CMAKE_CURRENT_LIST_DIR}/SuppressSentryFormatStringWarning.h"
+            )
+        endif()
+    endforeach()
+
+    get_property(subdirs DIRECTORY "${dir}" PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirs})
+        o3de_suppress_vendored_warnings_recursive(${subdir})
+    endforeach()
+endfunction()
+
+if(DEFINED O3DE_COMPILE_OPTION_DISABLE_WARNINGS AND MSVC)
+    o3de_suppress_vendored_warnings_recursive(${sentry_native_SOURCE_DIR})
+endif()
+
+# sentry-native shells out to crashpad_handler at crash time and looks for it next to the running
+# executable, but sentry-native's own build drops it under _deps/ - so without staging, crash
+# capture silently does nothing. Anchored to a caller-supplied target that actually lands in the
+# binary output directory (a STATIC lib's TARGET_FILE_DIR is the lib folder, not bin).
+function(o3de_stage_crashpad_handler target)
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:crashpad_handler>
+            $<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_NAME:crashpad_handler>
+        COMMENT "Staging crashpad_handler next to ${target}"
+        VERBATIM
+    )
+    add_dependencies(${target} crashpad_handler)
+endfunction()

--- a/cmake/Platform/Windows/PAL_windows.cmake
+++ b/cmake/Platform/Windows/PAL_windows.cmake
@@ -19,6 +19,10 @@ ly_set(PAL_TRAIT_BUILD_UNITY_EXCLUDE_EXTENSIONS)
 ly_set(PAL_TRAIT_BUILD_EXCLUDE_ALL_TEST_RUNS_FROM_IDE FALSE)
 ly_set(PAL_TRAIT_BUILD_CPACK_SUPPORTED TRUE)
 ly_set(PAL_TRAIT_BUILD_EXTERNAL_CRASH_HANDLER_SUPPORTED FALSE)
+# Which backend the external crash handler uses when it is enabled above.
+# "Crashpad" (default) preserves existing behaviour; "SentryNative" builds the sentry-native
+# backend in Code/Tools/CrashHandler/SentryNative instead.
+ly_set(PAL_TRAIT_CRASH_HANDLER_BACKEND "Crashpad")
 
 ly_set(PAL_TRAIT_PROF_PIX_SUPPORTED TRUE)
 


### PR DESCRIPTION
Ok, this is a decently big pr.

This started as "why does our crash reporting produce nothing" and ended up covering three
separate things.

## 1. Bug fixes to the existing Crashpad path

**`CrashUploaderLog.txt` was written to an unpredictable directory.**
`CrashUploader::GetLogFileName()` returned a bare relative filename, so the log landed in whatever
working directory the handler process happened to inherit — in practice, nobody could find it.
Now resolved against the handler executable's own directory. This is what made the other bugs here
so hard to diagnose.

**The application log was never attached to crash reports.**
Reports contained the minidump and nothing else, so there was no record of what led up to the
crash. `CrashHandlerBase::Initialize` now resolves `@log@/<moduleTag>.log` and passes it via the
existing `--uploadpath` mechanism. Note this is registered unconditionally rather than guarded by
an existence check: `Initialize` runs at startup, *before* the logging system has created the file,
so an existence check there always fails. The handler only reads attachments when a crash actually
occurs, by which point the file exists.

Fixing this in `CrashHandlerBase` rather than per-caller means every host (Editor, AssetProcessor,
the Atom tools, ProjectManager, LuaIDE) gets it.

## 2. Crash reporter dialog

Replaces the fixed-size, absolutely-positioned confirmation dialog with a laid-out one modelled on
the Unreal Engine crash reporter: a description box for the user, a scrollable diagnostics summary
(report id, timestamp, executable, dump path), a link to the report directory, and Send-and-Close /
Send-and-Restart actions. User-entered text is written alongside the dump and uploaded with it.

Behaviour change worth calling out: **Send and Restart** relaunches the bare executable. The
original command line (project, level, arguments) is not recorded by the crash handler, so the
relaunch cannot reproduce it. Marked as such in the code.

## 3. Opt-in sentry-native backend

Adds a second crash-handler backend built on [sentry-native](https://github.com/getsentry/sentry-native),
selected at configure time:

```cmake
ly_set(PAL_TRAIT_CRASH_HANDLER_BACKEND "Crashpad")     # default, existing behaviour
ly_set(PAL_TRAIT_CRASH_HANDLER_BACKEND "SentryNative")
```

**No default behaviour changes.** `PAL_TRAIT_BUILD_EXTERNAL_CRASH_HANDLER_SUPPORTED` is left
`FALSE` as upstream ships it, and the new trait defaults to `Crashpad`, so a stock build neither
links sentry-native nor fetches it. Both backends expose the same
`CrashHandler::ToolsCrashHandler::InitCrashHandler(...)`, so none of the eleven existing call sites
change.

See `Code/Tools/CrashHandler/SentryNative/README.md` for layout, the full settings-registry schema,
and known gaps.

Highlights:
- Config via `/O3DE/CrashReporting/` in the SettingsRegistry, so projects configure crash reporting
  from `<project>/Registry/crash_handler.setreg` instead of compile-time defines.
- Log and screenshot attachment, breadcrumbs, tags/contexts, sessions, app-hang detection, and
  consent gating, all off or conservative by default.
- **Packaged builds**: the `CrashReporting` gem gains a system component that initializes on
  activation, so enabling the gem is sufficient. Previously nothing in the repo ever called
  `GameCrashHandler::InitCrashHandler` — packaged-build crash reporting could not have worked.
- **Editor level recovery**: a best-effort save from the crash handler via the existing
  `CCryEditDoc::SaveAutoBackup(true)`, offered back on restart. This deliberately does work that is
  not async-signal-safe; the trade-off and its risks are documented at the call site and in the
  README. It is opt-out via `AttemptLevelSaveOnCrash`.
- `simulate_crash` console command (Debug/Profile only, compiled out of Release) to exercise the
  pipeline without waiting for a real bug.

---

## Deliberately excluded

Two changes were made downstream and **left out of this PR** because they would regress upstream:

- Overriding the uploader's query parameter from `token=` to `sentry_key=`. That is required to
  target a Sentry-compatible ingest endpoint, but upstream's default is Backtrace, which expects
  `token=`. The sentry-native backend is the right upstream answer for Sentry.
- A project `crash_handler.setreg` carrying a real DSN. The schema is documented in the README
  instead; a DSN is an endpoint credential and does not belong in a shared repo.

## Testing

- Unit tests added for the config loader and the crash-envelope parser
  (`SentryCrashCore.Tests`, `SentryCrashReporterCore.Tests`).
- Manually exercised end-to-end on Windows & Linux via `simulate_crash`: capture, upload, the reporter
  dialog, feedback submission, and restart-with-project-path.
- The Crashpad path was exercised against a Sentry-compatible ingest endpoint during development;
  it has **not** been re-verified against Backtrace, which is worth checking before merging group 1.

## Notes for reviewers

- `sentry-native` is vendored via `FetchContent` at a pinned tag rather than added as an
  `ly_associate_package` 3rdParty binary. If O3DE would prefer a prebuilt package, that swap is
  contained to `cmake/3rdParty/sentry-native.cmake`.
- That file also force-includes a pragma header to suppress warnings the engine promotes to errors
  (`/we4774`, `/we4777`, …) across the vendored tree. A target-level `/wd` cannot win against a
  global `/we` on the MSVC command line, hence the pragma.
- No symbolication/debug-file upload step is included, so native frames appear as `module+offset`
  in Sentry until symbols are uploaded separately.
