### PR TITLE
[Atom] Let a material type build only the shaders it can actually use

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/ShaderEnable.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/ShaderEnable.lua
@@ -19,18 +19,22 @@ function GetMaterialPropertyDependencies()
 end
 
 -- Enables a shader with @shaderTag, if that shader exists.
+-- Returns whether that shader was there to set.
 function TrySetShaderEnabled(context, shaderTag, enabled)
     if(context:HasShaderWithTag(shaderTag)) then
         local shader = context:GetShaderByTag(shaderTag)
         if(shader) then
             --Print("Set shader enabled '" .. shaderTag .. "' = " .. tostring(enabled))
             shader:SetEnabled(enabled)
+            return true
         end
     end
+    return false
 end
 
 -- Enables a shader with @shaderTag, if that shader exists, and disables @fallbackShaderTag.
 -- Otherwise enables the shader @fallbackShaderTag, if that shader exists.
+-- Returns whether either of them was there to set.
 function TrySetShaderEnabledWithFallback(context, shaderTag, fallbackShaderTag, enabled)
     if(context:HasShaderWithTag(shaderTag)) then
         local shader = context:GetShaderByTag(shaderTag)
@@ -38,9 +42,11 @@ function TrySetShaderEnabledWithFallback(context, shaderTag, fallbackShaderTag, 
             --Print("Set shader enabled '" .. shaderTag .. "' = " .. tostring(enabled))
             shader:SetEnabled(enabled)
             TrySetShaderEnabled(context, fallbackShaderTag, false)
+            return true
         end
+        return false
     else
-        TrySetShaderEnabled(context, fallbackShaderTag, enabled)
+        return TrySetShaderEnabled(context, fallbackShaderTag, enabled)
     end
 end
 
@@ -66,13 +72,17 @@ function Process(context)
     enableMainPass = not isTransparent and not isTintedTransparent
     enableShadowPass = not isTransparent and not isTintedTransparent and castShadows
 
+    local mainPassResolved = false
+
     if hasPerPixelDepth or hasPerPixelClip then
         TrySetShaderEnabledWithFallback(context, "depth_customZ", "depth", enableDepthPass)
         TrySetShaderEnabledWithFallback(context, "shadow_customZ", "shadow", enableShadowPass)
         
         -- The main pass could have different names in different pipelines
-        TrySetShaderEnabledWithFallback(context, "forward_customZ", "forward", enableMainPass)
-        TrySetShaderEnabledWithFallback(context, "main_customZ", "main", enableMainPass)
+        -- Assigned first and combined after: or between the two calls would skip the second.
+        local resolvedForwardCustomZ = TrySetShaderEnabledWithFallback(context, "forward_customZ", "forward", enableMainPass)
+        local resolvedMainCustomZ = TrySetShaderEnabledWithFallback(context, "main_customZ", "main", enableMainPass)
+        mainPassResolved = resolvedForwardCustomZ or resolvedMainCustomZ
     else
         TrySetShaderEnabled(context, "depth", enableDepthPass)
         TrySetShaderEnabled(context, "shadow", enableShadowPass)
@@ -80,8 +90,9 @@ function Process(context)
         TrySetShaderEnabled(context, "shadow_customZ", false)
         
         -- The main pass could have different names in different pipelines
-        TrySetShaderEnabled(context, "forward", enableMainPass)
-        TrySetShaderEnabled(context, "main", enableMainPass)
+        local resolvedForward = TrySetShaderEnabled(context, "forward", enableMainPass)
+        local resolvedMain = TrySetShaderEnabled(context, "main", enableMainPass)
+        mainPassResolved = resolvedForward or resolvedMain
         TrySetShaderEnabled(context, "forward_customZ", false)
         TrySetShaderEnabled(context, "main_customZ", false)
     end
@@ -98,6 +109,25 @@ function Process(context)
         TrySetShaderEnabled(context, "tintedTransparent", isTintedTransparent)
         TrySetShaderEnabled(context, "depthPassTransparentMin", isTransparent or isTintedTransparent)
         TrySetShaderEnabled(context, "depthPassTransparentMax", isTransparent or isTintedTransparent)
+    end
+
+    -- A material type can be built for only some of the opacity modes -- see the "opacityMode" build setting -- and a
+    -- shader that was not built is simply absent here. The Try functions above are silent about that by design: a tag
+    -- one pipeline uses and another does not is normal, and warning on every such tag would bury anything real.
+    --
+    -- It is not normal when this material is asking for that exact shader. Nothing gets enabled, the material draws
+    -- nothing, and the property that caused it looks as though it were ignored. Naming the build setting here is what
+    -- connects the two, since it is several steps away from the symptom.
+    if(isTransparent and not context:HasShaderWithTag("transparent")) then
+        Warning('Material sets "isTransparent", but no transparent shader was built for this material pipeline. Nothing will be drawn.')
+    end
+
+    if(isTintedTransparent and not context:HasShaderWithTag("tintedTransparent")) then
+        Warning('Material sets "isTintedTransparent", but no tinted transparent shader was built for this material pipeline. Nothing will be drawn.')
+    end
+
+    if(enableMainPass and not mainPassResolved) then
+        Warning('Material is opaque, but no forward or main shader was built for this material pipeline. Nothing will be drawn.')
     end
 
 end

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/LowEndPipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/LowEndPipelineScript.lua
@@ -14,11 +14,29 @@ function MaterialTypeSetup(context)
     Print('Material type uses lighting model "' .. lightingModel .. '".')
 
     context:ExcludeAllShaders()
-    
+
+    opacityMode = context:GetBuildSetting("opacityMode", "Dynamic")
+    if(opacityMode ~= "Dynamic" and opacityMode ~= "Opaque" and opacityMode ~= "Cutout" and
+       opacityMode ~= "Blended" and opacityMode ~= "TintedTransparent") then
+        Warning('Unrecognised "opacityMode" build setting "' .. opacityMode .. '". Building every shader.')
+        opacityMode = "Dynamic"
+    end
+
+    buildOpaqueShader = opacityMode == "Dynamic" or opacityMode == "Opaque"
+    buildCutoutShaders = opacityMode == "Dynamic" or opacityMode == "Cutout"
+    buildBlendedShaders = opacityMode == "Dynamic" or opacityMode == "Blended"
+    buildTintedTransparentShaders = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
+    buildVertexShaders = opacityMode == "Dynamic" or context:GetBuildSetting("positionOffset", "Disconnected") == "Connected"
+
+    if(buildVertexShaders) then
         context:IncludeShader("DepthPass")
         context:IncludeShader("ShadowmapPass")
+    end
 
     if(lightingModel == "Base") then
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            Warning('The Base lighting model has no transparent shader. Building its forward shader instead.')
+        end
         context:IncludeShader("ForwardPass_BaseLighting")
         return true
     end
@@ -28,18 +46,28 @@ function MaterialTypeSetup(context)
             Warning("The low end pipeline does not support the Enhanced lighting model. Will use Standard lighting as a fallback.")
         end
 
-        context:IncludeShader("DepthPass_CustomZ")
-        context:IncludeShader("ShadowmapPass_CustomZ")
-        context:IncludeShader("ForwardPass_StandardLighting")
-        context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
-        context:IncludeShader("Transparent_StandardLighting")
-        context:IncludeShader("TintedTransparent_StandardLighting")
-        context:IncludeShader("DepthPassTransparentMin")
-        context:IncludeShader("DepthPassTransparentMax")
+        if(buildOpaqueShader) then
+            context:IncludeShader("ForwardPass_StandardLighting")
+        end
+        if(buildCutoutShaders) then
+            context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
+            context:IncludeShader("DepthPass_CustomZ")
+            context:IncludeShader("ShadowmapPass_CustomZ")
+        end
+        if(buildBlendedShaders) then
+            context:IncludeShader("Transparent_StandardLighting")
+        end
+        if(buildTintedTransparentShaders) then
+            context:IncludeShader("TintedTransparent_StandardLighting")
+        end
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            context:IncludeShader("DepthPassTransparentMin")
+            context:IncludeShader("DepthPassTransparentMax")
+        end
 
         return true
     end
-    
+
     if(lightingModel == "Skin") then
         Warning("The low end pipeline does not support the Skin lighting model. This combination should not be used at runtime.")
         -- This returns 'true' to pass the build, the surface won't be rendered at runtime.
@@ -55,4 +83,3 @@ function MaterialTypeSetup(context)
     Error('Unsupported lighting model "' .. lightingModel .. '".')
     return false
 end
-

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/MainPipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/MainPipelineScript.lua
@@ -14,50 +14,88 @@ function MaterialTypeSetup(context)
     Print('Material type uses lighting model "' .. lightingModel .. '".')
 
     context:ExcludeAllShaders()
-    
-    --TODO(MaterialPipeline): Add a way to configure this script through more than just lightingModel, for example
-    --set a transparency built setting to "AlwaysOpaque", "AlwaysTransparent", or "Dynamic". That way some Material
-    --types that don't care about transparency can set "AlwaysOpaque" and skip compiling the transparent shaders.
-    
-    context:IncludeShader("DepthPass")
-    context:IncludeShader("ShadowmapPass")
-    context:IncludeShader("MeshMotionVector")
 
+    opacityMode = context:GetBuildSetting("opacityMode", "Dynamic")
+    if(opacityMode ~= "Dynamic" and opacityMode ~= "Opaque" and opacityMode ~= "Cutout" and
+       opacityMode ~= "Blended" and opacityMode ~= "TintedTransparent") then
+        Warning('Unrecognised "opacityMode" build setting "' .. opacityMode .. '". Building every shader.')
+        opacityMode = "Dynamic"
+    end
+
+    buildOpaqueShader = opacityMode == "Dynamic" or opacityMode == "Opaque"
+    buildCutoutShaders = opacityMode == "Dynamic" or opacityMode == "Cutout"
+    buildBlendedShaders = opacityMode == "Dynamic" or opacityMode == "Blended"
+    buildTintedTransparentShaders = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
+    buildVertexShaders = opacityMode == "Dynamic" or context:GetBuildSetting("positionOffset", "Disconnected") == "Connected"
+
+    if(buildVertexShaders) then
+        context:IncludeShader("DepthPass")
+        context:IncludeShader("ShadowmapPass")
+        context:IncludeShader("MeshMotionVector")
+    end
+
+    -- The Base and Skin lighting models have no transparent shader in this pipeline, so there is no opaque/transparent split to make.
+    -- A "Blended" declaration on one of them would leave the material type with nothing that draws, so it is reported and ignored.
     if(lightingModel == "Base") then
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            Warning('The Base lighting model has no transparent shader. Building its forward shader instead.')
+        end
         context:IncludeShader("ForwardPass_BaseLighting")
         return true
     end
 
     if(lightingModel == "Standard") then
-        context:IncludeShader("ForwardPass_StandardLighting")
-        context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
-        context:IncludeShader("Transparent_StandardLighting")
-        context:IncludeShader("TintedTransparent_StandardLighting")
-        context:IncludeShader("DepthPass_CustomZ")
-        context:IncludeShader("ShadowmapPass_CustomZ")
-        context:IncludeShader("DepthPassTransparentMin")
-        context:IncludeShader("DepthPassTransparentMax")
+        if(buildOpaqueShader) then
+            context:IncludeShader("ForwardPass_StandardLighting")
+        end
+        if(buildCutoutShaders) then
+            context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
+            context:IncludeShader("DepthPass_CustomZ")
+            context:IncludeShader("ShadowmapPass_CustomZ")
+        end
+        if(buildBlendedShaders) then
+            context:IncludeShader("Transparent_StandardLighting")
+        end
+        if(buildTintedTransparentShaders) then
+            context:IncludeShader("TintedTransparent_StandardLighting")
+        end
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            context:IncludeShader("DepthPassTransparentMin")
+            context:IncludeShader("DepthPassTransparentMax")
+        end
         return true
     end
-    
+
     if(lightingModel == "Enhanced") then
-        context:IncludeShader("ForwardPass_EnhancedLighting")
-        context:IncludeShader("ForwardPass_EnhancedLighting_CustomZ")
-        context:IncludeShader("Transparent_EnhancedLighting")
-        context:IncludeShader("TintedTransparent_EnhancedLighting")
-        context:IncludeShader("DepthPass_CustomZ")
-        context:IncludeShader("ShadowmapPass_CustomZ")
-        context:IncludeShader("DepthPassTransparentMin")
-        context:IncludeShader("DepthPassTransparentMax")
+        if(buildOpaqueShader) then
+            context:IncludeShader("ForwardPass_EnhancedLighting")
+        end
+        if(buildCutoutShaders) then
+            context:IncludeShader("ForwardPass_EnhancedLighting_CustomZ")
+            context:IncludeShader("DepthPass_CustomZ")
+            context:IncludeShader("ShadowmapPass_CustomZ")
+        end
+        if(buildBlendedShaders) then
+            context:IncludeShader("Transparent_EnhancedLighting")
+        end
+        if(buildTintedTransparentShaders) then
+            context:IncludeShader("TintedTransparent_EnhancedLighting")
+        end
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            context:IncludeShader("DepthPassTransparentMin")
+            context:IncludeShader("DepthPassTransparentMax")
+        end
         return true
     end
-    
+
     if(lightingModel == "Skin") then
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            Warning('The Skin lighting model has no transparent shader. Building its forward shader instead.')
+        end
         context:IncludeShader("ForwardPass_SkinLighting")
         return true
     end
-     
+
     Error('Unsupported lighting model "' .. lightingModel .. '".')
     return false
 end
-

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
@@ -14,8 +14,23 @@ function MaterialTypeSetup(context)
     Print('Material type uses lighting model "' .. lightingModel .. '".')
 
     context:ExcludeAllShaders()
-    
-    context:IncludeShader("ShadowmapPass")
+
+    opacityMode = context:GetBuildSetting("opacityMode", "Dynamic")
+    if(opacityMode ~= "Dynamic" and opacityMode ~= "Opaque" and opacityMode ~= "Cutout" and
+       opacityMode ~= "Blended" and opacityMode ~= "TintedTransparent") then
+        Warning('Unrecognised "opacityMode" build setting "' .. opacityMode .. '". Building every shader.')
+        opacityMode = "Dynamic"
+    end
+
+    buildOpaqueShader = opacityMode == "Dynamic" or opacityMode == "Opaque"
+    buildCutoutShaders = opacityMode == "Dynamic" or opacityMode == "Cutout"
+    buildBlendedShader = opacityMode == "Dynamic" or opacityMode == "Blended"
+    buildTintedTransparentShader = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
+    buildVertexShaders = opacityMode == "Dynamic" or context:GetBuildSetting("positionOffset", "Disconnected") == "Connected"
+
+    if(buildVertexShaders) then
+        context:IncludeShader("ShadowmapPass")
+    end
 
     if(lightingModel == "Base") then
         context:IncludeShader("ForwardPass_BaseLighting")
@@ -27,11 +42,19 @@ function MaterialTypeSetup(context)
             Warning("The mobile pipeline does not support the Enhanced lighting model. Will use Standard lighting as a fallback.")
         end
         
-        context:IncludeShader("ShadowmapPass_CustomZ")
-        context:IncludeShader("ForwardPass_StandardLighting")
-        context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
-        context:IncludeShader("Transparent_StandardLighting")
-        context:IncludeShader("TintedTransparent_StandardLighting")
+        if(buildOpaqueShader) then
+            context:IncludeShader("ForwardPass_StandardLighting")
+        end
+        if(buildCutoutShaders) then
+            context:IncludeShader("ShadowmapPass_CustomZ")
+            context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
+        end
+        if(buildBlendedShader) then
+            context:IncludeShader("Transparent_StandardLighting")
+        end
+        if(buildTintedTransparentShader) then
+            context:IncludeShader("TintedTransparent_StandardLighting")
+        end
         return true
     end
     

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
@@ -24,15 +24,21 @@ function MaterialTypeSetup(context)
 
     buildOpaqueShader = opacityMode == "Dynamic" or opacityMode == "Opaque"
     buildCutoutShaders = opacityMode == "Dynamic" or opacityMode == "Cutout"
-    buildBlendedShader = opacityMode == "Dynamic" or opacityMode == "Blended"
-    buildTintedTransparentShader = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
+    buildBlendedShaders = opacityMode == "Dynamic" or opacityMode == "Blended"
+    buildTintedTransparentShaders = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
     buildVertexShaders = opacityMode == "Dynamic" or context:GetBuildSetting("positionOffset", "Disconnected") == "Connected"
 
     if(buildVertexShaders) then
         context:IncludeShader("ShadowmapPass")
     end
 
+    -- The Base lighting model has no transparent shader in this pipeline, so there is no opaque/transparent split to
+    -- make. A "Blended" declaration on it would leave the material type with nothing that draws, so it is reported and
+    -- ignored.
     if(lightingModel == "Base") then
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            Warning('The Base lighting model has no transparent shader. Building its forward shader instead.')
+        end
         context:IncludeShader("ForwardPass_BaseLighting")
         return true
     end
@@ -49,10 +55,10 @@ function MaterialTypeSetup(context)
             context:IncludeShader("ShadowmapPass_CustomZ")
             context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
         end
-        if(buildBlendedShader) then
+        if(buildBlendedShaders) then
             context:IncludeShader("Transparent_StandardLighting")
         end
-        if(buildTintedTransparentShader) then
+        if(buildTintedTransparentShaders) then
             context:IncludeShader("TintedTransparent_StandardLighting")
         end
         return true

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/MultiViewPipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/MultiViewPipelineScript.lua
@@ -14,6 +14,18 @@ function MaterialTypeSetup(context)
     Print('Material type uses lighting model "' .. lightingModel .. '".')
 
     context:ExcludeAllShaders()
+
+    opacityMode = context:GetBuildSetting("opacityMode", "Dynamic")
+    if(opacityMode ~= "Dynamic" and opacityMode ~= "Opaque" and opacityMode ~= "Cutout" and
+       opacityMode ~= "Blended" and opacityMode ~= "TintedTransparent") then
+        Warning('Unrecognised "opacityMode" build setting "' .. opacityMode .. '". Building every shader.')
+        opacityMode = "Dynamic"
+    end
+
+    buildOpaqueShader = opacityMode == "Dynamic" or opacityMode == "Opaque"
+    buildCutoutShader = opacityMode == "Dynamic" or opacityMode == "Cutout"
+    buildBlendedShader = opacityMode == "Dynamic" or opacityMode == "Blended"
+    buildTintedTransparentShader = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
     
     if(lightingModel == "Base") then
         context:IncludeShader("ForwardPass_BaseLighting")
@@ -25,10 +37,18 @@ function MaterialTypeSetup(context)
             Warning("The multi view pipeline does not support the Enhanced lighting model. Will use Standard lighting as a fallback.")
         end
         
-        context:IncludeShader("ForwardPass_StandardLighting")
-        context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
-        context:IncludeShader("Transparent_StandardLighting")
-        context:IncludeShader("TintedTransparent_StandardLighting")
+        if(buildOpaqueShader) then
+            context:IncludeShader("ForwardPass_StandardLighting")
+        end
+        if(buildCutoutShader) then
+            context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
+        end
+        if(buildBlendedShader) then
+            context:IncludeShader("Transparent_StandardLighting")
+        end
+        if(buildTintedTransparentShader) then
+            context:IncludeShader("TintedTransparent_StandardLighting")
+        end
         return true
     end
     

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/MultiViewPipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/MultiViewPipelineScript.lua
@@ -23,11 +23,20 @@ function MaterialTypeSetup(context)
     end
 
     buildOpaqueShader = opacityMode == "Dynamic" or opacityMode == "Opaque"
-    buildCutoutShader = opacityMode == "Dynamic" or opacityMode == "Cutout"
-    buildBlendedShader = opacityMode == "Dynamic" or opacityMode == "Blended"
-    buildTintedTransparentShader = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
+    buildCutoutShaders = opacityMode == "Dynamic" or opacityMode == "Cutout"
+    buildBlendedShaders = opacityMode == "Dynamic" or opacityMode == "Blended"
+    buildTintedTransparentShaders = opacityMode == "Dynamic" or opacityMode == "TintedTransparent"
+
+    -- This pipeline declares no depth or shadow shader, so there is nothing for a "positionOffset" build setting to
+    -- gate here. The other pipelines read it to decide whether to build their vertex-only passes.
     
+    -- The Base lighting model has no transparent shader in this pipeline, so there is no opaque/transparent split to
+    -- make. A "Blended" declaration on it would leave the material type with nothing that draws, so it is reported and
+    -- ignored.
     if(lightingModel == "Base") then
+        if(buildBlendedShaders or buildTintedTransparentShaders) then
+            Warning('The Base lighting model has no transparent shader. Building its forward shader instead.')
+        end
         context:IncludeShader("ForwardPass_BaseLighting")
         return true
     end
@@ -40,13 +49,13 @@ function MaterialTypeSetup(context)
         if(buildOpaqueShader) then
             context:IncludeShader("ForwardPass_StandardLighting")
         end
-        if(buildCutoutShader) then
+        if(buildCutoutShaders) then
             context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
         end
-        if(buildBlendedShader) then
+        if(buildBlendedShaders) then
             context:IncludeShader("Transparent_StandardLighting")
         end
-        if(buildTintedTransparentShader) then
+        if(buildTintedTransparentShaders) then
             context:IncludeShader("TintedTransparent_StandardLighting")
         end
         return true

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPipelineSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialPipelineSourceData.h
@@ -77,6 +77,15 @@ namespace AZ
                 AZStd::vector<Ptr<MaterialFunctorSourceDataHolder>> m_materialFunctorSourceData;
             } m_runtimeControls;
 
+            //! Name the generated shader collection is stored under, and the name a render pipeline asks for through
+            //! RenderPipelineDescriptor::m_materialPipelineTag, which defaults to "MainPipeline".
+            //!
+            //! Empty means the file stem is used, which is the original behaviour and what almost every pipeline wants. Setting it
+            //! separates the name a material type addresses this pipeline by, which is always the file stem, from the name the runtime
+            //! looks the resulting shaders up by. A pipeline that stands in for another one needs exactly that: a distinct file name so a
+            //! material type can ask for it, and the tag of the pipeline it replaces so the render pipeline still finds its shaders.
+            AZStd::string m_materialPipelineTag;
+
             AZStd::vector<ShaderTemplate> m_shaderTemplates;
 
             // A list of members to be added to the Object SRG. For example, writing:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialTypeSourceData.h
@@ -213,6 +213,31 @@ namespace AZ
             //! This is relevant for "abstract" material type files (see GetFormat()).
             AZStd::string m_lightingModel;
 
+            //! Build time facts about this material type that a .materialpipeline script can act on, as a free form name/value map.
+            //!
+            //! Material Canvas currently emits:
+            //!   "opacityMode" = "Opaque" | "Cutout" | "Blended" | "TintedTransparent"
+            //!   "positionOffset" = "Connected" when the Position Offset input has an incoming graph connection
+            //!
+            //! Material pipeline scripts use opacityMode to include only the shader group used by the generated material. A missing
+            //! opacityMode means Dynamic for backward compatibility and builds every group. The positionOffset fact allows optional
+            //! depth, shadow, and motion-vector vertex passes to be omitted when the graph leaves vertex positions unchanged.
+            //!
+            //! "materialPipelines" names the material pipelines this material type is built through, by file stem, separated by commas
+            //! or spaces. Absent, it is the project wide default list and nothing changes. Present, it selects from that list plus
+            //! /O3DE/Atom/RPI/OptInMaterialPipelineFiles, whose pipelines are registered but never built unless a material type asks for
+            //! one by name.
+            //!
+            //! This is what keeps a tool specific pipeline from becoming a project wide setting. A reduced pipeline for a preview
+            //! viewport can be registered permanently and used by exactly the material types that name it, rather than by swapping the
+            //! project's pipeline list out from under every other material type and needing an Asset Processor restart to swap it back.
+            //! A name that matches no registered pipeline is warned about and ignored; if none of the declared names match, the default
+            //! list is used, because a material type with no pipelines produces no shaders and renders as nothing with no clue why.
+            //!
+            //! This is relevant for "abstract" material type files (see GetFormat()).
+            using BuildSettings = AZStd::map<AZStd::string, AZStd::string>;
+            BuildSettings m_buildSettings;
+
             //! This indicates a .azsli file that contains only material-specific shader definitions, which will be included.
             //! in the final shader before any other files.
             //! The build system will automatically combine this code with .materialpipeline shader code

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialPipelineScriptRunner.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialPipelineScriptRunner.cpp
@@ -24,6 +24,7 @@ namespace AZ
             {
                 behaviorContext->Class<ScriptExecutionContext>()
                     ->Method("GetLightingModelName", &ScriptExecutionContext::GetLightingModelName)
+                    ->Method("GetBuildSetting", &ScriptExecutionContext::GetBuildSetting)
                     ->Method("IncludeAllShaders", &ScriptExecutionContext::IncludeAllShaders)
                     ->Method("ExcludeAllShaders", &ScriptExecutionContext::ExcludeAllShaders)
                     ->Method("IncludeShader", &ScriptExecutionContext::IncludeShader)
@@ -124,6 +125,20 @@ namespace AZ
         AZStd::string MaterialPipelineScriptRunner::ScriptExecutionContext::GetLightingModelName() const
         {
             return m_materialType.m_lightingModel;
+        }
+
+        AZStd::string MaterialPipelineScriptRunner::ScriptExecutionContext::GetBuildSetting(
+            const char* name, const char* defaultValue) const
+        {
+            const AZStd::string fallback = (defaultValue != nullptr) ? AZStd::string(defaultValue) : AZStd::string{};
+
+            if (name == nullptr)
+            {
+                return fallback;
+            }
+
+            const auto settingIter = m_materialType.m_buildSettings.find(name);
+            return (settingIter != m_materialType.m_buildSettings.end()) ? settingIter->second : fallback;
         }
 
         MaterialPipelineScriptRunner::MaterialPipelineScriptRunner() = default;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialPipelineScriptRunner.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialPipelineScriptRunner.h
@@ -45,6 +45,10 @@ namespace AZ
                 ScriptExecutionContext(const MaterialTypeSourceData& materialType, const ShaderTemplatesList& availableShaderTemplates);
 
                 AZStd::string GetLightingModelName() const;
+
+                //! Returns the value the material type declared for @name, or @defaultValue when it declared nothing.
+                //! See MaterialTypeSourceData::m_buildSettings for what this is for and what is recognised.
+                AZStd::string GetBuildSetting(const char* name, const char* defaultValue) const;
                 void IncludeAllShaders();
                 void ExcludeAllShaders();
                 void IncludeShader(const char* shaderTemplateName);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -189,14 +189,14 @@ namespace AZ
 
             // Note we report dependencies based on GetMaterialPipelinePaths() rather than LoadMaterialPipelines(), because dependencies are
             // needed even for pipelines that fail to load, so that the job will re-process when the broken pipeline gets fixed.
-            for (const auto& materialPipelineFilePath : GetMaterialPipelinePaths())
+            for (const auto& materialPipelineFilePath : GetMaterialPipelinePaths(&materialTypeSourceData))
             {
                 addPossibleDependencies(materialTypeSourcePath, materialPipelineFilePath);
             }
 
             // Add dependencies for each material pipeline, since the output of this builder is a combination of the .materialtype data and
             // the .materialpipeline data.
-            for (const auto& [materialPipelineFilePath, materialPipeline] : LoadMaterialPipelines())
+            for (const auto& [materialPipelineFilePath, materialPipeline] : LoadMaterialPipelines(&materialTypeSourceData))
             {
                 for (const MaterialPipelineSourceData::ShaderTemplate& shaderTemplate : materialPipeline.m_shaderTemplates)
                 {
@@ -341,39 +341,118 @@ namespace AZ
             }
         }
 
-        AZStd::set<AZStd::string> MaterialTypeBuilder::PipelineStage::GetMaterialPipelinePaths() const
+        AZStd::set<AZStd::string> MaterialTypeBuilder::PipelineStage::GetMaterialPipelinePaths(
+            const MaterialTypeSourceData* materialTypeSourceData) const
         {
-            AZStd::set<AZStd::string> combinedMaterialPipelines;
+            AZStd::set<AZStd::string> defaultMaterialPipelinePaths;
+            AZStd::set<AZStd::string> optInMaterialPipelinePaths;
 
-            auto ResolvePathAndAddToReturnValue = [&](const AZStd::string& path)
+            auto ResolvePathAndAddTo = [](AZStd::set<AZStd::string>& container, const AZStd::string& path)
             {
                 AZ::IO::FixedMaxPath pathWithoutAlias;
                 AZ::IO::FileIOBase::GetInstance()->ResolvePath(pathWithoutAlias, AZ::IO::PathView{ path });
-                combinedMaterialPipelines.insert(pathWithoutAlias.StringAsPosix());
+                container.insert(pathWithoutAlias.StringAsPosix());
             };
 
             if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
             {
                 AZStd::vector<AZStd::string> defaultMaterialPipelines;
                 settingsRegistry->GetObject(defaultMaterialPipelines, "/O3DE/Atom/RPI/MaterialPipelineFiles");
-                AZStd::for_each(defaultMaterialPipelines.begin(), defaultMaterialPipelines.end(), ResolvePathAndAddToReturnValue);
+                for (const auto& path : defaultMaterialPipelines)
+                {
+                    ResolvePathAndAddTo(defaultMaterialPipelinePaths, path);
+                }
 
                 AZStd::map<AZStd::string, AZStd::vector<AZStd::string>> gemMaterialPipelines;
                 settingsRegistry->GetObject(gemMaterialPipelines, "/O3DE/Atom/RPI/MaterialPipelineFilesByGem");
                 for (const auto& [_ /*gemName*/, gemMaterialPipelinePaths] : gemMaterialPipelines)
                 {
-                    AZStd::for_each(gemMaterialPipelinePaths.begin(), gemMaterialPipelinePaths.end(), ResolvePathAndAddToReturnValue);
+                    for (const auto& path : gemMaterialPipelinePaths)
+                    {
+                        ResolvePathAndAddTo(defaultMaterialPipelinePaths, path);
+                    }
+                }
+
+                // Registered but never built unless a material type names one. A tool that wants a material pipeline of its own -- a
+                // reduced one for a preview viewport, say -- can register it here without every material type in the project paying to
+                // build through it, which is what putting it in MaterialPipelineFiles would cost.
+                AZStd::vector<AZStd::string> optInMaterialPipelines;
+                settingsRegistry->GetObject(optInMaterialPipelines, "/O3DE/Atom/RPI/OptInMaterialPipelineFiles");
+                for (const auto& path : optInMaterialPipelines)
+                {
+                    ResolvePathAndAddTo(optInMaterialPipelinePaths, path);
                 }
             }
 
-            return combinedMaterialPipelines;
+            // No material type in hand, or nothing declared on it, means the project wide default. This is the path every existing
+            // material type takes, so nothing that does not opt in can change behaviour.
+            AZStd::string declaredPipelines;
+            if (materialTypeSourceData)
+            {
+                const auto buildSettingIter = materialTypeSourceData->m_buildSettings.find("materialPipelines");
+                if (buildSettingIter != materialTypeSourceData->m_buildSettings.end())
+                {
+                    declaredPipelines = buildSettingIter->second;
+                }
+            }
+
+            if (declaredPipelines.empty())
+            {
+                return defaultMaterialPipelinePaths;
+            }
+
+            AZStd::vector<AZStd::string> declaredPipelineNames;
+            AzFramework::StringFunc::Tokenize(declaredPipelines, declaredPipelineNames, ",; \t", false, false);
+
+            AZStd::set<AZStd::string> availableMaterialPipelinePaths = defaultMaterialPipelinePaths;
+            availableMaterialPipelinePaths.insert(optInMaterialPipelinePaths.begin(), optInMaterialPipelinePaths.end());
+
+            // Matched by file stem, which is the same name GetMaterialPipelineName reports and the same name that ends up in every
+            // generated shader's file name, so what a material type declares reads the same as what it produces.
+            AZStd::set<AZStd::string> selectedMaterialPipelinePaths;
+            for (const AZStd::string& declaredPipelineName : declaredPipelineNames)
+            {
+                [[maybe_unused]] bool matchedAnyPipeline = false;
+                for (const AZStd::string& availablePath : availableMaterialPipelinePaths)
+                {
+                    if (AzFramework::StringFunc::Equal(
+                            GetMaterialPipelineName(AZ::IO::Path(availablePath)).GetCStr(), declaredPipelineName.c_str()))
+                    {
+                        selectedMaterialPipelinePaths.insert(availablePath);
+                        matchedAnyPipeline = true;
+                    }
+                }
+
+                AZ_Warning(
+                    MaterialTypeBuilderName,
+                    matchedAnyPipeline,
+                    "Material type declares material pipeline '%s', which is not registered in MaterialPipelineFiles, "
+                    "MaterialPipelineFilesByGem or OptInMaterialPipelineFiles. It will be ignored.",
+                    declaredPipelineName.c_str());
+            }
+
+            // A declaration that matches nothing would otherwise produce a material type with no shaders at all, which renders as
+            // nothing and gives no clue why. Falling back to the default list keeps the material visible and leaves the warnings above
+            // as the explanation.
+            if (selectedMaterialPipelinePaths.empty())
+            {
+                AZ_Warning(
+                    MaterialTypeBuilderName,
+                    false,
+                    "None of the declared material pipelines ('%s') are registered. Falling back to the default list.",
+                    declaredPipelines.c_str());
+                return defaultMaterialPipelinePaths;
+            }
+
+            return selectedMaterialPipelinePaths;
         }
 
-        AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> MaterialTypeBuilder::PipelineStage::LoadMaterialPipelines() const
+        AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> MaterialTypeBuilder::PipelineStage::LoadMaterialPipelines(
+            const MaterialTypeSourceData* materialTypeSourceData) const
         {
             AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> materialPipelines;
 
-            for (const AZStd::string& file : GetMaterialPipelinePaths())
+            for (const AZStd::string& file : GetMaterialPipelinePaths(materialTypeSourceData))
             {
                 auto loadResult = MaterialUtils::LoadMaterialPipelineSourceData(file.c_str());
                 if (!loadResult.IsSuccess())
@@ -391,6 +470,21 @@ namespace AZ
         Name MaterialTypeBuilder::PipelineStage::GetMaterialPipelineName(const AZ::IO::Path& materialPipelineFilePath) const
         {
             return Name{ materialPipelineFilePath.Stem().Native() };
+        }
+
+        Name MaterialTypeBuilder::PipelineStage::GetMaterialPipelineTag(
+            const AZ::IO::Path& materialPipelineFilePath, const MaterialPipelineSourceData& materialPipeline) const
+        {
+            // The tag names the shader collection the runtime looks up, through RenderPipelineDescriptor::m_materialPipelineTag. It is
+            // the file stem unless the pipeline overrides it, which is how a pipeline can be addressed by one name and stand in for
+            // another: Material Canvas addresses its preview pipeline as MaterialCanvasPreview, but the viewport's render pipeline asks
+            // for MainPipeline, and a material with no collection under that name draws nothing at all.
+            if (!materialPipeline.m_materialPipelineTag.empty())
+            {
+                return Name{ materialPipeline.m_materialPipelineTag };
+            }
+
+            return GetMaterialPipelineName(materialPipelineFilePath);
         }
 
         //! Returns the number of redundant additions.
@@ -437,11 +531,12 @@ namespace AZ
             const AZStd::string& materialTypeSourcePath,
             MaterialTypeSourceData& materialTypeSourceData) const
         {
+
             AZ::u32 nextProductSubID = MaterialTypeSourceData::IntermediateMaterialTypeSubId + 1;
 
             const AZStd::string materialTypeName = AZ::IO::Path{ materialTypeSourcePath }.Stem().Native();
 
-            const AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> materialPipelines = LoadMaterialPipelines();
+            const AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> materialPipelines = LoadMaterialPipelines(&materialTypeSourceData);
 
             // A list of pointers to lists
             // Each leaf element is a line that will be included in the object SRG of every shader
@@ -467,6 +562,12 @@ namespace AZ
 
             // Some shader templates may be reused by multiple pipelines, so first collect a full picture of all the dependencies
             AZStd::map<MaterialPipelineSourceData::ShaderTemplate, AZStd::vector<Name /*materialPipielineName*/>> shaderTemplateReferences;
+
+            // Pipelines are tracked below by their own name, the file stem, because that is what the generated shader files are named
+            // after and what makes a product traceable back to the pipeline that produced it. The shader collections inside the material
+            // type are keyed by tag instead, which is usually the same string but not always: a pipeline standing in for another one
+            // carries that other one's tag so render pipelines still find its shaders. This maps one to the other.
+            AZStd::unordered_map<Name, Name> materialPipelineTagsByName;
             {
                 bool foundProblems = false;
 
@@ -484,6 +585,7 @@ namespace AZ
                     }
 
                     const Name materialPipelineName = GetMaterialPipelineName(materialPipelineFilePath);
+                    materialPipelineTagsByName[materialPipelineName] = GetMaterialPipelineTag(materialPipelineFilePath, materialPipeline);
 
                     const MaterialPipelineScriptRunner::ShaderTemplatesList& shaderTemplateList = scriptRunner.GetRelevantShaderTemplates();
 
@@ -626,6 +728,10 @@ namespace AZ
             materialTypeSourceData.m_pipelineData.clear();
 
             u32 commonCounter = 0;
+
+            // Loading the material pipeline files and running each one's Lua script to decide which shaders exist, plus building the
+            // material parameters. Largely independent of how many shaders come out of it, so a graph that builds one shader and one
+            // that builds twenty should land close together here.
 
             // Generate the required shaders
             for (const auto& [shaderTemplate, materialPipelineList] : shaderTemplateReferences)
@@ -770,8 +876,14 @@ namespace AZ
 
                 for (const Name& materialPipelineName : materialPipelineList)
                 {
+                    // Keyed by tag, not by the pipeline's own name, so that a stand-in pipeline's shaders land in the collection the
+                    // runtime will ask for. Pipelines that do not override their tag are unaffected: the two names are the same string.
+                    const auto materialPipelineTagIter = materialPipelineTagsByName.find(materialPipelineName);
+                    const Name& materialPipelineTag =
+                        materialPipelineTagIter != materialPipelineTagsByName.end() ? materialPipelineTagIter->second : materialPipelineName;
+
                     MaterialTypeSourceData::MaterialPipelineState& pipelineData =
-                        materialTypeSourceData.m_pipelineData[materialPipelineName];
+                        materialTypeSourceData.m_pipelineData[materialPipelineTag];
 
                     MaterialTypeSourceData::ShaderVariantReferenceData shaderVariantReferenceData;
                     shaderVariantReferenceData.m_shaderFilePath = AZ::IO::Path{ outputShaderFilePath.Filename() }.c_str();
@@ -789,6 +901,9 @@ namespace AZ
                 // list.
             }
 
+            // Per shader: loading the shader template JSON, assembling the generated azsl, and writing both out. This is the part
+            // that scales with shader count, and therefore the part the opacity and vertex gating already act on.
+
             // Sort the shader file reference just for convenience, for when the user inspects the intermediate .materialtype file
             for (auto& pipelineDataPair : materialTypeSourceData.m_pipelineData)
             {
@@ -805,7 +920,7 @@ namespace AZ
             // Add the material pipeline functors
             for (const auto& [materialPipelineFilePath, materialPipeline] : materialPipelines)
             {
-                const Name materialPipelineName = GetMaterialPipelineName(materialPipelineFilePath);
+                const Name materialPipelineName = GetMaterialPipelineTag(materialPipelineFilePath, materialPipeline);
                 MaterialTypeSourceData::MaterialPipelineState& pipelineData = materialTypeSourceData.m_pipelineData[materialPipelineName];
                 pipelineData.m_materialFunctorSourceData = materialPipeline.m_runtimeControls.m_materialFunctorSourceData;
                 pipelineData.m_pipelinePropertyLayout = materialPipeline.m_runtimeControls.m_materialTypeInternalProperties;
@@ -874,6 +989,7 @@ namespace AZ
             const AZStd::string& materialTypeSourcePath,
             const MaterialTypeSourceData& materialTypeSourceData) const
         {
+
             AZStd::string materialProductPath;
             AZStd::string fileName;
             AzFramework::StringFunc::Path::GetFileName(materialTypeSourcePath.c_str(), fileName);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.h
@@ -62,9 +62,25 @@ namespace AZ
                     MaterialTypeSourceData& materialTypeSourceData) const;
 
             private:
-                AZStd::set<AZStd::string> GetMaterialPipelinePaths() const;
-                AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> LoadMaterialPipelines() const;
+                //! Material pipelines this material type should be built through.
+                //!
+                //! Without a material type, or without a "materialPipelines" build setting on it, this is the project wide default list:
+                //! /O3DE/Atom/RPI/MaterialPipelineFiles plus everything under MaterialPipelineFilesByGem, exactly as before.
+                //!
+                //! A material type that names pipelines in its build settings gets only those, resolved by file stem against the default
+                //! list and against /O3DE/Atom/RPI/OptInMaterialPipelineFiles. Opt-in pipelines are registered but never built unless a
+                //! material type asks for one by name, which is what lets a tool ship a pipeline of its own without adding it to every
+                //! material type in the project.
+                AZStd::set<AZStd::string> GetMaterialPipelinePaths(const MaterialTypeSourceData* materialTypeSourceData = nullptr) const;
+                AZStd::map<AZ::IO::Path, MaterialPipelineSourceData> LoadMaterialPipelines(
+                    const MaterialTypeSourceData* materialTypeSourceData = nullptr) const;
+                //! The addressable name of a pipeline: its file stem. This is what a material type names in "materialPipelines".
                 Name GetMaterialPipelineName(const AZ::IO::Path& materialPipelineFilePath) const;
+
+                //! The name the generated shader collection is stored under, which the runtime looks up through
+                //! RenderPipelineDescriptor::m_materialPipelineTag. Same as the file stem unless the pipeline overrides it.
+                Name GetMaterialPipelineTag(
+                    const AZ::IO::Path& materialPipelineFilePath, const MaterialPipelineSourceData& materialPipeline) const;
 
             } m_pipelineStage;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPipelineSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialPipelineSourceData.cpp
@@ -35,6 +35,7 @@ namespace AZ
 
                 serializeContext->Class<MaterialPipelineSourceData>()
                     ->Version(5)    // Draw Srg Additions
+                    ->Field("materialPipelineTag", &MaterialPipelineSourceData::m_materialPipelineTag)
                     ->Field("shaderTemplates", &MaterialPipelineSourceData::m_shaderTemplates)
                     ->Field("runtime", &MaterialPipelineSourceData::m_runtimeControls)
                     ->Field("pipelineScript", &MaterialPipelineSourceData::m_pipelineScript)

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
@@ -123,6 +123,9 @@ namespace AZ
                     ;
 
                 serializeContext->RegisterGenericType<VersionUpdates>();
+                // BuildSettings is the same underlying type as UvNameMap (AZStd::map<AZStd::string, AZStd::string>), so the
+                // registration above already covers it. Registering it a second time would be a duplicate registration of one generic
+                // type.
                 serializeContext->RegisterGenericType<UvNameMap>();
 
                 serializeContext->Class<MaterialTypeSourceData>()
@@ -132,6 +135,7 @@ namespace AZ
                     ->Field("versionUpdates", &MaterialTypeSourceData::m_versionUpdates)
                     ->Field("propertyLayout", &MaterialTypeSourceData::m_propertyLayout)
                     ->Field("lightingModel", &MaterialTypeSourceData::m_lightingModel)
+                    ->Field("buildSettings", &MaterialTypeSourceData::m_buildSettings)
                     ->Field("materialShaderCode", &MaterialTypeSourceData::m_materialShaderCode)
                     ->Field("materialShaderDefines", &MaterialTypeSourceData::m_materialShaderDefines)
                     ->Field("shaders", &MaterialTypeSourceData::m_shaderCollection)


### PR DESCRIPTION
## Atom: let a material type build only the shaders it can actually use

A `.materialpipeline` script decides which shader templates to generate for a material type, but the
only thing it could ask about was the lighting model. Facts that would let it generate fewer — is
this material opaque, does it move vertices — had nowhere to live, so every material type built
every shader its lighting model could ever need.

This adds a place for those facts, a way for a material type to choose which pipelines it is built
through, and uses both from the four pipeline scripts.

Everything here is opt-in. A material type that declares nothing gets exactly what it got before.

### 1. `buildSettings` — a place for build-time facts

`MaterialTypeSourceData` gains a free-form `buildSettings` name/value map, and
`MaterialPipelineScriptRunner` exposes it to scripts as `GetBuildSetting(name, default)`. A script
asking for a setting nothing declared gets its default, so existing material types and existing
scripts are both unaffected.

`BuildSettings` is the same underlying type as `UvNameMap`, so the existing generic type
registration already covers it — registering it again would be a duplicate registration of one
generic type.

### 2. `materialPipelines` — choosing which pipelines to build through

A material type can name the pipelines it is built through by file stem, comma or space separated.
Absent, it gets the project-wide default list exactly as before. Present, it selects from that list
plus `/O3DE/Atom/RPI/OptInMaterialPipelineFiles` — pipelines that are registered but never built
unless a material type asks for one by name.

That opt-in list is the point. A tool that wants a material pipeline of its own — a reduced one for
a preview viewport, say — can register it permanently without every material type in the project
paying to build through it. The alternative was swapping the project's pipeline list out from under
every other material type, and needing an Asset Processor restart to swap it back.

A declared name matching no registered pipeline is warned about and ignored. If *none* of the
declared names match, the default list is used rather than an empty one: a material type with no
pipelines produces no shaders and renders as nothing, with no clue why.

Separately, `MaterialPipelineSourceData` gains `materialPipelineTag`. A pipeline's file stem is the
name a material type addresses it by; the tag is the name its generated shader collection is stored
under, and the name the runtime looks up through `RenderPipelineDescriptor::m_materialPipelineTag`.
These were the same string. Splitting them lets a pipeline stand in for another — a distinct file
name so a material type can ask for it, and the tag of the pipeline it replaces so the render
pipeline still finds its shaders. Empty means the file stem is used, which is what every existing
pipeline gets.

### 3. The pipeline scripts

All four scripts now read two settings:

- **`opacityMode`** (`Dynamic`, `Opaque`, `Cutout`, `Blended`, `TintedTransparent`) selects one
  shader group instead of generating all of them. Unset or unrecognised means `Dynamic`, which
  builds everything and warns if the value was not understood.
- **`positionOffset`** says whether the material moves vertices. When it does not, the optional
  depth, shadow and motion vector vertex passes have nothing to do and are left out.

The effect is easiest to see by counting includes in the script rather than by timing anything. In
the main pipeline, the Standard lighting model builds **eleven** shaders under `Dynamic`. A
material type declaring `Opaque` with no position offset builds **one**. Declaring `Opaque` while
still offsetting positions builds four. That saving is per pipeline, so it multiplies across a
project's pipeline list.

Material Canvas is the first thing to declare either setting, from what the graph actually connects.

### Diagnostics

Restricting what gets built introduces a new way to render nothing, so both halves of that report it.

At build time, a material type declaring itself transparent on a lighting model whose pipeline has
no transparent shader now warns and builds the forward shader instead of silently producing a
material type with nothing that draws. The multi view pipeline declares no depth or shadow shader at
all, so `positionOffset` has nothing to gate there; that is stated in the script where a reader
would otherwise look for the missing check.

At material processing time, `ShaderEnable.lua` reaches for shaders by tag through
`TrySetShaderEnabled`, which is deliberately silent when a tag is absent — a tag one pipeline uses
and another does not is normal, and warning on all of them would bury anything real. It is not
normal when the material is asking for that exact shader: with an opacity mode that excluded it, the
shader is simply missing, so setting `isTransparent` enables nothing and the material disappears.
The `Try` functions now report whether a shader was there to set, and `Process` warns when the
material asked for one that was not built, naming the build setting that has to change.

The two main-pass calls there are assigned to locals before being combined — `or` between the calls
would short-circuit and skip the second, which would be a behaviour change rather than a diagnostic.

### Compatibility

- A material type that declares no `buildSettings` builds the same shaders as before.
- A material type that declares no `materialPipelines` gets the same pipeline list as before.
- A `materialPipelineTag` left empty resolves to the file stem, which is what every pipeline in the
  tree does today.
- Scripts that never call `GetBuildSetting` are unaffected.

### Verification

- All six pipeline scripts parse clean, including the two this branch does not modify as a control.
- The generated shader sets were exercised end to end through a tool that declares both settings and
  its own opt-in pipeline.
- The flag names across the four scripts were brought into line (`buildBlendedShaders` rather than
  `buildBlendedShader`) — this is the same block of code in four files, and a reader comparing them
  should not have to work out whether a name difference means a behaviour difference.
