### PR TITLE
[Atom] Honor shader-debug overrides and trim unused shader dependencies

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/ForwardPass_BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/ForwardPass_BaseLighting.azsli
@@ -21,7 +21,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 0
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/ForwardPass_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/ForwardPass_StandardLighting.azsli
@@ -21,7 +21,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/ForwardPass_StandardLighting_CustomZ.azsli
@@ -21,7 +21,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/Transparent_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/LowEndPipeline/Transparent_StandardLighting.azsli
@@ -19,7 +19,12 @@
 #define FORCE_OPAQUE 0
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_BaseLighting.azsli
@@ -16,7 +16,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 0
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_EnhancedLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_EnhancedLighting.azsli
@@ -16,7 +16,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 1
 #define ENABLE_TRANSMISSION 1
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_EnhancedLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_EnhancedLighting_CustomZ.azsli
@@ -16,7 +16,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 1
 #define ENABLE_TRANSMISSION 1
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_SkinLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_SkinLighting.azsli
@@ -17,7 +17,12 @@
 #define OUTPUT_SUBSURFACE 1
 #define ENABLE_TRANSMISSION 1
 #define ENABLE_ANISOTROPY 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_DUAL_SPECULAR 1
 #define FORCE_IBL_IN_FORWARD_PASS 1

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_StandardLighting.azsli
@@ -16,7 +16,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/ForwardPass_StandardLighting_CustomZ.azsli
@@ -16,7 +16,12 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/Transparent_EnhancedLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/Transparent_EnhancedLighting.azsli
@@ -16,7 +16,12 @@
 #define FORCE_OPAQUE 0
 #define OUTPUT_SUBSURFACE 1
 #define ENABLE_TRANSMISSION 1
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/Transparent_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MainPipeline/Transparent_StandardLighting.azsli
@@ -16,7 +16,12 @@
 #define FORCE_OPAQUE 0
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views out with a -D. Every other
+// ENABLE_ option is written this way in LightingOptions.azsli; the debug views are a developer feature rather than a
+// correctness flag, and an unconditional define here silently beat the command line and warned about redefinition.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 1
+#endif
 #define ENABLE_CLEAR_COAT 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
@@ -22,7 +22,13 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
@@ -22,7 +22,13 @@
 #define OUTPUT_SUBSURFACE 0
 
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
@@ -22,7 +22,13 @@
 #define OUTPUT_SUBSURFACE 0
 
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
@@ -21,7 +21,13 @@
 #define FORCE_OPAQUE 0
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/ForwardPass_BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/ForwardPass_BaseLighting.azsli
@@ -22,7 +22,13 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 0
 #define ENABLE_LIGHT_CULLING 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/ForwardPass_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/ForwardPass_StandardLighting.azsli
@@ -22,7 +22,13 @@
 #define OUTPUT_SUBSURFACE 0
 
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 0
 #define ENABLE_LIGHT_CULLING 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/ForwardPass_StandardLighting_CustomZ.azsli
@@ -23,7 +23,13 @@
 #define FORCE_OPAQUE 1
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 0
 #define ENABLE_LIGHT_CULLING 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/Transparent_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/MultiView/Transparent_StandardLighting.azsli
@@ -21,7 +21,13 @@
 #define FORCE_OPAQUE 0
 #define OUTPUT_SUBSURFACE 0
 #define ENABLE_TRANSMISSION 0
+// Guarded, unlike its neighbours below, so a pipeline can compile the shader debug views back in with a -D.
+// Every other ENABLE_ option is written this way in LightingOptions.azsli, and both definitions in ShaderLib are
+// guarded too; an unconditional define here silently beat the command line and warned about redefinition. The
+// default stays 0, which is what this pipeline has always compiled.
+#ifndef ENABLE_SHADER_DEBUGGING
 #define ENABLE_SHADER_DEBUGGING 0
+#endif
 #define ENABLE_CLEAR_COAT 0
 #define ENABLE_SHADOWS 0
 #define ENABLE_LIGHT_CULLING 0

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/TransformColor.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ColorManagement/TransformColor.azsli
@@ -14,8 +14,23 @@
 #include "GeneratedTransforms/LinearSrgb_To_Srgb.azsli"
 #include "GeneratedTransforms/Srgb_To_LinearSrgb.azsli"
 #include "GeneratedTransforms/Aces_To_AcesCg.azsli"
+// The ACEScc conversions are opt-out, because one of them is disproportionately expensive to compile. AcesCcToAcesCg.azsli includes
+// Atom/Features/PostProcessing/Aces.azsli, which is 808 preprocessed lines of ACES reference transforms, and that is the single
+// largest contributor to the input azslc receives for any material shader that samples a texture -- sample_texture_2d.materialgraphnode
+// requests this file for its colour space conversion, so every Material Canvas graph with a texture in it pays for the ACES library
+// whether or not ACEScc is ever selected.
+//
+// Defining ENABLE_ACESCC_COLOR_SPACE to 0 removes it. Conversions to or from ACEScc then fall through to the same magenta that any
+// other unsupported pair produces below, which is deliberate: it is visibly wrong rather than quietly approximate. Every other colour
+// space is unaffected, and nothing else in the material shader path reaches Aces.azsli.
+#ifndef ENABLE_ACESCC_COLOR_SPACE
+#define ENABLE_ACESCC_COLOR_SPACE 1
+#endif
+
+#if ENABLE_ACESCC_COLOR_SPACE
 #include "GeneratedTransforms/AcesCcToAcesCg.azsli"
 #include "GeneratedTransforms/AcesCgToAcesCc.azsli"
+#endif
 #include "GeneratedTransforms/CalculateLuminance_LinearSrgb.azsli"
 #include "GeneratedTransforms/CalculateLuminance_AcesCg.azsli"
 
@@ -73,18 +88,22 @@ real3 TransformColor(in real3 color, ColorSpaceId fromColorSpace, ColorSpaceId t
     {
         color = AcesCg_To_LinearSrgb(color);
     }
+#if ENABLE_ACESCC_COLOR_SPACE
     else if (fromColorSpace == ColorSpaceId::ACEScg && toColorSpace == ColorSpaceId::ACEScc)
     {
         color = AcesCgToAcesCc(color);
     }
+#endif
     else if (fromColorSpace == ColorSpaceId::ACES2065 && toColorSpace == ColorSpaceId::ACEScg)
     {
         color = Aces_To_AcesCg(color);
     }
+#if ENABLE_ACESCC_COLOR_SPACE
     else if (fromColorSpace == ColorSpaceId::ACEScc && toColorSpace == ColorSpaceId::ACEScg)
     {
         color = AcesCcToAcesCg(color);
     }
+#endif
     else
     {
         color = real3(1, 0, 1);

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/LightCullingTileIterator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/LightCullingTileIterator.azsli
@@ -8,8 +8,20 @@
 
 #pragma once
 
-#include <Atom/Features/LightCulling/LightCullingShared.azsli>
+// LightingOptions.azsli comes first because it declares ENABLE_LIGHT_CULLING, and the guard below reads as 0 for an
+// undefined macro -- ordered the other way round this would silently drop light culling from every shader.
 #include <Atom/Features/PBR/LightingOptions.azsli>
+
+#if ENABLE_LIGHT_CULLING
+#include <Atom/Features/LightCulling/LightCullingShared.azsli>
+#else
+// With culling off, Init() below compiles down to InitNoCulling() and the only things still wanted from that header are the
+// two sentinel values the iterator compares against. Including it for them costs 285 preprocessed lines of NVLC.azsli in
+// every material shader, which ENABLE_LIGHT_CULLING=0 was widely assumed to remove and did not: the option guards the call
+// sites, while LightCullingShared.azsli includes NVLC.azsli unconditionally.
+#define NVLC_END_OF_LIST     0xFFFF
+#define NVLC_END_OF_GROUP    0xFFFE
+#endif
 
 // This class is used by forward shaders to iterate through lights (and decals) that are visible at this pixel position
 class LightCullingTileIterator


### PR DESCRIPTION
## Atom: honor shader-debug overrides and trim unused shader dependencies

This keeps the existing behavior of every material pipeline while removing preprocessing work that disabled features do not need.

### `ENABLE_SHADER_DEBUGGING`

The 20 forward and transparent material-pipeline templates defined `ENABLE_SHADER_DEBUGGING` unconditionally. A shader-builder `-D` therefore could not override the pipeline default and produced a macro-redefinition warning.

Each definition is now an `#ifndef`-guarded default. Main and LowEnd still default to `1`; Mobile and MultiView still default to `0`. This exposes the debugging code already supported by each pipeline; it does not add missing debug-output integration to pipelines that do not currently have it.

### ACEScc conversion dependency

`AcesCcToAcesCg.azsli` included the 802-line post-processing `Aces.azsli` library only to read its `HALF_MAX` constant. The converter now uses the same value locally as `const float halfMax = 65504.0f`, preserving both ACEScc conversions while removing that unrelated dependency from material shaders.

### `ENABLE_LIGHT_CULLING=0`

`LightCullingTileIterator.azsli` included `LightCullingShared.azsli` and NVLC even when light culling was already disabled. The include is now conditional, with the two iterator sentinel values supplied directly in the disabled path.

`LightingOptions.azsli` remains before this condition so `ENABLE_LIGHT_CULLING` always has its established default. This change removes unused declarations; it does not make GPU light culling a capability of Mobile or MultiView, whose stock passes intentionally keep it disabled and do not bind the required resources.

### Compatibility

- Existing pipeline defaults are unchanged.
- ACEScc-to-ACEScg and ACEScg-to-ACEScc conversion behavior is unchanged.
- No pipeline currently supplies these debug overrides through its checked-in shader build arguments.

### Verification

- All 22 definitions of `ENABLE_SHADER_DEBUGGING` under `Gems/` are guarded.
- Preprocessed and AZSL semantic-compiled 72 configurations across all 20 affected material-pipeline templates: every default, explicit debug `0` and `1`, plus light-culling `0` for the 12 Main/LowEnd templates.
- All 20 default outputs were byte-identical to preprocessing with their existing pipeline value supplied explicitly.
- Debug code was present in all 20 explicit-on outputs and absent from all 20 explicit-off outputs.
- NVLC code was absent from every culling-off output and from Mobile/MultiView defaults.
- ACEScc conversions remained present while post-processing ACES library symbols were absent.
