### PR TITLE
[Atom] Take the parallax clipping highlight in real3, like its callers pass

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
@@ -115,9 +115,9 @@ float GetNormalizedDepth(const MaterialParameters params, Texture2D heightmap, s
     return GetNormalizedDepth(params, heightmap, mapSampler, startDepth, stopDepth, inverseDepthRange, uv, uv_ddx, uv_ddy);
 }
 
-void ApplyParallaxClippingHighlight(inout float3 baseColor)
+void ApplyParallaxClippingHighlight(inout real3 baseColor)
 {
-    baseColor = lerp(baseColor, float3(1.0, 0.0, 1.0), 0.5);
+    baseColor = lerp(baseColor, real3(1.0, 0.0, 1.0), real(0.5));
 }
 
 struct ParallaxOffset


### PR DESCRIPTION
Atom: take the parallax clipping highlight in real3, like its callers pass
ApplyParallaxClippingHighlight declares its inout parameter as float3, but
every one of its four call sites passes a real3: StandardPBR and the Material
Canvas StandardPBR template pass surface.albedo, declared real3 in
StandardSurface.azsli, and EnhancedPBR and StandardMultilayerPBR pass a
baseColor local built from real3 expressions.

While real aliases float the mismatch is invisible. Under ENABLE_HALF_FLOAT
real becomes half, and an inout parameter cannot silently convert -- it has
to bind to the argument itself -- so DXC reports the mismatch rather than
promoting it. The highlight is behind o_parallax_highlightClipping, which is
why this has gone unnoticed.

The lerp constants become real3 and real for the same reason: leaving them
float3 puts the arithmetic back at full precision and truncates on assignment.