### PR TITLE
Support reading files over 2GB on Linux

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLikeDefault/AzCore/IO/SystemFile_UnixLikeDefault.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLikeDefault/AzCore/IO/SystemFile_UnixLikeDefault.cpp
@@ -207,12 +207,28 @@ namespace AZ::IO::Platform
     {
         if (handle != PlatformSpecificInvalidHandle)
         {
-            ssize_t bytesRead = read(handle, buffer, byteSize);
-            if (bytesRead == -1)
+            auto* cursor = static_cast<AZStd::byte*>(buffer);
+            SystemFile::SizeType totalBytesRead = 0;
+            while (totalBytesRead < byteSize)
             {
-                return 0;
+                // Read is not guaranteed to read the entire amount specified.
+                ssize_t bytesRead = read(handle, cursor + totalBytesRead, byteSize - totalBytesRead);
+                if (bytesRead == -1)
+                {
+                    if (errno == EINTR)
+                    {
+                        continue;
+                    }
+                    break;
+                }
+                if (bytesRead == 0)
+                {
+                    // End of file reached before the requested size was satisfied.
+                    break;
+                }
+                totalBytesRead += bytesRead;
             }
-            return bytesRead;
+            return totalBytesRead;
         }
 
         return 0;


### PR DESCRIPTION
## What does this PR do?

This PR allows reading files that are over 2,147,479,552 bytes long without errors on Linux.
In a very narrow use case it is reasonable to want load a single big asset (Ex. Pointcloud in .ply format) that exceeds this size limit.

Before this change it resulted in very obscure error such as
```
Error loading asset {48CD321F-B544-5CE7-A443-C58A73A874A1}:0
```

According to [Linux man-pages](https://man7.org/linux/man-pages/man2/read.2.html)
> read() attempts to read up to count bytes from file descriptor fd into the buffer starting at buf.

This means that, performing a single read and assuming that it reads all requested bytes should not be relied upon. This often manifests itself when performing this syscall on a network socket.

Furthermore in Notes
> On Linux, read() (and similar system calls) will transfer at most 0x7ffff000 (2,147,479,552) bytes, returning the number of bytes actually transferred.  (This is true on both 32-bit and 64-bit systems.)

This means that for any files larger than 2,147,479,552 bytes multiple reads should be performed to correctly read the entire file.


## How was this PR tested?

Added a single file test-asset.ply with size `3531354203` bytes to the project and loaded it in Pointcloud Component 
