### PR TITLE
Add velocity API in articulation link

### DIFF
--- a/Gems/PhysX/Core/Code/Source/Articulation.cpp
+++ b/Gems/PhysX/Core/Code/Source/Articulation.cpp
@@ -208,6 +208,26 @@ namespace PhysX
         return AZ::Aabb::CreateNull();
     }
 
+    AZ::Vector3 ArticulationLink::GetLinearVelocity() const
+    {
+        if (m_pxLink)
+        {
+            PHYSX_SCENE_READ_LOCK(m_pxLink->getScene());
+            return PxMathConvert(m_pxLink->getLinearVelocity());
+        }
+        return AZ::Vector3::CreateZero();
+    }
+
+    AZ::Vector3 ArticulationLink::GetAngularVelocity() const
+    {
+        if (m_pxLink)
+        {
+            PHYSX_SCENE_READ_LOCK(m_pxLink->getScene());
+            return PxMathConvert(m_pxLink->getAngularVelocity());
+        }
+        return AZ::Vector3::CreateZero();
+    }
+
     ArticulationLink* CreateArticulationLink([[maybe_unused]] const ArticulationLinkConfiguration* articulationConfig)
     {
         ArticulationLink* articulationLink = aznew ArticulationLink;

--- a/Gems/PhysX/Core/Code/Source/Articulation.h
+++ b/Gems/PhysX/Core/Code/Source/Articulation.h
@@ -87,6 +87,9 @@ namespace PhysX
         AZ::Quaternion GetOrientation() const override;
         AZ::Aabb GetAabb() const override;
 
+        AZ::Vector3 GetLinearVelocity() const;
+        AZ::Vector3 GetAngularVelocity() const;
+
     private:
         void AddCollisionShape(const ArticulationLinkData& thisLinkData);
 

--- a/Gems/PhysX/Core/PhysX5/CMakeLists.txt
+++ b/Gems/PhysX/Core/PhysX5/CMakeLists.txt
@@ -17,7 +17,16 @@ o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLAT
 include(${pal_source_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake) # for PAL_TRAIT_PHYSX_SUPPORTED
 
 if(PAL_TRAIT_PHYSX_SUPPORTED)
-    ly_add_target(NAME physx_5_dependency NAMESPACE Gem INTERFACE BUILD_DEPENDENCIES INTERFACE ciso646-include 3rdParty::PhysX5)
+    # The PhysX 5 SDK static libraries have circular dependencies on each other, FindPhysX5.cmake orders 
+    # them as a best-effort chain, but that isn't always sufficient for a single-pass GNU ld/lld link.
+    if(PAL_PLATFORM_NAME STREQUAL "Linux")
+        set(physx_5_link_group_start "-Wl,--start-group")
+        set(physx_5_link_group_end "-Wl,--end-group")
+    else()
+        set(physx_5_link_group_start)
+        set(physx_5_link_group_end)
+    endif()
+    ly_add_target(NAME physx_5_dependency NAMESPACE Gem INTERFACE BUILD_DEPENDENCIES INTERFACE ciso646-include ${physx_5_link_group_start} 3rdParty::PhysX5 ${physx_5_link_group_end})
     set(physx_dependency physx_5_dependency)
     set(physx_files ../Code/physx_files.cmake)
     set(physx_module_files physx_module_files.cmake)


### PR DESCRIPTION
## What does this PR do?

Adds `PhysX::ArticulationLink::GetLinearVelocity()` / `GetAngularVelocity()`, mirroring the existing `PhysX::RigidBody` accessors. Previously `ArticulationLink` only exposed transform/position/orientation, so any code reading velocity from a generic `AzPhysics::SimulatedBody*` (e.g. sensors) worked for rigid bodies but not articulation links. This unblocks o3de/o3de-extras#816 (ROS2 odometry/IMU sensors on articulation links).

Although the change is relatively simple, it fails to build without a fix in cmake due to a latent link-order problem in the PhysX5 gem. The PhysX SDK's static libs (`libPhysX_static_64.a` / `libPhysXPvdSDK_static_64.a`) have a circular symbol dependency that `FindPhysX5.cmake` resolves via a fixed forward+reverse library list. Adding these two methods shifted `libPhysX5.Static.a`'s object layout just enough that two passes stopped being sufficient, causing `undefined reference to PxSetPhysXGpuProfilerCallback` on Linux:
```
[1/6] Linking CXX static library lib/profile/libPhysX5.Editor.Static.a; Processing debug symbols ...
  [2/6] Linking CXX shared module bin/profile/libROS2Sensors.so; Processing debug symbols ...
  FAILED: [code=1] bin/profile/libROS2Sensors.so
  : && /usr/bin/clang++-21 ... -shared -Wl,--no-undefined ... -o bin/profile/libROS2Sensors.so
      ... lib/profile/libPhysX5.Static.a
      ... libPhysXFoundation_static_64.a libPhysXCommon_static_64.a libPhysXCooking_static_64.a
          libPhysXExtensions_static_64.a libPhysXCharacterKinematic_static_64.a libPhysXVehicle_static_64.a
          libPhysXPvdSDK_static_64.a libPhysX_static_64.a
      ... libPhysX_static_64.a libPhysXPvdSDK_static_64.a libPhysXVehicle_static_64.a
          libPhysXCharacterKinematic_static_64.a libPhysXExtensions_static_64.a libPhysXCooking_static_64.a
          libPhysXCommon_static_64.a libPhysXFoundation_static_64.a
      ... (rest of dependency graph) && cd ... && /usr/bin/cmake -P ProcessDebugSymbols.cmake ...

  /usr/bin/x86_64-linux-gnu-ld.bfd: .../libPhysXPvdSDK_static_64.a(PxPvdImpl.cpp.o): in function `physx::pvdsdk::PvdImpl::~PvdImpl()':
  PxPvdImpl.cpp:(.text._ZN5physx6pvdsdk7PvdImplD2Ev+0x3b): undefined reference to `PxSetPhysXGpuProfilerCallback'
  /usr/bin/x86_64-linux-gnu-ld.bfd: .../libPhysXPvdSDK_static_64.a(PxPvdImpl.cpp.o): in function
  `physx::pvdsdk::PvdImpl::connect(physx::PxPvdTransport&, physx::PxFlags<physx::PxPvdInstrumentationFlag::Enum, unsigned char>)':
  PxPvdImpl.cpp:(.text._ZN5physx6pvdsdk7PvdImpl7connectERNS_14PxPvdTransportENS_7PxFlagsINS_24PxPvdInstrumentationFlag4EnumEhEE+0x517)
  : undefined reference to `PxSetPhysXGpuProfilerCallback'
  clang++-21: error: linker command failed with exit code 1 (use -v to see invocation)

  [3/6] Linking CXX shared module bin/profile/libROS2Sensors.Editor.so; Processing debug symbols ...
  FAILED: [code=1] bin/profile/libROS2Sensors.Editor.so
  : && /usr/bin/clang++-21 ... (same shape as above, same library set) ...

  /usr/bin/x86_64-linux-gnu-ld.bfd: .../libPhysXPvdSDK_static_64.a(PxPvdImpl.cpp.o): in function `physx::pvdsdk::PvdImpl::~PvdImpl()':
  PxPvdImpl.cpp:(.text._ZN5physx6pvdsdk7PvdImplD2Ev+0x3b): undefined reference to `PxSetPhysXGpuProfilerCallback'
  /usr/bin/x86_64-linux-gnu-ld.bfd: .../libPhysXPvdSDK_static_64.a(PxPvdImpl.cpp.o): in function
  `physx::pvdsdk::PvdImpl::connect(physx::PxPvdTransport&, physx::PxFlags<physx::PxPvdInstrumentationFlag::Enum, unsigned char>)':
  PxPvdImpl.cpp:(.text._ZN5physx6pvdsdk7PvdImpl7connectERNS_14PxPvdTransportENS_7PxFlagsINS_24PxPvdInstrumentationFlag4EnumEhEE+0x517)
  : undefined reference to `PxSetPhysXGpuProfilerCallback'
  clang++-21: error: linker command failed with exit code 1 (use -v to see invocation)

  [4/6] Linking CXX shared module bin/profile/libROS2RobotImporter.Editor.so; Processing debug symbols ...
  [5/6] Linking CXX shared module bin/profile/libPhysX5.Editor.Gem.so; Processing debug symbols ...
  ninja: build stopped: subcommand failed.

```

Note the two occurrences of `libPhysX_static_64.a` / `libPhysXPvdSDK_static_64.a` in the link line above (forward list, then reversed) - that's the 2-pass workaround; _ld.bfd_ still couldn't resolve `PxSetPhysXGpuProfilerCallback` from `PxPvdImpl.cpp.o` within those two passes.

## How was this PR tested?

The values were read.
