### PR TITLE
Fix Android keystore generation hanging after worker errors

### DIFF
--- a/Code/Tools/Android/CMakeLists.txt
+++ b/Code/Tools/Android/CMakeLists.txt
@@ -11,3 +11,12 @@ ly_install_directory(
         ProjectBuilder
         ProjectGenerator
 )
+
+if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+    ly_add_pytest(
+        NAME android_project_generator
+        PATH ${CMAKE_CURRENT_LIST_DIR}/ProjectGenerator/tests
+        TEST_SUITE smoke
+        EXCLUDE_TEST_RUN_TARGET_FROM_IDE
+    )
+endif()

--- a/Code/Tools/Android/ProjectGenerator/keystore_generator.py
+++ b/Code/Tools/Android/ProjectGenerator/keystore_generator.py
@@ -72,9 +72,13 @@ class KeystoreGenerator(ThreadedLambda):
             timeOutSeconds=10,
         )
 
+        java_home = os.getenv("JAVA_HOME")
+        keytool = "keytool"
+        if java_home:
+            keytool = os.path.join(java_home, "bin", "keytool.exe" if os.name == "nt" else "keytool")
         self._keystoreCreateCmd = SubprocessRunner(
             [
-                "keytool",
+                keytool,
                 "-genkey",
                 "-keystore",
                 ks.keystore_file,

--- a/Code/Tools/Android/ProjectGenerator/subprocess_runner.py
+++ b/Code/Tools/Android/ProjectGenerator/subprocess_runner.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
+import locale
 import subprocess
 
 class SubprocessRunner:
@@ -32,24 +33,37 @@ class SubprocessRunner:
         """
         self._arg_list_str = " ".join(self._argList)
         print(f"{self._name} will run command:\n{self._arg_list_str}\n")
-        self._subprocess = subprocess.Popen(
-            self._argList, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._cwd
-        )
+        try:
+            self._subprocess = subprocess.Popen(
+                self._argList, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._cwd
+            )
+        except OSError as error:
+            self._error_code = -1
+            self._error_message = str(error)
+            return False
         try:
             outs, errs = self._subprocess.communicate(timeout=self._timeOut)
-            self._success_message = outs.decode("utf-8")
-            self._error_message = errs.decode("utf-8")
+            self._success_message = self._decode_output(outs)
+            self._error_message = self._decode_output(errs)
             print(f"ok:<{self._success_message}>, err:<{self._error_message}>")
             self._error_code = self._subprocess.returncode
             return self._subprocess.returncode == 0
         except subprocess.TimeoutExpired:
             self._subprocess.kill()
             outs, errs = self._subprocess.communicate()
-            self._success_message = outs.decode("utf-8")
-            self._error_message = errs.decode("utf-8")
+            self._success_message = self._decode_output(outs)
+            self._error_message = self._decode_output(errs)
             print(f"ok:<{self._success_message}>, err:<{self._error_message}>")
             self._error_code = -1
             return False
+
+
+    @staticmethod
+    def _decode_output(output: bytes) -> str:
+        try:
+            return output.decode("utf-8")
+        except UnicodeDecodeError:
+            return output.decode(locale.getpreferredencoding(False), errors="replace")
 
 
     def get_error_code(self):

--- a/Code/Tools/Android/ProjectGenerator/tests/test_operations.py
+++ b/Code/Tools/Android/ProjectGenerator/tests/test_operations.py
@@ -1,0 +1,199 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def generator_module_path(monkeypatch):
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.mark.parametrize("returncode", [0, 1])
+@pytest.mark.parametrize("output, encoding, expected", [
+    ("UTF-8: caf\u00e9".encode("utf-8"), "ascii", "UTF-8: caf\u00e9"),
+    (b"Generating 2\xa0048 bit RSA key pair", "cp1251", "Generating 2\u00a0048 bit RSA key pair"),
+    (b"Invalid byte: \xff", "utf-8", "Invalid byte: \ufffd"),
+])
+def test_subprocess_output(monkeypatch, returncode, output, encoding, expected):
+    from subprocess_runner import SubprocessRunner
+
+    process = Mock(returncode=returncode)
+    process.communicate.return_value = (output, output)
+    monkeypatch.setattr(subprocess, "Popen", Mock(return_value=process))
+    monkeypatch.setattr("locale.getpreferredencoding", lambda _: encoding)
+
+    runner = SubprocessRunner(["keytool"], 10)
+    assert runner.run() == (returncode == 0)
+    assert runner.get_error_code() == returncode
+    assert runner.get_stdout() == expected
+    assert runner.get_stderr() == expected
+
+
+def test_subprocess_missing_executable(tmp_path):
+    from subprocess_runner import SubprocessRunner
+
+    runner = SubprocessRunner([str(tmp_path / "missing-keytool")], 1)
+    assert not runner.run()
+    assert runner.get_error_code() == -1
+    assert runner.get_stderr()
+
+
+def test_subprocess_timeout_preserves_non_utf8_output(monkeypatch):
+    from subprocess_runner import SubprocessRunner
+
+    process = Mock()
+    process.communicate.side_effect = [
+        subprocess.TimeoutExpired("keytool", 1), (b"output\xa0", b"error\xa0")]
+    monkeypatch.setattr(subprocess, "Popen", Mock(return_value=process))
+    monkeypatch.setattr("locale.getpreferredencoding", lambda _: "cp1251")
+
+    runner = SubprocessRunner(["keytool"], 1)
+    assert not runner.run()
+    process.kill.assert_called_once_with()
+    assert runner.get_error_code() == -1
+    assert runner.get_stdout() == "output\u00a0"
+    assert runner.get_stderr() == "error\u00a0"
+
+
+def test_subprocess_real_timeout():
+    from subprocess_runner import SubprocessRunner
+
+    runner = SubprocessRunner([sys.executable, "-c", "import time; time.sleep(30)"], 0.1)
+    assert not runner.run()
+    assert runner.get_error_code() == -1
+    assert runner._subprocess.poll() is not None
+
+
+def test_worker_exception_finishes_operation():
+    from threaded_lambda import ThreadedLambda
+
+    def fail():
+        raise RuntimeError("worker failed")
+
+    operation = ThreadedLambda("test", fail)
+    operation.start()
+    operation._thread.join(timeout=5)
+    assert not operation._thread.is_alive()
+    assert operation.is_finished()
+    assert not operation.is_success()
+    assert "RuntimeError: worker failed" in operation.get_report_msg()
+
+
+def test_finished_waits_for_final_result_and_report():
+    from threaded_lambda import ThreadedLambda
+
+    finishing = threading.Event()
+    release = threading.Event()
+
+    def job():
+        operation._is_finished = True
+        finishing.set()
+        if not release.wait(timeout=5):
+            raise RuntimeError("Test did not release worker")
+        operation._is_success = True
+        operation._report_msg = "Complete report"
+
+    operation = ThreadedLambda("test", job)
+    assert not operation.is_finished()
+    operation.start()
+    try:
+        assert finishing.wait(timeout=5)
+        assert not operation.is_finished()
+    finally:
+        release.set()
+        operation._thread.join(timeout=5)
+    assert operation.is_finished()
+    assert operation.is_success()
+    assert operation.get_report_msg() == "Complete report"
+
+
+@pytest.mark.parametrize("generator_name, command_count", [("keystore_generator", 5), ("project_generator", 6)])
+@pytest.mark.parametrize("failure_index", [0, 2, -1])
+def test_generators_stop_on_command_failure(monkeypatch, generator_name, command_count, failure_index):
+    from config_data import ConfigData
+    from keystore_generator import KeystoreGenerator
+    from project_generator import ProjectGenerator
+
+    generator = KeystoreGenerator if generator_name == "keystore_generator" else ProjectGenerator
+    operation = generator(ConfigData())
+    success = Mock(returncode=0)
+    success.communicate.return_value = (b"", b"")
+    failure = Mock(returncode=7)
+    failure.communicate.return_value = (b"", b"command failed")
+    processes = [success] * command_count
+    processes[failure_index] = failure
+    popen = Mock(side_effect=processes)
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    operation.start()
+    operation._thread.join(timeout=5)
+    assert operation.is_finished()
+    assert not operation.is_success()
+    assert popen.call_count == (failure_index % command_count) + 1
+    assert "Completed with status code 7" in operation.get_report_msg()
+    assert "command failed" in operation.get_report_msg()
+    assert "Next Steps" not in operation.get_report_msg()
+
+
+@pytest.mark.parametrize("java_home", [None, "jdk with spaces"])
+def test_keystore_selects_java_home_before_path(monkeypatch, tmp_path, java_home):
+    from config_data import ConfigData
+    from keystore_generator import KeystoreGenerator
+
+    if java_home is None:
+        monkeypatch.delenv("JAVA_HOME", raising=False)
+        expected = "keytool"
+    else:
+        java_home = str(tmp_path / java_home)
+        monkeypatch.setenv("JAVA_HOME", java_home)
+        expected = str(Path(java_home) / "bin" / ("keytool.exe" if os.name == "nt" else "keytool"))
+    operation = KeystoreGenerator(ConfigData())
+    process = Mock(returncode=0)
+    process.communicate.return_value = (b"", b"")
+    popen = Mock(return_value=process)
+    monkeypatch.setattr(subprocess, "Popen", popen)
+
+    operation.start()
+    operation._thread.join(timeout=5)
+    assert operation.is_finished()
+    assert operation.is_success()
+    assert popen.call_count == 5
+    assert popen.call_args.args[0][0] == expected
+
+
+@pytest.mark.parametrize("failure", ["missing_keytool", "localized_output"])
+def test_keystore_operation_finishes_after_keytool(monkeypatch, failure):
+    from config_data import ConfigData
+    from keystore_generator import KeystoreGenerator
+
+    operation = KeystoreGenerator(ConfigData())
+    configure = Mock(returncode=0)
+    configure.communicate.return_value = (b"", b"")
+    keytool = Mock(returncode=0)
+    keytool.communicate.return_value = (b"", b"Generating 2\xa0048 bit RSA key pair")
+    result = FileNotFoundError("keytool is missing") if failure == "missing_keytool" else keytool
+    popen = Mock(side_effect=[configure] * 4 + [result])
+    monkeypatch.setattr(subprocess, "Popen", popen)
+    monkeypatch.setattr("locale.getpreferredencoding", lambda _: "cp1251")
+
+    operation.start()
+    operation._thread.join(timeout=5)
+    assert not operation._thread.is_alive()
+    assert operation.is_finished()
+    assert operation.is_success() == (failure == "localized_output")
+    if failure == "missing_keytool":
+        assert "keytool is missing" in operation.get_report_msg()
+    else:
+        assert "Generating 2\u00a0048 bit RSA key pair" in operation.get_report_msg()

--- a/Code/Tools/Android/ProjectGenerator/threaded_lambda.py
+++ b/Code/Tools/Android/ProjectGenerator/threaded_lambda.py
@@ -26,7 +26,16 @@ class ThreadedLambda:
         self._is_cancelled = False
         # Subclasses should store here the result of stdout+stderr.
         self._report_msg = ""
-        self._thread = threading.Thread(target=job_func)
+        def _run_job():
+            try:
+                job_func()
+            except Exception as error:
+                self._is_success = False
+                self._report_msg += f"{type(error).__name__}: {error}\n"
+            finally:
+                self._is_finished = True
+
+        self._thread = threading.Thread(target=_run_job)
 
 
     def start(self):
@@ -37,7 +46,7 @@ class ThreadedLambda:
 
 
     def is_finished(self) -> bool:
-        return self._is_finished
+        return self._is_finished and not self._thread.is_alive()
 
 
     def is_success(self) -> bool:


### PR DESCRIPTION
## What does this PR do?

Fixes Android Project Generator’s **Create Keystore** action remaining in the progress dialog after its worker thread exits with an exception.

<img width="648" height="262" alt="image" src="https://github.com/user-attachments/assets/6ff53b2c-e9dc-4389-ae61-8a60691e0ab6" />


Previously, this could happen when:
- `keytool` was absent from `PATH`, even with a valid `JAVA_HOME`.
- Java emitted locale-encoded output that could not be decoded as UTF-8, potentially after successfully creating the keystore.

The change:
- Resolves `keytool` from `JAVA_HOME/bin` when configured; otherwise uses `PATH`.
- Adds locale fallback decoding for subprocess output.
- Reports process launch failures and unexpected worker exceptions through the existing error handling.
- Waits for the worker to exit before the GUI reads its final status and report.

An invalid explicit `JAVA_HOME` now produces an error instead of using another JDK from `PATH`. Existing subprocess timeout and cancellation behavior is unchanged.

**This PR is a draft pending Linux and macOS runtime validation.** Feedback on cross-platform behavior, particularly `JAVA_HOME` precedence, is welcome.

## How was this PR tested?

- Added **21 regression tests** covering output decoding, executable lookup, launch failures, timeout handling, worker exceptions, completion ordering, and stopping command sequences on failure.
- Confirmed that the original hang regression cases fail against `upstream/development` and pass with the fix.
- Ran the new tests alongside existing Android CLI, support, and export tests:
  - **132 passed**
  - **1 skipped**
  - **14 xfailed**
  - **2 xpassed**
- Validated real keystore generation on **Windows with JDK 17**, including:
  - Paths containing spaces.
  - Persisted signing settings.
  - Locale-encoded Java output.
  - Alias verification using `keytool -list`.
- Exercised GUI callbacks and the Tk event loop for successful generation and missing-JDK failures, verifying progress completion, report population, and result handling. Modal dialogs were replaced with test objects for this automated check.
- Passed `git diff --check` and all **10 enabled O3DE commit validators**.

### Pending validation

On Linux and macOS:
- Run the regression tests.
- Generate and inspect a keystore with a valid `JAVA_HOME`.
- Verify `PATH` lookup with `JAVA_HOME` unset.
- Verify that an invalid `JAVA_HOME` produces an error without leaving the progress dialog open.
- Check paths containing spaces and launch through Project Manager.
