### PR TITLE
Fix Shader Builder AZSL compiler staging

### DIFF
--- a/Code/Tools/ShaderCompiler/README.md
+++ b/Code/Tools/ShaderCompiler/README.md
@@ -15,8 +15,6 @@ Configure a build directory, then build the command-line target:
 cmake --build <build-directory> --target Azslc --config Profile
 ```
 
-The executable is written to `<build-directory>/bin/profile/azslc`. Building Atom Shader Builder also builds and stages the executable under `Builders/AZSLc`.
-
 ## Grammar
 
 The generated ANTLR C++ sources are checked in. With Java and PowerShell available, regenerate them from the engine root:

--- a/Gems/Atom/Asset/Shader/Code/CMakeLists.txt
+++ b/Gems/Atom/Asset/Shader/Code/CMakeLists.txt
@@ -111,15 +111,6 @@ ly_add_target(
         AZ::Azslc
 )
 
-ly_add_target_files(
-    TARGETS
-        ${gem_name}.Builders
-    FILES
-        $<TARGET_FILE:Azslc>
-    OUTPUT_SUBDIRECTORY
-        Builders/AZSLc
-)
-
 # Inject the gem name into the Module source file
 ly_add_source_properties(
     SOURCES

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslCompiler.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslCompiler.cpp
@@ -53,9 +53,8 @@ namespace AZ
         bool AzslCompiler::Compile(const AZStd::string& compilerParams,
                                    const AZStd::string& outputFilePath) const
         {
-            // Shader compiler executable
-            AZStd::string azslcPath = "Builders/AZSLc/";
-            azslcPath += AZ_TRAIT_ATOM_SHADERBUILDER_AZSLC;
+            // Relative executable paths are resolved from the engine binary directory, where runtime dependencies are staged.
+            AZStd::string azslcPath = AZ_TRAIT_ATOM_SHADERBUILDER_AZSLC;
 
             if (auto setReg = AZ::Interface<SettingsRegistryInterface>::Get())
             {


### PR DESCRIPTION
The Shader Builder was launching a duplicate `azslc` executable staged under `Builders/AZSLc`. Unlike the previous packaged compiler, the engine-built executable depends on shared libraries such as `libAzCore`, which are staged in the main binary directory. This change removes the duplicate executable and launches the correctly staged runtime dependency from the binary directory.

## How was this PR tested?

- Built `Azslc` and `AtomShader.Builders`.
- Confirmed the runtime manifest no longer stages `Builders/AZSLc/azslc`.