### PR TITLE
This is an advanced feature to run PhysX's simulate in separate thread.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsEvents.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsEvents.h
@@ -105,8 +105,19 @@ namespace AzPhysics
         //! This will not trigger if the scene if not Enabled (Scene::IsEnabled() returns true).
         //! When triggered the event will send a handle to the Scene that triggers the event and the delta time in seconds used to step this update.
         //! @note This may fire multiple times per frame.
+        //! @note With SystemConfiguration::m_runSimulationInThread this is signaled on the simulation thread, once per
+        //! step, so handlers must be thread-safe and touch physics only. Use OnSceneSimulationSynchronizedWithTickEvent
+        //! for handlers that reach entities, the renderer, scripting or any other main-thread system.
         using OnSceneSimulationFinishEvent = AZ::OrderedEvent<AzPhysics::SceneHandle, float>;
         using OnSceneSimulationFinishHandler = AZ::OrderedEventHandler<AzPhysics::SceneHandle, float>;
+
+        //! Event triggers on the main thread once per tick, with the accumulated time delta.
+        //! It is used when physical simulation results need to be consumed on the main thread (e.g. transform graphics entities).
+        //! When physical simulation is run on the main thread (default approach in PhysX gem), it is the same as OnSceneSimulationFinish.
+        //! When the physical simulation is free-running in a background thread at a high rate,
+        //! this event is signaled in synchronization with the main thread, with the delta time accumulated.
+        using OnSceneSimulationSynchronizedWithTickEvent = AZ::OrderedEvent<AzPhysics::SceneHandle, float>;
+        using OnSceneSimulationSynchronizedWithTickHandler = AZ::OrderedEventHandler<AzPhysics::SceneHandle, float>;
 
         //! Event triggers during the Scene::FinishSimulation call before the OnSceneSimulationFinishEvent for a scene
         //! and only if the SceneConfiguration::m_enableActiveActors is true.

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.cpp
@@ -37,6 +37,7 @@ namespace AzPhysics
                 ->Field("ShapecastBufferSize", &SystemConfiguration::m_shapecastBufferSize)
                 ->Field("OverlapBufferSize", &SystemConfiguration::m_overlapBufferSize)
                 ->Field("CollisionConfig", &SystemConfiguration::m_collisionConfig)
+                ->Field("RunSimulationInThread", &SystemConfiguration::m_runSimulationInThread)
                 ;
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -66,6 +67,8 @@ namespace AzPhysics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_overlapBufferSize,
                         QT_TRANSLATE_NOOP("PhysX", "Overlap Query Buffer Size"), QT_TRANSLATE_NOOP("PhysX", "Maximum number of hits from a overlap query"))
                         ->Attribute(AZ::Edit::Attributes::Min, 1u)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SystemConfiguration::m_runSimulationInThread,
+                        QT_TRANSLATE_NOOP("PhysX", "Free run Simulation In Thread"), QT_TRANSLATE_NOOP("PhysX", "It runs simulation in separate thread, independent from rendering."))
                     ;
             }
         }
@@ -79,7 +82,8 @@ namespace AzPhysics
             m_overlapBufferSize == other.m_overlapBufferSize &&
             AZ::IsClose(m_maxTimestep, other.m_maxTimestep) &&
             AZ::IsClose(m_fixedTimestep, other.m_fixedTimestep) &&
-            m_collisionConfig == other.m_collisionConfig
+            m_collisionConfig == other.m_collisionConfig &&
+            m_runSimulationInThread == other.m_runSimulationInThread
             ;
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
@@ -46,6 +46,10 @@ namespace AzPhysics
         //! Disable this to manually control Physics Scene simulation logic.
         bool m_autoManageSimulationUpdate = true;
 
+        //! Executes the physics simulation on a dedicated thread, free-running at m_fixedTimestep
+        //! independently of the main tick.
+        bool m_runSimulationInThread = false;
+
         bool operator==(const SystemConfiguration& other) const;
         bool operator!=(const SystemConfiguration& other) const;
 

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
@@ -47,7 +47,10 @@ namespace AzPhysics
         bool m_autoManageSimulationUpdate = true;
 
         //! Executes the physics simulation on a dedicated thread, free-running at m_fixedTimestep
-        //! independently of the main tick.
+        //! independently of the main tick. Scene simulation start, trigger and collision events are
+        //! then signaled on that thread at simulation rate, so consumers can act on every step -
+        //! their handlers must be thread-safe and touch physics only. The scene simulation finish
+        //! event stays on the main tick.
         bool m_runSimulationInThread = false;
 
         bool operator==(const SystemConfiguration& other) const;

--- a/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.h
@@ -232,6 +232,13 @@ namespace AzPhysics
         //! @param handler The handler to receive the event.
         virtual void RegisterSceneSimulationFinishHandler(SceneHandle sceneHandle, SceneEvents::OnSceneSimulationFinishHandler& handler) = 0;
 
+        //! Register a handler to receive an event once per tick, on the main thread, when the results of the steps
+        //! taken since the previous tick have been published.
+        //! @param sceneHandle A handle to the scene to register the event with.
+        //! @param handler The handler to receive the event.
+        virtual void RegisterSceneSimulationSynchronizedWithTickHandler(
+            SceneHandle sceneHandle, SceneEvents::OnSceneSimulationSynchronizedWithTickHandler& handler) = 0;
+
         //! Register a handler to receive an event with a list of SimulatedBodyHandles that updated this scene tick.
         //! @note This will fire after the OnSceneSimulationStartEvent and before the OnSceneSimulationFinishEvent when SceneConfiguration::m_enableActiveActors is true.
         //! @param sceneHandle A handle to the scene to register the event with.
@@ -440,6 +447,11 @@ namespace AzPhysics
         //! @param handler The handler to receive the event.
         void RegisterSceneSimulationFinishHandler(SceneEvents::OnSceneSimulationFinishHandler& handler);
 
+        //! Register a handler to receive an event once per tick, on the main thread, when the results of the steps
+        //! taken since the previous tick have been published.
+        //! @param handler The handler to receive the event.
+        void RegisterSceneSimulationSynchronizedWithTickHandler(SceneEvents::OnSceneSimulationSynchronizedWithTickHandler& handler);
+
         //! Register a handler to receive an event with a list of SimulatedBodyHandles that updated this scene tick.
         //! @note This will fire after the OnSceneSimulationStartEvent and before the OnSceneSimulationFinishEvent when SceneConfiguration::m_enableActiveActors is true.
         //! @param handler The handler to receive the event.
@@ -465,6 +477,7 @@ namespace AzPhysics
         SceneEvents::OnSimulationBodySimulationDisabled m_simulatedBodySimulationDisabledEvent;
         SceneEvents::OnSceneSimulationStartEvent m_sceneSimulationStartEvent;
         SceneEvents::OnSceneSimulationFinishEvent m_sceneSimulationFinishEvent;
+        SceneEvents::OnSceneSimulationSynchronizedWithTickEvent m_sceneSimulationSynchronizedWithTickEvent;
         SceneEvents::OnSceneActiveSimulatedBodiesEvent m_sceneActiveSimulatedBodies;
         SceneEvents::OnSceneCollisionsEvent m_sceneCollisionEvent;
         SceneEvents::OnSceneTriggersEvent m_sceneTriggerEvent;
@@ -510,6 +523,12 @@ namespace AzPhysics
     inline void Scene::RegisterSceneSimulationFinishHandler(SceneEvents::OnSceneSimulationFinishHandler& handler)
     {
         handler.Connect(m_sceneSimulationFinishEvent);
+    }
+
+    inline void Scene::RegisterSceneSimulationSynchronizedWithTickHandler(
+        SceneEvents::OnSceneSimulationSynchronizedWithTickHandler& handler)
+    {
+        handler.Connect(m_sceneSimulationSynchronizedWithTickEvent);
     }
 
     inline void Scene::RegisterSceneActiveSimulatedBodiesHandler(SceneEvents::OnSceneActiveSimulatedBodiesEvent::Handler& handler)

--- a/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
+++ b/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
@@ -191,6 +191,7 @@ namespace Physics
         MOCK_METHOD2(GetJointFromHandle, AzPhysics::Joint* (AzPhysics::SceneHandle sceneHandle, AzPhysics::JointHandle bodyHandle));
         MOCK_CONST_METHOD1(GetGravity, AZ::Vector3(AzPhysics::SceneHandle sceneHandle));
         MOCK_METHOD2(RegisterSceneSimulationFinishHandler, void(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationFinishHandler& handler));
+        MOCK_METHOD2(RegisterSceneSimulationSynchronizedWithTickHandler, void(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationSynchronizedWithTickHandler& handler));
         MOCK_CONST_METHOD2(GetLegacyBody, AzPhysics::SimulatedBody* (AzPhysics::SceneHandle sceneHandle, AzPhysics::SimulatedBodyHandle handle));
         MOCK_METHOD2(QueryScene, AzPhysics::SceneQueryHits(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request));
         MOCK_METHOD3(QueryScene, bool(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits&));

--- a/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/NetworkRigidBodyTests.cpp
@@ -91,6 +91,9 @@ namespace Multiplayer
         MOCK_METHOD2(
             RegisterSceneSimulationFinishHandler, void(AzPhysics::SceneHandle, AzPhysics::SceneEvents::OnSceneSimulationFinishHandler&));
         MOCK_METHOD2(
+            RegisterSceneSimulationSynchronizedWithTickHandler,
+            void(AzPhysics::SceneHandle, AzPhysics::SceneEvents::OnSceneSimulationSynchronizedWithTickHandler&));
+        MOCK_METHOD2(
             RegisterSceneSimulationStartHandler, void(AzPhysics::SceneHandle, AzPhysics::SceneEvents::OnSceneSimulationStartHandler&));
         MOCK_METHOD2(
             RegisterSceneTriggersEventHandler,

--- a/Gems/PhysX/Common/Code/Mocks/PhysX/MockSceneInterface.h
+++ b/Gems/PhysX/Common/Code/Mocks/PhysX/MockSceneInterface.h
@@ -53,6 +53,8 @@ namespace UnitTest
             Handler&));
         MOCK_METHOD2(RegisterSceneSimulationFinishHandler, void(AzPhysics::SceneHandle, AzPhysics::SceneEvents::
             OnSceneSimulationFinishHandler&));
+        MOCK_METHOD2(RegisterSceneSimulationSynchronizedWithTickHandler, void(AzPhysics::SceneHandle, AzPhysics::SceneEvents::
+            OnSceneSimulationSynchronizedWithTickHandler&));
         MOCK_METHOD2(RegisterSceneSimulationStartHandler, void(AzPhysics::SceneHandle, AzPhysics::SceneEvents::
             OnSceneSimulationStartHandler&));
         MOCK_METHOD2(RegisterSceneTriggersEventHandler, void(AzPhysics::SceneHandle, AZ::Event<AZStd::tuple<AZ::Crc32, signed char>, const AZStd::vector<

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.cpp
@@ -124,7 +124,7 @@ namespace PhysX
             AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
             if (m_attachedSceneHandle != AzPhysics::InvalidSceneHandle)
             {
-                sceneInterface->RegisterSceneSimulationFinishHandler(m_attachedSceneHandle, m_sceneFinishSimHandler);
+                sceneInterface->RegisterSceneSimulationSynchronizedWithTickHandler(m_attachedSceneHandle, m_sceneFinishSimHandler);
 
                 // Create a handler that in the case that the scene was removed before the deactivation of the component,
                 // ensures that all articulations are destroyed.

--- a/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Core/Code/Source/ArticulationLinkComponent.h
@@ -143,7 +143,7 @@ namespace PhysX
         AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
         AZStd::vector<AzPhysics::SimulatedBodyHandle> m_articulationLinks;
         AzPhysics::SimulatedBodyHandle m_bodyHandle = AzPhysics::InvalidSimulatedBodyHandle;
-        AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler;
+        AzPhysics::SceneEvents::OnSceneSimulationSynchronizedWithTickHandler m_sceneFinishSimHandler;
         AzPhysics::SystemEvents::OnSceneRemovedEvent::Handler m_sceneRemovedHandler;
 
         using EntityIdArticulationLinkPair = AZStd::pair<AZ::EntityId, physx::PxArticulationLink*>;

--- a/Gems/PhysX/Core/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/RigidBodyComponent.cpp
@@ -359,7 +359,8 @@ namespace PhysX
             }
             else
             {
-                m_cachedSceneInterface->RegisterSceneSimulationFinishHandler(m_attachedSceneHandle, m_sceneFinishSimHandler);
+                m_cachedSceneInterface->RegisterSceneSimulationSynchronizedWithTickHandler(
+                    m_attachedSceneHandle, m_sceneFinishSimHandler);
             }
         }
 

--- a/Gems/PhysX/Core/Code/Source/RigidBodyComponent.h
+++ b/Gems/PhysX/Core/Code/Source/RigidBodyComponent.h
@@ -171,7 +171,7 @@ namespace PhysX
         bool m_rigidBodyTransformNeedsUpdateOnPhysReEnable = false; ///< True if rigid body transform needs to be synced to the entity's when physics is re-enabled.
         bool m_isEntityTransformSetManually = false; ///< False when PostPhysicsTick runs in order to handle user-set entity transform.
 
-        AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler;
+        AzPhysics::SceneEvents::OnSceneSimulationSynchronizedWithTickHandler m_sceneFinishSimHandler;
         AzPhysics::SimulatedBodyEvents::OnSyncTransform::Handler m_activeBodySyncTransformHandler;
     };
 

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
@@ -629,7 +629,7 @@ namespace PhysX
             // Keep the event signal outside of the scene lock since there may be handlers that want to lock the scene for write
             m_sceneActiveSimulatedBodies.Signal(m_sceneHandle, activeBodyHandles, m_currentDeltaTime);
 
-            if (physx_batchTransformSync)
+            if (physx_batchTransformSync ||  GetPhysXSystem()->IsSimulationThreadRunning())
             {
                 m_queuedActiveBodyIndices.IncreaseCapacity(activeBodyHandles.size());
 
@@ -647,12 +647,26 @@ namespace PhysX
             }
         }
 
-        FlushQueuedEvents();
-        ClearDeferedDeletions();
-
+        if (GetPhysXSystem()->IsSimulationThreadRunning())
         {
-            AZ_PROFILE_SCOPE(Physics, "OnSceneSimulationFinishedEvent::Signaled");
-            m_sceneSimulationFinishEvent.Signal(m_sceneHandle, m_currentDeltaTime);
+            //! We are on thread, so cache the events and flush them from Main thread.
+            DeferredStepEvents& stepEvents = m_deferredStepEvents.emplace_back();
+            stepEvents.m_deltaTime = m_currentDeltaTime;
+            stepEvents.m_triggerEvents = m_simulationEventCallback.GetQueuedTriggerEvents();
+            stepEvents.m_collisionEvents = m_simulationEventCallback.GetQueuedCollisionEvents();
+            m_simulationEventCallback.FlushQueuedTriggerEvents();
+            m_simulationEventCallback.FlushQueuedCollisionEvents();
+        }
+        else
+        {
+            //! PhysX simulation is on main thread - run directly callbacks.
+            FlushQueuedEvents();
+            ClearDeferedDeletions();
+
+            {
+                AZ_PROFILE_SCOPE(Physics, "OnSceneSimulationFinishedEvent::Signaled");
+                m_sceneSimulationFinishEvent.Signal(m_sceneHandle, m_currentDeltaTime);
+            }
         }
 
         UpdateAzProfilerDataPoints();
@@ -661,10 +675,39 @@ namespace PhysX
     void PhysXScene::FlushQueuedEvents()
     {
         //send queued trigger events
-        ProcessTriggerEvents();
+        ProcessTriggerEvents(m_simulationEventCallback.GetQueuedTriggerEvents());
+        m_simulationEventCallback.FlushQueuedTriggerEvents();
 
         //send queued collision events
-        ProcessCollisionEvents();
+        ProcessCollisionEvents(m_simulationEventCallback.GetQueuedCollisionEvents());
+        m_simulationEventCallback.FlushQueuedCollisionEvents();
+    }
+
+    void PhysXScene::FlushDeferredFinishEvents()
+    {
+        if (m_deferredStepEvents.empty())
+        {
+            return;
+        }
+        AZ_PROFILE_SCOPE(Physics, "PhysXScene::FlushDeferredFinishEvents");
+
+        //! Replayed per sub-step, not coalesced: handlers integrate against the step delta and the
+        //! collision lists are documented as one sub-step's worth.
+        for (DeferredStepEvents& stepEvents : m_deferredStepEvents)
+        {
+            m_currentDeltaTime = stepEvents.m_deltaTime;
+
+            ProcessTriggerEvents(stepEvents.m_triggerEvents);
+            ProcessCollisionEvents(stepEvents.m_collisionEvents);
+            ClearDeferedDeletions();
+
+            {
+                AZ_PROFILE_SCOPE(Physics, "OnSceneSimulationFinishedEvent::Signaled");
+                m_sceneSimulationFinishEvent.Signal(m_sceneHandle, stepEvents.m_deltaTime);
+            }
+        }
+
+        m_deferredStepEvents.clear();
     }
 
     void PhysXScene::SetEnabled(bool enable)
@@ -1178,11 +1221,10 @@ namespace PhysX
         }
     }
 
-    void PhysXScene::ProcessTriggerEvents()
+    void PhysXScene::ProcessTriggerEvents(AzPhysics::TriggerEventList& triggers)
     {
         AZ_PROFILE_SCOPE(Physics, "PhysXScene::ProcessTriggerEvents");
 
-        AzPhysics::TriggerEventList& triggers = m_simulationEventCallback.GetQueuedTriggerEvents();
         if (triggers.empty())
         {
             return; // nothing to signal
@@ -1200,16 +1242,12 @@ namespace PhysX
                 triggerEvent.m_otherBody->ProcessTriggerEvent(triggerEvent);
             }
         }
-
-        //cleanup events for next simulate
-        m_simulationEventCallback.FlushQueuedTriggerEvents();
     }
 
-    void PhysXScene::ProcessCollisionEvents()
+    void PhysXScene::ProcessCollisionEvents(AzPhysics::CollisionEventList& collisions)
     {
         AZ_PROFILE_SCOPE(Physics, "PhysXScene::ProcessCollisionEvents");
 
-        AzPhysics::CollisionEventList& collisions = m_simulationEventCallback.GetQueuedCollisionEvents();
         if (collisions.empty())
         {
             return; //nothing to signal
@@ -1236,9 +1274,6 @@ namespace PhysX
                 collision.m_body1->ProcessCollisionEvent(collision);
             }
         }
-
-        //cleanup events for next simulate
-        m_simulationEventCallback.FlushQueuedCollisionEvents();
     }
 
     void PhysXScene::UpdateAzProfilerDataPoints()
@@ -1347,7 +1382,9 @@ namespace PhysX
             }
         };
 
-        if (physx_parallelTransformSync)
+        //! ApplyParallel's tasks take a read lock while we wait on them - deadlocks under the write
+        //! lock the caller holds while a simulation thread is running.
+        if (physx_parallelTransformSync && !GetPhysXSystem()->IsSimulationThreadRunning())
         {
             m_queuedActiveBodyIndices.ApplyParallel(transformSync, m_pxScene);
         }

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
@@ -584,6 +584,8 @@ namespace PhysX
             return;
         }
 
+        const bool simulationThreaded = GetPhysXSystem() && GetPhysXSystem()->IsSimulationThreadRunning();
+
         {
             AZ_PROFILE_SCOPE(Physics, "PhysXScene::CheckResults");
 
@@ -629,7 +631,7 @@ namespace PhysX
             // Keep the event signal outside of the scene lock since there may be handlers that want to lock the scene for write
             m_sceneActiveSimulatedBodies.Signal(m_sceneHandle, activeBodyHandles, m_currentDeltaTime);
 
-            if (physx_batchTransformSync ||  GetPhysXSystem()->IsSimulationThreadRunning())
+            if (physx_batchTransformSync || simulationThreaded )
             {
                 m_queuedActiveBodyIndices.IncreaseCapacity(activeBodyHandles.size());
 
@@ -647,7 +649,7 @@ namespace PhysX
             }
         }
 
-        if (GetPhysXSystem()->IsSimulationThreadRunning())
+        if (simulationThreaded)
         {
             //! We are on thread, so cache the events and flush them from Main thread.
             DeferredStepEvents& stepEvents = m_deferredStepEvents.emplace_back();
@@ -1373,7 +1375,7 @@ namespace PhysX
     void PhysXScene::FlushTransformSync()
     {
         AZ_PROFILE_SCOPE(Physics, "PhysX::FlushTransformSync");
-
+        const bool simulationThreaded = GetPhysXSystem() && GetPhysXSystem()->IsSimulationThreadRunning();
         auto transformSync = [this](AzPhysics::SimulatedBodyIndex bodyIndex)
         {
             if (bodyIndex < m_simulatedBodies.size() && m_simulatedBodies[bodyIndex].second)
@@ -1384,7 +1386,7 @@ namespace PhysX
 
         //! ApplyParallel's tasks take a read lock while we wait on them - deadlocks under the write
         //! lock the caller holds while a simulation thread is running.
-        if (physx_parallelTransformSync && !GetPhysXSystem()->IsSimulationThreadRunning())
+        if (physx_parallelTransformSync && !simulationThreaded)
         {
             m_queuedActiveBodyIndices.ApplyParallel(transformSync, m_pxScene);
         }

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.cpp
@@ -631,7 +631,7 @@ namespace PhysX
             // Keep the event signal outside of the scene lock since there may be handlers that want to lock the scene for write
             m_sceneActiveSimulatedBodies.Signal(m_sceneHandle, activeBodyHandles, m_currentDeltaTime);
 
-            if (physx_batchTransformSync || simulationThreaded )
+            if (physx_batchTransformSync || simulationThreaded)
             {
                 m_queuedActiveBodyIndices.IncreaseCapacity(activeBodyHandles.size());
 
@@ -649,27 +649,17 @@ namespace PhysX
             }
         }
 
-        if (simulationThreaded)
-        {
-            //! We are on thread, so cache the events and flush them from Main thread.
-            DeferredStepEvents& stepEvents = m_deferredStepEvents.emplace_back();
-            stepEvents.m_deltaTime = m_currentDeltaTime;
-            stepEvents.m_triggerEvents = m_simulationEventCallback.GetQueuedTriggerEvents();
-            stepEvents.m_collisionEvents = m_simulationEventCallback.GetQueuedCollisionEvents();
-            m_simulationEventCallback.FlushQueuedTriggerEvents();
-            m_simulationEventCallback.FlushQueuedCollisionEvents();
-        }
-        else
-        {
-            //! PhysX simulation is on main thread - run directly callbacks.
-            FlushQueuedEvents();
-            ClearDeferedDeletions();
+        FlushQueuedEvents();
+        ClearDeferedDeletions();
 
-            {
-                AZ_PROFILE_SCOPE(Physics, "OnSceneSimulationFinishedEvent::Signaled");
-                m_sceneSimulationFinishEvent.Signal(m_sceneHandle, m_currentDeltaTime);
-            }
+        {
+            AZ_PROFILE_SCOPE(Physics, "OnSceneSimulationFinishedEvent::Signaled");
+            m_sceneSimulationFinishEvent.Signal(m_sceneHandle, m_currentDeltaTime);
         }
+
+        //! Covered by the next tick-synchronized signal, which the main thread sends once the results
+        //! of these steps are published.
+        m_tickSynchronizedDeltaTime = m_tickSynchronizedDeltaTime.value_or(0.0f) + m_currentDeltaTime;
 
         UpdateAzProfilerDataPoints();
     }
@@ -677,39 +667,22 @@ namespace PhysX
     void PhysXScene::FlushQueuedEvents()
     {
         //send queued trigger events
-        ProcessTriggerEvents(m_simulationEventCallback.GetQueuedTriggerEvents());
-        m_simulationEventCallback.FlushQueuedTriggerEvents();
+        ProcessTriggerEvents();
 
         //send queued collision events
-        ProcessCollisionEvents(m_simulationEventCallback.GetQueuedCollisionEvents());
-        m_simulationEventCallback.FlushQueuedCollisionEvents();
+        ProcessCollisionEvents();
     }
 
-    void PhysXScene::FlushDeferredFinishEvents()
+    void PhysXScene::SignalSimulationSynchronizedWithTick()
     {
-        if (m_deferredStepEvents.empty())
+        if (!m_tickSynchronizedDeltaTime.has_value())
         {
             return;
         }
-        AZ_PROFILE_SCOPE(Physics, "PhysXScene::FlushDeferredFinishEvents");
+        AZ_PROFILE_SCOPE(Physics, "OnSceneSimulationSynchronizedWithTickEvent::Signaled");
 
-        //! Replayed per sub-step, not coalesced: handlers integrate against the step delta and the
-        //! collision lists are documented as one sub-step's worth.
-        for (DeferredStepEvents& stepEvents : m_deferredStepEvents)
-        {
-            m_currentDeltaTime = stepEvents.m_deltaTime;
-
-            ProcessTriggerEvents(stepEvents.m_triggerEvents);
-            ProcessCollisionEvents(stepEvents.m_collisionEvents);
-            ClearDeferedDeletions();
-
-            {
-                AZ_PROFILE_SCOPE(Physics, "OnSceneSimulationFinishedEvent::Signaled");
-                m_sceneSimulationFinishEvent.Signal(m_sceneHandle, stepEvents.m_deltaTime);
-            }
-        }
-
-        m_deferredStepEvents.clear();
+        m_sceneSimulationSynchronizedWithTickEvent.Signal(m_sceneHandle, *m_tickSynchronizedDeltaTime);
+        m_tickSynchronizedDeltaTime.reset();
     }
 
     void PhysXScene::SetEnabled(bool enable)
@@ -1223,10 +1196,11 @@ namespace PhysX
         }
     }
 
-    void PhysXScene::ProcessTriggerEvents(AzPhysics::TriggerEventList& triggers)
+    void PhysXScene::ProcessTriggerEvents()
     {
         AZ_PROFILE_SCOPE(Physics, "PhysXScene::ProcessTriggerEvents");
 
+        AzPhysics::TriggerEventList& triggers = m_simulationEventCallback.GetQueuedTriggerEvents();
         if (triggers.empty())
         {
             return; // nothing to signal
@@ -1244,12 +1218,16 @@ namespace PhysX
                 triggerEvent.m_otherBody->ProcessTriggerEvent(triggerEvent);
             }
         }
+
+        //cleanup events for next simulate
+        m_simulationEventCallback.FlushQueuedTriggerEvents();
     }
 
-    void PhysXScene::ProcessCollisionEvents(AzPhysics::CollisionEventList& collisions)
+    void PhysXScene::ProcessCollisionEvents()
     {
         AZ_PROFILE_SCOPE(Physics, "PhysXScene::ProcessCollisionEvents");
 
+        AzPhysics::CollisionEventList& collisions = m_simulationEventCallback.GetQueuedCollisionEvents();
         if (collisions.empty())
         {
             return; //nothing to signal
@@ -1276,6 +1254,9 @@ namespace PhysX
                 collision.m_body1->ProcessCollisionEvent(collision);
             }
         }
+
+        //cleanup events for next simulate
+        m_simulationEventCallback.FlushQueuedCollisionEvents();
     }
 
     void PhysXScene::UpdateAzProfilerDataPoints()
@@ -1375,7 +1356,9 @@ namespace PhysX
     void PhysXScene::FlushTransformSync()
     {
         AZ_PROFILE_SCOPE(Physics, "PhysX::FlushTransformSync");
+
         const bool simulationThreaded = GetPhysXSystem() && GetPhysXSystem()->IsSimulationThreadRunning();
+
         auto transformSync = [this](AzPhysics::SimulatedBodyIndex bodyIndex)
         {
             if (bodyIndex < m_simulatedBodies.size() && m_simulatedBodies[bodyIndex].second)

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.h
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.h
@@ -13,6 +13,7 @@
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Configuration/SceneConfiguration.h>
 
+
 #include <Scene/PhysXSceneSimulationEventCallback.h>
 #include <Scene/PhysXSceneSimulationFilterCallback.h>
 
@@ -81,10 +82,14 @@ namespace PhysX
 
         physx::PxControllerManager* GetOrCreateControllerManager();
 
-        //! Apply batched transform sync events for the current simulation pass. 
+        //! Apply batched transform sync events for the current simulation pass.
         //! This will clear the batched data for the next simulation pass.
         void FlushTransformSync();
-        
+
+        //! Replay the scene events the simulation thread deferred, one record per sub-step.
+        //! Called on the main thread; a no-op unless a simulation thread is running.
+        void FlushDeferredFinishEvents();
+
     private:
 
         //! Data structure for efficient unique vector functionality.
@@ -108,8 +113,8 @@ namespace PhysX
 
         void FlushQueuedEvents();
         void ClearDeferedDeletions();
-        void ProcessTriggerEvents();
-        void ProcessCollisionEvents();
+        void ProcessTriggerEvents(AzPhysics::TriggerEventList& triggerEvents);
+        void ProcessCollisionEvents(AzPhysics::CollisionEventList& collisionEvents);
 
         void UpdateAzProfilerDataPoints();
 
@@ -126,6 +131,17 @@ namespace PhysX
         // When we run the batched transform sync, the accumulated simulation time is provided
         // to tell how much time was simulated in this full pass.
         float m_accumulatedDeltaTime = 0.0f;
+
+        // One simulation sub-step's events, cached by the free-running thread and replayed in order.
+        struct DeferredStepEvents
+        {
+            float m_deltaTime = 0.0f;
+            AzPhysics::CollisionEventList m_collisionEvents; //!< Owned copies - the SDK lists are
+            AzPhysics::TriggerEventList m_triggerEvents;     //!< only valid inside the callback.
+        };
+
+        // Filled by the simulation thread, drained by the main thread - both under the scene write lock.
+        AZStd::vector<DeferredStepEvents> m_deferredStepEvents;
 
         AzPhysics::SceneConfiguration m_config;
         AzPhysics::SceneHandle m_sceneHandle;

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.h
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXScene.h
@@ -13,7 +13,6 @@
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Configuration/SceneConfiguration.h>
 
-
 #include <Scene/PhysXSceneSimulationEventCallback.h>
 #include <Scene/PhysXSceneSimulationFilterCallback.h>
 
@@ -82,13 +81,13 @@ namespace PhysX
 
         physx::PxControllerManager* GetOrCreateControllerManager();
 
-        //! Apply batched transform sync events for the current simulation pass.
+        //! Apply batched transform sync events for the current simulation pass. 
         //! This will clear the batched data for the next simulation pass.
         void FlushTransformSync();
-
-        //! Replay the scene events the simulation thread deferred, one record per sub-step.
-        //! Called on the main thread; a no-op unless a simulation thread is running.
-        void FlushDeferredFinishEvents();
+        
+        //! Signal the tick-synchronized event for every step taken since the last time it was signaled.
+        //! Called on the main thread; a no-op when no step has run since.
+        void SignalSimulationSynchronizedWithTick();
 
     private:
 
@@ -113,8 +112,8 @@ namespace PhysX
 
         void FlushQueuedEvents();
         void ClearDeferedDeletions();
-        void ProcessTriggerEvents(AzPhysics::TriggerEventList& triggerEvents);
-        void ProcessCollisionEvents(AzPhysics::CollisionEventList& collisionEvents);
+        void ProcessTriggerEvents();
+        void ProcessCollisionEvents();
 
         void UpdateAzProfilerDataPoints();
 
@@ -132,16 +131,9 @@ namespace PhysX
         // to tell how much time was simulated in this full pass.
         float m_accumulatedDeltaTime = 0.0f;
 
-        // One simulation sub-step's events, cached by the free-running thread and replayed in order.
-        struct DeferredStepEvents
-        {
-            float m_deltaTime = 0.0f;
-            AzPhysics::CollisionEventList m_collisionEvents; //!< Owned copies - the SDK lists are
-            AzPhysics::TriggerEventList m_triggerEvents;     //!< only valid inside the callback.
-        };
-
-        // Filled by the simulation thread, drained by the main thread - both under the scene write lock.
-        AZStd::vector<DeferredStepEvents> m_deferredStepEvents;
+        // Sim time stepped since the main thread last signaled the tick-synchronized event. Written
+        // by the stepping thread, drained by the main thread - both under the scene write lock.
+        AZStd::optional<float> m_tickSynchronizedDeltaTime;
 
         AzPhysics::SceneConfiguration m_config;
         AzPhysics::SceneHandle m_sceneHandle;

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXSceneInterface.cpp
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXSceneInterface.cpp
@@ -306,6 +306,13 @@ namespace PhysX
         Internal::EventRegisterHelper(m_physxSystem, sceneHandle, handler, &AzPhysics::Scene::RegisterSceneSimulationFinishHandler);
     }
 
+    void PhysXSceneInterface::RegisterSceneSimulationSynchronizedWithTickHandler(
+        AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationSynchronizedWithTickHandler& handler)
+    {
+        Internal::EventRegisterHelper(
+            m_physxSystem, sceneHandle, handler, &AzPhysics::Scene::RegisterSceneSimulationSynchronizedWithTickHandler);
+    }
+
     void PhysXSceneInterface::RegisterSceneActiveSimulatedBodiesHandler(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneActiveSimulatedBodiesEvent::Handler& handler)
     {
         Internal::EventRegisterHelper(m_physxSystem, sceneHandle, handler, &AzPhysics::Scene::RegisterSceneActiveSimulatedBodiesHandler);

--- a/Gems/PhysX/Core/Code/Source/Scene/PhysXSceneInterface.h
+++ b/Gems/PhysX/Core/Code/Source/Scene/PhysXSceneInterface.h
@@ -67,6 +67,8 @@ namespace PhysX
         void RegisterSimulationBodySimulationDisabledHandler(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSimulationBodySimulationDisabled::Handler& handler) override;
         void RegisterSceneSimulationStartHandler(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationStartHandler& handler) override;
         void RegisterSceneSimulationFinishHandler(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationFinishHandler& handler) override;
+        void RegisterSceneSimulationSynchronizedWithTickHandler(
+            AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationSynchronizedWithTickHandler& handler) override;
         void RegisterSceneActiveSimulatedBodiesHandler(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneActiveSimulatedBodiesEvent::Handler& handler) override;
         void RegisterSceneCollisionEventHandler(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneCollisionsEvent::Handler& handler) override;
         void RegisterSceneTriggersEventHandler(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneTriggersEvent::Handler& handler) override;

--- a/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
@@ -283,6 +283,15 @@ namespace PhysX
                 }
             }
         }
+
+        for (auto& scenePtr : m_sceneList)
+        {
+            if (scenePtr != nullptr && scenePtr->IsEnabled())
+            {
+                static_cast<PhysXScene*>(scenePtr.get())->SignalSimulationSynchronizedWithTick();
+            }
+        }
+
         m_postSimulateEvent.Signal(tickTime);
     }
 
@@ -328,7 +337,6 @@ namespace PhysX
         return false;
     }
 
-
     void PhysXSystem::StartSimulationThread()
     {
         if (m_simulationThread)
@@ -360,22 +368,21 @@ namespace PhysX
         m_simulationThread->m_thread.join();
         m_simulationThread.reset();
 
-        //! Drain what the last steps deferred, so nothing is lost handing stepping back. Reset
+        //! Publish what the last steps produced, so nothing is lost handing stepping back. Reset
         //! first: the scene is no longer threaded, so these take their own locks as usual.
         for (auto& scenePtr : m_sceneList)
         {
             if (scenePtr != nullptr && scenePtr->IsEnabled())
             {
                 auto* physxScene = static_cast<PhysXScene*>(scenePtr.get());
-                physxScene->FlushDeferredFinishEvents();
                 physxScene->FlushTransformSync();
+                physxScene->SignalSimulationSynchronizedWithTick();
             }
         }
     }
 
     void PhysXSystem::FreeRunningSimulationLoop()
     {
-
         auto nextStepTime = AZStd::chrono::steady_clock::now();
 
         while (!m_simulationThread->m_exit)
@@ -385,11 +392,7 @@ namespace PhysX
                 ? m_systemConfig.m_fixedTimestep
                 : AzPhysics::SystemConfiguration::DefaultFixedTimestep;
 
-            {
-                SimulateScenes(fixedTimestep, 1);
-            }
-
-            m_simulationThread->m_simulatedTime.fetch_add(fixedTimestep, AZStd::memory_order_release);
+            SimulateScenes(fixedTimestep, 1);
             m_performanceCollector->FrameTick();
 
             constexpr float realTimeFactor = 1.0f;
@@ -406,7 +409,6 @@ namespace PhysX
                     AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(nextStepTime - now));
             }
         }
-
     }
 
     void PhysXSystem::PublishSimulationResults()
@@ -417,26 +419,23 @@ namespace PhysX
         }
         AZ_PROFILE_FUNCTION(Physics);
 
-        const double simulatedTime = m_simulationThread->m_simulatedTime.load(AZStd::memory_order_acquire);
-        const float tickTime = aznumeric_cast<float>(simulatedTime - m_simulationThread->m_lastPublishedSimTime);
-        m_simulationThread->m_lastPublishedSimTime = simulatedTime;
-
-        m_preSimulateEvent.Signal(tickTime);
-
-        //! Drain what the simulation thread queued, on the main thread. The write lock waits out an
-        //! in-flight step and lets the handlers below take scene locks of their own.
+        //! Publish what the simulation thread produced, on the main thread. The write lock waits
+        //! out an in-flight step and lets the handlers below take scene locks of their own.
         for (auto& scenePtr : m_sceneList)
         {
             if (scenePtr != nullptr && scenePtr->IsEnabled())
             {
                 auto* physxScene = static_cast<PhysXScene*>(scenePtr.get());
-                PHYSX_SCENE_WRITE_LOCK(static_cast<physx::PxScene*>(physxScene->GetNativePointer()));
-                physxScene->FlushDeferredFinishEvents();
-                physxScene->FlushTransformSync();
+                {
+                    PHYSX_SCENE_WRITE_LOCK(static_cast<physx::PxScene*>(physxScene->GetNativePointer()));
+                    physxScene->FlushTransformSync();
+                }
+
+                //! Signaled outside the scene lock: its handlers are main-thread systems whose work
+                //! must not stall the simulation thread.
+                physxScene->SignalSimulationSynchronizedWithTick();
             }
         }
-
-        m_postSimulateEvent.Signal(tickTime);
     }
 
     AzPhysics::SceneHandle PhysXSystem::AddScene(const AzPhysics::SceneConfiguration& config)
@@ -446,10 +445,12 @@ namespace PhysX
             AZ_Error("PhysXSystem", false, "AddScene: Trying to Add a scene without a name. SceneConfiguration::m_sceneName must have a value");
             return AzPhysics::InvalidSceneHandle;
         }
+
         if (IsSimulationThreadRunning())
         {
             StopSimulationThread();
         }
+
         if (!m_freeSceneSlots.empty()) //fill any free slots first before increasing the size of the scene list vector.
         {
             AzPhysics::SceneIndex freeIndex = m_freeSceneSlots.front();

--- a/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
@@ -305,8 +305,6 @@ namespace PhysX
             {
                 if (scenePtr != nullptr && scenePtr->IsEnabled())
                 {
-                    AZ::Debug::ScopeDuration performanceScopeDuration(m_performanceCollector.get(), PerformanceSpecPhysXSimulationTime);
-
                     //! One write lock for the whole step, so the main tick's publication lock waits
                     //! it out. The locks inside recurse on this thread, which PhysX allows.
                     PHYSX_SCENE_WRITE_LOCK(static_cast<physx::PxScene*>(scenePtr->GetNativePointer()));
@@ -393,7 +391,6 @@ namespace PhysX
                 : AzPhysics::SystemConfiguration::DefaultFixedTimestep;
 
             SimulateScenes(fixedTimestep, 1);
-            m_performanceCollector->FrameTick();
 
             constexpr float realTimeFactor = 1.0f;
 

--- a/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
@@ -9,6 +9,7 @@
 
 #include <PxPhysicsAPI.h>
 #include <PhysX/Debug/PhysXDebugConfiguration.h>
+#include <PhysX/PhysXLocks.h>
 #include <Scene/PhysXScene.h>
 #include <System/PhysXAllocator.h>
 #include <System/PhysXCpuDispatcher.h>
@@ -22,6 +23,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/PlatformId/PlatformId.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/parallel/thread.h>
 
 // only enable physx timestep warning when not running debug or in Release
 #if !defined(DEBUG) && !defined(RELEASE)
@@ -164,6 +166,10 @@ namespace PhysX
 
     void PhysXSystem::Shutdown()
     {
+        if (IsSimulationThreadRunning())
+        {
+            StopSimulationThread();
+        }
         if (m_state != State::Initialized)
         {
             return;
@@ -183,6 +189,26 @@ namespace PhysX
         {
             AZ_Warning("PhysXSystem", false, "Call Simulate when PhysX system is not initialized");
             return;
+        }
+        const bool freeRunning = ShouldRunFreeThreaded();
+
+        //! Free-running: the simulation thread owns stepping and its own clock, so the main tick
+        //! only publishes whatever it has produced since last frame.
+        if (freeRunning)
+        {
+            if (!m_simulationThread)
+            {
+                StartSimulationThread();
+            }
+
+            PublishSimulationResults();
+            return;
+        }
+
+        //! Leaving game mode, or the config turned off, hands stepping back to the main thread below.
+        if (IsSimulationThreadRunning())
+        {
+            StopSimulationThread();
         }
 
         auto simulateScenes = [this](float timeStep)
@@ -256,12 +282,168 @@ namespace PhysX
                 }
             }
         }
+        m_postSimulateEvent.Signal(tickTime);
+    }
+
+    void PhysXSystem::SimulateScenes(float timeStep, AZ::u32 numSubSteps)
+    {
+        AZ_PROFILE_FUNCTION(Physics);
+
+        for (AZ::u32 subStep = 0; subStep < numSubSteps; subStep++)
+        {
+            for (auto& scenePtr : m_sceneList)
+            {
+                if (scenePtr != nullptr && scenePtr->IsEnabled())
+                {
+                    AZ::Debug::ScopeDuration performanceScopeDuration(m_performanceCollector.get(), PerformanceSpecPhysXSimulationTime);
+
+                    //! One write lock for the whole step, so the main tick's publication lock waits
+                    //! it out. The locks inside recurse on this thread, which PhysX allows.
+                    PHYSX_SCENE_WRITE_LOCK(static_cast<physx::PxScene*>(scenePtr->GetNativePointer()));
+                    scenePtr->StartSimulation(timeStep);
+                    scenePtr->FinishSimulation();
+                }
+            }
+        }
+    }
+
+    bool PhysXSystem::ShouldRunFreeThreaded() const
+    {
+        if (!m_systemConfig.m_runSimulationInThread)
+        {
+            return false;
+        }
+
+        //! Prevent free-running simulation in Editor
+        for (const auto& scenePtr : m_sceneList)
+        {
+            if (scenePtr != nullptr && scenePtr->IsEnabled() &&
+                scenePtr->GetConfiguration().m_sceneName != AzPhysics::EditorPhysicsSceneName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    void PhysXSystem::StartSimulationThread()
+    {
+        if (m_simulationThread)
+        {
+            return;
+        }
+        //! Constructed in place: the atomic members make SimulationThread non-movable.
+        m_simulationThread.emplace();
+
+        AZStd::thread_desc threadDesc;
+        threadDesc.m_name = "PhysX Simulate"; //!< 16 character limit on Linux.
+        m_simulationThread->m_thread = AZStd::thread(
+            threadDesc,
+            [this]()
+            {
+                FreeRunningSimulationLoop();
+            });
+    }
+
+    void PhysXSystem::StopSimulationThread()
+    {
+        if (!m_simulationThread || !m_simulationThread->m_thread.joinable())
+        {
+            return;
+        }
+
+        //! The loop checks m_exit once per step, so this returns within one step period.
+        m_simulationThread->m_exit = true;
+        m_simulationThread->m_thread.join();
+        m_simulationThread.reset();
+
+        //! Drain what the last steps deferred, so nothing is lost handing stepping back. Reset
+        //! first: the scene is no longer threaded, so these take their own locks as usual.
+        for (auto& scenePtr : m_sceneList)
+        {
+            if (scenePtr != nullptr && scenePtr->IsEnabled())
+            {
+                auto* physxScene = static_cast<PhysXScene*>(scenePtr.get());
+                physxScene->FlushDeferredFinishEvents();
+                physxScene->FlushTransformSync();
+            }
+        }
+    }
+
+    void PhysXSystem::FreeRunningSimulationLoop()
+    {
+
+        auto nextStepTime = AZStd::chrono::steady_clock::now();
+
+        while (!m_simulationThread->m_exit)
+        {
+            //! Config changes are rare, and a one-step-stale timestep is harmless.
+            const float fixedTimestep = m_systemConfig.m_fixedTimestep > 0.0f
+                ? m_systemConfig.m_fixedTimestep
+                : AzPhysics::SystemConfiguration::DefaultFixedTimestep;
+
+            {
+                SimulateScenes(fixedTimestep, 1);
+            }
+
+            m_simulationThread->m_simulatedTime.fetch_add(fixedTimestep, AZStd::memory_order_release);
+            m_performanceCollector->FrameTick();
+
+            constexpr float realTimeFactor = 1.0f;
+
+            const auto stepBudget = AZStd::chrono::duration_cast<AZStd::chrono::steady_clock::duration>(
+                AZStd::chrono::duration<float>(fixedTimestep / realTimeFactor));
+            nextStepTime += stepBudget;
+
+            //! Running late simply skips the sleep, so the loop steps back to back until it catches up.
+            const auto now = AZStd::chrono::steady_clock::now();
+            if (now < nextStepTime)
+            {
+                AZStd::this_thread::sleep_for(
+                    AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(nextStepTime - now));
+            }
+        }
+
+    }
+
+    void PhysXSystem::PublishSimulationResults()
+    {
+        if (!m_simulationThread)
+        {
+            return;
+        }
+        AZ_PROFILE_FUNCTION(Physics);
+
+        const double simulatedTime = m_simulationThread->m_simulatedTime.load(AZStd::memory_order_acquire);
+        const float tickTime = aznumeric_cast<float>(simulatedTime - m_simulationThread->m_lastPublishedSimTime);
+        m_simulationThread->m_lastPublishedSimTime = simulatedTime;
+
+        m_preSimulateEvent.Signal(tickTime);
+
+        //! Drain what the simulation thread queued, on the main thread. The write lock waits out an
+        //! in-flight step and lets the handlers below take scene locks of their own.
+        for (auto& scenePtr : m_sceneList)
+        {
+            if (scenePtr != nullptr && scenePtr->IsEnabled())
+            {
+                auto* physxScene = static_cast<PhysXScene*>(scenePtr.get());
+                PHYSX_SCENE_WRITE_LOCK(static_cast<physx::PxScene*>(physxScene->GetNativePointer()));
+                physxScene->FlushDeferredFinishEvents();
+                physxScene->FlushTransformSync();
+            }
+        }
 
         m_postSimulateEvent.Signal(tickTime);
     }
 
     AzPhysics::SceneHandle PhysXSystem::AddScene(const AzPhysics::SceneConfiguration& config)
     {
+        if (IsSimulationThreadRunning())
+        {
+            StopSimulationThread();
+        }
         if (config.m_sceneName.empty())
         {
             AZ_Error("PhysXSystem", false, "AddScene: Trying to Add a scene without a name. SceneConfiguration::m_sceneName must have a value");
@@ -365,6 +547,10 @@ namespace PhysX
         {
             return;
         }
+        if (IsSimulationThreadRunning())
+        {
+            StopSimulationThread();
+        }
 
         AZ::u64 index = AZStd::get<AzPhysics::HandleTypeIndex::Index>(handle);
         if (index < m_sceneList.size() )
@@ -392,6 +578,10 @@ namespace PhysX
 
     void PhysXSystem::RemoveAllScenes()
     {
+        if (IsSimulationThreadRunning())
+        {
+            StopSimulationThread();
+        }
         m_sceneList.clear();
 
         //clear the free slots queue

--- a/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Core/Code/Source/System/PhysXSystem.cpp
@@ -166,13 +166,14 @@ namespace PhysX
 
     void PhysXSystem::Shutdown()
     {
-        if (IsSimulationThreadRunning())
-        {
-            StopSimulationThread();
-        }
         if (m_state != State::Initialized)
         {
             return;
+        }
+
+        if (IsSimulationThreadRunning())
+        {
+            StopSimulationThread();
         }
 
         RemoveAllScenes();
@@ -440,16 +441,15 @@ namespace PhysX
 
     AzPhysics::SceneHandle PhysXSystem::AddScene(const AzPhysics::SceneConfiguration& config)
     {
-        if (IsSimulationThreadRunning())
-        {
-            StopSimulationThread();
-        }
         if (config.m_sceneName.empty())
         {
             AZ_Error("PhysXSystem", false, "AddScene: Trying to Add a scene without a name. SceneConfiguration::m_sceneName must have a value");
             return AzPhysics::InvalidSceneHandle;
         }
-
+        if (IsSimulationThreadRunning())
+        {
+            StopSimulationThread();
+        }
         if (!m_freeSceneSlots.empty()) //fill any free slots first before increasing the size of the scene list vector.
         {
             AzPhysics::SceneIndex freeIndex = m_freeSceneSlots.front();

--- a/Gems/PhysX/Core/Code/Source/System/PhysXSystem.h
+++ b/Gems/PhysX/Core/Code/Source/System/PhysXSystem.h
@@ -10,6 +10,8 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/std/parallel/atomic.h>
+#include <AzCore/std/parallel/thread.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/Configuration/SystemConfiguration.h>
 
@@ -37,6 +39,17 @@ namespace physx
 
 namespace PhysX
 {
+    //! State of the free-running simulation thread.
+    struct SimulationThread
+    {
+        AZStd::thread m_thread;
+        AZStd::atomic_bool m_exit{ false };
+
+        //! Total sim time advanced by the thread, in seconds.
+        AZStd::atomic<double> m_simulatedTime{ 0.0 };
+        double m_lastPublishedSimTime = 0.0; //!< Main-thread cursor into m_simulatedTime.
+    };
+
     class PhysXSystem
         : public AZ::Interface<AzPhysics::SystemInterface>::Registrar
     {
@@ -87,6 +100,9 @@ namespace PhysX
 
         AZ::Debug::PerformanceCollector* GetPerformanceCollector();
 
+        //! True while a simulation thread owns scene stepping.
+        bool IsSimulationThreadRunning() const { return m_simulationThread.has_value(); }
+
     private:
         //! Initializes the PhysX SDK.
         //! This sets up the PhysX Foundation, Cooking, and other PhysX sub-systems.
@@ -96,12 +112,33 @@ namespace PhysX
 
         void InitializePerformanceCollector();
 
+        //! Steps every enabled scene @a numSubSteps times, each sub-step advancing by @a timeStep.
+        void SimulateScenes(float timeStep, AZ::u32 numSubSteps);
+
+        //! Free-running is gameplay only. In Editor edit mode just the editor preview scene is
+        //! enabled and the viewport mutates bodies constantly, so stepping stays on the main thread.
+        bool ShouldRunFreeThreaded() const;
+
+
+        void StartSimulationThread();
+        void StopSimulationThread();
+
+        //! Free-running loop: owns its own clock and steps the scenes between publication windows.
+        void FreeRunningSimulationLoop();
+
+        //! Main-tick half of the free-running mode - pushes results to entities and signals the
+        //! pre/post simulate events with the sim time the physics thread advanced since last tick.
+        void PublishSimulationResults();
+
         PhysXSystemConfiguration m_systemConfig;
         AzPhysics::SceneConfiguration m_defaultSceneConfiguration;
         AzPhysics::SceneList m_sceneList;
         AZStd::queue<AzPhysics::SceneIndex> m_freeSceneSlots; //when a scene is removed cache its index here to be used for the next add.
 
         float m_accumulatedTime = 0.0f;
+
+        //! Simulation thread, initialized on first tick.
+        AZStd::optional<SimulationThread> m_simulationThread;
 
         struct PhysXSdk
         {

--- a/Gems/PhysX/Core/Code/Source/System/PhysXSystem.h
+++ b/Gems/PhysX/Core/Code/Source/System/PhysXSystem.h
@@ -44,10 +44,6 @@ namespace PhysX
     {
         AZStd::thread m_thread;
         AZStd::atomic_bool m_exit{ false };
-
-        //! Total sim time advanced by the thread, in seconds.
-        AZStd::atomic<double> m_simulatedTime{ 0.0 };
-        double m_lastPublishedSimTime = 0.0; //!< Main-thread cursor into m_simulatedTime.
     };
 
     class PhysXSystem
@@ -119,15 +115,19 @@ namespace PhysX
         //! enabled and the viewport mutates bodies constantly, so stepping stays on the main thread.
         bool ShouldRunFreeThreaded() const;
 
-
         void StartSimulationThread();
         void StopSimulationThread();
 
         //! Free-running loop: owns its own clock and steps the scenes between publication windows.
+        //! Scene start, trigger and collision events fire from here at simulation rate, so
+        //! consumers can act on every step; those handlers - and the body add/remove events they
+        //! cause - must be thread-safe and touch physics only. The finish event is recorded and
+        //! signaled by PublishSimulationResults, whose scene write lock also serializes handler
+        //! state against this loop.
         void FreeRunningSimulationLoop();
 
-        //! Main-tick half of the free-running mode - pushes results to entities and signals the
-        //! pre/post simulate events with the sim time the physics thread advanced since last tick.
+        //! Main-tick half of the free-running mode - signals the scene simulation finish events the
+        //! simulation thread deferred and pushes the transforms it produced to the entities.
         void PublishSimulationResults();
 
         PhysXSystemConfiguration m_systemConfig;

--- a/Gems/ScriptCanvasPhysics/Code/Tests/ScriptCanvasPhysicsTest.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Tests/ScriptCanvasPhysicsTest.cpp
@@ -138,6 +138,7 @@ namespace ScriptCanvasPhysicsTests
             GetJointFromHandle, AzPhysics::Joint*(AzPhysics::SceneHandle sceneHandle, AzPhysics::JointHandle jointHandle));
         MOCK_CONST_METHOD1(GetGravity, AZ::Vector3(AzPhysics::SceneHandle sceneHandle));
         MOCK_METHOD2(RegisterSceneSimulationFinishHandler, void(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationFinishHandler& handler));
+        MOCK_METHOD2(RegisterSceneSimulationSynchronizedWithTickHandler, void(AzPhysics::SceneHandle sceneHandle, AzPhysics::SceneEvents::OnSceneSimulationSynchronizedWithTickHandler& handler));
         MOCK_CONST_METHOD2(GetLegacyBody, AzPhysics::SimulatedBody* (AzPhysics::SceneHandle sceneHandle, AzPhysics::SimulatedBodyHandle handle));
         MOCK_METHOD2(QueryScene, AzPhysics::SceneQueryHits(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request));
         MOCK_METHOD3(QueryScene, bool(AzPhysics::SceneHandle sceneHandle, const AzPhysics::SceneQueryRequest* request, AzPhysics::SceneQueryHits&));


### PR DESCRIPTION
In main and development branch PhysX simulation is run for few substeps in main thread after render tick.
This PR ads a mode in which PhysX simulation is executed in the separate thread parallel to rendering. This is useful for simulation, especially simulation of control systems when this bulk simulations leads to unecesary delays that contributes to sim 2 real gap.

I've added:
 - optional thread handle for simulation thread
 - mechanism for defer events from simulation thread to main thread

Default threading model:
<img width="1453" height="210" alt="Screenshot from 2026-09-02 16-30-00" src="https://github.com/user-attachments/assets/8ecf57e7-96e9-406e-be3e-e28c52ac5152" />

New threading model
<img width="1257" height="280" alt="Screenshot from 2026-09-02 16-29-09" src="https://github.com/user-attachments/assets/b8c64d53-2c58-4145-8179-4766f83ed0dc" />

The switch is done in PhysX 
## What does this PR do?

There is plenty complains on 

## How was this PR tested?

Running templates projects.
Runs PhysX test 