### PR TITLE
[3rdParty] xxhash v0.8.3

### DIFF
--- a/Code/3rdParty/xxhash/CMakeLists.txt
+++ b/Code/3rdParty/xxhash/CMakeLists.txt
@@ -1,0 +1,43 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+o3de_fetch_content(xxhash
+    VERSION "0.8.3"
+    LICENSE "BSD-2-Clause"
+    URL "https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.3.tar.gz"
+    URL_HASH "aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80"
+    GIT "https://github.com/Cyan4973/xxHash.git"
+    GIT_HASH "e626a72bc2321cd320e953a0ccf1584cad60f363"
+    SOURCE_SUBDIR "no-add-subdir"
+)
+FetchContent_MakeAvailable(xxhash)
+
+file(
+    COPY "${xxhash_SOURCE_DIR}/xxhash.h"
+    DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/Include"
+)
+
+o3de_disable_warnings()
+
+ly_add_target(
+    NAME xxhash STATIC
+    NAMESPACE 3rdParty
+    NO_UNITY
+    FILES_CMAKE files.cmake
+)
+
+ly_target_include_system_directories(
+    TARGET xxhash
+    PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/Include"
+)
+
+ly_install_files(
+    FILES
+        LICENSE.txt
+        PackageInfo.json
+    DESTINATION Code/3rdParty/xxhash
+)

--- a/Code/3rdParty/xxhash/CMakeLists.txt
+++ b/Code/3rdParty/xxhash/CMakeLists.txt
@@ -30,8 +30,7 @@ ly_add_target(
     FILES_CMAKE files.cmake
 )
 
-ly_target_include_system_directories(
-    TARGET xxhash
+target_include_directories(xxhash SYSTEM
     PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/Include"
 )
 

--- a/Code/3rdParty/xxhash/LICENSE.txt
+++ b/Code/3rdParty/xxhash/LICENSE.txt
@@ -1,0 +1,26 @@
+xxHash Library
+Copyright (c) 2012-2021 Yann Collet
+All rights reserved.
+
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Code/3rdParty/xxhash/PackageInfo.json
+++ b/Code/3rdParty/xxhash/PackageInfo.json
@@ -1,0 +1,12 @@
+{
+    "PackageName": "xxHash",
+    "Version": "0.8.3",
+    "URL": "https://github.com/Cyan4973/xxHash",
+    "License": "BSD-2-Clause",
+    "LicenseFile": "LICENSE.txt",
+    "Source": {
+        "URL": "https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.3.tar.gz",
+        "Revision": "v0.8.3",
+        "SHA256": "aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80"
+    }
+}

--- a/Code/3rdParty/xxhash/files.cmake
+++ b/Code/3rdParty/xxhash/files.cmake
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
-add_subdirectory(antlr4)
-add_subdirectory(cli11)
-add_subdirectory(jsoncpp)
-add_subdirectory(xxhash)
+set(FILES
+    "${xxhash_SOURCE_DIR}/xxhash.c"
+)

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
@@ -27,10 +27,10 @@
 
 namespace AssetBuilderSDK
 {
-    // Defined XXH_INLINE_ALL and include <xxhash/xxhash.h> inside the AssetBuilderSDK namespace to prevent any possible
-    // symbol collision outside of this module
+    // Define XXH_INLINE_ALL and include <xxhash.h> inside the AssetBuilderSDK namespace
+    // to prevent any possible symbol collision outside of this module.
     #define XXH_INLINE_ALL
-    #include <xxhash/xxhash.h>
+    #include <xxhash.h>
 
     const char* const ErrorWindow = "Error"; //Use this window name to log error messages.
     const char* const WarningWindow = "Warning"; //Use this window name to log warning messages.

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -40,8 +40,8 @@
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Platform/PlatformDefaults.h>
 #include <AzToolsFramework/UI/Logging/LogLine.h>
-#include <xxhash/xxhash.h>
 #include <native/utilities/UuidManager.h>
+#include <xxhash.h>
 
 #if defined(AZ_PLATFORM_WINDOWS)
 #   include <windows.h>

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_aarch64.cmake
@@ -11,7 +11,6 @@
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
-ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-linux-aarch64                             TARGETS expat                       PACKAGE_HASH 934a535c1492d11906789d7ddf105b1a530cf8d8fb126063ffde16c5caeb0179)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux_x86_64.cmake
@@ -11,7 +11,6 @@
 # shared by other platforms:
 ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform                TARGETS RapidJSON                   PACKAGE_HASH 2f5e26ecf86c3b7a262753e7da69ac59928e78e9534361f3d00c1ad5879e4023)
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
-ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                        TARGETS cityhash                    PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)
 
 # platform-specific:

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
@@ -13,7 +13,6 @@ ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform            
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                        TARGETS cityhash                    PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)
 ly_associate_package(PACKAGE_NAME zstd-1.35-multiplatform                           TARGETS zstd                        PACKAGE_HASH 45d466c435f1095898578eedde85acf1fd27190e7ea99aeaa9acfd2f09e12665)
-ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-mac                              TARGETS expat                       PACKAGE_HASH 70f195977a17b08a4dc8687400fd7f2589e3b414d4961b562129166965b6f658)

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac_arm64.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac_arm64.cmake
@@ -13,7 +13,6 @@ ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform            
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                  TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-rev1-mac-arm64                       TARGETS cityhash                    PACKAGE_HASH c5844582b4fe819e74ca923dbb58405dd687a4b9acb82d7de04e3e766addb4ed)
 ly_associate_package(PACKAGE_NAME zstd-1.35-rev1-mac-arm64                          TARGETS zstd                        PACKAGE_HASH bb401d198d9fd2be2669acb6fe8dbe59fd7d33a66b5f2fd7d3e0221e5b72d1f4)
-ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                   TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.7.3-rev2-mac-arm64                        TARGETS expat                       PACKAGE_HASH 2b3a0c2cd041dcb2709681589cbd5b349d82aed80f41fef0379f0f1329735011)

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -13,7 +13,6 @@ ly_associate_package(PACKAGE_NAME RapidJSON-1.1.0-rev1-multiplatform            
 ly_associate_package(PACKAGE_NAME RapidXML-1.13-rev1-multiplatform                      TARGETS RapidXML                    PACKAGE_HASH 4b7b5651e47cfd019b6b295cc17bb147b65e53073eaab4a0c0d20a37ab74a246)
 ly_associate_package(PACKAGE_NAME cityhash-1.1-multiplatform                            TARGETS cityhash                    PACKAGE_HASH 0ace9e6f0b2438c5837510032d2d4109125845c0efd7d807f4561ec905512dd2)
 ly_associate_package(PACKAGE_NAME zstd-1.35-multiplatform                               TARGETS zstd                        PACKAGE_HASH 45d466c435f1095898578eedde85acf1fd27190e7ea99aeaa9acfd2f09e12665)
-ly_associate_package(PACKAGE_NAME xxhash-0.7.4-rev1-multiplatform                       TARGETS xxhash                      PACKAGE_HASH e81f3e6c4065975833996dd1fcffe46c3cf0f9e3a4207ec5f4a1b564ba75861e)
 
 # platform-specific:
 ly_associate_package(PACKAGE_NAME expat-2.4.2-rev2-windows                              TARGETS expat                       PACKAGE_HASH 748d08f21f5339757059a7887e72b52d15e954c549245c638b0b05bd5961e307)


### PR DESCRIPTION
Updates xxHash from the legacy packaged v0.7.4 dependency to a source-fetched 3rdParty library using xxHash v0.8.3.

The upstream archive and fallback Git revision are pinned, while O3DE defines the static library target directly instead of consuming xxHash's CMake project. Only the public header is copied into the generated include directory. The implementation is compiled directly from the fetched source tree.

Existing Asset Processor consumers now include the upstream `<xxhash.h>` header directly. Installed builds include the public header, package metadata, and license information.