### PR TITLE
Fix oversized SystemFile transfers on Unix-like platforms

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLikeDefault/AzCore/IO/SystemFile_UnixLikeDefault.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLikeDefault/AzCore/IO/SystemFile_UnixLikeDefault.cpp
@@ -12,6 +12,8 @@
 
 #include <AzCore/PlatformIncl.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/std/algorithm.h>
+#include <AzCore/std/limits.h>
 
 #include <stdio.h>
 
@@ -144,6 +146,14 @@ namespace AZ::IO::Platform
 {
     using FileHandleType = AZ::IO::SystemFile::FileHandleType;
 
+    constexpr SystemFile::SizeType MaxTransferSize = AZStd::numeric_limits<int>::max();
+
+    static bool IsRegularFile(FileHandleType handle)
+    {
+        struct stat fileStatus;
+        return fstat(handle, &fileStatus) == 0 && S_ISREG(fileStatus.st_mode);
+    }
+
     void Seek(FileHandleType handle, const SystemFile* systemFile, SystemFile::SeekSizeType offset, SystemFile::SeekMode mode)
     {
         if (handle != PlatformSpecificInvalidHandle)
@@ -207,6 +217,23 @@ namespace AZ::IO::Platform
     {
         if (handle != PlatformSpecificInvalidHandle)
         {
+            if (byteSize > MaxTransferSize && IsRegularFile(handle))
+            {
+                AZStd::byte* cursor = static_cast<AZStd::byte*>(buffer);
+                SizeType totalBytesRead = 0;
+                while (totalBytesRead < byteSize)
+                {
+                    const ssize_t bytesRead =
+                        read(handle, cursor + totalBytesRead, AZStd::min(byteSize - totalBytesRead, MaxTransferSize));
+                    if (bytesRead <= 0)
+                    {
+                        break;
+                    }
+                    totalBytesRead += bytesRead;
+                }
+                return totalBytesRead;
+            }
+
             ssize_t bytesRead = read(handle, buffer, byteSize);
             if (bytesRead == -1)
             {
@@ -222,12 +249,29 @@ namespace AZ::IO::Platform
     {
         if (handle != PlatformSpecificInvalidHandle)
         {
-            ssize_t result = write(handle, buffer, byteSize);
-            if (result == -1)
+            if (byteSize > MaxTransferSize && IsRegularFile(handle))
+            {
+                const AZStd::byte* cursor = static_cast<const AZStd::byte*>(buffer);
+                SizeType totalBytesWritten = 0;
+                while (totalBytesWritten < byteSize)
+                {
+                    const ssize_t bytesWritten =
+                        write(handle, cursor + totalBytesWritten, AZStd::min(byteSize - totalBytesWritten, MaxTransferSize));
+                    if (bytesWritten <= 0)
+                    {
+                        break;
+                    }
+                    totalBytesWritten += bytesWritten;
+                }
+                return totalBytesWritten;
+            }
+
+            ssize_t bytesWritten = write(handle, buffer, byteSize);
+            if (bytesWritten == -1)
             {
                 return 0;
             }
-            return result;
+            return bytesWritten;
         }
 
         return 0;

--- a/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/IO/SystemFileTest_UnixLike.cpp
+++ b/Code/Framework/AzCore/Tests/Platform/Common/UnixLike/Tests/IO/SystemFileTest_UnixLike.cpp
@@ -5,10 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <AzCore/IO/SystemFile.h>
 #include <AzCore/IO/Path/Path.h>
+#include <AzCore/IO/SystemFile.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/limits.h>
 #include <AzTest/Utils.h>
+
+#include <sys/mman.h>
 
 namespace UnitTest
 {
@@ -56,5 +59,25 @@ namespace UnitTest
         AZ::IO::PosixInternal::Close(fileHandle);
 
         EXPECT_EQ(testData, readData);
+    }
+
+    TEST_F(SystemFilePlatformFixture, Read_OversizedRequest_ReturnsDataUntilEof)
+    {
+        constexpr AZStd::string_view testData{ "Testing oversized reads" };
+        auto testFileName = m_tempDirectory.GetDirectoryAsFixedMaxPath() / "TestFile.txt";
+        AZ::IO::SystemFile testFile(testFileName.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_READ_WRITE);
+        ASSERT_TRUE(testFile.IsOpen());
+        ASSERT_EQ(testData.size(), testFile.Write(testData.data(), testData.size()));
+        testFile.Seek(0, AZ::IO::SystemFile::SF_SEEK_BEGIN);
+
+        // Reserve the requested address range.
+        // Only the small file's contents consume physical memory.
+        constexpr size_t requestSize = static_cast<size_t>(AZStd::numeric_limits<int>::max()) + 1;
+        void* buffer = mmap(nullptr, requestSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        ASSERT_NE(MAP_FAILED, buffer);
+        EXPECT_EQ(testData.size(), testFile.Read(requestSize, buffer));
+        EXPECT_EQ(testData, AZStd::string_view(static_cast<const char*>(buffer), testData.size()));
+        EXPECT_TRUE(testFile.Eof());
+        EXPECT_EQ(0, munmap(buffer, requestSize));
     }
 }   // namespace UnitTest


### PR DESCRIPTION
## What does this PR do?

Fixes `SystemFile::Read` and `SystemFile::Write` requests larger than INT_MAX. Oversized transfers are chunked for regular files, avoiding Mac errors and Linux truncation while preserving existing single-call behavior for pipes, sockets, and other non-regular descriptors.

Supersedes #20111.

## How was this PR tested?

- Added regression coverage for reads larger than `INT_MAX`.
- Passed all 13 SystemFile tests on macOS.
- Verified a 2.2 GB write/read round trip on macOS.
- The original author also [verified the change on Linux](https://github.com/o3de/o3de/pull/20111#issuecomment-5632273362).