### PR TITLE
Prefab: return a failure instead of crashing when InstantiatePrefab cannot load the file

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -512,7 +512,17 @@ namespace AzToolsFramework
             {
                 // Load the template from the file
                 templateId = m_prefabLoaderInterface->LoadTemplateFromFile(filePath);
-                AZ_Assert(templateId != InvalidTemplateId, "Template with source path %.*s couldn't be loaded correctly.", AZ_STRING_ARG(filePath));
+            }
+
+            if (templateId == InvalidTemplateId)
+            {
+                // A missing or unreadable .prefab is a user error, not an internal one. Falling through here
+                // used to call FindTemplateDom(InvalidTemplateId), which dereferences an empty optional and
+                // crashes the Editor (see https://github.com/o3de/o3de/issues/7957).
+                return AZ::Failure(AZStd::string::format(
+                    "Could not instantiate prefab - the template with source path '%.*s' could not be loaded. "
+                    "Check that the file exists and is a valid .prefab.",
+                    AZ_STRING_ARG(filePath)));
             }
 
             const PrefabDom& templateDom = m_prefabSystemComponentInterface->FindTemplateDom(templateId);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstantiateTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstantiateTests.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <AzCore/Utils/Utils.h>
+#include <AzTest/Utils.h>
 #include <Prefab/PrefabTestFixture.h>
 
 namespace UnitTest
@@ -17,6 +19,39 @@ namespace UnitTest
         AZ_TEST_START_TRACE_SUPPRESSION;
         EXPECT_FALSE(m_prefabSystemComponent->InstantiatePrefab(AzToolsFramework::Prefab::InvalidTemplateId));
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+    }
+
+    TEST_F(PrefabInstantiateTest, PrefabInstantiate_MissingPrefabFile_ReturnsFailureWithoutCrashing)
+    {
+        // Regression test for https://github.com/o3de/o3de/issues/7957: instantiating a prefab whose
+        // file cannot be loaded used to fall through into FindTemplateDom(InvalidTemplateId), which
+        // dereferences an empty optional and crashes the Editor. The loader reports the unreadable file
+        // with a single AZ_Error, which is the one suppressed trace expected below.
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        AzToolsFramework::Prefab::InstantiatePrefabResult result = m_prefabPublicInterface->InstantiatePrefab(
+            "Prefabs/DoesNotExist.prefab", GetRootContainerEntityId(), AZ::Vector3());
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        ASSERT_FALSE(result.IsSuccess());
+        EXPECT_NE(result.GetError().find("could not be loaded"), AZStd::string::npos);
+    }
+
+    TEST_F(PrefabInstantiateTest, PrefabInstantiate_EmptyPrefabFile_ReturnsFailureWithoutCrashing)
+    {
+        // The corrupted-file case from https://github.com/o3de/o3de/issues/7957: a .prefab that exists but
+        // holds no JSON. LoadTemplateFromString reports the parse failure with one AZ_Error and returns
+        // InvalidTemplateId, after which the fall-through is the same as for a missing file.
+        AZ::Test::ScopedAutoTempDirectory tempDir;
+        const AZ::IO::Path emptyPrefabPath = tempDir.GetDirectoryAsPath() / "Empty.prefab";
+        ASSERT_TRUE(AZ::Utils::WriteFile("", emptyPrefabPath.Native()).IsSuccess());
+
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        AzToolsFramework::Prefab::InstantiatePrefabResult result = m_prefabPublicInterface->InstantiatePrefab(
+            emptyPrefabPath.Native(), GetRootContainerEntityId(), AZ::Vector3());
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+
+        ASSERT_FALSE(result.IsSuccess());
+        EXPECT_NE(result.GetError().find("could not be loaded"), AZStd::string::npos);
     }
 
     TEST_F(PrefabInstantiateTest, PrefabInstantiate_NoNestingTemplate_InstantiateSucceeds)


### PR DESCRIPTION
## What does this PR do?

Fixes #7957. Related to #2331.

`PrefabPublicHandler::InstantiatePrefab` can crash the Editor when the prefab file cannot be loaded. The original report used a corrupted `.prefab`; in my testing a path that does not exist is enough, and it reproduces from the Python console with any level open:

```python
import azlmbr.bus as bus, azlmbr.entity as entity, azlmbr.math as math, azlmbr.prefab as prefab
prefab.PrefabPublicRequestBus(bus.Broadcast, 'InstantiatePrefab',
                              'Prefabs/DoesNotExist.prefab', entity.EntityId(), math.Vector3(0.0, 0.0, 0.0))
```

**Old behavior:** `LoadTemplateFromFile` returns `InvalidTemplateId`, an `AZ_Assert` fires but only logs (as asserts do in the Editor), and execution continues into `FindTemplateDom(InvalidTemplateId)`. That reads through an empty optional, so the `PrefabDom&` it returns is not valid, and `PrefabDomUtils::GetTemplateSourcePaths` segfaults on the first `FindMember`:

```
#0  rapidjson_ly::GenericValue<...>::StringEqual
#1  rapidjson_ly::GenericValue<...>::FindMember
#2  AzToolsFramework::Prefab::PrefabDomUtils::GetTemplateSourcePaths
#3  AzToolsFramework::Prefab::PrefabPublicHandler::InstantiatePrefab
```

**New behavior:** if the template id is still invalid after the load attempt, the function returns `AZ::Failure` with a message naming the path, following the pattern the other precondition checks in this function already use. The loader's existing `AZ_Error` still reports the unreadable file.

I treated a missing or unreadable prefab as a user error rather than an internal invariant, which is why the assert is replaced by the early return rather than kept alongside it. If the maintainers would rather keep an assert or add an `AZ_Warning` there, I am happy to change it.

The corrupted-file case from the original report goes through the same path (`LoadTemplateFromString` fails and `InvalidTemplateId` comes back), so it is covered by the same check; the second test exercises it with an empty file.

## How was this PR tested?

- Added two tests to `PrefabInstantiateTests.cpp`: `PrefabInstantiate_MissingPrefabFile_ReturnsFailureWithoutCrashing` (a path that does not exist) and `PrefabInstantiate_EmptyPrefabFile_ReturnsFailureWithoutCrashing` (a `.prefab` that exists but holds no JSON, the case in the original report). Each calls `PrefabPublicInterface::InstantiatePrefab` under the root container, expects a failure whose message says the template could not be loaded, and expects one suppressed trace (the loader's `AZ_Error`).
- With `PrefabPublicHandler.cpp` reverted to `development` and the tests kept, `AzTestRunner` exits with code 139 (SIGSEGV) on each of them. With the change in place both pass.
- `AzTestRunner libAzToolsFramework.Tests.so AzRunUnitTests --gtest_filter='Prefab*'`: 139 tests, all passing.
- Reproduced the crash three times on a 26.10.0 (stabilization build) profile Editor on Linux from the Python snippet above, with the same stack each time. The fix itself was verified through the unit test rather than by rebuilding the Editor.

Environment: Linux (Fedora 44), clang, Ninja Multi-Config, profile.

Thanks for taking a look. Happy to make any changes.
