### PR TITLE
Add optional PhysX collision for the editor camera

### DIFF
--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -11,6 +11,7 @@
 #include <Atom/RPI.Public/ViewportContextBus.h>
 #include <AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/Render/IntersectorInterface.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
@@ -90,6 +91,16 @@ namespace SandboxEditor
         SetupCameras();
 
         auto controller = AZStd::make_shared<AtomToolsFramework::ModularViewportCameraController>();
+
+        controller->SetCameraMovementConstraint(
+            [](const AZ::Vector3& previousPosition, const AZ::Vector3& desiredPosition)
+            {
+                if (auto* collision = AZ::Interface<Camera::EditorCameraCollisionInterface>::Get())
+                {
+                    return collision->ConstrainCameraMovement(previousPosition, desiredPosition);
+                }
+                return desiredPosition;
+            });
 
         controller->SetCameraViewportContextBuilderCallback(
             [viewportId = m_viewportId](AZStd::unique_ptr<AtomToolsFramework::ModularCameraViewportContext>& cameraViewportContext)

--- a/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
+++ b/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
@@ -9,6 +9,7 @@
 #include <AZTestShared/Math/MathTestHelpers.h>
 #include <AtomToolsFramework/Viewport/ModularViewportCameraController.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/Interface/Interface.h>
 #include <AzFramework/Viewport/ViewportControllerList.h>
 #include <AzTest/GemTestEnvironment.h>
 #include <AzToolsFramework/API/EditorCameraBus.h>
@@ -23,6 +24,31 @@
 
 namespace UnitTest
 {
+    class TestCameraCollisionProvider : public Camera::EditorCameraCollisionInterface
+    {
+    public:
+        TestCameraCollisionProvider()
+        {
+            AZ::Interface<Camera::EditorCameraCollisionInterface>::Register(this);
+        }
+        ~TestCameraCollisionProvider() override
+        {
+            AZ::Interface<Camera::EditorCameraCollisionInterface>::Unregister(this);
+        }
+        bool IsCameraCollisionEnabled() const override { return m_enabled; }
+        void SetCameraCollisionEnabled(bool enabled) override { m_enabled = enabled; }
+        AZ::Vector3 ConstrainCameraMovement([[maybe_unused]] const AZ::Vector3& previous, const AZ::Vector3& desired) const override
+        {
+            auto result = desired;
+            if (m_enabled)
+            {
+                result.SetY(AZ::GetMin(result.GetY(), 2.0f));
+            }
+            return result;
+        }
+        bool m_enabled = true;
+    };
+
     class EditorCameraFixture : public UnitTest::LeakDetectionFixture
     {
     public:
@@ -108,6 +134,66 @@ namespace UnitTest
             }
         }
     };
+
+    TEST_F(EditorCameraFixture, CameraCollisionSynchronizesSmoothedTarget)
+    {
+        TestCameraCollisionProvider provider;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
+            TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::SetCameraPivotAttached,
+            AZ::Vector3(0.0f, 10.0f, 0.0f));
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.2f), AZ::ScriptTimePoint() });
+        EXPECT_NEAR(m_cameraViewportContextView->GetCameraTransform().GetTranslation().GetY(), 2.0f, 0.001f);
+
+        // Disabling collision must not release movement that accumulated behind the wall.
+        provider.SetCameraCollisionEnabled(false);
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(2.0f), AZ::ScriptTimePoint() });
+        EXPECT_NEAR(m_cameraViewportContextView->GetCameraTransform().GetTranslation().GetY(), 2.0f, 0.001f);
+
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
+            TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::SetCameraPivotAttached,
+            AZ::Vector3::CreateZero());
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(2.0f), AZ::ScriptTimePoint() });
+        EXPECT_TRUE(m_cameraViewportContextView->GetCameraTransform().GetTranslation().IsClose(AZ::Vector3::CreateZero()));
+    }
+
+    TEST_F(EditorCameraFixture, CameraCollisionPreservesOrbitPivot)
+    {
+        TestCameraCollisionProvider provider;
+        using Bus = AtomToolsFramework::ModularViewportCameraControllerRequestBus;
+        Bus::Event(TestViewportId, &Bus::Events::SetCameraPivotAttachedImmediate, AZ::Vector3(0.0f, 10.0f, 0.0f));
+        Bus::Event(TestViewportId, &Bus::Events::SetCameraOffsetImmediate, AZ::Vector3(0.0f, -10.0f, 0.0f));
+        Bus::Event(TestViewportId, &Bus::Events::SetCameraOffset, AZ::Vector3(0.0f, -1.0f, 0.0f));
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(2.0f), AZ::ScriptTimePoint() });
+        EXPECT_NEAR(m_cameraViewportContextView->GetCameraTransform().GetTranslation().GetY(), 2.0f, 0.001f);
+
+        provider.SetCameraCollisionEnabled(false);
+        Bus::Event(TestViewportId, &Bus::Events::SetCameraPivotAttached, AZ::Vector3(0.0f, 11.0f, 0.0f));
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(2.0f), AZ::ScriptTimePoint() });
+        EXPECT_NEAR(m_cameraViewportContextView->GetCameraTransform().GetTranslation().GetY(), 3.0f, 0.001f);
+    }
+
+    TEST_F(EditorCameraFixture, CameraCollisionStopsFocusAnimationAtObstacle)
+    {
+        TestCameraCollisionProvider provider;
+        using Bus = AtomToolsFramework::ModularViewportCameraControllerRequestBus;
+        Bus::Event(TestViewportId, &Bus::Events::InterpolateToTransform,
+            AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 10.0f, 0.0f)), 1.0f);
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
+        EXPECT_NEAR(m_cameraViewportContextView->GetCameraTransform().GetTranslation().GetY(), 2.0f, 0.001f);
+        bool interpolating = true;
+        Bus::EventResult(interpolating, TestViewportId, &Bus::Events::IsInterpolating);
+        EXPECT_FALSE(interpolating);
+    }
+
+    TEST_F(EditorCameraFixture, CameraCollisionDoesNotOverrideTrackedEntity)
+    {
+        TestCameraCollisionProvider provider;
+        const auto transform = AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 10.0f, 0.0f));
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
+            TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::StartTrackingTransform, transform);
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(2.0f), AZ::ScriptTimePoint() });
+        EXPECT_TRUE(m_cameraViewportContextView->GetCameraTransform().IsClose(transform));
+    }
 
     TEST_F(EditorCameraFixture, ModularViewportCameraControllerReferenceFrameUpdatedWhenViewportEntityisChanged)
     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorCameraBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorCameraBus.h
@@ -21,6 +21,19 @@ namespace AzFramework
 
 namespace Camera
 {
+    //! Optional provider of collision constraints for the free editor camera.
+    //! A physics gem can register this interface without adding a physics dependency to the camera controller.
+    class EditorCameraCollisionInterface
+    {
+    public:
+        AZ_RTTI(EditorCameraCollisionInterface, "{A01AD0D8-967B-41DF-B531-417083720567}");
+        virtual ~EditorCameraCollisionInterface() = default;
+
+        virtual bool IsCameraCollisionEnabled() const = 0;
+        virtual void SetCameraCollisionEnabled(bool enabled) = 0;
+        virtual AZ::Vector3 ConstrainCameraMovement(const AZ::Vector3& previousPosition, const AZ::Vector3& desiredPosition) const = 0;
+    };
+
     /**
      * This bus allows you to get and set the current editor viewport camera
      */

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -35,6 +35,8 @@ namespace AtomToolsFramework
     using CameraControllerPriorityFn =
         AZStd::function<AzFramework::ViewportControllerPriority(const AzFramework::CameraSystem& cameraSystem)>;
     using CameraViewportContextFn = AZStd::function<AZStd::unique_ptr<ModularCameraViewportContext>(AzFramework::ViewportId)>;
+    //! Resolve movement from the previous position to the desired position, returning an allowed world position.
+    using CameraMovementConstraint = AZStd::function<AZ::Vector3(const AZ::Vector3&, const AZ::Vector3&)>;
 
     //! The default behavior for what priority the camera controller should respond to events at.
     //! @note This can change based on the state of the camera controller/system.
@@ -62,6 +64,8 @@ namespace AtomToolsFramework
         void SetCameraPriorityBuilderCallback(const CameraPriorityBuilder& builder);
         //! Sets the camera controller viewport context builder callback to populate new ModularViewportCameraControllerInstances.
         void SetCameraViewportContextBuilderCallback(const CameraViewportContextBuilder& builder);
+        //! Optionally constrain camera movement after smoothing. Set before registering viewport instances.
+        void SetCameraMovementConstraint(const CameraMovementConstraint& constraint);
 
     private:
         //! Sets up a camera list based on this controller's CameraListBuilderCallback.
@@ -81,6 +85,7 @@ namespace AtomToolsFramework
         CameraPriorityBuilder m_cameraControllerPriorityBuilder;
         //! Builder to define what viewport context interface the camera controller should use.
         CameraViewportContextBuilder m_cameraViewportContextBuilder;
+        CameraMovementConstraint m_cameraMovementConstraint;
     };
 
     //! The production modular camera viewport context backed by an AZ::RPI::ViewportContextPtr.
@@ -138,6 +143,8 @@ namespace AtomToolsFramework
         //! Combine the current camera transform with any potential roll from the tracked
         //! transform (this is usually zero).
         AZ::Transform CombinedCameraTransform() const;
+        //! Constrain the rendered position and synchronize the target to avoid accumulating blocked movement.
+        void ConstrainCameraMovement(const AZ::Vector3& previousPosition);
 
         //! Reconnect the current view matrix change handler after the viewport context view group has changed.
         //! @note: This happens after switching to track a different camera/viewport transform.
@@ -165,6 +172,7 @@ namespace AtomToolsFramework
         AZStd::optional<AzFramework::Camera> m_storedCamera; //!< A potentially stored camera for when a transform is being tracked.
         AzFramework::CameraSystem m_cameraSystem; //!< The camera system responsible for managing all CameraInputs.
         AzFramework::CameraProps m_cameraProps; //!< Camera properties to control rotate and translate smoothness.
+        CameraMovementConstraint m_cameraMovementConstraint;
         CameraControllerPriorityFn m_priorityFn; //!< Controls at what priority the camera controller should respond to events.
 
         AZStd::optional<CameraAnimation> m_cameraAnimation; //!< Camera animation state (used during CameraMode::Animation).

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -123,6 +123,11 @@ namespace AtomToolsFramework
         }
     }
 
+    void ModularViewportCameraController::SetCameraMovementConstraint(const CameraMovementConstraint& constraint)
+    {
+        m_cameraMovementConstraint = constraint;
+    }
+
     void ModularViewportCameraController::SetupCameraProperties(AzFramework::CameraProps& cameraProps)
     {
         if (m_cameraPropsBuilder)
@@ -171,6 +176,7 @@ namespace AtomToolsFramework
         controller->SetupCameraProperties(m_cameraProps);
         controller->SetupCameraControllerPriority(m_priorityFn);
         controller->SetupCameraControllerViewportContext(m_modularCameraViewportContext);
+        m_cameraMovementConstraint = controller->m_cameraMovementConstraint;
 
         auto handleCameraChangeFn = [this]([[maybe_unused]] const AZ::Matrix4x4& cameraView)
         {
@@ -242,6 +248,7 @@ namespace AtomToolsFramework
         }
 
         m_updatingTransformInternally = true;
+        const AZ::Vector3 previousPosition = m_camera.Translation();
 
         if (m_cameraMode == CameraMode::Control)
         {
@@ -249,6 +256,7 @@ namespace AtomToolsFramework
             m_camera = AzFramework::SmoothCamera(m_camera, m_targetCamera, m_cameraProps, event.m_deltaTime.count());
             m_roll = AzFramework::SmoothValue(m_targetRoll, m_roll, m_cameraProps.m_rotateSmoothnessFn(), event.m_deltaTime.count());
 
+            ConstrainCameraMovement(previousPosition);
             m_modularCameraViewportContext->SetCameraTransform(CombinedCameraTransform());
         }
         else if (m_cameraMode == CameraMode::Animation)
@@ -285,9 +293,12 @@ namespace AtomToolsFramework
             m_targetRoll = eulerAngles.GetY();
             m_targetCamera = m_camera;
 
-            m_modularCameraViewportContext->SetCameraTransform(current);
+            ConstrainCameraMovement(previousPosition);
+            AZ::Transform constrainedTransform = current;
+            constrainedTransform.SetTranslation(m_camera.Translation());
+            m_modularCameraViewportContext->SetCameraTransform(constrainedTransform);
 
-            if (animationTime >= 1.0f)
+            if (animationTime >= 1.0f || !constrainedTransform.GetTranslation().IsClose(current.GetTranslation(), 1.0e-5f))
             {
                 m_cameraMode = CameraMode::Control;
                 m_cameraAnimation.reset();
@@ -295,6 +306,35 @@ namespace AtomToolsFramework
         }
 
         m_updatingTransformInternally = false;
+    }
+
+    void ModularViewportCameraControllerInstance::ConstrainCameraMovement(const AZ::Vector3& previousPosition)
+    {
+        if (!m_cameraMovementConstraint || IsTrackingTransform())
+        {
+            return;
+        }
+
+        const AZ::Vector3 desiredPosition = m_camera.Translation();
+        const AZ::Vector3 position = m_cameraMovementConstraint(previousPosition, desiredPosition);
+        if (position.IsClose(desiredPosition, 1.0e-5f))
+        {
+            return;
+        }
+
+        if (m_camera.m_offset.IsZero())
+        {
+            m_camera.m_pivot = position;
+            m_targetCamera.m_pivot = position;
+            m_targetCamera.m_offset = AZ::Vector3::CreateZero();
+        }
+        else
+        {
+            // Preserve the orbit pivot, expressing the corrected position in each camera's local frame.
+            m_camera.m_offset = m_camera.Rotation().GetTranspose() * (position - m_camera.m_pivot);
+            m_targetCamera.m_pivot = m_camera.m_pivot;
+            m_targetCamera.m_offset = m_targetCamera.Rotation().GetTranspose() * (position - m_targetCamera.m_pivot);
+        }
     }
 
     bool ModularViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal, const float duration)

--- a/Gems/PhysX/Core/Code/Editor/Source/Components/EditorCameraCollision.cpp
+++ b/Gems/PhysX/Core/Code/Editor/Source/Components/EditorCameraCollision.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Editor/Source/Components/EditorCameraCollision.h>
+
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/containers/fixed_vector.h>
+#include <AzFramework/Physics/PhysicsScene.h>
+#include <Shape.h>
+#include <PhysX/MathConversion.h>
+#include <extensions/PxShapeExt.h>
+
+namespace PhysX
+{
+    namespace
+    {
+        AZ::Vector3 FindCameraPenetration(
+            AzPhysics::SceneInterface& sceneInterface, const AzPhysics::SceneHandle sceneHandle,
+            const AZ::Vector3& position, const float radius, const float contactGap)
+        {
+            AZ::Vector3 separation = AZ::Vector3::CreateZero();
+            float deepestPenetration = 0.0f;
+            const physx::PxSphereGeometry sphere(radius);
+            const physx::PxTransform pose(PxMathConvert(position));
+            auto overlap = AzPhysics::OverlapRequestHelpers::CreateSphereOverlapRequest(
+                radius, AZ::Transform::CreateTranslation(position),
+                [&](const AzPhysics::SimulatedBody*, const Physics::Shape* shape)
+                {
+                    const auto* physxShape = azrtti_cast<const PhysX::Shape*>(shape);
+                    if (physxShape && !physxShape->IsTrigger())
+                    {
+                        const auto* nativeShape = static_cast<const physx::PxShape*>(physxShape->GetNativePointer());
+                        const auto* actor = nativeShape->getActor();
+                        physx::PxVec3 direction;
+                        float depth = 0.0f;
+                        // The query invokes this callback under the scene read lock. Compute the actual overlap here
+                        // and retain no native pointers after the query. This also avoids a bounded hit buffer.
+                        if (actor && physx::PxGeometryQuery::computePenetration(
+                                direction, depth, sphere, pose, nativeShape->getGeometry(),
+                                physx::PxShapeExt::getGlobalPose(*nativeShape, *actor))
+                            && direction.isFinite() && AZ::IsFiniteFloat(depth) && depth > deepestPenetration)
+                        {
+                            deepestPenetration = depth;
+                            separation = PxMathConvert(direction) * (depth + contactGap);
+                        }
+                    }
+                    return false;
+                });
+            sceneInterface.QueryScene(sceneHandle, &overlap);
+            return separation;
+        }
+    } // namespace
+
+    AZ::Vector3 ResolveCameraCollision(
+        const AzPhysics::SceneHandle sceneHandle, const AZ::Vector3& previousPosition, const AZ::Vector3& desiredPosition)
+    {
+        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        if (!sceneInterface || sceneHandle == AzPhysics::InvalidSceneHandle)
+        {
+            return desiredPosition;
+        }
+
+        constexpr float CameraRadius = 0.25f;
+        constexpr float ContactGap = 0.001f;
+        constexpr float MovementTolerance = 1.0e-5f;
+        constexpr int MaxIterations = 4;
+
+        auto request = AzPhysics::ShapeCastRequestHelpers::CreateSphereCastRequest(
+            CameraRadius, AZ::Transform::CreateTranslation(previousPosition), AZ::Vector3::CreateAxisZ(), 0.0f,
+            AzPhysics::SceneQuery::QueryType::StaticAndDynamic, AzPhysics::CollisionGroup::All,
+            []([[maybe_unused]] const AzPhysics::SimulatedBody* body, const Physics::Shape* shape)
+            {
+                const auto* physxShape = azrtti_cast<const PhysX::Shape*>(shape);
+                return physxShape && !physxShape->IsTrigger()
+                    ? AzPhysics::SceneQuery::QueryHitType::Block : AzPhysics::SceneQuery::QueryHitType::None;
+            });
+        request.m_hitFlags |= AzPhysics::SceneQuery::HitFlags::MeshBothSides;
+
+        AZ::Vector3 position = previousPosition;
+        AZ::Vector3 remaining = desiredPosition - previousPosition;
+        AZStd::fixed_vector<AZ::Vector3, MaxIterations> contactNormals;
+        for (int iteration = 0; iteration < MaxIterations; ++iteration)
+        {
+            // A zero-length sweep can miss an initial heightfield overlap. Recover penetration independently
+            // of movement direction, including when collision is enabled while the camera is stationary.
+            const AZ::Vector3 separation = FindCameraPenetration(*sceneInterface, sceneHandle, position, CameraRadius, ContactGap);
+            if (!separation.IsZero(MovementTolerance))
+            {
+                position += separation;
+                continue;
+            }
+            const float distance = remaining.GetLength();
+            if (distance <= MovementTolerance)
+            {
+                return position;
+            }
+            request.m_start.SetTranslation(position);
+            request.m_distance = distance;
+            request.m_direction = remaining / distance;
+            const auto hits = sceneInterface->QueryScene(sceneHandle, &request);
+            if (hits.m_hits.empty())
+            {
+                return position + remaining;
+            }
+
+            const auto& hit = hits.m_hits.front();
+            const AZ::Vector3 normal = hit.m_normal.GetNormalizedSafe();
+            if (!normal.IsFinite() || normal.IsZero() || !AZ::IsFiniteFloat(hit.m_distance))
+            {
+                return position;
+            }
+
+            if (hit.m_distance <= 0.0f)
+            {
+                // MTD provides a separation direction and negative penetration depth. Also separate exact contacts
+                // so a camera placed on a surface can move away without repeatedly hitting it at zero distance.
+                position += normal * (-hit.m_distance + ContactGap);
+            }
+            else if (distance > MovementTolerance)
+            {
+                const float travel = AZ::GetClamp(hit.m_distance - ContactGap, 0.0f, distance);
+                position += request.m_direction * travel;
+                remaining -= request.m_direction * travel;
+            }
+            else
+            {
+                return position;
+            }
+
+            contactNormals.push_back(normal);
+            const float intoSurface = remaining.Dot(normal);
+            if (intoSurface < 0.0f)
+            {
+                remaining -= normal * intoSurface;
+            }
+
+            // In a corner, slide along the intersection of the contact planes instead of re-entering an earlier surface.
+            for (const auto& previousNormal : contactNormals)
+            {
+                if (remaining.Dot(previousNormal) < -MovementTolerance)
+                {
+                    const AZ::Vector3 crease = normal.Cross(previousNormal).GetNormalizedSafe();
+                    remaining = crease * remaining.Dot(crease);
+                    for (const auto& contactNormal : contactNormals)
+                    {
+                        if (remaining.Dot(contactNormal) < -MovementTolerance)
+                        {
+                            remaining = AZ::Vector3::CreateZero();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Never apply untested displacement if the iteration budget was exhausted.
+        return position;
+    }
+} // namespace PhysX

--- a/Gems/PhysX/Core/Code/Editor/Source/Components/EditorCameraCollision.h
+++ b/Gems/PhysX/Core/Code/Editor/Source/Components/EditorCameraCollision.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Vector3.h>
+#include <AzFramework/Physics/Common/PhysicsTypes.h>
+
+namespace PhysX
+{
+    //! Sweep the free editor camera through a physics scene, sliding along blocking surfaces.
+    AZ::Vector3 ResolveCameraCollision(
+        AzPhysics::SceneHandle sceneHandle, const AZ::Vector3& previousPosition, const AZ::Vector3& desiredPosition);
+} // namespace PhysX

--- a/Gems/PhysX/Core/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Core/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -14,6 +14,10 @@
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzFramework/Physics/Collision/CollisionEvents.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
+#include <AzToolsFramework/ActionManager/Action/ActionManagerInterface.h>
+#include <AzToolsFramework/ActionManager/Menu/MenuManagerInterface.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorContextIdentifiers.h>
+#include <AzToolsFramework/Editor/ActionManagerIdentifiers/EditorMenuIdentifiers.h>
 
 #include <IEditor.h>
 
@@ -23,11 +27,14 @@
 #include <Editor/PropertyTypes.h>
 #include <Editor/Source/ComponentModes/Joints/JointsComponentMode.h>
 #include <Editor/Source/Material/PhysXEditorMaterialAsset.h>
+#include <Editor/Source/Components/EditorCameraCollision.h>
 #include <Pipeline/PhysicsPrefabProcessor.h>
 #include <System/PhysXSystem.h>
 
 namespace PhysX
 {
+    constexpr AZStd::string_view CameraCollisionActionIdentifier = "o3de.action.game.cameraCollision";
+
     void EditorSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         ColliderComponentMode::Reflect(context);
@@ -111,10 +118,12 @@ namespace PhysX
         AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusConnect();
+        AZ::Interface<Camera::EditorCameraCollisionInterface>::Register(this);
     }
 
     void EditorSystemComponent::Deactivate()
     {
+        AZ::Interface<Camera::EditorCameraCollisionInterface>::Unregister(this);
         AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
@@ -148,18 +157,71 @@ namespace PhysX
     {
         ColliderComponentMode::RegisterActions();
         JointsComponentMode::RegisterActions();
+
+        if (auto* actionManager = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get())
+        {
+            AzToolsFramework::ActionProperties properties;
+            properties.m_name = "Camera Collision";
+            properties.m_description = "Stop the editor camera at physical colliders and slide along them.";
+            properties.m_category = "Game";
+            properties.m_menuVisibility = AzToolsFramework::ActionVisibility::AlwaysShow;
+            actionManager->RegisterCheckableAction(
+                EditorIdentifiers::MainWindowActionContextIdentifier, CameraCollisionActionIdentifier, properties,
+                [this]
+                {
+                    SetCameraCollisionEnabled(!IsCameraCollisionEnabled());
+                },
+                [this]
+                {
+                    return IsCameraCollisionEnabled();
+                });
+        }
     }
 
     void EditorSystemComponent::OnActionContextModeBindingHook()
     {
         ColliderComponentMode::BindActionsToModes();
         JointsComponentMode::BindActionsToModes();
+        if (auto* actionManager = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get())
+        {
+            actionManager->AssignModeToAction(AzToolsFramework::DefaultActionContextModeIdentifier, CameraCollisionActionIdentifier);
+        }
     }
 
     void EditorSystemComponent::OnMenuBindingHook()
     {
         ColliderComponentMode::BindActionsToMenus();
         JointsComponentMode::BindActionsToMenus();
+        if (auto* menuManager = AZ::Interface<AzToolsFramework::MenuManagerInterface>::Get())
+        {
+            // Immediately after Move Player and Camera Separately (700).
+            menuManager->AddActionToMenu(EditorIdentifiers::GameMenuIdentifier, CameraCollisionActionIdentifier, 750);
+        }
+    }
+
+    bool EditorSystemComponent::IsCameraCollisionEnabled() const
+    {
+        return m_cameraCollisionEnabled;
+    }
+
+    void EditorSystemComponent::SetCameraCollisionEnabled(const bool enabled)
+    {
+        m_cameraCollisionEnabled = enabled;
+        if (auto* actionManager = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get())
+        {
+            if (actionManager->IsActionRegistered(CameraCollisionActionIdentifier))
+            {
+                actionManager->UpdateAction(CameraCollisionActionIdentifier);
+            }
+        }
+    }
+
+    AZ::Vector3 EditorSystemComponent::ConstrainCameraMovement(
+        const AZ::Vector3& previousPosition, const AZ::Vector3& desiredPosition) const
+    {
+        return m_cameraCollisionEnabled
+            ? ResolveCameraCollision(m_editorWorldSceneHandle, previousPosition, desiredPosition)
+            : desiredPosition;
     }
 
     void EditorSystemComponent::OnStartPlayInEditorBegin()

--- a/Gems/PhysX/Core/Code/Editor/Source/Components/EditorSystemComponent.h
+++ b/Gems/PhysX/Core/Code/Editor/Source/Components/EditorSystemComponent.h
@@ -15,6 +15,7 @@
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzToolsFramework/ActionManager/ActionManagerRegistrationNotificationBus.h>
+#include <AzToolsFramework/API/EditorCameraBus.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <Editor/Source/Material/PhysXEditorMaterialAssetBuilder.h>
 #include <EditorPhysXJointInterface.h>
@@ -35,6 +36,7 @@ namespace PhysX
         , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
         , private AzToolsFramework::EditorEvents::Bus::Handler
         , public AzToolsFramework::ActionManagerRegistrationNotificationBus::Handler
+        , public Camera::EditorCameraCollisionInterface
     {
     public:
         AZ_COMPONENT(EditorSystemComponent, "{560F08DC-94F5-4D29-9AD4-CDFB3B57C654}");
@@ -61,6 +63,11 @@ namespace PhysX
         void OnActionContextModeBindingHook() override;
         void OnMenuBindingHook() override;
 
+        // Camera::EditorCameraCollisionInterface overrides ...
+        bool IsCameraCollisionEnabled() const override;
+        void SetCameraCollisionEnabled(bool enabled) override;
+        AZ::Vector3 ConstrainCameraMovement(const AZ::Vector3& previousPosition, const AZ::Vector3& desiredPosition) const override;
+
     private:
         // AzToolsFramework::EditorEntityContextNotificationBus overrides...
         void OnStartPlayInEditorBegin() override;
@@ -70,6 +77,7 @@ namespace PhysX
         void NotifyRegisterViews() override;
 
         AzPhysics::SceneHandle m_editorWorldSceneHandle = AzPhysics::InvalidSceneHandle;
+        bool m_cameraCollisionEnabled = false;
 
         // Assets related data
         AZStd::vector<AZStd::unique_ptr<AZ::Data::AssetHandler>> m_assetHandlers;

--- a/Gems/PhysX/Core/Code/Tests/EditorCameraCollisionTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/EditorCameraCollisionTests.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Editor/Source/Components/EditorCameraCollision.h>
+#include <Tests/EditorTestUtilities.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzFramework/Physics/Configuration/RigidBodyConfiguration.h>
+#include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
+#include <AzFramework/Physics/PhysicsScene.h>
+#include <AzFramework/Physics/Shape.h>
+#include <AzFramework/Physics/ShapeConfiguration.h>
+#include <AzToolsFramework/API/EditorCameraBus.h>
+
+namespace PhysXEditorTests
+{
+    class EditorCameraCollisionFixture : public PhysXEditorFixture
+    {
+    public:
+        void AddBox(
+            const AZ::Vector3& position, const AZ::Vector3& dimensions, bool dynamic = false, bool trigger = false,
+            const AZ::Quaternion& orientation = AZ::Quaternion::CreateIdentity())
+        {
+            auto collider = AZStd::make_shared<Physics::ColliderConfiguration>();
+            collider->m_isTrigger = trigger;
+            const AzPhysics::ShapeColliderPair shape(collider, AZStd::make_shared<Physics::BoxShapeConfiguration>(dimensions));
+            if (dynamic)
+            {
+                AzPhysics::RigidBodyConfiguration configuration;
+                configuration.m_position = position;
+                configuration.m_orientation = orientation;
+                configuration.m_colliderAndShapeData = shape;
+                ASSERT_NE(m_defaultScene->AddSimulatedBody(&configuration), AzPhysics::InvalidSimulatedBodyHandle);
+            }
+            else
+            {
+                AzPhysics::StaticRigidBodyConfiguration configuration;
+                configuration.m_position = position;
+                configuration.m_orientation = orientation;
+                configuration.m_colliderAndShapeData = shape;
+                ASSERT_NE(m_defaultScene->AddSimulatedBody(&configuration), AzPhysics::InvalidSimulatedBodyHandle);
+            }
+        }
+
+        void AddHeightfield(float slope = 0.0f, bool centralHole = false)
+        {
+            auto heightfield = AZStd::make_shared<Physics::HeightfieldShapeConfiguration>();
+            heightfield->SetNumColumnVertices(21);
+            heightfield->SetNumRowVertices(21);
+            heightfield->SetGridResolution(AZ::Vector2(1.0f));
+            heightfield->SetMinHeightBounds(-10.0f);
+            heightfield->SetMaxHeightBounds(10.0f);
+            AZStd::vector<Physics::HeightMaterialPoint> samples;
+            for (int row = 0; row < 21; ++row)
+            {
+                for (int column = 0; column < 21; ++column)
+                {
+                    const bool hole = centralHole && row >= 8 && row < 12 && column >= 8 && column < 12;
+                    samples.emplace_back(
+                        slope * (column - 10),
+                        hole ? Physics::QuadMeshType::Hole : Physics::QuadMeshType::SubdivideUpperLeftToBottomRight, 0);
+                }
+            }
+            heightfield->SetSamples(samples);
+            AzPhysics::StaticRigidBodyConfiguration configuration;
+            configuration.m_colliderAndShapeData =
+                AzPhysics::ShapeColliderPair(AZStd::make_shared<Physics::ColliderConfiguration>(), heightfield);
+            ASSERT_NE(m_defaultScene->AddSimulatedBody(&configuration), AzPhysics::InvalidSimulatedBodyHandle);
+        }
+
+        AZ::Vector3 Move(const AZ::Vector3& from, const AZ::Vector3& to)
+        {
+            return PhysX::ResolveCameraCollision(m_defaultSceneHandle, from, to);
+        }
+    };
+
+    TEST_F(EditorCameraCollisionFixture, NoColliderAllowsFreeMovement)
+    {
+        const AZ::Vector3 target(10.0f, -20.0f, 5.0f);
+        EXPECT_TRUE(Move(AZ::Vector3::CreateZero(), target).IsClose(target));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, StaticThinWallStopsHighSpeedMovement)
+    {
+        AddBox(AZ::Vector3(0.0f, 5.0f, 0.0f), AZ::Vector3(100.0f, 0.02f, 100.0f));
+        const auto result = Move(AZ::Vector3::CreateZero(), AZ::Vector3(0.0f, 1000.0f, 0.0f));
+        EXPECT_NEAR(result.GetY(), 4.739f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, DynamicBodyAlsoStopsCamera)
+    {
+        AddBox(AZ::Vector3(0.0f, 5.0f, 0.0f), AZ::Vector3(10.0f, 1.0f, 10.0f), true);
+        const auto result = Move(AZ::Vector3::CreateZero(), AZ::Vector3(0.0f, 10.0f, 0.0f));
+        EXPECT_NEAR(result.GetY(), 4.249f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, TriggerDoesNotBlockCamera)
+    {
+        AddBox(AZ::Vector3(0.0f, 5.0f, 0.0f), AZ::Vector3(10.0f, 1.0f, 10.0f), false, true);
+        const AZ::Vector3 target(0.0f, 10.0f, 0.0f);
+        EXPECT_TRUE(Move(AZ::Vector3::CreateZero(), target).IsClose(target));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, CameraSlidesAlongWall)
+    {
+        AddBox(AZ::Vector3(0.0f, 5.0f, 0.0f), AZ::Vector3(100.0f, 1.0f, 100.0f));
+        const auto result = Move(AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.0f));
+        EXPECT_NEAR(result.GetX(), 10.0f, 0.003f);
+        EXPECT_NEAR(result.GetY(), 4.25f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, CameraStopsInCornerAndCanMoveAway)
+    {
+        AddBox(AZ::Vector3(0.0f, 5.0f, 0.0f), AZ::Vector3(100.0f, 1.0f, 100.0f));
+        AddBox(AZ::Vector3(5.0f, 0.0f, 0.0f), AZ::Vector3(1.0f, 100.0f, 100.0f));
+        const auto result = Move(AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 10.0f, 0.0f));
+        EXPECT_NEAR(result.GetX(), 4.25f, 0.003f);
+        EXPECT_NEAR(result.GetY(), 4.25f, 0.003f);
+        EXPECT_TRUE(Move(result, AZ::Vector3::CreateZero()).IsClose(AZ::Vector3::CreateZero()));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, CameraSlidesAlongRotatedCollider)
+    {
+        const auto rotation = AZ::Quaternion::CreateRotationZ(AZ::DegToRad(45.0f));
+        const auto normal = rotation.TransformVector(AZ::Vector3::CreateAxisY());
+        const auto tangent = rotation.TransformVector(AZ::Vector3::CreateAxisX());
+        AddBox(normal * 5.0f, AZ::Vector3(100.0f, 1.0f, 100.0f), false, false, rotation);
+        const auto result = Move(AZ::Vector3::CreateZero(), normal * 10.0f + tangent * 10.0f);
+        EXPECT_NEAR(result.Dot(normal), 4.25f, 0.004f);
+        EXPECT_NEAR(result.Dot(tangent), 10.0f, 0.004f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, RepeatedMovementIntoWallRemainsStable)
+    {
+        AddBox(AZ::Vector3(0.0f, 5.0f, 0.0f), AZ::Vector3(100.0f, 1.0f, 100.0f));
+        auto position = Move(AZ::Vector3::CreateZero(), AZ::Vector3(0.0f, 10.0f, 0.0f));
+        const auto stoppedPosition = position;
+        for (int frame = 0; frame < 120; ++frame)
+        {
+            position = Move(position, position + AZ::Vector3(0.0f, 0.1f, 0.0f));
+            EXPECT_TRUE(position.IsClose(stoppedPosition, 0.001f));
+        }
+        EXPECT_TRUE(Move(position, AZ::Vector3::CreateZero()).IsClose(AZ::Vector3::CreateZero()));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, InitialPenetrationSeparatesStationaryCamera)
+    {
+        AddBox(AZ::Vector3::CreateZero(), AZ::Vector3(10.0f, 1.0f, 10.0f));
+        const AZ::Vector3 position(0.0f, 0.6f, 0.0f);
+        const auto result = Move(position, position);
+        EXPECT_GE(result.GetY(), 0.749f);
+        EXPECT_LT(result.GetY(), 0.76f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, CameraCanMoveAwayFromExactContact)
+    {
+        AddBox(AZ::Vector3(0.0f, 5.0f, 0.0f), AZ::Vector3(100.0f, 1.0f, 100.0f));
+        EXPECT_TRUE(Move(AZ::Vector3(0.0f, 4.25f, 0.0f), AZ::Vector3::CreateZero()).IsClose(AZ::Vector3::CreateZero(), 0.003f));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, HeightfieldStopsHighSpeedDescent)
+    {
+        AddHeightfield();
+        const auto result = Move(AZ::Vector3(0.0f, 0.0f, 10.0f), AZ::Vector3(0.0f, 0.0f, -1000.0f));
+        EXPECT_NEAR(result.GetZ(), 0.251f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, CameraSlidesAlongHeightfield)
+    {
+        AddHeightfield();
+        const auto result = Move(AZ::Vector3(0.0f, 0.0f, 2.0f), AZ::Vector3(4.0f, 0.0f, -2.0f));
+        EXPECT_NEAR(result.GetX(), 4.0f, 0.003f);
+        EXPECT_NEAR(result.GetZ(), 0.25f, 0.003f);
+        EXPECT_TRUE(Move(result, result + AZ::Vector3::CreateAxisZ()).IsClose(result + AZ::Vector3::CreateAxisZ()));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, CameraSlidesAlongSlopedHeightfield)
+    {
+        AddHeightfield(0.5f);
+        const auto result = Move(AZ::Vector3(0.0f, 0.0f, 2.0f), AZ::Vector3(4.0f, 0.0f, -2.0f));
+        const auto normal = AZ::Vector3(-0.5f, 0.0f, 1.0f).GetNormalized();
+        EXPECT_NEAR(result.Dot(normal), 0.25f, 0.004f);
+        EXPECT_GT(result.GetX(), 1.0f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, CameraPassesThroughHeightfieldHole)
+    {
+        AddHeightfield(0.0f, true);
+        const AZ::Vector3 target(0.0f, 0.0f, -2.0f);
+        EXPECT_TRUE(Move(AZ::Vector3(0.0f, 0.0f, 2.0f), target).IsClose(target));
+        // Solid terrain alongside the hole must still block the camera.
+        EXPECT_NEAR(Move(AZ::Vector3(5.0f, 0.0f, 2.0f), AZ::Vector3(5.0f, 0.0f, -2.0f)).GetZ(), 0.251f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, HeightfieldSeparatesInitiallyOverlappingCamera)
+    {
+        AddHeightfield();
+        const AZ::Vector3 position(0.0f, 0.0f, 0.1f);
+        EXPECT_NEAR(Move(position, position).GetZ(), 0.251f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, HeightfieldBlocksCameraFromBelow)
+    {
+        AddHeightfield();
+        EXPECT_NEAR(Move(AZ::Vector3(0.0f, 0.0f, -2.0f), AZ::Vector3(0.0f, 0.0f, 2.0f)).GetZ(), -0.251f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, SlopedHeightfieldSeparatesStationaryCamera)
+    {
+        AddHeightfield(0.5f);
+        const auto normal = AZ::Vector3(-0.5f, 0.0f, 1.0f).GetNormalized();
+        const AZ::Vector3 position = normal * 0.1f;
+        const auto result = Move(position, position);
+        EXPECT_NEAR(result.Dot(normal), 0.251f, 0.004f);
+        EXPECT_TRUE(Move(result, result).IsClose(result, 0.001f));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, HeightfieldRecoversPenetrationDuringTangentialMovement)
+    {
+        AddHeightfield();
+        const auto result = Move(AZ::Vector3(0.0f, 0.0f, 0.1f), AZ::Vector3(1.0f, 0.0f, 0.1f));
+        EXPECT_NEAR(result.GetX(), 1.0f, 0.003f);
+        EXPECT_NEAR(result.GetZ(), 0.251f, 0.003f);
+    }
+
+    TEST_F(EditorCameraCollisionFixture, PenetrationRecoveryIgnoresTriggers)
+    {
+        AddBox(AZ::Vector3::CreateZero(), AZ::Vector3(10.0f), false, true);
+        const auto position = AZ::Vector3::CreateZero();
+        EXPECT_TRUE(Move(position, position).IsClose(position));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, InvalidSceneAllowsFreeMovement)
+    {
+        const AZ::Vector3 target(0.0f, 10.0f, 0.0f);
+        EXPECT_TRUE(PhysX::ResolveCameraCollision(AzPhysics::InvalidSceneHandle, AZ::Vector3::CreateZero(), target).IsClose(target));
+    }
+
+    TEST_F(EditorCameraCollisionFixture, EditorProviderToggleControlsCollision)
+    {
+        auto* provider = AZ::Interface<Camera::EditorCameraCollisionInterface>::Get();
+        ASSERT_NE(provider, nullptr);
+        auto wall = CreateBoxPrimitiveColliderEditorEntity(
+            AZ::Vector3(100.0f, 1.0f, 100.0f), AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 5.0f, 0.0f)));
+        const AZ::Vector3 target(0.0f, 10.0f, 0.0f);
+
+        provider->SetCameraCollisionEnabled(false);
+        EXPECT_TRUE(provider->ConstrainCameraMovement(AZ::Vector3::CreateZero(), target).IsClose(target));
+        provider->SetCameraCollisionEnabled(true);
+        EXPECT_NEAR(provider->ConstrainCameraMovement(AZ::Vector3::CreateZero(), target).GetY(), 4.249f, 0.003f);
+        provider->SetCameraCollisionEnabled(false);
+        EXPECT_TRUE(provider->ConstrainCameraMovement(AZ::Vector3::CreateZero(), target).IsClose(target));
+    }
+} // namespace PhysXEditorTests

--- a/Gems/PhysX/Core/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
+++ b/Gems/PhysX/Core/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
@@ -24,6 +24,7 @@
 #include <PhysX/Material/PhysXMaterialConfiguration.h>
 #include <AzCore/Casting/lossy_cast.h>
 #include <Utils.h>
+#include <AzToolsFramework/API/EditorCameraBus.h>
 
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -281,6 +282,29 @@ namespace PhysXEditorTests
         AZStd::unique_ptr<NiceMock<UnitTest::MockPhysXHeightfieldProvider>> m_editorMockShapeRequests;
         AZStd::unique_ptr<NiceMock<UnitTest::MockPhysXHeightfieldProvider>> m_gameMockShapeRequests;
     };
+
+    TEST_F(PhysXEditorHeightfieldFixture, EditorCameraCollidesWithHeightfieldWhenEnabled)
+    {
+        auto* provider = AZ::Interface<Camera::EditorCameraCollisionInterface>::Get();
+        ASSERT_NE(provider, nullptr);
+        AzPhysics::RayCastRequest request;
+        request.m_start = AZ::Vector3(1.25f, 2.25f, 10.0f);
+        request.m_direction = -AZ::Vector3::CreateAxisZ();
+        request.m_distance = 20.0f;
+        AzPhysics::SceneQueryHit hit;
+        AzPhysics::SimulatedBodyComponentRequestsBus::EventResult(
+            hit, m_editorEntity->GetId(), &AzPhysics::SimulatedBodyComponentRequests::RayCast, request);
+        ASSERT_TRUE(hit);
+
+        const AZ::Vector3 from = hit.m_position + hit.m_normal * 2.0f;
+        const AZ::Vector3 target = hit.m_position - hit.m_normal * 0.5f;
+        provider->SetCameraCollisionEnabled(true);
+        const auto result = provider->ConstrainCameraMovement(from, target);
+        EXPECT_GE((result - hit.m_position).Dot(hit.m_normal), 0.249f);
+        EXPECT_FALSE(result.IsClose(from));
+        provider->SetCameraCollisionEnabled(false);
+        EXPECT_TRUE(provider->ConstrainCameraMovement(from, target).IsClose(target));
+    }
 
     TEST_F(PhysXEditorFixture, EditorHeightfieldColliderComponentDependenciesSatisfiedEntityIsValid)
     {

--- a/Gems/PhysX/Core/Code/physx_editor_files.cmake
+++ b/Gems/PhysX/Core/Code/physx_editor_files.cmake
@@ -119,6 +119,8 @@ set(FILES
     Editor/KinematicDescriptionDialog.ui
     Editor/Source/Components/EditorSystemComponent.h
     Editor/Source/Components/EditorSystemComponent.cpp
+    Editor/Source/Components/EditorCameraCollision.cpp
+    Editor/Source/Components/EditorCameraCollision.h
     Editor/Source/Components/Conversion/CollidersPrefabConversion.cpp
     Editor/Source/Components/Conversion/PrefabConversionUtils.h
     Editor/Source/Components/Conversion/PrefabConversionUtils.cpp

--- a/Gems/PhysX/Core/Code/physx_editor_tests_files.cmake
+++ b/Gems/PhysX/Core/Code/physx_editor_tests_files.cmake
@@ -32,4 +32,5 @@ set(FILES
     Tests/ShapeGeometryTests.cpp
     Tests/EditorCharacterControllerTests.cpp
     Tests/EditorGameplayControllerTests.cpp
+    Tests/EditorCameraCollisionTests.cpp
 )


### PR DESCRIPTION
## What does this PR do?

<img width="322" height="202" alt="image" src="https://github.com/user-attachments/assets/7dddb633-dcd5-4a34-8c09-006f61d15dc1" />

Adds an optional **Camera Collision** toggle to the editor's **Game** menu. The option is available when the PhysX editor component is active and is disabled by default.

When enabled, the free camera:
- Uses sphere sweeps to stop at physical colliders and slide along surfaces
- Recovers from initial penetration, including overlaps with terrain heightfields
- Ignores triggers and meshes without physical colliders
- Keeps smoothing, orbit navigation, and focus animations consistent with collision constraints

The editor camera controller accesses collision through an optional interface without depending directly on PhysX.

## How was this PR tested?

- Passed **editor camera tests**, covering existing behavior and collision integration.
- Passed **PhysX tests**, covering static and dynamic colliders, thin walls, sliding, corners, triggers, heightfields, and penetration recovery.
- Verified the menu action's placement and checked state in the running Editor.
- Ran an automated Editor test with actual Terrain components:
  - Enabling collision separated a stationary camera from the terrain
  - Raising the terrain updated its collider and displaced the camera
  - The camera remained stable after separation
  - Disabling collision restored unrestricted positioning