### PR TITLE
Expose InputDeviceId to Script Canvas

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/InputDeviceId.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/InputDeviceId.cpp
@@ -10,6 +10,8 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Script/ScriptContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
+#include <AzCore/std/string/string.h>
 
 namespace
 {
@@ -55,13 +57,28 @@ namespace AzFramework
     {
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
+            const AZ::BehaviorParameterOverrides nameParameter(
+                "Name", "Name of the input device, such as gamepad, keyboard, or mouse");
+            const AZ::BehaviorParameterOverrides indexParameter(
+                "Index", "Zero-based index used to address a specific device of the same type");
+
             behaviorContext->Class<InputDeviceId>()
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
-                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Category, "Input")
+                ->Attribute(AZ::ScriptCanvasAttributes::AllowInternalCreation, true)
+                ->Attribute(AZ::ScriptCanvasAttributes::VariableCreationForbidden, true)
                 ->Constructor<const char*>()
                 ->Constructor<const char*, AZ::u32>()
                 ->Attribute(AZ::Script::Attributes::ConstructorOverride, &InputDeviceIdScriptConstructor)
+                ->Method(
+                    "Create",
+                    [](const AZStd::string& name, AZ::u32 index)
+                    {
+                        return InputDeviceId(name, index);
+                    },
+                    { nameParameter, indexParameter },
+                    "Creates an input device id for use as the source of addressed input requests")
                 ->Property("name", [](InputDeviceId* thisPtr) { return thisPtr->GetName(); }, nullptr)
                 ->Property("index", BehaviorValueProperty(&InputDeviceId::m_index))
             ;

--- a/Code/Framework/AzFramework/Tests/InputDeviceIdReflectionTests.cpp
+++ b/Code/Framework/AzFramework/Tests/InputDeviceIdReflectionTests.cpp
@@ -97,7 +97,7 @@ namespace InputDeviceIdReflectionTests
         EXPECT_TRUE(g_constructorArgumentsPreserved);
     }
 
-    TEST_F(InputDeviceIdReflectionTest, Reflection_AllowsTransientScriptCanvasSlotsButNotVariables)
+    TEST_F(InputDeviceIdReflectionTest, Reflection_DeclaresScriptCanvasCreationAttributes)
     {
         const auto behaviorClassIterator = m_behaviorContext->m_typeToClassMap.find(azrtti_typeid<AzFramework::InputDeviceId>());
         ASSERT_NE(behaviorClassIterator, m_behaviorContext->m_typeToClassMap.end());

--- a/Code/Framework/AzFramework/Tests/InputDeviceIdReflectionTests.cpp
+++ b/Code/Framework/AzFramework/Tests/InputDeviceIdReflectionTests.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Script/ScriptContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/UnitTest/TestTypes.h>
 
 namespace InputDeviceIdReflectionTests
@@ -83,5 +84,29 @@ namespace InputDeviceIdReflectionTests
 
         EXPECT_TRUE(executed);
         EXPECT_TRUE(g_constructorArgumentsPreserved);
+    }
+
+    TEST_F(InputDeviceIdReflectionTest, CreateMethod_PreservesNameAndIndexInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local deviceId = InputDeviceId.Create('gamepad', 2)\n"
+            "constructorArgumentsPreserved = "
+            "deviceId.name == 'gamepad' and deviceId.index == 2\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorArgumentsPreserved);
+    }
+
+    TEST_F(InputDeviceIdReflectionTest, Reflection_AllowsTransientScriptCanvasSlotsButNotVariables)
+    {
+        const auto behaviorClassIterator = m_behaviorContext->m_typeToClassMap.find(azrtti_typeid<AzFramework::InputDeviceId>());
+        ASSERT_NE(behaviorClassIterator, m_behaviorContext->m_typeToClassMap.end());
+
+        const AZ::BehaviorClass* behaviorClass = behaviorClassIterator->second;
+        ASSERT_NE(behaviorClass, nullptr);
+        EXPECT_EQ(AZ::FindAttribute(AZ::Script::Attributes::ExcludeFrom, behaviorClass->m_attributes), nullptr);
+        EXPECT_NE(AZ::FindAttribute(AZ::ScriptCanvasAttributes::AllowInternalCreation, behaviorClass->m_attributes), nullptr);
+        EXPECT_NE(AZ::FindAttribute(AZ::ScriptCanvasAttributes::VariableCreationForbidden, behaviorClass->m_attributes), nullptr);
+        EXPECT_NE(behaviorClass->m_methods.find("Create"), behaviorClass->m_methods.end());
     }
 } // namespace InputDeviceIdReflectionTests

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputDeviceId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputDeviceId.names
@@ -6,7 +6,7 @@
             "variant": "",
             "details": {
                 "name": "Input Device Id",
-                "category": "Gameplay"
+                "category": "Input"
             },
             "methods": [
                 {

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputDeviceId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputDeviceId.names
@@ -23,6 +23,79 @@
                         "name": "Create Input Device Id",
                         "tooltip": "Creates an input device identifier from a device name and index"
                     }
+                },
+                {
+                    "base": "Getname",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Name",
+                        "tooltip": "Returns the input device name"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{E58630A4-D380-4289-AA29-83300636A954}",
+                            "details": {
+                                "name": "Input Device Id"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{3AB0037F-AF8D-48CE-BCA0-A170D18B2C03}",
+                            "details": {
+                                "name": "Name",
+                                "tooltip": "Name of the input device"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "Getindex",
+                    "context": "Getter",
+                    "details": {
+                        "name": "Get Index",
+                        "tooltip": "Returns the input device index"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{E58630A4-D380-4289-AA29-83300636A954}",
+                            "details": {
+                                "name": "Input Device Id"
+                            }
+                        }
+                    ],
+                    "results": [
+                        {
+                            "typeid": "{43DA906B-7DEF-4CA8-9790-854106D3F983}",
+                            "details": {
+                                "name": "Index",
+                                "tooltip": "Zero-based index of the input device"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "base": "Setindex",
+                    "context": "Setter",
+                    "details": {
+                        "name": "Set Index",
+                        "tooltip": "Sets the input device index"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{E58630A4-D380-4289-AA29-83300636A954}",
+                            "details": {
+                                "name": "Input Device Id"
+                            }
+                        },
+                        {
+                            "typeid": "{43DA906B-7DEF-4CA8-9790-854106D3F983}",
+                            "details": {
+                                "name": "Index",
+                                "tooltip": "Zero-based index to assign to the input device"
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputDeviceId.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Classes/InputDeviceId.names
@@ -1,0 +1,30 @@
+{
+    "entries": [
+        {
+            "base": "InputDeviceId",
+            "context": "BehaviorClass",
+            "variant": "",
+            "details": {
+                "name": "Input Device Id",
+                "category": "Gameplay"
+            },
+            "methods": [
+                {
+                    "base": "Create",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will create an Input Device Id"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after the Input Device Id is created"
+                    },
+                    "details": {
+                        "name": "Create Input Device Id",
+                        "tooltip": "Creates an input device identifier from a device name and index"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -433,9 +433,24 @@ namespace ScriptCanvasEditor::Nodes
 
                 if (isBusIdSlot)
                 {
-                    key = ::ScriptCanvasEditor::TranslationHelper::GlobalKeys::EBusSenderIDKey;
+                    GraphCanvas::TranslationKey busIdKey;
+                    busIdKey << context << className << "methods" << updatedMethodName << "busId" << "details";
+
+                    GraphCanvas::TranslationRequests::Details busIdDetails;
                     GraphCanvas::TranslationRequestBus::BroadcastResult(
-                        details, &GraphCanvas::TranslationRequests::GetDetails, key + ".details", details);
+                        busIdDetails, &GraphCanvas::TranslationRequests::GetDetails, busIdKey, busIdDetails);
+
+                    if (busIdDetails.m_name.empty() && busIdDetails.m_tooltip.empty())
+                    {
+                        key = ::ScriptCanvasEditor::TranslationHelper::GlobalKeys::EBusSenderIDKey;
+                        GraphCanvas::TranslationRequestBus::BroadcastResult(
+                            details, &GraphCanvas::TranslationRequests::GetDetails, key + ".details", details);
+                    }
+                    else
+                    {
+                        details.m_name = busIdDetails.m_name.empty() ? details.m_name : busIdDetails.m_name;
+                        details.m_tooltip = busIdDetails.m_tooltip.empty() ? details.m_tooltip : busIdDetails.m_tooltip;
+                    }
                 }
                 else if (slot.IsData())
                 {

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -433,24 +433,16 @@ namespace ScriptCanvasEditor::Nodes
 
                 if (isBusIdSlot)
                 {
+                    key = ::ScriptCanvasEditor::TranslationHelper::GlobalKeys::EBusSenderIDKey;
+                    GraphCanvas::TranslationRequestBus::BroadcastResult(
+                        details, &GraphCanvas::TranslationRequests::GetDetails, key + ".details", details);
+
+                    // Allow an individual EBus event to provide a more descriptive BusId label while preserving
+                    // the global sender BusId translation as the fallback for unspecified fields.
                     GraphCanvas::TranslationKey busIdKey;
                     busIdKey << context << className << "methods" << updatedMethodName << "busId" << "details";
-
-                    GraphCanvas::TranslationRequests::Details busIdDetails;
                     GraphCanvas::TranslationRequestBus::BroadcastResult(
-                        busIdDetails, &GraphCanvas::TranslationRequests::GetDetails, busIdKey, busIdDetails);
-
-                    if (busIdDetails.m_name.empty() && busIdDetails.m_tooltip.empty())
-                    {
-                        key = ::ScriptCanvasEditor::TranslationHelper::GlobalKeys::EBusSenderIDKey;
-                        GraphCanvas::TranslationRequestBus::BroadcastResult(
-                            details, &GraphCanvas::TranslationRequests::GetDetails, key + ".details", details);
-                    }
-                    else
-                    {
-                        details.m_name = busIdDetails.m_name.empty() ? details.m_name : busIdDetails.m_name;
-                        details.m_tooltip = busIdDetails.m_tooltip.empty() ? details.m_tooltip : busIdDetails.m_tooltip;
-                    }
+                        details, &GraphCanvas::TranslationRequests::GetDetails, busIdKey, details);
                 }
                 else if (slot.IsData())
                 {

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -436,13 +436,6 @@ namespace ScriptCanvasEditor::Nodes
                     key = ::ScriptCanvasEditor::TranslationHelper::GlobalKeys::EBusSenderIDKey;
                     GraphCanvas::TranslationRequestBus::BroadcastResult(
                         details, &GraphCanvas::TranslationRequests::GetDetails, key + ".details", details);
-
-                    // Allow an individual EBus event to provide a more descriptive BusId label while preserving
-                    // the global sender BusId translation as the fallback for unspecified fields.
-                    GraphCanvas::TranslationKey busIdKey;
-                    busIdKey << context << className << "methods" << updatedMethodName << "busId" << "details";
-                    GraphCanvas::TranslationRequestBus::BroadcastResult(
-                        details, &GraphCanvas::TranslationRequests::GetDetails, busIdKey, details);
                 }
                 else if (slot.IsData())
                 {

--- a/Gems/ScriptCanvas/Code/Tests/Data/InputDeviceIdDataRegistryTest.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Data/InputDeviceIdDataRegistryTest.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Input/Devices/InputDeviceId.h>
+
+#include <ScriptCanvas/Data/DataRegistry.h>
+#include <ScriptCanvas/Data/DataTypeUtils.h>
+#include <ScriptCanvas/SystemComponent.h>
+#include <Tests/Framework/ScriptCanvasUnitTestFixture.h>
+
+namespace ScriptCanvasUnitTest
+{
+    namespace
+    {
+        class TestSystemComponent
+            : public ScriptCanvas::SystemComponent
+        {
+        public:
+            using ScriptCanvas::SystemComponent::GetCreatibility;
+        };
+    } // namespace
+
+    TEST_F(ScriptCanvasUnitTestFixture, InputDeviceId_IsUsableInSlotsButNotAsAVariable)
+    {
+        AZ::BehaviorContext behaviorContext;
+        AzFramework::InputDeviceId::Reflect(&behaviorContext);
+
+        const AZ::TypeId inputDeviceIdTypeId = azrtti_typeid<AzFramework::InputDeviceId>();
+        const auto behaviorClassIterator = behaviorContext.m_typeToClassMap.find(inputDeviceIdTypeId);
+        ASSERT_NE(behaviorClassIterator, behaviorContext.m_typeToClassMap.end());
+        ASSERT_NE(behaviorClassIterator->second, nullptr);
+
+        AZ::SerializeContext serializeContext;
+        serializeContext.Class<AzFramework::InputDeviceId>();
+
+        TestSystemComponent systemComponent;
+        const auto [createability, typeProperties] =
+            systemComponent.GetCreatibility(&serializeContext, behaviorClassIterator->second);
+
+        EXPECT_EQ(createability, ScriptCanvas::DataRegistry::Createability::SlotOnly);
+        EXPECT_TRUE(typeProperties.m_isTransient);
+
+        ScriptCanvas::DataRegistry dataRegistry;
+        dataRegistry.RegisterType(inputDeviceIdTypeId, typeProperties, createability);
+
+        const ScriptCanvas::Data::Type inputDeviceIdType = ScriptCanvas::Data::FromAZType(inputDeviceIdTypeId);
+        EXPECT_TRUE(dataRegistry.IsUseableInSlot(inputDeviceIdType));
+        EXPECT_TRUE(dataRegistry.m_slottableTypes.contains(inputDeviceIdType));
+        EXPECT_FALSE(dataRegistry.m_creatableTypes.contains(inputDeviceIdType));
+    }
+} // namespace ScriptCanvasUnitTest

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_tests_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_tests_files.cmake
@@ -10,6 +10,7 @@ set(FILES
     Tests/AutoGen/ScriptCanvasAutoGenRegistryTest.cpp
     Tests/Data/DataTypeTest.cpp
     Tests/Data/DataTypeUtilsTest.cpp
+    Tests/Data/InputDeviceIdDataRegistryTest.cpp
     Tests/Framework/ScriptCanvasUnitTestFixture.h
     Tests/Libraries/Entity/ScriptCanvasUnitTest_EntityFunctions.cpp
     Tests/Libraries/Math/ScriptCanvasUnitTest_AABB.cpp


### PR DESCRIPTION
## What does this PR do?

This PR exposes `AzFramework::InputDeviceId` to Script Canvas.

Previously, Script Canvas could expose APIs addressed by `InputDeviceId`, such as input-device request buses, but it had no supported way to create an `InputDeviceId` value. 

<img width="419" height="180" alt="image" src="https://github.com/user-attachments/assets/716816f3-36fc-40da-aabd-8598af0a926d" />
<img width="304" height="178" alt="image" src="https://github.com/user-attachments/assets/11dc7942-ab96-4926-8a83-dbbad89d18d1" />


This PR:

- Makes `InputDeviceId` available as a transient Script Canvas data type.
- Adds the `Create Input Device Id` node under the `Gameplay` category.
- Allows an identifier to be created from a device name and index.
- Prevents standalone `InputDeviceId` variables, because the type internally contains a name reference whose lifetime must remain valid.
- Preserves the existing Lua reflection and constructor behavior.

## How was this PR tested?

- Added an AzFramework unit test verifying that `InputDeviceId` is exposed for transient Script Canvas slots but cannot be created as a graph variable.
- Verified that the factory preserves both the device name and device index.
- Built the Editor successfully.