### PR TITLE
Fix DX12 transient resource discard ordering and state

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <RHI/FrameGraphCompiler.h>
+
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/RHISystemInterface.h>
@@ -14,12 +15,14 @@
 #include <RHI/CommandQueueContext.h>
 #include <RHI/Conversions.h>
 #include <RHI/Device.h>
+#include <RHI/DX12.h>
 #include <RHI/Image.h>
 #include <RHI/Scope.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ScopeAttachment.h>
 #include <Atom/RHI/SwapChainFrameAttachment.h>
+#include <AzCore/std/optional.h>
 // #define AZ_DX12_FRAMESCHEDULER_LOG_TRANSITIONS
 
 namespace AZ
@@ -216,7 +219,7 @@ namespace AZ
             return AZ::Success();
         }
 
-        D3D12_RESOURCE_STATES FrameGraphCompiler::GetResourceState(const RHI::ScopeAttachment& scopeAttachment)
+        static D3D12_RESOURCE_STATES GetResourceState(const RHI::ScopeAttachment& scopeAttachment)
         {
             static const D3D12_RESOURCE_STATES ReadWriteState[RHI::HardwareQueueClassCount] =
             {
@@ -312,25 +315,39 @@ namespace AZ
             return resourceState;
         }
 
-        AZStd::optional<D3D12_RESOURCE_STATES> FrameGraphCompiler::GetDiscardResourceState(const RHI::ScopeAttachment& scopeAttachment, D3D12_RESOURCE_FLAGS bindflags)
+        static AZStd::optional<D3D12_RESOURCE_STATES> GetBufferDiscardResourceState(
+            const RHI::BufferScopeAttachment& scopeAttachment,
+            D3D12_RESOURCE_FLAGS bindFlags)
         {
-            //Discard transitions described here https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-discardresource
-            const RHI::Scope& parentScope = scopeAttachment.GetScope();
-            const RHI::HardwareQueueClass hardwareQueueClass = parentScope.GetHardwareQueueClass();
+            if (scopeAttachment.GetScope().GetHardwareQueueClass() == RHI::HardwareQueueClass::Compute)
+            {
+                if (bindFlags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+                {
+                    return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+                }
+            }
 
-            switch(hardwareQueueClass)
+            return {};
+        }
+
+        static AZStd::optional<D3D12_RESOURCE_STATES> GetImageDiscardResourceState(
+            const RHI::ImageScopeAttachment& scopeAttachment,
+            D3D12_RESOURCE_FLAGS bindFlags)
+        {
+            // Discard transitions described here: https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-discardresource
+            switch (scopeAttachment.GetScope().GetHardwareQueueClass())
             {
             case RHI::HardwareQueueClass::Graphics:
             {
-                if (bindflags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET)
+                if (bindFlags & D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET)
                 {
                     return D3D12_RESOURCE_STATE_RENDER_TARGET;
                 }
-                else if (bindflags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)
+                else if (bindFlags & D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)
                 {
                     return D3D12_RESOURCE_STATE_DEPTH_WRITE;
                 }
-                else if (bindflags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+                else if (bindFlags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
                 {
                     return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
                 }
@@ -338,7 +355,7 @@ namespace AZ
             }
             case RHI::HardwareQueueClass::Compute:
             {
-                if (bindflags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+                if (bindFlags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
                 {
                     return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
                 }
@@ -348,7 +365,7 @@ namespace AZ
 
             return {};
         }
-    
+
         void FrameGraphCompiler::CompileResourceBarriers(Scope* rootScope, const RHI::FrameGraphAttachmentDatabase& attachmentDatabase)
         {
             AZ_PROFILE_SCOPE(RHI, "FrameGraphCompiler: CompileResourceBarriers(DX12)");
@@ -396,8 +413,7 @@ namespace AZ
 
                 if (firstScope.IsResourceDiscarded(*scopeAttachment))
                 {
-                    auto afterState = GetDiscardResourceState(*scopeAttachment, ConvertBufferBindFlags(buffer.GetDescriptor().m_bindFlags));
-                    if (afterState)
+                    if (auto afterState = GetBufferDiscardResourceState(*scopeAttachment, ConvertBufferBindFlags(buffer.GetDescriptor().m_bindFlags)))
                     {
                         transition.StateAfter = afterState.value();
                         if (firstScope.IsStateSupportedByQueue(transition.StateBefore) &&
@@ -477,8 +493,7 @@ namespace AZ
                 // Apply appropriate pre-discard transition
                 if (firstScope.IsResourceDiscarded(*scopeAttachment))
                 {
-                    auto afterState = GetDiscardResourceState(*scopeAttachment, ConvertImageBindFlags(image.GetDescriptor().m_bindFlags));
-                    if (afterState)
+                    if (auto afterState = GetImageDiscardResourceState(*scopeAttachment, ConvertImageBindFlags(image.GetDescriptor().m_bindFlags)))
                     {
                         transition.StateAfter = afterState.value();
                         for (const auto& subresourceState : image.GetAttachmentStateByIndex())

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -330,6 +330,10 @@ namespace AZ
                 {
                     return D3D12_RESOURCE_STATE_DEPTH_WRITE;
                 }
+                else if (bindflags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+                {
+                    return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+                }
                 break;
             }
             case RHI::HardwareQueueClass::Compute:

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.h
@@ -9,8 +9,6 @@
 
 #include <Atom/RHI/FrameGraphCompiler.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <AzCore/std/optional.h>
-#include <RHI/DX12.h>
 
 namespace AZ
 {
@@ -18,7 +16,6 @@ namespace AZ
     {
         class BufferFrameAttachment;
         class ImageFrameAttachment;
-        class ScopeAttachment;
     }
 
     namespace DX12
@@ -45,11 +42,6 @@ namespace AZ
             RHI::MessageOutcome CompileInternal(const RHI::FrameGraphCompileRequest& request) override;
             //////////////////////////////////////////////////////////////////////////
 
-            static D3D12_RESOURCE_STATES GetResourceState(const RHI::ScopeAttachment& scopeAttachment);
-
-            //Returns pre-discard transition state.
-            static AZStd::optional<D3D12_RESOURCE_STATES> GetDiscardResourceState(const RHI::ScopeAttachment& scopeAttachment, D3D12_RESOURCE_FLAGS bindflags);
-            
             void CompileResourceBarriers(Scope* rootScope, const RHI::FrameGraphAttachmentDatabase& attachmentDatabase);
             void CompileBufferBarriers(Scope* rootScope, RHI::BufferFrameAttachment& frameGraphAttachment);
             void CompileImageBarriers(RHI::ImageFrameAttachment& frameGraphAttachment);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -379,6 +379,11 @@ namespace AZ
                     PIXBeginEvent(commandList.GetCommandList(), PIX_MARKER_CMDLIST_COL, GetMarkerLabel().data());
                 }
 
+                for (const auto& barrier : m_aliasingBarriers)
+                {
+                    commandList.QueueAliasingBarrier(barrier);
+                }
+
                 for (const auto& barrier : m_preDiscardTransitionBarrierRequests)
                 {
                     commandList.QueueTransitionBarrier(barrier);
@@ -394,11 +399,6 @@ namespace AZ
                 for (RHI::ResourcePoolResolver* resolvePolicyBase : GetResourcePoolResolves())
                 {
                     static_cast<ResourcePoolResolver*>(resolvePolicyBase)->QueuePrologueTransitionBarriers(commandList);
-                }
-
-                for (const auto& barrier : m_aliasingBarriers)
-                {
-                    commandList.QueueAliasingBarrier(barrier);
                 }
 
                 for (const auto& barrier : m_prologueTransitionBarrierRequests)

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -218,12 +218,21 @@ namespace AZ
             const bool isFirstUsage = scopeAttachment.GetPrevious() == nullptr;
             const bool isTransient = scopeAttachment.GetFrameAttachment().GetLifetimeType() == RHI::AttachmentLifetimeType::Transient;
 
-            // We are required to discard transient resources on first use, but only if aren't
-            // clearing the *full* resource. Since it's possible that our first use is just a
-            // partial clear, we may still need to 
+            // Discard transient resources on first use when the command list supports it, unless a full clear
+            // initializes the whole resource. DiscardResource is only supported on graphics queues, or compute
+            // queues for resources that allow unordered access.
             if (isFirstUsage && isTransient && !isFullResourceClear)
             {
-                m_discardResourceRequests.push_back(resource);
+                const RHI::HardwareQueueClass hardwareQueueClass = GetHardwareQueueClass();
+                const bool canDiscardResource =
+                    hardwareQueueClass == RHI::HardwareQueueClass::Graphics
+                    || (hardwareQueueClass == RHI::HardwareQueueClass::Compute
+                        && (resource->GetDesc().Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS));
+
+                if (canDiscardResource)
+                {
+                    m_discardResourceRequests.push_back(resource);
+                }
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes DX12 validation errors and the resulting editor crash when transient UAV resources are reused from an aliased heap.

Placed resources are inactive until an aliasing barrier activates them. The DX12 scope prologue previously called `DiscardResource` before submitting its aliasing barriers. It also selected the required pre-discard state for render-target and depth-stencil resources on graphics queues, but not UAV resources. This left UAV-only images such as the light culling attachments in a shader-resource state when they were discarded, producing `INVALID_SUBRESOURCE_STATE` and `RESOURCE_BARRIER_BEFORE_AFTER_MISMATCH` errors.

What does:

- Submits aliasing barriers before pre-discard transitions and DiscardResource.
- Uses `D3D12_RESOURCE_STATE_UNORDERED_ACCESS` as the graphics-queue discard state for UAV resources, while preserving the existing render-target and depth-stencil priority.

The resource is now activated -> transitioned into its valid discard state -> discarded -> then transitioned normally for its first use. This fixes the resource lifecycle and state tracking instead of disabling or filtering DX12 validation.

This follows the DirectX 12 requirements for [activating placed resources before initialization](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-createplacedresource) and [using the correct resource state with `DiscardResource`](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-discardresource).

Related reports: #18776 and #19107.

## How was this PR tested?

- Built the Debug Editor on Windows.
- Built `Atom_RHI.Tests` and passed `Gem::Atom_RHI.Tests.main::TEST_RUN`.
- Started the AutomatedTesting debug editor with DX12 device validation enabled. DX12 initialized successfully, and the Editor ran past the previous failure without a DX12 validation error, crash, or new error dump.
