### PR TITLE
Fix shortcut event handling and harden CI artifact caches

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -164,14 +164,14 @@ jobs:
       - name: Extract artifact
         # Extract the tar file from the artifact
         id: extract-artifact
-        continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         run: |
-          if [ -f ${{ github.workspace }}/cache.tar ]; then
-            tar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
-            rm ${{ github.workspace }}/cache.tar
-            ccache --zero-stats --cleanup
+          if ! tar -xvpf "${{ github.workspace }}/cache.tar"; then
+            echo "::warning::Ignoring invalid cache archive"
+            rm -rf .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
           fi
+          rm -f "${{ github.workspace }}/cache.tar"
+          ccache --zero-stats --cleanup
 
       - name: Setup cmake
         # Pin the version of cmake
@@ -260,7 +260,8 @@ jobs:
         if: ${{ (steps.extract-artifact.outcome == 'success' || steps.extract-artifact.outcome == 'skipped') && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         run: |
-          tar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+          mkdir -p .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
+          tar --format=posix -cvpf ${{ github.workspace }}/cache.tar \
             .ccache \
             .o3de/python/downloaded_packages \
             3rdParty/downloaded_packages \
@@ -268,7 +269,7 @@ jobs:
 
       - name: Save artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
+        if: ${{ steps.compress-artifacts.outcome == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         with:
           name: O3DE-${{ inputs.platform }}-${{ inputs.config }}-build

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -120,16 +120,16 @@ jobs:
       - name: Extract artifact
         # Extract the tar file from the artifact
         id: extract-artifact
-        continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         run: |
-          if [ -f "${{ github.workspace }}/cache.tar" ]; then
-            trap 'rm -f "${{ github.workspace }}/cache.tar"' EXIT
-            gtar -xpf "${{ github.workspace }}/cache.tar" --ignore-failed-read
-            rm -f "${{ github.workspace }}/cache.tar"
-            trap - EXIT
-            ccache --zero-stats --cleanup
+          trap 'rm -f "${{ github.workspace }}/cache.tar"' EXIT
+          if ! gtar -xpf "${{ github.workspace }}/cache.tar"; then
+            echo "::warning::Ignoring invalid cache archive"
+            rm -rf .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
           fi
+          rm -f "${{ github.workspace }}/cache.tar"
+          trap - EXIT
+          ccache --zero-stats --cleanup
 
       - name: Setup cmake
         # Pin the version of cmake
@@ -167,7 +167,8 @@ jobs:
         continue-on-error: true
         run: |
           ccache --cleanup
-          gtar --format=posix -cpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+          mkdir -p .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
+          gtar --format=posix -cpf ${{ github.workspace }}/cache.tar \
             .ccache \
             .o3de/python/downloaded_packages \
             3rdParty/downloaded_packages \
@@ -175,7 +176,7 @@ jobs:
 
       - name: Save artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
+        if: ${{ steps.compress-artifacts.outcome == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         with:
           name: O3DE-iOS-${{ inputs.config }}-build

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -161,14 +161,14 @@ jobs:
       - name: Extract artifact
         # Extract the tar file from the artifact
         id: extract-artifact
-        continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         run: |
-          if [ -f ${{ github.workspace }}/cache.tar ]; then
-            tar -xvpf ${{ github.workspace }}/cache.tar --ignore-failed-read
-            rm ${{ github.workspace }}/cache.tar
-            ccache --zero-stats --cleanup
+          if ! tar -xvpf "${{ github.workspace }}/cache.tar"; then
+            echo "::warning::Ignoring invalid cache archive"
+            rm -rf .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
           fi
+          rm -f "${{ github.workspace }}/cache.tar"
+          ccache --zero-stats --cleanup
 
       - name: Setup cmake
         # Pin the version of cmake
@@ -249,7 +249,8 @@ jobs:
         if: ${{ (steps.extract-artifact.outcome == 'success' || steps.extract-artifact.outcome == 'skipped') && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         run: |
-          tar --format=posix -cvpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+          mkdir -p .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
+          tar --format=posix -cvpf ${{ github.workspace }}/cache.tar \
             .ccache \
             .o3de/python/downloaded_packages \
             3rdParty/downloaded_packages \
@@ -257,7 +258,7 @@ jobs:
 
       - name: Save artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
+        if: ${{ steps.compress-artifacts.outcome == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         with:
           name: O3DE-${{ inputs.platform }}-${{ inputs.config }}-build

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -121,16 +121,16 @@ jobs:
       - name: Extract artifact
         # Extract the tar file from the artifact
         id: extract-artifact
-        continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         run: |
-          if [ -f "${{ github.workspace }}/cache.tar" ]; then
-            trap 'rm -f "${{ github.workspace }}/cache.tar"' EXIT
-            gtar -xpf "${{ github.workspace }}/cache.tar" --ignore-failed-read
-            rm -f "${{ github.workspace }}/cache.tar"
-            trap - EXIT
-            ccache --zero-stats --cleanup
+          trap 'rm -f "${{ github.workspace }}/cache.tar"' EXIT
+          if ! gtar -xpf "${{ github.workspace }}/cache.tar"; then
+            echo "::warning::Ignoring invalid cache archive"
+            rm -rf .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
           fi
+          rm -f "${{ github.workspace }}/cache.tar"
+          trap - EXIT
+          ccache --zero-stats --cleanup
 
       - name: Setup cmake
         # Pin the version of cmake
@@ -168,7 +168,8 @@ jobs:
         continue-on-error: true
         run: |
           ccache --cleanup
-          gtar --format=posix -cpf ${{ github.workspace }}/cache.tar --ignore-failed-read \
+          mkdir -p .ccache .o3de/python/downloaded_packages 3rdParty/downloaded_packages AutomatedTesting/Cache
+          gtar --format=posix -cpf ${{ github.workspace }}/cache.tar \
             .ccache \
             .o3de/python/downloaded_packages \
             3rdParty/downloaded_packages \
@@ -176,7 +177,7 @@ jobs:
 
       - name: Save artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
+        if: ${{ steps.compress-artifacts.outcome == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         with:
           name: O3DE-Mac-${{ inputs.config }}-build

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -163,15 +163,17 @@ jobs:
       - name: Extract artifact
         # Extract the tar file from the artifact
         id: extract-artifact
-        continue-on-error: true
         if: ${{ steps.restore-artifact-cache.outcome == 'success' }}
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
-          if (Test-Path ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar) {
-            tar -xvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
-            rm ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
-            ccache --zero-stats --cleanup
+          $PSNativeCommandUseErrorActionPreference = $false
+          tar -xvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar
+          if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Ignoring invalid cache archive"
+            Remove-Item -Recurse -Force .ccache, .o3de\python\downloaded_packages, 3rdParty\downloaded_packages, AutomatedTesting\Cache -ErrorAction SilentlyContinue
           }
+          Remove-Item ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar -Force -ErrorAction SilentlyContinue
+          ccache --zero-stats --cleanup
 
       - name: Setup cmake
         # Pin the version of cmake
@@ -255,19 +257,16 @@ jobs:
         continue-on-error: true
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         run: |
-          try {
-            tar --format=posix -cvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar `
-              .ccache `
-              .o3de\python\downloaded_packages `
-              3rdParty\downloaded_packages `
-              AutomatedTesting\Cache
-          } catch {
-            echo "Warning: Error during tar compression"
-          }
+          New-Item -ItemType Directory -Force .ccache, .o3de\python\downloaded_packages, 3rdParty\downloaded_packages, AutomatedTesting\Cache | Out-Null
+          tar --format=posix -cvpf ${{ env.DEV_DRIVE_WORKSPACE }}\cache.tar `
+            .ccache `
+            .o3de\python\downloaded_packages `
+            3rdParty\downloaded_packages `
+            AutomatedTesting\Cache
 
       - name: Save artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ steps.compress-artifacts.conclusion == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
+        if: ${{ steps.compress-artifacts.outcome == 'success' && !cancelled() && !contains(inputs.type, 'test') }}
         continue-on-error: true
         with:
           name: O3DE-${{ inputs.platform }}-${{ inputs.config }}-build

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -118,24 +118,13 @@ namespace AzToolsFramework
         }
         case QEvent::Shortcut:
         {
-            // QActions default "autoRepeat" to true, which is not an ideal user experience.
-            // We globally disable that behavior here - in the unlikely event a shortcut needs to
-            // replicate it, its owner can instead implement a keyEvent handler
-            if (static_cast<QKeyEvent*>(event)->isAutoRepeat())
+            auto* shortcutEvent = static_cast<QShortcutEvent*>(event);
+            QWidget* watchedWidget = qobject_cast<QWidget*>(watched);
+
+            if (TriggerActiveActionsWithShortcut(
+                    m_editorActionContext->GetActions(), watchedWidget->actions(), shortcutEvent->key()))
             {
-                event->accept();
                 return true;
-            }
-
-            if (auto shortcutEvent = static_cast<QShortcutEvent*>(event))
-            {
-                QWidget* watchedWidget = qobject_cast<QWidget*>(watched);
-
-                if (TriggerActiveActionsWithShortcut(
-                        m_editorActionContext->GetActions(), watchedWidget->actions(), shortcutEvent->key()))
-                {
-                    return true;
-                }
             }
             break;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
@@ -42,6 +42,7 @@ namespace AzToolsFramework
         UpdateIconFromPath();
         m_action = new QAction(m_icon, m_name.c_str(), this);
         m_action->setObjectName(m_identifier.c_str());
+        m_action->setAutoRepeat(false);
 
         QObject::connect(
             m_action, &QAction::triggered, this,

--- a/Code/Framework/AzToolsFramework/Tests/ActionManager/HotKeyManagerTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ActionManager/HotKeyManagerTests.cpp
@@ -62,6 +62,7 @@ namespace UnitTest
 
         QAction* action = m_actionManagerInternalInterface->GetAction("o3de.action.test");
         EXPECT_TRUE(action->shortcut() == QKeySequence("Ctrl+Z"));
+        EXPECT_FALSE(action->autoRepeat());
     }
 
     TEST_F(ActionManagerFixture, VerifyActionHotkeyTriggered)
@@ -83,7 +84,7 @@ namespace UnitTest
         m_widget->setFocus();
 
         // Trigger a shortcut event to our widget, which should in turn trigger our action
-        QShortcutEvent testEvent(QKeySequence("Ctrl+Z"), 0, true);
+        QShortcutEvent testEvent(QKeySequence("Ctrl+Z"), nullptr, false);
         QApplication::sendEvent(m_widget, &testEvent);
 
         EXPECT_TRUE(actionTriggered);
@@ -129,7 +130,7 @@ namespace UnitTest
         QCoreApplication::processEvents();
 
         // Trigger a shortcut event to our child widget, which should in turn only trigger our child action
-        QShortcutEvent testEvent(QKeySequence("Ctrl+Z"), 0, true);
+        QShortcutEvent testEvent(QKeySequence("Ctrl+Z"), nullptr, true);
         QApplication::sendEvent(childWidget, &testEvent);
 
         EXPECT_TRUE(childActionTriggered);


### PR DESCRIPTION
## What does this PR do?

Improves CI reliability in two places identified while investigating intermittent test failures.

The Action Manager shortcut event filter was treating a `QShortcutEvent` as a `QKeyEvent` when checking for auto-repeat. This is undefined behavior and could cause the shortcut event to be consumed without triggering its action. Shortcut events are now handled using their correct type, while auto-repeat is disabled through `QAction::setAutoRepeat(false)`. The related tests also use the correct values for normal and ambiguous shortcut events.

The platform build workflows could continue after an artifact failed to extract, leaving a partially restored cache for later build and test steps. Artifact caches remain optional, but a failed extraction now removes the partial cache so the job can continue with a clean build. Archive creation no longer ignores read failures, and uploads now check the original compression outcome so an incomplete archive isn't saved.

https://discord.com/channels/805939474655346758/1415808365699006556/1540441812928299098