### PR TITLE
Fix AssetId construction

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
@@ -10,11 +10,56 @@
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/string/conversions.h>
 
 AZ_INSTANTIATE_EBUS_MULTI_ADDRESS(AZCORE_API, AZ::Data::AssetEvents);
+
+namespace
+{
+    void AssetIdScriptConstructor(AZ::Data::AssetId* thisPtr, AZ::ScriptDataContext& scriptDataContext)
+    {
+        new (thisPtr) AZ::Data::AssetId();
+
+        const int argumentCount = scriptDataContext.GetNumArguments();
+        if (argumentCount == 0)
+        {
+            return;
+        }
+
+        if ((argumentCount == 1 || argumentCount == 2)
+            && (scriptDataContext.IsString(0) || scriptDataContext.IsClass<AZ::Uuid>(0))
+            && (argumentCount == 1 || scriptDataContext.IsNumber(1)))
+        {
+            AZ::u32 subId = 0;
+            if (argumentCount == 2)
+            {
+                scriptDataContext.ReadArg(1, subId);
+            }
+
+            if (scriptDataContext.IsString(0))
+            {
+                const char* guidString = nullptr;
+                scriptDataContext.ReadArg(0, guidString);
+                *thisPtr = AZ::Data::AssetId(guidString, subId);
+            }
+            else
+            {
+                AZ::Uuid guid;
+                scriptDataContext.ReadArg(0, guid);
+                *thisPtr = AZ::Data::AssetId(guid, subId);
+            }
+            return;
+        }
+
+        scriptDataContext.GetScriptContext()->Error(
+            AZ::ScriptContext::ErrorType::Error,
+            true,
+            "AssetId expects zero arguments, or a UUID or UUID string and an optional numeric sub ID");
+    }
+} // namespace
 
 namespace AZ::Data
 {
@@ -73,6 +118,7 @@ namespace AZ::Data
                 ->Constructor()
                 ->Constructor<const Uuid&, u32>()
                 ->Constructor<AZStd::string_view, u32>()
+                ->Attribute(AZ::Script::Attributes::ConstructorOverride, &AssetIdScriptConstructor)
                 ->Method("CreateString", &Data::AssetId::CreateString)
                 ->Method("IsValid", &Data::AssetId::IsValid)
                     ->Attribute(AZ::Script::Attributes::Alias, "is_valid")

--- a/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
@@ -8,6 +8,7 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetInternal/WeakAsset.h>
+#include <AzCore/Math/MathReflection.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Script/ScriptContext.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
@@ -115,6 +116,7 @@ namespace UnitTest
 
             g_constructorResultMatches = false;
             m_behaviorContext = AZStd::make_unique<BehaviorContext>();
+            MathReflect(m_behaviorContext.get());
             AssetId::Reflect(m_behaviorContext.get());
             m_behaviorContext->Property(
                 "constructorResultMatches", BehaviorValueProperty(&g_constructorResultMatches));
@@ -160,6 +162,30 @@ namespace UnitTest
     {
         const bool executed = m_scriptContext->Execute(
             "local assetId = AssetId('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}', 42)\n"
+            "local expected = AssetId.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}:2a')\n"
+            "constructorResultMatches = assetId == expected\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
+    }
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithUuidObject_UsesDefaultSubIdInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local uuid = Uuid.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}')\n"
+            "local assetId = AssetId(uuid)\n"
+            "local expected = AssetId.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}:0')\n"
+            "constructorResultMatches = assetId == expected\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
+    }
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithUuidObjectAndSubId_PreservesBothArgumentsInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local uuid = Uuid.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}')\n"
+            "local assetId = AssetId(uuid, 42)\n"
             "local expected = AssetId.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}:2a')\n"
             "constructorResultMatches = assetId == expected\n");
 

--- a/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetCommon.cpp
@@ -8,11 +8,19 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetInternal/WeakAsset.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 
 namespace UnitTest
 {
     using namespace AZ;
     using namespace AZ::Data;
+
+    namespace
+    {
+        bool g_constructorResultMatches = false;
+    }
 
     using AssetIdTest = LeakDetectionFixture;
 
@@ -95,6 +103,68 @@ namespace UnitTest
         AZStd::string asString = assetId.ToString<AZStd::string>(AZ::Data::AssetId::SubIdDisplayType::Decimal);
         auto subId = asString.substr(asString.find_first_of(':') + 1);
         EXPECT_STRCASEEQ(subId.c_str(), "4294967295");
+    }
+
+    class AssetIdScriptConstructorTest
+        : public LeakDetectionFixture
+    {
+    protected:
+        void SetUp() override
+        {
+            LeakDetectionFixture::SetUp();
+
+            g_constructorResultMatches = false;
+            m_behaviorContext = AZStd::make_unique<BehaviorContext>();
+            AssetId::Reflect(m_behaviorContext.get());
+            m_behaviorContext->Property(
+                "constructorResultMatches", BehaviorValueProperty(&g_constructorResultMatches));
+
+            m_scriptContext = AZStd::make_unique<ScriptContext>();
+            m_scriptContext->BindTo(m_behaviorContext.get());
+        }
+
+        void TearDown() override
+        {
+            m_scriptContext.reset();
+            m_behaviorContext.reset();
+
+            LeakDetectionFixture::TearDown();
+        }
+
+        AZStd::unique_ptr<BehaviorContext> m_behaviorContext;
+        AZStd::unique_ptr<ScriptContext> m_scriptContext;
+    };
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithNoArguments_CreatesInvalidAssetIdInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local assetId = AssetId()\n"
+            "constructorResultMatches = not assetId:IsValid()\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
+    }
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithGuid_UsesDefaultSubIdInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local assetId = AssetId('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}')\n"
+            "local expected = AssetId.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}:0')\n"
+            "constructorResultMatches = assetId == expected\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
+    }
+
+    TEST_F(AssetIdScriptConstructorTest, ConstructorWithGuidAndSubId_PreservesBothArgumentsInLua)
+    {
+        const bool executed = m_scriptContext->Execute(
+            "local assetId = AssetId('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}', 42)\n"
+            "local expected = AssetId.CreateString('{A9F596D7-9913-4BA4-AD4E-7E477FB9B542}:2a')\n"
+            "constructorResultMatches = assetId == expected\n");
+
+        EXPECT_TRUE(executed);
+        EXPECT_TRUE(g_constructorResultMatches);
     }
 
     using AssetTest = LeakDetectionFixture;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -350,8 +350,9 @@ namespace AzToolsFramework
     bool PropertyAssetCtrl::CanAcceptAsset(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType) const
     {
         const auto selectableAssetTypes = GetSelectableAssetTypes();
-        const auto isSelectableAssetType =
-            AZStd::find(selectableAssetTypes.begin(), selectableAssetTypes.end(), assetType) != selectableAssetTypes.end();
+        // An empty list means no type filter is configured, matching the asset browser display filter behavior.
+        const auto isSelectableAssetType = selectableAssetTypes.empty()
+            || AZStd::find(selectableAssetTypes.begin(), selectableAssetTypes.end(), assetType) != selectableAssetTypes.end();
         return (assetId.IsValid() && !assetType.IsNull() && isSelectableAssetType);
     }
 

--- a/Code/Framework/AzToolsFramework/Tests/UI/PropertyAssetCtrlTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/UI/PropertyAssetCtrlTests.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
+
+namespace UnitTest
+{
+    class TestPropertyAssetCtrl : public AzToolsFramework::PropertyAssetCtrl
+    {
+    public:
+        bool CanAccept(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType) const
+        {
+            return CanAcceptAsset(assetId, assetType);
+        }
+    };
+
+    class PropertyAssetCtrlTest : public ToolsApplicationFixture<>
+    {
+    };
+
+    TEST_F(PropertyAssetCtrlTest, CanAcceptAsset_EmptySelectableTypes_AcceptsAnyValidAssetType)
+    {
+        TestPropertyAssetCtrl propertyAssetCtrl;
+        const AZ::Data::AssetId assetId(AZ::Uuid::CreateRandom(), 1);
+        const AZ::Data::AssetType assetType = AZ::Uuid::CreateRandom();
+
+        EXPECT_TRUE(propertyAssetCtrl.CanAccept(assetId, assetType));
+    }
+
+    TEST_F(PropertyAssetCtrlTest, CanAcceptAsset_EmptySelectableTypes_RejectsInvalidAssetData)
+    {
+        TestPropertyAssetCtrl propertyAssetCtrl;
+        const AZ::Data::AssetId assetId(AZ::Uuid::CreateRandom(), 1);
+        const AZ::Data::AssetType assetType = AZ::Uuid::CreateRandom();
+
+        EXPECT_FALSE(propertyAssetCtrl.CanAccept(AZ::Data::AssetId(), assetType));
+        EXPECT_FALSE(propertyAssetCtrl.CanAccept(assetId, AZ::Data::AssetType::CreateNull()));
+    }
+
+    TEST_F(PropertyAssetCtrlTest, CanAcceptAsset_NonEmptySelectableTypes_OnlyAcceptsListedTypes)
+    {
+        TestPropertyAssetCtrl propertyAssetCtrl;
+        const AZ::Data::AssetId assetId(AZ::Uuid::CreateRandom(), 1);
+        const AZ::Data::AssetType supportedAssetType = AZ::Uuid::CreateRandom();
+        const AZ::Data::AssetType unsupportedAssetType = AZ::Uuid::CreateRandom();
+        propertyAssetCtrl.SetSupportedAssetTypes({ supportedAssetType });
+
+        EXPECT_TRUE(propertyAssetCtrl.CanAccept(assetId, supportedAssetType));
+        EXPECT_FALSE(propertyAssetCtrl.CanAccept(assetId, unsupportedAssetType));
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -186,6 +186,7 @@ set(FILES
     UI/EntityIdQLineEditTests.cpp
     UI/EntityOutlinerTests.cpp
     UI/EntityPropertyEditorTests.cpp
+    UI/PropertyAssetCtrlTests.cpp
     UI/AssetBrowserTests.cpp
     UndoStack.cpp
     Viewport/ClusterTests.cpp


### PR DESCRIPTION
## What does this PR do?
Fixes Lua AssetId construction by adding an explicit constructor override supporting:
- AssetId() for an empty ID.
- AssetId(uuid) or AssetId(uuidString) with a default sub-ID of zero.
- AssetId(uuid, subId) or AssetId(uuidString, subId).
Also fixes asset selection for properties without a type filter. Previously, an empty list of selectable types rejected every asset. It now accepts any valid asset with a non-null type, matching the asset browser’s filtering behavior. Explicit type filters remain enforced.

## How was this PR tested?
Added regression tests covering:
- Lua construction with no arguments, a UUID string, and a UUID string with an explicit sub-ID
- Asset acceptance when no type filter is configured
- Rejection of invalid asset IDs and null asset types
- Acceptance of matching types and rejection of nonmatching types when a filter is configured

This PR is a separate #20032, scoped implementation of the fixes from the draft version. It does not introduce the draft’s assetType filtering feature