### PR TITLE
Do not cap max viewport and fly input camera speed.

### DIFF
--- a/Code/Editor/Core/Widgets/ViewportSettingsWidgets.cpp
+++ b/Code/Editor/Core/Widgets/ViewportSettingsWidgets.cpp
@@ -55,6 +55,7 @@ ViewportCameraSpeedScalePropertyWidget::ViewportCameraSpeedScalePropertyWidget()
     m_label->setText(tr("Camera Speed Scale"));
 
     // Set starting value.
+    m_spinBox->setMaximum(1.0e6f);
     m_spinBox->setValue(SandboxEditor::CameraSpeedScale());
 
     const int DefaultViewportId = 0;

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/FlyCameraInputComponent.cpp
@@ -90,8 +90,7 @@ void FlyCameraInputComponent::GetIncompatibleServices(AZ::ComponentDescriptor::D
 //////////////////////////////////////////////////////////////////////////////
 void FlyCameraInputComponent::Reflect(AZ::ReflectContext* reflection)
 {
-    AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflection);
-    if (serializeContext)
+    if (auto* const serializeContext = azrtti_cast<AZ::SerializeContext*>(reflection))
     {
         serializeContext->Class<FlyCameraInputComponent, AZ::Component>()
             ->Version(1)
@@ -102,8 +101,7 @@ void FlyCameraInputComponent::Reflect(AZ::ReflectContext* reflection)
             ->Field("Invert Rotation Input Y", &FlyCameraInputComponent::m_InvertRotationInputAxisY)
             ->Field("Is enabled", &FlyCameraInputComponent::m_isEnabled);
 
-        AZ::EditContext* editContext = serializeContext->GetEditContext();
-        if (editContext)
+        if (auto* const editContext = serializeContext->GetEditContext())
         {
             editContext->Class<FlyCameraInputComponent>(QT_TRANSLATE_NOOP("AtomBridge", "Fly Camera Input"), QT_TRANSLATE_NOOP("AtomBridge", "The Fly Camera Input allows you to control the camera"))
                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
@@ -115,7 +113,6 @@ void FlyCameraInputComponent::Reflect(AZ::ReflectContext* reflection)
                 ->Attribute("AppearsInAddComponentMenu", AZ_CRC_CE("Game"))
                 ->DataElement(nullptr, &FlyCameraInputComponent::m_moveSpeed, QT_TRANSLATE_NOOP("AtomBridge", "Move Speed"), QT_TRANSLATE_NOOP("AtomBridge", "Speed at which the camera moves"))
                 ->Attribute("Min", 1.0f)
-                ->Attribute("Max", 100.0f)
                 ->Attribute("ChangeNotify", AZ_CRC_CE("RefreshValues"))
                 ->DataElement(nullptr, &FlyCameraInputComponent::m_rotationSpeed, QT_TRANSLATE_NOOP("AtomBridge", "Rotation Speed"), QT_TRANSLATE_NOOP("AtomBridge", "Speed at which the camera rotates"))
                 ->Attribute("Min", 1.0f)
@@ -134,8 +131,7 @@ void FlyCameraInputComponent::Reflect(AZ::ReflectContext* reflection)
         }
     }
 
-    AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflection);
-    if (behaviorContext)
+    if (auto* const behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflection))
     {
         behaviorContext->EBus<FlyCameraInputBus>("FlyCameraInputBus")
             ->Event("SetIsEnabled", &FlyCameraInputBus::Events::SetIsEnabled)


### PR DESCRIPTION
## What does this PR do?

Right now, the Editors view-port camera and the camera component do have a max cap on the speed of the camera. This is an unnecessary because it does not hurt to be able to move the camera faster through the level especially when having really large worlds. 
In my space game project i do have large distances and this makes it really hard to move around the scene quickly. 
I also did some changes which aren't needed but I thought to just slightly modernize it. I can remove those small changes if wished.

## How was this PR tested?

Tested on my local computer (Kubuntu 26.04) and used the Camera Fly Input Component and the Editors view-port to test.
