### PR TITLE
Add AZStd::bit with a constexpr byteswap for pre-C++23 toolchains

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
+++ b/Code/Framework/AzCore/AzCore/std/azstd_files.cmake
@@ -18,6 +18,7 @@ set(FILES
     allocator_traits.h
     any.h
     base.h
+    bit.h
     config.h
     concepts/concepts.h
     concepts/concepts_assignable.h

--- a/Code/Framework/AzCore/AzCore/std/bit.h
+++ b/Code/Framework/AzCore/AzCore/std/bit.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <bit>
+
+#if !defined(__cpp_lib_byteswap) || __cpp_lib_byteswap < 202110L
+#include <concepts>
+#include <cstddef>
+#include <cstdlib>
+#include <type_traits>
+#endif
+
+namespace AZStd
+{
+    using std::bit_cast;
+
+    using std::endian;
+
+    using std::rotl;
+    using std::rotr;
+
+    using std::countl_zero;
+    using std::countl_one;
+    using std::countr_zero;
+    using std::countr_one;
+    using std::popcount;
+
+    using std::has_single_bit;
+    using std::bit_ceil;
+    using std::bit_floor;
+    using std::bit_width;
+
+#if defined(__cpp_lib_byteswap) && __cpp_lib_byteswap >= 202110L
+    // C++23
+    using std::byteswap;
+#else
+    //! Pre-C++23
+    template<std::integral T>
+    [[nodiscard]] constexpr T byteswap(T value) noexcept
+    {
+        // Must come first, as make_unsigned is ill-formed for bool and the character types.
+        if constexpr (sizeof(T) == 1)
+        {
+            return value;
+        }
+#if defined(_MSC_VER) && !defined(__clang__)
+        // The MSVC intrinsics are not constexpr, unlike __builtin_bswap* below.
+        else if constexpr (sizeof(T) == 2)
+        {
+            const auto bits = static_cast<unsigned short>(value);
+            if (std::is_constant_evaluated())
+            {
+                return static_cast<T>(static_cast<unsigned short>((bits << 8) | (bits >> 8)));
+            }
+            else
+            {
+                return static_cast<T>(_byteswap_ushort(bits));
+            }
+        }
+        else if constexpr (sizeof(T) == 4)
+        {
+            const auto bits = static_cast<unsigned long>(value);
+            if (std::is_constant_evaluated())
+            {
+                return static_cast<T>(static_cast<unsigned long>(
+                    ((bits & 0x0000'00FFuL) << 24) | ((bits & 0x0000'FF00uL) << 8) |
+                    ((bits & 0x00FF'0000uL) >> 8) | ((bits & 0xFF00'0000uL) >> 24)));
+            }
+            else
+            {
+                return static_cast<T>(_byteswap_ulong(bits));
+            }
+        }
+        else if constexpr (sizeof(T) == 8)
+        {
+            const auto bits = static_cast<unsigned long long>(value);
+            if (std::is_constant_evaluated())
+            {
+                return static_cast<T>(static_cast<unsigned long long>(
+                    ((bits & 0x0000'0000'0000'00FFuLL) << 56) | ((bits & 0x0000'0000'0000'FF00uLL) << 40) |
+                    ((bits & 0x0000'0000'00FF'0000uLL) << 24) | ((bits & 0x0000'0000'FF00'0000uLL) << 8) |
+                    ((bits & 0x0000'00FF'0000'0000uLL) >> 8) | ((bits & 0x0000'FF00'0000'0000uLL) >> 24) |
+                    ((bits & 0x00FF'0000'0000'0000uLL) >> 40) | ((bits & 0xFF00'0000'0000'0000uLL) >> 56)));
+            }
+            else
+            {
+                return static_cast<T>(_byteswap_uint64(bits));
+            }
+        }
+#else
+        else if constexpr (sizeof(T) == 2)
+        {
+            return static_cast<T>(__builtin_bswap16(static_cast<unsigned short>(value)));
+        }
+        else if constexpr (sizeof(T) == 4)
+        {
+            return static_cast<T>(__builtin_bswap32(static_cast<unsigned int>(value)));
+        }
+        else if constexpr (sizeof(T) == 8)
+        {
+            return static_cast<T>(__builtin_bswap64(static_cast<unsigned long long>(value)));
+        }
+#endif
+        else
+        {
+            // Extended integer types such as __int128.
+            using UnsignedType = std::make_unsigned_t<T>;
+            auto bits = static_cast<UnsignedType>(value);
+            UnsignedType result{};
+            for (std::size_t byteIndex = 0; byteIndex < sizeof(T); ++byteIndex)
+            {
+                result = static_cast<UnsignedType>(static_cast<UnsignedType>(result << 8) | (bits & UnsignedType{ 0xFF }));
+                bits = static_cast<UnsignedType>(bits >> 8);
+            }
+            return static_cast<T>(result);
+        }
+    }
+#endif
+} // namespace AZStd

--- a/Code/Framework/AzCore/Tests/AZStd/BitTests.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/BitTests.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/algorithm.h>
+#include <AzCore/std/bit.h>
+#include <AzCore/std/containers/array.h>
+
+namespace UnitTest
+{
+    class ByteswapFixture : public LeakDetectionFixture
+    {
+    };
+
+    static_assert(AZStd::byteswap(AZ::u8{ 0xAB }) == AZ::u8{ 0xAB });
+    static_assert(AZStd::byteswap(AZ::u16{ 0x1234 }) == AZ::u16{ 0x3412 });
+    static_assert(AZStd::byteswap(AZ::u32{ 0x12345678 }) == AZ::u32{ 0x78563412 });
+    static_assert(AZStd::byteswap(AZ::u64{ 0x0123456789ABCDEF }) == AZ::u64{ 0xEFCDAB8967452301 });
+    static_assert(AZStd::byteswap(AZ::s16{ -2 }) == static_cast<AZ::s16>(0xFEFF));
+    static_assert(AZStd::byteswap(AZ::s32{ -2 }) == static_cast<AZ::s32>(0xFEFFFFFF));
+    static_assert(AZStd::byteswap(AZ::s64{ -1 }) == AZ::s64{ -1 });
+    static_assert(AZStd::byteswap(true) == true);
+    static_assert(AZStd::byteswap('a') == 'a');
+    static_assert(AZStd::byteswap(char16_t{ 0x1234 }) == char16_t{ 0x3412 });
+
+    //! Independent reference: reverses the object representation without touching AZStd::byteswap.
+    template<class T>
+    static T ReverseObjectRepresentation(T value)
+    {
+        auto bytes = AZStd::bit_cast<AZStd::array<AZ::u8, sizeof(T)>>(value);
+        AZStd::reverse(bytes.begin(), bytes.end());
+        return AZStd::bit_cast<T>(bytes);
+    }
+
+    TEST_F(ByteswapFixture, ReversesKnownValues)
+    {
+        EXPECT_EQ(AZStd::byteswap(AZ::u16{ 0x1234 }), AZ::u16{ 0x3412 });
+        EXPECT_EQ(AZStd::byteswap(AZ::u32{ 0x12345678 }), AZ::u32{ 0x78563412 });
+        EXPECT_EQ(AZStd::byteswap(AZ::u64{ 0x0123456789ABCDEF }), AZ::u64{ 0xEFCDAB8967452301 });
+    }
+
+    TEST_F(ByteswapFixture, LeavesSingleByteTypesUnchanged)
+    {
+        EXPECT_EQ(AZStd::byteswap(AZ::u8{ 0xAB }), AZ::u8{ 0xAB });
+        EXPECT_EQ(AZStd::byteswap(AZ::s8{ -3 }), AZ::s8{ -3 });
+        EXPECT_EQ(AZStd::byteswap('a'), 'a');
+        EXPECT_EQ(AZStd::byteswap(true), true);
+    }
+
+    TEST_F(ByteswapFixture, ReversesSignedValues)
+    {
+        EXPECT_EQ(AZStd::byteswap(AZ::s16{ -2 }), static_cast<AZ::s16>(0xFEFF));
+        EXPECT_EQ(AZStd::byteswap(AZ::s32{ -2 }), static_cast<AZ::s32>(0xFEFFFFFF));
+        EXPECT_EQ(AZStd::byteswap(AZ::s64{ -1 }), AZ::s64{ -1 });
+    }
+
+    TEST_F(ByteswapFixture, MatchesReversedObjectRepresentation)
+    {
+        AZ::u64 bits = 1;
+        for (int iteration = 0; iteration < 1000; ++iteration)
+        {
+            bits = bits * 6364136223846793005ULL + 1442695040888963407ULL;
+
+            EXPECT_EQ(AZStd::byteswap(static_cast<AZ::u16>(bits)), ReverseObjectRepresentation(static_cast<AZ::u16>(bits)));
+            EXPECT_EQ(AZStd::byteswap(static_cast<AZ::u32>(bits)), ReverseObjectRepresentation(static_cast<AZ::u32>(bits)));
+            EXPECT_EQ(AZStd::byteswap(bits), ReverseObjectRepresentation(bits));
+            EXPECT_EQ(AZStd::byteswap(static_cast<AZ::s16>(bits)), ReverseObjectRepresentation(static_cast<AZ::s16>(bits)));
+            EXPECT_EQ(AZStd::byteswap(static_cast<AZ::s32>(bits)), ReverseObjectRepresentation(static_cast<AZ::s32>(bits)));
+            EXPECT_EQ(AZStd::byteswap(static_cast<AZ::s64>(bits)), ReverseObjectRepresentation(static_cast<AZ::s64>(bits)));
+        }
+    }
+
+    TEST_F(ByteswapFixture, IsItsOwnInverse)
+    {
+        AZ::u64 bits = 1;
+        for (int iteration = 0; iteration < 1000; ++iteration)
+        {
+            bits = bits * 6364136223846793005ULL + 1442695040888963407ULL;
+
+            EXPECT_EQ(AZStd::byteswap(AZStd::byteswap(static_cast<AZ::u16>(bits))), static_cast<AZ::u16>(bits));
+            EXPECT_EQ(AZStd::byteswap(AZStd::byteswap(static_cast<AZ::u32>(bits))), static_cast<AZ::u32>(bits));
+            EXPECT_EQ(AZStd::byteswap(AZStd::byteswap(bits)), bits);
+        }
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -21,6 +21,7 @@ set(FILES
     AZStd/Allocators.cpp
     AZStd/Atomics.cpp
     AZStd/Any.cpp
+    AZStd/BitTests.cpp
     AZStd/Bitset.cpp
     AZStd/Charconv.cpp
     AZStd/ConceptsTests.cpp


### PR DESCRIPTION
## What does this PR do?

Adds `AzCore/std/bit.h`, which exposes the `<bit>` facilities under AZStd and provides byteswap on toolchains that predate C++23. We currently target C++20, so `std::byteswap` isn't available. The header forwards to `std::byteswap` when `__cpp_lib_byteswap >= 202110L` and uses its own implementation otherwise.

Byte swapping is used for endian conversion in serialization and asset baking, file and network header parsing, and packed color and hash values. A constexpr version lets those conversions fold into compile-time tables and literals, replacing hand-rolled shift-and-mask helpers that are easy to get wrong on signed types.

The implementation follows libc++ and the MSVC STL:
- GCC and Clang use `__builtin_bswap16/32/64`, which already constant fold.
- MSVC uses _byteswap_ushort, _byteswap_ulong and _byteswap_uint64 at runtime, with shift-based fallbacks under `std::is_constant_evaluated()`, since those intrinsics are not constexpr.
- Single-byte types return unchanged. Extended integers such as `__int128` use a generic constexpr byte-reversal loop.

At `-O2` each call compiles to one instruction (`rev`/`rev16` on ARM, `bswap` on x64).

## How was this PR tested?

Added `Tests/AZStd/BitTests.cpp` to `AzCore.Tests`:

- static_assert's covering constant evaluation for 16/32/64-bit signed and unsigned types, bool, char and char16_t. These cover the MSVC constexpr path, which is separate from its runtime path.
- Five runtime tests: known values, single-byte types, signed values, 1000 pseudorandom values per type checked against a reference that bit_cast's to a byte array and reverses it, and an involution check.