### PR TITLE
Add Script Canvas translations for haptic feedback

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/InputHapticFeedbackRequestBus.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/EBus/Senders/InputHapticFeedbackRequestBus.names
@@ -1,0 +1,46 @@
+{
+    "entries": [
+        {
+            "base": "InputHapticFeedbackRequestBus",
+            "context": "EBusSender",
+            "variant": "",
+            "details": {
+                "name": "Input Haptic Feedback",
+                "category": "Input"
+            },
+            "methods": [
+                {
+                    "base": "SetVibration",
+                    "entry": {
+                        "name": "In",
+                        "tooltip": "When signaled, this will set vibration for the selected input device"
+                    },
+                    "exit": {
+                        "name": "Out",
+                        "tooltip": "Signaled after vibration is set"
+                    },
+                    "details": {
+                        "name": "Set Vibration",
+                        "tooltip": "Sets the vibration motor speeds for a specific input device"
+                    },
+                    "params": [
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Left Motor Speed",
+                                "tooltip": "Normalized speed of the left (large, low-frequency) vibration motor, from 0.0 to 1.0"
+                            }
+                        },
+                        {
+                            "typeid": "{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}",
+                            "details": {
+                                "name": "Right Motor Speed",
+                                "tooltip": "Normalized speed of the right (small, high-frequency) vibration motor, from 0.0 to 1.0"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## What does this PR do?

Adds Script Canvas translation metadata for `InputHapticFeedbackRequestBus`.

<img width="246" height="176" alt="image" src="https://github.com/user-attachments/assets/6fadceec-333e-401c-871c-d905b5da98af" />


The `SetVibration` node now has a readable name, category, tooltip, execution slot descriptions, and labels for the left and right motor speed inputs.

This change only affects how the existing haptic feedback bus is displayed in Script Canvas. It does not change its runtime behavior.

## How was this PR tested?

Built the Editor and verified the `Set Vibration` node in Script Canvas. Confirmed that the node name, category, tooltips, and motor input labels are displayed correctly.