### PR TITLE
Fix non-unity build

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h
@@ -13,6 +13,8 @@
 
 #include <AzFramework/Entity/EntityContextBus.h>
 
+#include <AzToolsFramework/Entity/EntityTypes.h>
+
 namespace AzToolsFramework
 {
     //! An entity registered as read-only cannot be altered in the editor.


### PR DESCRIPTION
## What does this PR do?

`ReadOnlyEntityQueryInterface::RefreshReadOnlyState` takes an `AzToolsFramework::EntityIdList` but the header never includes `AzToolsFramework/Entity/EntityTypes.h` that declares it.

#19993 added an include of `ReadOnlyEntityInterface.h` to `ReadOnlyEntityBus.h`. `ProceduralPrefabReadOnlyHandler.h` includes that bus header before any AzToolsFramework entity header, so the interface is now reached first and the missing declaration is exposed. CI does not detect the issue with the unity build switched on.

The same  problem is present on `development`.

## How was this PR tested?

The code was built.