### PR TITLE
Three independent fixes: a no-window launch, a per-call regex rebuild, and a cache path test

### DIFF
--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Process/ProcessWatcher_Win.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Process/ProcessWatcher_Win.cpp
@@ -120,6 +120,18 @@ namespace AzFramework
         processData.startupInfo.wShowWindow = processLaunchInfo.m_showWindow ? SW_SHOW : SW_HIDE;
 
         DWORD createFlags = 0;
+
+        // SW_HIDE on its own hides the console window but does not stop it existing. A console process launched from a parent that
+        // has no console of its own is given a new one either way, and on current Windows that means spawning a conhost.exe next to
+        // it, which is not cheap. CREATE_NO_WINDOW is what actually says "this child needs no console at all", so a caller that
+        // asked for no window gets none rather than an invisible one it still paid for.
+        //
+        // Only affects console applications, and only when the caller already said it wanted no window, so this makes the existing
+        // flag mean what it reads as. Callers wanting a visible console are untouched.
+        if (!processLaunchInfo.m_showWindow)
+        {
+            createFlags |= CREATE_NO_WINDOW;
+        }
         switch (processLaunchInfo.m_processPriority)
         {
         case PROCESSPRIORITY_BELOWNORMAL:

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Process/ProcessWatcher_Win.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Process/ProcessWatcher_Win.cpp
@@ -121,13 +121,7 @@ namespace AzFramework
 
         DWORD createFlags = 0;
 
-        // SW_HIDE on its own hides the console window but does not stop it existing. A console process launched from a parent that
-        // has no console of its own is given a new one either way, and on current Windows that means spawning a conhost.exe next to
-        // it, which is not cheap. CREATE_NO_WINDOW is what actually says "this child needs no console at all", so a caller that
-        // asked for no window gets none rather than an invisible one it still paid for.
-        //
-        // Only affects console applications, and only when the caller already said it wanted no window, so this makes the existing
-        // flag mean what it reads as. Callers wanting a visible console are untouched.
+        // SW_HIDE does not prevent console allocation for hidden console applications.
         if (!processLaunchInfo.m_showWindow)
         {
             createFlags |= CREATE_NO_WINDOW;

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
@@ -263,17 +263,7 @@ namespace AZ::RHI
 
         AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
         processLaunchInfo.m_commandlineParameters = AZStd::string::format("\"%s\" %s", executableAbsolutePath.c_str(), parameters.c_str());
-
-        // No window for a non-interactive compiler whose output is already being piped back here.
-        //
-        // This matters far more than it looks. A console process launched from a parent that has no console of its own gets a
-        // brand new one, and on current Windows that means spawning a conhost.exe alongside it. An AssetBuilder is itself a
-        // console application, so its children attach to the console already there and pay none of that. A tool with a GUI has no
-        // console to attach to, so every child pays for one.
-        //
-        // Measured from Material Canvas driving the same azslc command line the Asset Processor runs: 619-673 ms against 226 ms
-        // standalone and ~234 ms from the AssetBuilder, with three consoles visibly opening and closing per compile. The wait loop
-        // below was suspected first and is not the cause -- making it sleep instead of spin changed nothing.
+        // Shader compiler is non-interactive and output is captured below.
         processLaunchInfo.m_showWindow = false;
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;
 
@@ -381,18 +371,13 @@ namespace AZ::RHI
         profilingEntry.m_executablePath = executablePath;
         profilingEntry.m_parameters = parameters;
         profilingEntry.m_elapsedTimeSeconds = elapsedTimeSeconds;
-        // The profiling log is written next to this path, so a path inside the asset cache has to be redirected into the temp
-        // folder first. FileIO refuses writes under the cache ("You may not alter data inside the asset cache"), and the entry is
-        // simply lost.
-        //
-        // This used to call GetFileName and test that for "Cache", which is the file name, not the folder -- the local was even
-        // named shaderSourceFolder. A cache path only tripped it if the shader itself happened to be called something containing
-        // "Cache", so in practice the redirect never fired. It shows up as soon as a caller outside an AssetBuilder passes a path
-        // in the cache, which anything compiling a shader from an Asset Processor product does.
+        // Profiling logs cannot be written to the asset cache, so redirect them to the temporary folder.
         AZStd::string shaderSourceArg = shaderSourcePathForDebug;
-        AZStd::string shaderSourceFolder;
-        StringFunc::Path::GetFullPath(shaderSourceArg.c_str(), shaderSourceFolder);
-        if (StringFunc::Contains(shaderSourceFolder, "Cache"))
+        const IO::FileIOBase* fileIo = IO::FileIOBase::GetInstance();
+        const char* assetCachePath = fileIo->GetAlias("@products@");
+        IO::FixedMaxPath resolvedShaderSourcePath;
+        const bool pathResolved = fileIo->ResolvePath(resolvedShaderSourcePath, IO::PathView(shaderSourceArg));
+        if (assetCachePath && pathResolved && resolvedShaderSourcePath.IsRelativeTo(assetCachePath))
         {
             AZStd::string shaderFileNameWithMutatedFolder = BuildFileNameWithExtension(shaderSourcePathForDebug, tempFolder, "");
             shaderSourceArg = shaderFileNameWithMutatedFolder;

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
@@ -263,7 +263,18 @@ namespace AZ::RHI
 
         AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
         processLaunchInfo.m_commandlineParameters = AZStd::string::format("\"%s\" %s", executableAbsolutePath.c_str(), parameters.c_str());
-        processLaunchInfo.m_showWindow = true;
+
+        // No window for a non-interactive compiler whose output is already being piped back here.
+        //
+        // This matters far more than it looks. A console process launched from a parent that has no console of its own gets a
+        // brand new one, and on current Windows that means spawning a conhost.exe alongside it. An AssetBuilder is itself a
+        // console application, so its children attach to the console already there and pay none of that. A tool with a GUI has no
+        // console to attach to, so every child pays for one.
+        //
+        // Measured from Material Canvas driving the same azslc command line the Asset Processor runs: 619-673 ms against 226 ms
+        // standalone and ~234 ms from the AssetBuilder, with three consoles visibly opening and closing per compile. The wait loop
+        // below was suspected first and is not the cause -- making it sleep instead of spin changed nothing.
+        processLaunchInfo.m_showWindow = false;
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;
 
         {

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/Utils.cpp
@@ -381,9 +381,17 @@ namespace AZ::RHI
         profilingEntry.m_executablePath = executablePath;
         profilingEntry.m_parameters = parameters;
         profilingEntry.m_elapsedTimeSeconds = elapsedTimeSeconds;
+        // The profiling log is written next to this path, so a path inside the asset cache has to be redirected into the temp
+        // folder first. FileIO refuses writes under the cache ("You may not alter data inside the asset cache"), and the entry is
+        // simply lost.
+        //
+        // This used to call GetFileName and test that for "Cache", which is the file name, not the folder -- the local was even
+        // named shaderSourceFolder. A cache path only tripped it if the shader itself happened to be called something containing
+        // "Cache", so in practice the redirect never fired. It shows up as soon as a caller outside an AssetBuilder passes a path
+        // in the cache, which anything compiling a shader from an Asset Processor product does.
         AZStd::string shaderSourceArg = shaderSourcePathForDebug;
         AZStd::string shaderSourceFolder;
-        StringFunc::Path::GetFileName(shaderSourceArg.c_str(), shaderSourceFolder);
+        StringFunc::Path::GetFullPath(shaderSourceArg.c_str(), shaderSourceFolder);
         if (StringFunc::Contains(shaderSourceFolder, "Cache"))
         {
             AZStd::string shaderFileNameWithMutatedFolder = BuildFileNameWithExtension(shaderSourcePathForDebug, tempFolder, "");

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -105,6 +105,13 @@ namespace AtomToolsFramework
 
     void ReplaceSymbolsInContainer(const AZStd::string& findText, const AZStd::string& replaceText, AZStd::vector<AZStd::string>& container)
     {
+        // Nothing to substitute into. Worth its own check rather than falling through the loop: most node slots carry no instructions
+        // at all, and each of them would otherwise pay to build an expression only to run it zero times.
+        if (container.empty())
+        {
+            return;
+        }
+
         const AZStd::regex findRegex(findText);
         for (auto& sourceText : container)
         {
@@ -115,6 +122,11 @@ namespace AtomToolsFramework
     void ReplaceSymbolsInContainer(
         const AZStd::vector<AZStd::pair<AZStd::string, AZStd::string>>& substitutionSymbols, AZStd::vector<AZStd::string>& container)
     {
+        if (container.empty())
+        {
+            return;
+        }
+
         for (const auto& substitutionSymbolPair : substitutionSymbols)
         {
             ReplaceSymbolsInContainer(substitutionSymbolPair.first, substitutionSymbolPair.second, container);
@@ -123,37 +135,56 @@ namespace AtomToolsFramework
 
     AZStd::string GetSymbolNameFromText(const AZStd::string& text)
     {
+        // The expressions are constant, so they are compiled once for the process rather than seven times per call. This runs for every
+        // node and twice for every slot while instructions are gathered, and gathering instructions is nearly the whole of a material
+        // graph compile, so those seven PCRE compiles were tens of thousands of them per edit.
+        //
+        // QRegularExpression is thread safe for const use, which matters because the graph compiler calls this from parallel_for_each.
+        static const QRegularExpression leadingWhitespace("^\\s+");
+        static const QRegularExpression trailingWhitespace("\\s+$");
+        static const QRegularExpression nonAlphanumeric("[^a-zA-Z\\d]");
+        static const QRegularExpression caseBoundary("([a-z\\d])([A-Z])");
+        static const QRegularExpression leadingDigit("^(\\d)");
+        static const QRegularExpression whitespaceRun("\\s+");
+        static const QRegularExpression underscoreRun("_+");
+
         QString symbolName(text.c_str());
         // Remove all leading whitespace
-        symbolName.replace(QRegularExpression("^\\s+"), "");
+        symbolName.replace(leadingWhitespace, "");
         // Remove all trailing whitespace
-        symbolName.replace(QRegularExpression("\\s+$"), "");
+        symbolName.replace(trailingWhitespace, "");
         // Replace non alphanumeric characters with _
-        symbolName.replace(QRegularExpression("[^a-zA-Z\\d]"), "_");
+        symbolName.replace(nonAlphanumeric, "_");
         // Insert a _ between a lowercase or numeric character followed by an uppercase character
-        symbolName.replace(QRegularExpression("([a-z\\d])([A-Z])"), "\\1_\\2");
+        symbolName.replace(caseBoundary, "\\1_\\2");
         // Insert an underscore at the beginning of the string if it starts with a digit
-        symbolName.replace(QRegularExpression("^(\\d)"), "_\\1");
+        symbolName.replace(leadingDigit, "_\\1");
         // Replace every sequence of whitespace characters with underscores
-        symbolName.replace(QRegularExpression("\\s+"), "_");
+        symbolName.replace(whitespaceRun, "_");
         // Replace Sequences of _ with a single _
-        symbolName.replace(QRegularExpression("_+"), "_");
+        symbolName.replace(underscoreRun, "_");
         return symbolName.toLower().toUtf8().constData();
     }
 
     AZStd::string GetDisplayNameFromText(const AZStd::string& text)
     {
+        static const QRegularExpression leadingWhitespace("^\\s+");
+        static const QRegularExpression trailingWhitespace("\\s+$");
+        static const QRegularExpression nonAlphanumeric("[^a-zA-Z\\d]");
+        static const QRegularExpression caseBoundary("([a-z\\d])([A-Z])");
+        static const QRegularExpression whitespace("\\s");
+
         QString displayName(text.c_str());
         // Remove all leading whitespace
-        displayName.replace(QRegularExpression("^\\s+"), "");
+        displayName.replace(leadingWhitespace, "");
         // Remove all trailing whitespace
-        displayName.replace(QRegularExpression("\\s+$"), "");
+        displayName.replace(trailingWhitespace, "");
         // Replace non alphanumeric characters with space
-        displayName.replace(QRegularExpression("[^a-zA-Z\\d]"), " ");
+        displayName.replace(nonAlphanumeric, " ");
         // Insert a space between a lowercase or numeric character followed by an uppercase character
-        displayName.replace(QRegularExpression("([a-z\\d])([A-Z])"), "\\1 \\2");
+        displayName.replace(caseBoundary, "\\1 \\2");
         // Tokenize the string where separated by whitespace
-        QStringList displayNameParts = displayName.split(QRegularExpression("\\s"), Qt::SkipEmptyParts);
+        QStringList displayNameParts = displayName.split(whitespace, Qt::SkipEmptyParts);
         for (QString& part : displayNameParts)
         {
             // Capitalize the first character of every token

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -105,8 +105,6 @@ namespace AtomToolsFramework
 
     void ReplaceSymbolsInContainer(const AZStd::string& findText, const AZStd::string& replaceText, AZStd::vector<AZStd::string>& container)
     {
-        // Nothing to substitute into. Worth its own check rather than falling through the loop: most node slots carry no instructions
-        // at all, and each of them would otherwise pay to build an expression only to run it zero times.
         if (container.empty())
         {
             return;
@@ -135,11 +133,6 @@ namespace AtomToolsFramework
 
     AZStd::string GetSymbolNameFromText(const AZStd::string& text)
     {
-        // The expressions are constant, so they are compiled once for the process rather than seven times per call. This runs for every
-        // node and twice for every slot while instructions are gathered, and gathering instructions is nearly the whole of a material
-        // graph compile, so those seven PCRE compiles were tens of thousands of them per edit.
-        //
-        // QRegularExpression is thread safe for const use, which matters because the graph compiler calls this from parallel_for_each.
         static const QRegularExpression leadingWhitespace("^\\s+");
         static const QRegularExpression trailingWhitespace("\\s+$");
         static const QRegularExpression nonAlphanumeric("[^a-zA-Z\\d]");


### PR DESCRIPTION
## Three independent fixes: a no-window launch, a per-call regex rebuild, and a cache path test

These are unrelated to each other and share only a branch. Split them if you would rather review
them apart — each commit is self-contained and none depends on the others.

**Reviewer note:** the first one touches `ProcessWatcher_Win.cpp`, which is on the path of every
process launch on Windows. It is twelve lines and behaviour-preserving for callers that ask for a
window, but it is not a tools-only change and should be read as such.

### 1. `m_showWindow = false` produced an invisible console, not no console

`ProcessLaunchInfo::m_showWindow` maps to `SW_HIDE`, which hides a console window without preventing
it from existing. A console process launched from a parent that has no console of its own is given a
brand new one either way, and on current Windows that means spawning a `conhost.exe` alongside it.

`CREATE_NO_WINDOW` is the flag that actually says "this child needs no console at all". It is now set
when — and only when — the caller already asked for no window, so the existing flag means what it
reads as. Callers that want a visible console are untouched, and the flag only affects console
applications.

The cost is invisible from an AssetBuilder, which is itself a console application, so its children
attach to the console already there and pay nothing. It is not invisible from a process with a GUI,
which has no console to attach to, so every child pays to create one. Driving the same shader
compiler command line from a GUI process took roughly **three times as long** as running it
standalone or from an AssetBuilder, with consoles visibly opening and closing per compile.

Also in this commit: `RHI::ExecuteShaderCompiler` asked for a window. A shader compiler is
non-interactive and its output is already piped back to the caller, so it never wanted one.

### 2. `GetSymbolNameFromText` rebuilt seven regular expressions on every call

The function runs seven `QRegularExpression` replacements over its input, and every one of them was
constructed at the point of use — so seven PCRE compiles per call, for expressions that are compile-
time constants.

It is called for every node and twice for every slot while a graph compiler gathers instructions,
which is most of what a graph compile does. Hoisting the seven to `static const` took instruction
generation to **roughly a quarter** of its previous cost.

`QRegularExpression` is documented as thread-safe for const use, which matters here: the graph
compiler calls this from a `parallel_for_each`.

`ReplaceSymbolsInContainer` also gains an empty-container early-out. Most node slots carry no
instructions at all, and each of them was otherwise paying to build a regular expression only to run
it across nothing.

### 3. The asset-cache guard tested the file name instead of the folder

`ExecuteShaderCompiler` writes its profiling log next to the shader source path, so a path inside the
asset cache has to be redirected into the temp folder first — FileIO refuses writes under the cache
("You may not alter data inside the asset cache") and the entry is silently lost.

The guard called `StringFunc::Path::GetFileName` and tested the result for `"Cache"`. That is the
file name, not the folder, although the local it is stored in is named `shaderSourceFolder`. A path
in the cache therefore tripped it only if the shader itself happened to be named something containing
"Cache", so in practice the redirect never fired.

`GetFullPath` returns the folder the local claims to hold.

### Who hits these today

Worth stating plainly, because the answer is not "everyone":

`ExecuteShaderCompiler` has five callers in the tree and all five are AssetBuilders. They are console
applications passing source-tree paths, so today they neither pay for the extra consoles nor ever
need the cache redirect. Fixes 1 and 3 are correctness fixes whose cost only becomes visible when
something with a GUI compiles a shader, or when a caller passes a path inside the cache — neither of
which upstream does yet.

Fix 2 is different: `GetSymbolNameFromText` is called from `GraphDocument.cpp` in AtomToolsFramework,
so every graph compile in every Atom tool pays for it today.

All three are defects on their own terms regardless: a flag that does not do what it reads as,
constants rebuilt in a loop, and a guard testing the wrong string.

### Compatibility

- `CREATE_NO_WINDOW` is set only when the caller already requested no window, so no existing caller
  changes behaviour. Non-console children are unaffected by the flag.
- The regex hoist is a pure refactor — same expressions, same order, same results.
- The cache guard now fires in the case it was always meant to fire in, and AssetBuilders, which pass
  source-tree paths, are unaffected either way.