### PR TITLE
Fix ShaderCompiler compilation in Debug builds

### DIFF
--- a/Code/Tools/ShaderCompiler/Source/AzslcMangling.h
+++ b/Code/Tools/ShaderCompiler/Source/AzslcMangling.h
@@ -542,7 +542,7 @@ namespace AZ::ShaderCompiler
 #ifndef NDEBUG
 namespace AZ::Tests
 {
-    inline void Func(AZ::ShaderCompiler::UnqualifiedName un) {}
+    inline void Func([[maybe_unused]] AZ::ShaderCompiler::UnqualifiedName un) {}
 
     inline void DoAsserts5()
     {

--- a/Code/Tools/ShaderCompiler/Source/MetaUtils.h
+++ b/Code/Tools/ShaderCompiler/Source/MetaUtils.h
@@ -392,7 +392,7 @@ namespace AZ::Tests
             });
 
         using TL = TypeList< ConstVal<10>, int >;
-        ForEachType< TL >([](auto inst, auto ii_c)
+        ForEachType< TL >([]([[maybe_unused]] auto inst, auto ii_c)
             {
                 using KeyAtii = At_t<decltype(ii_c)::value, TL>;
                 static_assert(ii_c == 0 && isIntegralConstant_v< KeyAtii > && KeyAtii{} == 10

--- a/Code/Tools/ShaderCompiler/Source/ReflectableEnums.h
+++ b/Code/Tools/ShaderCompiler/Source/ReflectableEnums.h
@@ -184,9 +184,9 @@ namespace AZ::Tests
         assert(!e.IsOneOf(MyEnum::Enumerand1, MyEnum::Enumerand3));
 
         i = 0;
-        for (auto e : MyEnumFlaggable::Enumerate{})
+        for (auto flag : MyEnumFlaggable::Enumerate{})
         {
-            assert(e == 1 << i);
+            assert(flag == 1 << i);
             ++i;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes ShaderCompiler failing to compile in a Debug build.

When I initially integrated ShaderCompiler into the source tree, I missed testing the Debug configuration. A few debug-only test helpers had intentionally unused parameters, and one test loop declared a variable that shadowed an existing variable. Because these warnings are treated as errors, they prevented the build from completing.

This change marks the intentionally unused parameters with `[[maybe_unused]]` and gives the shadowed loop variable a distinct name. The changes are limited to debug-only test code and do not affect ShaderCompiler behavior.

## How was this PR tested?

- Built the Debug Editor on Windows.