### PR TITLE
Dynamically include 3rdParty directories

### DIFF
--- a/Code/3rdParty/CMakeLists.txt
+++ b/Code/3rdParty/CMakeLists.txt
@@ -5,7 +5,21 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
-add_subdirectory(antlr4)
-add_subdirectory(cli11)
-add_subdirectory(jsoncpp)
-add_subdirectory(xxhash)
+file(
+    GLOB third_party_cmake_lists
+    LIST_DIRECTORIES FALSE
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/*/CMakeLists.txt"
+)
+list(
+    SORT third_party_cmake_lists
+    COMPARE NATURAL
+    CASE INSENSITIVE
+    ORDER ASCENDING
+)
+
+foreach(third_party_cmake_list IN LISTS third_party_cmake_lists)
+    cmake_path(GET third_party_cmake_list PARENT_PATH third_party_directory)
+    add_subdirectory("${third_party_directory}")
+endforeach()


### PR DESCRIPTION
Automatically discovers and eagerly registers source-built integrations under `Code/3rdParty`.

This supports the ongoing migration away from packaged third-party dependencies without requiring every migration PR to modify the centralized `Code/3rdParty/CMakeLists.txt` and `BuiltInPackages_*.cmake` files. Once a source integration creates its existing `3rdParty::` target, the dependency resolver naturally bypasses the retained package association.

Legacy associations can therefore remain temporarily and be removed together after the migrations are complete, reducing merge conflicts between otherwise independent PRs.